### PR TITLE
[ty] Extract reusable place-load resolution.

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/attribute.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/attribute.md
@@ -47,3 +47,53 @@ def f() -> None:
     box = StrBox()
     reveal_type(box.attr)  # revealed: str
 ```
+
+## Local prefixes block enclosing whole-place bindings
+
+An enclosing binding for an entire member access refers to a different object when the nested scope
+binds the root locally. The local object's member type takes precedence.
+
+```py
+class OuterBox:
+    attr: int
+
+class InnerBox:
+    attr: str
+
+def outer_root() -> None:
+    box = OuterBox()
+    box.attr = 1
+
+    def inner() -> None:
+        box = InnerBox()
+        reveal_type(box.attr)  # revealed: str
+```
+
+The same rule applies when an intermediate member, rather than the root, is bound in the nested
+scope.
+
+```py
+class Holder:
+    box: OuterBox | InnerBox
+
+def outer_member() -> None:
+    holder = Holder()
+    holder.box = OuterBox()
+    holder.box.attr = 1
+
+    def inner() -> None:
+        holder.box = InnerBox()
+        reveal_type(holder.box.attr)  # revealed: str
+```
+
+If none of the prefixes are bound in the nested scope, the enclosing whole-place binding remains
+visible.
+
+```py
+def outer_fallback() -> None:
+    box = OuterBox()
+    box.attr = 1
+
+    def inner() -> None:
+        reveal_type(box.attr)  # revealed: int
+```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/builtin.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/builtin.md
@@ -2,8 +2,8 @@
 
 ## Conditional local override of builtin
 
-If a builtin name is conditionally shadowed by a local variable, a name lookup should union the
-builtin type with the conditionally-defined type:
+If a builtin name is conditionally shadowed by a local variable, the function's binding scope
+terminates name resolution. The name can be unbound, but it cannot refer to the builtin:
 
 ```py
 def _(flag: bool) -> None:
@@ -11,8 +11,10 @@ def _(flag: bool) -> None:
         abs = 1
         chr: int = 1
 
-    reveal_type(abs)  # revealed: Literal[1] | (def abs[_T](x: SupportsAbs[_T], /) -> _T)
-    reveal_type(chr)  # revealed: Literal[1] | (def chr(i: SupportsIndex, /) -> str)
+    # error: [possibly-unresolved-reference]
+    reveal_type(abs)  # revealed: Literal[1]
+    # error: [possibly-unresolved-reference]
+    reveal_type(chr)  # revealed: Literal[1]
 ```
 
 ## Conditionally global override of builtin

--- a/crates/ty_python_semantic/resources/mdtest/scopes/unbound.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/unbound.md
@@ -71,3 +71,14 @@ def f():
     # revealed: Literal[2]
     reveal_type(x)
 ```
+
+## Unbound function local named `reveal_type`
+
+The convenience fallback for an unimported `reveal_type` only applies when name resolution does not
+find the name. It does not replace an unbound local.
+
+```py
+def f():
+    reveal_type(1)  # error: [unresolved-reference]
+    reveal_type = lambda value: value
+```

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -55,6 +55,7 @@ mod dunder_all;
 mod fixes;
 pub mod lint;
 pub(crate) mod place;
+pub(crate) mod place_load;
 mod reachability;
 mod semantic_model;
 mod subscript;

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -1,0 +1,557 @@
+//! Defines a [`PlaceLoad`], which combines the semantics of name resolution
+//! with the results of reaching definition analysis to describe the sources
+//! that may provide the value read from a place.
+//!
+//! More specifically, a [`PlaceLoad`] encapsulates:
+//!
+//! 1. [`PlaceLoad::local_source`], the (optional) value source from the load's
+//!    own scope.
+//! 2. The lexical ([`PlaceLoad::lexical_fallbacks`]) and post-lexical fallbacks
+//!    ([`PlaceLoad::post_lexical_fallbacks`]) considered if the local source
+//!    does not supply a value for the load.
+//! 3. Any condition that controls whether those fallbacks are applicable (via
+//!    [`PlaceLoad::with_conditional_fallbacks`] and
+//!    [`PlaceLoad::place_expr_prefix_loads`]).
+//! 4. [`PlaceLoad::failure_on_exhaustion`] the resolution failure that occurs
+//!    if none of those sources ultimately supply a value.
+//! 5. [`PlaceLoad::constraint_keys`], the type-narrowing constraints associated
+//!    with each source.
+//! 6. [`PlaceLoad::scope_declarations`], the explicit scope declarations
+//!    (`global` or `nonlocal`) crossed while resolving the place.
+//!
+//! We consume this model to different ends:
+//!
+//! - Type inference uses it to determine the type and definedness of a place
+//! - The language server uses it to determine, e.g., what references to an
+//!   imported module should be rewritten in response to the module itself being
+//!   renamed
+//!
+//! Here is an example describing how a [`PlaceLoad`] is constructed:
+//!
+//! ```py
+//! from collections.abc import Callable
+//!
+//! def make_counter(start: int, enabled: bool) -> Callable[[], int | None]:
+//!     if enabled:
+//!         value = start
+//!     else:
+//!         value = None
+//!
+//!     def next_value() -> int | None:
+//!         nonlocal value
+//!         if value is not None:
+//!             current = value  # load U
+//!             value += 1
+//!             return current
+//!         return None
+//!
+//!     return next_value
+//! ```
+//!
+//! As mentioned previously, constructing the [`PlaceLoad`] at `U` combines
+//! reaching definition analysis with a lexical scope walk:
+//!
+//! 1. Reaching definition analysis from the use-def module supplies the binding
+//!    state for `value` at `U` in `next_value`. (In this case, no value-binding
+//!    definition reaches U because the `value += 1` assignment occurs after `U`,
+//!    so the state records `value` as unbound.)
+//! 2. The use-def model also supplies the narrowing constraint `value is not None`
+//!    that is associated with the source. That constraint can affect an
+//!    inferred type but does not affect name resolution.
+//! 3. Name resolution encounters the `nonlocal` declaration and continues
+//!    the lexical scope walk into `make_counter`, where `value` is owned.
+//! 4. Once name resolution reaches the scope that owns value, it records
+//!    `make_counter.value` as an enclosing source of a potential value for `U`.
+//!
+//! Schematically, the resulting [`PlaceLoad`] looks like this:
+//!
+//! ```text
+//! PlaceLoad {
+//!     local_source: Bindings(next_value.value at U),  // unbound
+//!     lexical_fallbacks: [
+//!         DefinitionsFromOwningScope(make_counter.value),
+//!     ],
+//!     failure_on_exhaustion: UnboundFree,
+//!     constraint_keys: [
+//!         value is not None,
+//!     ],
+//!     scope_declarations: [
+//!         Nonlocal(next_value),
+//!     ],
+//! }
+//! ```
+//!
+//! The enclosing function's binding scope terminates name resolution, even if
+//! none of its definitions supply a value at runtime. [`PlaceLoad`] therefore
+//! records `UnboundFree` as the failure if both sources are exhausted instead
+//! of recording module globals or builtins as later sources. In this example,
+//! type inference establishes that the branches in `make_counter` always
+//! define `value`, so the failure is unreachable.
+
+use ruff_python_ast::name::Name;
+use smallvec::SmallVec;
+use ty_python_core::ast_ids::ScopedUseId;
+use ty_python_core::definition::Definition;
+use ty_python_core::narrowing_constraints::ConstraintKey;
+use ty_python_core::place::ScopedPlaceId;
+use ty_python_core::scope::{ScopeId, ScopeKind};
+use ty_python_core::{BindingWithConstraintsIterator, FileScopeId, ProgramFile};
+
+/// A semantic description of reading a place without inferring its type.
+pub(crate) struct PlaceLoad<'db> {
+    /// The source from the load's own scope.
+    local_source: Option<PlaceLoadSource<'db>>,
+    /// The sources considered after the local source but before implicit globals and builtins.
+    lexical_fallbacks: SmallVec<[PlaceLoadSource<'db>; 1]>,
+    /// The implicit global and builtin fallbacks considered after lexical resolution.
+    post_lexical_fallbacks: Option<PostLexicalFallbacks<'db>>,
+    /// The name resolution failure associated with exhausting all sources.
+    failure_on_exhaustion: PlaceLoadFailure,
+    /// The narrowing constraints collected while resolving the load.
+    constraint_keys: Vec<(FileScopeId, ConstraintKey)>,
+    /// The explicit `global` and `nonlocal` declarations crossed during name resolution.
+    pub(crate) scope_declarations: SmallVec<[ScopedDeclaration; 1]>,
+    /// Place-expression prefix loads that must all be undefined before fallbacks are applicable.
+    place_expr_prefix_loads: Option<PlaceExprPrefixLoads<'db>>,
+}
+
+impl<'db> PlaceLoad<'db> {
+    /// Creates a new load with no sources.
+    pub(crate) fn new() -> Self {
+        Self {
+            local_source: None,
+            lexical_fallbacks: SmallVec::new(),
+            post_lexical_fallbacks: None,
+            failure_on_exhaustion: PlaceLoadFailure::NotFound,
+            constraint_keys: Vec::new(),
+            scope_declarations: SmallVec::new(),
+            place_expr_prefix_loads: None,
+        }
+    }
+
+    /// Creates a load whose first source is from its own scope.
+    ///
+    /// `exit_constraint`, when present, is activated only after inference
+    /// visits the local source (that source was already selected from the
+    /// binding state identified by the constraint, it is deliberately not
+    /// reapplied to the local source).
+    pub(crate) fn from_local_source(
+        local: PlaceLoadSourceKind<'db>,
+        exit_constraint: Option<(FileScopeId, ConstraintKey)>,
+    ) -> Self {
+        let mut load = Self::new();
+        load.local_source =
+            Some(load.make_source(local, PlaceLoadSourceRole::Ordinary, exit_constraint));
+        load
+    }
+
+    /// Records the name resolution failure associated with exhausting all sources.
+    pub(crate) fn with_failure_on_exhaustion(
+        mut self,
+        failure_on_exhaustion: PlaceLoadFailure,
+    ) -> Self {
+        self.failure_on_exhaustion = failure_on_exhaustion;
+        self
+    }
+
+    /// Returns the name resolution failure associated with exhausting all sources.
+    pub(crate) fn failure_on_exhaustion(&self) -> PlaceLoadFailure {
+        self.failure_on_exhaustion
+    }
+
+    /// Makes fallbacks conditional on every tracked place-expression prefix being undefined in
+    /// the load's scope.
+    pub(crate) fn with_conditional_fallbacks(
+        mut self,
+        place_expr_prefix_loads: PlaceExprPrefixLoads<'db>,
+    ) -> Self {
+        self.place_expr_prefix_loads = Some(place_expr_prefix_loads);
+        self
+    }
+
+    /// Returns the constraints used to narrow `source`
+    /// (and records which constraints are active after it).
+    pub(crate) fn narrowing_constraints_for(
+        &self,
+        source: &PlaceLoadSource<'db>,
+        checkpoint: &mut PlaceLoadConstraintCheckpoint,
+    ) -> &[(FileScopeId, ConstraintKey)] {
+        checkpoint.0 = checkpoint.0.max(source.exit_checkpoint.0);
+        &self.constraint_keys[..source.entry_checkpoint.0]
+    }
+
+    /// Returns the constraints used after all lexical sources are exhausted
+    /// (and records that inference reached that point).
+    pub(crate) fn narrowing_constraints_on_exhaustion(
+        &self,
+        checkpoint: &mut PlaceLoadConstraintCheckpoint,
+    ) -> &[(FileScopeId, ConstraintKey)] {
+        checkpoint.0 = self.constraint_keys.len();
+        &self.constraint_keys
+    }
+
+    /// Consumes the load and returns the constraints active at `checkpoint`.
+    pub(crate) fn into_constraints(
+        mut self,
+        checkpoint: &PlaceLoadConstraintCheckpoint,
+    ) -> Vec<(FileScopeId, ConstraintKey)> {
+        self.constraint_keys.truncate(checkpoint.0);
+        self.constraint_keys
+    }
+
+    /// Returns the source from the load's own scope as a zero-or-one slice.
+    pub(crate) fn local_sources(&self) -> &[PlaceLoadSource<'db>] {
+        self.local_source.as_slice()
+    }
+
+    /// Returns the lexical and post-lexical fallbacks together with their applicability condition.
+    pub(crate) fn fallbacks(&self) -> PlaceLoadFallbacks<'_, 'db> {
+        self.place_expr_prefix_loads.as_ref().map_or(
+            PlaceLoadFallbacks::Unconditional {
+                lexical: &self.lexical_fallbacks,
+                post_lexical: self.post_lexical_fallbacks.as_ref(),
+            },
+            |prefix_loads| PlaceLoadFallbacks::IfNoPlaceExprPrefixIsBound {
+                prefix_loads,
+                lexical: &self.lexical_fallbacks,
+                post_lexical: self.post_lexical_fallbacks.as_ref(),
+            },
+        )
+    }
+
+    /// Appends a lexical fallback source.
+    pub(crate) fn push_source(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+    ) {
+        let source = self.make_source(kind, role, None);
+        self.lexical_fallbacks.push(source);
+    }
+
+    /// Appends a lexical fallback source and a constraint that becomes active
+    /// after that source is visited.
+    pub(crate) fn push_source_with_exit_constraint(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+        constraint: (FileScopeId, ConstraintKey),
+    ) {
+        let source = self.make_source(kind, role, Some(constraint));
+        self.lexical_fallbacks.push(source);
+    }
+
+    /// Appends a lexical fallback source without applying any narrowing constraints to it.
+    pub(crate) fn push_unnarrowed_source(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+    ) {
+        let exit_checkpoint = self.current_constraint_checkpoint();
+        self.lexical_fallbacks.push(PlaceLoadSource {
+            kind,
+            entry_checkpoint: PlaceLoadConstraintCheckpoint::default(),
+            exit_checkpoint,
+            role,
+        });
+    }
+
+    /// Extends the list of constraints used by subsequent sources.
+    pub(crate) fn push_constraint(&mut self, scope: FileScopeId, key: ConstraintKey) {
+        self.constraint_keys.push((scope, key));
+    }
+
+    /// Finishes a load that can fall through to implicit globals and builtins.
+    pub(crate) fn finish_at_global_scope(
+        mut self,
+        file: ProgramFile<'db>,
+        name: Option<&Name>,
+    ) -> Self {
+        if let Some(name) = name {
+            self.post_lexical_fallbacks = Some(PostLexicalFallbacks {
+                file,
+                name: name.clone(),
+            });
+        }
+
+        self.with_failure_on_exhaustion(PlaceLoadFailure::NotFound)
+    }
+
+    /// Finishes a load at an enclosing binding scope.
+    pub(crate) fn finish_at_enclosing_scope(
+        self,
+        enclosing_scope_kind: ScopeKind,
+        file: ProgramFile<'db>,
+        name: Option<&Name>,
+    ) -> Self {
+        if enclosing_scope_kind.is_class() {
+            self.finish_at_global_scope(file, name)
+        } else {
+            self.with_failure_on_exhaustion(PlaceLoadFailure::UnboundFree)
+        }
+    }
+
+    fn make_source(
+        &mut self,
+        kind: PlaceLoadSourceKind<'db>,
+        role: PlaceLoadSourceRole,
+        exit_constraint: Option<(FileScopeId, ConstraintKey)>,
+    ) -> PlaceLoadSource<'db> {
+        let entry_checkpoint = self.current_constraint_checkpoint();
+        self.constraint_keys.extend(exit_constraint);
+        PlaceLoadSource {
+            kind,
+            entry_checkpoint,
+            exit_checkpoint: self.current_constraint_checkpoint(),
+            role,
+        }
+    }
+
+    fn current_constraint_checkpoint(&self) -> PlaceLoadConstraintCheckpoint {
+        PlaceLoadConstraintCheckpoint(self.constraint_keys.len())
+    }
+}
+
+/// Tracks how far inference has progressed through a [`PlaceLoad`]'s constraints.
+///
+/// Only [`PlaceLoad`] can advance or interpret this checkpoint.
+#[derive(Clone, Default)]
+pub(crate) struct PlaceLoadConstraintCheckpoint(usize);
+
+/// The implicit module-global and builtin fallbacks considered after lexical resolution.
+///
+/// The implicit global is narrowed by all constraints collected during resolution.
+/// The builtin fallback deliberately remains unnarrowed.
+pub(crate) struct PostLexicalFallbacks<'db> {
+    file: ProgramFile<'db>,
+    name: Name,
+}
+
+impl<'db> PostLexicalFallbacks<'db> {
+    /// Returns the file containing the load.
+    pub(crate) fn file(&self) -> ProgramFile<'db> {
+        self.file
+    }
+
+    /// Returns the loaded name.
+    pub(crate) fn name(&self) -> &Name {
+        &self.name
+    }
+}
+
+/// The sources considered after a [`PlaceLoad`]'s local source is exhausted.
+#[derive(Clone, Copy)]
+pub(crate) enum PlaceLoadFallbacks<'a, 'db> {
+    /// The fallback sources are always applicable.
+    Unconditional {
+        /// Sources considered during lexical resolution after the local source.
+        lexical: &'a [PlaceLoadSource<'db>],
+        /// The implicit module-global and builtin fallbacks.
+        post_lexical: Option<&'a PostLexicalFallbacks<'db>>,
+    },
+    /// The fallback sources apply only if every tracked prefix is locally undefined.
+    ///
+    /// For example, the enclosing binding of `obj.value` cannot supply the value read in `inner`:
+    ///
+    /// ```python
+    /// class Outer:
+    ///     value: int
+    ///
+    /// class Inner:
+    ///     value: str
+    ///
+    /// def outer():
+    ///     obj = Outer()
+    ///     obj.value = 1
+    ///
+    ///     def inner():
+    ///         obj = Inner()
+    ///         reveal_type(obj.value)  # revealed: str
+    /// ```
+    ///
+    /// The nested scope binds `obj` to a different object, so normal member lookup on the local
+    /// `obj` must handle the load instead.
+    IfNoPlaceExprPrefixIsBound {
+        /// The place-expression prefix loads that control whether fallback is applicable.
+        prefix_loads: &'a PlaceExprPrefixLoads<'db>,
+        /// Sources considered during lexical resolution after the local source.
+        lexical: &'a [PlaceLoadSource<'db>],
+        /// The implicit module-global and builtin fallbacks.
+        post_lexical: Option<&'a PostLexicalFallbacks<'db>>,
+    },
+}
+
+/// Compact descriptions of loads for the tracked prefixes of a place expression.
+pub(crate) struct PlaceExprPrefixLoads<'db> {
+    scope: ScopeId<'db>,
+    loads: SmallVec<[PlaceExprPrefixLoad; 2]>,
+}
+
+impl<'db> PlaceExprPrefixLoads<'db> {
+    /// Creates prefix loads, returning `None` when the iterator is empty.
+    pub(crate) fn from_iter(
+        scope: ScopeId<'db>,
+        loads: impl IntoIterator<Item = PlaceExprPrefixLoad>,
+    ) -> Option<Self> {
+        let loads = loads.into_iter().collect::<SmallVec<_>>();
+        (!loads.is_empty()).then_some(Self { scope, loads })
+    }
+
+    /// Returns the scope containing the prefix loads.
+    pub(crate) fn scope(&self) -> ScopeId<'db> {
+        self.scope
+    }
+
+    /// Iterates over the prefix loads.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = PlaceExprPrefixLoad> + '_ {
+        self.loads.iter().copied()
+    }
+}
+
+/// Describes how a consumer can evaluate one prefix of a place expression.
+#[derive(Clone, Copy)]
+pub(crate) enum PlaceExprPrefixLoad {
+    /// Use the bindings that reach this expression occurrence.
+    AtUse(ScopedUseId),
+    /// Use every binding reachable for this place at the end of its scope.
+    AllReachable(ScopedPlaceId),
+    /// The syntax itself guarantees that the prefix is bound.
+    DefinitelyBound,
+}
+
+/// One source that can supply the value of a place load.
+///
+/// [`PlaceLoad`] stores one shared list of constraint keys. Each source maintains two checkpoints
+/// into that list:
+///
+/// - `entry_checkpoint` identifies the constraints used to narrow the source.
+/// - `exit_checkpoint` identifies the constraints active after inference visits the source.
+///
+/// Those two checkpoints differ when a key identifies the binding state used to construct a source.
+/// That key becomes active after inference visits the source, but applying it to the same source
+/// again would duplicate work.
+///
+/// For `U` in the preceding example, the constraint representation is schematically:
+///
+/// ```text
+/// PlaceLoad {
+///     constraint_keys: [
+///         (next_value, UseId(U)),
+///     ],
+///     sources: [
+///         PlaceLoadSource {
+///             kind: Bindings(next_value at U),
+///             entry_checkpoint: 0,
+///             exit_checkpoint: 1,
+///         },
+///         PlaceLoadSource {
+///             kind: DefinitionsFromOwningScope(make_counter.value),
+///             entry_checkpoint: 1,
+///             exit_checkpoint: 1,
+///         },
+///     ],
+///     failure_on_exhaustion: UnboundFree,
+///     scope_declarations: [Nonlocal(next_value)],
+/// }
+/// ```
+///
+/// The first source already comes from `bindings_at_use(U)`, so its `UseId` key becomes active on
+/// exit but is not applied on entry. If that source is undefined, the `UseId` key narrows the
+/// enclosing `int | None` place to `int`. If both sources are exhausted, the key remains active
+/// for expression-level narrowing.
+#[derive(Clone)]
+pub(crate) struct PlaceLoadSource<'db> {
+    /// How this source supplies the loaded value.
+    pub(crate) kind: PlaceLoadSourceKind<'db>,
+    /// Selects the constraints used to narrow this source.
+    entry_checkpoint: PlaceLoadConstraintCheckpoint,
+    /// Selects the constraints active after inference visits this source.
+    exit_checkpoint: PlaceLoadConstraintCheckpoint,
+    /// The role this source plays in the load.
+    role: PlaceLoadSourceRole,
+}
+
+impl PlaceLoadSource<'_> {
+    /// Returns whether this source is the module fallback for a class-local name.
+    pub(crate) fn is_class_body_global_fallback(&self) -> bool {
+        self.role == PlaceLoadSourceRole::ClassBodyGlobalFallback
+    }
+}
+
+/// Describes how a source can supply a place's value.
+#[derive(Clone)]
+pub(crate) enum PlaceLoadSourceKind<'db> {
+    /// Bindings selected at a use, from an enclosing scope snapshot, or from
+    /// all bindings reachable in a scope.
+    Bindings(BindingWithConstraintsIterator<'db, 'db>),
+    /// Definitions for the loaded place from the scope that binds or declares it.
+    DefinitionsFromOwningScope {
+        /// The scope containing the place.
+        scope: ScopeId<'db>,
+        /// The place within `scope`.
+        id: ScopedPlaceId,
+    },
+    /// A source represented by a specialized query or rule.
+    Implicit(ImplicitPlaceLoad<'db>),
+}
+
+/// A source that consumers evaluate using a specialized query or rule.
+#[derive(Clone)]
+pub(crate) enum ImplicitPlaceLoad<'db> {
+    /// The implicit `__class__` cell for a method, lambda, or generator expression defined directly
+    /// in a class body, e.g.:
+    ///
+    /// ```py
+    /// class C:
+    ///     def method(self):
+    ///         return __class__
+    /// ```
+    DunderClass(Definition<'db>),
+    /// An implicit symbol supplied directly in a class body, e.g.:
+    ///
+    /// ```py
+    /// class C:
+    ///     defining_module = __module__
+    /// ```
+    ClassBodySymbol(Name),
+    /// A symbol in the module's explicit global namespace, e.g.:
+    ///
+    /// ```py
+    /// answer = 42
+    ///
+    /// def get_answer():
+    ///     return answer
+    /// ```
+    ExplicitGlobalSymbol { file: ProgramFile<'db>, name: Name },
+}
+
+/// The role a source plays in a place load.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PlaceLoadSourceRole {
+    /// The source follows ordinary Python name resolution rules.
+    Ordinary,
+    /// The source follows Python’s class-local-to-module fallback rules.
+    ClassBodyGlobalFallback,
+}
+
+/// The name resolution failure associated with exhausting a place load's sources.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PlaceLoadFailure {
+    /// No namespace supplies the name, which raises `NameError`.
+    NotFound,
+    /// The current function-like binding scope owns the name but supplies no value, which raises
+    /// `UnboundLocalError`.
+    UnboundLocal,
+    /// An enclosing function-like binding scope owns the name but its closure cell is empty, which
+    /// raises `NameError`.
+    UnboundFree,
+}
+
+/// An explicit declaration crossed while resolving a load.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScopedDeclaration {
+    /// A `global` declaration in this scope.
+    Global(FileScopeId),
+    /// A `nonlocal` declaration in this scope.
+    Nonlocal(FileScopeId),
+}

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -88,14 +88,41 @@
 //! type inference establishes that the branches in `make_counter` always
 //! define `value`, so the failure is unreachable.
 
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{self as ast, name::Name};
 use smallvec::SmallVec;
