### PR TITLE
[ty] Cache protocol receiver binding

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3771,6 +3771,34 @@ static_assert(is_subtype_of(Text, ConsoleRenderable))
 static_assert(is_assignable_to(Text, ConsoleRenderable))
 ```
 
+## Recursive protocol receiver binding
+
+A classmethod on a generic protocol can cause receiver binding for another method to depend on
+itself. The cached receiver-binding query must reach a fixed point and report the ordinary
+return-type error instead of panicking.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from __future__ import annotations
+
+from datetime import datetime, timedelta, tzinfo
+from typing import ClassVar, Optional, Protocol, TypeVar
+
+T = TypeVar("T", bound=Optional[tzinfo], covariant=True)
+
+class DateTime(Protocol[T]):
+    resolution: ClassVar[timedelta]
+
+    def __sub__(self: DateTime[tzinfo], other: DateTime[tzinfo]) -> timedelta: ...
+    @classmethod
+    def now(cls, tz: Optional[tzinfo] = None) -> DateTime[Optional[tzinfo]]:
+        return datetime.now(tz)  # error: [invalid-return-type]
+```
+
 ## Subtyping of protocols with generic method members
 
 Protocol method members can be generic. They can have generic contexts scoped to the class:

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -3095,7 +3095,11 @@ fn protocol_bind_self<'db>(
 }
 
 /// Cache receiver and `Self` binding only for protocol-member compatibility checks.
-#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial=|db, _, _, _, _| CallableType::bottom(db),
+    heap_size=ruff_memory_usage::heap_size
+)]
 fn protocol_apply_self_with_receiver<'db>(
     db: &'db dyn Db,
     callable: CallableType<'db>,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2355,14 +2355,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     self.check_callables_vs_callable(
                         db,
                         &callables.map(|callable| {
-                            callable.apply_self_with_receiver(
+                            protocol_apply_self_with_receiver(
                                 db,
+                                callable,
                                 implementation_receiver_binding_ty,
                                 implementation_self_binding_ty,
                             )
                         }),
-                        required_callable.apply_self_with_receiver(
+                        protocol_apply_self_with_receiver(
                             db,
+                            required_callable,
                             protocol_receiver_binding_ty,
                             protocol_self_binding_ty,
                         ),
@@ -2404,8 +2406,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             self.check_type_pair(
                 db,
                 attribute_type,
-                Type::Callable(required_callable.apply_self_with_receiver(
+                Type::Callable(protocol_apply_self_with_receiver(
                     db,
+                    required_callable,
                     protocol_receiver_binding_ty,
                     protocol_self_binding_ty,
                 )),
@@ -2678,7 +2681,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     if member.is_method()
                         && let Type::Callable(callable) = member_type.ty()
                     {
-                        Some(Type::Callable(callable.apply_self(db, source_type)))
+                        Some(Type::Callable(protocol_apply_self_with_receiver(
+                            db,
+                            callable,
+                            source_type,
+                            source_type,
+                        )))
                     } else {
                         member_type.bind_self(db, source_type)
                     }
@@ -3084,6 +3092,21 @@ fn protocol_bind_self<'db>(
     self_type: Option<Type<'db>>,
 ) -> CallableType<'db> {
     callable.bind_self(db, self_type).into_regular(db)
+}
+
+/// Cache receiver and `Self` binding only for protocol-member compatibility checks.
+#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+fn protocol_apply_self_with_receiver<'db>(
+    db: &'db dyn Db,
+    callable: CallableType<'db>,
+    receiver_type: Type<'db>,
+    self_type: Type<'db>,
+) -> CallableType<'db> {
+    if receiver_type == self_type {
+        callable.apply_self(db, self_type)
+    } else {
+        callable.apply_self_with_receiver(db, receiver_type, self_type)
+    }
 }
 
 /// Return `true` if a callable has at least one overload and none return `Never`.


### PR DESCRIPTION
## Summary

Protocol-member compatibility repeatedly specializes the same callable for the same runtime receiver and typing `Self`, rebuilding signatures and constraint sets on each structural comparison.

- Add a private Salsa-tracked protocol receiver-binding cache keyed by the callable, receiver type, and `Self` type.
- Route all four existing protocol compatibility binding sites through the cache, including protocol-to-protocol member comparisons.
- Preserve distinct receiver and `Self` bindings and reuse `apply_self` when they are identical.

This is independently useful on `main` and becomes even more relevant with #27267.

## Performance

DateType on clean `main` and this PR, with 40 samples per version:

| Version | Estimate | 95% confidence interval |
| --- | ---: | ---: |
| Baseline | 38.701 ms | 38.336–39.125 ms |
| Protocol receiver cache with fixed-point recovery | 33.887 ms | 33.742–34.033 ms |

The change is **12.4% faster**, with non-overlapping confidence intervals.

## Test plan

- Add a minimized mdtest for a generic protocol whose receiver-specific method and classmethod produce a recursive receiver-binding query; verify that the expected return-type diagnostic is reported instead of a Salsa panic.
- Reproduce the exact ecosystem-analyzer configuration for DateType, scipy-stubs, and trio, and verify that all three projects produce byte-for-byte identical diagnostics to `main`.
