### PR TITLE
[ty] Lazily materialize protocol attributes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -150,7 +150,7 @@ def get_any() -> Any:
 async def test():
     x = get_any()
     if inspect.isawaitable(x):
-        reveal_type(x)  # revealed: Any & Awaitable[object]
+        reveal_type(x)  # revealed: Any & Top[Awaitable[object]]
         y = await x
         reveal_type(y)  # revealed: Any
 ```
@@ -239,10 +239,10 @@ def is_async_callable(x: object) -> TypeIs[Top[Callable[..., Awaitable[object]]]
 
 async def f(fn: Callable[[int], int | Awaitable[int]]) -> None:
     if is_async_callable(fn):
-        reveal_type(fn)  # revealed: ((int, /) -> int | Awaitable[int]) & Top[(...) -> Awaitable[object]]
+        reveal_type(fn)  # revealed: ((int, /) -> int | Awaitable[int]) & Top[(...) -> Top[Awaitable[object]]]
         result = fn(1)
-        # This includes `int & Awaitable[object]`: an `int` subtype could define `__await__`.
-        reveal_type(result)  # revealed: (int & Awaitable[object]) | Awaitable[int]
+        # This includes `int & Top[Awaitable[object]]`: an `int` subtype could define `__await__`.
+        reveal_type(result)  # revealed: (int & Top[Awaitable[object]]) | Awaitable[int]
         reveal_type(await result)  # revealed: object
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2220,6 +2220,23 @@ But calling `asdict` on the class object is not allowed:
 asdict(Foo)
 ```
 
+## `dataclasses.is_dataclass`
+
+`is_dataclass` recognizes both dataclass instances and dataclass classes. A concrete dataclass
+instance always satisfies the `DataclassInstance` protocol, so the negative branch is unreachable:
+
+```py
+from dataclasses import dataclass, is_dataclass
+
+@dataclass
+class Event:
+    x: int
+
+def check(event: Event) -> None:
+    if not is_dataclass(event):
+        reveal_type(event)  # revealed: Never
+```
+
 ## `dataclasses.KW_ONLY`
 
 If an attribute is annotated with `dataclasses.KW_ONLY`, it is not added to the synthesized

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -499,6 +499,12 @@ static_assert(is_equivalent_to(Bottom[type[int | Any]], type[int]))
 def _(top: Top[list[type[Any]]], bottom: Bottom[list[type[Any]]]):
     reveal_type(top)  # revealed: Top[list[type[Any]]]
     reveal_type(bottom)  # revealed: Bottom[list[type[Any]]]
+
+def annotated_materialized_list_classes(top: type[Top[list[Any]]], bottom: type[Bottom[list[Any]]]) -> None:
+    reveal_type(top)  # revealed: type[Top[list[Any]]]
+    reveal_type(bottom)  # revealed: type[Bottom[list[Any]]]
+    reveal_type(top())  # revealed: Top[list[Any]]
+    reveal_type(bottom())  # revealed: Bottom[list[Any]]
 ```
 
 ## Materialized class annotations and constructors
@@ -703,6 +709,10 @@ def _(
     top_two: Top[int, str],  # error: [invalid-type-form]
     bottom_two: Bottom[int, str],  # error: [invalid-type-form]
 ): ...
+def nested_invalid_arity(
+    top_two: type[Top[int, str]],  # error: [invalid-type-form]
+    bottom_two: type[Bottom[int, str]],  # error: [invalid-type-form]
+) -> None: ...
 ```
 
 The argument must be a type expression:
@@ -1075,6 +1085,14 @@ def constructors(top: Top[MutableAny]) -> None:
     reveal_type(type(top))  # revealed: type[Top[MutableAny]]
     reveal_type(type(top)())  # revealed: Top[MutableAny]
     reveal_type(invoke(type(top)))  # revealed: Top[MutableAny]
+
+def annotated_constructors(top: type[Top[MutableAny]], bottom: type[Bottom[MutableAny]]) -> None:
+    reveal_type(top)  # revealed: type[Top[MutableAny]]
+    reveal_type(bottom)  # revealed: type[Bottom[MutableAny]]
+    reveal_type(top())  # revealed: Top[MutableAny]
+    reveal_type(bottom())  # revealed: Bottom[MutableAny]
+    reveal_type(invoke(top))  # revealed: Top[MutableAny]
+    reveal_type(invoke(bottom))  # revealed: Bottom[MutableAny]
 ```
 
 Materialization preserves sound class-member access: an ordinary instance attribute is not available
@@ -1084,6 +1102,10 @@ on `type[Top[MutableAny]]` or `type[Bottom[MutableAny]]`.
 def class_instance_attributes(top: Top[MutableAny], bottom: Bottom[MutableAny]) -> None:
     type(top).value  # error: [unresolved-attribute]
     type(bottom).value  # error: [unresolved-attribute]
+
+def annotated_class_instance_attributes(top: type[Top[MutableAny]], bottom: type[Bottom[MutableAny]]) -> None:
+    top.value  # error: [unresolved-attribute]
+    bottom.value  # error: [unresolved-attribute]
 ```
 
 ### Writable properties
@@ -1223,7 +1245,8 @@ async def narrow_awaitable_union(fn: Callable[[int], int | Awaitable[int]]) -> N
 ### Class variables
 
 Class variables have separate read and write types. `Top` reads `object` and writes `Never`, while
-`Bottom` reads `Never` and writes `object`:
+`Bottom` reads `Never` and writes `object`. These requirements are preserved on both inferred and
+explicitly annotated class objects:
 
 ```py
 from typing import Any, ClassVar, Protocol
@@ -1240,18 +1263,37 @@ def class_writes(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
 def class_reads(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
     reveal_type(type(top).value)  # revealed: object
     reveal_type(type(bottom).value)  # revealed: Never
+
+def annotated_class_writes(top: type[Top[ClassVarAny]], bottom: type[Bottom[ClassVarAny]]) -> None:
+    reveal_type(top)  # revealed: type[Top[ClassVarAny]]
+    reveal_type(bottom)  # revealed: type[Bottom[ClassVarAny]]
+    top.value = 1  # error: [invalid-assignment]
+    bottom.value = object()
+
+def annotated_class_reads(top: type[Top[ClassVarAny]], bottom: type[Bottom[ClassVarAny]]) -> None:
+    reveal_type(top.value)  # revealed: object
+    reveal_type(bottom.value)  # revealed: Never
 ```
 
 Structural protocol checks use the mapped read and write types as well. `ClassVarInt` satisfies the
-top-materialized protocol, but not the bottom-materialized one:
+top-materialized protocol, but not the bottom-materialized one; a class missing the class variable
+does not satisfy the top-materialized protocol:
 
 ```py
 class ClassVarInt:
     value: ClassVar[int] = 1
 
+class MissingClassVar: ...
+
 static_assert(is_subtype_of(ClassVarInt, Top[ClassVarAny]))
 static_assert(not is_subtype_of(ClassVarInt, Bottom[ClassVarAny]))
 top_class: type[Top[ClassVarAny]] = ClassVarInt
+missing_top_class: type[Top[ClassVarAny]] = MissingClassVar  # error: [invalid-assignment]
+invalid_bottom_class: type[Bottom[ClassVarAny]] = ClassVarInt  # error: [invalid-assignment]
+
+def materialized_bottom_class(bottom: Bottom[ClassVarAny]) -> None:
+    valid_bottom_class: type[Bottom[ClassVarAny]] = type(bottom)
+    reveal_type(valid_bottom_class)  # revealed: type[Bottom[ClassVarAny]]
 ```
 
 Union simplification preserves the materialized class variable regardless of operand order:
@@ -1366,6 +1408,7 @@ A descriptor can expose separate read and write types. `Top` maps an `Any` read 
 
 ```py
 from typing import Any, Callable, Never, Protocol
+from typing_extensions import TypeIs
 from ty_extensions import Bottom, Top, static_assert
 from ty_extensions._internal import is_subtype_of
 
@@ -1398,6 +1441,23 @@ class NarrowBottomDescriptorProperty:
 
 static_assert(is_subtype_of(TopDescriptorProperty, Top[DescriptorProperty]))
 static_assert(not is_subtype_of(NarrowBottomDescriptorProperty, Bottom[DescriptorProperty]))
+
+def top_descriptor_write(top: Top[DescriptorProperty]) -> None:
+    top.value = 1  # error: [invalid-assignment]
+
+def bottom_descriptor_write(bottom: Bottom[DescriptorProperty]) -> None:
+    bottom.value = object()
+
+def plain_descriptor_write(plain: DescriptorProperty) -> None:
+    plain.value = object()
+
+def is_descriptor_property(value: object) -> TypeIs[DescriptorProperty]:
+    return True
+
+def narrowed_descriptor_write(value: object) -> None:
+    if is_descriptor_property(value):
+        reveal_type(value)  # revealed: Top[DescriptorProperty]
+        value.value = 1  # error: [invalid-assignment]
 ```
 
 ### Property accessor types
@@ -1448,10 +1508,12 @@ def property_assignment_narrowing(top: Top[TransformingProperty]) -> None:
 ### Generic inference through inherited and structural protocols
 
 Generic inference uses a member's materialized type, not its original `Any`. This applies both to
-inherited members and to the finite requirements of independently declared structural protocols:
+inherited members and to the finite requirements of independently declared structural protocols.
+Bounds, constraints, and invariant requirements must still reject an incompatible materialized
+member instead of accepting an invalid call or selecting the wrong overload:
 
 ```py
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol, TypeVar, overload
 from ty_extensions import Top
 
 class InferenceBase[T](Protocol):
@@ -1473,6 +1535,105 @@ def materialized_inference(inherited: Top[InheritedInferenceAny]) -> None:
 
 def materialized_structural_inference(structural: Top[StructuralInferenceAny]) -> None:
     reveal_type(infer_item(structural))  # revealed: object
+
+def bounded_item[T: str](value: InferenceBase[T]) -> T:
+    raise NotImplementedError
+
+def union_bounded_item[T: str | bytes](value: InferenceBase[T]) -> T:
+    raise NotImplementedError
+
+def constrained_item[T: (str, bytes)](value: InferenceBase[T]) -> T:
+    raise NotImplementedError
+
+LegacyConstrained = TypeVar("LegacyConstrained", str, bytes)
+
+def legacy_constrained_item(value: InferenceBase[LegacyConstrained]) -> LegacyConstrained:
+    raise NotImplementedError
+
+def invalid_materialized_bounds(
+    inherited: Top[InheritedInferenceAny],
+    structural: Top[StructuralInferenceAny],
+) -> None:
+    bounded_item(inherited)  # error: [invalid-argument-type]
+    bounded_item(structural)  # error: [invalid-argument-type]
+    union_bounded_item(inherited)  # error: [invalid-argument-type]
+    union_bounded_item(structural)  # error: [invalid-argument-type]
+    constrained_item(inherited)  # error: [invalid-argument-type]
+    constrained_item(structural)  # error: [invalid-argument-type]
+    legacy_constrained_item(inherited)  # error: [invalid-argument-type]
+    legacy_constrained_item(structural)  # error: [invalid-argument-type]
+
+def consistent_item[T](value: InferenceBase[T], values: list[T]) -> T:
+    raise NotImplementedError
+
+def invalid_materialized_invariant_arguments(
+    inherited: Top[InheritedInferenceAny],
+    structural: Top[StructuralInferenceAny],
+    values: list[int],
+) -> None:
+    consistent_item(inherited, values)  # error: [invalid-argument-type]
+    consistent_item(structural, values)  # error: [invalid-argument-type]
+
+class InvariantInferenceBase[T](Protocol):
+    item: T
+
+class InheritedInvariantAny(InvariantInferenceBase[Any], Protocol):
+    marker: Any
+
+class StructuralInvariantAny(Protocol):
+    item: Any
+
+def invariant_item[T](value: InvariantInferenceBase[T], required: T) -> T:
+    raise NotImplementedError
+
+def invalid_materialized_invariant_members(
+    inherited: Top[InheritedInvariantAny],
+    structural: Top[StructuralInvariantAny],
+) -> None:
+    invariant_item(inherited, "required")  # error: [invalid-argument-type]
+    invariant_item(structural, "required")  # error: [invalid-argument-type]
+
+@overload
+def select_item[T: str](value: InferenceBase[T]) -> Literal["bounded"]: ...
+@overload
+def select_item(value: object) -> Literal["fallback"]: ...
+def select_item(value: object) -> Literal["bounded", "fallback"]:
+    return "fallback"
+
+@overload
+def select_specific_item(value: InferenceBase[str]) -> Literal["str"]: ...
+@overload
+def select_specific_item(value: InferenceBase[bytes]) -> Literal["bytes"]: ...
+def select_specific_item(value: object) -> str:
+    raise NotImplementedError
+
+def materialized_overload_resolution(
+    inherited: Top[InheritedInferenceAny],
+    structural: Top[StructuralInferenceAny],
+    valid: InferenceBase[str],
+) -> None:
+    reveal_type(select_item(inherited))  # revealed: Literal["fallback"]
+    reveal_type(select_item(structural))  # revealed: Literal["fallback"]
+    reveal_type(select_item(valid))  # revealed: Literal["bounded"]
+    select_specific_item(inherited)  # error: [no-matching-overload]
+    select_specific_item(structural)  # error: [no-matching-overload]
+
+@overload
+def select_consistent_item[T](value: InferenceBase[T], values: list[T]) -> T: ...
+@overload
+def select_consistent_item(value: object, values: list[int]) -> object: ...
+def select_consistent_item(value: object, values: object) -> object:
+    raise NotImplementedError
+
+def materialized_invariant_overload_resolution(
+    inherited: Top[InheritedInferenceAny],
+    structural: Top[StructuralInferenceAny],
+    valid: InferenceBase[int],
+    values: list[int],
+) -> None:
+    reveal_type(select_consistent_item(inherited, values))  # revealed: object
+    reveal_type(select_consistent_item(structural, values))  # revealed: object
+    reveal_type(select_consistent_item(valid, values))  # revealed: int
 ```
 
 ### Generator delegation
@@ -1574,6 +1735,17 @@ def alias_writes(
 ) -> None:
     top.value = 1  # error: [invalid-assignment]
     bottom.value = object()
+
+def annotated_generic_protocol_classes(
+    top: type[Top[GenericMutable[Any]]],
+    bottom: type[Bottom[GenericMutable[Any]]],
+    aliased_top: type[Top[MutableAlias[Any]]],
+    aliased_bottom: type[Bottom[MutableAlias[Any]]],
+) -> None:
+    reveal_type(top)  # revealed: type[Top[GenericMutable[Any]]]
+    reveal_type(bottom)  # revealed: type[Bottom[GenericMutable[Any]]]
+    reveal_type(aliased_top)  # revealed: type[Top[GenericMutable[Any]]]
+    reveal_type(aliased_bottom)  # revealed: type[Bottom[GenericMutable[Any]]]
 ```
 
 ### Nested generic protocols

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1057,6 +1057,77 @@ def annotated_constructors(top: type[Top[MutableAny]], bottom: type[Bottom[Mutab
     reveal_type(invoke(bottom))  # revealed: Bottom[MutableAny]
 ```
 
+A protocol's constructor can explicitly return a value that is not an instance of the protocol.
+Materializing the protocol must preserve that return type, including when its class object is
+converted to a callable:
+
+```py
+class IntConstructor(Protocol):
+    value: Any
+
+    def __new__(cls) -> int:
+        return 1
+
+def non_instance_constructors(
+    plain: type[IntConstructor],
+    top: type[Top[IntConstructor]],
+    bottom: type[Bottom[IntConstructor]],
+) -> None:
+    reveal_type(invoke(plain))  # revealed: int
+    reveal_type(invoke(top))  # revealed: int
+    reveal_type(invoke(bottom))  # revealed: int
+```
+
+A custom protocol metaclass can likewise construct a value that is not a protocol instance. Its
+`__call__` return type is preserved when the protocol is materialized.
+
+```py
+class IntConstructorMetaclass(type(Protocol)):
+    def __call__(cls) -> int:
+        return 1
+
+class MetaclassConstructor(Protocol, metaclass=IntConstructorMetaclass):
+    value: Any
+
+def metaclass_constructors(
+    plain: type[MetaclassConstructor],
+    top: type[Top[MetaclassConstructor]],
+    bottom: type[Bottom[MetaclassConstructor]],
+) -> None:
+    reveal_type(invoke(plain))  # revealed: int
+    reveal_type(invoke(top))  # revealed: int
+    reveal_type(invoke(bottom))  # revealed: int
+```
+
+Overloaded constructors preserve each return type separately: an instance-returning overload uses
+the materialized protocol, while an overload returning a different type retains that type.
+
+```py
+from typing import Self, overload
+
+class MixedConstructor(Protocol):
+    value: Any
+
+    @overload
+    def __new__(cls) -> Self: ...
+    @overload
+    def __new__(cls, value: int) -> int: ...
+    def __new__(cls, value: int | None = None) -> Self | int:
+        raise NotImplementedError
+
+def invoke_with_int[T](factory: Callable[[int], T]) -> T:
+    return factory(1)
+
+def mixed_constructors(
+    top: type[Top[MixedConstructor]],
+    bottom: type[Bottom[MixedConstructor]],
+) -> None:
+    reveal_type(invoke(top))  # revealed: Top[MixedConstructor]
+    reveal_type(invoke(bottom))  # revealed: Bottom[MixedConstructor]
+    reveal_type(invoke_with_int(top))  # revealed: int
+    reveal_type(invoke_with_int(bottom))  # revealed: int
+```
+
 Materialization preserves sound class-member access: an ordinary instance attribute is not available
 on `type[Top[MutableAny]]` or `type[Bottom[MutableAny]]`.
 