-use ty_python_core::ast_ids::ScopedUseId;
+use ty_python_core::ast_ids::{HasScopedUseId, ScopedUseId};
 use ty_python_core::definition::Definition;
 use ty_python_core::narrowing_constraints::ConstraintKey;
-use ty_python_core::place::ScopedPlaceId;
-use ty_python_core::scope::{ScopeId, ScopeKind};
-use ty_python_core::{BindingWithConstraintsIterator, FileScopeId, ProgramFile};
+use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
+use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, ScopeId, ScopeKind};
+use ty_python_core::symbol::Symbol;
+use ty_python_core::{
+    BindingWithConstraintsIterator, EnclosingSnapshotResult, ProgramFile, SemanticIndex,
+};
+
+use crate::Db;
+
+/// Resolves a place load into its local source and ordered fallbacks.
+///
+/// This describes name resolution without inferring the type supplied by any source. Eager nested
+/// scopes prefer a snapshot taken where the nested scope was created. Otherwise, the search walks
+/// outward and records the scope that owns the place for consumers to evaluate.
+pub(crate) fn resolve_place_load<'db>(
+    db: &'db dyn Db,
+    index: &'db SemanticIndex<'db>,
+    scope: ScopeId<'db>,
+    place: PlaceExprRef,
+    mode: PlaceLoadMode<'_>,
+) -> PlaceLoad<'db> {
+    PlaceLoadResolutionContext {
+        db,
+        index,
+        scope,
+        file: scope.program_file(db),
+        mode,
+    }
+    .resolve(place)
+}
 
 /// A semantic description of reading a place without inferring its type.
 pub(crate) struct PlaceLoad<'db> {
