### PR TITLE
[ty] Infer generic class parameters from bounded receivers

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -193,6 +193,29 @@ def bounded(stream: S) -> None:
     reveal_type(helper(stream))  # revealed: tuple[int, bytes]
 ```
 
+A constrained function parameter cannot combine incompatible alternatives inferred from a bounded
+receiver and another argument.
+
+```py
+BoxT = TypeVar("BoxT", covariant=True)
+ConstrainedT = TypeVar("ConstrainedT", int, str)
+
+class Box(Generic[BoxT]):
+    def get(self) -> BoxT:
+        raise NotImplementedError
+
+BoundedBoxT = TypeVar("BoundedBoxT", bound=Box[int])
+
+def add_same(box: Box[ConstrainedT], value: ConstrainedT) -> ConstrainedT:
+    return box.get() + value
+
+def reject(box: BoundedBoxT, value: str) -> None:
+    add_same(box, value)  # error: [invalid-argument-type]
+
+def accept(box: BoundedBoxT, value: int) -> None:
+    add_same(box, value)
+```
+
 ## Inferring tuple parameter types
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -162,6 +162,37 @@ def pick(x: object) -> str | bool:
 reveal_type(pick([1]))  # revealed: bool
 ```
 
+## Inferring generic class parameters from `self`
+
+A generic function should infer its type variables from the enclosing class specialization when an
+implicit `self` argument is passed to it, even when those type variables have defaults.
+
+```py
+from typing_extensions import Generic, TypeVar
+
+T = TypeVar("T", default=None)
+U = TypeVar("U", default=str)
+
+class Stream(Generic[T, U]):
+    def handle(self) -> None:
+        reveal_type(helper(self))  # revealed: tuple[T@Stream, U@Stream]
+        requires_int(self)  # error: [invalid-argument-type]
+
+def helper(stream: Stream[T, U]) -> tuple[T, U]:
+    raise NotImplementedError
+
+def requires_int(stream: Stream[int, U]) -> None: ...
+```
+
+The same inference also applies to other type variables bounded by a specialized generic class.
+
+```py
+S = TypeVar("S", bound=Stream[int, bytes])
+
+def bounded(stream: S) -> None:
+    reveal_type(helper(stream))  # revealed: tuple[int, bytes]
+```
+
 ## Inferring tuple parameter types
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -233,6 +233,26 @@ def accept[S: Box[int]](box: S, value: int) -> None:
     add_same(box, value)
 ```
 
+A constrained legacy type variable cannot evade that restriction by appearing inside a PEP 695 type
+alias.
+
+```py
+from typing import TypeVar
+
+type Identity[U] = U
+
+ConstrainedT = TypeVar("ConstrainedT", int, str)
+
+def add_same_aliased(box: Box[Identity[ConstrainedT]], value: ConstrainedT) -> ConstrainedT:
+    return box.get() + value
+
+def reject_aliased[S: Box[int]](box: S, value: str) -> None:
+    add_same_aliased(box, value)  # error: [invalid-argument-type]
+
+def accept_aliased[S: Box[int]](box: S, value: int) -> None:
+    add_same_aliased(box, value)
+```
+
 The same restriction applies when the receiver is an implicit `self` argument.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -186,6 +186,63 @@ def _(a: A, b: B, x: A | B):
     reveal_type(takes_in_supports_foo(x))  # revealed: A | B
 ```
 
