### PR TITLE
Fix Ruff 0.16 diagnostics in ty_benchmark

### DIFF
--- a/scripts/ty_benchmark/src/benchmark/__init__.py
+++ b/scripts/ty_benchmark/src/benchmark/__init__.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import logging
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Mapping, NamedTuple
+from typing import NamedTuple
 
 if sys.platform == "win32":
     import mslex as shlex
 else:
     import shlex
+
+
+logger = logging.getLogger(__name__)
 
 
 class Command(NamedTuple):
@@ -76,6 +80,6 @@ class Hyperfine(NamedTuple):
         for command in self.commands:
             args.append(shlex.join(command.command))
 
-        logging.info(f"Running {args}")
+        logger.info(f"Running {args}")
 
-        subprocess.run(args, cwd=cwd, env=env)
+        subprocess.run(args, cwd=cwd, env=env, check=True)

--- a/scripts/ty_benchmark/src/benchmark/lsp_client.py
+++ b/scripts/ty_benchmark/src/benchmark/lsp_client.py
@@ -9,6 +9,8 @@ from typing import Any, NamedTuple, override
 from lsprotocol import types as lsp
 from pygls.lsp.client import LanguageClient
 
+logger = logging.getLogger(__name__)
+
 
 def _register_notebook_structure_hooks(converter):
     """Register structure hooks for notebook document types to work around cattrs deserialization issues."""
@@ -64,7 +66,7 @@ class LSPClient(LanguageClient):
         def publish_diagnostics(
             client: LSPClient, params: lsp.PublishDiagnosticsParams
         ):
