### PR TITLE
[ty] Preserve exact numeric types in covariant collections

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -137,6 +137,95 @@ reveal_type(s)  # revealed: dict[int | str, int | str]
 reveal_type(s)  # revealed: dict[int | str, int | str]
 ```
 
+### Exact float types in covariant contexts
+
+A covariant collection context must preserve an exact float when numeric promotion would introduce
+an `int` that the expected element type rejects.
+
+```py
+from collections.abc import Iterable, Sequence
+from ty_extensions import JustFloat
+
+def takes_exact_sequence(values: Sequence[JustFloat]) -> None: ...
+def takes_exact_iterable(values: Iterable[JustFloat]) -> None: ...
+def takes_exact_list(values: list[JustFloat]) -> None: ...
+
+takes_exact_sequence([1.0])
+takes_exact_sequence((1.0,))
+takes_exact_sequence([1])  # error: [invalid-argument-type]
+
+takes_exact_iterable([1.0])
+takes_exact_iterable((1.0,))
+takes_exact_iterable([1])  # error: [invalid-argument-type]
+
+takes_exact_list([1.0])
+
+annotated: list[JustFloat] = [1.0]
+takes_exact_sequence(annotated)
+```
+
+Ordinary `float` contexts and unannotated mutable lists must retain numeric promotion.
+
+```py
+def takes_float_sequence(values: Sequence[float]) -> None: ...
+
+takes_float_sequence([1.0])
+takes_float_sequence([1])
+
+mutable_floats = [1.0]
+mutable_floats.append(1)
+reveal_type(mutable_floats)  # revealed: list[int | float]
+```
+
+### Exact complex types in covariant contexts
+
+The same contextual restriction applies when promoting an exact complex number would introduce `int`
+and `float`.
+
+```py
+from collections.abc import Sequence
+from ty_extensions import JustComplex
+
+def takes_exact_complexes(values: Sequence[JustComplex]) -> None: ...
+
+takes_exact_complexes([1j])
+takes_exact_complexes((1j,))
+takes_exact_complexes([1])  # error: [invalid-argument-type]
+takes_exact_complexes([1.0])  # error: [invalid-argument-type]
+```
+
+### Exact-type protocols in covariant contexts
+
+A writable `__class__` property allows an invariant protocol to distinguish a runtime float from an
+integer. A covariant sequence of a union containing this protocol must preserve that distinction.
+
+```py
+from collections.abc import Sequence
+from typing import Generic, Protocol, TypeVar
+
+T = TypeVar("T")
+
+class Just(Protocol, Generic[T]):
+    @property
+    def __class__(self, /) -> type[T]: ...
+    @__class__.setter
+    def __class__(self, value: type[T], /) -> None: ...
+
+def takes_exact_float(value: Just[float]) -> None: ...
+def takes_exact_values(values: Sequence[str | Just[float]]) -> None: ...
+
+takes_exact_float(1.0)
+takes_exact_float(1)  # error: [invalid-argument-type]
+
+takes_exact_values(["1", 1.0])
+takes_exact_values(["1", float("nan")])
+takes_exact_values(("1", 1.0))
+takes_exact_values(["1", 1])  # error: [invalid-argument-type]
+
+annotated: list[str | Just[float]] = ["1", 1.0]
+takes_exact_values(annotated)
+```
+
 ### Optional unions
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7380,9 +7380,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 }
 
-                // We promote element literal types in invariant position by default, unless they were
-                // inferred with an explicit literal annotation.
-                let inferred_elt_ty = inferred_elt_ty.promote(self.db());
+                // A covariant context is an upper bound, so promotion must not widen an otherwise
+                // compatible element beyond that bound. In particular, promoting an exact float
+                // introduces `int`, which is not assignable to an exact-float context.
+                let promoted_elt_ty = inferred_elt_ty.promote(self.db());
+                let inferred_elt_ty = if let Some(elt_tcx) = elt_tcx
+                    && elt_tcx_variance[&elt_ty_identity].is_covariant()
+                    && promoted_elt_ty != inferred_elt_ty
+                    && !promoted_elt_ty.is_assignable_to(self.db(), elt_tcx)
+                    && inferred_elt_ty.is_assignable_to(self.db(), elt_tcx)
+                {
+                    inferred_elt_ty
+                } else {
+                    promoted_elt_ty
+                };
 
                 let inferred_type_for_typevar = if elt.is_starred_expr() {
                     inferred_elt_ty


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4111.

Collection inference promotes exact runtime `float` and `complex` elements to their numeric-tower unions, which can introduce types that violate a covariant `Sequence` or `Iterable` context. Preserve the original inferred element when it satisfies that context but the promoted type does not.

This fixes the original `Sequence[str | Just[float]]` false positive without changing `Just` protocol matching, invariant collection inference, or ordinary mutable-list numeric widening.

## Test plan

Added focused bidirectional mdtests covering exact-float `Sequence` and `Iterable` contexts, exact-complex sequence contexts, the original `Just[float]` union, tuples, invariant and explicitly annotated lists, rejection of actual integer and float mismatches, and preserved widening for mutable float lists.

The full `ty_python_semantic` test suite and all applicable file-scoped repository hooks pass.