+## Inferring generic class parameters from `self`
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+Class type parameters are inferred from an implicit `self` argument instead of falling back to their
+defaults.
+
+```py
+class Stream[T = None, U = str]:
+    def handle(self) -> None:
+        reveal_type(helper(self))  # revealed: tuple[T@Stream, U@Stream]
+        requires_int(self)  # error: [invalid-argument-type]
+
+def helper[T = None, U = str](stream: Stream[T, U]) -> tuple[T, U]:
+    raise NotImplementedError
+
+def requires_int[U](stream: Stream[int, U]) -> None: ...
+```
+
+A type variable with an explicit generic upper bound carries the same specialization information.
+
+```py
+def bounded[S: Stream[int, bytes]](stream: S) -> None:
+    reveal_type(helper(stream))  # revealed: tuple[int, bytes]
+```
+
+## Bounded receivers passed to generic protocols
+
+Passing an implicit `Self` receiver to a generic protocol must not produce an invalid return type.
+
+```py
+from typing import Protocol, Self
+
+class Clonable[T](Protocol):
+    def clone(self) -> T: ...
+
+class Base:
+    def clone(self) -> Self:
+        return self
+
+    def preserve(self) -> Self:
+        return clone(self)
+
+def clone[T](value: Clonable[T]) -> T:
+    return value.clone()
+```
+
+A type variable bounded by the implementing class must also remain valid as a return type.
+
+```py
+def preserve[S: Base](value: S) -> S:
+    return clone(value)
+```
+
 ## Bound violations inferred through protocols
 
 If matching a protocol argument infers a type that violates a type variable's bound, the call should

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -215,6 +215,32 @@ def bounded[S: Stream[int, bytes]](stream: S) -> None:
     reveal_type(helper(stream))  # revealed: tuple[int, bytes]
 ```
 
+A constrained function parameter cannot select different alternatives from a bounded receiver and
+another argument. The matching case remains valid.
+
+```py
+class Box[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def add_same[T: (int, str)](box: Box[T], value: T) -> T:
+    return box.get() + value
+
+def reject[S: Box[int]](box: S, value: str) -> None:
+    add_same(box, value)  # error: [invalid-argument-type]
+
+def accept[S: Box[int]](box: S, value: int) -> None:
+    add_same(box, value)
+```
+
+The same restriction applies when the receiver is an implicit `self` argument.
+
+```py
+class IntBox(Box[int]):
+    def reject(self, value: str) -> None:
+        add_same(self, value)  # error: [invalid-argument-type]
+```
+
 ## Bounded receivers passed to generic protocols
 
 Passing an implicit `Self` receiver to a generic protocol must not produce an invalid return type.

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5231,8 +5231,8 @@ def invoke_bounded_callable[T: FactoryHandler](factory: T) -> T:
     return invoke_callable(factory)
 ```
 
-Receiver-specialized overloads remain available when a bounded receiver is forwarded to a generic
-protocol.
+Bounded receivers remain compatible with generic protocols whose methods use receiver-specialized
+overloads.
 
 ```py
 class OverloadedCallback[T](Protocol):

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1374,6 +1374,35 @@ def needs_something_hashable(x: Hashable):
 needs_something_hashable([])
 ```
 
+## Bounded receivers and mutable protocol members
+
+A union-bounded receiver must satisfy a mutable protocol separately for each union alternative.
+Combining differently typed attributes would allow an incompatible value to be written.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class Cell[T](Protocol):
+    item: T
+
+class IntCell:
+    item: int
+
+class StrCell:
+    item: str
+
+def accept(cell: Cell[int | str]) -> None:
+    cell.item = ""
+
+def reject[T: IntCell | StrCell](cell: T) -> None:
+    accept(cell)  # error: [invalid-argument-type]
+```
+
 ## Diagnostics for protocols with invalid attribute members
 
 This is a short appendix to the previous section with the `snapshot-diagnostics` directive enabled
@@ -5143,6 +5172,104 @@ def _(source: NoArgs):
     target: Variadic[Any] = source  # error: [invalid-assignment]
 ```
 
+## Bounded callable receivers
+
+An implicit `self` argument and a bounded type variable should satisfy a callback protocol when
+their callable signatures match.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, Protocol, Self, overload
+
+class Callback(Protocol):
+    def __call__(self, value: int) -> str: ...
+
+def accept(callback: Callback) -> None: ...
+
+class Handler:
+    def __call__(self, value: int) -> str:
+        return str(value)
+
+    def forward(self) -> None:
+        accept(self)
+
+def forward[T: Handler](handler: T) -> None:
+    accept(handler)
+```
+
+A generic callback returning `Self` must accept both an implicit receiver and a bounded receiver.
+
+```py
+class Factory[T](Protocol):
+    def __call__(self) -> T: ...
+
+def invoke[T](factory: Factory[T]) -> T:
+    return factory()
+
+class FactoryHandler:
+    def __call__(self) -> Self:
+        return self
+
+    def forward(self) -> Self:
+        return invoke(self)
+
+def invoke_bounded[T: FactoryHandler](factory: T) -> T:
+    return invoke(factory)
+```
+
+A `Callable` annotation must also accept a bounded receiver whose `__call__` method returns `Self`.
+
+```py
+def invoke_callable[T](callback: Callable[[], T]) -> T:
+    return callback()
+
+def invoke_bounded_callable[T: FactoryHandler](factory: T) -> T:
+    return invoke_callable(factory)
+```
+
+Receiver-specialized overloads remain available when a bounded receiver is forwarded to a generic
+protocol.
+
+```py
+class OverloadedCallback[T](Protocol):
+    @overload
+    def __call__(self: "OverloadedCallback[int]", value: int) -> int: ...
+    @overload
+    def __call__(self: "OverloadedCallback[str]", value: str) -> str: ...
+
+class OverloadedMethod[T](Protocol):
+    @overload
+    def method(self: "OverloadedMethod[int]", value: int) -> int: ...
+    @overload
+    def method(self: "OverloadedMethod[str]", value: str) -> str: ...
+
+def accept_overloaded[T](callback: OverloadedCallback[T]) -> None: ...
+def accept_overloaded_method[T](value: OverloadedMethod[T]) -> None: ...
+def forward_overloaded[T: OverloadedCallback[str]](callback: T) -> None:
+    accept_overloaded(callback)
+
+def forward_overloaded_method[T: OverloadedMethod[str]](value: T) -> None:
+    accept_overloaded_method(value)
+```
+
+An incompatible callable signature must still be rejected for both receiver forms.
+
+```py
+class WrongHandler:
+    def __call__(self, value: str) -> str:
+        return value
+
+    def forward(self) -> None:
+        accept(self)  # error: [invalid-argument-type]
+
+def reject[T: WrongHandler](handler: T) -> None:
+    accept(handler)  # error: [invalid-argument-type]
+```
+
 ## Class constructors and static callback protocols
 
 A class object's call signature comes from its constructor. An unrelated `__call__` method on the
@@ -5164,6 +5291,30 @@ class Constructor(Protocol):
     def __call__(value: int) -> Product: ...
 
 constructor: Constructor = Product
+```
+
+A bounded class object uses its metaclass's bound call signature, without exposing the implicit
+class receiver as a regular argument.
+
+```py
+from typing import TypeVar
+
+class Meta(type):
+    def __call__(cls, value: str) -> int:
+        return len(value)
+
+class Factory(metaclass=Meta): ...
+
+class MetaConstructor(Protocol):
+    @staticmethod
+    def __call__(value: str) -> int: ...
+
+def accept_constructor(constructor: MetaConstructor) -> None: ...
+
+ClassType = TypeVar("ClassType", bound=type[Factory])
+
+def forward_constructor(constructor: ClassType) -> None:
+    accept_constructor(constructor)
 ```
 
 ## Generic protocols and union arguments
@@ -5367,6 +5518,54 @@ class TypeVarRecursive(Protocol):
 def _(t: TypeVarRecursive):
     # reveal_type(t.x)  # revealed: T
     reveal_type(t.y)  # revealed: TypeVarRecursive
+```
+
+### Bounded receivers satisfying recursive protocols
+
+A recursive protocol can be implemented by a property returning the bounded receiver itself.
+Checking either an implicit `self` or an explicitly bounded receiver must terminate.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol, Self
+
+class Recursive(Protocol):
+    @property
+    def parent(self) -> Recursive: ...
+
+def accept(value: Recursive) -> None: ...
+
+class Node:
+    @property
+    def parent(self) -> Self:
+        return self
+
+    def forward(self) -> None:
+        accept(self)
+
+def forward[T: Node](node: T) -> None:
+    accept(node)
+```
+
+An incompatible property must still be rejected for either receiver.
+
+```py
+class WrongNode:
+    @property
+    def parent(self) -> int:
+        return 0
+
+    def forward(self) -> None:
+        accept(self)  # error: [invalid-argument-type]
+
+def reject[T: WrongNode](node: T) -> None:
+    accept(node)  # error: [invalid-argument-type]
 ```
 
 ### Nested occurrences of self-reference

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3372,9 +3372,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // `Stream[T@helper, U@helper]` infer the enclosing class's type variables.
             // Constrained type variables must not be inferred this way: independently merging
             // their alternatives can produce a union that is not an allowed specialization.
+            // Visit lazy type attributes so that constraints hidden inside aliases are included.
             (formal @ Type::NominalInstance(_), Type::TypeVar(actual_typevar))
                 if !actual_typevar.is_inferable(self.db, self.inferable)
-                    && !any_over_type(self.db, formal, false, |ty| {
+                    && !any_over_type(self.db, formal, true, |ty| {
                         matches!(
                             ty,
                             Type::TypeVar(typevar)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3370,8 +3370,18 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // A bounded argument exposes the specialization needed by a generic nominal parameter.
             // For example, `Self@handle <: Stream[T@Stream, U@Stream]` lets a function expecting
             // `Stream[T@helper, U@helper]` infer the enclosing class's type variables.
+            // Constrained type variables must not be inferred this way: independently merging
+            // their alternatives can produce a union that is not an allowed specialization.
             (formal @ Type::NominalInstance(_), Type::TypeVar(actual_typevar))
                 if !actual_typevar.is_inferable(self.db, self.inferable)
+                    && !any_over_type(self.db, formal, false, |ty| {
+                        matches!(
+                            ty,
+                            Type::TypeVar(typevar)
+                                if typevar.is_inferable(self.db, self.inferable)
+                                    && typevar.typevar(self.db).constraints(self.db).is_some()
+                        )
+                    })
                     && let Some(upper_bound) =
                         actual_typevar.typevar(self.db).upper_bound(self.db) =>
             {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3367,6 +3367,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
+            // A bounded argument exposes the specialization needed by a generic nominal parameter.
+            // For example, `Self@handle <: Stream[T@Stream, U@Stream]` lets a function expecting
+            // `Stream[T@helper, U@helper]` infer the enclosing class's type variables.
+            (formal @ Type::NominalInstance(_), Type::TypeVar(actual_typevar))
+                if !actual_typevar.is_inferable(self.db, self.inferable)
+                    && let Some(upper_bound) =
+                        actual_typevar.typevar(self.db).upper_bound(self.db) =>
+            {
+                return self.infer_map_impl(formal, upper_bound, polarity, seen);
+            }
+
             (Type::Intersection(formal_intersection), _) => {
                 // The actual type must be assignable to every (positive) element of the
                 // formal intersection, so we must infer type mappings for each of them. (The


### PR DESCRIPTION
## Summary

Prior to this change, passing an implicit `self` argument to a generic function could incorrectly select its type-variable defaults instead of inferring the enclosing class specialization:

```py
class Stream[T = None]:
    def handle(self) -> None:
        reveal_type(read(self))  # revealed: T@Stream

def read[T = None](stream: Stream[T]) -> T: ...
```

We now infer nominal generic parameters from bounded receivers while preserving existing protocol behavior and excluding constrained TypeVars whose alternatives cannot be combined safely.

Closes https://github.com/astral-sh/ty/issues/3257.