### PR TITLE
[ty] Separate place-load resolution from type inference.

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/attribute.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/attribute.md
@@ -47,3 +47,86 @@ def f() -> None:
     box = StrBox()
     reveal_type(box.attr)  # revealed: str
 ```
+
+## Local prefixes block enclosing whole-place bindings
+
+When a nested function binds the root name of a whole-place access, the local root binding takes
+precedence over the root binding from the enclosing scope.
+
+```py
+class IntBox:
+    attr: int
+
+class StrBox:
+    attr: str
+
+box = IntBox()
+
+def outer_root() -> None:
+    box.attr = 1
+
+    def inner() -> None:
+        box = StrBox()
+        reveal_type(box.attr)  # revealed: str
+```
+
+Similarly, a nested rebinding of an intermediate member, rather than the root, takes precedence over
+the enclosing binding of that same intermediate member.
+
+```py
+class Holder:
+    box: IntBox | StrBox
+
+def outer_member() -> None:
+    holder = Holder()
+    holder.box = IntBox()
+    holder.box.attr = 1
+
+    def inner() -> None:
+        holder.box = StrBox()
+        reveal_type(holder.box.attr)  # revealed: str
+```
+
+Under Python's function name-resolution rules, even a conditional assignment to the root name makes
+the local root take precedence over the enclosing binding. When the condition is false, the unbound
+local root cannot fall back to the binding in the enclosing scope.
+
+```py
+def with_inner_conditional_root(flag: bool) -> None:
+    box = IntBox()
+    box.attr = 1
+
+    def inner() -> None:
+        if flag:
+            box = StrBox()
+        # error: [possibly-unresolved-reference] "Name `box` used when possibly not defined"
+        reveal_type(box.attr)  # revealed: str
+```
+
+By contrast, binding an intermediate member does not affect resolution of the root, which still
+comes from the enclosing scope. When the intermediate member is conditionally rebound, it can refer
+to either object, so both member types remain visible in the whole-place access.
+
+```py
+def with_inner_conditional_member(flag: bool) -> None:
+    holder = Holder()
+    holder.box = IntBox()
+    holder.box.attr = 1
+
+    def inner() -> None:
+        if flag:
+            holder.box = StrBox()
+        reveal_type(holder.box.attr)  # revealed: int | str
+```
+
+If none of the prefixes are bound in the nested scope, the enclosing whole-place binding remains
+visible.
+
+```py
+def outer_fallback() -> None:
+    box = IntBox()
+    box.attr = 1
+
+    def inner() -> None:
+        reveal_type(box.attr)  # revealed: int
+```

--- a/crates/ty_python_semantic/resources/mdtest/expression/attribute.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/attribute.md
@@ -47,3 +47,53 @@ def f() -> None:
     box = StrBox()
     reveal_type(box.attr)  # revealed: str
 ```
+
+## Local prefixes block enclosing whole-place bindings
+
+An enclosing binding for an entire member access refers to a different object when the nested scope
+binds the root locally. The local object's member type takes precedence.
+
+```py
+class OuterBox:
+    attr: int
+
+class InnerBox:
+    attr: str
+
+def outer_root() -> None:
+    box = OuterBox()
+    box.attr = 1
+
+    def inner() -> None:
+        box = InnerBox()
+        reveal_type(box.attr)  # revealed: str
+```
+
+The same rule applies when an intermediate member, rather than the root, is bound in the nested
+scope.
+
+```py
+class Holder:
+    box: OuterBox | InnerBox
+
+def outer_member() -> None:
+    holder = Holder()
+    holder.box = OuterBox()
+    holder.box.attr = 1
+
+    def inner() -> None:
+        holder.box = InnerBox()
+        reveal_type(holder.box.attr)  # revealed: str
+```
+
+If none of the prefixes are bound in the nested scope, the enclosing whole-place binding remains
+visible.
+
+```py
+def outer_fallback() -> None:
+    box = OuterBox()
+    box.attr = 1
+
+    def inner() -> None:
+        reveal_type(box.attr)  # revealed: int
+```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/builtin.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/builtin.md
@@ -2,8 +2,8 @@
 
 ## Conditional local override of builtin
 
-If a builtin name is conditionally shadowed by a local variable, a name lookup should union the
-builtin type with the conditionally-defined type:
+If a builtin name is conditionally shadowed by a local variable, the function's binding scope
+terminates name resolution. The name can be unbound, but it cannot refer to the builtin:
 
 ```py
 def _(flag: bool) -> None:
@@ -11,8 +11,10 @@ def _(flag: bool) -> None:
         abs = 1
         chr: int = 1
 
-    reveal_type(abs)  # revealed: Literal[1] | (def abs[_T](x: SupportsAbs[_T], /) -> _T)
-    reveal_type(chr)  # revealed: Literal[1] | (def chr(i: SupportsIndex, /) -> str)
+    # error: [possibly-unresolved-reference]
+    reveal_type(abs)  # revealed: Literal[1]
+    # error: [possibly-unresolved-reference]
+    reveal_type(chr)  # revealed: Literal[1]
 ```
 
 ## Conditionally global override of builtin

--- a/crates/ty_python_semantic/resources/mdtest/scopes/class_implicit_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/class_implicit_attrs.md
@@ -72,6 +72,18 @@ reveal_type(__qualname__)  # revealed: Literal[42]
 reveal_type(__module__)  # revealed: Literal[42]
 ```
 
+They also take priority over a possibly-bound snapshot from an enclosing `global` declaration:
+
+```py
+def enclosing(flag: bool) -> None:
+    global __module__
+    if flag:
+        __module__ = 1
+
+    class Foo:
+        reveal_type(__module__)  # revealed: str
+```
+
 ## `__firstlineno__` has priority over globals (Python 3.13+)
 
 The same applies to `__firstlineno__` on Python 3.13+:

--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -299,6 +299,30 @@ def factory():
         reveal_type(x)  # revealed: Literal[1]
 ```
 
+If the rebinding is conditional, an unbound enclosing snapshot continues to the implicit global:
+
+```py
+def conditional_factory(flag: bool):
+    global __file__
+    if flag:
+        __file__ = "shadow"
+
+    class C:
+        reveal_type(__file__)  # revealed: str
+```
+
+An unbound snapshot can also continue through the module scope to a builtin.
+
+```py
+def conditional_builtin_factory(flag: bool):
+    global len  # error: [unresolved-global] "Invalid global declaration of `len`: `len` has no declarations or bindings in the global scope"
+    if flag:
+        len = 1
+
+    class C:
+        reveal_type(len)  # revealed: Literal[1] | (def len(obj: Sized, /) -> int)
+```
+
 ## References to variables before they are defined within a class scope are considered global
 
 If we try to access a variable in a class before it has been defined, the lookup will fall back to

