### PR TITLE
[ty] Treat bottom-materialized invariant generics as disjoint

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -827,12 +827,50 @@ def no_return_annotation(*args, **kwargs): ...
 static_assert(is_assignable_to(~type & ~RegularCallableTypeOf[no_return_annotation], ~type))
 ```
 
+## Assignability to negated invariant generic types
+
+A gradual invariant specialization can be assignable to the negation of another specialization when
+some materialization of its type argument is incompatible with the negated specialization.
+
+```pyi
+from typing import Any, Generic, TypeVar
+from ty_extensions import Bottom, static_assert
+from ty_extensions._internal import is_assignable_to
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+
+class Invariant(Generic[T]):
+    value: T
+
+class Covariant(Generic[T_co]):
+    def get(self) -> T_co: ...
+
+static_assert(is_assignable_to(list[Any], ~list[int]))
+static_assert(is_assignable_to(list[Any], ~list[object]))
+static_assert(is_assignable_to(list[int], ~list[Any]))
+static_assert(is_assignable_to(list[Any], ~list[Any]))
+static_assert(is_assignable_to(list[list[Any]], ~list[list[int]]))
+static_assert(is_assignable_to(list[int | Any], ~list[int]))
+static_assert(is_assignable_to(Bottom[list[Any]], ~list[int]))
+static_assert(is_assignable_to(Bottom[list[Any]], ~list[Any]))
+static_assert(is_assignable_to(Invariant[Any], ~Invariant[int]))
+static_assert(is_assignable_to(Invariant[int], ~Invariant[Any]))
+
+static_assert(not is_assignable_to(list[int], ~list[int]))
+static_assert(not is_assignable_to(list[Any], ~object))
+static_assert(not is_assignable_to(Bottom[list[Any]], ~object))
+static_assert(not is_assignable_to(Covariant[Any], ~Covariant[int]))
+```
+
 ## Intersections with non-fully-static negated elements
 
 A type can be _assignable_ to an intersection containing negated elements only if the _bottom_
 materialization of that type is disjoint from the _bottom_ materialization of all negated elements
-in the intersection. This differs from subtyping, which should do the disjointness check against the
-_top_ materialization of the negated elements.
+in the intersection. This includes bottom materializations of invariant gradual generics: they are
+uninhabited even though their `Bottom[...]` representation remains distinct from `Never`. This
+differs from subtyping, which should do the disjointness check against the _top_ materialization of
+the negated elements.
 
 ```pyi
 from typing_extensions import Any, Never, Sequence
@@ -887,14 +925,13 @@ static_assert(not is_assignable_to(tuple[Any, ...], ~tuple[Any, ...]))
 # and `Never` *is* disjoint from itself
 static_assert(is_assignable_to(tuple[Any], ~tuple[Any]))
 
-# The same principle applies for non-fully-static `list` specializations.
-# TODO: this should pass (`Bottom[list[Any]]` should simplify to `Never`)
-static_assert(is_assignable_to(list[Any], ~list[Any]))  # error: [static-assert-error]
+# The same principle applies for non-fully-static `list` specializations: their invariant type
+# arguments can materialize to incompatible types even though `Bottom[list[Any]]` is not `Never`.
+static_assert(is_assignable_to(list[Any], ~list[Any]))
 
-# `Bottom[list[Any]]` is `Never`, which is disjoint from `Bottom[Sequence[Any]]`
-# (which is `Sequence[Never]`).
-# TODO: this should pass (`Bottom[list[Any]]` should simplify to `Never`)
-static_assert(is_assignable_to(list[Any], ~Sequence[Any]))  # error: [static-assert-error]
+# `list[Any]` can materialize to specializations that are disjoint from
+# `Bottom[Sequence[Any]]` (which is `Sequence[Never]`).
+static_assert(is_assignable_to(list[Any], ~Sequence[Any]))
 ```
 
 ## General properties

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -166,7 +166,7 @@ not: a covariant container can be inhabited by an empty value.
 ```pyi
 from collections.abc import Sequence
 from typing import Any, Generic, TypeVar
-from ty_extensions import static_assert
+from ty_extensions import Bottom, static_assert
 from ty_extensions._internal import is_disjoint_from
 
 T = TypeVar("T")
@@ -204,6 +204,12 @@ static_assert(is_disjoint_from(Invariant[B], Invariant[A | Any]))
 static_assert(is_disjoint_from(Invariant[A & Any], Invariant[B]))
 static_assert(is_disjoint_from(Invariant[B], Invariant[A & Any]))
 static_assert(is_disjoint_from(InvariantPair[A, A], InvariantPair[A, B]))
+static_assert(is_disjoint_from(Bottom[Invariant[Any]], Invariant[A]))
+static_assert(is_disjoint_from(Invariant[A], Bottom[Invariant[Any]]))
+static_assert(is_disjoint_from(Bottom[Invariant[Any]], Bottom[Invariant[Any]]))
+static_assert(is_disjoint_from(Bottom[Invariant[Any]], object))
+static_assert(is_disjoint_from(Bottom[list[Any]], list[int]))
+static_assert(is_disjoint_from(list[int], Bottom[list[Any]]))
 static_assert(not is_disjoint_from(Covariant[A], Covariant[B]))
 static_assert(not is_disjoint_from(Covariant[A], CoSubB))
 static_assert(not is_disjoint_from(Sequence[int], Sequence[str]))

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -18,8 +18,8 @@ use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
-    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    MaterializationKind, MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType,
+    SubclassOfInner, SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -2723,6 +2723,21 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
 
         match (left, right) {
             (Type::Never, _) | (_, Type::Never) => self.always(),
+
+            (Type::NominalInstance(instance), _) | (_, Type::NominalInstance(instance))
+                if instance
+                    .class(db)
+                    .into_generic_alias()
+                    .is_some_and(|alias| {
+                        alias.specialization(db).materialization_kind(db)
+                            == Some(MaterializationKind::Bottom)
+                    }) =>
+            {
+                // A bottom materialization with an invariant gradual argument is the
+                // intersection of incompatible specializations. It is uninhabited even though we
+                // preserve its `Bottom[...]` representation instead of normalizing it to `Never`.
+                self.always()
+            }
 
             (Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => self.never(),
             (Type::Divergent(_), _) | (_, Type::Divergent(_)) => self.never(),


### PR DESCRIPTION
## Summary

- Treat bottom-materialized invariant generic specializations as uninhabited in ordinary disjointness checks, while preserving their distinct `Bottom[...]` representation.
- Accept `list[Any]` and `Bottom[list[Any]]` where `~list[int]` is expected, and resolve existing negated `list[Any]` and `Sequence[Any]` regression cases.
- Add direct disjointness and assignability coverage for built-in lists, custom invariant generics, nested generics, and covariant controls.

The previous behavior rejected these assignments because `Bottom[list[Any]]` was not considered disjoint from `list[int]`, even though invariance makes the intersection of all `list[Any]` materializations uninhabited.

Fixes https://github.com/astral-sh/ty/issues/4122

## Validation

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG=line-tables-only MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic --status-level fail --final-status-level fail` (790 passed, 34 skipped)
- `uvx prek run --files crates/ty_python_semantic/src/types/relation.rs crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md`
