### PR TITLE
PLW1508: allow integer defaults immediately wrapped by int

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/invalid_envvar_default.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/invalid_envvar_default.py
@@ -1,6 +1,7 @@
 import os
 
 tempVar = os.getenv("TEST", 12)  # [invalid-envvar-default]
+int(os.getenv("TEST", 1))
 goodVar = os.getenv("TESTING", None)
 dictVarBad = os.getenv("AAA", {"a", 7})  # [invalid-envvar-default]
 print(os.getenv("TEST", False))  # [invalid-envvar-default]

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -63,6 +63,7 @@ fn is_integer_default_wrapped_in_int(checker: &Checker, call: &ast::ExprCall, de
         && parent.arguments.keywords.is_empty()
         && parent.arguments.args[0].range() == call.range()
 }
+
 /// PLW1508
 pub(crate) fn invalid_envvar_default(checker: &Checker, call: &ast::ExprCall) {
     if !checker.semantic().seen_module(Modules::OS) {

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -23,7 +23,7 @@ use crate::checkers::ast::Checker;
 /// ```python
 /// import os
 ///
-/// int(os.getenv("FOO", 1))
+/// os.getenv("FOO", 1)
 /// ```
 ///
 /// Use instead:

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -43,6 +43,26 @@ impl Violation for InvalidEnvvarDefault {
     }
 }
 
+fn is_integer_default_wrapped_in_int(checker: &Checker, call: &ast::ExprCall, default: &ast::Expr) -> bool {
+    if !matches!(
+        default,
+        ast::Expr::NumberLiteral(ast::ExprNumberLiteral {
+            value: ast::Number::Int(_),
+            ..
+        })
+    ) {
+        return false;
+    }
+
+    let Some(ast::Expr::Call(parent)) = checker.semantic().current_expression_parent() else {
+        return false;
+    };
+
+    checker.semantic().match_builtin_expr(&parent.func, "int")
+        && parent.arguments.args.len() == 1
+        && parent.arguments.keywords.is_empty()
+        && parent.arguments.args[0].range() == call.range()
+}
 /// PLW1508
 pub(crate) fn invalid_envvar_default(checker: &Checker, call: &ast::ExprCall) {
     if !checker.semantic().seen_module(Modules::OS) {

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -91,6 +91,10 @@ pub(crate) fn invalid_envvar_default(checker: &Checker, call: &ast::ExprCall) {
         ) {
             return;
         }
+        if is_integer_default_wrapped_in_int(checker, call, expr) {
+            return;
+        }
+
         checker.report_diagnostic(InvalidEnvvarDefault, expr.range());
     }
 }


### PR DESCRIPTION
This keeps PLW1508 focused on genuinely inconsistent return types. An integer default is allowed when the `os.getenv` call is the single argument to the builtin `int`, and the rule example now shows the unwrapped form. A fixture input covers the exempt case.

Fixes #27039