--- a/crates/ty_python_semantic/resources/mdtest/scopes/unbound.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/unbound.md
@@ -71,3 +71,14 @@ def f():
     # revealed: Literal[2]
     reveal_type(x)
 ```
+
+## Unbound function local named `reveal_type`
+
+The convenience fallback for an unimported `reveal_type` only applies when name resolution does not
+find the name. It does not replace an unbound local.
+
+```py
+def f():
+    reveal_type(1)  # error: [unresolved-reference]
+    reveal_type = lambda value: value
+```

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -55,6 +55,7 @@ mod dunder_all;
 mod fixes;
 pub mod lint;
 pub(crate) mod place;
+pub(crate) mod place_load;
 mod reachability;
 mod semantic_model;
 mod subscript;

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -1,0 +1,1105 @@
+//! This module combines the semantics of name resolution with the results of
+//! reaching definition analysis to expose a [`PlaceLoadResolution`], which
+//! provides a lazy iterator over the steps that resolve the value read from a
+//! place.
+//!
+//! More specifically, a [`PlaceLoadResolution`] iterates over a series of
+//! [`PlaceLoadResolutionStep`] values, each of which represents a phase of the
+//! process that ultimately either supplies a definite value for a load or ends
+//! in explicit failure:
+//!
+//! - A source ([`PlaceLoadResolutionStep::Source`]) (and its associated type-
+//!   narrowing constraints) which may supply the value for a load.
+//! - A boolean condition ([`PlaceLoadResolutionStep::MemberResolutionCondition`])
+//!   that determines whether resolution continues for member loads specifically
+//!   (i.e., `foo.bar.baz` as opposed to the plain symbol `foo`). This describes
+//!   the loads of member prefixes (e.g., `foo.bar` and `foo`) that must all be
+//!   unbound before resolution continues.
+//! - A marker ([`PlaceLoadResolutionStep::Exhausted`]) which declares that the
+//!   resolution process ended in failure.
+//!
+//! We consume this model to different ends:
+//!
+//! - Type inference uses it to determine the type and definedness of a place
+//! - The language server uses it to determine, e.g., what references to an
+//!   imported module should be rewritten in response to the module itself being
+//!   renamed
+//!
+//! ## Example
+//!
+//! ```py
+//! from collections.abc import Callable
+//!
+//! def make_counter(start: int, enabled: bool) -> Callable[[], int | None]:
+//!     if enabled:
+//!         value = start
+//!     else:
+//!         value = None
+//!
+//!     def next_value() -> int | None:
+//!         nonlocal value
+//!         if value is not None:
+//!             current = value  # load U
+//!             value += 1
+//!             return current
+//!         return None
+//!
+//!     return next_value
+//! ```
+//!
+//! [`PlaceLoadResolution`] at `U` combines reaching definition analysis with a
+//! lexical scope walk:
+//!
+//! 1. Reaching definition analysis from the use-def module supplies the binding
+//!    state for `value` at `U` in `next_value`. In this case, no value-binding
+//!    definition reaches U because the `value += 1` assignment occurs after `U`,
+//!    so the state records `value` as unbound.
+//! 2. The use-def model also supplies the narrowing constraint `value is not None`
+//!    that is associated with the source. That constraint can affect an
+//!    inferred type but does not affect name resolution.
+//! 3. Name resolution encounters the `nonlocal` declaration and continues
+//!    the lexical scope walk into `make_counter`, where `value` is owned.
+//! 4. Once name resolution reaches the scope that owns value, it records
+//!    `make_counter.value` as an enclosing source of a potential value for `U`.
+//!
+//! Schematically, fully consuming the resulting [`PlaceLoadResolution`] yields:
+//!
+//! ```text
+//! Source(Bindings(next_value.value at U))  // unbound
+//! Source(DefinitionsFromOwningScope(make_counter.value))
+//! Exhausted(UnboundFree)
+//! ```
+//!
+//! While yielding those steps, the resolution accumulates `value is not None`
+//! as a narrowing constraint and records that it crossed the `nonlocal`
+//! declaration in `next_value`.
+//!
+//! The enclosing function's binding scope terminates name resolution, even if
+//! none of its definitions supply a value at runtime. [`PlaceLoadResolution`]
+//! therefore yields `Exhausted(UnboundFree)` if both sources are exhausted
+//! instead of yielding module globals or builtins as later sources. In this
+//! example, type inference establishes that the branches in `make_counter`
+//! always define `value`, so the `Exhausted` step is unreachable.
+
+use ruff_python_ast::{self as ast, name::Name};
+use smallvec::SmallVec;
+use ty_python_core::ast_ids::{HasScopedUseId, ScopedUseId};
+use ty_python_core::definition::Definition;
+use ty_python_core::narrowing_constraints::ConstraintKey;
+use ty_python_core::place::{PlaceExpr, PlaceExprRef, ScopedPlaceId};
+use ty_python_core::scope::{NodeWithScopeKind, ScopeId, ScopeKind};
+use ty_python_core::symbol::{ScopedSymbolId, Symbol};
+use ty_python_core::{
+    AncestorsIter, BindingWithConstraintsIterator, EnclosingSnapshotResult, FileScopeId,
+    ProgramFile, SemanticIndex,
+};
+
+use crate::Db;
+
+/// Returns an iterator over the steps that resolve a value for a place load.
+pub(crate) fn resolve_place_load<'db, 'ast>(
+    db: &'db dyn Db,
+    index: &'db SemanticIndex<'db>,
+    scope: ScopeId<'db>,
+    place_expr: PlaceExpr,
+    mode: PlaceLoadMode<'ast>,
+) -> PlaceLoadResolution<'db, 'ast> {
+    PlaceLoadResolution::new(
+        PlaceLoadResolutionContext {
+            db,
+            index,
+            scope,
+            file: scope.program_file(db),
+            mode,
+        },
+        place_expr,
+    )
+}
+
+/// Selects the binding state used for a place load's own scope.
+#[derive(Clone, Copy)]
+pub(crate) enum PlaceLoadMode<'ast> {
+    /// Resolve bindings live at an expression occurrence.
+    ///
+    /// For example, a caller resolving `value` in `print(value)` uses this mode so that only
+    /// bindings that reach that occurrence are considered.
+    AtExpression(ast::ExprRef<'ast>),
+    /// Resolve all bindings reachable in the scope.
+    ///
+    /// A caller uses this mode for an annotation in any of these contexts:
+    ///
+    /// - A stub file.
+    /// - A module containing `from __future__ import annotations`.
+    /// - Python 3.14 or later.
+    ///
+    /// Callers also use this mode for other deferred type expressions, including type-parameter
+    /// bounds and defaults and, in stub files, class bases and type alias values.
+    ///
+    /// For example, `Model` in `item: Model` can resolve to a class defined later in the scope.
+    Deferred,
+    /// Resolve reachable bindings in a parsed string annotation.
+    ///
+    /// A caller uses this mode for a name such as `Model` after parsing `item: "Model"`. The
+    /// parsed expression is not part of the original semantic index, so it may not have its own
+    /// place-table entry.
+    StringAnnotation,
+}
+
+/// Exposes an iterator over the steps that resolve the value for a place load.
+pub(crate) struct PlaceLoadResolution<'db, 'ast> {
+    /// The place expression whose loaded value is being resolved.
+    place_expr: PlaceExpr,
+    /// Read-only context shared by every source-selection phase.
+    context: PlaceLoadResolutionContext<'db, 'ast>,
+    /// The next node to visit in the resolution graph, or `None` after reaching a leaf.
+    next_node: Option<PlaceLoadResolutionNode<'db>>,
+    /// Narrowing constraints accumulated while resolution advances.
+    constraints: PlaceLoadConstraints,
+    /// Whether resolution has crossed a `global` or `nonlocal` declaration so far.
+    crosses_scope_declaration: bool,
+}
+
+impl<'db> Iterator for PlaceLoadResolution<'db, '_> {
+    type Item = PlaceLoadResolutionStep<'db>;
+
+    /// Lazily yields [`PlaceLoadResolutionStep`] values to describe the resolution process.
+    ///
+    /// Internally, this traverses a directed, acyclic graph that models the resolution process.
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(current_node) = self.next_node.take() {
+            match current_node {
+                PlaceLoadResolutionNode::LocalSource => {
+                    self.next_node =
+                        Some(PlaceLoadResolutionNode::AskConsumerWhetherToContinueForMember);
+
+                    if let Some((kind, exit_constraint)) =
+                        self.context.local_source(self.place_expr())
+                    {
+                        let source = self.constraints.source(
+                            kind,
+                            PlaceLoadSourceRole::Ordinary,
+                            exit_constraint,
+                        );
+                        return Some(PlaceLoadResolutionStep::Source(source));
+                    }
+                }
+                PlaceLoadResolutionNode::AskConsumerWhetherToContinueForMember => {
+                    self.next_node = Some(PlaceLoadResolutionNode::DecideResolutionPath);
+
+                    if let Some(prefix_loads) =
+                        self.context.place_expr_prefix_loads(self.place_expr())
+                    {
+                        return Some(PlaceLoadResolutionStep::MemberResolutionCondition(
+                            prefix_loads,
+                        ));
+                    }
+                }
+                PlaceLoadResolutionNode::DecideResolutionPath => {
+                    self.next_node = Some(self.decide_resolution_path());
+                }
+                PlaceLoadResolutionNode::DunderClassSource {
+                    definition,
+                    enclosing_scopes,
+                } => {
+                    self.next_node = Some(PlaceLoadResolutionNode::EnclosingScopeSource(
+                        enclosing_scopes,
+                    ));
+
+                    return Some(PlaceLoadResolutionStep::Source(
+                        PlaceLoadConstraints::unnarrowed_source(
+                            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::DunderClass(
+                                definition,
+                            )),
+                            PlaceLoadSourceRole::Ordinary,
+                        ),
+                    ));
+                }
+                PlaceLoadResolutionNode::EnclosingScopeSource(mut scopes) => {
+                    let (next_node, source) = self.resolve_enclosing_scopes(&mut scopes);
+                    self.next_node = Some(next_node);
+
+                    if let Some(source) = source {
+                        return Some(PlaceLoadResolutionStep::Source(source));
+                    }
+                }
+                PlaceLoadResolutionNode::ImplicitClassBodySource(forwarded_global_snapshot) => {
+                    self.next_node = Some(forwarded_global_snapshot.map_or(
+                        PlaceLoadResolutionNode::ExplicitGlobalSource(
+                            PlaceLoadSourceRole::Ordinary,
+                        ),
+                        PlaceLoadResolutionNode::ForwardedGlobalSnapshotSource,
+                    ));
+
+                    if self.context.is_class_body_scope()
+                        && let Some(name) = self.loaded_symbol_name()
+                    {
+                        let source = self.constraints.source(
+                            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ClassBodySymbol(
+                                name.clone(),
+                            )),
+                            PlaceLoadSourceRole::Ordinary,
+                            None,
+                        );
+                        return Some(PlaceLoadResolutionStep::Source(source));
+                    }
+                }
+                PlaceLoadResolutionNode::ForwardedGlobalSnapshotSource(snapshot) => {
+                    let ForwardedGlobalSnapshot {
+                        bindings,
+                        enclosing_scope,
+                    } = snapshot;
+                    self.next_node = Some(PlaceLoadResolutionNode::ImplicitGlobalSource);
+
+                    let source = self.constraints.source(
+                        PlaceLoadSourceKind::Bindings(bindings),
+                        PlaceLoadSourceRole::Ordinary,
+                        Some((
+                            enclosing_scope,
+                            ConstraintKey::NestedScope(
+                                self.context.scope.file_scope_id(self.context.db),
+                            ),
+                        )),
+                    );
+                    return Some(PlaceLoadResolutionStep::Source(source));
+                }
+                PlaceLoadResolutionNode::ExplicitGlobalSource(role) => {
+                    self.next_node = Some(PlaceLoadResolutionNode::ImplicitGlobalSource);
+
+                    if let Some(source) = self.resolve_global(role) {
+                        return Some(PlaceLoadResolutionStep::Source(source));
+                    }
+                }
+                PlaceLoadResolutionNode::ImplicitGlobalSource => {
+                    if let Some(name) = self.loaded_symbol_name().cloned() {
+                        self.next_node = Some(PlaceLoadResolutionNode::BuiltinSource(name.clone()));
+
+                        let source = self.constraints.source(
+                            PlaceLoadSourceKind::Implicit(
+                                ImplicitPlaceLoad::ModuleImplicitGlobal {
+                                    file: self.context.file,
+                                    name,
+                                },
+                            ),
+                            PlaceLoadSourceRole::Ordinary,
+                            None,
+                        );
+                        return Some(PlaceLoadResolutionStep::Source(source));
+                    }
+
+                    self.next_node =
+                        Some(PlaceLoadResolutionNode::Failure(PlaceLoadFailure::NotFound));
+                }
+                PlaceLoadResolutionNode::BuiltinSource(name) => {
+                    self.next_node =
+                        Some(PlaceLoadResolutionNode::Failure(PlaceLoadFailure::NotFound));
+
+                    return Some(PlaceLoadResolutionStep::Source(
+                        PlaceLoadConstraints::unnarrowed_source(
+                            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::Builtin(name)),
+                            PlaceLoadSourceRole::Ordinary,
+                        ),
+                    ));
+                }
+                PlaceLoadResolutionNode::Failure(failure) => {
+                    return Some(PlaceLoadResolutionStep::Exhausted(failure));
+                }
+            }
+        }
+
+        None
+    }
+}
+
+impl<'db, 'ast> PlaceLoadResolution<'db, 'ast> {
+    fn new(context: PlaceLoadResolutionContext<'db, 'ast>, place_expr: PlaceExpr) -> Self {
+        Self {
+            context,
+            place_expr,
+            next_node: Some(PlaceLoadResolutionNode::LocalSource),
+            constraints: PlaceLoadConstraints::default(),
+            crosses_scope_declaration: false,
+        }
+    }
+
+    fn decide_resolution_path(&mut self) -> PlaceLoadResolutionNode<'db> {
+        let db = self.context.db;
+        let scope = self.context.scope;
+        let file_scope = scope.file_scope_id(db);
+        let place_table = self.context.index.place_table(file_scope);
+
+        let mut symbol_is_local = false;
+        let place_expr = PlaceExprRef::from(&self.place_expr);
+        if let Some(symbol) = place_expr.as_symbol()
+            && let Some(symbol_id) = place_table.symbol_id(symbol.name())
+        {
+            let indexed_symbol = place_table.symbol(symbol_id);
+            symbol_is_local = indexed_symbol.is_local();
+            self.crosses_scope_declaration |=
+                indexed_symbol.is_global() || indexed_symbol.is_nonlocal();
+
+            let class_body_global_fallback = self.context.is_class_body_scope() && symbol_is_local;
+            if self.context.skips_non_global_scopes(symbol_id) || class_body_global_fallback {
+                return PlaceLoadResolutionNode::ExplicitGlobalSource(
+                    if class_body_global_fallback {
+                        PlaceLoadSourceRole::ClassBodyGlobalFallback
+                    } else {
+                        PlaceLoadSourceRole::Ordinary
+                    },
+                );
+            }
+        }
+
+        if symbol_is_local {
+            return if scope.node(db).scope_kind().is_module() {
+                PlaceLoadResolutionNode::ImplicitGlobalSource
+            } else {
+                PlaceLoadResolutionNode::Failure(PlaceLoadFailure::UnboundLocal)
+            };
+        }
+
+        let mut scopes = self.context.index.ancestor_scopes(file_scope);
+        // The first scope is the input scope itself; skip it to arrive at the first true ancestor.
+        scopes.next();
+
+        if let PlaceExprRef::Symbol(symbol) = place_expr
+            && symbol.name() == "__class__"
+            && let Some(definition) = self.context.dunder_class_cell_definition()
+        {
+            PlaceLoadResolutionNode::DunderClassSource {
+                definition,
+                enclosing_scopes: scopes,
+            }
+        } else {
+            PlaceLoadResolutionNode::EnclosingScopeSource(scopes)
+        }
+    }
+
+    fn resolve_enclosing_scopes(
+        &mut self,
+        scopes: &mut AncestorsIter<'db>,
+    ) -> (PlaceLoadResolutionNode<'db>, Option<PlaceLoadSource<'db>>) {
+        let db = self.context.db;
+        let scope = self.context.scope;
+        let file_scope = scope.file_scope_id(db);
+
+        for (enclosing_file_scope, _) in scopes {
+            if enclosing_file_scope.is_global() {
+                break;
+            }
+
+            let enclosing_scope = self.context.index.scope(enclosing_file_scope);
+            let is_lexical_enclosing_scope = self
+                .context
+                .is_lexical_enclosing_scope(enclosing_file_scope);
+
+            let enclosing_place_table = self.context.index.place_table(enclosing_file_scope);
+            let place_expr = PlaceExprRef::from(&self.place_expr);
+            let enclosing_place_id = enclosing_place_table.place_id(place_expr);
+            let enclosing_place = enclosing_place_id.map(|id| enclosing_place_table.place(id));
+            // A `global` declaration forwards the place to the module instead of making this
+            // enclosing scope its owner. A possibly-unbound snapshot must still fall through.
+            let forwards_to_global = is_lexical_enclosing_scope
+                && enclosing_place
+                    .is_some_and(|place| place.as_symbol().is_some_and(Symbol::is_global));
+            let root_place_was_reassigned = || {
+                enclosing_place_table
+                    .parents(place_expr)
+                    .any(|root| enclosing_place_table.place(root).is_bound())
+            };
+
+            let mut eagerly_undefined = false;
+            if self.context.uses_enclosing_snapshots() {
+                match self.context.index.enclosing_snapshot(
+                    enclosing_file_scope,
+                    place_expr,
+                    file_scope,
+                ) {
+                    EnclosingSnapshotResult::FoundConstraint(constraint) => {
+                        self.constraints.push(
+                            enclosing_file_scope,
+                            ConstraintKey::NarrowingConstraint(constraint),
+                        );
+                        if scope.scope(db).is_eager() {
+                            eagerly_undefined = true;
+                        }
+                    }
+                    EnclosingSnapshotResult::FoundBindings(bindings) => {
+                        if forwards_to_global {
+                            self.crosses_scope_declaration = true;
+                            return (
+                                PlaceLoadResolutionNode::ImplicitClassBodySource(Some(
+                                    ForwardedGlobalSnapshot {
+                                        bindings,
+                                        enclosing_scope: enclosing_file_scope,
+                                    },
+                                )),
+                                None,
+                            );
+                        }
+
+                        return (
+                            Self::node_after_enclosing_scope(enclosing_scope.kind()),
+                            Some(self.constraints.source(
+                                PlaceLoadSourceKind::Bindings(bindings),
+                                PlaceLoadSourceRole::Ordinary,
+                                Some((
+                                    enclosing_file_scope,
+                                    ConstraintKey::NestedScope(file_scope),
+                                )),
+                            )),
+                        );
+                    }
+                    EnclosingSnapshotResult::NotFound => {
+                        if root_place_was_reassigned() {
+                            return (
+                                Self::node_after_enclosing_scope(enclosing_scope.kind()),
+                                None,
+                            );
+                        }
+                        continue;
+                    }
+                    EnclosingSnapshotResult::NoLongerInEagerContext => {
+                        if root_place_was_reassigned() {
+                            return (
+                                Self::node_after_enclosing_scope(enclosing_scope.kind()),
+                                None,
+                            );
+                        }
+                    }
+                }
+            }
+
+            if !is_lexical_enclosing_scope {
+                continue;
+            }
+
+            let (Some(enclosing_place_id), Some(enclosing_place)) =
+                (enclosing_place_id, enclosing_place)
+            else {
+                continue;
+            };
+
+            if forwards_to_global {
+                self.crosses_scope_declaration = true;
+                return (PlaceLoadResolutionNode::ImplicitClassBodySource(None), None);
+            }
+            // Keep walking across `nonlocal` declarations until reaching the owning scope.
+            if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
+                self.crosses_scope_declaration = true;
+                continue;
+            }
+            if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
+                continue;
+            }
+
+            // The first bound or declared place owns the load. Its public value includes nested
+            // writes represented by synthetic definitions in this scope.
+            return (
+                Self::node_after_enclosing_scope(enclosing_scope.kind()),
+                (!eagerly_undefined).then(|| {
+                    self.constraints.source(
+                        PlaceLoadSourceKind::DefinitionsFromOwningScope {
+                            scope: enclosing_file_scope.to_scope_id(db, self.context.file),
+                            id: enclosing_place_id,
+                        },
+                        PlaceLoadSourceRole::Ordinary,
+                        None,
+                    )
+                }),
+            );
+        }
+
+        (PlaceLoadResolutionNode::ImplicitClassBodySource(None), None)
+    }
+
+    /// Resolves a load that has reached the module's explicit global scope.
+    ///
+    /// An eager nested scope uses the global snapshot captured when it began, so a class body
+    /// cannot see a module binding created only after that body finishes.
+    fn resolve_global(&mut self, role: PlaceLoadSourceRole) -> Option<PlaceLoadSource<'db>> {
+        let current_scope = self.context.scope.file_scope_id(self.context.db);
+        if current_scope.is_global() {
+            return None;
+        }
+
+        if self.context.uses_enclosing_snapshots() {
+            match self.context.index.enclosing_snapshot(
+                FileScopeId::global(),
+                PlaceExprRef::from(&self.place_expr),
+                current_scope,
+            ) {
+                EnclosingSnapshotResult::FoundConstraint(constraint) => {
+                    self.constraints.push(
+                        FileScopeId::global(),
+                        ConstraintKey::NarrowingConstraint(constraint),
+                    );
+                    return None;
+                }
+                EnclosingSnapshotResult::FoundBindings(bindings) => {
+                    return Some(self.constraints.source(
+                        PlaceLoadSourceKind::Bindings(bindings),
+                        role,
+                        Some((
+                            FileScopeId::global(),
+                            ConstraintKey::NestedScope(current_scope),
+                        )),
+                    ));
+                }
+                EnclosingSnapshotResult::NotFound => return None,
+                EnclosingSnapshotResult::NoLongerInEagerContext => {}
+            }
+        }
+
+        let name = self.loaded_symbol_name()?.clone();
+        Some(self.constraints.source(
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ExplicitGlobalSymbol {
+                file: self.context.file,
+                name,
+            }),
+            role,
+            None,
+        ))
+    }
+
+    fn node_after_enclosing_scope(kind: ScopeKind) -> PlaceLoadResolutionNode<'db> {
+        if kind.is_class() {
+            PlaceLoadResolutionNode::ImplicitGlobalSource
+        } else {
+            PlaceLoadResolutionNode::Failure(PlaceLoadFailure::UnboundFree)
+        }
+    }
+
+    pub(crate) fn narrowing_constraints_for(
+        &self,
+        source: &PlaceLoadSource<'_>,
+    ) -> &[(FileScopeId, ConstraintKey)] {
+        self.constraints.narrowing_constraints_for(source)
+    }
+
+    pub(crate) fn into_constraints(self) -> Vec<(FileScopeId, ConstraintKey)> {
+        self.constraints.into_constraints()
+    }
+
+    pub(crate) fn place_expr(&self) -> PlaceExprRef<'_> {
+        PlaceExprRef::from(&self.place_expr)
+    }
+
+    /// Returns the loaded symbol's name, or `None` when the loaded place is a member.
+    ///
+    /// For example, this returns a name for `value`, but not for `value.attr` or `value[0]`.
+    fn loaded_symbol_name(&self) -> Option<&Name> {
+        self.place_expr().as_symbol().map(Symbol::name)
+    }
+}
+
+pub(crate) enum PlaceLoadResolutionStep<'db> {
+    // A source that can supply the value for a load.
+    Source(PlaceLoadSource<'db>),
+    // A condition that the caller must evaluate to determine whether resolution should continue
+    // for a member load.
+    MemberResolutionCondition(PlaceExprPrefixLoads<'db>),
+    // A marker that declares that resolution ended in a explicit failure.
+    Exhausted(PlaceLoadFailure),
+}
+
+/// One source that can supply the value of a place load, along with the
+/// type narrowing constraints that apply to it.
+///
+/// ## How constraint tracking is implemented
+///
+/// [`PlaceLoadResolution`] stores one shared list of constraint keys. Each
+/// source maintains an `entry_checkpoint` into that list, which identifies the
+/// constraints used to narrow the source.
+///
+/// When a key identifies the binding state used to construct a source, that key
+/// becomes active after the source is requested, but applying it to the same
+/// source again would duplicate work.
+///
+/// ### Example
+///
+/// ```py
+/// from collections.abc import Callable
+///
+/// def make_counter(start: int, enabled: bool) -> Callable[[], int | None]:
+///     if enabled:
+///         value = start
+///     else:
+///         value = None
+///
+///     def next_value() -> int | None:
+///         nonlocal value
+///         if value is not None:
+///             current = value  # load U
+///             value += 1
+///             return current
+///         return None
+///
+///     return next_value
+/// ```
+///
+/// For `U` above, the constraint representation after both sources have been
+/// requested is schematically:
+///
+/// ```text
+/// PlaceLoadResolution {
+///     constraint_keys: [
+///         (next_value, UseId(U)),
+///     ],
+/// }
+/// PlaceLoadSource {
+///     kind: Bindings(next_value at U),
+///     entry_checkpoint: 0,
+/// }
+/// PlaceLoadSource {
+///     kind: DefinitionsFromOwningScope(make_counter.value),
+///     entry_checkpoint: 1,
+/// }
+/// ```
+///
+/// The first source already comes from `bindings_at_use(U)`, so its `UseId` key
+/// becomes active when the source is requested but is not applied on entry. If
+/// that source is undefined and the consumer requests the next source, the
+/// `UseId` key narrows the enclosing `int | None` place to `int`. If both
+/// sources are exhausted, the key remains active for expression-level narrowing.
+pub(crate) struct PlaceLoadSource<'db> {
+    /// How this source supplies the loaded value.
+    pub(crate) kind: PlaceLoadSourceKind<'db>,
+    /// Selects the constraints used to narrow this source.
+    entry_checkpoint: usize,
+    /// The role this source plays in the load.
+    role: PlaceLoadSourceRole,
+}
+
+impl PlaceLoadSource<'_> {
+    /// Returns whether this source is the module fallback for a class-local name.
+    pub(crate) fn is_class_body_global_fallback(&self) -> bool {
+        self.role == PlaceLoadSourceRole::ClassBodyGlobalFallback
+    }
+
+    /// Returns whether this source is considered after lexical name resolution.
+    pub(crate) fn is_post_lexical(&self) -> bool {
+        matches!(
+            self.kind,
+            PlaceLoadSourceKind::Implicit(
+                ImplicitPlaceLoad::ModuleImplicitGlobal { .. } | ImplicitPlaceLoad::Builtin(_)
+            )
+        )
+    }
+}
+
+/// Describes how a source can supply a place's value.
+pub(crate) enum PlaceLoadSourceKind<'db> {
+    /// Bindings already selected for this load state.
+    ///
+    /// For an ordinary expression, these are the bindings that reach that point:
+    ///
+    /// ```py
+    /// value = 1
+    /// reveal_type(value)  # Only the first binding reaches this load.
+    /// value = "later"
+    /// ```
+    ///
+    /// An enclosing eager snapshot is likewise a point-in-time view. A deferred load instead
+    /// selects all bindings reachable in its scope.
+    Bindings(BindingWithConstraintsIterator<'db, 'db>),
+    /// The whole place in the scope that owns it.
+    ///
+    /// A free-variable load in a lazy nested scope can observe any definition reachable for the
+    /// owning place, rather than the state at a single point:
+    ///
+    /// ```py
+    /// def outer():
+    ///     value: int | str = 1
+    ///
+    ///     def inner():
+    ///         return value
+    ///
+    ///     value = "later"
+    /// ```
+    ///
+    /// Keeping the scope and place ID lets inference evaluate both the declaration and all
+    /// reachable bindings for `outer.value`; an already-selected binding iterator does not retain
+    /// that whole-place information.
+    DefinitionsFromOwningScope {
+        /// The scope containing the place.
+        scope: ScopeId<'db>,
+        /// The place within `scope`.
+        id: ScopedPlaceId,
+    },
+    /// A source represented by a specialized query or rule.
+    Implicit(ImplicitPlaceLoad<'db>),
+}
+
+/// A source that consumers evaluate using a specialized query or rule.
+pub(crate) enum ImplicitPlaceLoad<'db> {
+    /// The implicit `__class__` cell for a method, lambda, or generator expression defined directly
+    /// in a class body, e.g.:
+    ///
+    /// ```py
+    /// class C:
+    ///     def method(self):
+    ///         return __class__
+    /// ```
+    DunderClass(Definition<'db>),
+    /// An implicit symbol supplied directly in a class body, e.g.:
+    ///
+    /// ```py
+    /// class C:
+    ///     defining_module = __module__
+    /// ```
+    ClassBodySymbol(Name),
+    /// A symbol in the module's explicit global namespace, e.g.:
+    ///
+    /// ```py
+    /// answer = 42
+    ///
+    /// def get_answer():
+    ///     return answer
+    /// ```
+    ExplicitGlobalSymbol { file: ProgramFile<'db>, name: Name },
+    /// An implicit attribute supplied by a module, such as `__name__`.
+    ModuleImplicitGlobal { file: ProgramFile<'db>, name: Name },
+    /// A name supplied by the builtin namespace.
+    Builtin(Name),
+}
+
+/// The role a source plays in a place load.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PlaceLoadSourceRole {
+    /// The source follows ordinary Python name resolution rules.
+    Ordinary,
+    /// The source follows Python’s class-local-to-module fallback rules.
+    ClassBodyGlobalFallback,
+}
+
+/// The reason resolution stops if the preceding sources do not supply a value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PlaceLoadFailure {
+    /// No additional place-load source applies.
+    ///
+    /// For a symbol load, this means runtime lookup raises `NameError`.
+    NotFound,
+    /// The current function-like binding scope owns the loaded symbol but
+    /// supplies no value.
+    ///
+    /// Loading the symbol at runtime raises `UnboundLocalError`.
+    UnboundLocal,
+    /// An enclosing function-like binding scope owns the place, so resolution
+    /// cannot continue to module globals or builtins.
+    ///
+    /// For a symbol load, an empty closure cell raises `NameError` at runtime.
+    UnboundFree,
+}
+
+/// Compact descriptions of loads for the tracked prefixes of a place expression.
+///
+/// Resolution continues past the local source only if every tracked prefix is locally undefined.
+///
+/// For example, the enclosing binding of `obj.value` cannot supply the value read in `inner`:
+///
+/// ```python
+/// class Outer:
+///     value: int
+///
+/// class Inner:
+///     value: str
+///
+/// def outer():
+///     obj = Outer()
+///     obj.value = 1
+///
+///     def inner():
+///         obj = Inner()
+///         reveal_type(obj.value)  # revealed: str
+/// ```
+///
+/// The nested scope binds `obj` to a different object, so normal member lookup on the local
+/// `obj` must handle the load instead.
+pub(crate) struct PlaceExprPrefixLoads<'db> {
+    scope: ScopeId<'db>,
+    loads: SmallVec<[PlaceExprPrefixLoad; 2]>,
+}
+
+impl<'db> PlaceExprPrefixLoads<'db> {
+    /// Creates prefix loads, returning `None` when the iterator is empty.
+    fn from_iter(
+        scope: ScopeId<'db>,
+        loads: impl IntoIterator<Item = PlaceExprPrefixLoad>,
+    ) -> Option<Self> {
+        let loads = loads.into_iter().collect::<SmallVec<_>>();
+        (!loads.is_empty()).then_some(Self { scope, loads })
+    }
+
+    /// Returns the scope containing the prefix loads.
+    pub(crate) fn scope(&self) -> ScopeId<'db> {
+        self.scope
+    }
+
+    /// Iterates over the prefix loads.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = PlaceExprPrefixLoad> + '_ {
+        self.loads.iter().copied()
+    }
+}
+
+/// Describes how a consumer can evaluate one prefix of a place expression.
+#[derive(Clone, Copy)]
+pub(crate) enum PlaceExprPrefixLoad {
+    /// Use the bindings that reach this expression occurrence.
+    AtUse(ScopedUseId),
+    /// Use every binding reachable for this place in its scope.
+    AllReachable(ScopedPlaceId),
+    /// The syntax itself guarantees that the prefix is bound.
+    DefinitelyBound,
+}
+
+/// Read-only context used to select sources for a place load.
+#[derive(Clone, Copy)]
+struct PlaceLoadResolutionContext<'db, 'ast> {
+    db: &'db dyn Db,
+    index: &'db SemanticIndex<'db>,
+    scope: ScopeId<'db>,
+    file: ProgramFile<'db>,
+    mode: PlaceLoadMode<'ast>,
+}
+
+impl<'db> PlaceLoadResolutionContext<'db, '_> {
+    fn is_class_body_scope(self) -> bool {
+        self.scope.node(self.db).scope_kind().is_class()
+    }
+
+    fn uses_enclosing_snapshots(self) -> bool {
+        matches!(self.mode, PlaceLoadMode::AtExpression(_))
+    }
+
+    fn is_lexical_enclosing_scope(self, enclosing_scope: FileScopeId) -> bool {
+        self.index.scope(enclosing_scope).kind().is_function_like()
+            || (self.scope.is_annotation(self.db)
+                && self.scope.scope(self.db).parent() == Some(enclosing_scope))
+    }
+
+    fn local_source(
+        self,
+        place_expr: PlaceExprRef,
+    ) -> Option<(
+        PlaceLoadSourceKind<'db>,
+        Option<(FileScopeId, ConstraintKey)>,
+    )> {
+        let scope = self.scope.file_scope_id(self.db);
+        let table = self.index.place_table(scope);
+        let use_def = self.index.use_def_map(scope);
+
+        match self.mode {
+            PlaceLoadMode::AtExpression(expr_ref) => {
+                if expr_ref
+                    .as_name_expr()
+                    .is_some_and(|name| name.is_invalid())
+                {
+                    return None;
+                }
+
+                let use_id = expr_ref.scoped_use_id(self.db, self.file);
+                Some((
+                    PlaceLoadSourceKind::Bindings(use_def.bindings_at_use(use_id)),
+                    Some((scope, ConstraintKey::UseId(use_id))),
+                ))
+            }
+            PlaceLoadMode::Deferred | PlaceLoadMode::StringAnnotation => {
+                let source = table
+                    .place_id(place_expr)
+                    .map(|id| PlaceLoadSourceKind::Bindings(use_def.reachable_bindings(id)));
+                assert!(
+                    source.is_some() || matches!(self.mode, PlaceLoadMode::StringAnnotation),
+                    "Expected the place table to create a place for every valid PlaceExpr node"
+                );
+                source.map(|source| (source, None))
+            }
+        }
+    }
+
+    /// Describes how to evaluate the tracked prefixes of `place_expr` in this scope.
+    fn place_expr_prefix_loads(
+        self,
+        place_expr: PlaceExprRef,
+    ) -> Option<PlaceExprPrefixLoads<'db>> {
+        let table = self.index.place_table(self.scope.file_scope_id(self.db));
+
+        PlaceExprPrefixLoads::from_iter(
+            self.scope,
+            table
+                .parents(place_expr)
+                .filter_map(|prefix_id| match self.mode {
+                    PlaceLoadMode::Deferred | PlaceLoadMode::StringAnnotation => {
+                        Some(PlaceExprPrefixLoad::AllReachable(prefix_id))
+                    }
+                    PlaceLoadMode::AtExpression(mut prefix_expr_ref) => {
+                        let prefix = table.place(prefix_id);
+                        for _ in
+                            0..(place_expr.num_member_segments() - prefix.num_member_segments())
+                        {
+                            prefix_expr_ref = match prefix_expr_ref {
+                                ast::ExprRef::Attribute(attribute) => {
+                                    ast::ExprRef::from(&attribute.value)
+                                }
+                                ast::ExprRef::Subscript(subscript) => {
+                                    ast::ExprRef::from(&subscript.value)
+                                }
+                                _ => return None,
+                            };
+                        }
+
+                        if prefix_expr_ref
+                            .as_name_expr()
+                            .is_some_and(|name| name.is_invalid())
+                        {
+                            return None;
+                        }
+
+                        if let ast::ExprRef::Named(named) = prefix_expr_ref {
+                            return named
+                                .target
+                                .is_name_expr()
+                                .then_some(PlaceExprPrefixLoad::DefinitelyBound);
+                        }
+
+                        Some(PlaceExprPrefixLoad::AtUse(
+                            prefix_expr_ref.scoped_use_id(self.db, self.file),
+                        ))
+                    }
+                }),
+        )
+    }
+
+    fn skips_non_global_scopes(self, symbol: ScopedSymbolId) -> bool {
+        let scope = self.scope.file_scope_id(self.db);
+        !scope.is_global() && self.index.symbol_is_global_in_scope(symbol, scope)
+    }
+
+    fn dunder_class_cell_definition(self) -> Option<Definition<'db>> {
+        let current_scope = self.scope.file_scope_id(self.db);
+        if let Some(definition) = self.index.class_definition_of_method(current_scope) {
+            return Some(definition);
+        }
+
+        let scope = self.index.scope(current_scope);
+        if !matches!(
+            scope.node(),
+            NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
+        ) {
+            return None;
+        }
+        let class = self.index.parent_scope(current_scope)?.node().as_class()?;
+        Some(self.index.expect_single_definition(class))
+    }
+}
+
+/// A node in the acyclic graph traversed by a [`PlaceLoadResolution`].
+///
+/// Source-named nodes may yield a [`PlaceLoadResolutionStep::Source`]. The two verb-named nodes
+/// either ask the consumer whether traversal should continue or decide which outgoing edge to
+/// follow. Every transition advances toward a [`PlaceLoadResolutionNode::Failure`] leaf; no node
+/// is revisited.
+enum PlaceLoadResolutionNode<'db> {
+    /// The source selected from the load's own scope, if one exists.
+    LocalSource,
+    /// Ask the consumer whether resolution should continue for a member load.
+    AskConsumerWhetherToContinueForMember,
+    /// Decide whether resolution ends, continues through enclosing scopes, or moves to the module
+    /// scope.
+    DecideResolutionPath,
+    /// The implicit `__class__` source, followed by enclosing scopes.
+    DunderClassSource {
+        definition: Definition<'db>,
+        enclosing_scopes: AncestorsIter<'db>,
+    },
+    /// A source from the remaining enclosing scopes, if one exists.
+    EnclosingScopeSource(AncestorsIter<'db>),
+    /// The implicit class-body source, followed by the applicable global source.
+    ImplicitClassBodySource(Option<ForwardedGlobalSnapshot<'db>>),
+    /// Bindings from an enclosing `global` declaration that were visible when the nested eager
+    /// scope began.
+    ForwardedGlobalSnapshotSource(ForwardedGlobalSnapshot<'db>),
+    /// An explicit global source with the given role, if one exists.
+    ExplicitGlobalSource(PlaceLoadSourceRole),
+    /// An implicit global considered after explicit lookup, if one exists.
+    ImplicitGlobalSource,
+    /// The builtin with the given name.
+    BuiltinSource(Name),
+    /// The failure that ends resolution.
+    Failure(PlaceLoadFailure),
+}
+
+struct ForwardedGlobalSnapshot<'db> {
+    bindings: BindingWithConstraintsIterator<'db, 'db>,
+    enclosing_scope: FileScopeId,
+}
+
+/// Narrowing constraints accumulated while a consumer advances through a place load.
+#[derive(Default)]
+struct PlaceLoadConstraints {
+    constraint_keys: Vec<(FileScopeId, ConstraintKey)>,
+}
+
+impl PlaceLoadConstraints {
+    /// Creates a source narrowed by the constraints accumulated before it.
+    ///
+    /// `exit_constraint`, when present, is activated only after the source is requested (that
+    /// source was already selected from the binding state identified by the constraint, so it is
+    /// deliberately not reapplied to the same source).
+    ///
+    /// For example, consider the load at `U`:
+    ///
+    /// ```py
+    /// def outer(value: int | None):
+    ///     def inner():
+    ///         if value is not None:
+    ///             return value  # U
+    /// ```
+    ///
+    /// The local source is selected by `bindings_at_use(U)`. Its `UseId(U)` is the exit constraint:
+    /// it is not applied again to that source, but becomes active if the source is unbound so that
+    /// the enclosing `outer.value` source is narrowed from `int | None` to `int`.
+    fn source<'db>(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+        exit_constraint: Option<(FileScopeId, ConstraintKey)>,
+    ) -> PlaceLoadSource<'db> {
+        let entry_checkpoint = self.constraint_keys.len();
+        self.constraint_keys.extend(exit_constraint);
+        PlaceLoadSource {
+            kind,
+            entry_checkpoint,
+            role,
+        }
+    }
+
+    /// Creates a source without applying accumulated narrowing constraints to it.
+    fn unnarrowed_source(
+        kind: PlaceLoadSourceKind<'_>,
+        role: PlaceLoadSourceRole,
+    ) -> PlaceLoadSource<'_> {
+        PlaceLoadSource {
+            kind,
+            entry_checkpoint: 0,
+            role,
+        }
+    }
+
+    /// Extends the list of constraints used by subsequent sources.
+    fn push(&mut self, scope: FileScopeId, key: ConstraintKey) {
+        self.constraint_keys.push((scope, key));
+    }
+
+    /// Returns the constraints used to narrow `source`.
+    fn narrowing_constraints_for(
+        &self,
+        source: &PlaceLoadSource<'_>,
+    ) -> &[(FileScopeId, ConstraintKey)] {
+        &self.constraint_keys[..source.entry_checkpoint]
+    }
+
+    /// Returns the constraints activated by the sources that were requested.
+    fn into_constraints(self) -> Vec<(FileScopeId, ConstraintKey)> {
+        self.constraint_keys
+    }
+}

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -1,0 +1,557 @@
+//! Defines a [`PlaceLoad`], which combines the semantics of name resolution
+//! with the results of reaching definition analysis to describe the sources
+//! that may provide the value read from a place.
+//!
+//! More specifically, a [`PlaceLoad`] encapsulates:
+//!
+//! 1. [`PlaceLoad::local_source`], the (optional) value source from the load's
+//!    own scope.
+//! 2. The lexical ([`PlaceLoad::lexical_fallbacks`]) and post-lexical fallbacks
+//!    ([`PlaceLoad::post_lexical_fallbacks`]) considered if the local source
+//!    does not supply a value for the load.
+//! 3. Any condition that controls whether those fallbacks are applicable (via
+//!    [`PlaceLoad::with_conditional_fallbacks`] and
+//!    [`PlaceLoad::place_expr_prefix_loads`]).
+//! 4. [`PlaceLoad::failure_on_exhaustion`] the resolution failure that occurs
+//!    if none of those sources ultimately supply a value.
+//! 5. [`PlaceLoad::constraint_keys`], the type-narrowing constraints associated
+//!    with each source.
+//! 6. [`PlaceLoad::scope_declarations`], the explicit scope declarations
+//!    (`global` or `nonlocal`) crossed while resolving the place.
+//!
+//! We consume this model to different ends:
+//!
+//! - Type inference uses it to determine the type and definedness of a place
+//! - The language server uses it to determine, e.g., what references to an
+//!   imported module should be rewritten in response to the module itself being
+//!   renamed
+//!
+//! Here is an example describing how a [`PlaceLoad`] is constructed:
+//!
+//! ```py
+//! from collections.abc import Callable
+//!
+//! def make_counter(start: int, enabled: bool) -> Callable[[], int | None]:
+//!     if enabled:
+//!         value = start
+//!     else:
+//!         value = None
+//!
+//!     def next_value() -> int | None:
+//!         nonlocal value
+//!         if value is not None:
+//!             current = value  # load U
+//!             value += 1
+//!             return current
+//!         return None
+//!
+//!     return next_value
+//! ```
+//!
+//! As mentioned previously, constructing the [`PlaceLoad`] at `U` combines
+//! reaching definition analysis with a lexical scope walk:
+//!
+//! 1. Reaching definition analysis from the use-def module supplies the binding
+//!    state for `value` at `U` in `next_value`. (In this case, no value-binding
+//!    definition reaches U because the `value += 1` assignment occurs after `U`,
+//!    so the state records `value` as unbound.)
+//! 2. The use-def model also supplies the narrowing constraint `value is not None`
+//!    that is associated with the source. That constraint can affect an
+//!    inferred type but does not affect name resolution.
+//! 3. Name resolution encounters the `nonlocal` declaration and continues
+//!    the lexical scope walk into `make_counter`, where `value` is owned.
+//! 4. Once name resolution reaches the scope that owns value, it records
+//!    `make_counter.value` as an enclosing source of a potential value for `U`.
+//!
+//! Schematically, the resulting [`PlaceLoad`] looks like this:
+//!
+//! ```text
+//! PlaceLoad {
+//!     local_source: Bindings(next_value.value at U),  // unbound
+//!     lexical_fallbacks: [
+//!         DefinitionsFromOwningScope(make_counter.value),
+//!     ],
+//!     failure_on_exhaustion: UnboundFree,
+//!     constraint_keys: [
+//!         value is not None,
+//!     ],
+//!     scope_declarations: [
+//!         Nonlocal(next_value),
+//!     ],
+//! }
+//! ```
+//!
+//! The enclosing function's binding scope terminates name resolution, even if
+//! none of its definitions supply a value at runtime. [`PlaceLoad`] therefore
+//! records `UnboundFree` as the failure if both sources are exhausted instead
+//! of recording module globals or builtins as later sources. In this example,
+//! type inference establishes that the branches in `make_counter` always
+//! define `value`, so the failure is unreachable.
+
+use ruff_python_ast::name::Name;
+use smallvec::SmallVec;
+use ty_python_core::ast_ids::ScopedUseId;
+use ty_python_core::definition::Definition;
+use ty_python_core::narrowing_constraints::ConstraintKey;
+use ty_python_core::place::ScopedPlaceId;
+use ty_python_core::scope::{ScopeId, ScopeKind};
+use ty_python_core::{BindingWithConstraintsIterator, FileScopeId, ProgramFile};
+
+/// A semantic description of reading a place without inferring its type.
+pub(crate) struct PlaceLoad<'db> {
+    /// The source from the load's own scope.
+    local_source: Option<PlaceLoadSource<'db>>,
+    /// The sources considered after the local source but before implicit globals and builtins.
+    lexical_fallbacks: SmallVec<[PlaceLoadSource<'db>; 1]>,
+    /// The implicit global and builtin fallbacks considered after lexical resolution.
+    post_lexical_fallbacks: Option<PostLexicalFallbacks<'db>>,
+    /// The name resolution failure associated with exhausting all sources.
+    failure_on_exhaustion: PlaceLoadFailure,
+    /// The narrowing constraints collected while resolving the load.
+    constraint_keys: Vec<(FileScopeId, ConstraintKey)>,
+    /// The explicit `global` and `nonlocal` declarations crossed during name resolution.
+    pub(crate) scope_declarations: SmallVec<[ScopedDeclaration; 1]>,
+    /// Place-expression prefix loads that must all be undefined before fallbacks are applicable.
+    place_expr_prefix_loads: Option<PlaceExprPrefixLoads<'db>>,
+}
+
+impl<'db> PlaceLoad<'db> {
+    /// Creates a new load with no sources.
+    pub(crate) fn new() -> Self {
+        Self {
+            local_source: None,
+            lexical_fallbacks: SmallVec::new(),
+            post_lexical_fallbacks: None,
+            failure_on_exhaustion: PlaceLoadFailure::NotFound,
+            constraint_keys: Vec::new(),
+            scope_declarations: SmallVec::new(),
+            place_expr_prefix_loads: None,
+        }
+    }
+
+    /// Creates a load whose first source is from its own scope.
+    ///
+    /// `exit_constraint`, when present, is activated only after inference
+    /// visits the local source (that source was already selected from the
+    /// binding state identified by the constraint, it is deliberately not
+    /// reapplied to the local source).
+    pub(crate) fn from_local_source(
+        local: PlaceLoadSourceKind<'db>,
+        exit_constraint: Option<(FileScopeId, ConstraintKey)>,
+    ) -> Self {
+        let mut load = Self::new();
+        load.local_source =
+            Some(load.make_source(local, PlaceLoadSourceRole::Ordinary, exit_constraint));
+        load
+    }
+
+    /// Records the name resolution failure associated with exhausting all sources.
+    pub(crate) fn with_failure_on_exhaustion(
+        mut self,
+        failure_on_exhaustion: PlaceLoadFailure,
+    ) -> Self {
+        self.failure_on_exhaustion = failure_on_exhaustion;
+        self
+    }
+
+    /// Returns the name resolution failure associated with exhausting all sources.
+    pub(crate) fn failure_on_exhaustion(&self) -> PlaceLoadFailure {
+        self.failure_on_exhaustion
+    }
+
+    /// Makes fallbacks conditional on every tracked place-expression prefix being undefined in
+    /// the load's scope.
+    pub(crate) fn with_conditional_fallbacks(
+        mut self,
+        place_expr_prefix_loads: PlaceExprPrefixLoads<'db>,
+    ) -> Self {
+        self.place_expr_prefix_loads = Some(place_expr_prefix_loads);
+        self
+    }
+
+    /// Returns the constraints used to narrow `source`
+    /// (and records which constraints are active after it).
+    pub(crate) fn narrowing_constraints_for(
+        &self,
+        source: &PlaceLoadSource<'db>,
+        checkpoint: &mut PlaceLoadConstraintCheckpoint,
+    ) -> &[(FileScopeId, ConstraintKey)] {
+        checkpoint.0 = checkpoint.0.max(source.exit_checkpoint.0);
+        &self.constraint_keys[..source.entry_checkpoint.0]
+    }
+
+    /// Returns the constraints used after all lexical sources are exhausted
+    /// (and records that inference reached that point).
+    pub(crate) fn narrowing_constraints_on_exhaustion(
+        &self,
+        checkpoint: &mut PlaceLoadConstraintCheckpoint,
+    ) -> &[(FileScopeId, ConstraintKey)] {
+        checkpoint.0 = self.constraint_keys.len();
+        &self.constraint_keys
+    }
+
+    /// Consumes the load and returns the constraints active at `checkpoint`.
+    pub(crate) fn into_constraints(
+        mut self,
+        checkpoint: &PlaceLoadConstraintCheckpoint,
+    ) -> Vec<(FileScopeId, ConstraintKey)> {
+        self.constraint_keys.truncate(checkpoint.0);
+        self.constraint_keys
+    }
+
+    /// Returns the source from the load's own scope as a zero-or-one slice.
+    pub(crate) fn local_sources(&self) -> &[PlaceLoadSource<'db>] {
+        self.local_source.as_slice()
+    }
+
+    /// Returns the lexical and post-lexical fallbacks together with their applicability condition.
+    pub(crate) fn fallbacks(&self) -> PlaceLoadFallbacks<'_, 'db> {
+        self.place_expr_prefix_loads.as_ref().map_or(
+            PlaceLoadFallbacks::Unconditional {
+                lexical: &self.lexical_fallbacks,
+                post_lexical: self.post_lexical_fallbacks.as_ref(),
+            },
+            |prefix_loads| PlaceLoadFallbacks::IfNoPlaceExprPrefixIsBound {
+                prefix_loads,
+                lexical: &self.lexical_fallbacks,
+                post_lexical: self.post_lexical_fallbacks.as_ref(),
+            },
+        )
+    }
+
+    /// Appends a lexical fallback source.
+    pub(crate) fn push_source(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+    ) {
+        let source = self.make_source(kind, role, None);
+        self.lexical_fallbacks.push(source);
+    }
+
+    /// Appends a lexical fallback source and a constraint that becomes active
+    /// after that source is visited.
+    pub(crate) fn push_source_with_exit_constraint(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+        constraint: (FileScopeId, ConstraintKey),
+    ) {
+        let source = self.make_source(kind, role, Some(constraint));
+        self.lexical_fallbacks.push(source);
+    }
+
+    /// Appends a lexical fallback source without applying any narrowing constraints to it.
+    pub(crate) fn push_unnarrowed_source(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+    ) {
+        let exit_checkpoint = self.current_constraint_checkpoint();
+        self.lexical_fallbacks.push(PlaceLoadSource {
+            kind,
+            entry_checkpoint: PlaceLoadConstraintCheckpoint::default(),
+            exit_checkpoint,
+            role,
+        });
+    }
+
+    /// Extends the list of constraints used by subsequent sources.
+    pub(crate) fn push_constraint(&mut self, scope: FileScopeId, key: ConstraintKey) {
+        self.constraint_keys.push((scope, key));
+    }
+
+    /// Finishes a load that can fall through to implicit globals and builtins.
+    pub(crate) fn finish_at_global_scope(
+        mut self,
+        file: ProgramFile<'db>,
+        name: Option<&Name>,
+    ) -> Self {
+        if let Some(name) = name {
+            self.post_lexical_fallbacks = Some(PostLexicalFallbacks {
+                file,
+                name: name.clone(),
+            });
+        }
+
+        self.with_failure_on_exhaustion(PlaceLoadFailure::NotFound)
+    }
+
+    /// Finishes a load at an enclosing binding scope.
+    pub(crate) fn finish_at_enclosing_scope(
+        self,
+        enclosing_scope_kind: ScopeKind,
+        file: ProgramFile<'db>,
+        name: Option<&Name>,
+    ) -> Self {
+        if enclosing_scope_kind.is_class() {
+            self.finish_at_global_scope(file, name)
+        } else {
+            self.with_failure_on_exhaustion(PlaceLoadFailure::UnboundFree)
+        }
+    }
+
+    fn make_source(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+        exit_constraint: Option<(FileScopeId, ConstraintKey)>,
+    ) -> PlaceLoadSource<'db> {
+        let entry_checkpoint = self.current_constraint_checkpoint();
+        self.constraint_keys.extend(exit_constraint);
+        PlaceLoadSource {
+            kind,
+            entry_checkpoint,
+            exit_checkpoint: self.current_constraint_checkpoint(),
+            role,
+        }
+    }
+
+    fn current_constraint_checkpoint(&self) -> PlaceLoadConstraintCheckpoint {
+        PlaceLoadConstraintCheckpoint(self.constraint_keys.len())
+    }
+}
+
+/// Tracks how far inference has progressed through a [`PlaceLoad`]'s constraints.
+///
+/// Only [`PlaceLoad`] can advance or interpret this checkpoint.
+#[derive(Clone, Default)]
+pub(crate) struct PlaceLoadConstraintCheckpoint(usize);
+
+/// The implicit module-global and builtin fallbacks considered after lexical resolution.
+///
+/// The implicit global is narrowed by all constraints collected during resolution.
+/// The builtin fallback deliberately remains unnarrowed.
+pub(crate) struct PostLexicalFallbacks<'db> {
+    file: ProgramFile<'db>,
+    name: Name,
+}
+
+impl<'db> PostLexicalFallbacks<'db> {
+    /// Returns the file containing the load.
+    pub(crate) fn file(&self) -> ProgramFile<'db> {
+        self.file
+    }
+
+    /// Returns the loaded name.
+    pub(crate) fn name(&self) -> &Name {
+        &self.name
+    }
+}
+
+/// The sources considered after a [`PlaceLoad`]'s local source is exhausted.
+#[derive(Clone, Copy)]
+pub(crate) enum PlaceLoadFallbacks<'a, 'db> {
+    /// The fallback sources are always applicable.
+    Unconditional {
+        /// Sources considered during lexical resolution after the local source.
+        lexical: &'a [PlaceLoadSource<'db>],
+        /// The implicit module-global and builtin fallbacks.
+        post_lexical: Option<&'a PostLexicalFallbacks<'db>>,
+    },
+    /// The fallback sources apply only if every tracked prefix is locally undefined.
+    ///
+    /// For example, the enclosing binding of `obj.value` cannot supply the value read in `inner`:
+    ///
+    /// ```python
+    /// class Outer:
+    ///     value: int
+    ///
+    /// class Inner:
+    ///     value: str
+    ///
+    /// def outer():
+    ///     obj = Outer()
+    ///     obj.value = 1
+    ///
+    ///     def inner():
+    ///         obj = Inner()
+    ///         reveal_type(obj.value)  # revealed: str
+    /// ```
+    ///
+    /// The nested scope binds `obj` to a different object, so normal member lookup on the local
+    /// `obj` must handle the load instead.
+    IfNoPlaceExprPrefixIsBound {
+        /// The place-expression prefix loads that control whether fallback is applicable.
+        prefix_loads: &'a PlaceExprPrefixLoads<'db>,
+        /// Sources considered during lexical resolution after the local source.
+        lexical: &'a [PlaceLoadSource<'db>],
+        /// The implicit module-global and builtin fallbacks.
+        post_lexical: Option<&'a PostLexicalFallbacks<'db>>,
+    },
+}
+
+/// Compact descriptions of loads for the tracked prefixes of a place expression.
+pub(crate) struct PlaceExprPrefixLoads<'db> {
+    scope: ScopeId<'db>,
+    loads: SmallVec<[PlaceExprPrefixLoad; 2]>,
+}
+
+impl<'db> PlaceExprPrefixLoads<'db> {
+    /// Creates prefix loads, returning `None` when the iterator is empty.
+    pub(crate) fn from_iter(
+        scope: ScopeId<'db>,
+        loads: impl IntoIterator<Item = PlaceExprPrefixLoad>,
+    ) -> Option<Self> {
+        let loads = loads.into_iter().collect::<SmallVec<_>>();
+        (!loads.is_empty()).then_some(Self { scope, loads })
+    }
+
+    /// Returns the scope containing the prefix loads.
+    pub(crate) fn scope(&self) -> ScopeId<'db> {
+        self.scope
+    }
+
+    /// Iterates over the prefix loads.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = PlaceExprPrefixLoad> + '_ {
+        self.loads.iter().copied()
+    }
+}
+
+/// Describes how a consumer can evaluate one prefix of a place expression.
+#[derive(Clone, Copy)]
+pub(crate) enum PlaceExprPrefixLoad {
+    /// Use the bindings that reach this expression occurrence.
+    AtUse(ScopedUseId),
+    /// Use every binding reachable for this place at the end of its scope.
+    AllReachable(ScopedPlaceId),
+    /// The syntax itself guarantees that the prefix is bound.
+    DefinitelyBound,
+}
+
+/// One source that can supply the value of a place load.
+///
+/// [`PlaceLoad`] stores one shared list of constraint keys. Each source maintains two checkpoints
+/// into that list:
+///
+/// - `entry_checkpoint` identifies the constraints used to narrow the source.
+/// - `exit_checkpoint` identifies the constraints active after inference visits the source.
+///
+/// Those two checkpoints differ when a key identifies the binding state used to construct a source.
+/// That key becomes active after inference visits the source, but applying it to the same source
+/// again would duplicate work.
+///
+/// For `U` in the preceding example, the constraint representation is schematically:
+///
+/// ```text
+/// PlaceLoad {
+///     constraint_keys: [
+///         (next_value, UseId(U)),
+///     ],
+///     sources: [
+///         PlaceLoadSource {
+///             kind: Bindings(next_value at U),
+///             entry_checkpoint: 0,
+///             exit_checkpoint: 1,
+///         },
+///         PlaceLoadSource {
+///             kind: DefinitionsFromOwningScope(make_counter.value),
+///             entry_checkpoint: 1,
+///             exit_checkpoint: 1,
+///         },
+///     ],
+///     failure_on_exhaustion: UnboundFree,
+///     scope_declarations: [Nonlocal(next_value)],
+/// }
+/// ```
+///
+/// The first source already comes from `bindings_at_use(U)`, so its `UseId` key becomes active on
+/// exit but is not applied on entry. If that source is undefined, the `UseId` key narrows the
+/// enclosing `int | None` place to `int`. If both sources are exhausted, the key remains active
+/// for expression-level narrowing.
+#[derive(Clone)]
+pub(crate) struct PlaceLoadSource<'db> {
+    /// How this source supplies the loaded value.
+    pub(crate) kind: PlaceLoadSourceKind<'db>,
+    /// Selects the constraints used to narrow this source.
+    entry_checkpoint: PlaceLoadConstraintCheckpoint,
+    /// Selects the constraints active after inference visits this source.
+    exit_checkpoint: PlaceLoadConstraintCheckpoint,
+    /// The role this source plays in the load.
+    role: PlaceLoadSourceRole,
+}
+
+impl PlaceLoadSource<'_> {
+    /// Returns whether this source is the module fallback for a class-local name.
+    pub(crate) fn is_class_body_global_fallback(&self) -> bool {
+        self.role == PlaceLoadSourceRole::ClassBodyGlobalFallback
+    }
+}
+
+/// Describes how a source can supply a place's value.
+#[derive(Clone)]
+pub(crate) enum PlaceLoadSourceKind<'db> {
+    /// Bindings selected at a use, from an enclosing scope snapshot, or from
+    /// all bindings reachable in a scope.
+    Bindings(BindingWithConstraintsIterator<'db, 'db>),
+    /// Definitions for the loaded place from the scope that binds or declares it.
+    DefinitionsFromOwningScope {
+        /// The scope containing the place.
+        scope: ScopeId<'db>,
+        /// The place within `scope`.
+        id: ScopedPlaceId,
+    },
+    /// A source represented by a specialized query or rule.
+    Implicit(ImplicitPlaceLoad<'db>),
+}
+
+/// A source that consumers evaluate using a specialized query or rule.
+#[derive(Clone)]
+pub(crate) enum ImplicitPlaceLoad<'db> {
+    /// The implicit `__class__` cell for a method, lambda, or generator expression defined directly
+    /// in a class body, e.g.:
+    ///
+    /// ```py
+    /// class C:
+    ///     def method(self):
+    ///         return __class__
+    /// ```
+    DunderClass(Definition<'db>),
+    /// An implicit symbol supplied directly in a class body, e.g.:
+    ///
+    /// ```py
+    /// class C:
+    ///     defining_module = __module__
+    /// ```
+    ClassBodySymbol(Name),
+    /// A symbol in the module's explicit global namespace, e.g.:
+    ///
+    /// ```py
+    /// answer = 42
+    ///
+    /// def get_answer():
+    ///     return answer
+    /// ```
+    ExplicitGlobalSymbol { file: ProgramFile<'db>, name: Name },
+}
+
+/// The role a source plays in a place load.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PlaceLoadSourceRole {
+    /// The source follows ordinary Python name resolution rules.
+    Ordinary,
+    /// The source follows Python’s class-local-to-module fallback rules.
+    ClassBodyGlobalFallback,
+}
+
+/// The name resolution failure associated with exhausting a place load's sources.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PlaceLoadFailure {
+    /// No namespace supplies the name, which raises `NameError`.
+    NotFound,
+    /// The current function-like binding scope owns the name but supplies no value, which raises
+    /// `UnboundLocalError`.
+    UnboundLocal,
+    /// An enclosing function-like binding scope owns the name but its closure cell is empty, which
+    /// raises `NameError`.
+    UnboundFree,
+}
+
+/// An explicit declaration crossed while resolving a load.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScopedDeclaration {
+    /// A `global` declaration in this scope.
+    Global(FileScopeId),
+    /// A `nonlocal` declaration in this scope.
+    Nonlocal(FileScopeId),
+}

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -40,6 +40,11 @@ use crate::place::{
     place_from_bindings_with_reachability_cache, place_from_declarations_with_reachability_cache,
     typing_extensions_symbol,
 };