@@ -116,8 +143,8 @@ pub(crate) struct PlaceLoad<'db> {
 }
 
 impl<'db> PlaceLoad<'db> {
-    /// Creates a new load with no sources.
-    pub(crate) fn new() -> Self {
+    /// Creates a load with no sources.
+    fn new() -> Self {
         Self {
             local_source: None,
             lexical_fallbacks: SmallVec::new(),
@@ -135,7 +162,7 @@ impl<'db> PlaceLoad<'db> {
     /// visits the local source (that source was already selected from the
     /// binding state identified by the constraint, it is deliberately not
     /// reapplied to the local source).
-    pub(crate) fn from_local_source(
+    fn from_local_source(
         local: PlaceLoadSourceKind<'db>,
         exit_constraint: Option<(FileScopeId, ConstraintKey)>,
     ) -> Self {
@@ -146,10 +173,7 @@ impl<'db> PlaceLoad<'db> {
     }
 
     /// Records the name resolution failure associated with exhausting all sources.
-    pub(crate) fn with_failure_on_exhaustion(
-        mut self,
-        failure_on_exhaustion: PlaceLoadFailure,
-    ) -> Self {
+    fn with_failure_on_exhaustion(mut self, failure_on_exhaustion: PlaceLoadFailure) -> Self {
         self.failure_on_exhaustion = failure_on_exhaustion;
         self
     }
@@ -161,7 +185,7 @@ impl<'db> PlaceLoad<'db> {
 
     /// Makes fallbacks conditional on every tracked place-expression prefix being undefined in
     /// the load's scope.
-    pub(crate) fn with_conditional_fallbacks(
+    fn with_conditional_fallbacks(
         mut self,
         place_expr_prefix_loads: PlaceExprPrefixLoads<'db>,
     ) -> Self {
@@ -220,18 +244,14 @@ impl<'db> PlaceLoad<'db> {
     }
 
     /// Appends a lexical fallback source.
-    pub(crate) fn push_source(
-        &mut self,
-        kind: PlaceLoadSourceKind<'db>,
-        role: PlaceLoadSourceRole,
-    ) {
+    fn push_source(&mut self, kind: PlaceLoadSourceKind<'db>, role: PlaceLoadSourceRole) {
         let source = self.make_source(kind, role, None);
         self.lexical_fallbacks.push(source);
     }
 
     /// Appends a lexical fallback source and a constraint that becomes active
     /// after that source is visited.
-    pub(crate) fn push_source_with_exit_constraint(
+    fn push_source_with_exit_constraint(
         &mut self,
         kind: PlaceLoadSourceKind<'db>,
         role: PlaceLoadSourceRole,
@@ -242,7 +262,7 @@ impl<'db> PlaceLoad<'db> {
     }
 
     /// Appends a lexical fallback source without applying any narrowing constraints to it.
-    pub(crate) fn push_unnarrowed_source(
+    fn push_unnarrowed_source(
         &mut self,
         kind: PlaceLoadSourceKind<'db>,
         role: PlaceLoadSourceRole,
@@ -257,16 +277,12 @@ impl<'db> PlaceLoad<'db> {
     }
 
     /// Extends the list of constraints used by subsequent sources.
-    pub(crate) fn push_constraint(&mut self, scope: FileScopeId, key: ConstraintKey) {
+    fn push_constraint(&mut self, scope: FileScopeId, key: ConstraintKey) {
         self.constraint_keys.push((scope, key));
     }
 
     /// Finishes a load that can fall through to implicit globals and builtins.
-    pub(crate) fn finish_at_global_scope(
-        mut self,
-        file: ProgramFile<'db>,
-        name: Option<&Name>,
-    ) -> Self {
+    fn finish_at_global_scope(mut self, file: ProgramFile<'db>, name: Option<&Name>) -> Self {
         if let Some(name) = name {
             self.post_lexical_fallbacks = Some(PostLexicalFallbacks {
                 file,
@@ -278,7 +294,7 @@ impl<'db> PlaceLoad<'db> {
     }
 
     /// Finishes a load at an enclosing binding scope.
-    pub(crate) fn finish_at_enclosing_scope(
+    fn finish_at_enclosing_scope(
         self,
         enclosing_scope_kind: ScopeKind,
         file: ProgramFile<'db>,
@@ -389,7 +405,7 @@ pub(crate) struct PlaceExprPrefixLoads<'db> {
 
 impl<'db> PlaceExprPrefixLoads<'db> {
     /// Creates prefix loads, returning `None` when the iterator is empty.
-    pub(crate) fn from_iter(
+    fn from_iter(
         scope: ScopeId<'db>,
         loads: impl IntoIterator<Item = PlaceExprPrefixLoad>,
     ) -> Option<Self> {
@@ -417,6 +433,23 @@ pub(crate) enum PlaceExprPrefixLoad {
     AllReachable(ScopedPlaceId),
     /// The syntax itself guarantees that the prefix is bound.
     DefinitelyBound,
+}
+
+/// The evaluation context used to resolve a place load.
+#[derive(Clone, Copy)]
+pub(crate) enum PlaceLoadMode<'ast> {
+    /// Resolve bindings live at an expression occurrence.
+    AtExpression(ast::ExprRef<'ast>),
+    /// Resolve all bindings reachable at the end of the scope.
+    Deferred,
+    /// Resolve reachable bindings in a parsed string annotation.
+    StringAnnotation,
+}
+
+impl PlaceLoadMode<'_> {
+    fn is_deferred(self) -> bool {
+        matches!(self, Self::Deferred | Self::StringAnnotation)
+    }
 }
 
 /// One source that can supply the value of a place load.
@@ -554,4 +587,451 @@ pub(crate) enum ScopedDeclaration {
     Global(FileScopeId),
     /// A `nonlocal` declaration in this scope.
     Nonlocal(FileScopeId),
+}
+
+#[derive(Clone, Copy)]
+struct PlaceLoadResolutionContext<'db, 'ast> {
+    db: &'db dyn Db,
+    index: &'db SemanticIndex<'db>,
+    scope: ScopeId<'db>,
+    file: ProgramFile<'db>,
+    mode: PlaceLoadMode<'ast>,
+}
+
+impl<'db> PlaceLoadResolutionContext<'db, '_> {
+    fn resolve(self, place: PlaceExprRef) -> PlaceLoad<'db> {
+        let current_scope = self.scope.file_scope_id(self.db);
+        let place_table = self.index.place_table(current_scope);
+        let mut load = match self.local_source(place) {
+            Some((local_source, exit_constraint)) => {
+                PlaceLoad::from_local_source(local_source, exit_constraint)
+            }
+            None => PlaceLoad::new(),
+        };
+
+        if let Some(prefix_loads) = self.place_expr_prefix_loads(place) {
+            load = load.with_conditional_fallbacks(prefix_loads);
+        }
+
+        let mut symbol_is_local = false;
+        if let Some(symbol) = place.as_symbol()
+            && let Some(symbol_id) = place_table.symbol_id(symbol.name())
+        {
+            // Footgun: `place` and `symbol` were probably constructed with all-zero
+            // flags. We need to read the place table to get correct flags.
+            let indexed_symbol = place_table.symbol(symbol_id);
+            symbol_is_local = indexed_symbol.is_local();
+            if indexed_symbol.is_global() {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Global(current_scope));
+            }
+            if indexed_symbol.is_nonlocal() {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Nonlocal(current_scope));
+            }
+
+            // If we try to access a variable in a class before it has been defined, the
+            // name resolution will fall back to global. See the comment on `Symbol::is_local`.
+            let class_body_global_fallback =
+                self.scope.node(self.db).scope_kind().is_class() && symbol_is_local;
+            if self.skips_non_global_scopes(symbol_id) || class_body_global_fallback {
+                let role = if class_body_global_fallback {
+                    PlaceLoadSourceRole::ClassBodyGlobalFallback
+                } else {
+                    PlaceLoadSourceRole::Ordinary
+                };
+                return self.resolve_global(load, place, Some(symbol.name()), role);
+            }
+        }
+
+        // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
+        // `global`, never refer to an enclosing scope. (If you reference such a symbol before
+        // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
+        // enclosing scopes in this case. The one exception to this rule is the global fallback
+        // in class bodies, which we already handled above.
+        if symbol_is_local {
+            if self.scope.node(self.db).scope_kind().is_module() {
+                return load.finish_at_global_scope(self.file, place.as_symbol().map(Symbol::name));
+            }
+            return load.with_failure_on_exhaustion(PlaceLoadFailure::UnboundLocal);
+        }
+
+        if let PlaceExprRef::Symbol(symbol) = place
+            && symbol.name() == "__class__"
+            && let Some(definition) = self.dunder_class_cell_definition()
+        {
+            load.push_unnarrowed_source(
+                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::DunderClass(definition)),
+                PlaceLoadSourceRole::Ordinary,
+            );
+        }
+
+        // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
+        // There are two main ways we try to model these loads:
+        //
+        // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
+        //    just before a nested scope begins. For variables that aren't modified after that
+        //    point, that's the only value that the nested scope can see. If a variable is
+        //    reassigned later, lazy snapshots for that variable can be updated or swept.
+        //
+        // 2. Otherwise, we keep walking until we get to the variable's original defining
+        //    scope and record that scope as a source. Each consumer decides which of the
+        //    place's definitions to evaluate there.
+        //
+        // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
+        // local to the current scope never falls back to an enclosing scope, even if it's only
+        // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
+        for (enclosing_scope, _) in self.index.ancestor_scopes(current_scope).skip(1) {
+            match self.search_scope(&mut load, place, enclosing_scope) {
+                ScopeContinuation::Stop(enclosing_scope_kind) => {
+                    return load.finish_at_enclosing_scope(
+                        enclosing_scope_kind,
+                        self.file,
+                        place.as_symbol().map(Symbol::name),
+                    );
+                }
+                ScopeContinuation::Enclosing => {}
+                ScopeContinuation::Module => break,
+            }
+        }
+
+        // If we're in a class body, check for implicit class body symbols first.
+        // These take precedence over globals.
+        if self.scope.node(self.db).scope_kind().is_class()
+            && let Some(symbol) = place.as_symbol()
+        {
+            load.push_source(
+                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ClassBodySymbol(
+                    symbol.name().clone(),
+                )),
+                PlaceLoadSourceRole::Ordinary,
+            );
+        }
+
+        // Continue resolution in the module's explicit global scope.
+        self.resolve_global(
+            load,
+            place,
+            place.as_symbol().map(Symbol::name),
+            PlaceLoadSourceRole::Ordinary,
+        )
+    }
+
+    fn local_source(
+        self,
+        place: PlaceExprRef,
+    ) -> Option<(
+        PlaceLoadSourceKind<'db>,
+        Option<(FileScopeId, ConstraintKey)>,
+    )> {
+        let scope = self.scope.file_scope_id(self.db);
+        let table = self.index.place_table(scope);
+        let use_def = self.index.use_def_map(scope);
+
+        match self.mode {
+            PlaceLoadMode::AtExpression(expr_ref) => {
+                if expr_ref
+                    .as_name_expr()
+                    .is_some_and(|name| name.is_invalid())
+                    || matches!(expr_ref, ast::ExprRef::Named(_))
+                {
+                    return None;
+                }
+
+                let use_id = expr_ref.scoped_use_id(self.db, self.file);
+                Some((
+                    PlaceLoadSourceKind::Bindings(use_def.bindings_at_use(use_id)),
+                    Some((scope, ConstraintKey::UseId(use_id))),
+                ))
+            }
+            PlaceLoadMode::Deferred | PlaceLoadMode::StringAnnotation => {
+                let source = table
+                    .place_id(place)
+                    .map(|id| PlaceLoadSourceKind::Bindings(use_def.reachable_bindings(id)));
+                assert!(
+                    source.is_some() || matches!(self.mode, PlaceLoadMode::StringAnnotation),
+                    "Expected the place table to create a place for every valid PlaceExpr node"
+                );
+                source.map(|source| (source, None))
+            }
+        }
+    }
+
+    /// Describes how to evaluate the tracked place-expression prefixes of `place` in this scope.
+    fn place_expr_prefix_loads(self, place: PlaceExprRef) -> Option<PlaceExprPrefixLoads<'db>> {
+        let table = self.index.place_table(self.scope.file_scope_id(self.db));
+
+        PlaceExprPrefixLoads::from_iter(
+            self.scope,
+            table
+                .parents(place)
+                .filter_map(|prefix_id| match self.mode {
+                    PlaceLoadMode::Deferred | PlaceLoadMode::StringAnnotation => {
+                        Some(PlaceExprPrefixLoad::AllReachable(prefix_id))
+                    }
+                    PlaceLoadMode::AtExpression(mut prefix_expr_ref) => {
+                        let prefix = table.place(prefix_id);
+                        for _ in 0..(place.num_member_segments() - prefix.num_member_segments()) {
+                            prefix_expr_ref = match prefix_expr_ref {
+                                ast::ExprRef::Attribute(attribute) => {
+                                    ast::ExprRef::from(&attribute.value)
+                                }
+                                ast::ExprRef::Subscript(subscript) => {
+                                    ast::ExprRef::from(&subscript.value)
+                                }
+                                _ => return None,
+                            };
+                        }
+
+                        if prefix_expr_ref
+                            .as_name_expr()
+                            .is_some_and(|name| name.is_invalid())
+                        {
+                            return None;
+                        }
+
+                        if let ast::ExprRef::Named(named) = prefix_expr_ref {
+                            return named
+                                .target
+                                .is_name_expr()
+                                .then_some(PlaceExprPrefixLoad::DefinitelyBound);
+                        }
+
+                        Some(PlaceExprPrefixLoad::AtUse(
+                            prefix_expr_ref.scoped_use_id(self.db, self.file),
+                        ))
+                    }
+                }),
+        )
+    }
+
+    fn search_scope(
+        self,
+        load: &mut PlaceLoad<'db>,
+        place: PlaceExprRef,
+        enclosing_scope: FileScopeId,
+    ) -> ScopeContinuation {
+        // If the current enclosing scope is global, no place resolution is performed here,
+        // instead falling back to the module's explicit global resolution below.
+        if enclosing_scope.is_global() {
+            return ScopeContinuation::Module;
+        }
+
+        let enclosing = self.index.scope(enclosing_scope);
+        let mut eagerly_undefined = false;
+        if !self.mode.is_deferred() {
+            // If the reference is in a nested eager scope, we need to look for the place at
+            // the point where the previous enclosing scope was defined, instead of at the end
+            // of the scope. (Note that the semantic index builder takes care of only
+            // registering eager bindings for nested scopes that are actually eager, and for
+            // enclosing scopes that actually contain bindings that we should use when
+            // resolving the reference.)
+            match self.index.enclosing_snapshot(
+                enclosing_scope,
+                place,
+                self.scope.file_scope_id(self.db),
+            ) {
+                EnclosingSnapshotResult::FoundConstraint(constraint) => {
+                    load.push_constraint(
+                        enclosing_scope,
+                        ConstraintKey::NarrowingConstraint(constraint),
+                    );
+                    // If the current scope is eager, it is certain that the place is undefined in
+                    // the current scope. Do not add the place below as a fallback.
+                    if self.scope.scope(self.db).is_eager() {
+                        eagerly_undefined = true;
+                    }
+                }
+                EnclosingSnapshotResult::FoundBindings(bindings) => {
+                    load.push_source_with_exit_constraint(
+                        PlaceLoadSourceKind::Bindings(bindings),
+                        PlaceLoadSourceRole::Ordinary,
+                        (
+                            enclosing_scope,
+                            ConstraintKey::NestedScope(self.scope.file_scope_id(self.db)),
+                        ),
+                    );
+                    return ScopeContinuation::Stop(enclosing.kind());
+                }
+                EnclosingSnapshotResult::NotFound => {
+                    // There are no visible bindings or constraints here. Don't fall back to
+                    // non-eager place resolution if the root place has been reassigned.
+                    if self.root_place_was_reassigned(place, enclosing_scope) {
+                        return ScopeContinuation::Stop(enclosing.kind());
+                    }
+                    return ScopeContinuation::Enclosing;
+                }
+                EnclosingSnapshotResult::NoLongerInEagerContext => {
+                    if self.root_place_was_reassigned(place, enclosing_scope) {
+                        return ScopeContinuation::Stop(enclosing.kind());
+                    }
+                }
+            }
+        }
+
+        // Class scopes are not visible to nested scopes, and we need to handle global
+        // scope differently (because an unbound name there falls back to builtins), so
+        // check only function-like scopes.
+        // There is one exception to this rule: annotation scopes can see
+        // names defined in an immediately-enclosing class scope.
+        let is_immediately_enclosing_class = self.scope.is_annotation(self.db)
+            && self
+                .scope
+                .scope(self.db)
+                .parent()
+                .is_some_and(|parent| parent == enclosing_scope);
+        if !enclosing.kind().is_function_like() && !is_immediately_enclosing_class {
+            return ScopeContinuation::Enclosing;
+        }
+
+        let table = self.index.place_table(enclosing_scope);
+        let Some(id) = table.place_id(place) else {
+            return ScopeContinuation::Enclosing;
+        };
+        let enclosing_place = table.place(id);
+        // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
+        // marks the variable `global`, whether or not that scope actually binds the
+        // variable. If we see a `global` declaration, stop walking scopes and proceed to
+        // the global handling below. (If we're walking from a prior/inner scope where this
+        // variable is `nonlocal`, then this is a semantic syntax error, but we don't
+        // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
+        if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
+            load.scope_declarations
+                .push(ScopedDeclaration::Global(enclosing_scope));
+            return ScopeContinuation::Module;
+        }
+        // Keep walking until we reach the defining scope of the variable. The synthetic
+        // nested bindings definitions installed there will see everything below it.
+        if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
+            load.scope_declarations
+                .push(ScopedDeclaration::Nonlocal(enclosing_scope));
+            return ScopeContinuation::Enclosing;
+        }
+        if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
+            // Note that this check includes members like `x.y` and `x[0]`, which aren't
+            // symbols and can't be explicitly `nonlocal`.
+            return ScopeContinuation::Enclosing;
+        }
+
+        // We've reached the scope that owns the place. Record it so each consumer can evaluate
+        // the considered definitions it needs.
+        if !eagerly_undefined {
+            load.push_source(
+                PlaceLoadSourceKind::DefinitionsFromOwningScope {
+                    scope: enclosing_scope.to_scope_id(self.db, self.file),
+                    id,
+                },
+                PlaceLoadSourceRole::Ordinary,
+            );
+        }
+        ScopeContinuation::Stop(enclosing.kind())
+    }
+
+    /// Resolve a load that has fallen through to the module's explicit global scope.
+    ///
+    /// For eager nested scopes, this uses the global enclosing snapshot instead of the completed
+    /// module scope, so a class body cannot see a class name that is bound only after the body
+    /// finishes:
+    ///
+    /// ```python
+    /// class A:
+    ///     A = A
+    /// ```
+    ///
+    /// `symbol_name` is only needed when no snapshot is available: snapshots can resolve complex
+    /// places like `a.x`, but the fallback global query only works for bare symbols. `role`
+    /// preserves the class-body fallback behavior for names that are also local to the class body.
+    fn resolve_global(
+        self,
+        mut load: PlaceLoad<'db>,
+        place: PlaceExprRef,
+        symbol_name: Option<&Name>,
+        role: PlaceLoadSourceRole,
+    ) -> PlaceLoad<'db> {
+        let current_scope = self.scope.file_scope_id(self.db);
+        let post_lexical_name = place.as_symbol().map(Symbol::name);
+        if current_scope.is_global() {
+            return load.finish_at_global_scope(self.file, post_lexical_name);
+        }
+
+        if !self.mode.is_deferred() {
+            match self
+                .index
+                .enclosing_snapshot(FileScopeId::global(), place, current_scope)
+            {
+                EnclosingSnapshotResult::FoundConstraint(constraint) => {
+                    load.push_constraint(
+                        FileScopeId::global(),
+                        ConstraintKey::NarrowingConstraint(constraint),
+                    );
+                    // Reaching here means that no bindings are found in any scope.
+                    // Since `explicit_global_symbol` may return a cycle initial value,
+                    // don't add it as a fallback.
+                    return load.finish_at_global_scope(self.file, post_lexical_name);
+                }
+                EnclosingSnapshotResult::FoundBindings(bindings) => {
+                    load.push_source_with_exit_constraint(
+                        PlaceLoadSourceKind::Bindings(bindings),
+                        role,
+                        (
+                            FileScopeId::global(),
+                            ConstraintKey::NestedScope(current_scope),
+                        ),
+                    );
+                    return load.finish_at_global_scope(self.file, post_lexical_name);
+                }
+                // There are no visible bindings / constraint here.
+                EnclosingSnapshotResult::NotFound => {
+                    return load.finish_at_global_scope(self.file, post_lexical_name);
+                }
+                EnclosingSnapshotResult::NoLongerInEagerContext => {}
+            }
+        }
+
+        if let Some(name) = symbol_name {
+            load.push_source(
+                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ExplicitGlobalSymbol {
+                    file: self.file,
+                    name: name.clone(),
+                }),
+                role,
+            );
+        }
+        load.finish_at_global_scope(self.file, post_lexical_name)
+    }
+
+    fn root_place_was_reassigned(self, place: PlaceExprRef, scope: FileScopeId) -> bool {
+        let table = self.index.place_table(scope);
+        table
+            .parents(place)
+            .any(|root| table.place(root).is_bound())
+    }
+
+    fn skips_non_global_scopes(self, symbol: ty_python_core::symbol::ScopedSymbolId) -> bool {
+        let scope = self.scope.file_scope_id(self.db);
+        !scope.is_global() && self.index.symbol_is_global_in_scope(symbol, scope)
+    }
+
+    fn dunder_class_cell_definition(self) -> Option<Definition<'db>> {
+        let current_scope = self.scope.file_scope_id(self.db);
+        if let Some(definition) = self.index.class_definition_of_method(current_scope) {
+            return Some(definition);
+        }
+
+        let scope = self.index.scope(current_scope);
+        if !matches!(
+            scope.node(),
+            NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
+        ) {
+            return None;
+        }
+        let class = self.index.parent_scope(current_scope)?.node().as_class()?;
+        Some(self.index.expect_single_definition(class))
+    }
+}
+
+enum ScopeContinuation {
+    Stop(ty_python_core::scope::ScopeKind),
+    Enclosing,
+    Module,
 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -40,6 +40,11 @@ use crate::place::{
     place_from_bindings_with_reachability_cache, place_from_declarations_with_reachability_cache,
     typing_extensions_symbol,
 };
+use crate::place_load::{
+    ImplicitPlaceLoad, PlaceExprPrefixLoad, PlaceExprPrefixLoads, PlaceLoad,
+    PlaceLoadConstraintCheckpoint, PlaceLoadFailure, PlaceLoadFallbacks, PlaceLoadSource,
+    PlaceLoadSourceKind, PlaceLoadSourceRole, PostLexicalFallbacks, ScopedDeclaration,
+};
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attribute_members};
@@ -1891,27 +1896,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     /// Returns the implicit `__class__` cell in the current direct method body or
     /// lazy scope defined directly in a class body.
-    fn dunder_class_cell_type(&self) -> Option<ClassLiteral<'db>> {
+    fn dunder_class_cell_definition(&self) -> Option<Definition<'db>> {
         let current_scope_id = self.scope().file_scope_id(self.db());
-        let class_definition =
-            if let Some(definition) = self.index.class_definition_of_method(current_scope_id) {
-                definition
-            } else {
-                let current_scope = self.index.scope(current_scope_id);
-                if !matches!(
-                    current_scope.node(),
-                    NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
-                ) {
-                    return None;
-                }
-                let class = self
-                    .index
-                    .parent_scope(current_scope_id)?
-                    .node()
-                    .as_class()?;
-                self.index.expect_single_definition(class)
-            };
-        original_class_type(self.db(), class_definition)
+        if let Some(definition) = self.index.class_definition_of_method(current_scope_id) {
+            return Some(definition);
+        }
+
+        let current_scope = self.index.scope(current_scope_id);
+        if !matches!(
+            current_scope.node(),
+            NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
+        ) {
+            return None;
+        }
+        let class = self
+            .index
+            .parent_scope(current_scope_id)?
+            .node()
+            .as_class()?;
+        Some(self.index.expect_single_definition(class))
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.
@@ -9605,84 +9608,31 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
         let db = self.db();
-        let ast::ExprName {
-            range: _,
-            node_index: _,
-            id: symbol_name,
-            ctx: _,
-        } = name_node;
         let expr = PlaceExpr::from_expr_name(name_node);
 
-        let (resolved, constraint_keys) =
+        let (resolved, _) =
             self.infer_place_load(PlaceExprRef::from(&expr), ast::ExprRef::Name(name_node));
         let env = self.program_environment();
 
-        let resolved_after_fallback = resolved
-            // Not found in the module's explicitly declared global symbols?
-            // Check the "implicit globals" such as `__doc__`, `__file__`, `__name__`, etc.
-            // These are looked up as attributes on `types.ModuleType`.
-            .or_fall_back_to(db, env, || {
-                module_type_implicit_global_symbol(db, self.program_file(), symbol_name).map_type(
-                    |ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            PlaceExprRef::from(&expr),
-                            ty,
-                            &constraint_keys,
-                        )
-                    },
-                )
-            })
-            // Not found in globals? Fallback to builtins
-            // (without infinite recursion if we're already in builtins.)
-            .or_fall_back_to(db, env, || {
-                if Some(self.scope()) == builtins_module_scope(db, env) {
-                    Place::Undefined.into()
-                } else {
-                    implicit_builtins_symbol(db, env, symbol_name)
-                }
-            })
-            // Still not found? It might be `reveal_type`...
-            .or_fall_back_to(db, env, || {
-                if symbol_name == "reveal_type" {
-                    if !self.in_stub()
-                        && !self.is_in_type_checking_block(self.scope(), name_node)
-                        && let Some(builder) =
-                            self.context.report_lint(&UNDEFINED_REVEAL, name_node)
-                    {
-                        let mut diag =
-                            builder.into_diagnostic("`reveal_type` used without importing it");
-                        diag.info(
-                            "This is allowed for debugging convenience but will fail at runtime",
-                        );
-                    }
-                    typing_extensions_symbol(db, env, symbol_name)
-                } else {
-                    Place::Undefined.into()
-                }
-            });
-
-        let ty = resolved_after_fallback.unwrap_with_diagnostic(db, env, |lookup_error| {
-            match lookup_error {
-                LookupError::Undefined(qualifiers) => {
-                    self.report_unresolved_reference(name_node);
-                    TypeAndQualifiers::new(Type::unknown(), TypeOrigin::Inferred, qualifiers)
-                }
-                LookupError::PossiblyUndefined(type_when_bound) => {
-                    report_possibly_unresolved_reference(&self.context, name_node);
-                    type_when_bound
-                }
+        let ty = resolved.unwrap_with_diagnostic(db, env, |lookup_error| match lookup_error {
+            LookupError::Undefined(qualifiers) => {
+                self.report_unresolved_reference(name_node);
+                TypeAndQualifiers::new(Type::unknown(), TypeOrigin::Inferred, qualifiers)
+            }
+            LookupError::PossiblyUndefined(type_when_bound) => {
+                report_possibly_unresolved_reference(&self.context, name_node);
+                type_when_bound
             }
         });
 
         ty.inner_type()
     }
 
-    fn infer_local_place_load(
+    fn local_place_load_source(
         &self,
         expr: PlaceExprRef,
         expr_ref: ast::ExprRef,
-    ) -> (Place<'db>, Option<ScopedUseId>) {
-        let env = self.program_environment();
+    ) -> Option<(PlaceLoadSourceKind<'db>, Option<ScopedUseId>)> {
         let db = self.db();
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
@@ -9691,53 +9641,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // If we're inferring types of deferred expressions, look them up from end-of-scope.
         if self.is_deferred() {
-            let place = if let Some(place_id) = place_table.place_id(expr) {
-                place_from_bindings_with_reachability_cache(
-                    db,
-                    env,
-                    use_def.reachable_bindings(place_id),
-                    self.reachability_cache(),
-                )
-                .place
-            } else {
+            let source = place_table.place_id(expr).map(|place_id| {
+                PlaceLoadSourceKind::Bindings(use_def.reachable_bindings(place_id))
+            });
+            if source.is_none() {
                 assert!(
                     self.in_string_annotation(),
                     "Expected the place table to create a place for every valid PlaceExpr node"
                 );
-                Place::Undefined
-            };
-            (place, None)
+            }
+            source.map(|source| (source, None))
         } else {
             if expr_ref
                 .as_name_expr()
                 .is_some_and(|name| name.is_invalid())
             {
-                return (Place::Undefined, None);
+                return None;
             }
 
-            // A named expression can show up here when resolving the parent place of something
-            // like `(foo := bar()).baz`. It binds `foo`, but it is not a normal load site and
-            // therefore has no `ScopedUseId`, so resolve it from its binding definition instead.
-            if let ast::ExprRef::Named(named) = expr_ref {
-                let place = if named.target.is_name_expr() {
-                    let definition = self.index.expect_single_definition(named);
-                    Place::bound(binding_type(self.db(), definition)).with_definition(definition)
-                } else {
-                    Place::Undefined
-                };
-                return (place, None);
+            if matches!(expr_ref, ast::ExprRef::Named(_)) {
+                return None;
             }
 
             let use_id = expr_ref.scoped_use_id(db, self.program_file());
-            let place = place_from_bindings_with_reachability_cache(
-                db,
-                env,
-                use_def.bindings_at_use(use_id),
-                self.reachability_cache(),
-            )
-            .place;
-
-            (place, Some(use_id))
+            Some((
+                PlaceLoadSourceKind::Bindings(use_def.bindings_at_use(use_id)),
+                Some(use_id),
+            ))
         }
     }
 
@@ -9753,19 +9683,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// ```
     ///
     /// `symbol_name` is only needed when no snapshot is available: snapshots can resolve complex
-    /// places like `a.x`, but the fallback global query only works for bare symbols. `assume_bound`
+    /// places like `a.x`, but the fallback global query only works for bare symbols. `role`
     /// preserves the class-body fallback behavior for names that are also local to the class body.
-    fn infer_explicit_global_symbol_load(
+    fn resolve_global_place_load(
         &self,
+        mut load: PlaceLoad<'db>,
         place_expr: PlaceExprRef,
-        symbol_name: Option<&str>,
+        expr_ref: ast::ExprRef,
+        symbol_name: Option<&Name>,
         current_scope_id: FileScopeId,
-        constraint_keys: &mut Vec<(FileScopeId, ConstraintKey)>,
-        assume_bound: bool,
-    ) -> PlaceAndQualifiers<'db> {
-        let db = self.db();
+        role: PlaceLoadSourceRole,
+    ) -> PlaceLoad<'db> {
+        let file = self.program_file();
+        let post_lexical_name = expr_ref.as_name_expr().map(|name| &name.id);
+
         if current_scope_id.is_global() {
-            return Place::Undefined.into();
+            return load.finish_at_global_scope(file, post_lexical_name);
         }
 
         if !self.is_deferred() {
@@ -9774,362 +9707,669 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .enclosing_snapshot(FileScopeId::global(), place_expr, current_scope_id)
             {
                 EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                    constraint_keys.push((
+                    load.push_constraint(
                         FileScopeId::global(),
                         ConstraintKey::NarrowingConstraint(constraint),
-                    ));
+                    );
                     // Reaching here means that no bindings are found in any scope.
-                    // Since `explicit_global_symbol` may return a cycle initial value, we return `Place::Undefined` here.
-                    return Place::Undefined.into();
+                    // Since `explicit_global_symbol` may return a cycle initial value,
+                    // don't add it to the `sources` on the `PlaceLoad`.
+                    return load.finish_at_global_scope(file, post_lexical_name);
                 }
                 EnclosingSnapshotResult::FoundBindings(bindings) => {
-                    let mut place_and_qualifiers = place_from_bindings_with_reachability_cache(
-                        db,
-                        self.program_environment(),
-                        bindings,
-                        self.reachability_cache(),
+                    load.push_source_with_exit_constraint(
+                        PlaceLoadSourceKind::Bindings(bindings),
+                        role,
+                        (
+                            FileScopeId::global(),
+                            ConstraintKey::NestedScope(current_scope_id),
+                        ),
                     );
-                    if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place {
-                        place_and_qualifiers.place =
-                            Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
-                    }
-                    let place = place_and_qualifiers.place.map_type(|ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            place_expr,
-                            ty,
-                            constraint_keys,
-                        )
-                    });
-                    constraint_keys.push((
-                        FileScopeId::global(),
-                        ConstraintKey::NestedScope(current_scope_id),
-                    ));
-                    return place.into();
+                    return load.finish_at_global_scope(file, post_lexical_name);
                 }
                 // There are no visible bindings / constraint here.
                 EnclosingSnapshotResult::NotFound => {
-                    return Place::Undefined.into();
+                    return load.finish_at_global_scope(file, post_lexical_name);
                 }
                 EnclosingSnapshotResult::NoLongerInEagerContext => {}
             }
         }
 
         let Some(symbol_name) = symbol_name else {
-            return Place::Undefined.into();
+            return load.finish_at_global_scope(file, post_lexical_name);
         };
 
-        explicit_global_symbol(self.db(), self.program_file(), symbol_name).map_type(|ty| {
-            self.narrow_place_with_applicable_constraints(place_expr, ty, constraint_keys)
-        })
+        load.push_source(
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ExplicitGlobalSymbol {
+                file: self.program_file(),
+                name: symbol_name.clone(),
+            }),
+            role,
+        );
+        load.finish_at_global_scope(file, post_lexical_name)
     }
 
-    /// Infer the type of a place expression from definitions, assuming a load context.
-    /// This method also returns the [`ConstraintKey`]s for each scope associated with `expr`,
-    /// which is used to narrow by condition rather than by assignment.
-    fn infer_place_load(
+    /// Resolves a place load into an ordered list of sources that might supply its value.
+    ///
+    /// Please see the [`place_load` module](crate::place_load) for a description
+    /// of the resolution model.
+    fn resolve_place_load(
         &self,
         place_expr: PlaceExprRef,
         expr_ref: ast::ExprRef,
-    ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
-        let env = self.program_environment();
+    ) -> PlaceLoad<'db> {
         let db = self.db();
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
         let place_table = self.index.place_table(file_scope_id);
 
-        let mut constraint_keys = vec![];
-        let (local_scope_place, use_id) = self.infer_local_place_load(place_expr, expr_ref);
-        if let Some(use_id) = use_id {
-            constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
+        let mut load = match self.local_place_load_source(place_expr, expr_ref) {
+            Some((local_source, use_id)) => PlaceLoad::from_local_source(
+                local_source,
+                use_id.map(|use_id| (file_scope_id, ConstraintKey::UseId(use_id))),
+            ),
+            None => PlaceLoad::new(),
+        };
+
+        if let Some(prefix_loads) = self.place_expr_prefix_loads(place_expr, expr_ref) {
+            load = load.with_conditional_fallbacks(prefix_loads);
         }
 
-        let fallback = || {
-            let mut symbol_resolves_locally = false;
-            if let Some(symbol) = place_expr.as_symbol()
-                && let Some(symbol_id) = place_table.symbol_id(symbol.name())
-            {
-                // Footgun: `place_expr` and `symbol` were probably constructed with all-zero
-                // flags. We need to read the place table to get correct flags.
-                symbol_resolves_locally = place_table.symbol(symbol_id).is_local();
-                // If we try to access a variable in a class before it has been defined, the
-                // lookup will fall back to global. See the comment on `Symbol::is_local`.
-                let fallback_to_global =
-                    scope.node(db).scope_kind().is_class() && symbol_resolves_locally;
-                if self.skip_non_global_scopes(file_scope_id, symbol_id) || fallback_to_global {
-                    return self.infer_explicit_global_symbol_load(
-                        place_expr,
-                        Some(symbol.name()),
-                        file_scope_id,
-                        &mut constraint_keys,
-                        fallback_to_global,
-                    );
-                }
+        let mut symbol_is_local = false;
+        if let Some(symbol) = place_expr.as_symbol()
+            && let Some(symbol_id) = place_table.symbol_id(symbol.name())
+        {
+            // Footgun: `place_expr` and `symbol` were probably constructed with all-zero
+            // flags. We need to read the place table to get correct flags.
+            let indexed_symbol = place_table.symbol(symbol_id);
+            symbol_is_local = indexed_symbol.is_local();
+            if indexed_symbol.is_global() {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Global(file_scope_id));
             }
-
-            // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
-            // `global`, never refer to an enclosing scope. (If you reference such a symbol before
-            // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
-            // enclosing scopes in this case. The one exception to this rule is the global fallback
-            // in class bodies, which we already handled above.
-            if symbol_resolves_locally {
-                return Place::Undefined.into();
+            if indexed_symbol.is_nonlocal() {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Nonlocal(file_scope_id));
             }
-
-            if let PlaceExprRef::Symbol(symbol) = place_expr
-                && symbol.name() == "__class__"
-                && let Some(class) = self.dunder_class_cell_type()
-            {
-                return Place::bound(class).into();
-            }
-
-            for parent_id in place_table.parents(place_expr) {
-                let parent_expr = place_table.place(parent_id);
-                let mut expr_ref = expr_ref;
-                for _ in 0..(place_expr.num_member_segments() - parent_expr.num_member_segments()) {
-                    match expr_ref {
-                        ast::ExprRef::Attribute(attribute) => {
-                            expr_ref = ast::ExprRef::from(&attribute.value);
-                        }
-                        ast::ExprRef::Subscript(subscript) => {
-                            expr_ref = ast::ExprRef::from(&subscript.value);
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                let (parent_place, _use_id) = self.infer_local_place_load(parent_expr, expr_ref);
-                if let Place::Defined(_) = parent_place {
-                    return Place::Undefined.into();
-                }
-            }
-
-            // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
-            // There are two main ways we try to model these loads:
-            //
-            // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
-            //    just before a nested scope begins. For variables that aren't modified after that
-            //    point, that's the only value that the nested scope can see. If a variable is
-            //    reassigned later, lazy snapshots for that variable can be updated or swept.
-            //
-            // 2. Otherwise, we keep walking until we get to the variable's original defining
-            //    scope, and we use its "public type" there, which respects all reachable bindings,
-            //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
-            //    definitions that we install after each nested scope is closed, so it has
-            //    a complete view of the nested `global` and `nonlocal` writes beneath it.
-            //
-            // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
-            // local to the current scope never falls back to an enclosing scope, even if it's only
-            // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
-            //
-            // Note that we only get to this walk via `or_fall_back_to` above. In other words, for
-            // definitely-locally-bound variables, we defer to the current scope's bindings instead
-            // of looking at enclosing scopes. Concretely:
-            //
-            // def f():
-            //     x = None
-            //
-            //     def g():
-            //         nonlocal x
-            //         if flag:
-            //             x = 42
-            //
-            //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
-            //         # public type in `f`.
-            //         reveal_type(x)  # revealed: Literal[42, 99] | None
-            //
-            //         x = 99
-            //         # But now `x` is definitely bound, so we don't do the walk.
-            //         reveal_type(x)  # revealed: Literal[99]
-            //
-            // Importantly, this approach isn't generally sound. The public type could include
-            // nested bindings from sibling scopes, which really could run at any time, and in some
-            // cases we're being too deferential to local bindings. Unfortunately the fully sound
-            // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
-            // which is too frustrating for users in practice.
-            for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
-                // If the current enclosing scope is global, no place lookup is performed here,
-                // instead falling back to the module's explicit global lookup below.
-                if enclosing_scope_file_id.is_global() {
-                    break;
-                }
-
-                // Class scopes are not visible to nested scopes, and we need to handle global
-                // scope differently (because an unbound name there falls back to builtins), so
-                // check only function-like scopes.
-                // There is one exception to this rule: annotation scopes can see
-                // names defined in an immediately-enclosing class scope.
-                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
-
-                let is_immediately_enclosing_scope = scope.is_annotation(db)
-                    && scope
-                        .scope(db)
-                        .parent()
-                        .is_some_and(|parent| parent == enclosing_scope_file_id);
-
-                let has_root_place_been_reassigned = || {
-                    let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                    enclosing_place_table
-                        .parents(place_expr)
-                        .any(|enclosing_root_place_id| {
-                            enclosing_place_table
-                                .place(enclosing_root_place_id)
-                                .is_bound()
-                        })
+            // If we try to access a variable in a class before it has been defined, the
+            // lookup will fall back to global. See the comment on `Symbol::is_local`.
+            let class_body_global_fallback =
+                scope.node(db).scope_kind().is_class() && symbol_is_local;
+            if self.skip_non_global_scopes(file_scope_id, symbol_id) || class_body_global_fallback {
+                let role = if class_body_global_fallback {
+                    PlaceLoadSourceRole::ClassBodyGlobalFallback
+                } else {
+                    PlaceLoadSourceRole::Ordinary
                 };
+                return self.resolve_global_place_load(
+                    load,
+                    place_expr,
+                    expr_ref,
+                    Some(symbol.name()),
+                    file_scope_id,
+                    role,
+                );
+            }
+        }
 
+        // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
+        // `global`, never refer to an enclosing scope. (If you reference such a symbol before
+        // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
+        // enclosing scopes in this case. The one exception to this rule is the global fallback
+        // in class bodies, which we already handled above.
+        if symbol_is_local {
+            if scope.node(db).scope_kind().is_module() {
+                return load.finish_at_global_scope(
+                    self.program_file(),
+                    expr_ref.as_name_expr().map(|name| &name.id),
+                );
+            }
+            return load.with_failure_on_exhaustion(PlaceLoadFailure::UnboundLocal);
+        }
+
+        if let PlaceExprRef::Symbol(symbol) = place_expr
+            && symbol.name() == "__class__"
+            && let Some(definition) = self.dunder_class_cell_definition()
+        {
+            load.push_unnarrowed_source(
+                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::DunderClass(definition)),
+                PlaceLoadSourceRole::Ordinary,
+            );
+        }
+
+        // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
+        // There are two main ways we try to model these loads:
+        //
+        // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
+        //    just before a nested scope begins. For variables that aren't modified after that
+        //    point, that's the only value that the nested scope can see. If a variable is
+        //    reassigned later, lazy snapshots for that variable can be updated or swept.
+        //
+        // 2. Otherwise, we keep walking until we get to the variable's original defining
+        //    scope, and we use its "public type" there, which respects all reachable bindings,
+        //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
+        //    definitions that we install after each nested scope is closed, so it has
+        //    a complete view of the nested `global` and `nonlocal` writes beneath it.
+        //
+        // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
+        // local to the current scope never falls back to an enclosing scope, even if it's only
+        // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
+        //
+        // The sources are evaluated in order. For definitely-locally-bound variables,
+        // inference stops at the current scope's bindings instead of evaluating enclosing
+        // sources. Concretely:
+        //
+        // def f():
+        //     x = None
+        //
+        //     def g():
+        //         nonlocal x
+        //         if flag:
+        //             x = 42
+        //
+        //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
+        //         # public type in `f`.
+        //         reveal_type(x)  # revealed: Literal[42, 99] | None
+        //
+        //         x = 99
+        //         # But now `x` is definitely bound, so we don't do the walk.
+        //         reveal_type(x)  # revealed: Literal[99]
+        //
+        // Importantly, this approach isn't generally sound. The public type could include
+        // nested bindings from sibling scopes, which really could run at any time, and in some
+        // cases we're being too deferential to local bindings. Unfortunately the fully sound
+        // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
+        // which is too frustrating for users in practice.
+        for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
+            // If the current enclosing scope is global, no place lookup is performed here,
+            // instead falling back to the module's explicit global lookup below.
+            if enclosing_scope_file_id.is_global() {
+                break;
+            }
+
+            // Class scopes are not visible to nested scopes, and we need to handle global
+            // scope differently (because an unbound name there falls back to builtins), so
+            // check only function-like scopes.
+            // There is one exception to this rule: annotation scopes can see
+            // names defined in an immediately-enclosing class scope.
+            let enclosing_scope = self.index.scope(enclosing_scope_file_id);
+
+            let is_immediately_enclosing_scope = scope.is_annotation(db)
+                && scope
+                    .scope(db)
+                    .parent()
+                    .is_some_and(|parent| parent == enclosing_scope_file_id);
+
+            let has_root_place_been_reassigned = || {
+                let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
+                enclosing_place_table
+                    .parents(place_expr)
+                    .any(|enclosing_root_place_id| {
+                        enclosing_place_table
+                            .place(enclosing_root_place_id)
+                            .is_bound()
+                    })
+            };
+
+            let mut eagerly_undefined = false;
+            if !self.is_deferred() {
                 // If the reference is in a nested eager scope, we need to look for the place at
                 // the point where the previous enclosing scope was defined, instead of at the end
                 // of the scope. (Note that the semantic index builder takes care of only
                 // registering eager bindings for nested scopes that are actually eager, and for
                 // enclosing scopes that actually contain bindings that we should use when
                 // resolving the reference.)
-                let mut eagerly_resolved_place = None;
-                if !self.is_deferred() {
-                    match self.index.enclosing_snapshot(
-                        enclosing_scope_file_id,
-                        place_expr,
-                        file_scope_id,
-                    ) {
-                        EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                            constraint_keys.push((
-                                enclosing_scope_file_id,
-                                ConstraintKey::NarrowingConstraint(constraint),
-                            ));
-                            // If the current scope is eager, it is certain that the place is undefined in the current scope.
-                            // Do not call the `place` query below as a fallback.
-                            if scope.scope(db).is_eager() {
-                                eagerly_resolved_place = Some(Place::Undefined.into());
-                            }
+                match self.index.enclosing_snapshot(
+                    enclosing_scope_file_id,
+                    place_expr,
+                    file_scope_id,
+                ) {
+                    EnclosingSnapshotResult::FoundConstraint(constraint) => {
+                        load.push_constraint(
+                            enclosing_scope_file_id,
+                            ConstraintKey::NarrowingConstraint(constraint),
+                        );
+                        // If the current scope is eager, it is certain that the place is undefined
+                        // in the current scope. Do not add the place below as a fallback.
+                        if scope.scope(db).is_eager() {
+                            eagerly_undefined = true;
                         }
-                        EnclosingSnapshotResult::FoundBindings(bindings) => {
-                            let place = place_from_bindings_with_reachability_cache(
-                                db,
-                                env,
-                                bindings,
-                                self.reachability_cache(),
-                            )
-                            .place
-                            .map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
-                            constraint_keys.push((
+                    }
+                    EnclosingSnapshotResult::FoundBindings(bindings) => {
+                        load.push_source_with_exit_constraint(
+                            PlaceLoadSourceKind::Bindings(bindings),
+                            PlaceLoadSourceRole::Ordinary,
+                            (
                                 enclosing_scope_file_id,
                                 ConstraintKey::NestedScope(file_scope_id),
-                            ));
-                            return place.into();
+                            ),
+                        );
+                        return load.finish_at_enclosing_scope(
+                            enclosing_scope.kind(),
+                            self.program_file(),
+                            expr_ref.as_name_expr().map(|name| &name.id),
+                        );
+                    }
+                    EnclosingSnapshotResult::NotFound => {
+                        // There are no visible bindings or constraints here. Don't fall back to
+                        // non-eager place resolution if the root place has been reassigned.
+                        if has_root_place_been_reassigned() {
+                            return load.finish_at_enclosing_scope(
+                                enclosing_scope.kind(),
+                                self.program_file(),
+                                expr_ref.as_name_expr().map(|name| &name.id),
+                            );
                         }
-                        // There are no visible bindings / constraint here.
-                        // Don't fall back to non-eager place resolution.
-                        EnclosingSnapshotResult::NotFound => {
-                            if has_root_place_been_reassigned() {
-                                return Place::Undefined.into();
-                            }
-                            continue;
-                        }
-                        EnclosingSnapshotResult::NoLongerInEagerContext => {
-                            if has_root_place_been_reassigned() {
-                                return Place::Undefined.into();
-                            }
+                        continue;
+                    }
+                    EnclosingSnapshotResult::NoLongerInEagerContext => {
+                        if has_root_place_been_reassigned() {
+                            return load.finish_at_enclosing_scope(
+                                enclosing_scope.kind(),
+                                self.program_file(),
+                                expr_ref.as_name_expr().map(|name| &name.id),
+                            );
                         }
                     }
                 }
-
-                if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope {
-                    continue;
-                }
-
-                let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
-                    continue;
-                };
-
-                let enclosing_place = enclosing_place_table.place(enclosing_place_id);
-
-                // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
-                // marks the variable `global`, whether or not that scope actually binds the
-                // variable. If we see a `global` declaration, stop walking scopes and proceed to
-                // the global handling below. (If we're walking from a prior/inner scope where this
-                // variable is `nonlocal`, then this is a semantic syntax error, but we don't
-                // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
-                if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
-                    break;
-                }
-
-                // Keep walking until we reach the defining scope of the variable. The synthetic
-                // nested bindings definitions installed there will see everything below it.
-                if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
-                    continue;
-                }
-                if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
-                    // Note that this check includes members like `x.y` and `x[0]`, which aren't
-                    // symbols and can't be explicitly `nonlocal`.
-                    continue;
-                }
-
-                // We've reached the defining scope of the variable. Infer its public type.
-                debug_assert!(enclosing_place.is_bound() || enclosing_place.is_declared());
-                let enclosing_scope_id =
-                    enclosing_scope_file_id.to_scope_id(db, self.program_file());
-                return eagerly_resolved_place.unwrap_or_else(|| {
-                    place_by_id(
-                        self.db(),
-                        enclosing_scope_id,
-                        enclosing_place_id,
-                        RequiresExplicitReExport::No,
-                        ConsideredDefinitions::AllReachable,
-                    )
-                    .map_type(|ty| {
-                        self.narrow_place_with_applicable_constraints(
-                            place_expr,
-                            ty,
-                            &constraint_keys,
-                        )
-                    })
-                });
             }
 
-            PlaceAndQualifiers::default()
-                // If we're in a class body, check for implicit class body symbols first.
-                // These take precedence over globals.
-                .or_fall_back_to(db, env, || {
-                    if scope.node(db).scope_kind().is_class()
-                        && let Some(symbol) = place_expr.as_symbol()
-                    {
-                        let implicit = class_body_implicit_symbol(db, env, symbol.name());
-                        if implicit.place.is_definitely_bound() {
-                            return implicit.map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
-                        }
-                    }
-                    Place::Undefined.into()
-                })
-                // No nonlocal binding? Check the module's explicit globals.
-                // Avoid infinite recursion if `self.scope` already is the module's global scope.
-                .or_fall_back_to(db, env, || {
-                    self.infer_explicit_global_symbol_load(
-                        place_expr,
-                        place_expr.as_symbol().map(|symbol| symbol.name().as_str()),
-                        file_scope_id,
-                        &mut constraint_keys,
-                        false,
-                    )
-                })
-        };
-        let place = PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, env, fallback);
+            if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope {
+                continue;
+            }
 
-        if let Some(ty) = place.place.ignore_possibly_undefined() {
+            let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
+            let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
+                continue;
+            };
+
+            let enclosing_place = enclosing_place_table.place(enclosing_place_id);
+
+            // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
+            // marks the variable `global`, whether or not that scope actually binds the
+            // variable. If we see a `global` declaration, stop walking scopes and proceed to
+            // the global handling below. (If we're walking from a prior/inner scope where this
+            // variable is `nonlocal`, then this is a semantic syntax error, but we don't
+            // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
+            if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Global(enclosing_scope_file_id));
+                break;
+            }
+
+            // Keep walking until we reach the defining scope of the variable. The synthetic
+            // nested bindings definitions installed there will see everything below it.
+            if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
+                load.scope_declarations
+                    .push(ScopedDeclaration::Nonlocal(enclosing_scope_file_id));
+                continue;
+            }
+            if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
+                // Note that this check includes members like `x.y` and `x[0]`, which aren't
+                // symbols and can't be explicitly `nonlocal`.
+                continue;
+            }
+
+            // We've reached the scope that owns the place. Record it so each consumer can
+            // evaluate the considered definitions it needs.
+            if !eagerly_undefined {
+                let enclosing_scope_id =
+                    enclosing_scope_file_id.to_scope_id(db, self.program_file());
+                load.push_source(
+                    PlaceLoadSourceKind::DefinitionsFromOwningScope {
+                        scope: enclosing_scope_id,
+                        id: enclosing_place_id,
+                    },
+                    PlaceLoadSourceRole::Ordinary,
+                );
+            }
+            return load.finish_at_enclosing_scope(
+                enclosing_scope.kind(),
+                self.program_file(),
+                expr_ref.as_name_expr().map(|name| &name.id),
+            );
+        }
+
+        // If we're in a class body, check for implicit class body symbols first.
+        // These take precedence over globals.
+        if scope.node(db).scope_kind().is_class()
+            && let Some(symbol) = place_expr.as_symbol()
+        {
+            load.push_source(
+                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ClassBodySymbol(
+                    symbol.name().clone(),
+                )),
+                PlaceLoadSourceRole::Ordinary,
+            );
+        }
+
+        // Continue resolution in the module's explicit global scope.
+        self.resolve_global_place_load(
+            load,
+            place_expr,
+            expr_ref,
+            place_expr.as_symbol().map(Symbol::name),
+            file_scope_id,
+            PlaceLoadSourceRole::Ordinary,
+        )
+    }
+
+    /// Infer the type of a place expression from its ordered load sources.
+    ///
+    /// This also returns the [`ConstraintKey`]s used by expression-level narrowing.
+    fn infer_place_load(
+        &self,
+        place_expr: PlaceExprRef,
+        expr_ref: ast::ExprRef,
+    ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
+        let env = self.program_environment();
+        // Named expressions bind their target but are not ordinary load sites, so resolve the
+        // target from its binding definition.
+        if let ast::ExprRef::Named(named) = expr_ref
+            && named.target.is_name_expr()
+        {
+            let definition = self.index.expect_single_definition(named);
+            let place =
+                Place::bound(binding_type(self.db(), definition)).with_definition(definition);
+            if let Some(ty) = place.ignore_possibly_undefined() {
+                self.check_deprecated(expr_ref, ty);
+            }
+            return (place.into(), Vec::new());
+        }
+
+        let load = self.resolve_place_load(place_expr, expr_ref);
+        let mut constraint_checkpoint = PlaceLoadConstraintCheckpoint::default();
+
+        let (prefix_loads, lexical_fallbacks, post_lexical_fallbacks) = match load.fallbacks() {
+            PlaceLoadFallbacks::Unconditional {
+                lexical,
+                post_lexical,
+            } => (None, lexical, post_lexical),
+            PlaceLoadFallbacks::IfNoPlaceExprPrefixIsBound {
+                prefix_loads,
+                lexical,
+                post_lexical,
+            } => (Some(prefix_loads), lexical, post_lexical),
+        };
+        let local_place = self.infer_place_load_sources(
+            place_expr,
+            Place::Undefined.into(),
+            load.local_sources(),
+            &load,
+            &mut constraint_checkpoint,
+        );
+        let fallbacks_blocked_by_bound_prefix = !local_place.place.is_definitely_bound()
+            && prefix_loads
+                .is_some_and(|prefix_loads| self.has_bound_place_expr_prefix(prefix_loads));
+
+        let lexical_place = if fallbacks_blocked_by_bound_prefix {
+            local_place
+        } else {
+            self.infer_place_load_sources(
+                place_expr,
+                local_place,
+                lexical_fallbacks,
+                &load,
+                &mut constraint_checkpoint,
+            )
+        };
+
+        if let Some(ty) = lexical_place.place.ignore_possibly_undefined() {
             self.check_deprecated(expr_ref, ty);
         }
 
+        let post_lexical_place = if fallbacks_blocked_by_bound_prefix {
+            lexical_place
+        } else {
+            self.infer_post_lexical_fallbacks(
+                place_expr,
+                lexical_place,
+                post_lexical_fallbacks,
+                &load,
+                &mut constraint_checkpoint,
+            )
+        };
+
+        let place = if load.failure_on_exhaustion() == PlaceLoadFailure::NotFound {
+            post_lexical_place.or_fall_back_to(self.db(), env, || {
+                self.infer_unimported_reveal_type_fallback(expr_ref)
+            })
+        } else {
+            post_lexical_place
+        };
+
+        let constraint_keys = load.into_constraints(&constraint_checkpoint);
+
         (place, constraint_keys)
+    }
+
+    fn infer_place_load_sources(
+        &self,
+        place_expr: PlaceExprRef,
+        mut place: PlaceAndQualifiers<'db>,
+        sources: &[PlaceLoadSource<'db>],
+        load: &PlaceLoad<'db>,
+        constraint_checkpoint: &mut PlaceLoadConstraintCheckpoint,
+    ) -> PlaceAndQualifiers<'db> {
+        for source in sources {
+            if place.place.is_definitely_bound() {
+                break;
+            }
+
+            let narrowing_constraints =
+                load.narrowing_constraints_for(source, constraint_checkpoint);
+            let fallback = self.infer_place_load_source(place_expr, source, narrowing_constraints);
+            place = place.or_fall_back_to(self.db(), self.program_environment(), || fallback);
+        }
+
+        place
+    }
+
+    fn infer_place_load_source(
+        &self,
+        place_expr: PlaceExprRef,
+        source: &PlaceLoadSource<'db>,
+        narrowing_constraints: &[(FileScopeId, ConstraintKey)],
+    ) -> PlaceAndQualifiers<'db> {
+        let db = self.db();
+        let env = self.program_environment();
+
+        let place = match source.kind.clone() {
+            PlaceLoadSourceKind::Bindings(bindings) => {
+                let mut place = place_from_bindings_with_reachability_cache(
+                    db,
+                    env,
+                    bindings,
+                    self.reachability_cache(),
+                )
+                .place;
+
+                // Compatibility policy: ty historically treats a possibly-bound module snapshot
+                // reached through a class-body global fallback as definitely bound. At runtime,
+                // an unbound snapshot would continue to builtins or produce a name error.
+                if source.is_class_body_global_fallback()
+                    && let Place::Defined(defined) = place
+                {
+                    place = Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
+                }
+
+                place.into()
+            }
+            PlaceLoadSourceKind::DefinitionsFromOwningScope { scope, id } => place_by_id(
+                db,
+                scope,
+                id,
+                RequiresExplicitReExport::No,
+                ConsideredDefinitions::AllReachable,
+            ),
+            PlaceLoadSourceKind::Implicit(implicit) => match implicit {
+                ImplicitPlaceLoad::DunderClass(definition) => original_class_type(db, definition)
+                    .map_or_else(
+                        || Place::Undefined.into(),
+                        |class| Place::bound(class).into(),
+                    ),
+                ImplicitPlaceLoad::ClassBodySymbol(name) => {
+                    let implicit = class_body_implicit_symbol(db, env, &name);
+                    if implicit.place.is_definitely_bound() {
+                        implicit
+                    } else {
+                        Place::Undefined.into()
+                    }
+                }
+                ImplicitPlaceLoad::ExplicitGlobalSymbol { file, name } => {
+                    explicit_global_symbol(db, file, &name)
+                }
+            },
+        };
+
+        place.map_type(|ty| {
+            self.narrow_place_with_applicable_constraints(place_expr, ty, narrowing_constraints)
+        })
+    }
+
+    fn infer_post_lexical_fallbacks(
+        &self,
+        place_expr: PlaceExprRef,
+        mut place: PlaceAndQualifiers<'db>,
+        fallbacks: Option<&PostLexicalFallbacks<'db>>,
+        load: &PlaceLoad<'db>,
+        constraint_checkpoint: &mut PlaceLoadConstraintCheckpoint,
+    ) -> PlaceAndQualifiers<'db> {
+        if place.place.is_definitely_bound() {
+            return place;
+        }
+
+        let constraints = load.narrowing_constraints_on_exhaustion(constraint_checkpoint);
+
+        let Some(fallbacks) = fallbacks else {
+            return place;
+        };
+
+        let db = self.db();
+        let env = self.program_environment();
+        let implicit_global =
+            module_type_implicit_global_symbol(db, fallbacks.file(), fallbacks.name()).map_type(
+                |ty| self.narrow_place_with_applicable_constraints(place_expr, ty, constraints),
+            );
+        place = place.or_fall_back_to(db, env, || implicit_global);
+
+        if place.place.is_definitely_bound() {
+            return place;
+        }
+
+        place.or_fall_back_to(db, env, || {
+            if Some(self.scope()) == builtins_module_scope(db, env) {
+                Place::Undefined.into()
+            } else {
+                implicit_builtins_symbol(db, env, fallbacks.name())
+            }
+        })
+    }
+
+    /// Applies ty's convenience fallback for an unimported `reveal_type`.
+    fn infer_unimported_reveal_type_fallback(
+        &self,
+        expr_ref: ast::ExprRef,
+    ) -> PlaceAndQualifiers<'db> {
+        let Some(name) = expr_ref
+            .as_name_expr()
+            .filter(|name| name.id == "reveal_type")
+        else {
+            return Place::Undefined.into();
+        };
+
+        if !self.in_stub()
+            && !self.is_in_type_checking_block(self.scope(), name)
+            && let Some(builder) = self.context.report_lint(&UNDEFINED_REVEAL, name)
+        {
+            let mut diag = builder.into_diagnostic("`reveal_type` used without importing it");
+            diag.info("This is allowed for debugging convenience but will fail at runtime");
+        }
+
+        typing_extensions_symbol(self.db(), self.program_environment(), "reveal_type")
+    }
+
+    /// Describes how to evaluate the tracked place-expression prefixes of `expr` in this scope.
+    fn place_expr_prefix_loads(
+        &self,
+        expr: PlaceExprRef,
+        expr_ref: ast::ExprRef,
+    ) -> Option<PlaceExprPrefixLoads<'db>> {
+        let db = self.db();
+        let scope = self.scope();
+        let place_table = self.index.place_table(scope.file_scope_id(db));
+
+        PlaceExprPrefixLoads::from_iter(
+            scope,
+            place_table.parents(expr).filter_map(|prefix_id| {
+                if self.is_deferred() {
+                    return Some(PlaceExprPrefixLoad::AllReachable(prefix_id));
+                }
+
+                let prefix = place_table.place(prefix_id);
+                let mut prefix_expr_ref = expr_ref;
+                for _ in 0..(expr.num_member_segments() - prefix.num_member_segments()) {
+                    prefix_expr_ref = match prefix_expr_ref {
+                        ast::ExprRef::Attribute(attribute) => ast::ExprRef::from(&attribute.value),
+                        ast::ExprRef::Subscript(subscript) => ast::ExprRef::from(&subscript.value),
+                        _ => unreachable!(),
+                    };
+                }
+
+                if prefix_expr_ref
+                    .as_name_expr()
+                    .is_some_and(|name| name.is_invalid())
+                {
+                    return None;
+                }
+
+                if let ast::ExprRef::Named(named) = prefix_expr_ref {
+                    return named
+                        .target
+                        .is_name_expr()
+                        .then_some(PlaceExprPrefixLoad::DefinitelyBound);
+                }
+
+                Some(PlaceExprPrefixLoad::AtUse(
+                    prefix_expr_ref.scoped_use_id(db, self.program_file()),
+                ))
+            }),
+        )
+    }
+
+    /// Returns whether any tracked place-expression prefix has a definite or possible binding in
+    /// this scope.
+    fn has_bound_place_expr_prefix(&self, prefix_loads: &PlaceExprPrefixLoads<'db>) -> bool {
+        let db = self.db();
+        let env = self.program_environment();
+        let file_scope_id = prefix_loads.scope().file_scope_id(db);
+        let use_def = self.index.use_def_map(file_scope_id);
+
+        prefix_loads.iter().any(|prefix| {
+            let place = match prefix {
+                PlaceExprPrefixLoad::AtUse(use_id) => {
+                    place_from_bindings_with_reachability_cache(
+                        db,
+                        env,
+                        use_def.bindings_at_use(use_id),
+                        self.reachability_cache(),
+                    )
+                    .place
+                }
+                PlaceExprPrefixLoad::AllReachable(place_id) => {
+                    place_from_bindings_with_reachability_cache(
+                        db,
+                        env,
+                        use_def.reachable_bindings(place_id),
+                        self.reachability_cache(),
+                    )
+                    .place
+                }
+                PlaceExprPrefixLoad::DefinitelyBound => return true,
+            };
+
+            !place.is_undefined()
+        })
     }
 
     fn report_unresolved_reference(&self, expr_name_node: &ast::ExprName) {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -42,8 +42,8 @@ use crate::place::{
 };
 use crate::place_load::{
     ImplicitPlaceLoad, PlaceExprPrefixLoad, PlaceExprPrefixLoads, PlaceLoad,
-    PlaceLoadConstraintCheckpoint, PlaceLoadFailure, PlaceLoadFallbacks, PlaceLoadSource,
-    PlaceLoadSourceKind, PlaceLoadSourceRole, PostLexicalFallbacks, ScopedDeclaration,
+    PlaceLoadConstraintCheckpoint, PlaceLoadFailure, PlaceLoadFallbacks, PlaceLoadMode,
+    PlaceLoadSource, PlaceLoadSourceKind, PostLexicalFallbacks, resolve_place_load,
 };
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
@@ -125,7 +125,6 @@ use crate::types::{
     infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet};
-use ty_python_core::ast_ids::ScopedUseId;
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
     Definition, DefinitionKind, DefinitionNodeKey, DefinitionState, ExceptHandlerDefinitionKind,
@@ -139,10 +138,10 @@ use ty_python_core::node_key::NodeKey;
 use ty_python_core::place::{PlaceExpr, PlaceExprRef};
 use ty_python_core::predicate::PatternPredicate;
 use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, NodeWithScopeRef, ScopeId, ScopeKind};
-use ty_python_core::symbol::{ScopedSymbolId, Symbol};
+use ty_python_core::symbol::ScopedSymbolId;
 use ty_python_core::{
-    ApplicableConstraints, EnclosingSnapshotResult, EvaluationMode, ProgramFile, SemanticIndex,
-    Truthiness, unpack::UnpackPosition,
+    ApplicableConstraints, EvaluationMode, ProgramFile, SemanticIndex, Truthiness,
+    unpack::UnpackPosition,
 };
 use ty_python_core::{ExpressionNodeKey, Statement};
 
@@ -1892,29 +1891,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         diagnostic::report_undeclared_protocol_attribute(&self.context, target, protocol);
-    }
-
-    /// Returns the implicit `__class__` cell in the current direct method body or
-    /// lazy scope defined directly in a class body.
-    fn dunder_class_cell_definition(&self) -> Option<Definition<'db>> {
-        let current_scope_id = self.scope().file_scope_id(self.db());
-        if let Some(definition) = self.index.class_definition_of_method(current_scope_id) {
-            return Some(definition);
-        }
-
-        let current_scope = self.index.scope(current_scope_id);
-        if !matches!(
-            current_scope.node(),
-            NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
-        ) {
-            return None;
-        }
-        let class = self
-            .index
-            .parent_scope(current_scope_id)?
-            .node()
-            .as_class()?;
-        Some(self.index.expect_single_definition(class))
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.
@@ -9628,432 +9604,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty.inner_type()
     }
 
-    fn local_place_load_source(
-        &self,
-        expr: PlaceExprRef,
-        expr_ref: ast::ExprRef,
-    ) -> Option<(PlaceLoadSourceKind<'db>, Option<ScopedUseId>)> {
-        let db = self.db();
-        let scope = self.scope();
-        let file_scope_id = scope.file_scope_id(db);
-        let place_table = self.index.place_table(file_scope_id);
-        let use_def = self.index.use_def_map(file_scope_id);
-
-        // If we're inferring types of deferred expressions, look them up from end-of-scope.
-        if self.is_deferred() {
-            let source = place_table.place_id(expr).map(|place_id| {
-                PlaceLoadSourceKind::Bindings(use_def.reachable_bindings(place_id))
-            });
-            if source.is_none() {
-                assert!(
-                    self.in_string_annotation(),
-                    "Expected the place table to create a place for every valid PlaceExpr node"
-                );
-            }
-            source.map(|source| (source, None))
-        } else {
-            if expr_ref
-                .as_name_expr()
-                .is_some_and(|name| name.is_invalid())
-            {
-                return None;
-            }
-
-            if matches!(expr_ref, ast::ExprRef::Named(_)) {
-                return None;
-            }
-
-            let use_id = expr_ref.scoped_use_id(db, self.program_file());
-            Some((
-                PlaceLoadSourceKind::Bindings(use_def.bindings_at_use(use_id)),
-                Some(use_id),
-            ))
-        }
-    }
-
-    /// Resolve a load that has fallen through to the module's explicit global scope.
-    ///
-    /// For eager nested scopes, this uses the global enclosing snapshot instead of the completed
-    /// module scope, so a class body cannot see a class name that is bound only after the body
-    /// finishes:
-    ///
-    /// ```python
-    /// class A:
-    ///     A = A
-    /// ```
-    ///
-    /// `symbol_name` is only needed when no snapshot is available: snapshots can resolve complex
-    /// places like `a.x`, but the fallback global query only works for bare symbols. `role`
-    /// preserves the class-body fallback behavior for names that are also local to the class body.
-    fn resolve_global_place_load(
-        &self,
-        mut load: PlaceLoad<'db>,
-        place_expr: PlaceExprRef,
-        expr_ref: ast::ExprRef,
-        symbol_name: Option<&Name>,
-        current_scope_id: FileScopeId,
-        role: PlaceLoadSourceRole,
-    ) -> PlaceLoad<'db> {
-        let file = self.program_file();
-        let post_lexical_name = expr_ref.as_name_expr().map(|name| &name.id);
-
-        if current_scope_id.is_global() {
-            return load.finish_at_global_scope(file, post_lexical_name);
-        }
-
-        if !self.is_deferred() {
-            match self
-                .index
-                .enclosing_snapshot(FileScopeId::global(), place_expr, current_scope_id)
-            {
-                EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                    load.push_constraint(
-                        FileScopeId::global(),
-                        ConstraintKey::NarrowingConstraint(constraint),
-                    );
-                    // Reaching here means that no bindings are found in any scope.
-                    // Since `explicit_global_symbol` may return a cycle initial value,
-                    // don't add it to the `sources` on the `PlaceLoad`.
-                    return load.finish_at_global_scope(file, post_lexical_name);
-                }
-                EnclosingSnapshotResult::FoundBindings(bindings) => {
-                    load.push_source_with_exit_constraint(
-                        PlaceLoadSourceKind::Bindings(bindings),
-                        role,
-                        (
-                            FileScopeId::global(),
-                            ConstraintKey::NestedScope(current_scope_id),
-                        ),
-                    );
-                    return load.finish_at_global_scope(file, post_lexical_name);
-                }
-                // There are no visible bindings / constraint here.
-                EnclosingSnapshotResult::NotFound => {
-                    return load.finish_at_global_scope(file, post_lexical_name);
-                }
-                EnclosingSnapshotResult::NoLongerInEagerContext => {}
-            }
-        }
-
-        let Some(symbol_name) = symbol_name else {
-            return load.finish_at_global_scope(file, post_lexical_name);
-        };
-
-        load.push_source(
-            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ExplicitGlobalSymbol {
-                file: self.program_file(),
-                name: symbol_name.clone(),
-            }),
-            role,
-        );
-        load.finish_at_global_scope(file, post_lexical_name)
-    }
-
-    /// Resolves a place load into an ordered list of sources that might supply its value.
-    ///
-    /// Please see the [`place_load` module](crate::place_load) for a description
-    /// of the resolution model.
-    fn resolve_place_load(
-        &self,
-        place_expr: PlaceExprRef,
-        expr_ref: ast::ExprRef,
-    ) -> PlaceLoad<'db> {
-        let db = self.db();
-        let scope = self.scope();
-        let file_scope_id = scope.file_scope_id(db);
-        let place_table = self.index.place_table(file_scope_id);
-
-        let mut load = match self.local_place_load_source(place_expr, expr_ref) {
-            Some((local_source, use_id)) => PlaceLoad::from_local_source(
-                local_source,
-                use_id.map(|use_id| (file_scope_id, ConstraintKey::UseId(use_id))),
-            ),
-            None => PlaceLoad::new(),
-        };
-
-        if let Some(prefix_loads) = self.place_expr_prefix_loads(place_expr, expr_ref) {
-            load = load.with_conditional_fallbacks(prefix_loads);
-        }
-
-        let mut symbol_is_local = false;
-        if let Some(symbol) = place_expr.as_symbol()
-            && let Some(symbol_id) = place_table.symbol_id(symbol.name())
-        {
-            // Footgun: `place_expr` and `symbol` were probably constructed with all-zero
-            // flags. We need to read the place table to get correct flags.
-            let indexed_symbol = place_table.symbol(symbol_id);
-            symbol_is_local = indexed_symbol.is_local();
-            if indexed_symbol.is_global() {
-                load.scope_declarations
-                    .push(ScopedDeclaration::Global(file_scope_id));
-            }
-            if indexed_symbol.is_nonlocal() {
-                load.scope_declarations
-                    .push(ScopedDeclaration::Nonlocal(file_scope_id));
-            }
-            // If we try to access a variable in a class before it has been defined, the
-            // lookup will fall back to global. See the comment on `Symbol::is_local`.
-            let class_body_global_fallback =
-                scope.node(db).scope_kind().is_class() && symbol_is_local;
-            if self.skip_non_global_scopes(file_scope_id, symbol_id) || class_body_global_fallback {
-                let role = if class_body_global_fallback {
-                    PlaceLoadSourceRole::ClassBodyGlobalFallback
-                } else {
-                    PlaceLoadSourceRole::Ordinary
-                };
-                return self.resolve_global_place_load(
-                    load,
-                    place_expr,
-                    expr_ref,
-                    Some(symbol.name()),
-                    file_scope_id,
-                    role,
-                );
-            }
-        }
-
-        // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
-        // `global`, never refer to an enclosing scope. (If you reference such a symbol before
-        // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
-        // enclosing scopes in this case. The one exception to this rule is the global fallback
-        // in class bodies, which we already handled above.
-        if symbol_is_local {
-            if scope.node(db).scope_kind().is_module() {
-                return load.finish_at_global_scope(
-                    self.program_file(),
-                    expr_ref.as_name_expr().map(|name| &name.id),
-                );
-            }
-            return load.with_failure_on_exhaustion(PlaceLoadFailure::UnboundLocal);
-        }
-
-        if let PlaceExprRef::Symbol(symbol) = place_expr
-            && symbol.name() == "__class__"
-            && let Some(definition) = self.dunder_class_cell_definition()
-        {
-            load.push_unnarrowed_source(
-                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::DunderClass(definition)),
-                PlaceLoadSourceRole::Ordinary,
-            );
-        }
-
-        // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
-        // There are two main ways we try to model these loads:
-        //
-        // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
-        //    just before a nested scope begins. For variables that aren't modified after that
-        //    point, that's the only value that the nested scope can see. If a variable is
-        //    reassigned later, lazy snapshots for that variable can be updated or swept.
-        //
-        // 2. Otherwise, we keep walking until we get to the variable's original defining
-        //    scope, and we use its "public type" there, which respects all reachable bindings,
-        //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
-        //    definitions that we install after each nested scope is closed, so it has
-        //    a complete view of the nested `global` and `nonlocal` writes beneath it.
-        //
-        // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
-        // local to the current scope never falls back to an enclosing scope, even if it's only
-        // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
-        //
-        // The sources are evaluated in order. For definitely-locally-bound variables,
-        // inference stops at the current scope's bindings instead of evaluating enclosing
-        // sources. Concretely:
-        //
-        // def f():
-        //     x = None
-        //
-        //     def g():
-        //         nonlocal x
-        //         if flag:
-        //             x = 42
-        //
-        //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
-        //         # public type in `f`.
-        //         reveal_type(x)  # revealed: Literal[42, 99] | None
-        //
-        //         x = 99
-        //         # But now `x` is definitely bound, so we don't do the walk.
-        //         reveal_type(x)  # revealed: Literal[99]
-        //
-        // Importantly, this approach isn't generally sound. The public type could include
-        // nested bindings from sibling scopes, which really could run at any time, and in some
-        // cases we're being too deferential to local bindings. Unfortunately the fully sound
-        // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
-        // which is too frustrating for users in practice.
-        for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
-            // If the current enclosing scope is global, no place lookup is performed here,
-            // instead falling back to the module's explicit global lookup below.
-            if enclosing_scope_file_id.is_global() {
-                break;
-            }
-
-            // Class scopes are not visible to nested scopes, and we need to handle global
-            // scope differently (because an unbound name there falls back to builtins), so
-            // check only function-like scopes.
-            // There is one exception to this rule: annotation scopes can see
-            // names defined in an immediately-enclosing class scope.
-            let enclosing_scope = self.index.scope(enclosing_scope_file_id);
-
-            let is_immediately_enclosing_scope = scope.is_annotation(db)
-                && scope
-                    .scope(db)
-                    .parent()
-                    .is_some_and(|parent| parent == enclosing_scope_file_id);
-
-            let has_root_place_been_reassigned = || {
-                let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                enclosing_place_table
-                    .parents(place_expr)
-                    .any(|enclosing_root_place_id| {
-                        enclosing_place_table
-                            .place(enclosing_root_place_id)
-                            .is_bound()
-                    })
-            };
-
-            let mut eagerly_undefined = false;
-            if !self.is_deferred() {
-                // If the reference is in a nested eager scope, we need to look for the place at
-                // the point where the previous enclosing scope was defined, instead of at the end
-                // of the scope. (Note that the semantic index builder takes care of only
-                // registering eager bindings for nested scopes that are actually eager, and for
-                // enclosing scopes that actually contain bindings that we should use when
-                // resolving the reference.)
-                match self.index.enclosing_snapshot(
-                    enclosing_scope_file_id,
-                    place_expr,
-                    file_scope_id,
-                ) {
-                    EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                        load.push_constraint(
-                            enclosing_scope_file_id,
-                            ConstraintKey::NarrowingConstraint(constraint),
-                        );
-                        // If the current scope is eager, it is certain that the place is undefined
-                        // in the current scope. Do not add the place below as a fallback.
-                        if scope.scope(db).is_eager() {
-                            eagerly_undefined = true;
-                        }
-                    }
-                    EnclosingSnapshotResult::FoundBindings(bindings) => {
-                        load.push_source_with_exit_constraint(
-                            PlaceLoadSourceKind::Bindings(bindings),
-                            PlaceLoadSourceRole::Ordinary,
-                            (
-                                enclosing_scope_file_id,
-                                ConstraintKey::NestedScope(file_scope_id),
-                            ),
-                        );
-                        return load.finish_at_enclosing_scope(
-                            enclosing_scope.kind(),
-                            self.program_file(),
-                            expr_ref.as_name_expr().map(|name| &name.id),
-                        );
-                    }
-                    EnclosingSnapshotResult::NotFound => {
-                        // There are no visible bindings or constraints here. Don't fall back to
-                        // non-eager place resolution if the root place has been reassigned.
-                        if has_root_place_been_reassigned() {
-                            return load.finish_at_enclosing_scope(
-                                enclosing_scope.kind(),
-                                self.program_file(),
-                                expr_ref.as_name_expr().map(|name| &name.id),
-                            );
-                        }
-                        continue;
-                    }
-                    EnclosingSnapshotResult::NoLongerInEagerContext => {
-                        if has_root_place_been_reassigned() {
-                            return load.finish_at_enclosing_scope(
-                                enclosing_scope.kind(),
-                                self.program_file(),
-                                expr_ref.as_name_expr().map(|name| &name.id),
-                            );
-                        }
-                    }
-                }
-            }
-
-            if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope {
-                continue;
-            }
-
-            let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-            let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
-                continue;
-            };
-
-            let enclosing_place = enclosing_place_table.place(enclosing_place_id);
-
-            // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
-            // marks the variable `global`, whether or not that scope actually binds the
-            // variable. If we see a `global` declaration, stop walking scopes and proceed to
-            // the global handling below. (If we're walking from a prior/inner scope where this
-            // variable is `nonlocal`, then this is a semantic syntax error, but we don't
-            // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
-            if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
-                load.scope_declarations
-                    .push(ScopedDeclaration::Global(enclosing_scope_file_id));
-                break;
-            }
-
-            // Keep walking until we reach the defining scope of the variable. The synthetic
-            // nested bindings definitions installed there will see everything below it.
-            if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
-                load.scope_declarations
-                    .push(ScopedDeclaration::Nonlocal(enclosing_scope_file_id));
-                continue;
-            }
-            if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
-                // Note that this check includes members like `x.y` and `x[0]`, which aren't
-                // symbols and can't be explicitly `nonlocal`.
-                continue;
-            }
-
-            // We've reached the scope that owns the place. Record it so each consumer can
-            // evaluate the considered definitions it needs.
-            if !eagerly_undefined {
-                let enclosing_scope_id =
-                    enclosing_scope_file_id.to_scope_id(db, self.program_file());
-                load.push_source(
-                    PlaceLoadSourceKind::DefinitionsFromOwningScope {
-                        scope: enclosing_scope_id,
-                        id: enclosing_place_id,
-                    },
-                    PlaceLoadSourceRole::Ordinary,
-                );
-            }
-            return load.finish_at_enclosing_scope(
-                enclosing_scope.kind(),
-                self.program_file(),
-                expr_ref.as_name_expr().map(|name| &name.id),
-            );
-        }
-
-        // If we're in a class body, check for implicit class body symbols first.
-        // These take precedence over globals.
-        if scope.node(db).scope_kind().is_class()
-            && let Some(symbol) = place_expr.as_symbol()
-        {
-            load.push_source(
-                PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ClassBodySymbol(
-                    symbol.name().clone(),
-                )),
-                PlaceLoadSourceRole::Ordinary,
-            );
-        }
-
-        // Continue resolution in the module's explicit global scope.
-        self.resolve_global_place_load(
-            load,
-            place_expr,
-            expr_ref,
-            place_expr.as_symbol().map(Symbol::name),
-            file_scope_id,
-            PlaceLoadSourceRole::Ordinary,
-        )
-    }
-
     /// Infer the type of a place expression from its ordered load sources.
     ///
     /// This also returns the [`ConstraintKey`]s used by expression-level narrowing.