@@ -1411,14 +1482,15 @@ def fully_static_property(
     reveal_type(bottom)  # revealed: FullyStaticProperty
 ```
 
-### Assigning to properties
+### Assignment narrowing of materialized properties
 
-A property setter may transform the assigned value. Assigning a literal therefore must not narrow
-subsequent reads to that literal:
+A materialized protocol exposes a property's return type, not the underlying descriptor, when
+reading that property. Assignment narrowing must still recover the descriptor: its setter can
+transform the assigned value, so the next read must not narrow to the assigned literal.
 
 ```py
 from typing import Any, Protocol
-from ty_extensions import Top
+from ty_extensions import Bottom, Top
 
 class TransformingProperty(Protocol):
     marker: Any
@@ -1428,9 +1500,14 @@ class TransformingProperty(Protocol):
     @value.setter
     def value(self, value: int) -> None: ...
 
-def property_assignment_narrowing(top: Top[TransformingProperty]) -> None:
+def materialized_property_assignment_narrowing(
+    top: Top[TransformingProperty],
+    bottom: Bottom[TransformingProperty],
+) -> None:
     top.value = 1
     reveal_type(top.value)  # revealed: int
+    bottom.value = 2
+    reveal_type(bottom.value)  # revealed: int
 ```
 
 ### Generic inference through inherited and structural protocols

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1012,32 +1012,6 @@ writes are contravariant.
 python-version = "3.12"
 ```
 
-### Class-backed protocol specialization during interface construction
-
-An ordinary specialization of a class-backed protocol only maps its class specialization. It must
-not inspect the protocol interface, because the specialization can occur while that same interface
-is being constructed:
-
-```py
-from __future__ import annotations
-
-from typing import Generic, Protocol, TypeVar, overload
-
-S = TypeVar("S")
-T = TypeVar("T")
-
-class Unit(Protocol):
-    def __mul__(self, other: S | Quantity[S]): ...
-
-class Vector(Protocol): ...
-
-class Quantity(Generic[T], Protocol):
-    @overload
-    def __mul__(self, other: Unit | Quantity[S]): ...
-    @overload
-    def __mul__(self, other: Vector) -> Vector: ...
-```
-
 ### Instance attributes
 
 For a mutable `Any` attribute, `Top` reads `object` and writes `Never`; `Bottom` does the reverse:
@@ -1054,12 +1028,10 @@ def mutable_top_attributes(top: Top[MutableAny]) -> None:
     reveal_type(top.value)  # revealed: object
     top.value = 1  # error: [invalid-assignment]
 
-def mutable_bottom_attribute_read(bottom: Bottom[MutableAny]) -> None:
+def mutable_bottom_attributes(bottom: Bottom[MutableAny]) -> None:
     reveal_type(bottom)  # revealed: Bottom[MutableAny]
-    reveal_type(bottom.value)  # revealed: Never
-
-def mutable_bottom_attribute_write(bottom: Bottom[MutableAny]) -> None:
     bottom.value = object()
+    reveal_type(bottom.value)  # revealed: Never
 ```
 
 The class object of a materialized protocol preserves its instance type when called directly or
@@ -1116,11 +1088,9 @@ def writable_top_property(top: Top[WritableAny]) -> None:
     reveal_type(top.value)  # revealed: object
     top.value = 1  # error: [invalid-assignment]
 
-def writable_bottom_property_read(bottom: Bottom[WritableAny]) -> None:
-    reveal_type(bottom.value)  # revealed: Never
-
-def writable_bottom_property_write(bottom: Bottom[WritableAny]) -> None:
+def writable_bottom_property(bottom: Bottom[WritableAny]) -> None:
     bottom.value = object()
+    reveal_type(bottom.value)  # revealed: Never
 ```
 
 ### Protocol relations
@@ -1187,19 +1157,19 @@ override is structurally incompatible with the base protocol. Materializing the 
 also preserves the nominal relationship:
 
 ```py
-class NominalBase(Protocol):
+class BaseProtocol(Protocol):
     @property
     def value(self) -> int: ...
 
-class NominalChild(NominalBase, Protocol):
+class ChildProtocol(BaseProtocol, Protocol):
     marker: Any
 
     @property
     def value(self) -> str: ...
 
-static_assert(is_subtype_of(Top[NominalChild], NominalBase))
-static_assert(is_subtype_of(NominalChild, Top[NominalBase]))
-static_assert(is_subtype_of(NominalChild, Bottom[NominalBase]))
+static_assert(is_subtype_of(Top[ChildProtocol], BaseProtocol))
+static_assert(is_subtype_of(ChildProtocol, Top[BaseProtocol]))
+static_assert(is_subtype_of(ChildProtocol, Bottom[BaseProtocol]))
 ```
 
 A covariant `Awaitable[int]` satisfies the top-materialized `Awaitable[object]` protocol. Narrowing
@@ -1756,6 +1726,32 @@ def nested_specialization(
     holder.outer.leaf = top_leaf  # error: [invalid-assignment]
 ```
 
+### Class-backed protocol specialization during interface construction
+
+An ordinary specialization of a class-backed protocol only maps its class specialization. It must
+not inspect the protocol interface, because the specialization can occur while that same interface
+is being constructed:
+
+```py
+from __future__ import annotations
+
+from typing import Generic, Protocol, TypeVar, overload
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+class Unit(Protocol):
+    def __mul__(self, other: S | Quantity[S]): ...
+
+class Vector(Protocol): ...
+
+class Quantity(Generic[T], Protocol):
+    @overload
+    def __mul__(self, other: Unit | Quantity[S]): ...
+    @overload
+    def __mul__(self, other: Vector) -> Vector: ...
+```
+
 ### Recursive protocols
 
 Materializing a recursive protocol preserves its wrapper without eagerly expanding its recursive
@@ -1794,16 +1790,12 @@ def recursive_bottom_children(bottom: Bottom[RecursiveProtocol]) -> None:
     reveal_type(bottom)  # revealed: Bottom[RecursiveProtocol]
     reveal_type(bottom.child)  # revealed: Bottom[RecursiveProtocol]
     reveal_type(bottom.child.child)  # revealed: Bottom[RecursiveProtocol]
+    bottom.child.marker = object()
     reveal_type(bottom.child.marker)  # revealed: Never
 
 def recursive_bottom_marker(bottom: Bottom[RecursiveProtocol]) -> None:
-    reveal_type(bottom.marker)  # revealed: Never
-
-def recursive_bottom_marker_write(bottom: Bottom[RecursiveProtocol]) -> None:
     bottom.marker = object()
-
-def recursive_bottom_child_write(bottom: Bottom[RecursiveProtocol]) -> None:
-    bottom.child.marker = object()
+    reveal_type(bottom.marker)  # revealed: Never
 
 def recursive_nested_materialization(
     nested_top: Top[Top[RecursiveProtocol]],

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1001,3 +1001,683 @@ def _(top: Top[FunctionHolder[Any]], bottom: Bottom[FunctionHolder[Any]]) -> Non
     # revealed: (def shared(self, value: Never) -> object, /) -> def shared(self, value: object) -> Never
     reveal_type(bottom.nested)
 ```
+
+## Protocols
+
+Materializing a protocol maps each member according to how it is used. Reads are covariant and
+writes are contravariant.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+### Class-backed protocol specialization during interface construction
+
+An ordinary specialization of a class-backed protocol only maps its class specialization. It must
+not inspect the protocol interface, because the specialization can occur while that same interface
+is being constructed:
+
+```py
+from __future__ import annotations
+
+from typing import Generic, Protocol, TypeVar, overload
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+class Unit(Protocol):
+    def __mul__(self, other: S | Quantity[S]): ...
+
+class Vector(Protocol): ...
+
+class Quantity(Generic[T], Protocol):
+    @overload
+    def __mul__(self, other: Unit | Quantity[S]): ...
+    @overload
+    def __mul__(self, other: Vector) -> Vector: ...
+```
+
+### Instance attributes
+
+For a mutable `Any` attribute, `Top` reads `object` and writes `Never`; `Bottom` does the reverse:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class MutableAny(Protocol):
+    value: Any
+
+def mutable_top_attributes(top: Top[MutableAny]) -> None:
+    reveal_type(top)  # revealed: Top[MutableAny]
+    reveal_type(top.value)  # revealed: object
+    top.value = 1  # error: [invalid-assignment]
+
+def mutable_bottom_attribute_read(bottom: Bottom[MutableAny]) -> None:
+    reveal_type(bottom)  # revealed: Bottom[MutableAny]
+    reveal_type(bottom.value)  # revealed: Never
+
+def mutable_bottom_attribute_write(bottom: Bottom[MutableAny]) -> None:
+    bottom.value = object()
+```
+
+The class object of a materialized protocol preserves its instance type when called directly or
+passed through a generic callable:
+
+```py
+from typing import Callable
+
+def invoke[T](factory: Callable[[], T]) -> T:
+    return factory()
+
+def constructors(top: Top[MutableAny]) -> None:
+    reveal_type(type(top))  # revealed: type[Top[MutableAny]]
+    reveal_type(type(top)())  # revealed: Top[MutableAny]
+    reveal_type(invoke(type(top)))  # revealed: Top[MutableAny]
+```
+
+Materialization preserves sound class-member access: an ordinary instance attribute is not available
+on `type[Top[MutableAny]]` or `type[Bottom[MutableAny]]`.
+
+```py
+def class_instance_attributes(top: Top[MutableAny], bottom: Bottom[MutableAny]) -> None:
+    type(top).value  # error: [unresolved-attribute]
+    type(bottom).value  # error: [unresolved-attribute]
+```
+
+### Writable properties
+
+A property setter is already a write, so its parameter is mapped only once:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class WritableAny(Protocol):
+    @property
+    def value(self) -> Any: ...
+    @value.setter
+    def value(self, value: Any) -> None: ...
+
+def writable_top_property(top: Top[WritableAny]) -> None:
+    reveal_type(top.value)  # revealed: object
+    top.value = 1  # error: [invalid-assignment]
+
+def writable_bottom_property_read(bottom: Bottom[WritableAny]) -> None:
+    reveal_type(bottom.value)  # revealed: Never
+
+def writable_bottom_property_write(bottom: Bottom[WritableAny]) -> None:
+    bottom.value = object()
+```
+
+### Protocol relations
+
+`MutableAny` and `Top[MutableAny]` refer to the same protocol class, but they do not have the same
+read and write requirements. Subtyping and union simplification must use those requirements:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
+
+class MutableAny(Protocol):
+    value: Any
+
+static_assert(is_subtype_of(Bottom[MutableAny], MutableAny))
+static_assert(is_subtype_of(Bottom[MutableAny], Top[MutableAny]))
+static_assert(is_subtype_of(MutableAny, Top[MutableAny]))
+static_assert(not is_subtype_of(MutableAny, Bottom[MutableAny]))
+static_assert(not is_subtype_of(Top[MutableAny], Bottom[MutableAny]))
+static_assert(not is_subtype_of(Top[MutableAny], MutableAny))
+
+def union_order(
+    plain_first: MutableAny | Top[MutableAny],
+    top_first: Top[MutableAny] | MutableAny,
+) -> None:
+    reveal_type(plain_first)  # revealed: Top[MutableAny]
+    reveal_type(top_first)  # revealed: Top[MutableAny]
+    reveal_type(plain_first.value)  # revealed: object
+    reveal_type(top_first.value)  # revealed: object
+```
+
+Inheriting from a protocol must not bypass its materialized write requirement. A nominal subclass
+and a structurally identical class therefore have the same result here:
+
+```py
+class MutableAnySubclass(MutableAny):
+    value: int
+
+class StructuralMutableAny:
+    value: int
+
+static_assert(not is_subtype_of(MutableAnySubclass, Bottom[MutableAny]))
+static_assert(not is_subtype_of(StructuralMutableAny, Bottom[MutableAny]))
+```
+
+An inherited `Any` member is materialized along with members declared directly on the protocol, so
+it cannot satisfy a more specific inherited protocol:
+
+```py
+class GenericBase[T](Protocol):
+    item: T
+
+class InheritedAny(GenericBase[Any], Protocol):
+    marker: Any
+
+def requires_int_base(value: GenericBase[int]) -> None: ...
+def _(top: Top[InheritedAny]) -> None:
+    requires_int_base(top)  # error: [invalid-argument-type]
+```
+
+Materializing an unrelated member does not erase explicit protocol inheritance, even when an
+override is structurally incompatible with the base protocol. Materializing the fully static base
+also preserves the nominal relationship:
+
+```py
+class NominalBase(Protocol):
+    @property
+    def value(self) -> int: ...
+
+class NominalChild(NominalBase, Protocol):
+    marker: Any
+
+    @property
+    def value(self) -> str: ...
+
+static_assert(is_subtype_of(Top[NominalChild], NominalBase))
+static_assert(is_subtype_of(NominalChild, Top[NominalBase]))
+static_assert(is_subtype_of(NominalChild, Bottom[NominalBase]))
+```
+
+A covariant `Awaitable[int]` satisfies the top-materialized `Awaitable[object]` protocol. Narrowing
+to that protocol must therefore preserve `Awaitable[int]` without retaining a redundant
+intersection, including when it appears in a callable's union return type:
+
+```py
+from typing import Awaitable, Callable
+from typing_extensions import TypeIs
+
+static_assert(is_subtype_of(Awaitable[int], Top[Awaitable[object]]))
+
+def is_top_awaitable(value: object) -> TypeIs[Top[Awaitable[object]]]:
+    return True
+
+def narrow_awaitable(value: Awaitable[int]) -> None:
+    if is_top_awaitable(value):
+        reveal_type(value)  # revealed: Awaitable[int]
+
+def is_top_async_callable(value: object) -> TypeIs[Top[Callable[..., Awaitable[object]]]]:
+    return True
+
+async def narrow_awaitable_union(fn: Callable[[int], int | Awaitable[int]]) -> None:
+    if is_top_async_callable(fn):
+        # revealed: ((int, /) -> int | Awaitable[int]) & Top[(...) -> Top[Awaitable[object]]]
+        reveal_type(fn)
+        result = fn(1)
+        # revealed: (int & Top[Awaitable[object]]) | Awaitable[int]
+        reveal_type(result)
+        reveal_type(await result)  # revealed: object
+```
+
+### Class variables
+
+Class variables have separate read and write types. `Top` reads `object` and writes `Never`, while
+`Bottom` reads `Never` and writes `object`:
+
+```py
+from typing import Any, ClassVar, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
+
+class ClassVarAny(Protocol):
+    value: ClassVar[Any]
+
+def class_writes(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
+    type(top).value = 1  # error: [invalid-assignment]
+    type(bottom).value = object()
+
+def class_reads(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
+    reveal_type(type(top).value)  # revealed: object
+    reveal_type(type(bottom).value)  # revealed: Never
+```
+
+Structural protocol checks use the mapped read and write types as well. `ClassVarInt` satisfies the
+top-materialized protocol, but not the bottom-materialized one:
+
+```py
+class ClassVarInt:
+    value: ClassVar[int] = 1
+
+static_assert(is_subtype_of(ClassVarInt, Top[ClassVarAny]))
+static_assert(not is_subtype_of(ClassVarInt, Bottom[ClassVarAny]))
+top_class: type[Top[ClassVarAny]] = ClassVarInt
+```
+
+Union simplification preserves the materialized class variable regardless of operand order:
+
+```py
+def class_union_order(
+    plain: ClassVarAny,
+    top: Top[ClassVarAny],
+    flag: bool,
+) -> None:
+    plain_first = type(plain) if flag else type(top)
+    top_first = type(top) if flag else type(plain)
+    reveal_type(plain_first.value)  # revealed: object
+    reveal_type(top_first.value)  # revealed: object
+```
+
+### `TypeIs` narrowing
+
+`TypeIs` uses the top materialization of its protocol when narrowing, so an `Any` class variable is
+read as `object` through the narrowed class object.
+
+```py
+from typing import Any, ClassVar, Protocol
+from typing_extensions import TypeIs
+
+class HasClassVar(Protocol):
+    value: ClassVar[Any]
+
+def is_has_class_var(value: object) -> TypeIs[HasClassVar]:
+    return True
+
+def narrowed_class_variable(value: object) -> None:
+    if is_has_class_var(value):
+        reveal_type(type(value).value)  # revealed: object
+```
+
+### Methods through the class object
+
+Ordinary, static, and class methods use their materialized signatures when accessed through the
+class object. Ordinary methods remain unbound:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class DecoratedAny(Protocol):
+    def transform(self, value: Any) -> Any: ...
+    @staticmethod
+    def parse(value: Any) -> Any: ...
+    @classmethod
+    def create(cls, value: Any) -> Any: ...
+
+def decorated_class_access(
+    top: Top[DecoratedAny],
+    bottom: Bottom[DecoratedAny],
+) -> None:
+    reveal_type(type(top).transform)  # revealed: (self, /, value: Never) -> object
+    reveal_type(type(top).parse)  # revealed: (value: Never) -> object
+    reveal_type(type(top).create)  # revealed: (value: Never) -> object
+    reveal_type(type(bottom).transform)  # revealed: (self, /, value: object) -> Never
+    reveal_type(type(bottom).parse)  # revealed: (value: object) -> Never
+    reveal_type(type(bottom).create)  # revealed: (value: object) -> Never
+```
+
+### Members outside the protocol interface
+
+`__init__` is not a protocol requirement, but accessing it on a materialized value still uses the
+declaration on the protocol class:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Top
+
+class ProtocolWithInit(Protocol):
+    value: Any
+
+    def __init__(self, value: int) -> None: ...
+
+def constructor(top: Top[ProtocolWithInit]) -> None:
+    reveal_type(top.__init__)  # revealed: bound method Top[ProtocolWithInit].__init__(value: int) -> None
+```
+
+### Read-only property deletion
+
+Materializing a read-only property must not make it deletable:
+
+```py
+from typing import Any, Protocol
+from typing_extensions import TypeIs
+from ty_extensions import Top
+
+class ReadOnlyProperty(Protocol):
+    @property
+    def property(self) -> Any: ...
+
+def is_read_only_property(value: object) -> TypeIs[ReadOnlyProperty]:
+    return True
+
+def property_deletion(
+    top: Top[ReadOnlyProperty],
+    value: object,
+) -> None:
+    del top.property  # error: [invalid-assignment]
+    if is_read_only_property(value):
+        del value.property  # error: [invalid-assignment]
+```
+
+### Descriptor-decorated properties
+
+A descriptor can expose separate read and write types. `Top` maps an `Any` read to `object` and an
+`Any` write to `Never`; `Bottom` maps them in the opposite direction:
+
+```py
+from typing import Any, Callable, Never, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Descriptor:
+    def __get__(self, instance: object, owner: type[object] | None = None) -> Any: ...
+    def __set__(self, instance: object, value: Any) -> None: ...
+
+def descriptor(function: Callable[..., Any]) -> Descriptor:
+    raise NotImplementedError
+
+class DescriptorProperty(Protocol):
+    @descriptor
+    def value(self) -> Any: ...
+
+class TopDescriptorProperty:
+    @property
+    def value(self) -> object:
+        return object()
+
+    @value.setter
+    def value(self, value: Never) -> None: ...
+
+class NarrowBottomDescriptorProperty:
+    @property
+    def value(self) -> Never:
+        raise RuntimeError
+
+    @value.setter
+    def value(self, value: int) -> None: ...
+
+static_assert(is_subtype_of(TopDescriptorProperty, Top[DescriptorProperty]))
+static_assert(not is_subtype_of(NarrowBottomDescriptorProperty, Bottom[DescriptorProperty]))
+```
+
+### Property accessor types
+
+Materializing a property with fully static exposed types is a no-op. The accessor's implicit
+receiver and the setter's return type do not contribute to the property requirement:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class FullyStaticProperty(Protocol):
+    @property
+    def value(self) -> int: ...
+    @value.setter
+    def value(self, value: int) -> Any: ...
+
+def fully_static_property(
+    top: Top[FullyStaticProperty],
+    bottom: Bottom[FullyStaticProperty],
+) -> None:
+    reveal_type(top)  # revealed: FullyStaticProperty
+    reveal_type(bottom)  # revealed: FullyStaticProperty
+```
+
+### Assigning to properties
+
+A property setter may transform the assigned value. Assigning a literal therefore must not narrow
+subsequent reads to that literal:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Top
+
+class TransformingProperty(Protocol):
+    marker: Any
+
+    @property
+    def value(self) -> int: ...
+    @value.setter
+    def value(self, value: int) -> None: ...
+
+def property_assignment_narrowing(top: Top[TransformingProperty]) -> None:
+    top.value = 1
+    reveal_type(top.value)  # revealed: int
+```
+
+### Generic inference through inherited and structural protocols
+
+Generic inference uses a member's materialized type, not its original `Any`. This applies both to
+inherited members and to the finite requirements of independently declared structural protocols:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Top
+
+class InferenceBase[T](Protocol):
+    @property
+    def item(self) -> T: ...
+
+class InheritedInferenceAny(InferenceBase[Any], Protocol):
+    marker: Any
+
+class StructuralInferenceAny(Protocol):
+    @property
+    def item(self) -> Any: ...
+
+def infer_item[T](value: InferenceBase[T]) -> T:
+    raise NotImplementedError
+
+def materialized_inference(inherited: Top[InheritedInferenceAny]) -> None:
+    reveal_type(infer_item(inherited))  # revealed: object
+
+def materialized_structural_inference(structural: Top[StructuralInferenceAny]) -> None:
+    reveal_type(infer_item(structural))  # revealed: object
+```
+
+### Generator delegation
+
+`yield from` uses the same materialized yield and return types as direct generator methods. Applying
+another materialization must not change a result that no longer contains `Any`:
+
+```py
+from collections.abc import Generator
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class MaterializedGenerator(Generator[Any, Any, Any], Protocol):
+    marker: Any
+
+def generator_delegation(
+    generator: Top[MaterializedGenerator],
+    nested: Bottom[Top[MaterializedGenerator]],
+):
+    reveal_type(generator.__next__())  # revealed: object
+    result = yield from generator
+    reveal_type(result)  # revealed: object
+    nested_result = yield from nested
+    reveal_type(nested_result)  # revealed: object
+```
+
+The send type is contravariant. A top-materialized generator cannot accept values sent by a
+`Generator[object, object, object]`, while a bottom-materialized generator can:
+
+```py
+def top_generator_send(
+    generator: Top[MaterializedGenerator],
+) -> Generator[object, object, object]:
+    result = yield from generator  # error: [invalid-yield]
+    return result
+
+def bottom_generator_send(
+    generator: Bottom[MaterializedGenerator],
+) -> Generator[object, object, object]:
+    result = yield from generator
+    return result
+```
+
+### `Self` binding
+
+`Self` may appear in `Top[GenericProtocol[Self]]` even when the protocol member itself is `Any`. It
+must still bind to the class through which the attribute is accessed:
+
+```py
+from typing import Any, Protocol, Self
+from ty_extensions import Top
+
+class GenericProtocol[T](Protocol):
+    value: Any
+
+class SelfContainer:
+    member: Top[GenericProtocol[Self]]
+
+class SelfContainerChild(SelfContainer):
+    pass
+
+reveal_type(SelfContainerChild().member)  # revealed: Top[GenericProtocol[SelfContainerChild]]
+```
+
+### Legacy type variables
+
+A legacy type variable in the protocol's type arguments still makes the enclosing function generic:
+
+```py
+from typing import Any, Protocol, TypeVar
+from ty_extensions import Top
+
+T = TypeVar("T")
+
+class LegacyProtocol(Protocol[T]):
+    value: Any
+
+def accepts_legacy(value: Top[LegacyProtocol[T]]) -> None: ...
+
+reveal_type(accepts_legacy)  # revealed: def accepts_legacy[T](value: Top[LegacyProtocol[T]]) -> None
+```
+
+### Generic aliases
+
+Expanding a generic alias preserves the materialized write type:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class GenericMutable[T](Protocol):
+    value: T
+
+type MutableAlias[T] = GenericMutable[T]
+
+def alias_writes(
+    top: Top[MutableAlias[Any]],
+    bottom: Bottom[MutableAlias[Any]],
+) -> None:
+    top.value = 1  # error: [invalid-assignment]
+    bottom.value = object()
+```
+
+### Nested generic protocols
+
+A protocol nested inside another generic type preserves its separate read and write requirements
+after materialization:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class Leaf[T](Protocol):
+    value: T
+
+class Outer[T](Protocol):
+    leaf: Leaf[T]
+
+class ReadHolder[T]:
+    @property
+    def outer(self) -> Outer[T]:
+        raise NotImplementedError
+
+def nested_specialization(
+    holder: Top[ReadHolder[Any]],
+    top_leaf: Top[Leaf[Any]],
+    bottom_leaf: Bottom[Leaf[Any]],
+) -> None:
+    reveal_type(holder.outer)  # revealed: Top[Outer[Any]]
+    holder.outer.leaf = bottom_leaf
+    holder.outer.leaf = top_leaf  # error: [invalid-assignment]
+```
+
+### Recursive protocols
+
+Materializing a recursive protocol preserves its wrapper without eagerly expanding its recursive
+interface. Nonrecursive members are still materialized, and following the recursive child preserves
+both the protocol and its materialization polarity.
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type RecursiveAlias = RecursiveProtocol
+
+class RecursiveProtocol(Protocol):
+    marker: Any
+
+    @property
+    def child(self) -> RecursiveAlias: ...
+
+static_assert(is_equivalent_to(Top[RecursiveProtocol], Top[Top[RecursiveProtocol]]))
+static_assert(is_equivalent_to(Bottom[RecursiveProtocol], Bottom[Bottom[RecursiveProtocol]]))
+static_assert(is_equivalent_to(Top[RecursiveProtocol], Bottom[Top[RecursiveProtocol]]))
+static_assert(is_equivalent_to(Bottom[RecursiveProtocol], Top[Bottom[RecursiveProtocol]]))
+
+def recursive_top_materialization(top: Top[RecursiveProtocol]) -> None:
+    reveal_type(top)  # revealed: Top[RecursiveProtocol]
+    reveal_type(top.marker)  # revealed: object
+    top.marker = 1  # error: [invalid-assignment]
+
+    reveal_type(top.child)  # revealed: Top[RecursiveProtocol]
+    reveal_type(top.child.child)  # revealed: Top[RecursiveProtocol]
+    reveal_type(top.child.marker)  # revealed: object
+    top.child.marker = 1  # error: [invalid-assignment]
+
+def recursive_bottom_children(bottom: Bottom[RecursiveProtocol]) -> None:
+    reveal_type(bottom)  # revealed: Bottom[RecursiveProtocol]
+    reveal_type(bottom.child)  # revealed: Bottom[RecursiveProtocol]
+    reveal_type(bottom.child.child)  # revealed: Bottom[RecursiveProtocol]
+    reveal_type(bottom.child.marker)  # revealed: Never
+
+def recursive_bottom_marker(bottom: Bottom[RecursiveProtocol]) -> None:
+    reveal_type(bottom.marker)  # revealed: Never
+
+def recursive_bottom_marker_write(bottom: Bottom[RecursiveProtocol]) -> None:
+    bottom.marker = object()
+
+def recursive_bottom_child_write(bottom: Bottom[RecursiveProtocol]) -> None:
+    bottom.child.marker = object()
+
+def recursive_nested_materialization(
+    nested_top: Top[Top[RecursiveProtocol]],
+    nested_bottom: Bottom[Bottom[RecursiveProtocol]],
+) -> None:
+    reveal_type(nested_top)  # revealed: Top[RecursiveProtocol]
+    reveal_type(nested_top.marker)  # revealed: object
+    reveal_type(nested_bottom)  # revealed: Bottom[RecursiveProtocol]
+    reveal_type(nested_bottom.marker)  # revealed: Never
+```
+
+### Display
+
+Materialized protocols display `Top` and `Bottom` around the protocol class:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class ReadAny(Protocol):
+    @property
+    def value(self) -> Any: ...
+
+def _(top: Top[ReadAny], bottom: Bottom[ReadAny]) -> None:
+    reveal_type(top)  # revealed: Top[ReadAny]
+    reveal_type(bottom)  # revealed: Bottom[ReadAny]
+```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1584,6 +1584,138 @@ def materialized_invariant_overload_resolution(
     reveal_type(select_consistent_item(valid, values))  # revealed: int
 ```
 
+### Generic inference through recursive structural protocols
+
+A recursive protocol requirement must not cause inference to discard a structurally matching
+protocol's materialization. The nonrecursive property establishes the correct specialization without
+expanding the recursive property.
+
+```py
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
+
+class RecursiveValue[T](Protocol):
+    @property
+    def value(self) -> T: ...
+    @property
+    def child(self) -> RecursiveValue[T]: ...
+
+class RecursiveAny(Protocol):
+    @property
+    def value(self) -> Any: ...
+    @property
+    def child(self) -> RecursiveAny: ...
+
+static_assert(is_subtype_of(Top[RecursiveAny], RecursiveValue[object]))
+static_assert(not is_subtype_of(Top[RecursiveAny], RecursiveValue[str]))
+static_assert(is_subtype_of(Bottom[RecursiveAny], RecursiveValue[str]))
+```
+
+Inference preserves both materialization polarities: the top-materialized property infers `object`,
+while the bottom-materialized property infers `Never`.
+
+```py
+def infer_recursive_value[T](value: RecursiveValue[T]) -> T:
+    raise NotImplementedError
+
+def recursive_materialized_inference(
+    top: Top[RecursiveAny],
+    bottom: Bottom[RecursiveAny],
+    valid: RecursiveValue[str],
+) -> None:
+    reveal_type(top.value)  # revealed: object
+    reveal_type(infer_recursive_value(top))  # revealed: object
+    reveal_type(infer_recursive_value(valid))  # revealed: str
+    reveal_type(infer_recursive_value(bottom))  # revealed: Never
+```
+
+The nonrecursive property is used only to infer the specialization. The complete protocol must still
+be checked, so a matching `value` cannot hide an incompatible `child`.
+
+```py
+class WrongRecursiveAny(Protocol):
+    @property
+    def value(self) -> Any: ...
+    @property
+    def child(self) -> int: ...
+
+static_assert(not is_subtype_of(Top[WrongRecursiveAny], RecursiveValue[object]))
+
+def reject_incompatible_recursive_child(wrong: Top[WrongRecursiveAny]) -> None:
+    infer_recursive_value(wrong)  # error: [invalid-argument-type]
+```
+
+A top-materialized `object` cannot satisfy a `str` bound or a `str`/`bytes` constraint. An ordinary
+`RecursiveValue[str]` still satisfies both.
+
+```py
+def bounded_recursive_value[T: str](value: RecursiveValue[T]) -> T:
+    raise NotImplementedError
+
+def constrained_recursive_value[T: (str, bytes)](value: RecursiveValue[T]) -> T:
+    raise NotImplementedError
+
+def recursive_materialized_bounds(
+    top: Top[RecursiveAny],
+    valid: RecursiveValue[str],
+) -> None:
+    bounded_recursive_value(top)  # error: [invalid-argument-type]
+    constrained_recursive_value(top)  # error: [invalid-argument-type]
+    reveal_type(bounded_recursive_value(valid))  # revealed: str
+    reveal_type(constrained_recursive_value(valid))  # revealed: str
+```
+
+An invariant `list[T]` cannot narrow the materialized `object` property to `int`.
+
+```py
+def infer_recursive_with_list[T](value: RecursiveValue[T], values: list[T]) -> T:
+    raise NotImplementedError
+
+def recursive_materialized_invariant_arguments(
+    top: Top[RecursiveAny],
+    valid: RecursiveValue[str],
+    ints: list[int],
+    strings: list[str],
+) -> None:
+    infer_recursive_with_list(top, ints)  # error: [invalid-argument-type]
+    reveal_type(infer_recursive_with_list(valid, strings))  # revealed: str
+```
+
+Overload resolution also respects the bound and the complete recursive requirement. Both an
+incompatible materialized property and an incompatible child select the fallback or fail when no
+fallback is available; the valid `str` specialization selects the bounded overload.
+
+```py
+@overload
+def select_recursive_value[T: str](value: RecursiveValue[T]) -> Literal["bounded"]: ...
+@overload
+def select_recursive_value(value: object) -> Literal["fallback"]: ...
+def select_recursive_value(value: object) -> Literal["bounded", "fallback"]:
+    return "fallback"
+
+@overload
+def select_specific_recursive_value(value: RecursiveValue[str]) -> Literal["str"]: ...
+@overload
+def select_specific_recursive_value(value: RecursiveValue[bytes]) -> Literal["bytes"]: ...
+def select_specific_recursive_value(value: object) -> str:
+    raise NotImplementedError
+
+def recursive_materialized_overload_resolution(
+    top: Top[RecursiveAny],
+    wrong: Top[WrongRecursiveAny],
+    valid: RecursiveValue[str],
+) -> None:
+    reveal_type(select_recursive_value(top))  # revealed: Literal["fallback"]
+    reveal_type(select_recursive_value(wrong))  # revealed: Literal["fallback"]
+    reveal_type(select_recursive_value(valid))  # revealed: Literal["bounded"]
+    select_specific_recursive_value(top)  # error: [no-matching-overload]
+    select_specific_recursive_value(wrong)  # error: [no-matching-overload]
+    reveal_type(select_specific_recursive_value(valid))  # revealed: Literal["str"]
+```
+
 ### Generator delegation
 
 `yield from` uses the same materialized yield and return types as direct generator methods. Applying

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1258,26 +1258,6 @@ def class_union_order(
     reveal_type(top_first.value)  # revealed: object
 ```
 
-### `TypeIs` narrowing
-
-`TypeIs` uses the top materialization of its protocol when narrowing, so an `Any` class variable is
-read as `object` through the narrowed class object.
-
-```py
-from typing import Any, ClassVar, Protocol
-from typing_extensions import TypeIs
-
-class HasClassVar(Protocol):
-    value: ClassVar[Any]
-
-def is_has_class_var(value: object) -> TypeIs[HasClassVar]:
-    return True
-
-def narrowed_class_variable(value: object) -> None:
-    if is_has_class_var(value):
-        reveal_type(type(value).value)  # revealed: object
-```
-
 ### Methods through the class object
 
 Ordinary, static, and class methods use their materialized signatures when accessed through the
@@ -1337,7 +1317,7 @@ class ReadOnlyProperty(Protocol):
     @property
     def property(self) -> Any: ...
 
-def is_read_only_property(value: object) -> TypeIs[ReadOnlyProperty]:
+def is_read_only_property(value: object) -> TypeIs[Top[ReadOnlyProperty]]:
     return True
 
 def property_deletion(
@@ -1399,7 +1379,7 @@ def bottom_descriptor_write(bottom: Bottom[DescriptorProperty]) -> None:
 def plain_descriptor_write(plain: DescriptorProperty) -> None:
     plain.value = object()
 
-def is_descriptor_property(value: object) -> TypeIs[DescriptorProperty]:
+def is_descriptor_property(value: object) -> TypeIs[Top[DescriptorProperty]]:
     return True
 
 def narrowed_descriptor_write(value: object) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -499,12 +499,6 @@ static_assert(is_equivalent_to(Bottom[type[int | Any]], type[int]))
 def _(top: Top[list[type[Any]]], bottom: Bottom[list[type[Any]]]):
     reveal_type(top)  # revealed: Top[list[type[Any]]]
     reveal_type(bottom)  # revealed: Bottom[list[type[Any]]]
-
-def annotated_materialized_list_classes(top: type[Top[list[Any]]], bottom: type[Bottom[list[Any]]]) -> None:
-    reveal_type(top)  # revealed: type[Top[list[Any]]]
-    reveal_type(bottom)  # revealed: type[Bottom[list[Any]]]
-    reveal_type(top())  # revealed: Top[list[Any]]
-    reveal_type(bottom())  # revealed: Bottom[list[Any]]
 ```
 
 ## Materialized class annotations and constructors
@@ -709,10 +703,6 @@ def _(
     top_two: Top[int, str],  # error: [invalid-type-form]
     bottom_two: Bottom[int, str],  # error: [invalid-type-form]
 ): ...
-def nested_invalid_arity(
-    top_two: type[Top[int, str]],  # error: [invalid-type-form]
-    bottom_two: type[Bottom[int, str]],  # error: [invalid-type-form]
-) -> None: ...
 ```
 
 The argument must be a type expression:
@@ -1214,10 +1204,10 @@ static_assert(is_subtype_of(NominalChild, Bottom[NominalBase]))
 
 A covariant `Awaitable[int]` satisfies the top-materialized `Awaitable[object]` protocol. Narrowing
 to that protocol must therefore preserve `Awaitable[int]` without retaining a redundant
-intersection, including when it appears in a callable's union return type:
+intersection:
 
 ```py
-from typing import Awaitable, Callable
+from typing import Awaitable
 from typing_extensions import TypeIs
 
 static_assert(is_subtype_of(Awaitable[int], Top[Awaitable[object]]))
@@ -1228,18 +1218,6 @@ def is_top_awaitable(value: object) -> TypeIs[Top[Awaitable[object]]]:
 def narrow_awaitable(value: Awaitable[int]) -> None:
     if is_top_awaitable(value):
         reveal_type(value)  # revealed: Awaitable[int]
-
-def is_top_async_callable(value: object) -> TypeIs[Top[Callable[..., Awaitable[object]]]]:
-    return True
-
-async def narrow_awaitable_union(fn: Callable[[int], int | Awaitable[int]]) -> None:
-    if is_top_async_callable(fn):
-        # revealed: ((int, /) -> int | Awaitable[int]) & Top[(...) -> Top[Awaitable[object]]]
-        reveal_type(fn)
-        result = fn(1)
-        # revealed: (int & Top[Awaitable[object]]) | Awaitable[int]
-        reveal_type(result)
-        reveal_type(await result)  # revealed: object
 ```
 
 ### Class variables

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -842,6 +842,32 @@ def bar(x: Foo, value: int):
     x.value = value
 ```
 
+### Protocol members initialized in `__init__`
+
+A protocol may initialize its own `Final` member in `__init__`, even if another method specializes
+the protocol's `self` type. That specialization must not make the initializer appear to belong to a
+different class. Assignments to another instance or outside the initializer remain invalid.
+
+```py
+from __future__ import annotations
+
+from typing import Final, Protocol, TypeVar
+
+T = TypeVar("T", covariant=True)
+
+class Owned(Protocol[T]):
+    owner: Final[T]
+
+    def __init__(self, owner: T, other: Owned[T] | None = None) -> None:
+        self.owner = owner
+        if other is not None:
+            other.owner = owner  # error: [invalid-assignment]
+
+    def progress(self: Owned[int]) -> None: ...
+    def replace(self, owner: T) -> None:
+        self.owner = owner  # error: [invalid-assignment]
+```
+
 ### Explicit `Final` redeclaration
 
 Explicit `Final` redeclaration in the same scope is accepted (shadowing).

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1112,6 +1112,20 @@ struct GeneratorTypes<'db> {
     return_ty: Option<Type<'db>>,
 }
 
+impl<'db> GeneratorTypes<'db> {
+    /// Apply a generator's materialization with the variance of each operation.
+    fn materialize(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
+        let visitor = ApplyTypeMappingVisitor::default();
+        Self {
+            yield_ty: self.yield_ty.map(|ty| ty.materialize(db, kind, &visitor)),
+            send_ty: self
+                .send_ty
+                .map(|ty| ty.materialize(db, kind.flip(), &visitor)),
+            return_ty: self.return_ty.map(|ty| ty.materialize(db, kind, &visitor)),
+        }
+    }
+}
+
 fn object_type_form(db: &dyn Db) -> Type<'_> {
     TypeFormType::from_type_expression(db, Type::object())
 }
@@ -1363,9 +1377,9 @@ impl<'db> Type<'db> {
                         .any(|ty| ty.is_specialized_generic(db))
             }
             Type::NominalInstance(instance_type) => instance_type.is_definition_generic(db),
-            Type::ProtocolInstance(protocol) => {
-                matches!(protocol.inner, Protocol::FromClass(class) if class.is_generic())
-            }
+            Type::ProtocolInstance(protocol) => protocol
+                .class_origin(db)
+                .is_some_and(|class| class.is_generic()),
             Type::TypedDict(typed_dict) => typed_dict
                 .defining_class()
                 .is_some_and(ClassType::is_generic),
@@ -1474,7 +1488,9 @@ impl<'db> Type<'db> {
     pub(crate) fn nominal_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
         match self {
             Type::NominalInstance(instance) => Some(instance.class(db)),
-            Type::ProtocolInstance(instance) => instance.to_nominal_instance().map(|i| i.class(db)),
+            Type::ProtocolInstance(instance) => instance
+                .nominal_origin_instance(db)
+                .map(|instance| instance.class(db)),
             Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
             Type::TypeVar(typevar) => {
@@ -2061,7 +2077,7 @@ impl<'db> Type<'db> {
 
             Type::TypedDict(td) => td.defining_class().is_some(),
 
-            Type::ProtocolInstance(ProtocolInstanceType { inner, .. }) => !inner.is_synthesized(),
+            Type::ProtocolInstance(protocol) => protocol.class_origin(db).is_some(),
 
             Type::Dynamic(dynamic) => match dynamic {
                 DynamicType::Any => true,
@@ -2702,6 +2718,17 @@ impl<'db> Type<'db> {
         if let Some(fallback) = ty.materialized_divergent_fallback() {
             return fallback.class_member_with_policy(db, name, policy);
         }
+        if let Type::ProtocolInstance(protocol) = ty
+            && protocol.materialization_kind(db).is_some()
+            && let Some(origin) = protocol.class_origin(db)
+        {
+            let interface = protocol.interface(db);
+            return if interface.includes_member(db, name) {
+                interface.instance_member(db, name)
+            } else {
+                Type::instance(db, *origin).class_member_with_policy(db, name, policy)
+            };
+        }
 
         match ty {
             Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
@@ -2710,11 +2737,10 @@ impl<'db> Type<'db> {
             Type::Intersection(inter) => inter.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.class_member_with_policy(db, name, policy)
             }),
-            // TODO: Once `to_meta_type` for the synthesized protocol is fully implemented, this handling should be removed.
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::Synthesized(_),
-                ..
-            }) => ty.instance_member(db, name),
+            // TODO: Remove this once synthesized protocols have a precise meta-type.
+            Type::ProtocolInstance(protocol) if protocol.class_origin(db).is_none() => {
+                ty.instance_member(db, name)
+            }
 
             Type::LiteralValue(literal)
                 if name == "__len__"
@@ -2816,7 +2842,7 @@ impl<'db> Type<'db> {
         let own_class = match self {
             Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Protocol(protocol) => {
-                    protocol.class_origin().map(|origin| *origin)
+                    protocol.class_origin(db).map(|origin| *origin)
                 }
                 subclass_of => subclass_of.into_class(db),
             },
@@ -4115,11 +4141,10 @@ impl<'db> Type<'db> {
                 //
                 // Note that we could do this for *all* protocols, but it's only *necessary* for synthesized
                 // ones, and the standard logic is *probably* more performant for class-based protocols?
-                Type::ProtocolInstance(ProtocolInstanceType {
-                    inner: Protocol::Synthesized(protocol),
-                    ..
-                }) if policy.mro_no_object_fallback()
-                    && !protocol.interface().includes_member(db, name_str) =>
+                Type::ProtocolInstance(protocol)
+                    if protocol.class_origin(db).is_none()
+                        && policy.mro_no_object_fallback()
+                        && !protocol.interface(db).includes_member(db, name_str) =>
                 {
                     Place::Undefined.into()
                 }
@@ -4558,7 +4583,7 @@ impl<'db> Type<'db> {
                 // checking it structurally again during call inference.
                 if self_instance
                     .as_protocol_instance()
-                    .is_some_and(|protocol| protocol.to_nominal_instance().is_some())
+                    .is_some_and(|protocol| protocol.nominal_origin_instance(db).is_some())
                     && signature
                         .overloads
                         .iter()
@@ -4750,9 +4775,19 @@ impl<'db> Type<'db> {
                     Binding::single(self, Signature::dynamic(Type::Dynamic(dynamic_type))).into()
                 }
                 SubclassOfInner::Class(class) => self.constructor_bindings(db, class),
-                SubclassOfInner::Protocol(protocol) => protocol.class_origin().map_or_else(
+                SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map_or_else(
                     || Binding::single(self, Signature::dynamic(Type::unknown())).into(),
-                    |origin| self.constructor_bindings(db, *origin),
+                    |origin| {
+                        let bindings = self.constructor_bindings(db, *origin);
+                        if protocol.materialization_kind(db).is_some() {
+                            bindings.with_constructed_instance_type(
+                                db,
+                                Type::ProtocolInstance(protocol),
+                            )
+                        } else {
+                            bindings
+                        }
+                    },
                 ),
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
@@ -5825,10 +5860,16 @@ impl<'db> Type<'db> {
             Type::NominalInstance(instance) => {
                 instance.class(db).iter_mro(db).find_map(from_class_base)
             }
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::FromClass(class),
-                ..
-            }) => class.iter_mro(db).find_map(from_class_base),
+            Type::ProtocolInstance(protocol) => {
+                let generator_types = protocol
+                    .class_origin(db)
+                    .and_then(|class| class.iter_mro(db).find_map(from_class_base));
+                if let Some(kind) = protocol.materialization_kind(db) {
+                    generator_types.map(|types| types.materialize(db, kind))
+                } else {
+                    generator_types
+                }
+            }
             Type::Union(union) => {
                 let mut yield_builder = Some(UnionBuilder::new(db));
                 let mut send_builder = Some(UnionBuilder::new(db));
@@ -6560,16 +6601,9 @@ impl<'db> Type<'db> {
                 }))
             }),
 
-            Type::ProtocolInstance(instance) => {
-                // TODO: Add tests for materialization once subtyping/assignability is implemented for
-                // protocols. It _might_ require changing the logic here because:
-                //
-                // > Subtyping for protocol instances involves taking account of the fact that
-                // > read-only property members, and method members, on protocols act covariantly;
-                // > write-only property members act contravariantly; and read/write attribute
-                // > members on protocols act invariantly
-                Type::ProtocolInstance(instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-            }
+            Type::ProtocolInstance(instance) => Type::ProtocolInstance(
+                instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            ),
 
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(
@@ -7231,7 +7265,9 @@ impl<'db> Type<'db> {
             Self::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(_) => None,
                 SubclassOfInner::Class(class) => class.type_definition(db),
-                SubclassOfInner::Protocol(protocol) => protocol.class_origin()?.type_definition(db),
+                SubclassOfInner::Protocol(protocol) => {
+                    protocol.class_origin(db)?.type_definition(db)
+                }
                 SubclassOfInner::TypeVar(bound_typevar) => Some(TypeDefinition::TypeVar(
                     bound_typevar.typevar(db).definition(db)?,
                 )),
@@ -7266,10 +7302,9 @@ impl<'db> Type<'db> {
                 bound_typevar.typevar(db).definition(db)?,
             )),
 
-            Self::ProtocolInstance(protocol) => match protocol.inner {
-                Protocol::FromClass(class) => class.type_definition(db),
-                Protocol::Synthesized(_) => None,
-            },
+            Self::ProtocolInstance(protocol) => protocol
+                .class_origin(db)
+                .and_then(|class| class.type_definition(db)),
 
             Self::TypedDict(typed_dict) => typed_dict.type_definition(db),
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1488,9 +1488,7 @@ impl<'db> Type<'db> {
     pub(crate) fn nominal_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
         match self {
             Type::NominalInstance(instance) => Some(instance.class(db)),
-            Type::ProtocolInstance(instance) => instance
-                .nominal_origin_instance(db)
-                .map(|instance| instance.class(db)),
+            Type::ProtocolInstance(instance) => instance.class_origin(db).map(|class| *class),
             Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
             Type::TypeVar(typevar) => {
@@ -2719,8 +2717,7 @@ impl<'db> Type<'db> {
             return fallback.class_member_with_policy(db, name, policy);
         }
         if let Type::ProtocolInstance(protocol) = ty
-            && protocol.materialization_kind(db).is_some()
-            && let Some(origin) = protocol.class_origin(db)
+            && let Some(origin) = protocol.materialized_origin(db)
         {
             let interface = protocol.interface(db);
             return if interface.includes_member(db, name) {
@@ -4583,7 +4580,7 @@ impl<'db> Type<'db> {
                 // checking it structurally again during call inference.
                 if self_instance
                     .as_protocol_instance()
-                    .is_some_and(|protocol| protocol.nominal_origin_instance(db).is_some())
+                    .is_some_and(|protocol| protocol.class_origin(db).is_some())
                     && signature
                         .overloads
                         .iter()
@@ -5860,16 +5857,14 @@ impl<'db> Type<'db> {
             Type::NominalInstance(instance) => {
                 instance.class(db).iter_mro(db).find_map(from_class_base)
             }
-            Type::ProtocolInstance(protocol) => {
-                let generator_types = protocol
-                    .class_origin(db)
-                    .and_then(|class| class.iter_mro(db).find_map(from_class_base));
-                if let Some(kind) = protocol.materialization_kind(db) {
-                    generator_types.map(|types| types.materialize(db, kind))
-                } else {
-                    generator_types
-                }
-            }
+            Type::ProtocolInstance(protocol) => protocol
+                .class_origin(db)
+                .and_then(|class| class.iter_mro(db).find_map(from_class_base))
+                .map(|types| {
+                    protocol
+                        .materialization_kind(db)
+                        .map_or(types, |kind| types.materialize(db, kind))
+                }),
             Type::Union(union) => {
                 let mut yield_builder = Some(UnionBuilder::new(db));
                 let mut send_builder = Some(UnionBuilder::new(db));

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -645,6 +645,10 @@ pub(super) fn assignment_attribute_members<'db>(
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
         ) {
         object_ty.member(db, attribute)
+    } else if let Type::ProtocolInstance(protocol) = object_ty
+        && let Some(origin) = protocol.materialized_origin_property(db, attribute)
+    {
+        Type::instance(db, *origin).class_member(db, attribute)
     } else {
         object_ty.class_member(db, attribute)
     };

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -68,10 +68,11 @@ pub(super) enum ProtocolMemberWriteRequirement<'db> {
     AssignableTo(Type<'db>),
     /// Invoke every possible descriptor setter with the assigned value.
     ///
-    /// `domain` is the precisely derived write type when that domain fits in [`Type`]. It is used
-    /// for contextual inference and protocol compatibility, while descriptor calls remain the
-    /// authority for real assignments. `None` preserves a known write capability whose generic or
-    /// set-theoretic domain cannot be represented precisely.
+    /// `domain` is the precisely derived write type when that domain fits in [`Type`]. A
+    /// representable domain constrains contextual inference, assignment, and protocol
+    /// compatibility. Calling the original descriptor still validates the complete setter
+    /// contract. `None` preserves a known write capability whose generic or set-theoretic domain
+    /// cannot be represented precisely.
     Descriptor {
         descriptor_ty: Type<'db>,
         receiver_ty: Type<'db>,

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -637,7 +637,7 @@ impl<'db> BoundSuperType<'db> {
                             let class = match bound {
                                 Type::NominalInstance(instance) => Some(instance.class(db)),
                                 Type::ProtocolInstance(protocol) => protocol
-                                    .to_nominal_instance()
+                                    .nominal_origin_instance(db)
                                     .map(|instance| instance.class(db)),
                                 _ => None,
                             };
@@ -693,7 +693,7 @@ impl<'db> BoundSuperType<'db> {
             }
 
             Type::ProtocolInstance(protocol) => {
-                if let Some(nominal_instance) = protocol.to_nominal_instance() {
+                if let Some(nominal_instance) = protocol.nominal_origin_instance(db) {
                     SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
                         db,
                         pivot_class,
@@ -756,7 +756,7 @@ impl<'db> BoundSuperType<'db> {
                         let class = match bound {
                             Type::NominalInstance(instance) => Some(instance.class(db)),
                             Type::ProtocolInstance(protocol) => protocol
-                                .to_nominal_instance()
+                                .nominal_origin_instance(db)
                                 .map(|instance| instance.class(db)),
                             _ => None,
                         };

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -636,9 +636,9 @@ impl<'db> BoundSuperType<'db> {
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                             let class = match bound {
                                 Type::NominalInstance(instance) => Some(instance.class(db)),
-                                Type::ProtocolInstance(protocol) => protocol
-                                    .nominal_origin_instance(db)
-                                    .map(|instance| instance.class(db)),
+                                Type::ProtocolInstance(protocol) => {
+                                    protocol.class_origin(db).map(|class| *class)
+                                }
                                 _ => None,
                             };
                             if let Some(class) = class {
@@ -693,13 +693,13 @@ impl<'db> BoundSuperType<'db> {
             }
 
             Type::ProtocolInstance(protocol) => {
-                if let Some(nominal_instance) = protocol.nominal_origin_instance(db) {
+                if let Some(class) = protocol.class_origin(db) {
                     SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
                         db,
                         pivot_class,
                         pivot_class_type,
                         owner_type,
-                        nominal_instance.class(db),
+                        *class,
                         None,
                     )?)
                 } else {
@@ -755,9 +755,9 @@ impl<'db> BoundSuperType<'db> {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         let class = match bound {
                             Type::NominalInstance(instance) => Some(instance.class(db)),
-                            Type::ProtocolInstance(protocol) => protocol
-                                .nominal_origin_instance(db)
-                                .map(|instance| instance.class(db)),
+                            Type::ProtocolInstance(protocol) => {
+                                protocol.class_origin(db).map(|class| *class)
+                            }
                             _ => None,
                         };
                         if let Some(class) = class {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -152,24 +152,14 @@ impl<'db> Type<'db> {
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
                 SubclassOfInner::Class(class) => Some(class.into_callable(db)),
                 SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map(|origin| {
-                    let callables = (*origin).into_callable(db);
-                    if protocol.materialization_kind(db).is_none() {
-                        return callables;
+                    if protocol.materialization_kind(db).is_some() {
+                        // The origin supplies the constructor, but the actual receiver retains
+                        // `Top[P]` or `Bottom[P]`. Infer with both so instance-returning overloads
+                        // are materialized without replacing explicit non-instance returns.
+                        (*origin).into_callable_with_receiver(db, self)
+                    } else {
+                        (*origin).into_callable(db)
                     }
-
-                    let constructed_type = Type::ProtocolInstance(protocol);
-                    callables.map(|callable| {
-                        let signatures = callable
-                            .signatures(db)
-                            .into_iter()
-                            .map(|signature| signature.clone().with_return_type(constructed_type));
-                        CallableType::new(
-                            db,
-                            CallableSignature::from_overloads(signatures),
-                            callable.kind(db),
-                            callable.provenance(db),
-                        )
-                    })
                 }),
                 SubclassOfInner::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -151,9 +151,26 @@ impl<'db> Type<'db> {
             // TODO: This is unsound so in future we can consider an opt-in option to disable it.
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
                 SubclassOfInner::Class(class) => Some(class.into_callable(db)),
-                SubclassOfInner::Protocol(protocol) => protocol
-                    .class_origin()
-                    .map(|origin| (*origin).into_callable(db)),
+                SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map(|origin| {
+                    let callables = (*origin).into_callable(db);
+                    if protocol.materialization_kind(db).is_none() {
+                        return callables;
+                    }
+
+                    let constructed_type = Type::ProtocolInstance(protocol);
+                    callables.map(|callable| {
+                        let signatures = callable
+                            .signatures(db)
+                            .into_iter()
+                            .map(|signature| signature.clone().with_return_type(constructed_type));
+                        CallableType::new(
+                            db,
+                            CallableSignature::from_overloads(signatures),
+                            callable.kind(db),
+                            callable.provenance(db),
+                        )
+                    })
+                }),
                 SubclassOfInner::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         let upcast_callables = bound

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2051,12 +2051,25 @@ impl<'db> ClassType<'db> {
 
     /// Return a callable type (or union of callable types) that represents the callable
     /// constructor signature of this class.
+    pub(super) fn into_callable(self, db: &'db dyn Db) -> CallableTypes<'db> {
+        self.into_callable_with_receiver(db, Type::from(self))
+    }
+
+    /// Infer this class's constructor using the actual class-object receiver.
+    ///
+    /// A materialized protocol uses its class origin for constructor lookup, but `Self` must be
+    /// bound to the materialized receiver. Keeping lookup and receiver separate preserves both
+    /// instance-returning constructors and constructors that explicitly return another type.
     #[salsa::tracked(
         returns(clone),
-        cycle_initial=|db, _, _| CallableTypes::one(CallableType::bottom(db)),
+        cycle_initial=|db, _, _, _| CallableTypes::one(CallableType::bottom(db)),
         heap_size=ruff_memory_usage::heap_size
     )]
-    pub(super) fn into_callable(self, db: &'db dyn Db) -> CallableTypes<'db> {
+    pub(super) fn into_callable_with_receiver(
+        self,
+        db: &'db dyn Db,
+        receiver: Type<'db>,
+    ) -> CallableTypes<'db> {
         // TODO: This mimics a lot of the logic in Type::try_call_from_constructor. Can we
         // consolidate the two? Can we invoke a class by upcasting the class into a Callable, and
         // then relying on the call binding machinery to Just Work™?
@@ -2066,8 +2079,12 @@ impl<'db> ClassType<'db> {
             .static_class_literal(db)
             .and_then(|(class_literal, _)| class_literal.generic_context(db));
 
-        let self_ty = Type::from(self);
-        let metaclass_dunder_call_function_symbol = self_ty
+        let lookup_type = Type::from(self);
+        let instance_type = receiver
+            .to_instance_approximation(db)
+            .unwrap_or_else(Type::unknown);
+
+        let metaclass_dunder_call_function_symbol = lookup_type
             .member_lookup_with_policy(
                 db,
                 "__call__",
@@ -2093,11 +2110,17 @@ impl<'db> ClassType<'db> {
             // for dynamic Enum creation.
             let is_actual_enum = enum_metadata(db, self.class_literal(db)).is_some();
             if !is_actual_enum {
-                return CallableTypes::one(metaclass_dunder_call_function.into_callable_type(db));
+                let callable = if receiver == lookup_type {
+                    metaclass_dunder_call_function.into_callable_type(db)
+                } else {
+                    metaclass_dunder_call_function
+                        .into_callable_type_with_receiver(db, receiver, receiver)
+                };
+                return CallableTypes::one(callable);
             }
         }
 
-        let dunder_new_function_symbol = self_ty.lookup_dunder_new(db);
+        let dunder_new_function_symbol = lookup_type.lookup_dunder_new(db);
 
         let dunder_new_signature = dunder_new_function_symbol
             .and_then(|place_and_quals| place_and_quals.ignore_possibly_undefined())
@@ -2108,21 +2131,22 @@ impl<'db> ClassType<'db> {
             });
 
         let dunder_new_function = if let Some(dunder_new_signature) = dunder_new_signature {
+            let bound_signature = dunder_new_signature.bind_self_with_receiver(
+                db,
+                Some(receiver),
+                Some(instance_type),
+            );
+
             // Step 3: If the return type of the `__new__` evaluates to a type that is not a subclass of this class,
             // then we should ignore the `__init__` and just return the `__new__` method.
-            let returns_non_subclass = dunder_new_signature.overloads.iter().any(|signature| {
-                !signature.return_ty.is_assignable_to(
-                    db,
-                    self_ty
-                        .to_instance_approximation(db)
-                        .expect("ClassType should be instantiable"),
-                )
-            });
+            let returns_non_subclass = bound_signature
+                .overloads
+                .iter()
+                .any(|signature| !signature.return_ty.is_assignable_to(db, instance_type));
 
-            let instance_ty = Type::instance(db, self);
             let dunder_new_bound_method = CallableType::new(
                 db,
-                dunder_new_signature.bind_self_with_receiver(db, Some(self_ty), Some(instance_ty)),
+                bound_signature,
                 CallableTypeKind::Regular,
                 CallableFunctionProvenance::None,
             );
@@ -2135,7 +2159,7 @@ impl<'db> ClassType<'db> {
             None
         };
 
-        let dunder_init_function_symbol = self_ty
+        let dunder_init_function_symbol = lookup_type
             .member_lookup_with_policy(
                 db,
                 "__init__",
@@ -2143,10 +2167,6 @@ impl<'db> ClassType<'db> {
                     | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
             .place;
-
-        let correct_return_type = self_ty
-            .to_instance_approximation(db)
-            .unwrap_or_else(Type::unknown);
 
         // If the class defines an `__init__` method, then we synthesize a callable type with the
         // same parameters as the `__init__` method after it is bound, and with the return type of
@@ -2173,8 +2193,7 @@ impl<'db> ClassType<'db> {
                             ty.as_typevar()
                                 .is_none_or(|bound_typevar| !bound_typevar.typevar(db).is_self(db))
                         });
-                    let return_type = self_annotation.unwrap_or(correct_return_type);
-                    let instance_ty = Type::instance(db, self);
+                    let return_type = self_annotation.unwrap_or(instance_type);
                     let generic_context = GenericContext::merge_optional(
                         db,
                         class_generic_context,
@@ -2188,8 +2207,8 @@ impl<'db> ClassType<'db> {
                     .with_definition(signature.definition())
                     .bind_self_with_receiver(
                         db,
-                        Some(instance_ty),
-                        Some(instance_ty),
+                        Some(instance_type),
+                        Some(instance_type),
                     )
                 };
 
@@ -2223,7 +2242,7 @@ impl<'db> ClassType<'db> {
             (None, None) => {
                 // If no `__new__` or `__init__` method is found, then we fall back to looking for
                 // an `object.__new__` method.
-                let new_function_symbol = self_ty
+                let new_function_symbol = lookup_type
                     .member_lookup_with_policy(
                         db,
                         "__new__",
@@ -2242,7 +2261,7 @@ impl<'db> ClassType<'db> {
                     }
                     CallableTypes::one(
                         new_function
-                            .into_bound_method_type(db, correct_return_type)
+                            .into_bound_method_type(db, instance_type)
                             .into_callable_type(db),
                     )
                 } else {
@@ -2252,7 +2271,7 @@ impl<'db> ClassType<'db> {
                         Signature::new_generic(
                             class_generic_context,
                             Parameters::empty(),
-                            correct_return_type,
+                            instance_type,
                         ),
                     ))
                 }

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -138,7 +138,7 @@ impl<'db> DefinitionReferenceVisitor<'db> {
         }
 
         let class = match ty {
-            Type::ProtocolInstance(protocol) => *protocol.class_origin()?,
+            Type::ProtocolInstance(protocol) => *protocol.class_origin(db)?,
             Type::TypedDict(typed_dict) => typed_dict.defining_class()?,
             _ => return None,
         };
@@ -198,7 +198,7 @@ impl<'db> TypeVisitor<'db> for DefinitionReferenceVisitor<'db> {
     }
 
     fn visit_protocol_instance_type(&self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) {
-        if let Some(class) = protocol.class_origin() {
+        if let Some(class) = protocol.class_origin(db) {
             class.walk_recursive_member_types(db, self);
         }
     }
@@ -229,12 +229,12 @@ impl<'db> TypeAliasType<'db> {
 
 impl<'db> ProtocolInstanceType<'db> {
     fn definition(self, db: &'db dyn Db) -> Option<Definition<'db>> {
-        let (origin, _) = self.class_origin()?.static_class_literal(db)?;
+        let (origin, _) = self.class_origin(db)?.static_class_literal(db)?;
         Some(origin.definition(db))
     }
 
     fn is_recursive(self, db: &'db dyn Db) -> bool {
-        let Some(class) = self.class_origin() else {
+        let Some(class) = self.class_origin(db) else {
             return false;
         };
         let Some((origin, _)) = class.static_class_literal(db) else {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -26,9 +26,9 @@ use crate::types::tuple::TupleSpec;
 use crate::types::typed_dict::TypedDictSchema;
 use crate::types::typevar::TypeVarInstance;
 use crate::types::{
-    BoundTypeVarInstance, ClassType, DynamicType, ErrorContextTree, LintDiagnosticGuard, Protocol,
-    ProtocolInstanceType, SpecialFormType, SubclassOfInner, Type, TypeContext, TypeVarVariance,
-    binding_type, protocol_class::ProtocolClass,
+    BoundTypeVarInstance, ClassType, DynamicType, ErrorContextTree, LintDiagnosticGuard,
+    SpecialFormType, SubclassOfInner, Type, TypeContext, TypeVarVariance, binding_type,
+    protocol_class::ProtocolClass,
 };
 use crate::types::{KnownInstanceType, MemberLookupPolicy, TypeVarKind, TypedDictType, UnionType};
 use crate::{Db, DisplaySettings, FxIndexMap, Program, declare_lint};
@@ -2837,10 +2837,7 @@ pub(crate) fn report_undeclared_protocol_member(
     /// We also want to avoid suggesting invalid syntax such as `x: <class 'int'> = int`.
     fn should_give_hint<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
         let class = match ty {
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::FromClass(_),
-                ..
-            }) => return true,
+            Type::ProtocolInstance(protocol) if protocol.class_origin(db).is_some() => return true,
             Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Class(class) => class,
                 SubclassOfInner::Protocol(_) => return true,

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -33,9 +33,8 @@ use crate::types::visitor::TypeVisitor;
 use crate::types::{
     CallableType, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
     LiteralValueType, LiteralValueTypeKind, MaterializationKind, PropertyInstanceType, Protocol,
-    ProtocolInstanceType, SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType,
-    Type, TypeAliasType, TypeGuardLike, TypedDictModule, TypedDictType, UnionType,
-    WrapperDescriptorKind, visitor,
+    SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType, Type, TypeAliasType,
+    TypeGuardLike, TypedDictModule, TypedDictType, UnionType, WrapperDescriptorKind, visitor,
 };
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
@@ -582,10 +581,9 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'db> {
             // Visit the class (as if it were a nominal-instance type)
             // rather than the protocol members, if it is a class-based protocol.
             // (For the purposes of displaying the type, we'll use the class name.)
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::FromClass(class),
-                ..
-            }) => return self.visit_type(db, Type::from(class)),
+            Type::ProtocolInstance(protocol) if let Some(class) = protocol.class_origin(db) => {
+                return self.visit_type(db, Type::from(class));
+            }
             // no need to recurse into TypeVar bounds/constraints
             Type::TypeVar(_) => return,
             _ => {}
@@ -985,6 +983,31 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .display_with(self.db, self.settings.clone())
                         .fmt_detailed(f),
                 },
+                Protocol::Materialized(materialized) => {
+                    let materialization_kind = protocol.display_materialization_kind(self.db);
+                    if let Some(kind) = materialization_kind {
+                        let (name, form) = match kind {
+                            MaterializationKind::Top => ("Top", SpecialFormType::Top),
+                            MaterializationKind::Bottom => ("Bottom", SpecialFormType::Bottom),
+                        };
+                        f.with_type(Type::SpecialForm(form)).write_str(name)?;
+                        f.write_char('[')?;
+                    }
+
+                    match *materialized.origin(self.db) {
+                        ClassType::NonGeneric(class) => class
+                            .display_with(self.db, self.settings.clone())
+                            .fmt_detailed(f),
+                        ClassType::Generic(alias) => alias
+                            .display_with(self.db, self.settings.clone())
+                            .fmt_detailed(f),
+                    }?;
+
+                    if materialization_kind.is_some() {
+                        f.write_char(']')?;
+                    }
+                    Ok(())
+                }
                 Protocol::Synthesized(synthetic) => {
                     f.set_invalid_type_annotation();
                     f.write_char('<')?;

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3284,9 +3284,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (formal, Type::ProtocolInstance(actual_protocol)) => {
-                if actual_protocol.materialization_kind(self.db).is_some()
-                    && let Type::ProtocolInstance(formal_protocol) = formal
-                    && let Some(actual_origin) = actual_protocol.class_origin(self.db)
+                if let Type::ProtocolInstance(formal_protocol) = formal
+                    && let Some(actual_origin) = actual_protocol.materialized_origin(self.db)
                     && let Some(formal_origin) = formal_protocol.class_origin(self.db)
                     && (actual_origin
                         .iter_mro(self.db)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2715,7 +2715,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // fallback erases; restrict mixed unions to the protocol used by dictionary constructors.
         if !other_types.is_empty()
             && !matches!(formal, Type::ProtocolInstance(protocol)
-            if protocol.class_origin().is_some_and(|class| {
+            if protocol.class_origin(self.db).is_some_and(|class| {
                 class.is_known(self.db, KnownClass::SupportsKeysAndGetItem)
             }))
         {
@@ -3284,12 +3284,37 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (formal, Type::ProtocolInstance(actual_protocol)) => {
+                if actual_protocol.materialization_kind(self.db).is_some()
+                    && let Type::ProtocolInstance(formal_protocol) = formal
+                    && let Some(actual_origin) = actual_protocol.class_origin(self.db)
+                    && let Some(formal_origin) = formal_protocol.class_origin(self.db)
+                    && (actual_origin
+                        .iter_mro(self.db)
+                        .filter_map(ClassBase::into_class)
+                        .any(|base| {
+                            base.class_literal(self.db) == formal_origin.class_literal(self.db)
+                        })
+                        || formal_protocol
+                            .interface(self.db)
+                            .has_only_finite_members(self.db))
+                {
+                    // A materialized protocol can expose different member requirements from its
+                    // nominal origin. Infer explicitly inherited requirements structurally, and
+                    // also infer unrelated protocols when the formal requirements are finite.
+                    // Expanding an unrelated recursive requirement here would otherwise bypass
+                    // the finite-first ordering that keeps protocol comparison terminating.
+                    let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
+                    let when = self.constraints.load(self.db, &when);
+                    self.infer_from_constraint_set(when)?;
+                    return Ok(());
+                }
+
                 // TODO: This will only handle protocol classes that explicit inherit
                 // from other generic protocol classes by listing it as a base class.
                 // To handle classes that implicitly implement a generic protocol, we
                 // will need to check the types of the protocol members to be able to
                 // infer the specialization of the protocol that the class implements.
-                if let Some(actual_nominal) = actual_protocol.to_nominal_instance() {
+                if let Some(actual_nominal) = actual_protocol.nominal_origin_instance(self.db) {
                     return self.infer_map_impl(
                         formal,
                         Type::NominalInstance(actual_nominal),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3287,25 +3287,37 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 if let Type::ProtocolInstance(formal_protocol) = formal
                     && let Some(actual_origin) = actual_protocol.materialized_origin(self.db)
                     && let Some(formal_origin) = formal_protocol.class_origin(self.db)
-                    && (actual_origin
+                {
+                    let nominally_inherited = actual_origin
                         .iter_mro(self.db)
                         .filter_map(ClassBase::into_class)
                         .any(|base| {
                             base.class_literal(self.db) == formal_origin.class_literal(self.db)
-                        })
+                        });
+                    let when = if nominally_inherited
                         || formal_protocol
                             .interface(self.db)
-                            .has_only_finite_members(self.db))
-                {
-                    // A materialized protocol can expose different member requirements from its
-                    // nominal origin. Infer explicitly inherited requirements structurally, and
-                    // also infer unrelated protocols when the formal requirements are finite.
-                    // Expanding an unrelated recursive requirement here would otherwise bypass
-                    // the finite-first ordering that keeps protocol comparison terminating.
-                    let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
-                    let when = self.constraints.load(self.db, &when);
-                    self.infer_from_constraint_set(when)?;
-                    return Ok(());
+                            .has_only_finite_members(self.db)
+                    {
+                        Some(actual.when_constraint_set_assignable_to_owned(self.db, formal))
+                    } else {
+                        actual_protocol
+                            .when_non_recursive_members_assignable_to_owned(
+                                self.db,
+                                formal_protocol,
+                            )
+                            .map(Cow::Borrowed)
+                    };
+
+                    // Materialized protocols cannot be replaced by their nominal origin: doing
+                    // so would recover the original `Any` requirements. Infer from the complete
+                    // interface when doing so is cycle-safe; otherwise use its nonrecursive
+                    // requirements and leave full recursive compatibility to argument checking.
+                    if let Some(when) = when {
+                        let when = self.constraints.load(self.db, &when);
+                        self.infer_from_constraint_set(when)?;
+                        return Ok(());
+                    }
                 }
 
                 // TODO: This will only handle protocol classes that explicit inherit

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -239,7 +239,7 @@ pub fn definitions_for_attribute<'db>(
     // location for go-to-definition, even though the origin is not a nominal upper bound.
     let subclass_origin = |subclass_of: SubclassOfInner<'db>| {
         let class = match subclass_of {
-            SubclassOfInner::Protocol(protocol) => protocol.class_origin().map(|origin| *origin),
+            SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map(|origin| *origin),
             subclass_of => subclass_of.into_class(db),
         }?;
         class

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -12061,11 +12061,14 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                 builder.infer_maybe_standalone_expression(value, TypeContext::default())
             });
             // If the member is a data descriptor, the RHS value may differ from the value actually assigned.
-            if value_ty
-                .class_member(db, &attr.id)
-                .place
-                .ignore_possibly_undefined()
-                .is_some_and(|ty| ty.may_be_data_descriptor(db))
+            if assignment_attribute_members(db, value_ty, &attr.id)
+                .and_then(AssignmentAttributeMembers::type_member)
+                .is_some_and(|member| {
+                    member
+                        .place
+                        .ignore_possibly_undefined()
+                        .is_some_and(|ty| ty.may_be_data_descriptor(db))
+                })
             {
                 builder.discard_dict_key_assignments_for(self.binding);
                 bound_ty = declared_ty;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -12063,12 +12063,8 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
             // If the member is a data descriptor, the RHS value may differ from the value actually assigned.
             if assignment_attribute_members(db, value_ty, &attr.id)
                 .and_then(AssignmentAttributeMembers::type_member)
-                .is_some_and(|member| {
-                    member
-                        .place
-                        .ignore_possibly_undefined()
-                        .is_some_and(|ty| ty.may_be_data_descriptor(db))
-                })
+                .and_then(|member| member.place.ignore_possibly_undefined())
+                .is_some_and(|ty| ty.may_be_data_descriptor(db))
             {
                 builder.discard_dict_key_assignments_for(self.binding);
                 bound_ty = declared_ty;

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -260,6 +260,11 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         TypeContext::new(Some(domain.unwrap_or_else(Type::unknown))),
                         emit_diagnostics,
                     );
+                    if let Some(domain) = domain
+                        && !self.check_type_pair(value_ty, *domain, emit_diagnostics)
+                    {
+                        return false;
+                    }
                     self.evaluate_protocol_descriptor_write(
                         *descriptor_ty,
                         *receiver_ty,

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -238,10 +238,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // that happens to have the right type.
         let is_self_parameter = self.is_instance_attribute_assignment(target);
 
-        let class_instance_ty = Type::instance(db, class_ty).top_materialization(db);
-        let object_instance_ty = object_ty.bind_self_typevars(db, class_instance_ty);
-        let is_current_class_instance =
-            is_self_parameter && object_instance_ty.is_subtype_of(db, class_instance_ty);
+        // Final ownership is nominal: checking structural protocol requirements can
+        // incorrectly reject the declaring class's own receiver.
+        let is_current_class_instance = is_self_parameter
+            && object_ty.nominal_class(db).is_some_and(|object_class| {
+                object_class.is_subtype_of_class_literal(db, class_ty.class_literal(db))
+            });
         if !is_current_class_instance {
             report_not_in_init();
             return true;

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1349,15 +1349,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         }
                     }
                     Type::SpecialForm(
-                        special_form @ (SpecialFormType::Top | SpecialFormType::Bottom),
-                    ) => {
-                        let slice_ty = self.infer_parameterized_special_form_type_expression(
-                            subscript,
-                            special_form,
-                        );
-                        subclass_of_type_argument(self, slice, slice_ty)
-                    }
-                    Type::SpecialForm(
                         special_form @ (SpecialFormType::TypingCallable
                         | SpecialFormType::CollectionsAbcCallable),
                     ) => {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1349,6 +1349,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         }
                     }
                     Type::SpecialForm(
+                        special_form @ (SpecialFormType::Top | SpecialFormType::Bottom),
+                    ) => {
+                        let slice_ty = self.infer_parameterized_special_form_type_expression(
+                            subscript,
+                            special_form,
+                        );
+                        subclass_of_type_argument(self, slice, slice_ty)
+                    }
+                    Type::SpecialForm(
                         special_form @ (SpecialFormType::TypingCallable
                         | SpecialFormType::CollectionsAbcCallable),
                     ) => {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
-    ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
+    ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
 };
 use crate::types::enums::is_single_member_enum;
 use crate::types::generics::walk_specialization;
@@ -796,6 +796,43 @@ fn non_recursive_protocol_interface<'db>(
     })
 }
 
+/// Infers protocol constraints without expanding recursive member requirements.
+///
+/// The target view retains its materialization, so readable and writable members are still
+/// materialized in their respective variance positions. The complete target protocol must be
+/// checked separately after generic inference.
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial = |_, _, _, _| OwnedConstraintSet::always(),
+    heap_size = ruff_memory_usage::heap_size,
+)]
+fn non_recursive_protocol_constraints<'db>(
+    db: &'db dyn Db,
+    source: ProtocolInstanceType<'db>,
+    target: ProtocolInterfaceView<'db>,
+) -> OwnedConstraintSet<'db> {
+    let constraints = ConstraintSetBuilder::new();
+    constraints.into_owned(|constraints| {
+        let relation_visitor = HasRelationToVisitor::default(constraints);
+        let disjointness_visitor = IsDisjointVisitor::default(constraints);
+        let signature_relation_visitor = SignatureRelationVisitor::default();
+        let materialization_visitor = ApplyTypeMappingVisitor::default();
+        let checker = TypeRelationChecker::constraint_set_assignability(
+            constraints,
+            &relation_visitor,
+            &disjointness_visitor,
+            &signature_relation_visitor,
+            &materialization_visitor,
+        );
+        checker.check_protocol_interface_pair(
+            db,
+            Type::ProtocolInstance(source),
+            source.interface(db),
+            target,
+        )
+    })
+}
+
 impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
     /// Return `true` if this protocol type is disjoint from the protocol `other`.
     ///
@@ -1279,6 +1316,31 @@ impl<'db> ProtocolInstanceType<'db> {
 
     pub(super) fn interface(self, db: &'db dyn Db) -> ProtocolInterfaceView<'db> {
         self.inner.interface(db)
+    }
+
+    /// Returns constraints inferred from the nonrecursive requirements of `target`.
+    ///
+    /// Recursive requirements are omitted only while inferring a generic specialization. The
+    /// eventual argument check must still compare against the complete protocol interface.
+    pub(super) fn when_non_recursive_members_assignable_to_owned(
+        self,
+        db: &'db dyn Db,
+        target: Self,
+    ) -> Option<&'db OwnedConstraintSet<'db>> {
+        let origin = target.class_origin(db)?;
+        let interface = target.interface(db);
+        let non_recursive = non_recursive_protocol_interface(
+            db,
+            interface.base(),
+            origin,
+            Type::ProtocolInstance(target),
+        );
+        let target = ProtocolInterfaceView::new(non_recursive, interface.materialization_kind());
+        if target.member_count(db) == 0 {
+            return None;
+        }
+
+        Some(non_recursive_protocol_constraints(db, self, target))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use ruff_python_ast::name::Name;
 use ty_module_resolver::{ModuleName, file_to_module};
 
-use super::protocol_class::ProtocolInterface;
+use super::protocol_class::{ProtocolInterface, ProtocolInterfaceView};
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, ClassType, DivergentType, KnownClass,
     MaterializationKind, SubclassOfType, Type, TypeAliasType, TypeVarVariance,
@@ -492,16 +492,42 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         protocol: ProtocolInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // `ty` might satisfy the protocol nominally, if `protocol` is a class-based protocol and
-        // `ty` has the protocol class in its MRO. This is a much cheaper check than the
-        // structural check we perform below, so we do it first to avoid the structural check when
-        // we can.
+        // Explicit protocol inheritance is nominal, but materializing a protocol can change
+        // the requirements represented by that same class. The nominal shortcut is therefore
+        // valid only when materialization leaves the target's members unchanged.
         let mut result = self.never();
+        let source_protocol = ty.as_protocol_instance();
 
-        if let Some(nominal_instance) = protocol.to_nominal_instance() {
-            let source_protocol_as_nominal = ty
-                .as_protocol_instance()
-                .and_then(ProtocolInstanceType::to_nominal_instance);
+        // Every gradual type lies between its bottom and top materializations. Comparing the
+        // exact same class specialization can therefore settle these directions without expanding
+        // a recursive protocol's members or confusing opposite materialization requirements.
+        if let Some(source) = source_protocol
+            && let (Some(source_origin), Some(target_origin)) =
+                (source.class_origin(db), protocol.class_origin(db))
+            && source_origin == target_origin
+            && matches!(
+                (
+                    source.materialization_kind(db),
+                    protocol.materialization_kind(db)
+                ),
+                (
+                    None | Some(MaterializationKind::Bottom),
+                    Some(MaterializationKind::Top)
+                ) | (Some(MaterializationKind::Bottom), None)
+            )
+        {
+            return self.always();
+        }
+
+        let source_protocol_as_nominal =
+            source_protocol.and_then(|source| source.nominal_origin_instance(db));
+        let is_generator_pair = source_protocol
+            .and_then(|source| source.class_origin(db))
+            .is_some_and(|class| class.is_known(db, KnownClass::Generator))
+            && protocol
+                .class_origin(db)
+                .is_some_and(|class| class.is_known(db, KnownClass::Generator));
+        if let Some(nominal_instance) = protocol.nominal_origin_instance(db) {
             // if `ty` and `protocol` are *both* protocols, we also need to treat `ty` as if it
             // were a nominal type, or we won't consider a protocol `P` that explicitly inherits
             // from a protocol `Q` to be a subtype of `Q` to be a subtype of `Q` if it overrides
@@ -513,53 +539,57 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let nominally_satisfied =
                 self.check_type_pair(db, type_to_test, Type::NominalInstance(nominal_instance));
 
-            if result
-                .union(db, self.constraints, nominally_satisfied)
-                .is_trivially_always_satisfied()
-            {
-                return result;
-            }
-
-            // `Generator` special case: compare the type parameters nominally. Prior to 3.13,
-            // its return type does not appear non-recursively in the protocol; from 3.13 onward,
-            // structurally inferring through `close() -> ReturnT | None` can spuriously infer
-            // `None`.
-            // TODO: Remove the Python 3.13+ extension of this special case once
+            // `Generator` parameters must be compared nominally. The class specialization
+            // already materializes each parameter according to its variance, while structural
+            // inference through `close() -> ReturnT | None` can infer a spurious `None` on
+            // Python 3.13 and newer.
+            // TODO: Remove the Python 3.13+ extension once
             // https://github.com/astral-sh/ty/issues/3596 is fixed.
-            if let Some(source_protocol) = ty.as_protocol_instance()
-                && let Protocol::FromClass(source_class) = source_protocol.inner
-                && let Protocol::FromClass(proto_class) = protocol.inner
-                && source_class.is_known(db, KnownClass::Generator)
-                && proto_class.is_known(db, KnownClass::Generator)
-            {
-                return result;
+            if is_generator_pair {
+                return nominally_satisfied;
             }
 
-            if let Some(structurally_satisfied) = self.try_check_non_recursive_protocol_members(
-                db,
-                ty,
-                protocol,
-                source_protocol_as_nominal,
-                nominal_instance,
-            ) {
-                return result.or(db, self.constraints, || structurally_satisfied);
-            }
+            // A nominal relation that cannot succeed cannot bypass any materialized requirement.
+            // Check that inexpensive case first: comparing every requirement of an unrelated
+            // recursive protocol can expand its interface before structural member ordering gets
+            // a chance to reject an incompatible finite member.
+            let nominal_is_safe = nominally_satisfied.is_never_satisfied(db)
+                || (!protocol.materialization_changes_requirements(db, protocol)
+                    && !source_protocol.is_some_and(|source| {
+                        source.materialization_changes_requirements(db, protocol)
+                    }));
 
-            // For union simplification, failing the nominal relation between two
-            // specializations of the same protocol class is enough to keep both union elements.
-            // Falling back to the structural relation can recursively compare every protocol
-            // member even though a failed redundancy check only means that we preserve a
-            // potentially redundant union arm.
-            if matches!(self.relation, TypeRelation::Redundancy { pure: false })
-                && ty
-                    .as_protocol_instance()
-                    .and_then(ProtocolInstanceType::to_nominal_instance)
-                    .is_some_and(|source_instance| {
+            if nominal_is_safe {
+                if result
+                    .union(db, self.constraints, nominally_satisfied)
+                    .is_trivially_always_satisfied()
+                {
+                    return result;
+                }
+
+                if let Some(structurally_satisfied) = self.try_check_non_recursive_protocol_members(
+                    db,
+                    ty,
+                    protocol,
+                    source_protocol_as_nominal,
+                    nominal_instance,
+                ) {
+                    return result.or(db, self.constraints, || structurally_satisfied);
+                }
+
+                // For union simplification, failing the nominal relation between two
+                // specializations of the same protocol class is enough to keep both union elements.
+                // Falling back to the structural relation can recursively compare every protocol
+                // member even though a failed redundancy check only means that we preserve a
+                // potentially redundant union arm.
+                if matches!(self.relation, TypeRelation::Redundancy { pure: false })
+                    && source_protocol_as_nominal.is_some_and(|source_instance| {
                         source_instance.class(db).class_literal(db)
                             == nominal_instance.class(db).class_literal(db)
                     })
-            {
-                return nominally_satisfied;
+                {
+                    return nominally_satisfied;
+                }
             }
         }
 
@@ -581,7 +611,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             )
         } else {
             protocol
-                .inner
                 .interface(db)
                 .members(db)
                 .when_all(db, self.constraints, |member| {
@@ -637,19 +666,32 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let source_interface = source_protocol.interface(db);
         let target_interface = protocol.interface(db);
         let source_non_recursive =
-            non_recursive_protocol_interface(db, source_interface, identity_protocol, ty);
+            non_recursive_protocol_interface(db, source_interface.base(), identity_protocol, ty);
         let target_non_recursive = non_recursive_protocol_interface(
             db,
-            target_interface,
+            target_interface.base(),
             identity_protocol,
             Type::ProtocolInstance(protocol),
         );
 
-        if source_non_recursive == source_interface && target_non_recursive == target_interface {
+        if source_non_recursive == source_interface.base()
+            && target_non_recursive == target_interface.base()
+        {
             return None;
         }
 
-        Some(self.check_protocol_interface_pair(db, ty, source_non_recursive, target_non_recursive))
+        Some(self.check_protocol_interface_pair(
+            db,
+            ty,
+            ProtocolInterfaceView::new(
+                source_non_recursive,
+                source_interface.materialization_kind(),
+            ),
+            ProtocolInterfaceView::new(
+                target_non_recursive,
+                target_interface.materialization_kind(),
+            ),
+        ))
     }
 
     /// Return whether a class-object type inhabits `type[protocol]`.
@@ -735,7 +777,7 @@ fn non_recursive_protocol_interface<'db>(
 
             if ty
                 .as_protocol_instance()
-                .and_then(ProtocolInstanceType::to_nominal_instance)
+                .and_then(|protocol| protocol.nominal_origin_instance(db))
                 .is_some_and(|instance| instance.class_literal(db) == self.origin)
             {
                 self.found.set(true);
@@ -916,7 +958,7 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
     visitor: &V,
 ) {
     if visitor.should_visit_lazy_type_attributes() {
-        walk_protocol_interface(db, protocol.inner.interface(db), visitor);
+        walk_protocol_interface(db, protocol.interface(db), visitor);
     } else {
         match protocol.inner {
             Protocol::FromClass(class) => {
@@ -925,7 +967,18 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
                 }
             }
             Protocol::Synthesized(synthesized) => {
-                walk_protocol_interface(db, synthesized.interface(), visitor);
+                walk_protocol_interface(
+                    db,
+                    ProtocolInterfaceView::new(synthesized.interface(), None),
+                    visitor,
+                );
+            }
+            Protocol::Materialized(materialized) => {
+                if let Some((_, Some(specialization))) =
+                    materialized.origin(db).static_class_literal(db)
+                {
+                    walk_specialization(db, specialization, visitor);
+                }
             }
         }
     }
@@ -934,7 +987,7 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
 impl<'db> ProtocolInstanceType<'db> {
     /// Return `true` if this is the standard-library `Hashable` protocol.
     pub(super) fn is_hashable(self, db: &'db dyn Db) -> bool {
-        self.to_nominal_instance()
+        self.nominal_origin_instance(db)
             .is_some_and(|instance| instance.class(db).is_known(db, KnownClass::Hashable))
     }
 
@@ -956,40 +1009,128 @@ impl<'db> ProtocolInstanceType<'db> {
         }
     }
 
-    /// Return the class backing a class-based protocol instance.
-    pub(super) fn as_class_based(self) -> Option<ProtocolClass<'db>> {
-        match self.inner {
-            Protocol::FromClass(class) => Some(class),
-            Protocol::Synthesized(_) => None,
+    /// Preserves a class-based protocol and the polarity of its pending materialization.
+    ///
+    /// Member requirements are materialized only when an operation observes them.
+    fn materialized(
+        db: &'db dyn Db,
+        origin: ProtocolClass<'db>,
+        materialization_kind: MaterializationKind,
+    ) -> Self {
+        Self {
+            inner: Protocol::Materialized(MaterializedProtocolType::new(
+                db,
+                origin,
+                materialization_kind,
+            )),
+            _phantom: PhantomData,
         }
     }
 
-    /// If this is a class-based protocol, convert the protocol-instance into a nominal instance.
-    ///
-    /// If this is a synthesized protocol that does not correspond to a class definition
-    /// in source code, return `None`. These are "pure" abstract types, that cannot be
-    /// treated in a nominal way.
-    pub(super) fn to_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
-        match self.inner {
-            Protocol::FromClass(class) => Some(NominalInstanceType(
-                NominalInstanceInner::NonTuple(NominalInstanceClass::Plain(*class)),
-            )),
-            Protocol::Synthesized(_) => None,
-        }
+    /// Return the class backing a class-based protocol instance.
+    pub(super) fn as_class_based(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
+        self.class_origin(db)
+    }
+
+    /// Returns the nominal instance of a protocol's origin without asserting nominal subtyping.
+    pub(super) fn nominal_origin_instance(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<NominalInstanceType<'db>> {
+        self.class_origin(db).map(|origin| {
+            NominalInstanceType(NominalInstanceInner::NonTuple(NominalInstanceClass::Plain(
+                *origin,
+            )))
+        })
     }
 
     /// Return the class that defines this protocol, if it is class-backed.
-    pub(super) const fn class_origin(self) -> Option<ProtocolClass<'db>> {
+    pub(super) fn class_origin(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
         match self.inner {
             Protocol::FromClass(class) => Some(class),
             Protocol::Synthesized(_) => None,
+            Protocol::Materialized(materialized) => Some(materialized.origin(db)),
         }
+    }
+
+    /// Returns the pending materialization of a class-based protocol, if any.
+    pub(super) fn materialization_kind(self, db: &'db dyn Db) -> Option<MaterializationKind> {
+        match self.inner {
+            Protocol::Materialized(materialized) => Some(materialized.materialization_kind(db)),
+            Protocol::FromClass(_) | Protocol::Synthesized(_) => None,
+        }
+    }
+
+    /// Returns the class origin of a protocol with a pending materialization.
+    pub(super) fn materialized_origin(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
+        match self.inner {
+            Protocol::Materialized(materialized) => Some(materialized.origin(db)),
+            Protocol::FromClass(_) | Protocol::Synthesized(_) => None,
+        }
+    }
+
+    /// Returns the nominal origin when a materialized requirement is a property descriptor.
+    ///
+    /// Descriptor lookup needs the original property object even though ordinary reads expose
+    /// its lazily materialized value.
+    pub(super) fn materialized_origin_property(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<ProtocolClass<'db>> {
+        self.materialized_origin(db)
+            .filter(|_| self.interface(db).member_is_property(db, name))
+    }
+
+    /// Returns whether a materialization changes any member required by `target`.
+    ///
+    /// An unrelated changed member must not prevent an explicitly inherited protocol from
+    /// satisfying its base nominally.
+    fn materialization_changes_requirements(
+        self,
+        db: &'db dyn Db,
+        target: ProtocolInstanceType<'db>,
+    ) -> bool {
+        let Some(origin) = self.materialized_origin(db) else {
+            return false;
+        };
+        let original = ProtocolInterfaceView::new(origin.unmaterialized_interface(db), None);
+        self.interface(db)
+            .differs_for_members_required_by(db, original, target.interface(db))
+    }
+
+    /// Returns the materialization wrapper needed for displaying this protocol.
+    ///
+    /// Fully static requirements need no wrapper. A generic specialization can already display
+    /// its materialization, in which case adding another wrapper would duplicate `Top` or
+    /// `Bottom`.
+    pub(super) fn display_materialization_kind(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<MaterializationKind> {
+        let materialization_kind = self.materialization_kind(db)?;
+        let origin = self.materialized_origin(db)?;
+        if origin
+            .static_class_literal(db)
+            .and_then(|(_, specialization)| specialization)
+            .and_then(|specialization| specialization.materialization_kind(db))
+            .is_some()
+        {
+            return None;
+        }
+
+        let original = ProtocolInterfaceView::new(origin.unmaterialized_interface(db), None);
+        self.interface(db)
+            .differs_for_members_required_by(db, original, original)
+            .then_some(materialization_kind)
     }
 
     /// Return the structural meta-type of this protocol-instance type.
     pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
         match self.inner {
-            Protocol::FromClass(_) => SubclassOfType::from_protocol(self),
+            Protocol::FromClass(_) | Protocol::Materialized(_) => {
+                SubclassOfType::from_protocol(self)
+            }
 
             // TODO: we can and should do better here.
             //
@@ -1010,10 +1151,10 @@ impl<'db> ProtocolInstanceType<'db> {
 
     /// Return the nominal meta-type used for internal class-member lookup on a protocol instance.
     pub(super) fn to_nominal_meta_type(self, db: &'db dyn Db) -> Type<'db> {
-        match self.inner {
-            Protocol::FromClass(class) => SubclassOfType::from(db, *class),
-            Protocol::Synthesized(_) => self.to_meta_type(db),
-        }
+        self.class_origin(db).map_or_else(
+            || self.to_meta_type(db),
+            |origin| SubclassOfType::from(db, *origin),
+        )
     }
 
     /// Return `true` if this protocol is a supertype of `object`.
@@ -1062,10 +1203,26 @@ impl<'db> ProtocolInstanceType<'db> {
         })
     }
 
+    /// Returns an effective materialized member without applying the nominal class fallback.
+    pub(super) fn materialized_interface_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<PlaceAndQualifiers<'db>> {
+        self.materialization_kind(db)?;
+        let interface = self.interface(db);
+        interface
+            .includes_member(db, name)
+            .then(|| interface.instance_member(db, name))
+    }
+
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         match self.inner {
             Protocol::FromClass(class) => class.instance_member(db, name),
             Protocol::Synthesized(synthesized) => synthesized.interface().instance_member(db, name),
+            Protocol::Materialized(materialized) => self
+                .materialized_interface_member(db, name)
+                .unwrap_or_else(|| materialized.origin(db).instance_member(db, name)),
         }
     }
 
@@ -1078,11 +1235,32 @@ impl<'db> ProtocolInstanceType<'db> {
     ) -> Self {
         match self.inner {
             Protocol::FromClass(class) => {
-                Self::from_class(class.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                let mapped_class = class.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                if let TypeMapping::Materialize(materialization_kind) = type_mapping {
+                    Self::materialized(db, mapped_class, *materialization_kind)
+                } else {
+                    Self::from_class(mapped_class)
+                }
             }
             Protocol::Synthesized(synthesized) => Self::synthesized(
                 synthesized.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             ),
+            Protocol::Materialized(materialized) => {
+                if matches!(type_mapping, TypeMapping::Materialize(_)) {
+                    self
+                } else {
+                    Self::materialized(
+                        db,
+                        materialized.origin(db).apply_type_mapping_impl(
+                            db,
+                            type_mapping,
+                            tcx,
+                            visitor,
+                        ),
+                        materialized.materialization_kind(db),
+                    )
+                }
+            }
         }
     }
 
@@ -1100,10 +1278,18 @@ impl<'db> ProtocolInstanceType<'db> {
             Protocol::Synthesized(synthesized) => {
                 synthesized.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
+            Protocol::Materialized(materialized) => {
+                materialized.origin(db).find_legacy_typevars_impl(
+                    db,
+                    binding_context,
+                    typevars,
+                    visitor,
+                );
+            }
         }
     }
 
-    pub(super) fn interface(self, db: &'db dyn Db) -> ProtocolInterface<'db> {
+    pub(super) fn interface(self, db: &'db dyn Db) -> ProtocolInterfaceView<'db> {
         self.inner.interface(db)
     }
 }
@@ -1114,20 +1300,38 @@ impl<'db> VarianceInferable<'db> for ProtocolInstanceType<'db> {
     }
 }
 
-/// An enumeration of the two kinds of protocol types: those that originate from a class
-/// definition in source code, and those that are synthesized from a set of members.
+/// A class-backed protocol materialization whose member requirements remain lazy.
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+pub(super) struct MaterializedProtocolType<'db> {
+    #[returns(copy)]
+    pub(super) origin: ProtocolClass<'db>,
+    #[returns(copy)]
+    pub(super) materialization_kind: MaterializationKind,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for MaterializedProtocolType<'_> {}
+
+/// A class-backed, synthesized, or lazily materialized protocol.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) enum Protocol<'db> {
     FromClass(ProtocolClass<'db>),
     Synthesized(SynthesizedProtocolType<'db>),
+    Materialized(MaterializedProtocolType<'db>),
 }
 
 impl<'db> Protocol<'db> {
     /// Return the members of this protocol type
-    fn interface(self, db: &'db dyn Db) -> ProtocolInterface<'db> {
+    fn interface(self, db: &'db dyn Db) -> ProtocolInterfaceView<'db> {
         match self {
-            Self::FromClass(class) => class.interface(db),
-            Self::Synthesized(synthesized) => synthesized.interface(),
+            Self::FromClass(class) => ProtocolInterfaceView::new(class.interface(db), None),
+            Self::Synthesized(synthesized) => {
+                ProtocolInterfaceView::new(synthesized.interface(), None)
+            }
+            Self::Materialized(materialized) => ProtocolInterfaceView::new(
+                materialized.origin(db).unmaterialized_interface(db),
+                Some(materialized.materialization_kind(db)),
+            ),
         }
     }
 
@@ -1144,11 +1348,16 @@ impl<'db> Protocol<'db> {
             Self::Synthesized(synthesized) => Some(Self::Synthesized(
                 synthesized.recursive_type_normalized_impl(db, div, nested)?,
             )),
+            Self::Materialized(materialized) => {
+                Some(Self::Materialized(MaterializedProtocolType::new(
+                    db,
+                    materialized
+                        .origin(db)
+                        .recursive_type_normalized_impl(db, div, nested)?,
+                    materialized.materialization_kind(db),
+                )))
+            }
         }
-    }
-
-    pub(super) const fn is_synthesized(self) -> bool {
-        matches!(self, Self::Synthesized(_))
     }
 }
 
@@ -1158,6 +1367,9 @@ impl<'db> VarianceInferable<'db> for Protocol<'db> {
             Protocol::FromClass(class_type) => class_type.variance_of(db, typevar),
             Protocol::Synthesized(synthesized_protocol_type) => {
                 synthesized_protocol_type.variance_of(db, typevar)
+            }
+            Protocol::Materialized(materialized) => {
+                materialized.origin(db).variance_of(db, typevar)
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -502,9 +502,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // exact same class specialization can therefore settle these directions without expanding
         // a recursive protocol's members or confusing opposite materialization requirements.
         if let Some(source) = source_protocol
-            && let (Some(source_origin), Some(target_origin)) =
-                (source.class_origin(db), protocol.class_origin(db))
-            && source_origin == target_origin
             && matches!(
                 (
                     source.materialization_kind(db),
@@ -515,18 +512,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     Some(MaterializationKind::Top)
                 ) | (Some(MaterializationKind::Bottom), None)
             )
+            && let (Some(source_origin), Some(target_origin)) =
+                (source.class_origin(db), protocol.class_origin(db))
+            && source_origin == target_origin
         {
             return self.always();
         }
 
         let source_protocol_as_nominal =
             source_protocol.and_then(|source| source.nominal_origin_instance(db));
-        let is_generator_pair = source_protocol
-            .and_then(|source| source.class_origin(db))
-            .is_some_and(|class| class.is_known(db, KnownClass::Generator))
-            && protocol
-                .class_origin(db)
-                .is_some_and(|class| class.is_known(db, KnownClass::Generator));
         if let Some(nominal_instance) = protocol.nominal_origin_instance(db) {
             // if `ty` and `protocol` are *both* protocols, we also need to treat `ty` as if it
             // were a nominal type, or we won't consider a protocol `P` that explicitly inherits
@@ -545,7 +539,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // Python 3.13 and newer.
             // TODO: Remove the Python 3.13+ extension once
             // https://github.com/astral-sh/ty/issues/3596 is fixed.
-            if is_generator_pair {
+            if nominal_instance.has_known_class(db, KnownClass::Generator)
+                && source_protocol_as_nominal
+                    .is_some_and(|source| source.has_known_class(db, KnownClass::Generator))
+            {
                 return nominally_satisfied;
             }
 
@@ -961,8 +958,11 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
         walk_protocol_interface(db, protocol.interface(db), visitor);
     } else {
         match protocol.inner {
-            Protocol::FromClass(class) => {
-                if let Some((_, Some(specialization))) = class.static_class_literal(db) {
+            Protocol::FromClass(_) | Protocol::Materialized(_) => {
+                if let Some((_, Some(specialization))) = protocol
+                    .class_origin(db)
+                    .and_then(|class| class.static_class_literal(db))
+                {
                     walk_specialization(db, specialization, visitor);
                 }
             }
@@ -973,13 +973,6 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
                     visitor,
                 );
             }
-            Protocol::Materialized(materialized) => {
-                if let Some((_, Some(specialization))) =
-                    materialized.origin(db).static_class_literal(db)
-                {
-                    walk_specialization(db, specialization, visitor);
-                }
-            }
         }
     }
 }
@@ -987,8 +980,8 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
 impl<'db> ProtocolInstanceType<'db> {
     /// Return `true` if this is the standard-library `Hashable` protocol.
     pub(super) fn is_hashable(self, db: &'db dyn Db) -> bool {
-        self.nominal_origin_instance(db)
-            .is_some_and(|instance| instance.class(db).is_known(db, KnownClass::Hashable))
+        self.class_origin(db)
+            .is_some_and(|class| class.is_known(db, KnownClass::Hashable))
     }
 
     // Keep this method private, so that the only way of constructing `ProtocolInstanceType`
@@ -1025,11 +1018,6 @@ impl<'db> ProtocolInstanceType<'db> {
             )),
             _phantom: PhantomData,
         }
-    }
-
-    /// Return the class backing a class-based protocol instance.
-    pub(super) fn as_class_based(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
-        self.class_origin(db)
     }
 
     /// Returns the nominal instance of a protocol's origin without asserting nominal subtyping.
@@ -1091,12 +1079,10 @@ impl<'db> ProtocolInstanceType<'db> {
         db: &'db dyn Db,
         target: ProtocolInstanceType<'db>,
     ) -> bool {
-        let Some(origin) = self.materialized_origin(db) else {
-            return false;
-        };
-        let original = ProtocolInterfaceView::new(origin.unmaterialized_interface(db), None);
-        self.interface(db)
-            .differs_for_members_required_by(db, original, target.interface(db))
+        self.materialization_kind(db).is_some()
+            && self
+                .interface(db)
+                .differs_for_members_required_by(db, target.interface(db))
     }
 
     /// Returns the materialization wrapper needed for displaying this protocol.
@@ -1108,8 +1094,10 @@ impl<'db> ProtocolInstanceType<'db> {
         self,
         db: &'db dyn Db,
     ) -> Option<MaterializationKind> {
-        let materialization_kind = self.materialization_kind(db)?;
-        let origin = self.materialized_origin(db)?;
+        let Protocol::Materialized(materialized) = self.inner else {
+            return None;
+        };
+        let origin = materialized.origin(db);
         if origin
             .static_class_literal(db)
             .and_then(|(_, specialization)| specialization)
@@ -1119,10 +1107,10 @@ impl<'db> ProtocolInstanceType<'db> {
             return None;
         }
 
-        let original = ProtocolInterfaceView::new(origin.unmaterialized_interface(db), None);
-        self.interface(db)
-            .differs_for_members_required_by(db, original, original)
-            .then_some(materialization_kind)
+        let interface = self.interface(db);
+        interface
+            .differs_for_members_required_by(db, interface)
+            .then_some(materialized.materialization_kind(db))
     }
 
     /// Return the structural meta-type of this protocol-instance type.

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -251,7 +251,7 @@ impl<'db> AllMembers<'db> {
                 }
                 SubclassOfInner::Protocol(protocol) => {
                     if let Some((class_literal, _)) = protocol
-                        .class_origin()
+                        .class_origin(db)
                         .and_then(|origin| origin.static_class_literal(db))
                     {
                         self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -382,11 +382,7 @@ impl<'db> ProtocolInterfaceView<'db> {
         })
     }
 
-    pub(super) fn member_by_name<'a>(
-        self,
-        db: &'db dyn Db,
-        name: &'a str,
-    ) -> Option<ProtocolMember<'a, 'db>> {
+    fn member_by_name<'a>(self, db: &'db dyn Db, name: &'a str) -> Option<ProtocolMember<'a, 'db>> {
         self.interface
             .inner(db)
             .get(name)
@@ -401,80 +397,52 @@ impl<'db> ProtocolInterfaceView<'db> {
         self.interface.includes_member(db, name)
     }
 
-    pub(super) fn non_method_members(self, db: &'db dyn Db) -> Vec<ProtocolMember<'db, 'db>> {
-        self.members(db)
-            .filter(|member| !member.is_method())
-            .collect()
-    }
-
-    /// Compare only the members that can affect a relation to `required`.
+    /// Compare the original and materialized forms of members required by `required`.
     ///
     /// An unrelated materialized member must not prevent a protocol from retaining its
     /// nominal relationship to one of its bases.
-    pub(super) fn differs_for_members_required_by(
-        self,
-        db: &'db dyn Db,
-        original: Self,
-        required: Self,
-    ) -> bool {
+    pub(super) fn differs_for_members_required_by(self, db: &'db dyn Db, required: Self) -> bool {
         required.members(db).any(|required_member| {
-            let name = required_member.name();
-            match (
-                self.member_by_name(db, name),
-                original.member_by_name(db, name),
-            ) {
-                (Some(materialized), Some(original)) => {
-                    let instance_changed = materialized
-                        .access(db, ProtocolMemberAccessMode::Instance)
-                        .resolved(db)
-                        != original
-                            .access(db, ProtocolMemberAccessMode::Instance)
-                            .resolved(db);
-                    if instance_changed {
-                        return true;
-                    }
+            let Some(materialized) = self.member_by_name(db, required_member.name()) else {
+                return false;
+            };
+            let original = ProtocolMember {
+                name: materialized.name,
+                data: materialized.data,
+                materialization: None,
+            };
 
-                    // Class access to an ordinary instance method requires only that the method
-                    // exists. Its unbound `self` is not part of structural compatibility and can
-                    // recursively refer to this protocol, so do not materialize that signature.
-                    if materialized.is_instance_method() && original.is_instance_method() {
-                        return false;
-                    }
-
-                    materialized
-                        .access(db, ProtocolMemberAccessMode::Class)
-                        .resolved(db)
-                        != original
-                            .access(db, ProtocolMemberAccessMode::Class)
-                            .resolved(db)
-                }
-                (None, None) => false,
-                (Some(_), None) | (None, Some(_)) => true,
+            if materialized
+                .access(db, ProtocolMemberAccessMode::Instance)
+                .resolved(db)
+                != original
+                    .access(db, ProtocolMemberAccessMode::Instance)
+                    .resolved(db)
+            {
+                return true;
             }
+
+            // Class access to an ordinary instance method requires only that the method
+            // exists. Its unbound `self` is not part of structural compatibility and can
+            // recursively refer to this protocol, so do not materialize that signature.
+            if materialized.is_instance_method() {
+                return false;
+            }
+
+            materialized
+                .access(db, ProtocolMemberAccessMode::Class)
+                .resolved(db)
+                != original
+                    .access(db, ProtocolMemberAccessMode::Class)
+                    .resolved(db)
         })
     }
 
-    pub(super) fn includes_generic_writable_instance_member(
-        self,
-        db: &'db dyn Db,
-        name: &str,
-        generic_context: GenericContext<'db>,
-    ) -> bool {
-        self.member_by_name(db, name)
-            .and_then(|member| member.access(db, ProtocolMemberAccessMode::Instance).write)
-            .and_then(ProtocolMemberWrite::domain)
-            .and_then(|write| write.resolve(db))
-            .is_some_and(|write| {
-                matches!(
-                    write.ty(),
-                    Type::SubclassOf(subclass_of)
-                        if subclass_of.into_type_var().is_some_and(|typevar| {
-                            generic_context.contains(db, typevar.identity(db))
-                        })
-                )
-            })
-    }
-
+    /// Returns the declared instance-write requirement for a protocol member.
+    ///
+    /// `None` means that the protocol does not declare `name`; `Some((None, _))` means that the
+    /// member exists but is read-only. A writable member's requirement is bound to `receiver_ty`
+    /// before it is returned.
     pub(super) fn instance_write_requirement(
         self,
         db: &'db dyn Db,
@@ -492,6 +460,10 @@ impl<'db> ProtocolInterfaceView<'db> {
         })
     }
 
+    /// Returns the write requirement exposed through `type[Protocol]` lookup.
+    ///
+    /// Only members required on every class object that satisfies the meta-protocol are available.
+    /// Ordinary instance attributes are required on the constructed object instead.
     pub(super) fn meta_write_requirement(
         self,
         db: &'db dyn Db,
@@ -509,6 +481,10 @@ impl<'db> ProtocolInterfaceView<'db> {
         })
     }
 
+    /// Returns the callable signature exposed by instance access to a protocol's `__call__`
+    /// method.
+    ///
+    /// The callable is already in its instance-bound form, so callers must not bind it again.
     pub(super) fn call_method(self, db: &'db dyn Db) -> Option<CallableType<'db>> {
         self.member_by_name(db, "__call__").and_then(|member| {
             if !member.is_method() {
@@ -541,6 +517,11 @@ impl<'db> ProtocolInterfaceView<'db> {
             .unwrap_or_else(|| Type::object().member(db, name))
     }
 
+    /// Looks up a member guaranteed to exist on every inhabitant of `type[Protocol]`.
+    ///
+    /// Methods retain their unbound signatures and `ClassVar`s retain their class-side types.
+    /// Properties are only required on the constructed instance, so they are undefined even when
+    /// the nominal protocol origin provides a property descriptor.
     pub(super) fn meta_member(
         self,
         db: &'db dyn Db,
@@ -750,7 +731,9 @@ impl<'db> ProtocolInterface<'db> {
     }
 
     pub(super) fn non_method_members(self, db: &'db dyn Db) -> Vec<ProtocolMember<'db, 'db>> {
-        ProtocolInterfaceView::new(self, None).non_method_members(db)
+        self.members(db)
+            .filter(|member| !member.is_method())
+            .collect()
     }
 
     pub(super) fn includes_member(self, db: &'db dyn Db, name: &str) -> bool {
@@ -765,11 +748,20 @@ impl<'db> ProtocolInterface<'db> {
         name: &str,
         generic_context: GenericContext<'db>,
     ) -> bool {
-        ProtocolInterfaceView::new(self, None).includes_generic_writable_instance_member(
-            db,
-            name,
-            generic_context,
-        )
+        self.inner(db)
+            .get(name)
+            .and_then(|data| data.capabilities(db).instance.write)
+            .and_then(ProtocolMemberWrite::domain)
+            .and_then(|write| write.resolve(db))
+            .is_some_and(|write| {
+                matches!(
+                    write.ty(),
+                    Type::SubclassOf(subclass_of)
+                        if subclass_of.into_type_var().is_some_and(|typevar| {
+                            generic_context.contains(db, typevar.identity(db))
+                        })
+                )
+            })
     }
 
     pub(super) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -23,11 +23,11 @@ use crate::{
     },
     types::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
-        CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
+        CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor, GenericAlias,
         GenericContext, InstanceFallbackShadowsNonDataDescriptor, IntersectionType, KnownFunction,
-        MemberLookupKey, MemberLookupPolicy, Parameter, PropertyInstanceType, ProtocolInstanceType,
-        SelfBinding, Signature, StaticClassLiteral, Type, TypeMapping, TypeQualifiers,
-        TypeVarBoundOrConstraints, TypeVarVariance, UnionType, VarianceInferable,
+        MaterializationKind, MemberLookupKey, MemberLookupPolicy, Parameter, PropertyInstanceType,
+        ProtocolInstanceType, SelfBinding, Signature, StaticClassLiteral, Type, TypeMapping,
+        TypeQualifiers, TypeVarBoundOrConstraints, TypeVarVariance, UnionType, VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
@@ -74,6 +74,30 @@ impl<'db> ProtocolClass<'db> {
     pub(super) fn interface(self, db: &'db dyn Db) -> ProtocolInterface<'db> {
         let _span = tracing::trace_span!("protocol_members", "class='{}'", self.name(db)).entered();
         cached_protocol_interface(db, *self)
+    }
+
+    /// Returns the interface before an invariant specialization is materialized.
+    ///
+    /// A materialized generic origin retains its specialization for nominal identity and display.
+    /// Building member requirements from that specialization, however, would first materialize an
+    /// invariant type variable as a read and then reuse that result as its write. Strip only the
+    /// pending marker while constructing the shared interface so reads and writes can each apply
+    /// the original materialization in their own variance position.
+    pub(super) fn unmaterialized_interface(self, db: &'db dyn Db) -> ProtocolInterface<'db> {
+        let ClassType::Generic(alias) = *self else {
+            return self.interface(db);
+        };
+        let specialization = alias.specialization(db);
+        if specialization.materialization_kind(db).is_none() {
+            return self.interface(db);
+        }
+
+        let alias = GenericAlias::new(
+            db,
+            alias.origin(db),
+            specialization.with_materialization_kind(db, None),
+        );
+        ProtocolClass(ClassType::Generic(alias)).interface(db)
     }
 
     /// Walk the effective non-method member types declared by this protocol.
@@ -298,9 +322,252 @@ pub(super) struct ProtocolInterface<'db> {
 
 impl get_size2::GetSize for ProtocolInterface<'_> {}
 
+/// A protocol interface together with the materialization applied to its requirements.
+///
+/// The original interface remains shared. A member's readable and writable types are
+/// materialized only when that member is accessed or compared.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+pub(super) struct ProtocolInterfaceView<'db> {
+    interface: ProtocolInterface<'db>,
+    materialization: Option<MaterializationKind>,
+}
+
+impl<'db> ProtocolInterfaceView<'db> {
+    pub(super) const fn new(
+        interface: ProtocolInterface<'db>,
+        materialization: Option<MaterializationKind>,
+    ) -> Self {
+        Self {
+            interface,
+            materialization,
+        }
+    }
+
+    pub(super) const fn base(self) -> ProtocolInterface<'db> {
+        self.interface
+    }
+
+    pub(super) const fn materialization_kind(self) -> Option<MaterializationKind> {
+        self.materialization
+    }
+
+    pub(super) fn members<'a>(
+        self,
+        db: &'db dyn Db,
+    ) -> impl ExactSizeIterator<Item = ProtocolMember<'a, 'db>>
+    where
+        'db: 'a,
+    {
+        self.interface
+            .inner(db)
+            .iter()
+            .map(move |(name, data)| ProtocolMember {
+                name,
+                data,
+                materialization: self.materialization,
+            })
+    }
+
+    pub(super) fn member_count(self, db: &'db dyn Db) -> usize {
+        self.interface.member_count(db)
+    }
+
+    /// Returns whether structural comparison can avoid recursive member expansion.
+    pub(super) fn has_only_finite_members(self, db: &'db dyn Db) -> bool {
+        self.members(db).all(|member| {
+            !matches!(
+                member.structural_member_priority(db),
+                StructuralMemberPriority::Recursive
+            )
+        })
+    }
+
+    pub(super) fn member_by_name<'a>(
+        self,
+        db: &'db dyn Db,
+        name: &'a str,
+    ) -> Option<ProtocolMember<'a, 'db>> {
+        self.interface
+            .inner(db)
+            .get(name)
+            .map(|data| ProtocolMember {
+                name,
+                data,
+                materialization: self.materialization,
+            })
+    }
+
+    pub(super) fn includes_member(self, db: &'db dyn Db, name: &str) -> bool {
+        self.interface.includes_member(db, name)
+    }
+
+    pub(super) fn non_method_members(self, db: &'db dyn Db) -> Vec<ProtocolMember<'db, 'db>> {
+        self.members(db)
+            .filter(|member| !member.is_method())
+            .collect()
+    }
+
+    /// Compare only the members that can affect a relation to `required`.
+    ///
+    /// An unrelated materialized member must not prevent a protocol from retaining its
+    /// nominal relationship to one of its bases.
+    pub(super) fn differs_for_members_required_by(
+        self,
+        db: &'db dyn Db,
+        original: Self,
+        required: Self,
+    ) -> bool {
+        required.members(db).any(|required_member| {
+            let name = required_member.name();
+            match (
+                self.member_by_name(db, name),
+                original.member_by_name(db, name),
+            ) {
+                (Some(materialized), Some(original)) => {
+                    let instance_changed = materialized
+                        .access(db, ProtocolMemberAccessMode::Instance)
+                        .resolved(db)
+                        != original
+                            .access(db, ProtocolMemberAccessMode::Instance)
+                            .resolved(db);
+                    if instance_changed {
+                        return true;
+                    }
+
+                    // Class access to an ordinary instance method requires only that the method
+                    // exists. Its unbound `self` is not part of structural compatibility and can
+                    // recursively refer to this protocol, so do not materialize that signature.
+                    if materialized.is_instance_method() && original.is_instance_method() {
+                        return false;
+                    }
+
+                    materialized
+                        .access(db, ProtocolMemberAccessMode::Class)
+                        .resolved(db)
+                        != original
+                            .access(db, ProtocolMemberAccessMode::Class)
+                            .resolved(db)
+                }
+                (None, None) => false,
+                (Some(_), None) | (None, Some(_)) => true,
+            }
+        })
+    }
+
+    pub(super) fn includes_generic_writable_instance_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        generic_context: GenericContext<'db>,
+    ) -> bool {
+        self.member_by_name(db, name)
+            .and_then(|member| member.access(db, ProtocolMemberAccessMode::Instance).write)
+            .and_then(ProtocolMemberWrite::domain)
+            .and_then(|write| write.resolve(db))
+            .is_some_and(|write| {
+                matches!(
+                    write.ty(),
+                    Type::SubclassOf(subclass_of)
+                        if subclass_of.into_type_var().is_some_and(|typevar| {
+                            generic_context.contains(db, typevar.identity(db))
+                        })
+                )
+            })
+    }
+
+    pub(super) fn instance_write_requirement(
+        self,
+        db: &'db dyn Db,
+        receiver_ty: Type<'db>,
+        name: &str,
+    ) -> Option<(Option<ProtocolMemberWriteRequirement<'db>>, TypeQualifiers)> {
+        self.member_by_name(db, name).map(|member| {
+            (
+                member
+                    .access(db, ProtocolMemberAccessMode::Instance)
+                    .write
+                    .and_then(|write| write.bind_requirement(db, receiver_ty)),
+                member.qualifiers(),
+            )
+        })
+    }
+
+    pub(super) fn meta_write_requirement(
+        self,
+        db: &'db dyn Db,
+        receiver_ty: Type<'db>,
+        name: &str,
+    ) -> Option<(Option<Type<'db>>, TypeQualifiers)> {
+        self.member_by_name(db, name).map(|member| {
+            (
+                member
+                    .access(db, ProtocolMemberAccessMode::Class)
+                    .write
+                    .and_then(|write| write.bind_compatibility_type(db, receiver_ty)),
+                member.qualifiers(),
+            )
+        })
+    }
+
+    pub(super) fn call_method(self, db: &'db dyn Db) -> Option<CallableType<'db>> {
+        self.member_by_name(db, "__call__").and_then(|member| {
+            if !member.is_method() {
+                return None;
+            }
+            match member
+                .access(db, ProtocolMemberAccessMode::Instance)
+                .read
+                .and_then(|read| read.resolve(db))
+                .map(ProtocolMemberType::ty)
+            {
+                Some(Type::Callable(callable)) => Some(callable),
+                _ => None,
+            }
+        })
+    }
+
+    pub(super) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        self.member_by_name(db, name)
+            .map(|member| PlaceAndQualifiers {
+                place: member
+                    .access(db, ProtocolMemberAccessMode::Instance)
+                    .read
+                    .and_then(|read| read.resolve(db))
+                    .map(|read| Place::bound(read.ty()))
+                    .unwrap_or(Place::Undefined)
+                    .with_provenance(Provenance::from_definition(member.definition())),
+                qualifiers: member.qualifiers(),
+            })
+            .unwrap_or_else(|| Type::object().member(db, name))
+    }
+
+    pub(super) fn meta_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<PlaceAndQualifiers<'db>> {
+        self.member_by_name(db, name).map(|member| {
+            let read = member.access(db, ProtocolMemberAccessMode::Class).read;
+            PlaceAndQualifiers {
+                place: read
+                    .and_then(|read| read.resolve(db))
+                    .map(|read| Place::bound(read.ty()))
+                    .unwrap_or(Place::Undefined)
+                    .with_provenance(Provenance::from_definition(member.definition())),
+                qualifiers: member.qualifiers(),
+            }
+        })
+    }
+
+    pub(super) fn member_is_property(self, db: &'db dyn Db, name: &str) -> bool {
+        self.member_by_name(db, name)
+            .is_some_and(|member| member.is_property())
+    }
+}
+
 pub(super) fn walk_protocol_interface<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
-    interface: ProtocolInterface<'db>,
+    interface: ProtocolInterfaceView<'db>,
     visitor: &V,
 ) {
     for member in interface.members(db) {
@@ -323,7 +590,7 @@ pub(super) fn walk_protocol_instance_interface<
     V: super::visitor::TypeVisitor<'db> + ?Sized,
 >(
     db: &'db dyn Db,
-    interface: ProtocolInterface<'db>,
+    interface: ProtocolInterfaceView<'db>,
     receiver_ty: Type<'db>,
     visitor: &V,
 ) {
@@ -341,6 +608,9 @@ pub(super) fn walk_protocol_instance_member<'db, V: super::visitor::TypeVisitor<
 ) {
     match member.data.kind {
         ProtocolMemberKind::Method(method, _) => {
+            let method = member
+                .materialization
+                .map_or(method, |kind| method.materialize(db, kind));
             let Type::Callable(callable) = method.ty() else {
                 visitor.visit_type(db, method.ty());
                 return;
@@ -354,11 +624,12 @@ pub(super) fn walk_protocol_instance_member<'db, V: super::visitor::TypeVisitor<
                 }
             }
         }
-        ProtocolMemberKind::Property { read, write } => {
+        ProtocolMemberKind::Property { .. } => {
+            let access = member.access(db, ProtocolMemberAccessMode::Instance);
             for member_type in [
-                read,
-                write.and_then(ProtocolMemberWrite::domain),
-                write.and_then(ProtocolMemberWrite::descriptor_type),
+                access.read,
+                access.write.and_then(ProtocolMemberWrite::domain),
+                access.write.and_then(ProtocolMemberWrite::descriptor_type),
             ]
             .into_iter()
             .flatten()
@@ -369,6 +640,9 @@ pub(super) fn walk_protocol_instance_member<'db, V: super::visitor::TypeVisitor<
             }
         }
         ProtocolMemberKind::Attribute(attribute) => {
+            let attribute = member
+                .materialization
+                .map_or(attribute, |kind| attribute.materialize(db, kind));
             if let Some(ty) = attribute.bind_self(db, receiver_ty) {
                 visitor.visit_type(db, ty);
             }
@@ -443,9 +717,11 @@ impl<'db> ProtocolInterface<'db> {
     where
         'db: 'a,
     {
-        self.inner(db)
-            .iter()
-            .map(|(name, data)| ProtocolMember { name, data })
+        self.inner(db).iter().map(|(name, data)| ProtocolMember {
+            name,
+            data,
+            materialization: None,
+        })
     }
 
     pub(super) fn filter_members(
@@ -457,7 +733,13 @@ impl<'db> ProtocolInterface<'db> {
             db,
             self.inner(db)
                 .iter()
-                .filter(|&(name, data)| predicate(&ProtocolMember { name, data }))
+                .filter(|&(name, data)| {
+                    predicate(&ProtocolMember {
+                        name,
+                        data,
+                        materialization: None,
+                    })
+                })
                 .map(|(name, data)| (name.clone(), data.clone()))
                 .collect::<BTreeMap<_, _>>(),
         )
@@ -468,15 +750,7 @@ impl<'db> ProtocolInterface<'db> {
     }
 
     pub(super) fn non_method_members(self, db: &'db dyn Db) -> Vec<ProtocolMember<'db, 'db>> {
-        self.members(db)
-            .filter(|member| !member.is_method())
-            .collect()
-    }
-
-    fn member_by_name<'a>(self, db: &'db dyn Db, name: &'a str) -> Option<ProtocolMember<'a, 'db>> {
-        self.inner(db)
-            .get(name)
-            .map(|data| ProtocolMember { name, data })
+        ProtocolInterfaceView::new(self, None).non_method_members(db)
     }
 
     pub(super) fn includes_member(self, db: &'db dyn Db, name: &str) -> bool {
@@ -491,127 +765,15 @@ impl<'db> ProtocolInterface<'db> {
         name: &str,
         generic_context: GenericContext<'db>,
     ) -> bool {
-        self.member_by_name(db, name)
-            .and_then(|member| member.capabilities(db).instance.write)
-            .and_then(ProtocolMemberWrite::domain)
-            .and_then(|write| write.resolve(db))
-            .is_some_and(|write| {
-                matches!(
-                    write.ty(),
-                    Type::SubclassOf(subclass_of)
-                        if subclass_of.into_type_var().is_some_and(|typevar| {
-                            generic_context.contains(db, typevar.identity(db))
-                        })
-                )
-            })
-    }
-
-    /// Returns the declared instance-write requirement for a protocol member.
-    ///
-    /// `None` means that the protocol does not declare `name`; `Some((None, _))` means that the
-    /// member exists but is read-only. A writable member's requirement is bound to `receiver_ty`
-    /// before it is returned.
-    pub(super) fn instance_write_requirement(
-        self,
-        db: &'db dyn Db,
-        receiver_ty: Type<'db>,
-        name: &str,
-    ) -> Option<(Option<ProtocolMemberWriteRequirement<'db>>, TypeQualifiers)> {
-        self.member_by_name(db, name).map(|member| {
-            let capabilities = member.capabilities(db);
-            (
-                capabilities
-                    .instance
-                    .write
-                    .and_then(|write| write.bind_requirement(db, receiver_ty)),
-                member.qualifiers(),
-            )
-        })
-    }
-
-    /// Returns the write requirement exposed through `type[Protocol]` lookup.
-    ///
-    /// Only members required on every class object that satisfies the meta-protocol are available.
-    /// Ordinary instance attributes are required on the constructed object instead.
-    pub(super) fn meta_write_requirement(
-        self,
-        db: &'db dyn Db,
-        receiver_ty: Type<'db>,
-        name: &str,
-    ) -> Option<(Option<Type<'db>>, TypeQualifiers)> {
-        self.member_by_name(db, name).map(|member| {
-            (
-                member
-                    .capabilities(db)
-                    .class
-                    .write
-                    .and_then(|write| write.bind_compatibility_type(db, receiver_ty)),
-                member.qualifiers(),
-            )
-        })
-    }
-
-    /// Returns the callable signature exposed by instance access to a protocol's `__call__`
-    /// method.
-    ///
-    /// The callable is already in its instance-bound form, so callers must not bind it again.
-    pub(super) fn call_method(self, db: &'db dyn Db) -> Option<CallableType<'db>> {
-        self.member_by_name(db, "__call__").and_then(|member| {
-            if !member.is_method() {
-                return None;
-            }
-            match member
-                .capabilities(db)
-                .instance
-                .read
-                .and_then(|read| read.resolve(db))
-                .map(ProtocolMemberType::ty)
-            {
-                Some(Type::Callable(callable)) => Some(callable),
-                _ => None,
-            }
-        })
+        ProtocolInterfaceView::new(self, None).includes_generic_writable_instance_member(
+            db,
+            name,
+            generic_context,
+        )
     }
 
     pub(super) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
-        self.member_by_name(db, name)
-            .map(|member| {
-                let capabilities = member.capabilities(db);
-                PlaceAndQualifiers {
-                    place: capabilities
-                        .instance
-                        .read
-                        .and_then(|read| read.resolve(db))
-                        .map(|read| Place::bound(read.ty()))
-                        .unwrap_or(Place::Undefined)
-                        .with_provenance(Provenance::from_definition(member.definition())),
-                    qualifiers: member.qualifiers(),
-                }
-            })
-            .unwrap_or_else(|| Type::object().member(db, name))
-    }
-
-    /// Looks up a member guaranteed to exist on every inhabitant of `type[Protocol]`.
-    ///
-    /// Methods retain their unbound signatures and `ClassVar`s retain their class-side types.
-    /// Properties are only required on the constructed instance, so they are undefined even when
-    /// the nominal protocol origin provides a property descriptor.
-    pub(super) fn meta_member(
-        self,
-        db: &'db dyn Db,
-        name: &str,
-    ) -> Option<PlaceAndQualifiers<'db>> {
-        self.member_by_name(db, name).map(|member| {
-            let read = member.capabilities(db).class.read;
-            PlaceAndQualifiers {
-                place: read
-                    .and_then(|read| read.resolve(db))
-                    .map(|read| Place::bound(read.ty()))
-                    .unwrap_or(Place::Undefined)
-                    .with_provenance(Provenance::from_definition(member.definition())),
-                qualifiers: member.qualifiers(),
-            }
-        })
+        ProtocolInterfaceView::new(self, None).instance_member(db, name)
     }
 
     pub(super) fn recursive_type_normalized_impl(
@@ -778,6 +940,31 @@ impl<'db> ProtocolMemberWrite<'db> {
         }
     }
 
+    /// Materialize an exposed write domain in its contravariant position.
+    ///
+    /// The descriptor itself remains unchanged so normal descriptor dispatch and deletion
+    /// continue to use the declaration on the original protocol class.
+    fn materialize(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
+        match self {
+            Self::Type(member) => Self::Type(member.materialize(db, kind.flip())),
+            Self::Descriptor { descriptor, domain } => Self::Descriptor {
+                descriptor,
+                domain: domain.map(|domain| domain.materialize(db, kind.flip())),
+            },
+        }
+    }
+
+    /// Resolve accessor representations without changing descriptor identity.
+    fn resolved(self, db: &'db dyn Db) -> Self {
+        match self {
+            Self::Type(member) => Self::Type(member.resolve(db).unwrap_or(member)),
+            Self::Descriptor { descriptor, domain } => Self::Descriptor {
+                descriptor: descriptor.resolve(db).unwrap_or(descriptor),
+                domain: domain.map(|member| member.resolve(db).unwrap_or(member)),
+            },
+        }
+    }
+
     fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
         match (self, previous) {
             (Self::Type(current), Self::Type(previous)) => {
@@ -940,6 +1127,21 @@ impl<'db> ProtocolMemberType<'db> {
         }
     }
 
+    /// Materialize the value exposed by a member, not the accessor implementing it.
+    ///
+    /// In particular, resolving a property setter before materialization prevents its callable
+    /// parameter from introducing a second contravariant flip.
+    fn materialize(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
+        let Some(resolved) = self.resolve(db) else {
+            return self;
+        };
+        let ty = match kind {
+            MaterializationKind::Top => resolved.ty().top_materialization(db),
+            MaterializationKind::Bottom => resolved.ty().bottom_materialization(db),
+        };
+        resolved.with_ty(ty)
+    }
+
     /// Resolves this member type and binds member-local `Self` occurrences to `self_type`.
     fn bind_self(self, db: &'db dyn Db, self_type: Type<'db>) -> Option<Type<'db>> {
         let Self::Value {
@@ -1018,6 +1220,21 @@ impl<'db> ProtocolMemberAccess<'db> {
         Self { read, write }
     }
 
+    fn materialize(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
+        Self {
+            read: self.read.map(|read| read.materialize(db, kind)),
+            write: self.write.map(|write| write.materialize(db, kind)),
+        }
+    }
+
+    /// Resolve readable and writable accessor representations without losing descriptor identity.
+    fn resolved(self, db: &'db dyn Db) -> Self {
+        Self {
+            read: self.read.map(|member| member.resolve(db).unwrap_or(member)),
+            write: self.write.map(|write| write.resolved(db)),
+        }
+    }
+
     fn variances(self, db: &'db dyn Db) -> impl Iterator<Item = (Type<'db>, TypeVarVariance)> {
         self.read
             .and_then(|member| member.resolve(db))
@@ -1041,6 +1258,15 @@ impl<'db> ProtocolMemberAccess<'db> {
 struct ProtocolMemberCapabilities<'db> {
     instance: ProtocolMemberAccess<'db>,
     class: ProtocolMemberAccess<'db>,
+}
+
+impl<'db> ProtocolMemberCapabilities<'db> {
+    fn materialize(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
+        Self {
+            instance: self.instance.materialize(db, kind),
+            class: self.class.materialize(db, kind),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1402,6 +1628,7 @@ impl<'db> ProtocolMemberKind<'db> {
 pub(super) struct ProtocolMember<'a, 'db> {
     name: &'a str,
     data: &'a ProtocolMemberData<'db>,
+    materialization: Option<MaterializationKind>,
 }
 
 /// Orders protocol members so that finite constraints are established before recursive relations.
@@ -1423,6 +1650,23 @@ fn walk_protocol_member<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     member: &ProtocolMember<'_, 'db>,
     visitor: &V,
 ) {
+    if member.materialization.is_some() {
+        let capabilities = member.capabilities(db);
+        for access in [capabilities.instance, capabilities.class] {
+            for member_type in [
+                access.read,
+                access.write.and_then(ProtocolMemberWrite::domain),
+                access.write.and_then(ProtocolMemberWrite::descriptor_type),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                visitor.visit_type(db, member_type.ty());
+            }
+        }
+        return;
+    }
+
     for member_type in member.data.kind.member_types() {
         visitor.visit_type(db, member_type.ty());
     }
@@ -1634,38 +1878,52 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
     }
 
     fn capabilities(&self, db: &'db dyn Db) -> ProtocolMemberCapabilities<'db> {
-        self.data.capabilities(db)
+        let capabilities = self.data.capabilities(db);
+        self.materialization
+            .map_or(capabilities, |kind| capabilities.materialize(db, kind))
     }
 
-    /// Returns the accesses that a candidate value must provide for this member.
+    /// Materialize only the access that an operation actually observes.
+    ///
+    /// In particular, an instance-method relation must not materialize the class-side callable:
+    /// its unbound receiver can recursively refer to the very protocol being compared.
+    fn access(&self, db: &'db dyn Db, mode: ProtocolMemberAccessMode) -> ProtocolMemberAccess<'db> {
+        let capabilities = self.data.capabilities(db);
+        let access = match mode {
+            ProtocolMemberAccessMode::Instance => capabilities.instance,
+            ProtocolMemberAccessMode::Class => capabilities.class,
+        };
+        self.materialization
+            .map_or(access, |kind| access.materialize(db, kind))
+    }
+
+    /// Returns the access that a candidate value must provide for this member.
     ///
     /// A module-level callable can satisfy an ordinary or static method through direct member
     /// access. A class object can likewise satisfy a class, static, or ordinary instance method;
     /// special instance methods instead use special-method lookup through the meta-type. Neither
     /// case needs a separate class-side check for the same member.
-    fn implementation_capabilities(
+    fn implementation_access(
         &self,
         db: &'db dyn Db,
         ty: Type<'db>,
-    ) -> ProtocolMemberCapabilities<'db> {
-        let capabilities = self.capabilities(db);
-        if matches!(
-            (ty, self.data.kind),
-            (
-                Type::ModuleLiteral(_),
-                ProtocolMemberKind::Method(
-                    _,
-                    ProtocolMethodKind::Instance | ProtocolMethodKind::Static
+        mode: ProtocolMemberAccessMode,
+    ) -> ProtocolMemberAccess<'db> {
+        if mode == ProtocolMemberAccessMode::Class
+            && (matches!(
+                (ty, self.data.kind),
+                (
+                    Type::ModuleLiteral(_),
+                    ProtocolMemberKind::Method(
+                        _,
+                        ProtocolMethodKind::Instance | ProtocolMethodKind::Static
+                    )
                 )
-            )
-        ) || (is_class_object_type(ty) && self.is_method())
+            ) || (is_class_object_type(ty) && self.is_method()))
         {
-            ProtocolMemberCapabilities {
-                class: ProtocolMemberAccess::NONE,
-                ..capabilities
-            }
+            ProtocolMemberAccess::NONE
         } else {
-            capabilities
+            self.access(db, mode)
         }
     }
 }
@@ -2511,9 +2769,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let capabilities = member.implementation_capabilities(db, ty);
+        let instance_access =
+            member.implementation_access(db, ty, ProtocolMemberAccessMode::Instance);
         if let Some(context) = self.report_context() {
-            let instance_read_missing = capabilities.instance.read.is_some()
+            let instance_read_missing = instance_access.read.is_some()
                 && protocol_member_read_type(
                     db,
                     ty,
@@ -2522,7 +2781,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ProtocolMemberAccessMode::Instance,
                 )
                 .is_none();
-            let class_read_missing = capabilities.class.read.is_some()
+            let class_access =
+                member.implementation_access(db, ty, ProtocolMemberAccessMode::Class);
+            let class_read_missing = class_access.read.is_some()
                 && !(member.is_instance_method() && member.name == "__call__")
                 && protocol_member_read_type(
                     db,
@@ -2554,16 +2815,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 ty,
                 ty,
                 member,
-                capabilities.instance,
+                instance_access,
                 ProtocolMemberAccessMode::Instance,
             )
             .and(db, self.constraints, || {
+                let class_access =
+                    member.implementation_access(db, ty, ProtocolMemberAccessMode::Class);
                 self.type_satisfies_protocol_member_access(
                     db,
                     ty,
                     ty.to_meta_type(db),
                     member,
-                    capabilities.class,
+                    class_access,
                     ProtocolMemberAccessMode::Class,
                 )
             });
@@ -2594,7 +2857,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             .interface(db)
             .members(db)
             .when_all(db, self.constraints, |member| {
-                let required = member.capabilities(db).class;
+                let required = member.access(db, ProtocolMemberAccessMode::Class);
                 if required.read.is_none() && required.write.is_none() {
                     return self.always();
                 }
@@ -2647,8 +2910,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_member: &ProtocolMember<'_, 'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
-        let source_capabilities = source_member.capabilities(db);
-        let target_capabilities = target_member.capabilities(db);
+        let source = source_member.access(db, access);
 
         if access == ProtocolMemberAccessMode::Class
             && source_member.is_method()
@@ -2656,20 +2918,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         {
             // The instance-side check is authoritative for an ordinary method's signature. Class
             // access only establishes that the source member is also present on the class.
-            return ConstraintSet::from_bool(
-                self.constraints,
-                source_capabilities.class.read.is_some(),
-            );
+            return ConstraintSet::from_bool(self.constraints, source.read.is_some());
         }
-
-        let (source, target) = match access {
-            ProtocolMemberAccessMode::Instance => {
-                (source_capabilities.instance, target_capabilities.instance)
-            }
-            ProtocolMemberAccessMode::Class => {
-                (source_capabilities.class, target_capabilities.class)
-            }
-        };
+        let target = target_member.access(db, access);
 
         let read_result = match (source.read, target.read) {
             (_, None) => self.always(),
@@ -2741,8 +2992,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         &self,
         db: &'db dyn Db,
         source_type: Type<'db>,
-        source: ProtocolInterface<'db>,
-        target: ProtocolInterface<'db>,
+        source: ProtocolInterfaceView<'db>,
+        target: ProtocolInterfaceView<'db>,
     ) -> ConstraintSet<'db, 'c> {
         if source.member_count(db) < target.member_count(db)
             && !self.is_context_collection_enabled()
@@ -2807,7 +3058,11 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         member: &ProtocolMember<'_, 'db>,
         ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        if member.capabilities(db).instance.write.is_none() {
+        if member
+            .access(db, ProtocolMemberAccessMode::Instance)
+            .write
+            .is_none()
+        {
             return self.never();
         }
 
@@ -2838,21 +3093,17 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         if member.is_property() && matches!(ty, Type::PropertyInstance(_)) {
             return self.never();
         }
-        let capabilities = member.capabilities(db);
+        let access = member.access(db, ProtocolMemberAccessMode::Instance);
         if !member.is_method() {
-            capabilities
-                .instance
-                .read
-                .when_some_and(db, self.constraints, |read_ty| {
-                    read_ty
-                        .resolve(db)
-                        .when_some_and(db, self.constraints, |read_ty| {
-                            self.check_type_pair(db, ty, read_ty.ty())
-                        })
-                })
+            access.read.when_some_and(db, self.constraints, |read_ty| {
+                read_ty
+                    .resolve(db)
+                    .when_some_and(db, self.constraints, |read_ty| {
+                        self.check_type_pair(db, ty, read_ty.ty())
+                    })
+            })
         } else {
-            let Some(Type::Callable(method)) = capabilities
-                .instance
+            let Some(Type::Callable(method)) = access
                 .read
                 .and_then(|read| read.resolve(db))
                 .map(ProtocolMemberType::ty)

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -951,7 +951,7 @@ impl<'db> IntersectionType<'db> {
         if !self.iter_positive(db).any(|positive| {
             matches!(
                 positive,
-                Type::ProtocolInstance(protocol) if protocol.class_origin().is_some()
+                Type::ProtocolInstance(protocol) if protocol.class_origin(db).is_some()
             )
         }) {
             return None;

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -246,7 +246,7 @@ impl<'db> SubclassOfType<'db> {
         let class_like = match self.subclass_of.with_transposed_type_var(db) {
             SubclassOfInner::Class(class) => Type::from(class),
             SubclassOfInner::Dynamic(dynamic) => Type::Dynamic(dynamic),
-            SubclassOfInner::Protocol(protocol) => Type::from(*protocol.class_origin()?),
+            SubclassOfInner::Protocol(protocol) => Type::from(*protocol.class_origin(db)?),
             SubclassOfInner::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => unreachable!(),

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -444,7 +444,7 @@ pub(super) fn non_any_dynamic_content<'db>(db: &'db dyn Db, ty: Type<'db>) -> Dy
             protocol: ProtocolInstanceType<'db>,
         ) {
             let protocol_ty = Type::ProtocolInstance(protocol);
-            let Some(class) = protocol.as_class_based() else {
+            let Some(class) = protocol.as_class_based(db) else {
                 walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
                 return;
             };

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -444,7 +444,7 @@ pub(super) fn non_any_dynamic_content<'db>(db: &'db dyn Db, ty: Type<'db>) -> Dy
             protocol: ProtocolInstanceType<'db>,
         ) {
             let protocol_ty = Type::ProtocolInstance(protocol);
-            let Some(class) = protocol.as_class_based(db) else {
+            let Some(class) = protocol.class_origin(db) else {
                 walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
                 return;
             };


### PR DESCRIPTION
## Summary

Support materialization of class-based protocols via lazy materialization of attribute types.

- Represent a materialized protocol as its original protocol class plus its `Top` or `Bottom` polarity, materializing individual read and write requirements only when they are observed.
- Preserve recursive protocols, nominal inheritance, descriptors, properties, class variables, and class-object member access without eagerly rebuilding protocol interfaces.
- Propagate materialized member requirements through structural relations, generic inference, bounds, constraints, invariance, and overload resolution.
- Infer constructors using the materialized receiver while preserving explicit `__new__` return types, custom metaclass returns, and mixed `Self`/non-instance overloads.
- Fix `dataclasses.is_dataclass` narrowing.

## Test plan

- Add mdtests for top and bottom reads and writes, properties, descriptors, class variables, class-object access, and nominal versus structural protocol relationships.
- Cover recursive protocols, recursive structural inference, inherited and structural generic inference, bounds, constraints, invariant arguments, overload selection, generic aliases, `Self`, legacy type variables, and generator delegation.
- Cover constructors that return protocol instances, non-instance values, custom metaclass values, and mixed overloaded return types.
- Verify `dataclasses.is_dataclass` narrows an impossible branch to `Never`.

### Ecosystem

All added/removed diagnostics are favorable. Some diagnostics change to reflect top-materialized protocols explicitly.

Fixes astral-sh/ty#3443.

Co-authored-by: Charlie Marsh <charlie.r.marsh@gmail.com>