### PR TITLE
[ty] Fix enum class container assignability

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -1995,6 +1995,49 @@ reveal_type(Answer.name)  # revealed: Literal[Answer.name]
 reveal_type(Answer.value)  # revealed: Literal[Answer.value]
 ```
 
+## Enum classes as collection protocols
+
+An enum class is a container because `EnumMeta.__contains__` accepts any object. Consequently, the
+class satisfies `Container[T]` for every `T`, including types unrelated to its members. Its
+metaclass also provides the iteration, reversal, and length methods required by the corresponding
+collection protocols.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Collection, Container, Iterable, Reversible
+from enum import Enum, IntEnum, StrEnum, auto
+from typing import Any
+
+class Color(Enum):
+    RED = auto()
+
+unparameterized_container: Container = Color
+any_container: Container[Any] = Color
+object_container: Container[object] = Color
+member_container: Container[Color] = Color
+integer_container: Container[int] = Color
+string_container: Container[str] = Color
+iterable: Iterable[Color] = Color
+reversible: Reversible[Color] = Color
+collection: Collection[Color] = Color
+
+class Number(IntEnum):
+    ONE = 1
+
+integer_enum_container: Container[int] = Number
+integer_enum_iterable: Iterable[int] = Number
+
+class Word(StrEnum):
+    HELLO = "hello"
+
+string_enum_container: Container[str] = Word
+string_enum_iterable: Iterable[str] = Word
+```
+
 ## Iterating over enum members
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4291,6 +4291,75 @@ class Custom:
 static_assert(is_assignable_to(TypeOf[Custom], CustomProtocol))
 ```
 
+## Class objects with explicitly typed special-method receivers
+
+A special method defined on a metaclass receives the class object, not an instance of that class. An
+explicitly annotated metaclass receiver must therefore be checked against the class object when
+matching a collection protocol. Special-method lookup must also ignore conflicting methods defined
+on the class itself.
+
+```py
+from collections.abc import Collection, Container, Iterable, Iterator, Reversible
+from typing import Any, Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_assignable_to, is_subtype_of
+
+class Membership(Protocol):
+    def __contains__(self, value: int, /) -> bool: ...
+
+class CollectionMeta(type):
+    def __contains__(self: type[Any], value: object, /) -> bool:
+        return True
+
+    def __iter__(self: type[Any]) -> Iterator[int]:
+        return iter((1,))
+
+    def __reversed__(self: type[Any]) -> Iterator[int]:
+        return iter((1,))
+
+    def __len__(self: type[Any]) -> int:
+        return 1
+
+class ClassCollection(metaclass=CollectionMeta):
+    def __contains__(self, value: str, /) -> bool:
+        return True
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(("member",))
+
+    def __reversed__(self) -> Iterator[str]:
+        return iter(("member",))
+
+static_assert(is_assignable_to(TypeOf[ClassCollection], Membership))
+static_assert(is_assignable_to(TypeOf[ClassCollection], Container[int]))
+static_assert(is_assignable_to(TypeOf[ClassCollection], Container[str]))
+static_assert(is_subtype_of(TypeOf[ClassCollection], Container[int]))
+static_assert(is_assignable_to(TypeOf[ClassCollection], Iterable[int]))
+static_assert(is_assignable_to(TypeOf[ClassCollection], Reversible[int]))
+static_assert(is_assignable_to(TypeOf[ClassCollection], Collection[int]))
+```
+
+The explicit receiver must not hide an incompatible membership parameter or return type.
+
+```py
+class StringMembershipMeta(type):
+    def __contains__(self: type[Any], value: str, /) -> bool:
+        return True
+
+class StringMembership(metaclass=StringMembershipMeta):
+    pass
+
+class NonBooleanMembershipMeta(type):
+    def __contains__(self: type[Any], value: object, /) -> int:
+        return 1
+
+class NonBooleanMembership(metaclass=NonBooleanMembershipMeta):
+    pass
+
+static_assert(not is_assignable_to(TypeOf[StringMembership], Container[int]))
+static_assert(not is_assignable_to(TypeOf[NonBooleanMembership], Container[int]))
+```
+
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members
 
 The typing spec states that protocols may have `@classmethod` or `@staticmethod` method members.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2259,7 +2259,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         .unwrap_or_else(|| {
                             ConstraintSet::from_bool(
                                 self.constraints,
-                                self.is_eager_assignability(),
+                                self.relation.is_assignability(),
                             )
                         }),
                 }
@@ -2300,7 +2300,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         .unwrap_or_else(|| {
                             ConstraintSet::from_bool(
                                 self.constraints,
-                                self.is_eager_assignability(),
+                                self.relation.is_assignability(),
                             )
                         }),
                 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/4114.

Enum classes were incorrectly rejected as `Container[T]` even though `EnumMeta.__contains__` accepts `object`. The underlying issue was that concrete class objects and generic aliases were considered assignable to `type[Any]` during eager relation checks, but not while lazily solving explicitly annotated metaclass-receiver constraints. This produced an unsatisfiable hidden constraint on an otherwise correctly bound `__contains__` method.

Make class literals and generic aliases consistently assignable to gradual `type[...]` targets in both eager and lazy assignability checks, while preserving stricter subtyping and incompatible protocol signatures.

## Test plan

- Added enum mdtests covering `Enum`, `IntEnum`, and `StrEnum`, including unparameterized containers, `Container[Any]`, `Container[object]`, enum-member and unrelated-element container types, and iterable, reversible, and collection protocols.
- Added protocol mdtests covering explicitly typed metaclass receivers, conflicting class-level special methods, structural membership protocols, and rejection of incompatible membership parameters and return types.
- Verified the original issue reproducer on Python 3.11 through 3.14.