@@ -10077,7 +9627,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return (place.into(), Vec::new());
         }
 
-        let load = self.resolve_place_load(place_expr, expr_ref);
+        let mode = if self.is_deferred() && self.in_string_annotation() {
+            PlaceLoadMode::StringAnnotation
+        } else if self.is_deferred() {
+            PlaceLoadMode::Deferred
+        } else {
+            PlaceLoadMode::AtExpression(expr_ref)
+        };
+        let load = resolve_place_load(self.db(), self.index, self.scope(), place_expr, mode);
         let mut constraint_checkpoint = PlaceLoadConstraintCheckpoint::default();
 
         let (prefix_loads, lexical_fallbacks, post_lexical_fallbacks) = match load.fallbacks() {
@@ -10287,54 +9844,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         typing_extensions_symbol(self.db(), self.program_environment(), "reveal_type")
-    }
-
-    /// Describes how to evaluate the tracked place-expression prefixes of `expr` in this scope.
-    fn place_expr_prefix_loads(
-        &self,
-        expr: PlaceExprRef,
-        expr_ref: ast::ExprRef,
-    ) -> Option<PlaceExprPrefixLoads<'db>> {
-        let db = self.db();
-        let scope = self.scope();
-        let place_table = self.index.place_table(scope.file_scope_id(db));
-
-        PlaceExprPrefixLoads::from_iter(
-            scope,
-            place_table.parents(expr).filter_map(|prefix_id| {
-                if self.is_deferred() {
-                    return Some(PlaceExprPrefixLoad::AllReachable(prefix_id));
-                }
-
-                let prefix = place_table.place(prefix_id);
-                let mut prefix_expr_ref = expr_ref;
-                for _ in 0..(expr.num_member_segments() - prefix.num_member_segments()) {
-                    prefix_expr_ref = match prefix_expr_ref {
-                        ast::ExprRef::Attribute(attribute) => ast::ExprRef::from(&attribute.value),
-                        ast::ExprRef::Subscript(subscript) => ast::ExprRef::from(&subscript.value),
-                        _ => unreachable!(),
-                    };
-                }
-
-                if prefix_expr_ref
-                    .as_name_expr()
-                    .is_some_and(|name| name.is_invalid())
-                {
-                    return None;
-                }
-
-                if let ast::ExprRef::Named(named) = prefix_expr_ref {
-                    return named
-                        .target
-                        .is_name_expr()
-                        .then_some(PlaceExprPrefixLoad::DefinitelyBound);
-                }
-
-                Some(PlaceExprPrefixLoad::AtUse(
-                    prefix_expr_ref.scoped_use_id(db, self.program_file()),
-                ))
-            }),
-        )
     }
 
     /// Returns whether any tracked place-expression prefix has a definite or possible binding in


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This completes the extraction of place-load resolution logic that started in https://github.com/astral-sh/ruff/pull/27319. Specifically, it moves that logic from `TypeInferenceBuilder::resolve_place_load` to `place_load::resolve_place_load`, where it can now be used independently from type inference to [expose reachable binding definitions to the language server for file rename refactor support](https://github.com/astral-sh/ruff/pull/26677).

Most of the diff is a mechanical move out of `TypeInferenceBuilder`. The important adaptations in the port are:

- `place_load::resolve_place_load` is now a standalone entry point whose interface contains only the inputs required for name resolution: the database, semantic index, current scope, place, and resolution mode. It packages those inputs into a private `PlaceLoadResolutionContext` instead of depending on the larger `TypeInferenceBuilder`.
- `PlaceLoadMode` makes the builder state that affected resolution explicit. `AtExpression` resolves the bindings live at an expression occurrence, while `Deferred` resolves every binding reachable at the end of the scope. `StringAnnotation` uses the deferred behavior but permits a place that is not represented in the surrounding place table.
- The enclosing-scope walk is split into a per-scope helper with an explicit continuation result, and the methods that assemble a `PlaceLoad` are now private to the module. Consumers can inspect the completed resolution without taking on its construction invariants.

After this change, `TypeInferenceBuilder` only selects the appropriate mode, calls the shared resolver, and infers types from the returned sources. This is intended to preserve type-inference behavior.

## Test Plan

This is a refactor that relies on existing test coverage.
<!-- How was it tested? -->