+use crate::place_load::{
+    ImplicitPlaceLoad, PlaceExprPrefixLoad, PlaceExprPrefixLoads, PlaceLoad,
+    PlaceLoadConstraintCheckpoint, PlaceLoadFailure, PlaceLoadFallbacks, PlaceLoadSource,
+    PlaceLoadSourceKind, PlaceLoadSourceRole, PostLexicalFallbacks, ScopedDeclaration,
+};
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attribute_members};
@@ -1891,27 +1896,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     /// Returns the implicit `__class__` cell in the current direct method body or
     /// lazy scope defined directly in a class body.
-    fn dunder_class_cell_type(&self) -> Option<ClassLiteral<'db>> {
+    fn dunder_class_cell_definition(&self) -> Option<Definition<'db>> {
         let current_scope_id = self.scope().file_scope_id(self.db());
-        let class_definition =
-            if let Some(definition) = self.index.class_definition_of_method(current_scope_id) {
-                definition
-            } else {
-                let current_scope = self.index.scope(current_scope_id);
-                if !matches!(
-                    current_scope.node(),
-                    NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
-                ) {
-                    return None;
-                }
-                let class = self
-                    .index
-                    .parent_scope(current_scope_id)?
-                    .node()
-                    .as_class()?;
-                self.index.expect_single_definition(class)
-            };
-        original_class_type(self.db(), class_definition)
+        if let Some(definition) = self.index.class_definition_of_method(current_scope_id) {
+            return Some(definition);
+        }
+
+        let current_scope = self.index.scope(current_scope_id);
+        if !matches!(
+            current_scope.node(),
+            NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
+        ) {
+            return None;
+        }
+        let class = self
+            .index
+            .parent_scope(current_scope_id)?
+            .node()
+            .as_class()?;
+        Some(self.index.expect_single_definition(class))
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.
@@ -9605,84 +9608,31 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
         let db = self.db();
