### PR TITLE
[`ruff`] reintroduce `demisto/content` to `ruff-ecosystem`

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -35,15 +35,13 @@ DEFAULT_TARGETS = [
         repo=Repository(owner="bokeh", name="bokeh", ref="branch-3.10"),
         check_options=CheckOptions(select="ALL"),
     ),
-    # Disabled due to use of explicit `select` with `E999`, which has been removed.
-    # See: https://github.com/astral-sh/ruff/pull/12129
-    # Project(
-    #     repo=Repository(owner="demisto", name="content", ref="master"),
-    #     format_options=FormatOptions(
-    #         # Syntax errors in this file
-    #         exclude="Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py"
-    #     ),
-    # ),
+    Project(
+        repo=Repository(owner="demisto", name="content", ref="master"),
+        format_options=FormatOptions(
+            # Syntax errors in this file
+            exclude="Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py"
+        ),
+    ),
     Project(repo=Repository(owner="docker", name="docker-py", ref="main")),
     Project(repo=Repository(owner="facebookresearch", name="chameleon", ref="main")),
     Project(repo=Repository(owner="freedomofpress", name="securedrop", ref="develop")),

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -35,13 +35,7 @@ DEFAULT_TARGETS = [
         repo=Repository(owner="bokeh", name="bokeh", ref="branch-3.10"),
         check_options=CheckOptions(select="ALL"),
     ),
-    Project(
-        repo=Repository(owner="demisto", name="content", ref="master"),
-        format_options=FormatOptions(
-            # Syntax errors in this file
-            exclude="Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py"
-        ),
-    ),
+    Project(repo=Repository(owner="demisto", name="content", ref="master")),
     Project(repo=Repository(owner="docker", name="docker-py", ref="main")),
     Project(repo=Repository(owner="facebookresearch", name="chameleon", ref="main")),
     Project(repo=Repository(owner="freedomofpress", name="securedrop", ref="develop")),


### PR DESCRIPTION
## Summary

Reintroducing `demisto/content` back to `ruff-ecosystem`, it's a huge repo with 4.5K py file and 2.5M loc, so may have catch some cases for ecosystem report. It was previously commented out in https://github.com/astral-sh/ruff/pull/12129 due to the use of removed `E999`

Issue with the use of removed rules upstream is resolved, though apparently `E999` was dropped from selection a while ago and new issue with the use of removed `UP038` occurred, but it's resolved now too - https://github.com/demisto/content/pull/45227

Syntax error in  still present in https://github.com/demisto/content/blob/master/Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py, so keeping `exclude`. Though apparently it doesn't break `ruff-ecosystem` anymore, but keeping it safe for now. I've submitted a fix upstream https://github.com/demisto/content/pull/45275, so `exclude` can be removed later too.


## Test Plan

Tested running `ruff-ecosystem` locally, no issues found.
