### PR TITLE
[ty] Skip type variable inference for empty contexts

### DIFF
--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -384,6 +384,10 @@ impl<'db> GenericContext<'db> {
     /// also includes `A@C`. This is needed because at each call site, we need to infer the
     /// specialized class instance type whose method is being invoked.
     pub(crate) fn inferable_typevars(self, db: &'db dyn Db) -> TypeVarSet<'db> {
+        if self.variables_inner(db).is_empty() {
+            return TypeVarSet::None;
+        }
+
         #[derive(Default)]
         struct CollectTypeVars<'db> {
             typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,


### PR DESCRIPTION
## Summary

Avoid the cached type-variable inference query when a generic context has no variables.
Real-world A/B benchmarks showed no reliable end-to-end speedup, so keep this as a draft for discussion.

## Test Plan

Testing: The semantic suite and repository hooks pass; real-world benchmarks preserve identical diagnostics.