-        let ast::ExprName {
-            range: _,
-            node_index: _,
-            id: symbol_name,
-            ctx: _,
-        } = name_node;
         let expr = PlaceExpr::from_expr_name(name_node);
 
-        let (resolved, constraint_keys) =
+        let (resolved, _) =
             self.infer_place_load(PlaceExprRef::from(&expr), ast::ExprRef::Name(name_node));
         let env = self.program_environment();
 
-        let resolved_after_fallback = resolved
-            // Not found in the module's explicitly declared global symbols?
-            // Check the "implicit globals" such as `__doc__`, `__file__`, `__name__`, etc.
-            // These are looked up as attributes on `types.ModuleType`.
-            .or_fall_back_to(db, env, || {
-                module_type_implicit_global_symbol(db, self.program_file(), symbol_name).map_type(
-                    |ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            PlaceExprRef::from(&expr),
-                            ty,
-                            &constraint_keys,
-                        )
-                    },
-                )
-            })
-            // Not found in globals? Fallback to builtins
-            // (without infinite recursion if we're already in builtins.)
-            .or_fall_back_to(db, env, || {
-                if Some(self.scope()) == builtins_module_scope(db, env) {
-                    Place::Undefined.into()
-                } else {
-                    implicit_builtins_symbol(db, env, symbol_name)
-                }
-            })
-            // Still not found? It might be `reveal_type`...
-            .or_fall_back_to(db, env, || {
-                if symbol_name == "reveal_type" {
-                    if !self.in_stub()
-                        && !self.is_in_type_checking_block(self.scope(), name_node)
-                        && let Some(builder) =
-                            self.context.report_lint(&UNDEFINED_REVEAL, name_node)
-                    {
-                        let mut diag =
-                            builder.into_diagnostic("`reveal_type` used without importing it");
-                        diag.info(
-                            "This is allowed for debugging convenience but will fail at runtime",
-                        );
-                    }
-                    typing_extensions_symbol(db, env, symbol_name)
-                } else {
-                    Place::Undefined.into()
-                }
-            });
-
-        let ty = resolved_after_fallback.unwrap_with_diagnostic(db, env, |lookup_error| {
-            match lookup_error {
-                LookupError::Undefined(qualifiers) => {
-                    self.report_unresolved_reference(name_node);
-                    TypeAndQualifiers::new(Type::unknown(), TypeOrigin::Inferred, qualifiers)
-                }
-                LookupError::PossiblyUndefined(type_when_bound) => {
-                    report_possibly_unresolved_reference(&self.context, name_node);
-                    type_when_bound
-                }
+        let ty = resolved.unwrap_with_diagnostic(db, env, |lookup_error| match lookup_error {
+            LookupError::Undefined(qualifiers) => {
+                self.report_unresolved_reference(name_node);
+                TypeAndQualifiers::new(Type::unknown(), TypeOrigin::Inferred, qualifiers)
+            }
+            LookupError::PossiblyUndefined(type_when_bound) => {
+                report_possibly_unresolved_reference(&self.context, name_node);
+                type_when_bound
             }
         });
 
         ty.inner_type()
     }
 
-    fn infer_local_place_load(
+    fn local_place_load_source(
         &self,
         expr: PlaceExprRef,
         expr_ref: ast::ExprRef,
-    ) -> (Place<'db>, Option<ScopedUseId>) {
-        let env = self.program_environment();
+    ) -> Option<(PlaceLoadSourceKind<'db>, Option<ScopedUseId>)> {
         let db = self.db();
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
@@ -9691,53 +9641,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // If we're inferring types of deferred expressions, look them up from end-of-scope.
         if self.is_deferred() {
-            let place = if let Some(place_id) = place_table.place_id(expr) {
-                place_from_bindings_with_reachability_cache(
-                    db,
-                    env,
-                    use_def.reachable_bindings(place_id),
-                    self.reachability_cache(),
-                )
-                .place
-            } else {
+            let source = place_table.place_id(expr).map(|place_id| {
+                PlaceLoadSourceKind::Bindings(use_def.reachable_bindings(place_id))
+            });
+            if source.is_none() {
                 assert!(
                     self.in_string_annotation(),
                     "Expected the place table to create a place for every valid PlaceExpr node"
                 );
-                Place::Undefined
-            };
-            (place, None)
+            }
+            source.map(|source| (source, None))
         } else {
             if expr_ref
                 .as_name_expr()
                 .is_some_and(|name| name.is_invalid())
             {
-                return (Place::Undefined, None);
+                return None;
             }
 
-            // A named expression can show up here when resolving the parent place of something
-            // like `(foo := bar()).baz`. It binds `foo`, but it is not a normal load site and
-            // therefore has no `ScopedUseId`, so resolve it from its binding definition instead.
-            if let ast::ExprRef::Named(named) = expr_ref {
-                let place = if named.target.is_name_expr() {
-                    let definition = self.index.expect_single_definition(named);
-                    Place::bound(binding_type(self.db(), definition)).with_definition(definition)
-                } else {
-                    Place::Undefined
-                };
-                return (place, None);
+            if matches!(expr_ref, ast::ExprRef::Named(_)) {
+                return None;
             }
 
             let use_id = expr_ref.scoped_use_id(db, self.program_file());
-            let place = place_from_bindings_with_reachability_cache(
-                db,
-                env,
-                use_def.bindings_at_use(use_id),
-                self.reachability_cache(),
-            )
-            .place;
-
-            (place, Some(use_id))
+            Some((
+                PlaceLoadSourceKind::Bindings(use_def.bindings_at_use(use_id)),
+                Some(use_id),
+            ))
         }
     }
 
@@ -9753,19 +9683,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// ```
     ///
     /// `symbol_name` is only needed when no snapshot is available: snapshots can resolve complex
-    /// places like `a.x`, but the fallback global query only works for bare symbols. `assume_bound`
+    /// places like `a.x`, but the fallback global query only works for bare symbols. `role`
     /// preserves the class-body fallback behavior for names that are also local to the class body.
-    fn infer_explicit_global_symbol_load(
+    fn resolve_global_place_load(
         &self,
+        mut load: PlaceLoad<'db>,
         place_expr: PlaceExprRef,
-        symbol_name: Option<&str>,
+        expr_ref: ast::ExprRef,
+        symbol_name: Option<&Name>,
         current_scope_id: FileScopeId,
-        constraint_keys: &mut Vec<(FileScopeId, ConstraintKey)>,
-        assume_bound: bool,
-    ) -> PlaceAndQualifiers<'db> {
-        let db = self.db();
+        role: PlaceLoadSourceRole,
+    ) -> PlaceLoad<'db> {
+        let file = self.program_file();
+        let post_lexical_name = expr_ref.as_name_expr().map(|name| &name.id);
+
         if current_scope_id.is_global() {
-            return Place::Undefined.into();
+            return load.finish_at_global_scope(file, post_lexical_name);
         }
 
         if !self.is_deferred() {
@@ -9774,362 +9707,669 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .enclosing_snapshot(FileScopeId::global(), place_expr, current_scope_id)
             {
                 EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                    constraint_keys.push((
+                    load.push_constraint(
                         FileScopeId::global(),
                         ConstraintKey::NarrowingConstraint(constraint),
-                    ));
+                    );
                     // Reaching here means that no bindings are found in any scope.
-                    // Since `explicit_global_symbol` may return a cycle initial value, we return `Place::Undefined` here.
-                    return Place::Undefined.into();
+                    // Since `explicit_global_symbol` may return a cycle initial value,
+                    // don't add it to the `sources` on the `PlaceLoad`.
+                    return load.finish_at_global_scope(file, post_lexical_name);
                 }
                 EnclosingSnapshotResult::FoundBindings(bindings) => {
-                    let mut place_and_qualifiers = place_from_bindings_with_reachability_cache(
-                        db,
-                        self.program_environment(),
-                        bindings,
-                        self.reachability_cache(),
+                    load.push_source_with_exit_constraint(
+                        PlaceLoadSourceKind::Bindings(bindings),
+                        role,
+                        (
+                            FileScopeId::global(),
+                            ConstraintKey::NestedScope(current_scope_id),
+                        ),
                     );
-                    if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place {
-                        place_and_qualifiers.place =
-                            Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
-                    }
-                    let place = place_and_qualifiers.place.map_type(|ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            place_expr,
-                            ty,
-                            constraint_keys,
-                        )
-                    });
-                    constraint_keys.push((
-                        FileScopeId::global(),
-                        ConstraintKey::NestedScope(current_scope_id),
-                    ));
-                    return place.into();
+                    return load.finish_at_global_scope(file, post_lexical_name);
                 }
                 // There are no visible bindings / constraint here.
                 EnclosingSnapshotResult::NotFound => {
-                    return Place::Undefined.into();
+                    return load.finish_at_global_scope(file, post_lexical_name);
                 }
                 EnclosingSnapshotResult::NoLongerInEagerContext => {}
             }
         }
 
         let Some(symbol_name) = symbol_name else {
-            return Place::Undefined.into();
+            return load.finish_at_global_scope(file, post_lexical_name);
         };
 
-        explicit_global_symbol(self.db(), self.program_file(), symbol_name).map_type(|ty| {
-            self.narrow_place_with_applicable_constraints(place_expr, ty, constraint_keys)
-        })
+        load.push_source(
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ExplicitGlobalSymbol {
+                file: self.program_file(),
+                name: symbol_name.clone(),
+            }),
+            role,
+        );
+        load.finish_at_global_scope(file, post_lexical_name)
     }
 