-            logging.info(
+            logger.info(
                 f"Received publish_diagnostics for {params.uri} with version={params.version}, diagnostics count={len(params.diagnostics)}"
             )
             future = self.diagnostics.get(params.uri, None)
@@ -78,11 +80,11 @@ class LSPClient(LanguageClient):
         @self.feature(lsp.WINDOW_LOG_MESSAGE)
         def log_message(client: LSPClient, params: lsp.LogMessageParams):
             if params.type == lsp.MessageType.Error:
-                logging.error(f"server error: {params.message}")
+                logger.error(f"server error: {params.message}")
             elif params.type == lsp.MessageType.Warning:
-                logging.warning(f"server warning: {params.message}")
+                logger.warning(f"server warning: {params.message}")
             else:
-                logging.info(f"server info: {params.message}")
+                logger.info(f"server info: {params.message}")
 
     @override
     async def initialize_async(
@@ -92,9 +94,7 @@ class LSPClient(LanguageClient):
 
         self.server_capabilities = result.capabilities
 
-        logging.info(
-            f"Pull diagnostic support: {self.server_supports_pull_diagnostics}"
-        )
+        logger.info(f"Pull diagnostic support: {self.server_supports_pull_diagnostics}")
 
         return result
 
@@ -154,9 +154,9 @@ class LSPClient(LanguageClient):
             self.diagnostics[path.as_uri()] = future
 
         try:
-            logging.info(f"Waiting for push diagnostics for {path}")
+            logger.info(f"Waiting for push diagnostics for {path}")
             result = await asyncio.wait_for(future, timeout)
-            logging.info(f"Awaited push diagnostics for {path}")
+            logger.info(f"Awaited push diagnostics for {path}")
         finally:
             self.diagnostics.pop(path.as_uri())
 

--- a/scripts/ty_benchmark/src/benchmark/projects.py
+++ b/scripts/ty_benchmark/src/benchmark/projects.py
@@ -1,8 +1,11 @@
 import logging
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Final, Literal, NamedTuple
+
+logger = logging.getLogger(__name__)
 
 
 class Project(NamedTuple):
@@ -26,10 +29,10 @@ class Project(NamedTuple):
     skip: str | None = None
     """The project is skipped from benchmarking if not `None`."""
 
-    include: list[str] = []
+    include: Sequence[str] = ()
     """The directories and files to check. If empty, checks the current directory"""
 
-    exclude: list[str] = []
+    exclude: Sequence[str] = ()
     """The directories and files to exclude from checks."""
 
     edit: IncrementalEdit | None = None
@@ -39,7 +42,7 @@ class Project(NamedTuple):
         if (checkout_dir / ".git").exists():
             return
 
-        logging.debug(f"Cloning {self.repository} to {checkout_dir}")
+        logger.debug(f"Cloning {self.repository} to {checkout_dir}")
 
         try:
             # git doesn't support cloning a specific revision.
@@ -94,7 +97,7 @@ class Project(NamedTuple):
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Failed to clone {self.name}:\n\n{e.stderr}") from e
 
-        logging.info(f"Cloned {self.name} to {checkout_dir}.")
+        logger.info(f"Cloned {self.name} to {checkout_dir}.")
 
 
 class IncrementalEdit(NamedTuple):

--- a/scripts/ty_benchmark/src/benchmark/run.py
+++ b/scripts/ty_benchmark/src/benchmark/run.py
@@ -87,7 +87,7 @@ def main() -> None:
 
     args = parser.parse_args()
     logging.basicConfig(
-        level=logging.INFO if args.verbose else logging.WARN,
+        level=logging.INFO if args.verbose else logging.WARNING,
         format="%(asctime)s %(levelname)s %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
@@ -165,15 +165,15 @@ def main() -> None:
                 continue
 
             if not first:
-                print("")
+                print()
                 print(
                     "-------------------------------------------------------------------------------"
                 )
-                print("")
+                print()
 
             print(f"{project.name}")
             print("-" * len(project.name))
-            print("")
+            print()
 
             if args.snapshot:
                 # Get the directory where run.py is located to find snapshots directory.

--- a/scripts/ty_benchmark/src/benchmark/snapshot.py
+++ b/scripts/ty_benchmark/src/benchmark/snapshot.py
@@ -4,10 +4,13 @@ import difflib
 import logging
 import re
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Mapping, NamedTuple
+from typing import NamedTuple
 
 from benchmark import Command
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_output(output: str, cwd: Path) -> str:
@@ -66,7 +69,7 @@ class SnapshotRunner(NamedTuple):
 
             # Run the prepare command if provided.
             if command.prepare:
-                logging.info(f"Running prepare: {command.prepare}")
+                logger.info(f"Running prepare: {command.prepare}")
                 subprocess.run(
                     command.prepare,
                     cwd=cwd,
@@ -76,13 +79,14 @@ class SnapshotRunner(NamedTuple):
                 )
 
             # Run the actual command and capture output.
-            logging.info(f"Running {command.command}")
+            logger.info(f"Running {command.command}")
             result = subprocess.run(
                 command.command,
                 cwd=cwd,
                 env=env,
                 capture_output=True,
                 text=True,
+                check=False,
             )
 
             # Get the actual output and combine stdout and stderr for the snapshot.

--- a/scripts/ty_benchmark/src/benchmark/test_lsp_diagnostics.py
+++ b/scripts/ty_benchmark/src/benchmark/test_lsp_diagnostics.py
@@ -40,7 +40,7 @@ SEVERITY_LABELS: Final = {
 @pytest.fixture(scope="module", params=ALL_PROJECTS, ids=lambda p: p.name)
 def project_setup(
     request,
-) -> Generator[tuple[Project, Venv], None, None]:
+) -> Generator[tuple[Project, Venv]]:
     """Set up a project and its venv once per module (shared across all tests for this project)."""
     project: Project = request.param
 
@@ -187,7 +187,7 @@ class LspTest(ABC):
     def absolute_file_path(self, file_path: str) -> Path:
         return self.cwd / file_path
 
-    def files_to_check(self) -> Generator[Path, None, None]:
+    def files_to_check(self) -> Generator[Path]:
         yield self.edited_file_path
 
         for file in self.edit.affected_files:

--- a/scripts/ty_benchmark/src/benchmark/venv.py
+++ b/scripts/ty_benchmark/src/benchmark/venv.py
@@ -6,6 +6,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class Venv:
@@ -63,7 +65,7 @@ class Venv:
     ) -> None:
         """Installs the dependencies required to type check the project."""
 
-        logging.debug(f"Installing dependencies: {', '.join(pip_install_args)}")
+        logger.debug(f"Installing dependencies: {', '.join(pip_install_args)}")
         mypy_overrides = Path(__file__).with_name("mypy-overrides.txt")
 
         command = [


### PR DESCRIPTION
Summary
--

Stacked on #27293 to fix CI. I thought it might be worth reviewing separately instead of pushing directly to the renovate branch. Most of the changes are for [root-logger-call (LOG015)](https://docs.astral.sh/ruff/rules/root-logger-call/#root-logger-call-log015). I'll flag one change inline.

Other changes:

```console
$ uvx ruff@0.16.0 check scripts/ty_benchmark/ --statistics
13	LOG015 	[ ] root-logger-call
 3	FURB105	[*] print-empty-string
 2	PLW1510	[ ] subprocess-run-without-check
 2	RUF012 	[ ] mutable-class-default
 2	UP035  	[*] deprecated-import
 2	UP043  	[*] unnecessary-default-type-args
 1	LOG009 	[*] undocumented-warn
Found 25 errors.
[*] 8 fixable with the `--fix` option.
```

Test Plan
--

CI on this PR