### PR TITLE
fix: avoid EXE001 on non-leading shebang comments

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_executable/EXE001_4.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_executable/EXE001_4.py
@@ -1,0 +1,3 @@
+def f():
+    #! regular comment
+    return 1

--- a/crates/ruff_linter/src/rules/flake8_executable/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/mod.rs
@@ -17,6 +17,7 @@ mod tests {
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_1.py"))]
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_2.py"))]
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_3.py"))]
+    #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_4.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_1.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_2.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_3.py"))]

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_text_size::TextRange;
+use ruff_text_size::{TextRange, TextSize};
 
 use crate::Violation;
 use crate::checkers::ast::LintContext;
@@ -51,6 +51,12 @@ impl Violation for ShebangNotExecutable {
 /// EXE001
 #[cfg(target_family = "unix")]
 pub(crate) fn shebang_not_executable(filepath: &Path, range: TextRange, context: &LintContext) {
+    // A shebang only affects a file when it starts at the beginning of the file.
+    // Later `#!` comments are handled by EXE005 when that rule is enabled.
+    if range.start() != TextSize::from(0) {
+        return;
+    }
+
     // WSL supports Windows file systems, which do not have executable bits.
     // Instead, everything is executable. Therefore, we skip this rule on WSL.
 

--- a/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE001_4.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE001_4.py.snap
@@ -1,0 +1,3 @@
+---
+source: crates/ruff_linter/src/rules/flake8_executable/mod.rs
+---


### PR DESCRIPTION
## Summary
- restrict EXE001 to shebangs at the start of a file
- add a regression fixture for an ordinary `#!` comment inside a function
- retain EXE005 handling for non-leading shebang placement

## Testing
- `cargo test -p ruff_linter rules::flake8_executable::tests::rules`