-    /// Infer the type of a place expression from definitions, assuming a load context.
-    /// This method also returns the [`ConstraintKey`]s for each scope associated with `expr`,
-    /// which is used to narrow by condition rather than by assignment.
-    fn infer_place_load(
+    /// Resolves a place load into an ordered list of sources that might supply its value.
+    ///
+    /// Please see the [`place_load` module](crate::place_load) for a description
+    /// of the resolution model.
+    fn resolve_place_load(
         &self,
         place_expr: PlaceExprRef,
         expr_ref: ast::ExprRef,
-    ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
-        let env = self.program_environment();
+    ) -> PlaceLoad<'db> {
         let db = self.db();
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
         let place_table = self.index.place_table(file_scope_id);
 
-        let mut constraint_keys = vec![];
-        let (local_scope_place, use_id) = self.infer_local_place_load(place_expr, expr_ref);
-        if let Some(use_id) = use_id {
-            constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
+        let mut load = match self.local_place_load_source(place_expr, expr_ref) {
+            Some((local_source, use_id)) => PlaceLoad::from_local_source(
+                local_source,
+                use_id.map(|use_id| (file_scope_id, ConstraintKey::UseId(use_id))),
+            ),
+            None => PlaceLoad::new(),
+        };
+
+        if let Some(prefix_loads) = self.place_expr_prefix_loads(place_expr, expr_ref) {
+            load = load.with_conditional_fallbacks(prefix_loads);
         }
 
-        let fallback = || {
-            let mut symbol_resolves_locally = false;
-            if let Some(symbol) = place_expr.as_symbol()
-                && let Some(symbol_id) = place_table.symbol_id(symbol.name())
-            {
-                // Footgun: `place_expr` and `symbol` were probably constructed with all-zero
-                // flags. We need to read the place table to get correct flags.
-                symbol_resolves_locally = place_table.symbol(symbol_id).is_local();
-                // If we try to access a variable in a class before it has been defined, the
-                // lookup will fall back to global. See the comment on `Symbol::is_local`.
-                let fallback_to_global =
-                    scope.node(db).scope_kind().is_class() && symbol_resolves_locally;
-                if self.skip_non_global_scopes(file_scope_id, symbol_id) || fallback_to_global {
-                    return self.infer_explicit_global_symbol_load(
-                        place_expr,
-                        Some(symbol.name()),
-                        file_scope_id,
-                        &mut constraint_keys,
-                        fallback_to_global,
-                    );
-                }
+        let mut symbol_is_local = false;
+        if let Some(symbol) = place_expr.as_symbol()
+            && let Some(symbol_id) = place_table.symbol_id(symbol.name())
+        {
+            // Footgun: `place_expr` and `symbol` were probably constructed with all-zero
+            // flags. We need to read the place table to get correct flags.
+            let indexed_symbol = place_table.symbol(symbol_id);
+            symbol_is_local = indexed_symbol.is_local();
+            if indexed_symbol.is_global() {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Global(file_scope_id));
             }
-
-            // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
-            // `global`, never refer to an enclosing scope. (If you reference such a symbol before
-            // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
-            // enclosing scopes in this case. The one exception to this rule is the global fallback
-            // in class bodies, which we already handled above.
-            if symbol_resolves_locally {
-                return Place::Undefined.into();
+            if indexed_symbol.is_nonlocal() {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Nonlocal(file_scope_id));
             }
-
-            if let PlaceExprRef::Symbol(symbol) = place_expr
-                && symbol.name() == "__class__"
-                && let Some(class) = self.dunder_class_cell_type()
-            {
-                return Place::bound(class).into();
-            }
-
-            for parent_id in place_table.parents(place_expr) {
-                let parent_expr = place_table.place(parent_id);
-                let mut expr_ref = expr_ref;
-                for _ in 0..(place_expr.num_member_segments() - parent_expr.num_member_segments()) {
-                    match expr_ref {
-                        ast::ExprRef::Attribute(attribute) => {
-                            expr_ref = ast::ExprRef::from(&attribute.value);
-                        }
-                        ast::ExprRef::Subscript(subscript) => {
-                            expr_ref = ast::ExprRef::from(&subscript.value);
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                let (parent_place, _use_id) = self.infer_local_place_load(parent_expr, expr_ref);
-                if let Place::Defined(_) = parent_place {
-                    return Place::Undefined.into();
-                }
-            }
-
-            // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
-            // There are two main ways we try to model these loads:
-            //
-            // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
-            //    just before a nested scope begins. For variables that aren't modified after that
-            //    point, that's the only value that the nested scope can see. If a variable is
-            //    reassigned later, lazy snapshots for that variable can be updated or swept.
-            //
-            // 2. Otherwise, we keep walking until we get to the variable's original defining
-            //    scope, and we use its "public type" there, which respects all reachable bindings,
-            //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
-            //    definitions that we install after each nested scope is closed, so it has
-            //    a complete view of the nested `global` and `nonlocal` writes beneath it.
-            //
-            // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
-            // local to the current scope never falls back to an enclosing scope, even if it's only
-            // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
-            //
-            // Note that we only get to this walk via `or_fall_back_to` above. In other words, for
-            // definitely-locally-bound variables, we defer to the current scope's bindings instead
-            // of looking at enclosing scopes. Concretely:
-            //
-            // def f():
-            //     x = None
-            //
-            //     def g():
-            //         nonlocal x
-            //         if flag:
-            //             x = 42
-            //
-            //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
-            //         # public type in `f`.
-            //         reveal_type(x)  # revealed: Literal[42, 99] | None
-            //
-            //         x = 99
-            //         # But now `x` is definitely bound, so we don't do the walk.
-            //         reveal_type(x)  # revealed: Literal[99]
-            //
-            // Importantly, this approach isn't generally sound. The public type could include
-            // nested bindings from sibling scopes, which really could run at any time, and in some
-            // cases we're being too deferential to local bindings. Unfortunately the fully sound
-            // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
-            // which is too frustrating for users in practice.
-            for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
-                // If the current enclosing scope is global, no place lookup is performed here,
-                // instead falling back to the module's explicit global lookup below.
-                if enclosing_scope_file_id.is_global() {
-                    break;
-                }
-
-                // Class scopes are not visible to nested scopes, and we need to handle global
-                // scope differently (because an unbound name there falls back to builtins), so
-                // check only function-like scopes.
-                // There is one exception to this rule: annotation scopes can see
-                // names defined in an immediately-enclosing class scope.
-                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
-
-                let is_immediately_enclosing_scope = scope.is_annotation(db)
-                    && scope
-                        .scope(db)
-                        .parent()
-                        .is_some_and(|parent| parent == enclosing_scope_file_id);
-
-                let has_root_place_been_reassigned = || {
-                    let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                    enclosing_place_table
-                        .parents(place_expr)
-                        .any(|enclosing_root_place_id| {
-                            enclosing_place_table
-                                .place(enclosing_root_place_id)
-                                .is_bound()
-                        })
+            // If we try to access a variable in a class before it has been defined, the
+            // lookup will fall back to global. See the comment on `Symbol::is_local`.
+            let class_body_global_fallback =
+                scope.node(db).scope_kind().is_class() && symbol_is_local;
+            if self.skip_non_global_scopes(file_scope_id, symbol_id) || class_body_global_fallback {
+                let role = if class_body_global_fallback {
+                    PlaceLoadSourceRole::ClassBodyGlobalFallback
+                } else {
+                    PlaceLoadSourceRole::Ordinary
                 };
+                return self.resolve_global_place_load(
+                    load,
+                    place_expr,
+                    expr_ref,
+                    Some(symbol.name()),
+                    file_scope_id,
+                    role,
+                );
+            }
+        }
 
+        // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
+        // `global`, never refer to an enclosing scope. (If you reference such a symbol before
+        // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
+        // enclosing scopes in this case. The one exception to this rule is the global fallback
+        // in class bodies, which we already handled above.
+        if symbol_is_local {
+            if scope.node(db).scope_kind().is_module() {
+                return load.finish_at_global_scope(
+                    self.program_file(),
+                    expr_ref.as_name_expr().map(|name| &name.id),
+                );
+            }
+            return load.with_failure_on_exhaustion(PlaceLoadFailure::UnboundLocal);
+        }
+
+        if let PlaceExprRef::Symbol(symbol) = place_expr
+            && symbol.name() == "__class__"
+            && let Some(definition) = self.dunder_class_cell_definition()
+        {
+            load.push_unnarrowed_source(
+                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::DunderClass(definition)),
+                PlaceLoadSourceRole::Ordinary,
+            );
+        }
+
+        // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
+        // There are two main ways we try to model these loads:
+        //
+        // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
+        //    just before a nested scope begins. For variables that aren't modified after that
+        //    point, that's the only value that the nested scope can see. If a variable is
+        //    reassigned later, lazy snapshots for that variable can be updated or swept.
+        //
+        // 2. Otherwise, we keep walking until we get to the variable's original defining
+        //    scope, and we use its "public type" there, which respects all reachable bindings,
+        //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
+        //    definitions that we install after each nested scope is closed, so it has
+        //    a complete view of the nested `global` and `nonlocal` writes beneath it.
+        //
+        // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
+        // local to the current scope never falls back to an enclosing scope, even if it's only
+        // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
+        //
+        // The sources are evaluated in order. For definitely-locally-bound variables,
+        // inference stops at the current scope's bindings instead of evaluating enclosing
+        // sources. Concretely:
+        //
+        // def f():
+        //     x = None
+        //
+        //     def g():
+        //         nonlocal x
+        //         if flag:
+        //             x = 42
+        //
+        //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
+        //         # public type in `f`.
+        //         reveal_type(x)  # revealed: Literal[42, 99] | None
+        //
+        //         x = 99
+        //         # But now `x` is definitely bound, so we don't do the walk.
+        //         reveal_type(x)  # revealed: Literal[99]
+        //
+        // Importantly, this approach isn't generally sound. The public type could include
+        // nested bindings from sibling scopes, which really could run at any time, and in some
+        // cases we're being too deferential to local bindings. Unfortunately the fully sound
+        // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
+        // which is too frustrating for users in practice.
+        for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
+            // If the current enclosing scope is global, no place lookup is performed here,
+            // instead falling back to the module's explicit global lookup below.
+            if enclosing_scope_file_id.is_global() {
+                break;
+            }
+
+            // Class scopes are not visible to nested scopes, and we need to handle global
+            // scope differently (because an unbound name there falls back to builtins), so
+            // check only function-like scopes.
+            // There is one exception to this rule: annotation scopes can see
+            // names defined in an immediately-enclosing class scope.
+            let enclosing_scope = self.index.scope(enclosing_scope_file_id);
+
+            let is_immediately_enclosing_scope = scope.is_annotation(db)
+                && scope
+                    .scope(db)
+                    .parent()
+                    .is_some_and(|parent| parent == enclosing_scope_file_id);
+
+            let has_root_place_been_reassigned = || {
+                let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
+                enclosing_place_table
+                    .parents(place_expr)
+                    .any(|enclosing_root_place_id| {
+                        enclosing_place_table
+                            .place(enclosing_root_place_id)
+                            .is_bound()
+                    })
+            };
+
+            let mut eagerly_undefined = false;
+            if !self.is_deferred() {
                 // If the reference is in a nested eager scope, we need to look for the place at
                 // the point where the previous enclosing scope was defined, instead of at the end
                 // of the scope. (Note that the semantic index builder takes care of only
                 // registering eager bindings for nested scopes that are actually eager, and for
                 // enclosing scopes that actually contain bindings that we should use when
                 // resolving the reference.)
-                let mut eagerly_resolved_place = None;
-                if !self.is_deferred() {
-                    match self.index.enclosing_snapshot(
-                        enclosing_scope_file_id,
-                        place_expr,
-                        file_scope_id,
-                    ) {
-                        EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                            constraint_keys.push((
-                                enclosing_scope_file_id,
-                                ConstraintKey::NarrowingConstraint(constraint),
-                            ));
-                            // If the current scope is eager, it is certain that the place is undefined in the current scope.
-                            // Do not call the `place` query below as a fallback.
-                            if scope.scope(db).is_eager() {
-                                eagerly_resolved_place = Some(Place::Undefined.into());
-                            }
+                match self.index.enclosing_snapshot(
+                    enclosing_scope_file_id,
+                    place_expr,
+                    file_scope_id,
+                ) {
+                    EnclosingSnapshotResult::FoundConstraint(constraint) => {
+                        load.push_constraint(
+                            enclosing_scope_file_id,
+                            ConstraintKey::NarrowingConstraint(constraint),
+                        );
+                        // If the current scope is eager, it is certain that the place is undefined
+                        // in the current scope. Do not add the place below as a fallback.
+                        if scope.scope(db).is_eager() {
+                            eagerly_undefined = true;
                         }
-                        EnclosingSnapshotResult::FoundBindings(bindings) => {
-                            let place = place_from_bindings_with_reachability_cache(
-                                db,
-                                env,
-                                bindings,
-                                self.reachability_cache(),
-                            )
-                            .place
-                            .map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
-                            constraint_keys.push((
+                    }
+                    EnclosingSnapshotResult::FoundBindings(bindings) => {
+                        load.push_source_with_exit_constraint(
+                            PlaceLoadSourceKind::Bindings(bindings),
+                            PlaceLoadSourceRole::Ordinary,
+                            (
                                 enclosing_scope_file_id,
                                 ConstraintKey::NestedScope(file_scope_id),
-                            ));
-                            return place.into();
+                            ),
+                        );
+                        return load.finish_at_enclosing_scope(
+                            enclosing_scope.kind(),
+                            self.program_file(),
+                            expr_ref.as_name_expr().map(|name| &name.id),
+                        );
+                    }
+                    EnclosingSnapshotResult::NotFound => {
+                        // There are no visible bindings or constraints here. Don't fall back to
+                        // non-eager place resolution if the root place has been reassigned.
+                        if has_root_place_been_reassigned() {
+                            return load.finish_at_enclosing_scope(
+                                enclosing_scope.kind(),
+                                self.program_file(),
+                                expr_ref.as_name_expr().map(|name| &name.id),
+                            );
                         }
-                        // There are no visible bindings / constraint here.
-                        // Don't fall back to non-eager place resolution.
-                        EnclosingSnapshotResult::NotFound => {
-                            if has_root_place_been_reassigned() {
-                                return Place::Undefined.into();
-                            }
-                            continue;
-                        }
-                        EnclosingSnapshotResult::NoLongerInEagerContext => {
-                            if has_root_place_been_reassigned() {
-                                return Place::Undefined.into();
-                            }
+                        continue;
+                    }
+                    EnclosingSnapshotResult::NoLongerInEagerContext => {
+                        if has_root_place_been_reassigned() {
+                            return load.finish_at_enclosing_scope(
+                                enclosing_scope.kind(),
+                                self.program_file(),
+                                expr_ref.as_name_expr().map(|name| &name.id),
+                            );
                         }
                     }
                 }
-
-                if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope {
-                    continue;
-                }
-
-                let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
-                    continue;
-                };
-
-                let enclosing_place = enclosing_place_table.place(enclosing_place_id);
-
-                // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
-                // marks the variable `global`, whether or not that scope actually binds the
-                // variable. If we see a `global` declaration, stop walking scopes and proceed to
-                // the global handling below. (If we're walking from a prior/inner scope where this
-                // variable is `nonlocal`, then this is a semantic syntax error, but we don't
-                // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
-                if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
-                    break;
-                }
-
-                // Keep walking until we reach the defining scope of the variable. The synthetic
-                // nested bindings definitions installed there will see everything below it.
-                if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
-                    continue;
-                }
-                if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
-                    // Note that this check includes members like `x.y` and `x[0]`, which aren't
-                    // symbols and can't be explicitly `nonlocal`.
-                    continue;
-                }
-
-                // We've reached the defining scope of the variable. Infer its public type.
-                debug_assert!(enclosing_place.is_bound() || enclosing_place.is_declared());
-                let enclosing_scope_id =
-                    enclosing_scope_file_id.to_scope_id(db, self.program_file());
-                return eagerly_resolved_place.unwrap_or_else(|| {
-                    place_by_id(
-                        self.db(),
-                        enclosing_scope_id,
-                        enclosing_place_id,
-                        RequiresExplicitReExport::No,
-                        ConsideredDefinitions::AllReachable,
-                    )
-                    .map_type(|ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            place_expr,
-                            ty,
-                            &constraint_keys,
-                        )
-                    })
-                });
             }
 
-            PlaceAndQualifiers::default()
-                // If we're in a class body, check for implicit class body symbols first.
-                // These take precedence over globals.
-                .or_fall_back_to(db, env, || {
-                    if scope.node(db).scope_kind().is_class()
-                        && let Some(symbol) = place_expr.as_symbol()
-                    {
-                        let implicit = class_body_implicit_symbol(db, env, symbol.name());
-                        if implicit.place.is_definitely_bound() {
-                            return implicit.map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
-                        }
-                    }
-                    Place::Undefined.into()
-                })
-                // No nonlocal binding? Check the module's explicit globals.
-                // Avoid infinite recursion if `self.scope` already is the module's global scope.
-                .or_fall_back_to(db, env, || {
-                    self.infer_explicit_global_symbol_load(
-                        place_expr,
-                        place_expr.as_symbol().map(|symbol| symbol.name().as_str()),
-                        file_scope_id,
-                        &mut constraint_keys,
-                        false,
-                    )
-                })
-        };
-        let place = PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, env, fallback);
+            if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope {
+                continue;
+            }
 
-        if let Some(ty) = place.place.ignore_possibly_undefined() {
+            let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
+            let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
+                continue;
+            };
+
+            let enclosing_place = enclosing_place_table.place(enclosing_place_id);
+
+            // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
+            // marks the variable `global`, whether or not that scope actually binds the
+            // variable. If we see a `global` declaration, stop walking scopes and proceed to
+            // the global handling below. (If we're walking from a prior/inner scope where this
+            // variable is `nonlocal`, then this is a semantic syntax error, but we don't
+            // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
+            if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Global(enclosing_scope_file_id));
+                break;
+            }
+
+            // Keep walking until we reach the defining scope of the variable. The synthetic
+            // nested bindings definitions installed there will see everything below it.
+            if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Nonlocal(enclosing_scope_file_id));
+                continue;
+            }
+            if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
+                // Note that this check includes members like `x.y` and `x[0]`, which aren't
+                // symbols and can't be explicitly `nonlocal`.
+                continue;
+            }
+
+            // We've reached the scope that owns the place. Record it so each consumer can
+            // evaluate the considered definitions it needs.
+            if !eagerly_undefined {
+                let enclosing_scope_id =
+                    enclosing_scope_file_id.to_scope_id(db, self.program_file());
+                load.push_source(
+                    PlaceLoadSourceKind::DefinitionsFromOwningScope {
+                        scope: enclosing_scope_id,
+                        id: enclosing_place_id,
+                    },
+                    PlaceLoadSourceRole::Ordinary,
+                );
+            }
+            return load.finish_at_enclosing_scope(
+                enclosing_scope.kind(),
+                self.program_file(),
+                expr_ref.as_name_expr().map(|name| &name.id),
+            );
+        }
+
+        // If we're in a class body, check for implicit class body symbols first.
+        // These take precedence over globals.
+        if scope.node(db).scope_kind().is_class()
+            && let Some(symbol) = place_expr.as_symbol()
+        {
+            load.push_source(
+                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ClassBodySymbol(
+                    symbol.name().clone(),
+                )),
+                PlaceLoadSourceRole::Ordinary,
+            );
+        }
+
+        // Continue resolution in the module's explicit global scope.
+        self.resolve_global_place_load(
+            load,
+            place_expr,
+            expr_ref,
+            place_expr.as_symbol().map(Symbol::name),
+            file_scope_id,
+            PlaceLoadSourceRole::Ordinary,
+        )
+    }
+
+    /// Infer the type of a place expression from its ordered load sources.
+    ///
+    /// This also returns the [`ConstraintKey`]s used by expression-level narrowing.
+    fn infer_place_load(
+        &self,
+        place_expr: PlaceExprRef,
+        expr_ref: ast::ExprRef,
+    ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
+        let env = self.program_environment();
+        // Named expressions bind their target but are not ordinary load sites, so resolve the
+        // target from its binding definition.
+        if let ast::ExprRef::Named(named) = expr_ref
+            && named.target.is_name_expr()
+        {
+            let definition = self.index.expect_single_definition(named);
+            let place =
+                Place::bound(binding_type(self.db(), definition)).with_definition(definition);
+            if let Some(ty) = place.ignore_possibly_undefined() {
+                self.check_deprecated(expr_ref, ty);
+            }
+            return (place.into(), Vec::new());
+        }
+
+        let load = self.resolve_place_load(place_expr, expr_ref);
+        let mut constraint_checkpoint = PlaceLoadConstraintCheckpoint::default();
+
+        let (prefix_loads, lexical_fallbacks, post_lexical_fallbacks) = match load.fallbacks() {
+            PlaceLoadFallbacks::Unconditional {
+                lexical,
+                post_lexical,
+            } => (None, lexical, post_lexical),
+            PlaceLoadFallbacks::IfNoPlaceExprPrefixIsBound {
+                prefix_loads,
+                lexical,
+                post_lexical,
+            } => (Some(prefix_loads), lexical, post_lexical),
+        };
+        let local_place = self.infer_place_load_sources(
+            place_expr,
+            Place::Undefined.into(),
+            load.local_sources(),
+            &load,
+            &mut constraint_checkpoint,
+        );
+        let fallbacks_blocked_by_bound_prefix = !local_place.place.is_definitely_bound()
+            && prefix_loads
+                .is_some_and(|prefix_loads| self.has_bound_place_expr_prefix(prefix_loads));
+
+        let lexical_place = if fallbacks_blocked_by_bound_prefix {
+            local_place
+        } else {
+            self.infer_place_load_sources(
+                place_expr,
+                local_place,
+                lexical_fallbacks,
+                &load,
+                &mut constraint_checkpoint,
+            )
+        };
+
+        if let Some(ty) = lexical_place.place.ignore_possibly_undefined() {
             self.check_deprecated(expr_ref, ty);
         }
 
+        let post_lexical_place = if fallbacks_blocked_by_bound_prefix {
+            lexical_place
+        } else {
+            self.infer_post_lexical_fallbacks(
+                place_expr,
+                lexical_place,
+                post_lexical_fallbacks,
+                &load,
+                &mut constraint_checkpoint,
+            )
+        };
+
+        let place = if load.failure_on_exhaustion() == PlaceLoadFailure::NotFound {
+            post_lexical_place.or_fall_back_to(self.db(), env, || {
+                self.infer_unimported_reveal_type_fallback(expr_ref)
+            })
+        } else {
+            post_lexical_place
+        };
+
+        let constraint_keys = load.into_constraints(&constraint_checkpoint);
+
         (place, constraint_keys)
+    }
+
+    fn infer_place_load_sources(
+        &self,
+        place_expr: PlaceExprRef,
+        mut place: PlaceAndQualifiers<'db>,
+        sources: &[PlaceLoadSource<'db>],
+        load: &PlaceLoad<'db>,
+        constraint_checkpoint: &mut PlaceLoadConstraintCheckpoint,
+    ) -> PlaceAndQualifiers<'db> {
+        for source in sources {
+            if place.place.is_definitely_bound() {
+                break;
+            }
+
+            let narrowing_constraints =
+                load.narrowing_constraints_for(source, constraint_checkpoint);
+            let fallback = self.infer_place_load_source(place_expr, source, narrowing_constraints);
+            place = place.or_fall_back_to(self.db(), self.program_environment(), || fallback);
+        }
+
+        place
+    }
+
+    fn infer_place_load_source(
+        &self,
+        place_expr: PlaceExprRef,
+        source: &PlaceLoadSource<'db>,
+        narrowing_constraints: &[(FileScopeId, ConstraintKey)],
+    ) -> PlaceAndQualifiers<'db> {
+        let db = self.db();
+        let env = self.program_environment();
+
+        let place = match source.kind.clone() {
+            PlaceLoadSourceKind::Bindings(bindings) => {
+                let mut place = place_from_bindings_with_reachability_cache(
+                    db,
+                    env,
+                    bindings,
+                    self.reachability_cache(),
+                )
+                .place;
+
+                // Compatibility policy: ty historically treats a possibly-bound module snapshot
+                // reached through a class-body global fallback as definitely bound. At runtime,
+                // an unbound snapshot would continue to builtins or produce a name error.
+                if source.is_class_body_global_fallback()
+                    && let Place::Defined(defined) = place
+                {
+                    place = Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
+                }
+
+                place.into()
+            }
+            PlaceLoadSourceKind::DefinitionsFromOwningScope { scope, id } => place_by_id(
+                db,
+                scope,
+                id,
+                RequiresExplicitReExport::No,
+                ConsideredDefinitions::AllReachable,
+            ),
+            PlaceLoadSourceKind::Implicit(implicit) => match implicit {
+                ImplicitPlaceLoad::DunderClass(definition) => original_class_type(db, definition)
+                    .map_or_else(
+                        || Place::Undefined.into(),
+                        |class| Place::bound(class).into(),
+                    ),
+                ImplicitPlaceLoad::ClassBodySymbol(name) => {
+                    let implicit = class_body_implicit_symbol(db, env, &name);
+                    if implicit.place.is_definitely_bound() {
+                        implicit
+                    } else {
+                        Place::Undefined.into()
+                    }
+                }
+                ImplicitPlaceLoad::ExplicitGlobalSymbol { file, name } => {
+                    explicit_global_symbol(db, file, &name)
+                }
+            },
+        };
+
+        place.map_type(|ty| {
+            self.narrow_place_with_applicable_constraints(place_expr, ty, narrowing_constraints)
+        })
+    }
+
+    fn infer_post_lexical_fallbacks(
+        &self,
+        place_expr: PlaceExprRef,
+        mut place: PlaceAndQualifiers<'db>,
+        fallbacks: Option<&PostLexicalFallbacks<'db>>,
+        load: &PlaceLoad<'db>,
+        constraint_checkpoint: &mut PlaceLoadConstraintCheckpoint,
+    ) -> PlaceAndQualifiers<'db> {
+        if place.place.is_definitely_bound() {
+            return place;
+        }
+
+        let constraints = load.narrowing_constraints_on_exhaustion(constraint_checkpoint);
+
+        let Some(fallbacks) = fallbacks else {
+            return place;
+        };
+
+        let db = self.db();
+        let env = self.program_environment();
+        let implicit_global =
+            module_type_implicit_global_symbol(db, fallbacks.file(), fallbacks.name()).map_type(
+                |ty| self.narrow_place_with_applicable_constraints(place_expr, ty, constraints),
+            );
+        place = place.or_fall_back_to(db, env, || implicit_global);
+
+        if place.place.is_definitely_bound() {
+            return place;
+        }
+
+        place.or_fall_back_to(db, env, || {
+            if Some(self.scope()) == builtins_module_scope(db, env) {
+                Place::Undefined.into()
+            } else {
+                implicit_builtins_symbol(db, env, fallbacks.name())
+            }
+        })
+    }
+
+    /// Applies ty's convenience fallback for an unimported `reveal_type`.
+    fn infer_unimported_reveal_type_fallback(
+        &self,
+        expr_ref: ast::ExprRef,
+    ) -> PlaceAndQualifiers<'db> {
+        let Some(name) = expr_ref
+            .as_name_expr()
+            .filter(|name| name.id == "reveal_type")
+        else {
+            return Place::Undefined.into();
+        };
+
+        if !self.in_stub()
+            && !self.is_in_type_checking_block(self.scope(), name)
+            && let Some(builder) = self.context.report_lint(&UNDEFINED_REVEAL, name)
+        {
+            let mut diag = builder.into_diagnostic("`reveal_type` used without importing it");
+            diag.info("This is allowed for debugging convenience but will fail at runtime");
+        }
+
+        typing_extensions_symbol(self.db(), self.program_environment(), "reveal_type")
+    }
+
+    /// Describes how to evaluate the tracked place-expression prefixes of `expr` in this scope.
+    fn place_expr_prefix_loads(
+        &self,
+        expr: PlaceExprRef,
+        expr_ref: ast::ExprRef,
+    ) -> Option<PlaceExprPrefixLoads<'db>> {
+        let db = self.db();
+        let scope = self.scope();
+        let place_table = self.index.place_table(scope.file_scope_id(db));
+
+        PlaceExprPrefixLoads::from_iter(
+            scope,
+            place_table.parents(expr).filter_map(|prefix_id| {
+                if self.is_deferred() {
+                    return Some(PlaceExprPrefixLoad::AllReachable(prefix_id));
+                }
+
+                let prefix = place_table.place(prefix_id);
+                let mut prefix_expr_ref = expr_ref;
+                for _ in 0..(expr.num_member_segments() - prefix.num_member_segments()) {
+                    prefix_expr_ref = match prefix_expr_ref {
+                        ast::ExprRef::Attribute(attribute) => ast::ExprRef::from(&attribute.value),
+                        ast::ExprRef::Subscript(subscript) => ast::ExprRef::from(&subscript.value),
+                        _ => unreachable!(),
+                    };
+                }
+
+                if prefix_expr_ref
+                    .as_name_expr()
+                    .is_some_and(|name| name.is_invalid())
+                {
+                    return None;
+                }
+
+                if let ast::ExprRef::Named(named) = prefix_expr_ref {
+                    return named
+                        .target
+                        .is_name_expr()
+                        .then_some(PlaceExprPrefixLoad::DefinitelyBound);
+                }
+
+                Some(PlaceExprPrefixLoad::AtUse(
+                    prefix_expr_ref.scoped_use_id(db, self.program_file()),
+                ))
+            }),
+        )
+    }
+
+    /// Returns whether any tracked place-expression prefix has a definite or possible binding in
+    /// this scope.
+    fn has_bound_place_expr_prefix(&self, prefix_loads: &PlaceExprPrefixLoads<'db>) -> bool {
+        let db = self.db();
+        let env = self.program_environment();
+        let file_scope_id = prefix_loads.scope().file_scope_id(db);
+        let use_def = self.index.use_def_map(file_scope_id);
+
+        prefix_loads.iter().any(|prefix| {
+            let place = match prefix {
+                PlaceExprPrefixLoad::AtUse(use_id) => {
+                    place_from_bindings_with_reachability_cache(
+                        db,
+                        env,
+                        use_def.bindings_at_use(use_id),
+                        self.reachability_cache(),
+                    )
+                    .place
+                }
+                PlaceExprPrefixLoad::AllReachable(place_id) => {
+                    place_from_bindings_with_reachability_cache(
+                        db,
+                        env,
+                        use_def.reachable_bindings(place_id),
+                        self.reachability_cache(),
+                    )
+                    .place
+                }
+                PlaceExprPrefixLoad::DefinitelyBound => return true,
+            };
+
+            !place.is_undefined()
+        })
     }
 
     fn report_unresolved_reference(&self, expr_name_node: &ast::ExprName) {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -40,6 +40,10 @@ use crate::place::{
     place_from_bindings_with_reachability_cache, place_from_declarations_with_reachability_cache,
     typing_extensions_symbol,
 };
+use crate::place_load::{
+    ImplicitPlaceLoad, PlaceExprPrefixLoad, PlaceExprPrefixLoads, PlaceLoadFailure, PlaceLoadMode,
+    PlaceLoadResolutionStep, PlaceLoadSource, PlaceLoadSourceKind, resolve_place_load,
+};
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attribute_members};
@@ -120,7 +124,6 @@ use crate::types::{
     infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet};
-use ty_python_core::ast_ids::ScopedUseId;
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
     Definition, DefinitionKind, DefinitionNodeKey, DefinitionState, ExceptHandlerDefinitionKind,
@@ -134,10 +137,10 @@ use ty_python_core::node_key::NodeKey;
 use ty_python_core::place::{PlaceExpr, PlaceExprRef};
 use ty_python_core::predicate::PatternPredicate;
 use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, NodeWithScopeRef, ScopeId, ScopeKind};
-use ty_python_core::symbol::{ScopedSymbolId, Symbol};
+use ty_python_core::symbol::ScopedSymbolId;
 use ty_python_core::{
-    ApplicableConstraints, EnclosingSnapshotResult, EvaluationMode, ProgramFile, SemanticIndex,
-    Truthiness, unpack::UnpackPosition,
+    ApplicableConstraints, EvaluationMode, ProgramFile, SemanticIndex, Truthiness,
+    unpack::UnpackPosition,
 };
 use ty_python_core::{ExpressionNodeKey, Statement};
 
@@ -1887,31 +1890,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         diagnostic::report_undeclared_protocol_attribute(&self.context, target, protocol);
-    }
-
-    /// Returns the implicit `__class__` cell in the current direct method body or
-    /// lazy scope defined directly in a class body.
-    fn dunder_class_cell_type(&self) -> Option<ClassLiteral<'db>> {
-        let current_scope_id = self.scope().file_scope_id(self.db());
-        let class_definition =
-            if let Some(definition) = self.index.class_definition_of_method(current_scope_id) {
-                definition
-            } else {
-                let current_scope = self.index.scope(current_scope_id);
-                if !matches!(
-                    current_scope.node(),
-                    NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
-                ) {
-                    return None;
-                }
-                let class = self
-                    .index
-                    .parent_scope(current_scope_id)?
-                    .node()
-                    .as_class()?;
-                self.index.expect_single_definition(class)
-            };
-        original_class_type(self.db(), class_definition)
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.
@@ -9605,531 +9583,234 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
         let db = self.db();
-        let ast::ExprName {
-            range: _,
-            node_index: _,
-            id: symbol_name,
-            ctx: _,
-        } = name_node;
         let expr = PlaceExpr::from_expr_name(name_node);
 
-        let (resolved, constraint_keys) =
-            self.infer_place_load(PlaceExprRef::from(&expr), ast::ExprRef::Name(name_node));
+        let (resolved, _) = self.infer_place_load(expr, ast::ExprRef::Name(name_node));
         let env = self.program_environment();
 
-        let resolved_after_fallback = resolved
-            // Not found in the module's explicitly declared global symbols?
-            // Check the "implicit globals" such as `__doc__`, `__file__`, `__name__`, etc.
-            // These are looked up as attributes on `types.ModuleType`.
-            .or_fall_back_to(db, env, || {
-                module_type_implicit_global_symbol(db, self.program_file(), symbol_name).map_type(
-                    |ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            PlaceExprRef::from(&expr),
-                            ty,
-                            &constraint_keys,
-                        )
-                    },
-                )
-            })
-            // Not found in globals? Fallback to builtins
-            // (without infinite recursion if we're already in builtins.)
-            .or_fall_back_to(db, env, || {
-                if Some(self.scope()) == builtins_module_scope(db, env) {
-                    Place::Undefined.into()
-                } else {
-                    implicit_builtins_symbol(db, env, symbol_name)
-                }
-            })
-            // Still not found? It might be `reveal_type`...
-            .or_fall_back_to(db, env, || {
-                if symbol_name == "reveal_type" {
-                    if !self.in_stub()
-                        && !self.is_in_type_checking_block(self.scope(), name_node)
-                        && let Some(builder) =
-                            self.context.report_lint(&UNDEFINED_REVEAL, name_node)
-                    {
-                        let mut diag =
-                            builder.into_diagnostic("`reveal_type` used without importing it");
-                        diag.info(
-                            "This is allowed for debugging convenience but will fail at runtime",
-                        );
-                    }
-                    typing_extensions_symbol(db, env, symbol_name)
-                } else {
-                    Place::Undefined.into()
-                }
-            });
-
-        let ty = resolved_after_fallback.unwrap_with_diagnostic(db, env, |lookup_error| {
-            match lookup_error {
-                LookupError::Undefined(qualifiers) => {
-                    self.report_unresolved_reference(name_node);
-                    TypeAndQualifiers::new(Type::unknown(), TypeOrigin::Inferred, qualifiers)
-                }
-                LookupError::PossiblyUndefined(type_when_bound) => {
-                    report_possibly_unresolved_reference(&self.context, name_node);
-                    type_when_bound
-                }
+        let ty = resolved.unwrap_with_diagnostic(db, env, |lookup_error| match lookup_error {
+            LookupError::Undefined(qualifiers) => {
+                self.report_unresolved_reference(name_node);
+                TypeAndQualifiers::new(Type::unknown(), TypeOrigin::Inferred, qualifiers)
+            }
+            LookupError::PossiblyUndefined(type_when_bound) => {
+                report_possibly_unresolved_reference(&self.context, name_node);
+                type_when_bound
             }
         });
 
         ty.inner_type()
     }
 
-    fn infer_local_place_load(
-        &self,
-        expr: PlaceExprRef,
-        expr_ref: ast::ExprRef,
-    ) -> (Place<'db>, Option<ScopedUseId>) {
-        let env = self.program_environment();
-        let db = self.db();
-        let scope = self.scope();
-        let file_scope_id = scope.file_scope_id(db);
-        let place_table = self.index.place_table(file_scope_id);
-        let use_def = self.index.use_def_map(file_scope_id);
-
-        // If we're inferring types of deferred expressions, look them up from end-of-scope.
-        if self.is_deferred() {
-            let place = if let Some(place_id) = place_table.place_id(expr) {
-                place_from_bindings_with_reachability_cache(
-                    db,
-                    env,
-                    use_def.reachable_bindings(place_id),
-                    self.reachability_cache(),
-                )
-                .place
-            } else {
-                assert!(
-                    self.in_string_annotation(),
-                    "Expected the place table to create a place for every valid PlaceExpr node"
-                );
-                Place::Undefined
-            };
-            (place, None)
-        } else {
-            if expr_ref
-                .as_name_expr()
-                .is_some_and(|name| name.is_invalid())
-            {
-                return (Place::Undefined, None);
-            }
-
-            // A named expression can show up here when resolving the parent place of something
-            // like `(foo := bar()).baz`. It binds `foo`, but it is not a normal load site and
-            // therefore has no `ScopedUseId`, so resolve it from its binding definition instead.
-            if let ast::ExprRef::Named(named) = expr_ref {
-                let place = if named.target.is_name_expr() {
-                    let definition = self.index.expect_single_definition(named);
-                    Place::bound(binding_type(self.db(), definition)).with_definition(definition)
-                } else {
-                    Place::Undefined
-                };
-                return (place, None);
-            }
-
-            let use_id = expr_ref.scoped_use_id(db, self.program_file());
-            let place = place_from_bindings_with_reachability_cache(
-                db,
-                env,
-                use_def.bindings_at_use(use_id),
-                self.reachability_cache(),
-            )
-            .place;
-
-            (place, Some(use_id))
-        }
-    }
-
-    /// Resolve a load that has fallen through to the module's explicit global scope.
+    /// Infer the type of a place expression from its ordered load sources.
     ///
-    /// For eager nested scopes, this uses the global enclosing snapshot instead of the completed
-    /// module scope, so a class body cannot see a class name that is bound only after the body
-    /// finishes:
-    ///
-    /// ```python
-    /// class A:
-    ///     A = A
-    /// ```
-    ///
-    /// `symbol_name` is only needed when no snapshot is available: snapshots can resolve complex
-    /// places like `a.x`, but the fallback global query only works for bare symbols. `assume_bound`
-    /// preserves the class-body fallback behavior for names that are also local to the class body.
-    fn infer_explicit_global_symbol_load(
-        &self,
-        place_expr: PlaceExprRef,
-        symbol_name: Option<&str>,
-        current_scope_id: FileScopeId,
-        constraint_keys: &mut Vec<(FileScopeId, ConstraintKey)>,
-        assume_bound: bool,
-    ) -> PlaceAndQualifiers<'db> {
-        let db = self.db();
-        if current_scope_id.is_global() {
-            return Place::Undefined.into();
-        }
-
-        if !self.is_deferred() {
-            match self
-                .index
-                .enclosing_snapshot(FileScopeId::global(), place_expr, current_scope_id)
-            {
-                EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                    constraint_keys.push((
-                        FileScopeId::global(),
-                        ConstraintKey::NarrowingConstraint(constraint),
-                    ));
-                    // Reaching here means that no bindings are found in any scope.
-                    // Since `explicit_global_symbol` may return a cycle initial value, we return `Place::Undefined` here.
-                    return Place::Undefined.into();
-                }
-                EnclosingSnapshotResult::FoundBindings(bindings) => {
-                    let mut place_and_qualifiers = place_from_bindings_with_reachability_cache(
-                        db,
-                        self.program_environment(),
-                        bindings,
-                        self.reachability_cache(),
-                    );
-                    if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place {
-                        place_and_qualifiers.place =
-                            Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
-                    }
-                    let place = place_and_qualifiers.place.map_type(|ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            place_expr,
-                            ty,
-                            constraint_keys,
-                        )
-                    });
-                    constraint_keys.push((
-                        FileScopeId::global(),
-                        ConstraintKey::NestedScope(current_scope_id),
-                    ));
-                    return place.into();
-                }
-                // There are no visible bindings / constraint here.
-                EnclosingSnapshotResult::NotFound => {
-                    return Place::Undefined.into();
-                }
-                EnclosingSnapshotResult::NoLongerInEagerContext => {}
-            }
-        }
-
-        let Some(symbol_name) = symbol_name else {
-            return Place::Undefined.into();
-        };
-
-        explicit_global_symbol(self.db(), self.program_file(), symbol_name).map_type(|ty| {
-            self.narrow_place_with_applicable_constraints(place_expr, ty, constraint_keys)
-        })
-    }
-
-    /// Infer the type of a place expression from definitions, assuming a load context.
-    /// This method also returns the [`ConstraintKey`]s for each scope associated with `expr`,
-    /// which is used to narrow by condition rather than by assignment.
+    /// This also returns the [`ConstraintKey`]s used by expression-level narrowing.
     fn infer_place_load(
         &self,
-        place_expr: PlaceExprRef,
+        place_expr: PlaceExpr,
         expr_ref: ast::ExprRef,
     ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
         let env = self.program_environment();
-        let db = self.db();
-        let scope = self.scope();
-        let file_scope_id = scope.file_scope_id(db);
-        let place_table = self.index.place_table(file_scope_id);
+        let mode = if self.is_deferred() && self.in_string_annotation() {
+            PlaceLoadMode::StringAnnotation
+        } else if self.is_deferred() {
+            PlaceLoadMode::Deferred
+        } else {
+            PlaceLoadMode::AtExpression(expr_ref)
+        };
+        let mut resolution =
+            resolve_place_load(self.db(), self.index, self.scope(), place_expr, mode);
+        let mut place = PlaceAndQualifiers::from(Place::Undefined);
+        let mut failure = None;
+        let mut checked_deprecated = false;
 
-        let mut constraint_keys = vec![];
-        let (local_scope_place, use_id) = self.infer_local_place_load(place_expr, expr_ref);
-        if let Some(use_id) = use_id {
-            constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
+        while let Some(step) = resolution.next() {
+            match step {
+                PlaceLoadResolutionStep::Source(source) => {
+                    if !checked_deprecated && source.is_post_lexical() {
+                        // Deprecation diagnostics apply to the result of lexical name resolution,
+                        // before it is combined with implicit module globals or builtins. Hence, we
+                        // check for deprecation here when the first post-lexical source is yielded.
+                        // If resolution stops before this, then the check after the resolution loop
+                        // handles the final lexical result instead.
+                        if let Some(ty) = place.place.ignore_possibly_undefined() {
+                            self.check_deprecated(expr_ref, ty);
+                        }
+                        checked_deprecated = true;
+                    }
+                    let narrowing_constraints = resolution.narrowing_constraints_for(&source);
+                    place = place.or_fall_back_to(self.db(), env, || {
+                        self.infer_place_load_source(
+                            resolution.place_expr(),
+                            source,
+                            narrowing_constraints,
+                        )
+                    });
+                    if place.place.is_definitely_bound() {
+                        break;
+                    }
+                }
+                PlaceLoadResolutionStep::MemberResolutionCondition(prefix_loads) => {
+                    if self.has_bound_place_expr_prefix(&prefix_loads) {
+                        failure = Some(PlaceLoadFailure::NotFound);
+                        break;
+                    }
+                }
+                PlaceLoadResolutionStep::Exhausted(exhaustion_failure) => {
+                    failure = Some(exhaustion_failure);
+                    break;
+                }
+            }
         }
 
-        let fallback = || {
-            let mut symbol_resolves_locally = false;
-            if let Some(symbol) = place_expr.as_symbol()
-                && let Some(symbol_id) = place_table.symbol_id(symbol.name())
-            {
-                // Footgun: `place_expr` and `symbol` were probably constructed with all-zero
-                // flags. We need to read the place table to get correct flags.
-                symbol_resolves_locally = place_table.symbol(symbol_id).is_local();
-                // If we try to access a variable in a class before it has been defined, the
-                // lookup will fall back to global. See the comment on `Symbol::is_local`.
-                let fallback_to_global =
-                    scope.node(db).scope_kind().is_class() && symbol_resolves_locally;
-                if self.skip_non_global_scopes(file_scope_id, symbol_id) || fallback_to_global {
-                    return self.infer_explicit_global_symbol_load(
-                        place_expr,
-                        Some(symbol.name()),
-                        file_scope_id,
-                        &mut constraint_keys,
-                        fallback_to_global,
-                    );
-                }
-            }
-
-            // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
-            // `global`, never refer to an enclosing scope. (If you reference such a symbol before
-            // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
-            // enclosing scopes in this case. The one exception to this rule is the global fallback
-            // in class bodies, which we already handled above.
-            if symbol_resolves_locally {
-                return Place::Undefined.into();
-            }
-
-            if let PlaceExprRef::Symbol(symbol) = place_expr
-                && symbol.name() == "__class__"
-                && let Some(class) = self.dunder_class_cell_type()
-            {
-                return Place::bound(class).into();
-            }
-
-            for parent_id in place_table.parents(place_expr) {
-                let parent_expr = place_table.place(parent_id);
-                let mut expr_ref = expr_ref;
-                for _ in 0..(place_expr.num_member_segments() - parent_expr.num_member_segments()) {
-                    match expr_ref {
-                        ast::ExprRef::Attribute(attribute) => {
-                            expr_ref = ast::ExprRef::from(&attribute.value);
-                        }
-                        ast::ExprRef::Subscript(subscript) => {
-                            expr_ref = ast::ExprRef::from(&subscript.value);
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                let (parent_place, _use_id) = self.infer_local_place_load(parent_expr, expr_ref);
-                if let Place::Defined(_) = parent_place {
-                    return Place::Undefined.into();
-                }
-            }
-
-            // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
-            // There are two main ways we try to model these loads:
-            //
-            // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
-            //    just before a nested scope begins. For variables that aren't modified after that
-            //    point, that's the only value that the nested scope can see. If a variable is
-            //    reassigned later, lazy snapshots for that variable can be updated or swept.
-            //
-            // 2. Otherwise, we keep walking until we get to the variable's original defining
-            //    scope, and we use its "public type" there, which respects all reachable bindings,
-            //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
-            //    definitions that we install after each nested scope is closed, so it has
-            //    a complete view of the nested `global` and `nonlocal` writes beneath it.
-            //
-            // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
-            // local to the current scope never falls back to an enclosing scope, even if it's only
-            // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
-            //
-            // Note that we only get to this walk via `or_fall_back_to` above. In other words, for
-            // definitely-locally-bound variables, we defer to the current scope's bindings instead
-            // of looking at enclosing scopes. Concretely:
-            //
-            // def f():
-            //     x = None
-            //
-            //     def g():
-            //         nonlocal x
-            //         if flag:
-            //             x = 42
-            //
-            //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
-            //         # public type in `f`.
-            //         reveal_type(x)  # revealed: Literal[42, 99] | None
-            //
-            //         x = 99
-            //         # But now `x` is definitely bound, so we don't do the walk.
-            //         reveal_type(x)  # revealed: Literal[99]
-            //
-            // Importantly, this approach isn't generally sound. The public type could include
-            // nested bindings from sibling scopes, which really could run at any time, and in some
-            // cases we're being too deferential to local bindings. Unfortunately the fully sound
-            // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
-            // which is too frustrating for users in practice.
-            for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
-                // If the current enclosing scope is global, no place lookup is performed here,
-                // instead falling back to the module's explicit global lookup below.
-                if enclosing_scope_file_id.is_global() {
-                    break;
-                }
-
-                // Class scopes are not visible to nested scopes, and we need to handle global
-                // scope differently (because an unbound name there falls back to builtins), so
-                // check only function-like scopes.
-                // There is one exception to this rule: annotation scopes can see
-                // names defined in an immediately-enclosing class scope.
-                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
-
-                let is_immediately_enclosing_scope = scope.is_annotation(db)
-                    && scope
-                        .scope(db)
-                        .parent()
-                        .is_some_and(|parent| parent == enclosing_scope_file_id);
-
-                let has_root_place_been_reassigned = || {
-                    let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                    enclosing_place_table
-                        .parents(place_expr)
-                        .any(|enclosing_root_place_id| {
-                            enclosing_place_table
-                                .place(enclosing_root_place_id)
-                                .is_bound()
-                        })
-                };
-
-                // If the reference is in a nested eager scope, we need to look for the place at
-                // the point where the previous enclosing scope was defined, instead of at the end
-                // of the scope. (Note that the semantic index builder takes care of only
-                // registering eager bindings for nested scopes that are actually eager, and for
-                // enclosing scopes that actually contain bindings that we should use when
-                // resolving the reference.)
-                let mut eagerly_resolved_place = None;
-                if !self.is_deferred() {
-                    match self.index.enclosing_snapshot(
-                        enclosing_scope_file_id,
-                        place_expr,
-                        file_scope_id,
-                    ) {
-                        EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                            constraint_keys.push((
-                                enclosing_scope_file_id,
-                                ConstraintKey::NarrowingConstraint(constraint),
-                            ));
-                            // If the current scope is eager, it is certain that the place is undefined in the current scope.
-                            // Do not call the `place` query below as a fallback.
-                            if scope.scope(db).is_eager() {
-                                eagerly_resolved_place = Some(Place::Undefined.into());
-                            }
-                        }
-                        EnclosingSnapshotResult::FoundBindings(bindings) => {
-                            let place = place_from_bindings_with_reachability_cache(
-                                db,
-                                env,
-                                bindings,
-                                self.reachability_cache(),
-                            )
-                            .place
-                            .map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
-                            constraint_keys.push((
-                                enclosing_scope_file_id,
-                                ConstraintKey::NestedScope(file_scope_id),
-                            ));
-                            return place.into();
-                        }
-                        // There are no visible bindings / constraint here.
-                        // Don't fall back to non-eager place resolution.
-                        EnclosingSnapshotResult::NotFound => {
-                            if has_root_place_been_reassigned() {
-                                return Place::Undefined.into();
-                            }
-                            continue;
-                        }
-                        EnclosingSnapshotResult::NoLongerInEagerContext => {
-                            if has_root_place_been_reassigned() {
-                                return Place::Undefined.into();
-                            }
-                        }
-                    }
-                }
-
-                if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope {
-                    continue;
-                }
-
-                let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
-                    continue;
-                };
-
-                let enclosing_place = enclosing_place_table.place(enclosing_place_id);
-
-                // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
-                // marks the variable `global`, whether or not that scope actually binds the
-                // variable. If we see a `global` declaration, stop walking scopes and proceed to
-                // the global handling below. (If we're walking from a prior/inner scope where this
-                // variable is `nonlocal`, then this is a semantic syntax error, but we don't
-                // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
-                if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
-                    break;
-                }
-
-                // Keep walking until we reach the defining scope of the variable. The synthetic
-                // nested bindings definitions installed there will see everything below it.
-                if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
-                    continue;
-                }
-                if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
-                    // Note that this check includes members like `x.y` and `x[0]`, which aren't
-                    // symbols and can't be explicitly `nonlocal`.
-                    continue;
-                }
-
-                // We've reached the defining scope of the variable. Infer its public type.
-                debug_assert!(enclosing_place.is_bound() || enclosing_place.is_declared());
-                let enclosing_scope_id =
-                    enclosing_scope_file_id.to_scope_id(db, self.program_file());
-                return eagerly_resolved_place.unwrap_or_else(|| {
-                    place_by_id(
-                        self.db(),
-                        enclosing_scope_id,
-                        enclosing_place_id,
-                        RequiresExplicitReExport::No,
-                        ConsideredDefinitions::AllReachable,
-                    )
-                    .map_type(|ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            place_expr,
-                            ty,
-                            &constraint_keys,
-                        )
-                    })
-                });
-            }
-
-            PlaceAndQualifiers::default()
-                // If we're in a class body, check for implicit class body symbols first.
-                // These take precedence over globals.
-                .or_fall_back_to(db, env, || {
-                    if scope.node(db).scope_kind().is_class()
-                        && let Some(symbol) = place_expr.as_symbol()
-                    {
-                        let implicit = class_body_implicit_symbol(db, env, symbol.name());
-                        if implicit.place.is_definitely_bound() {
-                            return implicit.map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
-                        }
-                    }
-                    Place::Undefined.into()
-                })
-                // No nonlocal binding? Check the module's explicit globals.
-                // Avoid infinite recursion if `self.scope` already is the module's global scope.
-                .or_fall_back_to(db, env, || {
-                    self.infer_explicit_global_symbol_load(
-                        place_expr,
-                        place_expr.as_symbol().map(|symbol| symbol.name().as_str()),
-                        file_scope_id,
-                        &mut constraint_keys,
-                        false,
-                    )
-                })
-        };
-        let place = PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, env, fallback);
-
-        if let Some(ty) = place.place.ignore_possibly_undefined() {
+        if !checked_deprecated && let Some(ty) = place.place.ignore_possibly_undefined() {
             self.check_deprecated(expr_ref, ty);
         }
 
+        let place = if failure == Some(PlaceLoadFailure::NotFound) {
+            place.or_fall_back_to(self.db(), env, || {
+                self.infer_unimported_reveal_type_fallback(expr_ref)
+            })
+        } else {
+            place
+        };
+
+        let constraint_keys = resolution.into_constraints();
+
         (place, constraint_keys)
+    }
+
+    fn infer_place_load_source(
+        &self,
+        place_expr: PlaceExprRef,
+        source: PlaceLoadSource<'db>,
+        narrowing_constraints: &[(FileScopeId, ConstraintKey)],
+    ) -> PlaceAndQualifiers<'db> {
+        let db = self.db();
+        let env = self.program_environment();
+        let is_class_body_global_fallback = source.is_class_body_global_fallback();
+
+        let place = match source.kind {
+            PlaceLoadSourceKind::Bindings(bindings) => {
+                let mut place = place_from_bindings_with_reachability_cache(
+                    db,
+                    env,
+                    bindings,
+                    self.reachability_cache(),
+                )
+                .place;
+
+                // Compatibility policy: ty historically treats a possibly-bound module snapshot
+                // reached through a class-body global fallback as definitely bound. At runtime,
+                // an unbound snapshot would continue to builtins or produce a name error.
+                if is_class_body_global_fallback && let Place::Defined(defined) = place {
+                    place = Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
+                }
+
+                place.into()
+            }
+            PlaceLoadSourceKind::DefinitionsFromOwningScope { scope, id } => place_by_id(
+                db,
+                scope,
+                id,
+                RequiresExplicitReExport::No,
+                ConsideredDefinitions::AllReachable,
+            ),
+            PlaceLoadSourceKind::Implicit(implicit) => match implicit {
+                ImplicitPlaceLoad::DunderClass(definition) => original_class_type(db, definition)
+                    .map_or_else(
+                        || Place::Undefined.into(),
+                        |class| Place::bound(class).into(),
+                    ),
+                ImplicitPlaceLoad::ClassBodySymbol(name) => {
+                    let implicit = class_body_implicit_symbol(db, env, &name);
+                    if implicit.place.is_definitely_bound() {
+                        implicit
+                    } else {
+                        Place::Undefined.into()
+                    }
+                }
+                ImplicitPlaceLoad::ExplicitGlobalSymbol { file, name } => {
+                    explicit_global_symbol(db, file, &name)
+                }
+                ImplicitPlaceLoad::ModuleImplicitGlobal { file, name } => {
+                    module_type_implicit_global_symbol(db, file, &name)
+                }
+                ImplicitPlaceLoad::Builtin(name) => {
+                    if Some(self.scope()) == builtins_module_scope(db, env) {
+                        Place::Undefined.into()
+                    } else {
+                        implicit_builtins_symbol(db, env, &name)
+                    }
+                }
+            },
+        };
+
+        if narrowing_constraints.is_empty() {
+            place
+        } else {
+            place.map_type(|ty| {
+                self.narrow_place_with_applicable_constraints(place_expr, ty, narrowing_constraints)
+            })
+        }
+    }
+
+    /// Applies ty's convenience fallback for an unimported `reveal_type`.
+    fn infer_unimported_reveal_type_fallback(
+        &self,
+        expr_ref: ast::ExprRef,
+    ) -> PlaceAndQualifiers<'db> {
+        let Some(name) = expr_ref
+            .as_name_expr()
+            .filter(|name| name.id == "reveal_type")
+        else {
+            return Place::Undefined.into();
+        };
+
+        if !self.in_stub()
+            && !self.is_in_type_checking_block(self.scope(), name)
+            && let Some(builder) = self.context.report_lint(&UNDEFINED_REVEAL, name)
+        {
+            let mut diag = builder.into_diagnostic("`reveal_type` used without importing it");
+            diag.info("This is allowed for debugging convenience but will fail at runtime");
+        }
+
+        typing_extensions_symbol(self.db(), self.program_environment(), "reveal_type")
+    }
+
+    /// Returns whether any tracked place-expression prefix has a definite or possible binding in
+    /// this scope.
+    fn has_bound_place_expr_prefix(&self, prefix_loads: &PlaceExprPrefixLoads<'db>) -> bool {
+        let db = self.db();
+        let env = self.program_environment();
+        let file_scope_id = prefix_loads.scope().file_scope_id(db);
+        let use_def = self.index.use_def_map(file_scope_id);
+
+        prefix_loads.iter().any(|prefix| {
+            let place = match prefix {
+                PlaceExprPrefixLoad::AtUse(use_id) => {
+                    place_from_bindings_with_reachability_cache(
+                        db,
+                        env,
+                        use_def.bindings_at_use(use_id),
+                        self.reachability_cache(),
+                    )
+                    .place
+                }
+                PlaceExprPrefixLoad::AllReachable(place_id) => {
+                    place_from_bindings_with_reachability_cache(
+                        db,
+                        env,
+                        use_def.reachable_bindings(place_id),
+                        self.reachability_cache(),
+                    )
+                    .place
+                }
+                PlaceExprPrefixLoad::DefinitelyBound => return true,
+            };
+
+            !place.is_undefined()
+        })
     }
 
     fn report_unresolved_reference(&self, expr_name_node: &ast::ExprName) {
@@ -10303,10 +9984,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut assigned_type = None;
         if let Some(place_expr) = PlaceExpr::try_from_expr(attribute) {
-            let (resolved, keys) = self.infer_place_load(
-                PlaceExprRef::from(&place_expr),
-                ast::ExprRef::Attribute(attribute),
-            );
+            let (resolved, keys) =
+                self.infer_place_load(place_expr, ast::ExprRef::Attribute(attribute));
             constraint_keys.extend(keys);
             if let Place::Defined(DefinedPlace {
                 ty,

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -34,7 +34,7 @@ use crate::types::{
 };
 use crate::{Db, FxOrderSet, ProgramEnvironment};
 use ty_python_core::definition::Definition;
-use ty_python_core::place::{PlaceExpr, PlaceExprRef};
+use ty_python_core::place::PlaceExpr;
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::{SemanticIndex, place_table};
 
@@ -196,10 +196,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // If `value` is a valid reference, we attempt type narrowing by assignment.
         if !value_ty.is_unknown() {
             if let Some(expr) = PlaceExpr::try_from_expr(subscript) {
-                let (place, keys) = self.infer_place_load(
-                    PlaceExprRef::from(&expr),
-                    ast::ExprRef::Subscript(subscript),
-                );
+                let (place, keys) = self.infer_place_load(expr, ast::ExprRef::Subscript(subscript));
                 constraint_keys.extend(keys);
                 if let Place::Defined(DefinedPlace {
                     ty,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This introduces a model called a `PlaceLoad`, which provides access to place-load resolution logic (i.e., name resolution and reaching definition analysis) independently from type inference. That logic can then be used for things outside of type inference (e.g., for language server refactors which require reaching definition analysis, like [file rename support](https://github.com/astral-sh/ty/issues/1560)). 

In order to clarify exactly where we've carved out place-load resolution from type inference, this PR makes the separation directly in `TypeInferenceBuilder`, but a [subsequent change](https://github.com/astral-sh/ruff/pull/27320) will move that logic to a location that is more easily shared.

I recommend reading the new `place_load.rs` module first, and then the changes to `infer/builder.rs` that integrate it.

## Test Plan

This is primarily a refactor that relies on existing test coverage, but I have tweaked or added test coverage in places where we have corrected our name resolution logic.
<!-- How was it tested? -->
