### PR TITLE
[ty] Borrow from constraint set storage less often

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -86,7 +86,7 @@
 //!
 //! [duboc]: https://gldubc.github.io/#thesis
 
-use std::cell::{Cell, Ref, RefCell};
+use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::convert::Infallible;
@@ -417,8 +417,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         lower: Option<Type<'db>>,
         upper: Option<Type<'db>>,
     ) -> Self {
+        let mut storage = builder.storage.borrow_mut();
         let (node, source_order) =
-            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper);
+            Constraint::new_node_with_bounds(db, &mut storage, typevar, lower, upper);
         Self::from_node(builder, node, source_order)
     }
 
@@ -450,8 +451,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
     /// Returns whether this constraint set never holds.
     pub(crate) fn is_never_satisfied(self, db: &'db dyn Db) -> bool {
+        let mut storage = self.builder.storage.borrow_mut();
         self.node
-            .is_never_satisfied(db, self.builder, self.source_order)
+            .is_never_satisfied(db, &mut storage, self.source_order)
     }
 
     /// Returns whether this constraint set is the `never` terminal.
@@ -465,8 +467,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
     /// Returns whether this constraint set always holds.
     pub(crate) fn is_always_satisfied(self, db: &'db dyn Db) -> bool {
+        let mut storage = self.builder.storage.borrow_mut();
         self.node
-            .is_always_satisfied(db, self.builder, self.source_order)
+            .is_always_satisfied(db, &mut storage, self.source_order)
     }
 
     /// Returns whether this constraint set is the `always` terminal.
@@ -489,8 +492,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         rhs: Type<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        let (node, extra_source_order) = self.node.implies_subtype_of(db, builder, lhs, rhs);
-        let source_order = builder.ordered_source_order(self.source_order, extra_source_order);
+        let mut storage = builder.storage.borrow_mut();
+        let (node, extra_source_order) = self.node.implies_subtype_of(db, &mut storage, lhs, rhs);
+        let source_order = storage.ordered_source_order(self.source_order, extra_source_order);
         Self::from_node(builder, node, source_order)
     }
 
@@ -515,8 +519,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         inferable: TypeVarSet<'db>,
     ) -> bool {
         self.verify_builder(builder);
+        let mut storage = builder.storage.borrow_mut();
         self.node
-            .satisfied_by_all_typevars(db, builder, inferable, self.source_order)
+            .satisfied_by_all_typevars(db, &mut storage, inferable, self.source_order)
     }
 
     /// Updates this constraint set to hold the union of itself and another constraint set.
@@ -529,8 +534,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        self.node = self.node.or(builder, other.node);
-        self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
+        let mut storage = builder.storage.borrow_mut();
+        self.node = self.node.or(&mut storage, other.node);
+        self.source_order = storage.ordered_source_order(self.source_order, other.source_order);
         *self
     }
 
@@ -544,15 +550,17 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        self.node = self.node.and(builder, other.node);
-        self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
+        let mut storage = builder.storage.borrow_mut();
+        self.node = self.node.and(&mut storage, other.node);
+        self.source_order = storage.ordered_source_order(self.source_order, other.source_order);
         *self
     }
 
     /// Returns the negation of this constraint set.
     pub(crate) fn negate(self, _db: &'db dyn Db, builder: &'c ConstraintSetBuilder<'db>) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.negate(builder), self.source_order)
+        let mut storage = builder.storage.borrow_mut();
+        Self::from_node(builder, self.node.negate(&mut storage), self.source_order)
     }
 
     /// Returns the intersection of this constraint set and another. The other constraint set is
@@ -618,8 +626,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        let node = self.node.iff(builder, other.node);
-        let source_order = builder.ordered_source_order(self.source_order, other.source_order);
+        let mut storage = builder.storage.borrow_mut();
+        let node = self.node.iff(&mut storage, other.node);
+        let source_order = storage.ordered_source_order(self.source_order, other.source_order);
         Self::from_node(builder, node, source_order)
     }
 
@@ -634,9 +643,11 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: TypeVarSet<'db>,
     ) -> Self {
         self.verify_builder(builder);
+        let mut storage = builder.storage.borrow_mut();
         let (node, derived_source_order) =
-            self.node.exists(db, builder, to_remove, self.source_order);
-        let source_order = builder.ordered_source_order(self.source_order, derived_source_order);
+            self.node
+                .exists(db, &mut storage, to_remove, self.source_order);
+        let source_order = storage.ordered_source_order(self.source_order, derived_source_order);
         Self::from_node(builder, node, source_order)
     }
 
@@ -649,7 +660,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         fn rebuild_node(
-            builder: &ConstraintSetBuilder<'_>,
+            storage: &mut ConstraintSetStorage<'_>,
             old_node: NodeId,
             mapped_constraints: &FxHashMap<ConstraintId, (NodeId, Option<SourceOrderId>)>,
             mapped_nodes: &mut FxHashMap<NodeId, NodeId>,
@@ -661,102 +672,107 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                 return *mapped;
             }
 
-            let old_interior = builder.interior_node_data(old_node);
+            let old_interior = storage.interior_node_data(old_node);
             let (condition, _) = mapped_constraints[&old_interior.constraint];
             let if_true = rebuild_node(
-                builder,
+                storage,
                 old_interior.if_true,
                 mapped_constraints,
                 mapped_nodes,
             );
             let if_uncertain = rebuild_node(
-                builder,
+                storage,
                 old_interior.if_uncertain,
                 mapped_constraints,
                 mapped_nodes,
             );
             let if_false = rebuild_node(
-                builder,
+                storage,
                 old_interior.if_false,
                 mapped_constraints,
                 mapped_nodes,
             );
-            let mapped = condition.ite_uncertain(builder, if_true, if_uncertain, if_false);
+            let mapped = condition.ite_uncertain(storage, if_true, if_uncertain, if_false);
             mapped_nodes.insert(old_node, mapped);
             mapped
         }
 
-        let builder = self.builder;
-        let mut mapped_constraints = FxHashMap::default();
+        // We have to collect this into a temporary vec since we can't hold an open borrow on the
+        // storage during the apply_type_mapping calls below, since they also need to borrow the
+        // storage.
+        let storage = self.builder.storage.borrow();
+        let mut constraints = SmallVec::<[_; 8]>::new();
         self.node
-            .for_each_unique_constraint(builder, &mut |constraint_id| {
-                if mapped_constraints.contains_key(&constraint_id) {
-                    return;
-                }
-
-                let constraint = builder.constraint_data(constraint_id);
-                let subject = Type::TypeVar(constraint.typevar).apply_type_mapping_impl(
-                    db,
-                    type_mapping,
-                    tcx,
-                    visitor,
-                );
-                let lower = constraint
-                    .bounds
-                    .lower
-                    .map(|lower| lower.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
-                let upper = constraint
-                    .bounds
-                    .upper
-                    .map(|upper| upper.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
-
-                let mapped = if let Type::TypeVar(typevar) = subject {
-                    Constraint::new_node_with_bounds(db, builder, typevar, lower, upper)
-                } else {
-                    let lower_holds = lower.map_or_else(
-                        || ConstraintSet::always(builder),
-                        |lower| {
-                            builder.load(
-                                db,
-                                &lower.when_constraint_set_assignable_to_owned(db, subject),
-                            )
-                        },
-                    );
-                    let upper_holds = upper.map_or_else(
-                        || ConstraintSet::always(builder),
-                        |upper| {
-                            builder.load(
-                                db,
-                                &subject.when_constraint_set_assignable_to_owned(db, upper),
-                            )
-                        },
-                    );
-                    (
-                        lower_holds.node.and(builder, upper_holds.node),
-                        builder.ordered_source_order(
-                            lower_holds.source_order,
-                            upper_holds.source_order,
-                        ),
-                    )
-                };
-                mapped_constraints.insert(constraint_id, mapped);
+            .for_each_unique_constraint(&storage, &mut |constraint_id| {
+                let constraint = storage.constraint_data(constraint_id);
+                constraints.push((constraint_id, constraint));
             });
+        drop(storage);
 
-        let source_order = builder
+        let mut mapped_constraints = FxHashMap::default();
+        for (constraint_id, constraint) in constraints {
+            if mapped_constraints.contains_key(&constraint_id) {
+                continue;
+            }
+
+            let subject = Type::TypeVar(constraint.typevar).apply_type_mapping_impl(
+                db,
+                type_mapping,
+                tcx,
+                visitor,
+            );
+            let lower = constraint
+                .bounds
+                .lower
+                .map(|lower| lower.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+            let upper = constraint
+                .bounds
+                .upper
+                .map(|upper| upper.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+
+            let mut storage = self.builder.storage.borrow_mut();
+            let mapped = if let Type::TypeVar(typevar) = subject {
+                Constraint::new_node_with_bounds(db, &mut storage, typevar, lower, upper)
+            } else {
+                let (lower_holds, lower_holds_source_order) = match lower {
+                    Some(lower) => storage.load(
+                        db,
+                        &lower.when_constraint_set_assignable_to_owned(db, subject),
+                    ),
+                    None => (ALWAYS_TRUE, None),
+                };
+                let (upper_holds, upper_holds_source_order) = match upper {
+                    Some(upper) => storage.load(
+                        db,
+                        &subject.when_constraint_set_assignable_to_owned(db, upper),
+                    ),
+                    None => (ALWAYS_TRUE, None),
+                };
+                (
+                    lower_holds.and(&mut storage, upper_holds),
+                    storage
+                        .ordered_source_order(lower_holds_source_order, upper_holds_source_order),
+                )
+            };
+            mapped_constraints.insert(constraint_id, mapped);
+        }
+
+        let mut storage = self.builder.storage.borrow_mut();
+        let source_order = storage
             .calculate_source_orders(self.source_order)
             .into_iter()
             .fold(None, |source_order, constraint| {
                 mapped_constraints.get(&constraint).map_or(
                     source_order,
                     |(_, mapped_source_order)| {
-                        builder.ordered_source_order(source_order, *mapped_source_order)
+                        storage.ordered_source_order(source_order, *mapped_source_order)
                     },
                 )
             });
         Self::from_node(
-            builder,
+            self.builder,
             rebuild_node(
-                builder,
+                &mut storage,
                 self.node,
                 &mapped_constraints,
                 &mut FxHashMap::default(),
@@ -822,14 +838,33 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
         self.verify_builder(builder);
-        self.node
-            .solutions_with(db, builder, inferable, self.source_order, choose)
+        let mut storage = builder.storage.borrow_mut();
+        let path_bounds =
+            PathBounds::compute(db, &mut storage, self.node, inferable, self.source_order);
+        drop(storage);
+        path_bounds.solve_with(choose)
     }
 
     pub(crate) fn display(self, db: &'db dyn Db) -> impl Display {
-        self.node
-            .simplify_for_display(db, self.builder)
-            .display(db, self.builder)
+        struct DisplayConstraintSet<'c, 'db> {
+            node: NodeId,
+            db: &'db dyn Db,
+            builder: &'c ConstraintSetBuilder<'db>,
+        }
+
+        impl Display for DisplayConstraintSet<'_, '_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let mut storage = self.builder.storage.borrow_mut();
+                let node = self.node.simplify_for_display(self.db, &mut storage);
+                Display::fmt(&node.display(self.db, &mut storage), f)
+            }
+        }
+
+        DisplayConstraintSet {
+            node: self.node,
+            db,
+            builder: self.builder,
+        }
     }
 
     #[expect(dead_code)] // Keep this around for debugging purposes
@@ -837,12 +872,28 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         self,
         db: &'db dyn Db,
         prefix: &'a dyn Display,
-    ) -> impl Display + 'a
-    where
-        'db: 'a,
-        'c: 'a,
-    {
-        self.node.display_graph(db, self.builder, prefix)
+    ) -> impl Display {
+        struct DisplayConstraintSet<'a, 'c, 'db> {
+            node: NodeId,
+            prefix: &'a dyn Display,
+            db: &'db dyn Db,
+            builder: &'c ConstraintSetBuilder<'db>,
+        }
+
+        impl Display for DisplayConstraintSet<'_, '_, '_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let mut storage = self.builder.storage.borrow_mut();
+                let node = self.node.simplify_for_display(self.db, &mut storage);
+                Display::fmt(&node.display_graph(self.db, &storage, self.prefix), f)
+            }
+        }
+
+        DisplayConstraintSet {
+            node: self.node,
+            prefix,
+            db,
+            builder: self.builder,
+        }
     }
 }
 
@@ -1047,9 +1098,9 @@ impl<'db> ConstraintSetBuilder<'db> {
         // sidecar densely so redundant combinations cannot affect its IDs or owned-set equality.
         // Unlike node and constraint IDs, source-order IDs are not embedded in the BDD, so the
         // sidecar can be rebuilt without remapping the BDD.
-        let source_constraints = self.calculate_source_orders(Some(source_order));
-
         let mut storage = self.storage.into_inner();
+        let source_constraints = storage.calculate_source_orders(Some(source_order));
+
         let mut used_nodes = RankBitBox::bits_with_capacity(storage.nodes.len());
         let mut used_constraints = RankBitBox::bits_with_capacity(storage.constraints.len());
 
@@ -1131,8 +1182,291 @@ impl<'db> ConstraintSetBuilder<'db> {
         db: &'db dyn Db,
         other: &OwnedConstraintSet<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let mut storage = self.storage.borrow_mut();
+        let (node, source_order) = storage.load(db, other);
+        ConstraintSet::from_node(self, node, source_order)
+    }
+}
+
+impl<'db> ConstraintSetStorage<'db> {
+    /// Interns a single typevar, giving it a stable order in this builder
+    fn intern_typevar(&mut self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
+        let identity = typevar.identity(db);
+        self.ensure_overlay_identity_caches();
+        if let Some(id) = self.typevar_cache.get(&identity) {
+            return *id;
+        }
+        let id = self.typevars.push(identity);
+        let id = self.adjusted_typevar_id(id);
+        self.typevar_cache.insert(identity, id);
+        id
+    }
+
+    /// Interns all of the typevars mentioned in a type in a stable order.
+    fn intern_mentioned_typevars_in_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
+        struct InternMentionedTypevars<'a, 'db> {
+            storage: RefCell<&'a mut ConstraintSetStorage<'db>>,
+            recursion_guard: TypeCollector<'db>,
+        }
+
+        impl<'db> TypeVisitor<'db> for InternMentionedTypevars<'_, 'db> {
+            fn should_visit_lazy_type_attributes(&self) -> bool {
+                false
+            }
+
+            fn visit_bound_type_var_type(
+                &self,
+                db: &'db dyn Db,
+                bound_typevar: BoundTypeVarInstance<'db>,
+            ) {
+                let mut storage = self.storage.borrow_mut();
+                storage.intern_typevar(db, bound_typevar);
+                drop(storage);
+                walk_bound_type_var_type(db, bound_typevar, self);
+            }
+
+            fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+                for ty in alias.specialization(db).types(db) {
+                    self.visit_type(db, *ty);
+                }
+            }
+
+            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            }
+        }
+
+        InternMentionedTypevars {
+            storage: RefCell::new(self),
+            recursion_guard: TypeCollector::default(),
+        }
+        .visit_type(db, ty);
+    }
+
+    /// Interns all of the typevars mentioned in a constraint in a stable order.
+    fn intern_constraint_typevars(
+        &mut self,
+        db: &'db dyn Db,
+        typevar: BoundTypeVarInstance<'db>,
+        bounds: ConstraintBounds<'db>,
+    ) {
+        self.intern_typevar(db, typevar);
+        if let Some(lower) = bounds.lower {
+            self.intern_mentioned_typevars_in_type(db, lower);
+        }
+        if let Some(upper) = bounds.upper {
+            self.intern_mentioned_typevars_in_type(db, upper);
+        }
+    }
+
+    fn intern_constraint(&mut self, db: &'db dyn Db, data: Constraint<'db>) -> ConstraintId {
+        self.intern_constraint_typevars(db, data.typevar, data.bounds);
+
+        self.ensure_overlay_identity_caches();
+        if let Some(id) = self.constraint_cache.get(&data) {
+            return *id;
+        }
+        let id = self.constraints.push(data);
+        let id = self.adjusted_constraint_id(id);
+        self.constraint_cache.insert(data, id);
+        id
+    }
+
+    fn intern_interior_node(&mut self, data: InteriorNodeData) -> NodeId {
+        self.ensure_overlay_identity_caches();
+        if let Some(id) = self.node_cache.get(&data) {
+            return *id;
+        }
+        let id = self.nodes.push(data);
+        let id = self.adjusted_node_id(id);
+        self.node_cache.insert(data, id);
+        id
+    }
+
+    fn typevar_id(&mut self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
+        let identity = typevar.identity(db);
+        self.ensure_overlay_identity_caches();
+        self.typevar_cache
+            .get(&identity)
+            .copied()
+            .expect("typevar should be interned before ordering")
+    }
+
+    fn constraint_data(&self, constraint: ConstraintId) -> Constraint<'db> {
+        if let Some(compacted) = &self.compacted {
+            let index = constraint.index();
+            let split = compacted.constraint_indices.len();
+            if index < split {
+                let compacted_index = compacted.retained_constraint_index(constraint);
+                return compacted.constraints[compacted_index];
+            }
+            return self.constraints[ConstraintId::from_usize(index - split)];
+        }
+        self.constraints[constraint]
+    }
+
+    fn cached_constraint_bound_depth(
+        &mut self,
+        db: &'db dyn Db,
+        constraint: ConstraintId,
+    ) -> (u16, u16) {
+        if let Some(depth) = self.constraint_bound_depth_cache.get(&constraint) {
+            return *depth;
+        }
+
+        let depth = self.constraint_data(constraint).bound_depth(db);
+        self.constraint_bound_depth_cache.insert(constraint, depth);
+        depth
+    }
+
+    /// Returns how much sequent fuel is needed to derive this constraint.
+    ///
+    /// This cost is driven by two factors.
+    ///
+    /// First, nested types containing typevars can produce increasingly complex families of
+    /// derived constraints. Charge more fuel for those constraints so that each additional level
+    /// of typevar depth shortens the remaining derivation chain.
+    ///
+    /// Second, even without considering typevars, the lower and upper bounds can become more
+    /// structurally complex. We consider a type to be more complex if it has deeper nesting of
+    /// type constructors. Each sequent is charged the _increase_ in that complexity between its
+    /// antecedents and its consequent. (Measuring growth rather than absolute depth avoids
+    /// penalizing a complex concrete bound that is merely propagated unchanged.)
+    fn sequent_fuel_cost(
+        &mut self,
+        db: &'db dyn Db,
+        constraint: ConstraintId,
+        antecedent_constructor_depth: u16,
+    ) -> u16 {
+        let (constructor_depth, typevar_depth) = self.cached_constraint_bound_depth(db, constraint);
+        let constructor_growth = constructor_depth.saturating_sub(antecedent_constructor_depth);
+        typevar_depth.max(constructor_growth).saturating_add(1)
+    }
+
+    fn cached_constraint_implies(
+        &mut self,
+        db: &'db dyn Db,
+        ante: ConstraintId,
+        post: ConstraintId,
+    ) -> bool {
+        let key = (ante, post);
+        if let Some(result) = self.constraint_implication_cache.get(&key) {
+            return *result;
+        }
+
+        let result = ante.implies(db, self, post);
+        self.constraint_implication_cache.insert(key, result);
+        result
+    }
+
+    fn cached_is_constraint_set_subtype_of(
+        &mut self,
+        db: &'db dyn Db,
+        source: Type<'db>,
+        target: Type<'db>,
+    ) -> bool {
+        let key = (source, target);
+        if let Some(result) = self.constraint_set_subtype_cache.get(&key) {
+            return *result;
+        }
+
+        let result = source.is_constraint_set_subtype_of(db, target);
+        self.constraint_set_subtype_cache.insert(key, result);
+        result
+    }
+
+    fn interior_node_data(&self, node: NodeId) -> InteriorNodeData {
+        if let Some(compacted) = &self.compacted {
+            let index = node.index();
+            let split = compacted.node_indices.len();
+            if index < split {
+                let compacted_index = compacted.retained_node_index(node);
+                return compacted.nodes[compacted_index];
+            }
+            return self.nodes[NodeId::from_usize(index - split)];
+        }
+        self.nodes[node]
+    }
+
+    fn intern_source_order(&mut self, data: SourceOrder) -> SourceOrderId {
+        self.ensure_overlay_identity_caches();
+        if let Some(id) = self.source_order_cache.get(&data) {
+            return *id;
+        }
+        let id = self.source_orders.push(data);
+        let id = self.adjusted_source_order_id(id);
+        self.source_order_cache.insert(data, id);
+        id
+    }
+
+    /// Repeating a source-order tree cannot change the first occurrence of any constraint, so
+    /// combining identical trees must reuse their existing sidecar.
+    fn ordered_source_order(
+        &mut self,
+        left: Option<SourceOrderId>,
+        right: Option<SourceOrderId>,
+    ) -> Option<SourceOrderId> {
+        match (left, right) {
+            (None, None) => None,
+            (None, other) | (other, None) => other,
+            (Some(left), Some(right)) if left == right => Some(left),
+            (Some(left), Some(right)) => {
+                Some(self.intern_source_order(SourceOrder::Ordered(left, right)))
+            }
+        }
+    }
+
+    fn constraint_source_order(&mut self, constraint: ConstraintId) -> SourceOrderId {
+        self.intern_source_order(SourceOrder::Constraint(constraint))
+    }
+
+    fn source_order_data(&self, source_order: SourceOrderId) -> SourceOrder {
+        if let Some(compacted) = &self.compacted {
+            let index = source_order.index();
+            let split = compacted.source_orders.len();
+            if index < split {
+                return compacted.source_orders[index];
+            }
+            return self.source_orders[SourceOrderId::from_usize(index - split)];
+        }
+        self.source_orders[source_order]
+    }
+
+    fn calculate_source_orders(
+        &self,
+        source_order: Option<SourceOrderId>,
+    ) -> FxIndexSet<ConstraintId> {
+        fn walk(
+            storage: &ConstraintSetStorage,
+            current: SourceOrderId,
+            result: &mut FxIndexSet<ConstraintId>,
+        ) {
+            match storage.source_order_data(current) {
+                SourceOrder::Ordered(left, right) => {
+                    walk(storage, left, result);
+                    walk(storage, right, result);
+                }
+                SourceOrder::Constraint(constraint) => {
+                    result.insert(constraint);
+                }
+            }
+        }
+
+        let mut result = FxIndexSet::default();
+        if let Some(source_order) = source_order {
+            walk(self, source_order, &mut result);
+        }
+        result
+    }
+
+    /// Loads an [`OwnedConstraintSet`] into this storage.
+    fn load(
+        &mut self,
+        db: &'db dyn Db,
+        other: &OwnedConstraintSet<'db>,
+    ) -> (NodeId, Option<SourceOrderId>) {
         fn rebuild_node<'db>(
-            builder: &ConstraintSetBuilder<'db>,
+            storage: &mut ConstraintSetStorage<'db>,
             inner: &OwnedConstraintSetInner<'db>,
             constraints: &[(NodeId, Option<SourceOrderId>)],
             cache: &mut FxHashMap<NodeId, NodeId>,
@@ -1147,32 +1481,32 @@ impl<'db> ConstraintSetBuilder<'db> {
 
             let old_node_index = inner.retained_node_index(old_node);
             let old_interior = inner.nodes[old_node_index];
-            let if_true = rebuild_node(builder, inner, constraints, cache, old_interior.if_true);
+            let if_true = rebuild_node(storage, inner, constraints, cache, old_interior.if_true);
             let if_uncertain = rebuild_node(
-                builder,
+                storage,
                 inner,
                 constraints,
                 cache,
                 old_interior.if_uncertain,
             );
-            let if_false = rebuild_node(builder, inner, constraints, cache, old_interior.if_false);
+            let if_false = rebuild_node(storage, inner, constraints, cache, old_interior.if_false);
             let old_constraint_index = inner.retained_constraint_index(old_interior.constraint);
             let (condition, _) = constraints[old_constraint_index];
-            let remapped = condition.ite_uncertain(builder, if_true, if_uncertain, if_false);
+            let remapped = condition.ite_uncertain(storage, if_true, if_uncertain, if_false);
 
             cache.insert(old_node, remapped);
             remapped
         }
 
         if other.node.is_terminal() {
-            return ConstraintSet::from_node(self, other.node, None);
+            return (other.node, None);
         }
         let inner = other
             .inner
             .as_ref()
             .expect("storage-free owned constraint sets must have terminal roots");
 
-        // Load all of the constraints into the this builder first, to maximize the chance that the
+        // Load all of the constraints into the this storage first, to maximize the chance that the
         // constraints and typevars will appear in the same order. (This is important because many
         // of our mdtests try to force a particular ordering, to test that our algorithms are all
         // order-independent.)
@@ -1213,298 +1547,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             .source_order
             .expect("non-terminal constraint set should have a source_order");
         let source_order = source_orders[old_source_order.index()];
-        ConstraintSet::from_node(self, node, source_order)
-    }
-
-    /// Interns a single typevar, giving it a stable order in this builder
-    fn intern_typevar(&self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
-        let identity = typevar.identity(db);
-        let mut storage = self.storage.borrow_mut();
-        storage.ensure_overlay_identity_caches();
-        if let Some(id) = storage.typevar_cache.get(&identity) {
-            return *id;
-        }
-        let id = storage.typevars.push(identity);
-        let id = storage.adjusted_typevar_id(id);
-        storage.typevar_cache.insert(identity, id);
-        id
-    }
-
-    /// Interns all of the typevars mentioned in a type in a stable order.
-    fn intern_mentioned_typevars_in_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-        struct InternMentionedTypevars<'a, 'db> {
-            builder: &'a ConstraintSetBuilder<'db>,
-            recursion_guard: TypeCollector<'db>,
-        }
-
-        impl<'db> TypeVisitor<'db> for InternMentionedTypevars<'_, 'db> {
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
-            }
-
-            fn visit_bound_type_var_type(
-                &self,
-                db: &'db dyn Db,
-                bound_typevar: BoundTypeVarInstance<'db>,
-            ) {
-                self.builder.intern_typevar(db, bound_typevar);
-                walk_bound_type_var_type(db, bound_typevar, self);
-            }
-
-            fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
-                for ty in alias.specialization(db).types(db) {
-                    self.visit_type(db, *ty);
-                }
-            }
-
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
-            }
-        }
-
-        InternMentionedTypevars {
-            builder: self,
-            recursion_guard: TypeCollector::default(),
-        }
-        .visit_type(db, ty);
-    }
-
-    /// Interns all of the typevars mentioned in a constraint in a stable order.
-    fn intern_constraint_typevars(
-        &self,
-        db: &'db dyn Db,
-        typevar: BoundTypeVarInstance<'db>,
-        bounds: ConstraintBounds<'db>,
-    ) {
-        self.intern_typevar(db, typevar);
-        if let Some(lower) = bounds.lower {
-            self.intern_mentioned_typevars_in_type(db, lower);
-        }
-        if let Some(upper) = bounds.upper {
-            self.intern_mentioned_typevars_in_type(db, upper);
-        }
-    }
-
-    fn intern_constraint(&self, db: &'db dyn Db, data: Constraint<'db>) -> ConstraintId {
-        self.intern_constraint_typevars(db, data.typevar, data.bounds);
-
-        let mut storage = self.storage.borrow_mut();
-        storage.ensure_overlay_identity_caches();
-        if let Some(id) = storage.constraint_cache.get(&data) {
-            return *id;
-        }
-        let id = storage.constraints.push(data);
-        let id = storage.adjusted_constraint_id(id);
-        storage.constraint_cache.insert(data, id);
-        id
-    }
-
-    fn intern_interior_node(&self, data: InteriorNodeData) -> NodeId {
-        let mut storage = self.storage.borrow_mut();
-        storage.ensure_overlay_identity_caches();
-        if let Some(id) = storage.node_cache.get(&data) {
-            return *id;
-        }
-        let id = storage.nodes.push(data);
-        let id = storage.adjusted_node_id(id);
-        storage.node_cache.insert(data, id);
-        id
-    }
-
-    fn typevar_id(&self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
-        let identity = typevar.identity(db);
-        let mut storage = self.storage.borrow_mut();
-        storage.ensure_overlay_identity_caches();
-        storage
-            .typevar_cache
-            .get(&identity)
-            .copied()
-            .expect("typevar should be interned before ordering")
-    }
-
-    fn constraint_data(&self, constraint: ConstraintId) -> Constraint<'db> {
-        let storage = self.storage.borrow();
-        if let Some(compacted) = &storage.compacted {
-            let index = constraint.index();
-            let split = compacted.constraint_indices.len();
-            if index < split {
-                let compacted_index = compacted.retained_constraint_index(constraint);
-                return compacted.constraints[compacted_index];
-            }
-            return storage.constraints[ConstraintId::from_usize(index - split)];
-        }
-        storage.constraints[constraint]
-    }
-
-    fn cached_constraint_bound_depth(
-        &self,
-        db: &'db dyn Db,
-        constraint: ConstraintId,
-    ) -> (u16, u16) {
-        if let Some(depth) = self
-            .storage
-            .borrow()
-            .constraint_bound_depth_cache
-            .get(&constraint)
-        {
-            return *depth;
-        }
-
-        let depth = self.constraint_data(constraint).bound_depth(db);
-        self.storage
-            .borrow_mut()
-            .constraint_bound_depth_cache
-            .insert(constraint, depth);
-        depth
-    }
-
-    /// Returns how much sequent fuel is needed to derive this constraint.
-    ///
-    /// This cost is driven by two factors.
-    ///
-    /// First, nested types containing typevars can produce increasingly complex families of
-    /// derived constraints. Charge more fuel for those constraints so that each additional level
-    /// of typevar depth shortens the remaining derivation chain.
-    ///
-    /// Second, even without considering typevars, the lower and upper bounds can become more
-    /// structurally complex. We consider a type to be more complex if it has deeper nesting of
-    /// type constructors. Each sequent is charged the _increase_ in that complexity between its
-    /// antecedents and its consequent. (Measuring growth rather than absolute depth avoids
-    /// penalizing a complex concrete bound that is merely propagated unchanged.)
-    fn sequent_fuel_cost(
-        &self,
-        db: &'db dyn Db,
-        constraint: ConstraintId,
-        antecedent_constructor_depth: u16,
-    ) -> u16 {
-        let (constructor_depth, typevar_depth) = self.cached_constraint_bound_depth(db, constraint);
-        let constructor_growth = constructor_depth.saturating_sub(antecedent_constructor_depth);
-        typevar_depth.max(constructor_growth).saturating_add(1)
-    }
-
-    fn cached_constraint_implies(
-        &self,
-        db: &'db dyn Db,
-        ante: ConstraintId,
-        post: ConstraintId,
-    ) -> bool {
-        let key = (ante, post);
-        if let Some(result) = self.storage.borrow().constraint_implication_cache.get(&key) {
-            return *result;
-        }
-
-        let result = ante.implies(db, self, post);
-        self.storage
-            .borrow_mut()
-            .constraint_implication_cache
-            .insert(key, result);
-        result
-    }
-
-    fn cached_is_constraint_set_subtype_of(
-        &self,
-        db: &'db dyn Db,
-        source: Type<'db>,
-        target: Type<'db>,
-    ) -> bool {
-        let key = (source, target);
-        if let Some(result) = self.storage.borrow().constraint_set_subtype_cache.get(&key) {
-            return *result;
-        }
-
-        let result = source.is_constraint_set_subtype_of(db, target);
-        self.storage
-            .borrow_mut()
-            .constraint_set_subtype_cache
-            .insert(key, result);
-        result
-    }
-
-    fn interior_node_data(&self, node: NodeId) -> InteriorNodeData {
-        let storage = self.storage.borrow();
-        if let Some(compacted) = &storage.compacted {
-            let index = node.index();
-            let split = compacted.node_indices.len();
-            if index < split {
-                let compacted_index = compacted.retained_node_index(node);
-                return compacted.nodes[compacted_index];
-            }
-            return storage.nodes[NodeId::from_usize(index - split)];
-        }
-        storage.nodes[node]
-    }
-
-    fn intern_source_order(&self, data: SourceOrder) -> SourceOrderId {
-        let mut storage = self.storage.borrow_mut();
-        storage.ensure_overlay_identity_caches();
-        if let Some(id) = storage.source_order_cache.get(&data) {
-            return *id;
-        }
-        let id = storage.source_orders.push(data);
-        let id = storage.adjusted_source_order_id(id);
-        storage.source_order_cache.insert(data, id);
-        id
-    }
-
-    /// Repeating a source-order tree cannot change the first occurrence of any constraint, so
-    /// combining identical trees must reuse their existing sidecar.
-    fn ordered_source_order(
-        &self,
-        left: Option<SourceOrderId>,
-        right: Option<SourceOrderId>,
-    ) -> Option<SourceOrderId> {
-        match (left, right) {
-            (None, None) => None,
-            (None, other) | (other, None) => other,
-            (Some(left), Some(right)) if left == right => Some(left),
-            (Some(left), Some(right)) => {
-                Some(self.intern_source_order(SourceOrder::Ordered(left, right)))
-            }
-        }
-    }
-
-    fn constraint_source_order(&self, constraint: ConstraintId) -> SourceOrderId {
-        self.intern_source_order(SourceOrder::Constraint(constraint))
-    }
-
-    fn source_order_data(&self, source_order: SourceOrderId) -> SourceOrder {
-        let storage = self.storage.borrow();
-        if let Some(compacted) = &storage.compacted {
-            let index = source_order.index();
-            let split = compacted.source_orders.len();
-            if index < split {
-                return compacted.source_orders[index];
-            }
-            return storage.source_orders[SourceOrderId::from_usize(index - split)];
-        }
-        storage.source_orders[source_order]
-    }
-
-    fn calculate_source_orders(
-        &self,
-        source_order: Option<SourceOrderId>,
-    ) -> FxIndexSet<ConstraintId> {
-        fn walk(
-            builder: &ConstraintSetBuilder,
-            current: SourceOrderId,
-            result: &mut FxIndexSet<ConstraintId>,
-        ) {
-            match builder.source_order_data(current) {
-                SourceOrder::Ordered(left, right) => {
-                    walk(builder, left, result);
-                    walk(builder, right, result);
-                }
-                SourceOrder::Constraint(constraint) => {
-                    result.insert(constraint);
-                }
-            }
-        }
-
-        let mut result = FxIndexSet::default();
-        if let Some(source_order) = source_order {
-            walk(self, source_order, &mut result);
-        }
-        result
+        (node, source_order)
     }
 }
 
@@ -1521,11 +1564,11 @@ impl<'db> BoundTypeVarInstance<'db> {
     fn can_be_bound_for(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         typevar: Self,
     ) -> bool {
-        wobble_index(builder.typevar_id(db, self).index())
-            < wobble_index(builder.typevar_id(db, typevar).index())
+        wobble_index(storage.typevar_id(db, self).index())
+            < wobble_index(storage.typevar_id(db, typevar).index())
     }
 }
 
@@ -1748,38 +1791,46 @@ impl<'db> UpperBound<'db> {
     }
 
     /// Returns the constraints under which `lower` is assignable to every stored upper clause.
-    fn when_satisfied_by<'c>(
+    fn when_satisfied_by(
         &self,
         db: &'db dyn Db,
-        builder: &'c ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         lower: Type<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        self.clauses.iter().when_all(db, builder, |clause| {
+    ) -> (NodeId, Option<SourceOrderId>) {
+        let mut node = ALWAYS_TRUE;
+        let mut source_order = None;
+        for clause in &self.clauses {
             let when_clause = lower.when_constraint_set_assignable_to_owned(db, *clause);
-            builder.load(db, &when_clause)
-        })
+            let (clause_node, clause_source_order) = storage.load(db, &when_clause);
+            node = node.and(storage, clause_node);
+            source_order = storage.ordered_source_order(source_order, clause_source_order);
+            if node == ALWAYS_FALSE {
+                break;
+            }
+        }
+        (node, source_order)
     }
 }
 
 impl ConstraintId {
     fn new<'db>(
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
         upper: Type<'db>,
     ) -> ConstraintId {
-        Self::new_with_bounds(db, builder, typevar, Some(lower), Some(upper))
+        Self::new_with_bounds(db, storage, typevar, Some(lower), Some(upper))
     }
 
     fn new_with_bounds<'db>(
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         typevar: BoundTypeVarInstance<'db>,
         lower: Option<Type<'db>>,
         upper: Option<Type<'db>>,
     ) -> ConstraintId {
-        builder.intern_constraint(
+        storage.intern_constraint(
             db,
             Constraint {
                 typevar,
@@ -1889,7 +1940,7 @@ impl<'db> Constraint<'db> {
     /// Panics if present `lower` and `upper` bounds are not fully static.
     fn new_node_with_bounds(
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         typevar: BoundTypeVarInstance<'db>,
         mut lower: Option<Type<'db>>,
         mut upper: Option<Type<'db>>,
@@ -1912,13 +1963,13 @@ impl<'db> Constraint<'db> {
             for lower_element in lower_union.elements(db) {
                 let (element_node, element_source_order) = Constraint::new_node_with_bounds(
                     db,
-                    builder,
+                    storage,
                     typevar,
                     Some(*lower_element),
                     upper,
                 );
-                result = result.and(builder, element_node);
-                source_order = builder.ordered_source_order(source_order, element_source_order);
+                result = result.and(storage, element_node);
+                source_order = storage.ordered_source_order(source_order, element_source_order);
             }
             return (result, source_order);
         }
@@ -1933,24 +1984,24 @@ impl<'db> Constraint<'db> {
             for upper_element in upper_intersection.iter_positive(db) {
                 let (element_node, element_source_order) = Constraint::new_node_with_bounds(
                     db,
-                    builder,
+                    storage,
                     typevar,
                     lower,
                     Some(upper_element),
                 );
-                result = result.and(builder, element_node);
-                source_order = builder.ordered_source_order(source_order, element_source_order);
+                result = result.and(storage, element_node);
+                source_order = storage.ordered_source_order(source_order, element_source_order);
             }
             for upper_element in upper_intersection.iter_negative(db) {
                 let (element_node, element_source_order) = Constraint::new_node_with_bounds(
                     db,
-                    builder,
+                    storage,
                     typevar,
                     lower,
                     Some(upper_element.negate(db)),
                 );
-                result = result.and(builder, element_node);
-                source_order = builder.ordered_source_order(source_order, element_source_order);
+                result = result.and(storage, element_node);
+                source_order = storage.ordered_source_order(source_order, element_source_order);
             }
             return (result, source_order);
         }
@@ -1980,9 +2031,9 @@ impl<'db> Constraint<'db> {
                 }) =>
             {
                 let constraint =
-                    ConstraintId::new(db, builder, typevar, Type::Never, Type::object());
-                let (node, source_order) = Node::new_constraint(builder, constraint);
-                let node = node.negate(builder);
+                    ConstraintId::new(db, storage, typevar, Type::Never, Type::object());
+                let (node, source_order) = Node::new_constraint(storage, constraint);
+                let node = node.negate(storage);
                 return (node, source_order);
             }
             _ => {}
@@ -2005,7 +2056,7 @@ impl<'db> Constraint<'db> {
             _ => {}
         }
 
-        builder.intern_constraint_typevars(db, typevar, ConstraintBounds::new(lower, upper));
+        storage.intern_constraint_typevars(db, typevar, ConstraintBounds::new(lower, upper));
 
         // If `lower ≰ upper` for every possible assignment of typevars, then the constraint cannot
         // be satisfied, since there is no type that is both greater than `lower`, and less than
@@ -2015,7 +2066,7 @@ impl<'db> Constraint<'db> {
         let effective_lower = lower.unwrap_or(Type::Never);
         let effective_upper = upper.unwrap_or(Type::object());
         let when = effective_lower.when_constraint_set_assignable_to_owned(db, effective_upper);
-        let is_never_satisfied = when.query(|_builder, when| when.is_never_satisfied(db));
+        let is_never_satisfied = when.query(|_storage, when| when.is_never_satisfied(db));
         if is_never_satisfied {
             return (ALWAYS_FALSE, None);
         }
@@ -2029,97 +2080,97 @@ impl<'db> Constraint<'db> {
         match (effective_lower, effective_upper) {
             // L ≤ T ≤ L == (T ≤ [L] ≤ T)
             (Type::TypeVar(lower), Type::TypeVar(upper)) if lower.is_same_typevar_as(db, upper) => {
-                let (bound, typevar) = if lower.can_be_bound_for(db, builder, typevar) {
+                let (bound, typevar) = if lower.can_be_bound_for(db, storage, typevar) {
                     (lower, typevar)
                 } else {
                     (typevar, lower)
                 };
                 let constraint = ConstraintId::new(
                     db,
-                    builder,
+                    storage,
                     typevar,
                     Type::TypeVar(bound),
                     Type::TypeVar(bound),
                 );
-                Node::new_constraint(builder, constraint)
+                Node::new_constraint(storage, constraint)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
             (Type::TypeVar(lower), Type::TypeVar(upper))
-                if typevar.can_be_bound_for(db, builder, lower)
-                    && typevar.can_be_bound_for(db, builder, upper) =>
+                if typevar.can_be_bound_for(db, storage, lower)
+                    && typevar.can_be_bound_for(db, storage, upper) =>
             {
                 let lower_constraint = ConstraintId::new_with_bounds(
                     db,
-                    builder,
+                    storage,
                     lower,
                     None,
                     Some(Type::TypeVar(typevar)),
                 );
                 let (lower_node, lower_source_order) =
-                    Node::new_constraint(builder, lower_constraint);
+                    Node::new_constraint(storage, lower_constraint);
                 let upper_constraint = ConstraintId::new_with_bounds(
                     db,
-                    builder,
+                    storage,
                     upper,
                     Some(Type::TypeVar(typevar)),
                     None,
                 );
                 let (upper_node, upper_source_order) =
-                    Node::new_constraint(builder, upper_constraint);
-                let node = lower_node.and(builder, upper_node);
+                    Node::new_constraint(storage, upper_constraint);
+                let node = lower_node.and(storage, upper_node);
                 let source_order =
-                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                    storage.ordered_source_order(lower_source_order, upper_source_order);
                 (node, source_order)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && ([T] ≤ U)
-            (Type::TypeVar(lower), _) if typevar.can_be_bound_for(db, builder, lower) => {
+            (Type::TypeVar(lower), _) if typevar.can_be_bound_for(db, storage, lower) => {
                 let lower_constraint = ConstraintId::new_with_bounds(
                     db,
-                    builder,
+                    storage,
                     lower,
                     None,
                     Some(Type::TypeVar(typevar)),
                 );
                 let (lower_node, lower_source_order) =
-                    Node::new_constraint(builder, lower_constraint);
+                    Node::new_constraint(storage, lower_constraint);
                 let (upper_node, upper_source_order) = if upper.is_none() {
                     (ALWAYS_TRUE, None)
                 } else {
-                    Constraint::new_node_with_bounds(db, builder, typevar, None, upper)
+                    Constraint::new_node_with_bounds(db, storage, typevar, None, upper)
                 };
-                let node = lower_node.and(builder, upper_node);
+                let node = lower_node.and(storage, upper_node);
                 let source_order =
-                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                    storage.ordered_source_order(lower_source_order, upper_source_order);
                 (node, source_order)
             }
 
             // L ≤ T ≤ U == (L ≤ [T]) && (T ≤ [U])
-            (_, Type::TypeVar(upper)) if typevar.can_be_bound_for(db, builder, upper) => {
+            (_, Type::TypeVar(upper)) if typevar.can_be_bound_for(db, storage, upper) => {
                 let (lower_node, lower_source_order) = if lower.is_none() {
                     (ALWAYS_TRUE, None)
                 } else {
-                    Constraint::new_node_with_bounds(db, builder, typevar, lower, None)
+                    Constraint::new_node_with_bounds(db, storage, typevar, lower, None)
                 };
                 let upper_constraint = ConstraintId::new_with_bounds(
                     db,
-                    builder,
+                    storage,
                     upper,
                     Some(Type::TypeVar(typevar)),
                     None,
                 );
                 let (upper_node, upper_source_order) =
-                    Node::new_constraint(builder, upper_constraint);
-                let node = lower_node.and(builder, upper_node);
+                    Node::new_constraint(storage, upper_constraint);
+                let node = lower_node.and(storage, upper_node);
                 let source_order =
-                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                    storage.ordered_source_order(lower_source_order, upper_source_order);
                 (node, source_order)
             }
 
             _ => {
-                let constraint = ConstraintId::new_with_bounds(db, builder, typevar, lower, upper);
-                Node::new_constraint(builder, constraint)
+                let constraint = ConstraintId::new_with_bounds(db, storage, typevar, lower, upper);
+                Node::new_constraint(storage, constraint)
             }
         }
     }
@@ -2173,11 +2224,11 @@ impl ConstraintId {
     fn implies<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         other: Self,
     ) -> bool {
-        let self_constraint = builder.constraint_data(self);
-        let other_constraint = builder.constraint_data(other);
+        let self_constraint = storage.constraint_data(self);
+        let other_constraint = storage.constraint_data(other);
         if !self_constraint
             .typevar
             .is_same_typevar_as(db, other_constraint.typevar)
@@ -2198,11 +2249,11 @@ impl ConstraintId {
     fn intersect<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         other: Self,
     ) -> IntersectionResult<'db> {
-        let self_constraint = builder.constraint_data(self);
-        let other_constraint = builder.constraint_data(other);
+        let self_constraint = storage.constraint_data(self);
+        let other_constraint = storage.constraint_data(other);
 
         // (s₁ ≤ α ≤ t₁) ∧ (s₂ ≤ α ≤ t₂) = (s₁ ∪ s₂) ≤ α ≤ (t₁ ∩ t₂))
         let lower = match (self_constraint.bounds.lower, other_constraint.bounds.lower) {
@@ -2225,8 +2276,8 @@ impl ConstraintId {
         // rather than a universal check ("is `lower ≤ upper` for *all* assignments?"), because the
         // bounds may mention typevars — e.g., `Sequence[int] ≤ A ≤ Sequence[T]` is satisfiable
         // when `int ≤ T`, even though it's not universally true for all `T`.
-        let when = merged_upper.when_satisfied_by(db, builder, effective_lower);
-        if when.is_never_satisfied(db) {
+        let (when, source_order) = merged_upper.when_satisfied_by(db, storage, effective_lower);
+        if when.is_never_satisfied(db, storage, source_order) {
             return IntersectionResult::Disjoint;
         }
 
@@ -2250,12 +2301,8 @@ impl ConstraintId {
         })
     }
 
-    pub(crate) fn display<'db>(
-        self,
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
-    ) -> impl Display {
-        self.when_true().display(db, builder)
+    fn display<'db>(self, db: &'db dyn Db, storage: &ConstraintSetStorage<'db>) -> impl Display {
+        self.when_true().display(db, storage)
     }
 }
 
@@ -2305,17 +2352,17 @@ enum Node {
 impl NodeId {
     /// Creates a new BDD node, applying local TDD reductions.
     fn new(
-        builder: &ConstraintSetBuilder<'_>,
+        storage: &mut ConstraintSetStorage<'_>,
         constraint: ConstraintId,
         if_true: NodeId,
         if_false: NodeId,
     ) -> NodeId {
-        Self::with_uncertain(builder, constraint, if_true, ALWAYS_FALSE, if_false)
+        Self::with_uncertain(storage, constraint, if_true, ALWAYS_FALSE, if_false)
     }
 
     /// Creates a new TDD node with an explicit `if_uncertain` branch, applying local reductions.
     fn with_uncertain(
-        builder: &ConstraintSetBuilder<'_>,
+        storage: &mut ConstraintSetStorage<'_>,
         constraint: ConstraintId,
         if_true: NodeId,
         if_uncertain: NodeId,
@@ -2323,21 +2370,21 @@ impl NodeId {
     ) -> NodeId {
         debug_assert!(
             if_true
-                .root_constraint(builder)
+                .root_constraint(storage)
                 .is_none_or(|root_constraint| {
                     root_constraint.ordering() > constraint.ordering()
                 })
         );
         debug_assert!(
             if_uncertain
-                .root_constraint(builder)
+                .root_constraint(storage)
                 .is_none_or(|root_constraint| {
                     root_constraint.ordering() > constraint.ordering()
                 })
         );
         debug_assert!(
             if_false
-                .root_constraint(builder)
+                .root_constraint(storage)
                 .is_none_or(|root_constraint| {
                     root_constraint.ordering() > constraint.ordering()
                 })
@@ -2371,7 +2418,7 @@ impl NodeId {
             return if_uncertain;
         }
 
-        builder.intern_interior_node(InteriorNodeData {
+        storage.intern_interior_node(InteriorNodeData {
             constraint,
             if_true,
             if_uncertain,
@@ -2384,12 +2431,12 @@ impl Node {
     /// Creates a new BDD node for an individual constraint. (The BDD will evaluate to `true` when
     /// the constraint holds, and to `false` when it does not.)
     fn new_constraint(
-        builder: &ConstraintSetBuilder<'_>,
+        storage: &mut ConstraintSetStorage<'_>,
         constraint: ConstraintId,
     ) -> (NodeId, Option<SourceOrderId>) {
         (
-            NodeId::with_uncertain(builder, constraint, ALWAYS_TRUE, ALWAYS_FALSE, ALWAYS_FALSE),
-            Some(builder.constraint_source_order(constraint)),
+            NodeId::with_uncertain(storage, constraint, ALWAYS_TRUE, ALWAYS_FALSE, ALWAYS_FALSE),
+            Some(storage.constraint_source_order(constraint)),
         )
     }
 
@@ -2399,26 +2446,26 @@ impl Node {
     /// negation of that BDD node. For an unconstrained constraint, the result holds regardless
     /// of the constraint's truth value.)
     fn new_satisfied_constraint(
-        builder: &ConstraintSetBuilder<'_>,
+        storage: &mut ConstraintSetStorage<'_>,
         constraint: ConstraintAssignment,
     ) -> (NodeId, Option<SourceOrderId>) {
         let constraint_id = constraint.constraint();
         let node = match constraint {
             ConstraintAssignment::Positive(constraint) => {
-                NodeId::with_uncertain(builder, constraint, ALWAYS_TRUE, ALWAYS_FALSE, ALWAYS_FALSE)
+                NodeId::with_uncertain(storage, constraint, ALWAYS_TRUE, ALWAYS_FALSE, ALWAYS_FALSE)
             }
             ConstraintAssignment::Negative(constraint) => {
-                NodeId::with_uncertain(builder, constraint, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_TRUE)
+                NodeId::with_uncertain(storage, constraint, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_TRUE)
             }
             // The result holds regardless of the constraint's truth value, so only
             // `if_uncertain` needs to be `ALWAYS_TRUE` — `n? 0: 1: 0`. It would also be
             // correct to use `n? 1: 1: 1` (i.e., `ALWAYS_TRUE` for all outgoing edges), but
             // that would throw away some of the efficiency gains this representation gives us.
             ConstraintAssignment::Unconstrained(constraint) => {
-                NodeId::with_uncertain(builder, constraint, ALWAYS_FALSE, ALWAYS_TRUE, ALWAYS_FALSE)
+                NodeId::with_uncertain(storage, constraint, ALWAYS_FALSE, ALWAYS_TRUE, ALWAYS_FALSE)
             }
         };
-        (node, Some(builder.constraint_source_order(constraint_id)))
+        (node, Some(storage.constraint_source_order(constraint_id)))
     }
 }
 
@@ -2445,17 +2492,17 @@ impl NodeId {
 
     /// Returns the BDD variable of the root node of this BDD, or `None` if this BDD is a terminal
     /// node.
-    fn root_constraint(self, builder: &ConstraintSetBuilder<'_>) -> Option<ConstraintId> {
+    fn root_constraint(self, storage: &ConstraintSetStorage<'_>) -> Option<ConstraintId> {
         if self.is_terminal() {
             return None;
         }
-        let interior = builder.interior_node_data(self);
+        let interior = storage.interior_node_data(self);
         Some(interior.constraint)
     }
 
     /// Checks whether this BDD represents a single conjunction (of an arbitrary number of
     /// positive or negative constraints).
-    fn is_single_conjunction(self, builder: &ConstraintSetBuilder<'_>) -> bool {
+    fn is_single_conjunction(self, storage: &mut ConstraintSetStorage<'_>) -> bool {
         // A BDD can be viewed as an encoding of the formula's DNF representation (OR of ANDs).
         // Each path from the root node to the `always` terminals represents one of the disjoints.
         // The constraints that we encounter on the path represent the conjoints. That means that a
@@ -2473,7 +2520,7 @@ impl NodeId {
                 Node::AlwaysTrue => return true,
                 Node::AlwaysFalse => return false,
                 Node::Interior(interior) => {
-                    let data = builder.interior_node_data(interior.node());
+                    let data = storage.interior_node_data(interior.node());
 
                     // If both if_true and if_false point to non-never, there are multiple paths to
                     // `always`, so this cannot be a simple conjunction.
@@ -2502,15 +2549,15 @@ impl NodeId {
     fn is_always_satisfied<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         source_order: Option<SourceOrderId>,
     ) -> bool {
         match self.node() {
             Node::AlwaysTrue => true,
             Node::AlwaysFalse => false,
             Node::Interior(interior) => {
-                let mut path = interior.path_assignments(builder, source_order);
-                path.visit_negated(db, builder, self, &mut IsNeverSatisfiedVisitor)
+                let mut path = interior.path_assignments(storage, source_order);
+                path.visit_negated(db, storage, self, &mut IsNeverSatisfiedVisitor)
                     .is_continue()
             }
         }
@@ -2520,7 +2567,7 @@ impl NodeId {
     fn is_never_satisfied<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         source_order: Option<SourceOrderId>,
     ) -> bool {
         /// Checks whether this BDD is a single conjunction, where either (a) every constraint is
@@ -2528,7 +2575,7 @@ impl NodeId {
         /// so, `object` or `Never` respectively is a valid solution regardless of the contents of
         /// the constraints.
         fn simple_conjunction_is_satisfiable(
-            builder: &ConstraintSetBuilder<'_>,
+            storage: &mut ConstraintSetStorage<'_>,
             mut node: NodeId,
         ) -> bool {
             let mut found_lower = false;
@@ -2539,7 +2586,7 @@ impl NodeId {
                     Node::AlwaysFalse => return false,
 
                     Node::Interior(_) => {
-                        let interior = builder.interior_node_data(node);
+                        let interior = storage.interior_node_data(node);
 
                         if interior.if_false != ALWAYS_FALSE
                             || interior.if_uncertain != ALWAYS_FALSE
@@ -2548,7 +2595,7 @@ impl NodeId {
                             return false;
                         }
 
-                        let constraint = builder.constraint_data(interior.constraint);
+                        let constraint = storage.constraint_data(interior.constraint);
                         found_lower |= constraint.bounds.lower.is_some();
                         found_upper |= constraint.bounds.upper.is_some();
                         if found_lower && found_upper {
@@ -2567,56 +2614,40 @@ impl NodeId {
             Node::AlwaysTrue => false,
             Node::AlwaysFalse => true,
             Node::Interior(interior) => {
-                if let Some(result) = builder.storage.borrow().never_satisfied_cache.get(&self) {
+                if let Some(result) = storage.never_satisfied_cache.get(&self) {
                     return *result;
                 }
 
-                let result = if simple_conjunction_is_satisfiable(builder, self) {
+                let result = if simple_conjunction_is_satisfiable(storage, self) {
                     false
                 } else {
-                    let mut path = interior.path_assignments(builder, source_order);
-                    path.visit(db, builder, self, &mut IsNeverSatisfiedVisitor)
+                    let mut path = interior.path_assignments(storage, source_order);
+                    path.visit(db, storage, self, &mut IsNeverSatisfiedVisitor)
                         .is_continue()
                 };
-                builder
-                    .storage
-                    .borrow_mut()
-                    .never_satisfied_cache
-                    .insert(self, result);
+                storage.never_satisfied_cache.insert(self, result);
                 result
             }
         }
     }
 
-    fn solutions_with<'db>(
-        self,
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
-        inferable: TypeVarSet<'db>,
-        source_order: Option<SourceOrderId>,
-        choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
-    ) -> Solutions<'db> {
-        let path_bounds = PathBounds::compute(db, builder, self, inferable, source_order);
-        path_bounds.solve_with(choose)
-    }
-
     /// Returns the negation of this BDD.
-    fn negate(self, builder: &ConstraintSetBuilder<'_>) -> Self {
+    fn negate(self, storage: &mut ConstraintSetStorage<'_>) -> Self {
         match self.node() {
             Node::AlwaysTrue => ALWAYS_FALSE,
             Node::AlwaysFalse => ALWAYS_TRUE,
-            Node::Interior(interior) => interior.negate(builder),
+            Node::Interior(interior) => interior.negate(storage),
         }
     }
 
     /// Returns the `or` or union of two BDDs.
-    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
+    fn or(self, storage: &mut ConstraintSetStorage<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysTrue, _) | (_, Node::AlwaysTrue) => ALWAYS_TRUE,
             (Node::AlwaysFalse, _) => other,
             (_, Node::AlwaysFalse) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
-                self_interior.or(builder, other_interior)
+                self_interior.or(storage, other_interior)
             }
         }
     }
@@ -2644,7 +2675,7 @@ impl NodeId {
         nodes: impl Iterator<Item = (Self, Option<SourceOrderId>)>,
         zero: Self,
         one: Self,
-        mut combine: impl FnMut(Self, &ConstraintSetBuilder<'_>, Self) -> Self,
+        mut combine: impl FnMut(Self, &mut ConstraintSetStorage<'_>, Self) -> Self,
     ) -> (Self, Option<SourceOrderId>) {
         // To implement the "linear" shape described above, we could collect the iterator elements
         // into a vector, and then use the fold at the bottom of this method to combine the
@@ -2684,8 +2715,9 @@ impl NodeId {
             {
                 let (existing_node, existing_source_order, _) =
                     accumulator.pop().expect("accumulator should not be empty");
-                node = combine(existing_node, builder, node);
-                source_order = builder.ordered_source_order(existing_source_order, source_order);
+                let mut storage = builder.storage.borrow_mut();
+                node = combine(existing_node, &mut storage, node);
+                source_order = storage.ordered_source_order(existing_source_order, source_order);
                 if node == one {
                     return (node, source_order);
                 }
@@ -2697,12 +2729,13 @@ impl NodeId {
         // At this point, we've consumed all of the iterator. The length of the accumulator will be
         // the same as the number of 1 bits in the length of the iterator. We do a final fold to
         // produce the overall result.
+        let mut storage = builder.storage.borrow_mut();
         accumulator.into_iter().fold(
             (zero, None),
             |(result_node, result_source_order), (node, source_order, _)| {
                 (
-                    combine(result_node, builder, node),
-                    builder.ordered_source_order(result_source_order, source_order),
+                    combine(result_node, &mut storage, node),
+                    storage.ordered_source_order(result_source_order, source_order),
                 )
             },
         )
@@ -2723,36 +2756,40 @@ impl NodeId {
     }
 
     /// Returns the `and` or intersection of two BDDs.
-    fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
+    fn and(self, storage: &mut ConstraintSetStorage<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysFalse, _) | (_, Node::AlwaysFalse) => ALWAYS_FALSE,
             (Node::AlwaysTrue, _) => other,
             (_, Node::AlwaysTrue) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
-                self_interior.and(builder, other_interior)
+                self_interior.and(storage, other_interior)
             }
         }
     }
 
-    fn implies(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
+    fn implies(self, storage: &mut ConstraintSetStorage<'_>, other: Self) -> Self {
         // p → q == ¬p ∨ q
-        self.negate(builder).or(builder, other)
+        self.negate(storage).or(storage, other)
     }
 
     /// Returns a new BDD that evaluates to `true` when both input BDDs evaluate to the same
     /// result.
-    fn iff(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
+    fn iff(self, storage: &mut ConstraintSetStorage<'_>, other: Self) -> Self {
         // iff(a, b) = (a ∧ b) ∨ (¬a ∧ ¬b)
-        let a_and_b = self.and(builder, other);
-        let not_a_and_not_b = self.negate(builder).and(builder, other.negate(builder));
-        a_and_b.or(builder, not_a_and_not_b)
+        let a_and_b = self.and(storage, other);
+        let not_a = self.negate(storage);
+        let not_b = other.negate(storage);
+        let not_a_and_not_b = not_a.and(storage, not_b);
+        a_and_b.or(storage, not_a_and_not_b)
     }
 
     /// Returns the `if-then-else` of three BDDs: when `self` evaluates to `true`, it returns what
     /// `then_node` evaluates to; otherwise it returns what `else_node` evaluates to.
-    fn ite(self, builder: &ConstraintSetBuilder<'_>, then_node: Self, else_node: Self) -> Self {
-        self.and(builder, then_node)
-            .or(builder, self.negate(builder).and(builder, else_node))
+    fn ite(self, storage: &mut ConstraintSetStorage<'_>, then_node: Self, else_node: Self) -> Self {
+        let if_true = self.and(storage, then_node);
+        let negated = self.negate(storage);
+        let if_false = negated.and(storage, else_node);
+        if_true.or(storage, if_false)
     }
 
     /// Returns the TDD `if-then-else` of four BDDs: when `self` evaluates to `true`, it returns
@@ -2760,7 +2797,7 @@ impl NodeId {
     /// `else_node` evaluates to; and `uncertain_node` is included regardless of `self`'s value.
     fn ite_uncertain(
         self,
-        builder: &ConstraintSetBuilder<'_>,
+        storage: &mut ConstraintSetStorage<'_>,
         then_node: Self,
         uncertain_node: Self,
         else_node: Self,
@@ -2770,10 +2807,10 @@ impl NodeId {
         }
 
         match self.node() {
-            Node::AlwaysTrue => then_node.or(builder, uncertain_node),
-            Node::AlwaysFalse => else_node.or(builder, uncertain_node),
+            Node::AlwaysTrue => then_node.or(storage, uncertain_node),
+            Node::AlwaysFalse => else_node.or(storage, uncertain_node),
             Node::Interior(_) => {
-                let interior = builder.interior_node_data(self);
+                let interior = storage.interior_node_data(self);
                 // Fast path for a bare positive constraint whose branches are still later in the
                 // BDD variable ordering. This is the common case when loading an owned TDD into a
                 // fresh builder, and lets us preserve an existing uncertain branch directly.
@@ -2781,17 +2818,17 @@ impl NodeId {
                     && interior.if_uncertain == ALWAYS_FALSE
                     && interior.if_false == ALWAYS_FALSE
                     && then_node
-                        .root_constraint(builder)
+                        .root_constraint(storage)
                         .is_none_or(|root| root.ordering() > interior.constraint.ordering())
                     && uncertain_node
-                        .root_constraint(builder)
+                        .root_constraint(storage)
                         .is_none_or(|root| root.ordering() > interior.constraint.ordering())
                     && else_node
-                        .root_constraint(builder)
+                        .root_constraint(storage)
                         .is_none_or(|root| root.ordering() > interior.constraint.ordering())
                 {
                     return NodeId::with_uncertain(
-                        builder,
+                        storage,
                         interior.constraint,
                         then_node,
                         uncertain_node,
@@ -2802,9 +2839,11 @@ impl NodeId {
                 // For compound conditions, or when the new builder's variable ordering requires
                 // one of the branches to move above `self`, fall back to the semantic expansion:
                 // `(self ∧ then_node) ∨ uncertain_node ∨ (¬self ∧ else_node)`.
-                self.and(builder, then_node)
-                    .or(builder, uncertain_node)
-                    .or(builder, self.negate(builder).and(builder, else_node))
+                let if_true = self.and(storage, then_node);
+                let if_true_or_uncertain = if_true.or(storage, uncertain_node);
+                let negated = self.negate(storage);
+                let if_false = negated.and(storage, else_node);
+                if_true_or_uncertain.or(storage, if_false)
             }
         }
     }
@@ -2812,7 +2851,7 @@ impl NodeId {
     fn implies_subtype_of<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         lhs: Type<'db>,
         rhs: Type<'db>,
     ) -> (Self, Option<SourceOrderId>) {
@@ -2827,14 +2866,14 @@ impl NodeId {
         let (constraint, constraint_source_order) = match (lhs, rhs) {
             (Type::TypeVar(bound_typevar), _) => Constraint::new_node_with_bounds(
                 db,
-                builder,
+                storage,
                 bound_typevar,
                 None,
                 Some(rhs.bottom_materialization(db)),
             ),
             (_, Type::TypeVar(bound_typevar)) => Constraint::new_node_with_bounds(
                 db,
-                builder,
+                storage,
                 bound_typevar,
                 Some(lhs.top_materialization(db)),
                 None,
@@ -2842,14 +2881,14 @@ impl NodeId {
             _ => panic!("at least one type should be a typevar"),
         };
 
-        let node = self.implies(builder, constraint);
+        let node = self.implies(storage, constraint);
         (node, constraint_source_order)
     }
 
-    fn satisfied_by_all_typevars<'db, 'c>(
+    fn satisfied_by_all_typevars<'db>(
         self,
         db: &'db dyn Db,
-        builder: &'c ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         inferable: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
     ) -> bool {
@@ -2860,35 +2899,41 @@ impl NodeId {
         }
 
         let mut typevars = FxHashSet::default();
-        self.for_each_unique_constraint(builder, &mut |constraint| {
-            let constraint = builder.constraint_data(constraint);
+        self.for_each_unique_constraint_mut(storage, &mut |storage, constraint| {
+            let constraint = storage.constraint_data(constraint);
             typevars.insert(constraint.typevar);
         });
 
         // Specializations can introduce constraints that do not appear in the original BDD.
         // Compose full constraint sets so those constraints retain their source orders when the
         // resulting BDD is traversed.
-        let original = ConstraintSet::from_node(builder, self, source_order);
 
         // Returns if some specialization satisfies this constraint set.
-        let some_specialization_satisfies = move |specializations: ConstraintSet<'db, 'c>| {
-            let when_satisfied =
-                specializations
-                    .implies(db, builder, || original)
-                    .and(db, builder, || specializations);
-            !when_satisfied.is_never_satisfied(db)
-        };
+        let some_specialization_satisfies =
+            |storage: &mut ConstraintSetStorage<'db>,
+             specializations: (NodeId, Option<SourceOrderId>)| {
+                let (specializations, specializations_source_order) = specializations;
+                let when_satisfied = specializations
+                    .implies(storage, self)
+                    .and(storage, specializations);
+                let source_order =
+                    storage.ordered_source_order(source_order, specializations_source_order);
+                !when_satisfied.is_never_satisfied(db, storage, source_order)
+            };
 
         // Returns if all specializations satisfy this constraint set.
-        let all_specializations_satisfy = move |specializations: ConstraintSet<'db, 'c>| {
-            let when_satisfied =
-                specializations
-                    .implies(db, builder, || original)
-                    .and(db, builder, || specializations);
-            when_satisfied
-                .iff(db, builder, specializations)
-                .is_always_satisfied(db)
-        };
+        let all_specializations_satisfy =
+            |storage: &mut ConstraintSetStorage<'db>,
+             specializations: (NodeId, Option<SourceOrderId>)| {
+                let (specializations, specializations_source_order) = specializations;
+                let when_satisfied = specializations
+                    .implies(storage, self)
+                    .and(storage, specializations)
+                    .iff(storage, specializations);
+                let source_order =
+                    storage.ordered_source_order(source_order, specializations_source_order);
+                when_satisfied.is_always_satisfied(db, storage, source_order)
+            };
 
         #[expect(
             clippy::iter_over_hash_type,
@@ -2898,8 +2943,8 @@ impl NodeId {
             if typevar.is_inferable(db, inferable) {
                 // If the typevar is in inferable position, we need to verify that some valid
                 // specialization satisfies the constraint set.
-                let valid_specializations = typevar.valid_specializations(db, builder);
-                if !some_specialization_satisfies(valid_specializations) {
+                let valid_specializations = typevar.valid_specializations(db, storage);
+                if !some_specialization_satisfies(storage, valid_specializations) {
                     return false;
                 }
             } else {
@@ -2915,12 +2960,12 @@ impl NodeId {
                 // constraint to refer to the synthetic typevar instead of the original gradual
                 // constraint.
                 let (static_specializations, gradual_constraints) =
-                    typevar.required_specializations(db, builder);
-                if !all_specializations_satisfy(static_specializations) {
+                    typevar.required_specializations(db, storage);
+                if !all_specializations_satisfy(storage, static_specializations) {
                     return false;
                 }
                 for gradual_constraint in gradual_constraints {
-                    if !some_specialization_satisfies(gradual_constraint) {
+                    if !some_specialization_satisfies(storage, gradual_constraint) {
                         return false;
                     }
                 }
@@ -2936,7 +2981,7 @@ impl NodeId {
     fn exists<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         bound_typevars: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
     ) -> (Self, Option<SourceOrderId>) {
@@ -2949,15 +2994,12 @@ impl NodeId {
         };
 
         let key = (self, bound_typevars, source_order);
-        let storage = builder.storage.borrow();
         if let Some(result) = storage.exists_cache.get(&key) {
             return *result;
         }
-        drop(storage);
 
-        let result = interior.exists_inner(db, builder, bound_typevars, source_order);
+        let result = interior.exists_inner(db, storage, bound_typevars, source_order);
 
-        let mut storage = builder.storage.borrow_mut();
         storage.exists_cache.insert(key, result);
         result
     }
@@ -2965,7 +3007,7 @@ impl NodeId {
     fn remove_noninferable<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         inferable: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
     ) -> (Self, Option<SourceOrderId>) {
@@ -2973,7 +3015,7 @@ impl NodeId {
             Node::AlwaysTrue => (ALWAYS_TRUE, None),
             Node::AlwaysFalse => (ALWAYS_FALSE, None),
             Node::Interior(interior) => {
-                interior.remove_noninferable(db, builder, inferable, source_order)
+                interior.remove_noninferable(db, storage, inferable, source_order)
             }
         }
     }
@@ -2986,13 +3028,13 @@ impl NodeId {
     fn restrict<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         assignment: impl IntoIterator<Item = ConstraintAssignment>,
     ) -> (Self, bool) {
         assignment
             .into_iter()
             .fold((self, true), |(restricted, found), assignment| {
-                let (restricted, found_this) = restricted.restrict_one(db, builder, assignment);
+                let (restricted, found_this) = restricted.restrict_one(db, storage, assignment);
                 (restricted, found && found_this)
             })
     }
@@ -3005,12 +3047,12 @@ impl NodeId {
     fn restrict_one<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         assignment: ConstraintAssignment,
     ) -> (Self, bool) {
         match self.node() {
             Node::AlwaysTrue | Node::AlwaysFalse => (self, false),
-            Node::Interior(interior) => interior.restrict_one(db, builder, assignment),
+            Node::Interior(interior) => interior.restrict_one(db, storage, assignment),
         }
     }
 
@@ -3018,7 +3060,7 @@ impl NodeId {
     fn substitute_intersection<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         left: ConstraintAssignment,
         right: ConstraintAssignment,
         replacement: NodeId,
@@ -3028,7 +3070,7 @@ impl NodeId {
         //   - left is false
         //   - left is true and right is false
         // This covers the entire truth table of `left ∧ right`.
-        let (when_left_and_right, both_found) = self.restrict(db, builder, [left, right]);
+        let (when_left_and_right, both_found) = self.restrict(db, storage, [left, right]);
         if !both_found {
             // If left and right are not both present in the input BDD, we should not even attempt
             // the substitution, since the Shannon expansion might introduce the missing variables!
@@ -3036,8 +3078,8 @@ impl NodeId {
             // with the input.
             return self;
         }
-        let (when_not_left, _) = self.restrict(db, builder, [left.negated()]);
-        let (when_left_but_not_right, _) = self.restrict(db, builder, [left, right.negated()]);
+        let (when_not_left, _) = self.restrict(db, storage, [left.negated()]);
+        let (when_left_but_not_right, _) = self.restrict(db, storage, [left, right.negated()]);
 
         // The result should test `replacement`, and when it's true, it should produce the same
         // output that input would when `left ∧ right` is true. When replacement is false, it
@@ -3054,18 +3096,19 @@ impl NodeId {
         //     false
         //
         //  (Note that the `else` branch shouldn't be reachable, but we have to provide something!)
-        let (left_node, _) = Node::new_satisfied_constraint(builder, left);
-        let (right_node, _) = Node::new_satisfied_constraint(builder, right);
-        let right_result = right_node.ite(builder, ALWAYS_FALSE, when_left_but_not_right);
-        let left_result = left_node.ite(builder, right_result, when_not_left);
-        let result = replacement.ite(builder, when_left_and_right, left_result);
+        let (left_node, _) = Node::new_satisfied_constraint(storage, left);
+        let (right_node, _) = Node::new_satisfied_constraint(storage, right);
+        let right_result = right_node.ite(storage, ALWAYS_FALSE, when_left_but_not_right);
+        let left_result = left_node.ite(storage, right_result, when_not_left);
+        let result = replacement.ite(storage, when_left_and_right, left_result);
 
         // Lastly, verify that the result is consistent with the input. (It must produce the same
         // results when `left ∧ right`.) If it doesn't, the substitution isn't valid, and we should
         // return the original BDD unmodified.
-        let validity = replacement.iff(builder, left_node.and(builder, right_node));
-        let constrained_original = self.and(builder, validity);
-        let constrained_replacement = result.and(builder, validity);
+        let intersection = left_node.and(storage, right_node);
+        let validity = replacement.iff(storage, intersection);
+        let constrained_original = self.and(storage, validity);
+        let constrained_replacement = result.and(storage, validity);
         if constrained_original == constrained_replacement {
             result
         } else {
@@ -3077,7 +3120,7 @@ impl NodeId {
     fn substitute_union<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         left: ConstraintAssignment,
         right: ConstraintAssignment,
         replacement: NodeId,
@@ -3088,7 +3131,7 @@ impl NodeId {
         //   - left is false and right is true
         //   - left and right are both false
         // This covers the entire truth table of `left ∨ right`.
-        let (when_l1_r1, both_found) = self.restrict(db, builder, [left, right]);
+        let (when_l1_r1, both_found) = self.restrict(db, storage, [left, right]);
         if !both_found {
             // If left and right are not both present in the input BDD, we should not even attempt
             // the substitution, since the Shannon expansion might introduce the missing variables!
@@ -3096,9 +3139,9 @@ impl NodeId {
             // with the input.
             return self;
         }
-        let (when_l0_r0, _) = self.restrict(db, builder, [left.negated(), right.negated()]);
-        let (when_l1_r0, _) = self.restrict(db, builder, [left, right.negated()]);
-        let (when_l0_r1, _) = self.restrict(db, builder, [left.negated(), right]);
+        let (when_l0_r0, _) = self.restrict(db, storage, [left.negated(), right.negated()]);
+        let (when_l1_r0, _) = self.restrict(db, storage, [left, right.negated()]);
+        let (when_l0_r1, _) = self.restrict(db, storage, [left.negated(), right]);
 
         // The result should test `replacement`, and when it's true, it should produce the same
         // output that input would when `left ∨ right` is true. For OR, this is the union of what
@@ -3110,20 +3153,19 @@ impl NodeId {
         //     or(when_l1_r1, when_l1_r0, when_r0_l1)
         //   else
         //     when_l0_r0
-        let result = replacement.ite(
-            builder,
-            when_l1_r0.or(builder, when_l0_r1.or(builder, when_l1_r1)),
-            when_l0_r0,
-        );
+        let when_l0_r1_or_l1_r1 = when_l0_r1.or(storage, when_l1_r1);
+        let when_either = when_l1_r0.or(storage, when_l0_r1_or_l1_r1);
+        let result = replacement.ite(storage, when_either, when_l0_r0);
 
         // Lastly, verify that the result is consistent with the input. (It must produce the same
         // results when `left ∨ right`.) If it doesn't, the substitution isn't valid, and we should
         // return the original BDD unmodified.
-        let (left_node, _) = Node::new_satisfied_constraint(builder, left);
-        let (right_node, _) = Node::new_satisfied_constraint(builder, right);
-        let validity = replacement.iff(builder, left_node.or(builder, right_node));
-        let constrained_original = self.and(builder, validity);
-        let constrained_replacement = result.and(builder, validity);
+        let (left_node, _) = Node::new_satisfied_constraint(storage, left);
+        let (right_node, _) = Node::new_satisfied_constraint(storage, right);
+        let union = left_node.or(storage, right_node);
+        let validity = replacement.iff(storage, union);
+        let constrained_original = self.and(storage, validity);
+        let constrained_replacement = result.and(storage, validity);
         if constrained_original == constrained_replacement {
             result
         } else {
@@ -3138,26 +3180,50 @@ impl NodeId {
     /// root-to-leaf occurrence can be exponential in the presence of shared subgraphs.
     fn for_each_unique_constraint(
         self,
-        builder: &ConstraintSetBuilder<'_>,
+        storage: &ConstraintSetStorage<'_>,
         f: &mut dyn FnMut(ConstraintId),
     ) {
         fn walk(
             node: NodeId,
-            builder: &ConstraintSetBuilder<'_>,
+            storage: &ConstraintSetStorage<'_>,
             seen: &mut FxHashSet<NodeId>,
             f: &mut dyn FnMut(ConstraintId),
         ) {
             if node.is_terminal() || !seen.insert(node) {
                 return;
             }
-            let interior = builder.interior_node_data(node);
+            let interior = storage.interior_node_data(node);
             f(interior.constraint);
-            walk(interior.if_true, builder, seen, f);
-            walk(interior.if_uncertain, builder, seen, f);
-            walk(interior.if_false, builder, seen, f);
+            walk(interior.if_true, storage, seen, f);
+            walk(interior.if_uncertain, storage, seen, f);
+            walk(interior.if_false, storage, seen, f);
         }
 
-        walk(self, builder, &mut FxHashSet::default(), f);
+        walk(self, storage, &mut FxHashSet::default(), f);
+    }
+
+    fn for_each_unique_constraint_mut<'db>(
+        self,
+        storage: &mut ConstraintSetStorage<'db>,
+        f: &mut dyn FnMut(&mut ConstraintSetStorage<'db>, ConstraintId),
+    ) {
+        fn walk<'db>(
+            node: NodeId,
+            storage: &mut ConstraintSetStorage<'db>,
+            seen: &mut FxHashSet<NodeId>,
+            f: &mut dyn FnMut(&mut ConstraintSetStorage<'db>, ConstraintId),
+        ) {
+            if node.is_terminal() || !seen.insert(node) {
+                return;
+            }
+            let interior = storage.interior_node_data(node);
+            f(storage, interior.constraint);
+            walk(interior.if_true, storage, seen, f);
+            walk(interior.if_uncertain, storage, seen, f);
+            walk(interior.if_false, storage, seen, f);
+        }
+
+        walk(self, storage, &mut FxHashSet::default(), f);
     }
 
     /// Simplifies a BDD, replacing constraints with simpler or smaller constraints where possible.
@@ -3184,38 +3250,38 @@ impl NodeId {
     fn simplify_for_display<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
     ) -> Self {
         match self.node() {
             Node::AlwaysTrue | Node::AlwaysFalse => self,
-            Node::Interior(interior) => interior.simplify(db, builder),
+            Node::Interior(interior) => interior.simplify(db, storage),
         }
     }
 
     /// Returns clauses describing all of the variable assignments that cause this BDD to evaluate
     /// to `true`. (This translates the boolean function that this BDD represents into DNF form.)
-    fn satisfied_clauses(self, builder: &ConstraintSetBuilder<'_>) -> SatisfiedClauses {
+    fn satisfied_clauses(self, storage: &ConstraintSetStorage<'_>) -> SatisfiedClauses {
         struct Searcher {
             clauses: SatisfiedClauses,
             current_clause: SatisfiedClause,
         }
 
         impl Searcher {
-            fn visit_node(&mut self, builder: &ConstraintSetBuilder<'_>, node: NodeId) {
+            fn visit_node(&mut self, storage: &ConstraintSetStorage<'_>, node: NodeId) {
                 match node.node() {
                     Node::AlwaysFalse => {}
                     Node::AlwaysTrue => self.clauses.push(self.current_clause.clone()),
                     Node::Interior(_) => {
-                        let interior = builder.interior_node_data(node);
+                        let interior = storage.interior_node_data(node);
                         self.current_clause.push(interior.constraint.when_true());
-                        self.visit_node(builder, interior.if_true);
+                        self.visit_node(storage, interior.if_true);
                         self.current_clause.pop();
                         self.current_clause
                             .push(interior.constraint.when_unconstrained());
-                        self.visit_node(builder, interior.if_uncertain);
+                        self.visit_node(storage, interior.if_uncertain);
                         self.current_clause.pop();
                         self.current_clause.push(interior.constraint.when_false());
-                        self.visit_node(builder, interior.if_false);
+                        self.visit_node(storage, interior.if_false);
                         self.current_clause.pop();
                     }
                 }
@@ -3226,11 +3292,15 @@ impl NodeId {
             clauses: SatisfiedClauses::default(),
             current_clause: SatisfiedClause::default(),
         };
-        searcher.visit_node(builder, self);
+        searcher.visit_node(storage, self);
         searcher.clauses
     }
 
-    fn display<'db>(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> impl Display {
+    fn display<'db>(
+        self,
+        db: &'db dyn Db,
+        storage: &mut ConstraintSetStorage<'db>,
+    ) -> impl Display {
         // To render a BDD in DNF form, you perform a depth-first search of the BDD tree, looking
         // for any path that leads to the AlwaysTrue terminal. Each such path represents one of the
         // intersection clauses in the DNF form. The path traverses zero or more interior nodes,
@@ -3239,7 +3309,7 @@ impl NodeId {
         struct DisplayNode<'db, 'c> {
             node: NodeId,
             db: &'db dyn Db,
-            builder: &'c ConstraintSetBuilder<'db>,
+            storage: RefCell<&'c mut ConstraintSetStorage<'db>>,
         }
 
         impl Display for DisplayNode<'_, '_> {
@@ -3248,9 +3318,10 @@ impl NodeId {
                     Node::AlwaysTrue => f.write_str("always"),
                     Node::AlwaysFalse => f.write_str("never"),
                     Node::Interior(_) => {
-                        let mut clauses = self.node.satisfied_clauses(self.builder);
-                        clauses.simplify(self.db, self.builder);
-                        Display::fmt(&clauses.display(self.db, self.builder), f)
+                        let mut storage = self.storage.borrow_mut();
+                        let mut clauses = self.node.satisfied_clauses(&storage);
+                        clauses.simplify(self.db, &mut storage);
+                        Display::fmt(&clauses.display(self.db, &storage), f)
                     }
                 }
             }
@@ -3259,7 +3330,7 @@ impl NodeId {
         DisplayNode {
             node: self,
             db,
-            builder,
+            storage: RefCell::new(storage),
         }
     }
 
@@ -3284,12 +3355,12 @@ impl NodeId {
     fn display_graph<'db, 'a>(
         self,
         db: &'db dyn Db,
-        builder: &'a ConstraintSetBuilder<'db>,
+        storage: &'a ConstraintSetStorage<'db>,
         prefix: &'a dyn Display,
     ) -> impl Display + 'a {
         struct DisplayNode<'a, 'db> {
             db: &'db dyn Db,
-            builder: &'a ConstraintSetBuilder<'db>,
+            storage: &'a ConstraintSetStorage<'db>,
             node: NodeId,
             prefix: &'a dyn Display,
             seen: RefCell<FxIndexSet<NodeId>>,
@@ -3297,7 +3368,7 @@ impl NodeId {
 
         fn format_node<'db>(
             db: &'db dyn Db,
-            builder: &ConstraintSetBuilder<'db>,
+            storage: &ConstraintSetStorage<'db>,
             node: NodeId,
             prefix: &dyn Display,
             seen: &RefCell<FxIndexSet<NodeId>>,
@@ -3311,14 +3382,14 @@ impl NodeId {
                     if !is_new {
                         return write!(f, "<{index}> SHARED");
                     }
-                    let interior = builder.interior_node_data(node);
-                    write!(f, "<{index}> {}", interior.constraint.display(db, builder))?;
+                    let interior = storage.interior_node_data(node);
+                    write!(f, "<{index}> {}", interior.constraint.display(db, storage))?;
                     // Calling display_graph recursively here causes rustc to claim that the
                     // expect(unused) up above is unfulfilled!
                     write!(f, "\n{prefix}┡━₁ ")?;
                     format_node(
                         db,
-                        builder,
+                        storage,
                         interior.if_true,
                         &format_args!("{prefix}│   "),
                         seen,
@@ -3327,7 +3398,7 @@ impl NodeId {
                     write!(f, "\n{prefix}├─? ")?;
                     format_node(
                         db,
-                        builder,
+                        storage,
                         interior.if_uncertain,
                         &format_args!("{prefix}│   "),
                         seen,
@@ -3336,7 +3407,7 @@ impl NodeId {
                     write!(f, "\n{prefix}└─₀ ")?;
                     format_node(
                         db,
-                        builder,
+                        storage,
                         interior.if_false,
                         &format_args!("{prefix}    "),
                         seen,
@@ -3349,13 +3420,13 @@ impl NodeId {
 
         impl Display for DisplayNode<'_, '_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                format_node(self.db, self.builder, self.node, self.prefix, &self.seen, f)
+                format_node(self.db, self.storage, self.node, self.prefix, &self.seen, f)
             }
         }
 
         DisplayNode {
             db,
-            builder,
+            storage,
             node: self,
             prefix,
             seen: RefCell::default(),
@@ -3536,7 +3607,8 @@ impl<'db> Type<'db> {
         ) -> PathBounds<'db> {
             let when = source.when_constraint_set_assignable_to_owned(db, target);
             when.query(|builder, when| {
-                PathBounds::compute(db, builder, when.node, inferable, when.source_order)
+                let mut storage = builder.storage.borrow_mut();
+                PathBounds::compute(db, &mut storage, when.node, inferable, when.source_order)
             })
         }
 
@@ -3553,7 +3625,7 @@ fn is_possibly_constraint_set_assignable<'db>(db: &'db dyn Db, types: TypePair<'
     types
         .first(db)
         .when_constraint_set_assignable_to_owned(db, types.second(db))
-        .query(|_builder, when| !when.is_never_satisfied(db))
+        .query(|_storage, when| !when.is_never_satisfied(db))
 }
 
 /// Per-path bounds for all typevars. Each element is the set of typevar bounds for one BDD path.
@@ -3571,7 +3643,7 @@ impl<'db> PathBounds<'db> {
     /// typevar that appears in the path's constraints.
     fn compute(
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         node: NodeId,
         inferable: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
@@ -3588,7 +3660,7 @@ impl<'db> PathBounds<'db> {
             fn satisfied<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                _builder: &ConstraintSetBuilder<'db>,
+                _storage: &mut ConstraintSetStorage<'db>,
                 path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
                 let mut path: Vec<_> = path
@@ -3609,7 +3681,7 @@ impl<'db> PathBounds<'db> {
             fn unsatisfied<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                _builder: &ConstraintSetBuilder<'db>,
+                _storage: &mut ConstraintSetStorage<'db>,
                 _path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
                 ControlFlow::Continue(())
@@ -3618,7 +3690,7 @@ impl<'db> PathBounds<'db> {
             fn impossible<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                _builder: &ConstraintSetBuilder<'db>,
+                _storage: &mut ConstraintSetStorage<'db>,
                 _path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
                 ControlFlow::Continue(())
@@ -3627,7 +3699,7 @@ impl<'db> PathBounds<'db> {
             fn combine<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                _builder: &ConstraintSetBuilder<'db>,
+                _storage: &mut ConstraintSetStorage<'db>,
                 _if_true: Self::Result,
                 _if_uncertain: Self::Result,
                 _if_false: Self::Result,
@@ -3636,16 +3708,16 @@ impl<'db> PathBounds<'db> {
             }
         }
 
-        let mut source_orders = builder.calculate_source_orders(source_order);
+        let mut source_orders = storage.calculate_source_orders(source_order);
         if let Some(path_bounds) =
-            Self::compute_simple_bound_conjunction(db, builder, &source_orders, node, inferable)
+            Self::compute_simple_bound_conjunction(db, storage, &source_orders, node, inferable)
         {
             return path_bounds;
         }
 
         let (node, derived_source_order) =
-            node.remove_noninferable(db, builder, inferable, source_order);
-        source_orders.extend(builder.calculate_source_orders(derived_source_order));
+            node.remove_noninferable(db, storage, inferable, source_order);
+        source_orders.extend(storage.calculate_source_orders(derived_source_order));
         let interior = match node.node() {
             Node::AlwaysTrue => return PathBounds::Unconstrained,
             Node::AlwaysFalse => return PathBounds::Unsatisfiable,
@@ -3664,9 +3736,9 @@ impl<'db> PathBounds<'db> {
         // Sequent discovery must also happen in source order. Sorting the collected paths below
         // is too late: sequent pairs are not commutative, and TDD traversal order can otherwise
         // discard gradual evidence before solution extraction.
-        let path_source_order = builder.ordered_source_order(source_order, derived_source_order);
-        let mut path = interior.path_assignments(builder, path_source_order);
-        let _ = path.visit(db, builder, node, &mut collect_visitor);
+        let path_source_order = storage.ordered_source_order(source_order, derived_source_order);
+        let mut path = interior.path_assignments(storage, path_source_order);
+        let _ = path.visit(db, storage, node, &mut collect_visitor);
         collect_visitor.sorted_paths.sort_by(|path1, path2| {
             let source_orders1 = path1.iter().map(|(_, source_order)| *source_order);
             let source_orders2 = path2.iter().map(|(_, source_order)| *source_order);
@@ -3680,7 +3752,7 @@ impl<'db> PathBounds<'db> {
         for path in collect_visitor.sorted_paths {
             mappings.clear();
             for (constraint, _) in path {
-                let constraint = builder.constraint_data(constraint);
+                let constraint = storage.constraint_data(constraint);
                 let typevar = constraint.typevar;
                 if let Some(lower) = constraint.bounds.lower {
                     let bounds = mappings.entry(typevar).or_default();
@@ -3721,7 +3793,7 @@ impl<'db> PathBounds<'db> {
     /// accumulated bound against the typevar's declared bound or constraints.
     fn compute_simple_bound_conjunction(
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         source_orders: &FxIndexSet<ConstraintId>,
         node: NodeId,
         inferable: TypeVarSet<'db>,
@@ -3739,12 +3811,12 @@ impl<'db> PathBounds<'db> {
                 Node::AlwaysTrue => break,
                 Node::AlwaysFalse => return None,
                 Node::Interior(_) => {
-                    let interior = builder.interior_node_data(current);
+                    let interior = storage.interior_node_data(current);
                     if interior.if_uncertain != ALWAYS_FALSE || interior.if_false != ALWAYS_FALSE {
                         return None;
                     }
 
-                    let constraint = builder.constraint_data(interior.constraint);
+                    let constraint = storage.constraint_data(interior.constraint);
                     if !constraint.typevar.is_inferable(db, inferable) {
                         return None;
                     }
@@ -3866,8 +3938,10 @@ impl<'db> PathBounds<'db> {
                 // should only be used as a fallback when no concrete type was inferred.
                 if let Some(lower) = path_bound.lower {
                     if !path_bound.upper.is_satisfied_by(db, lower) {
-                        let when_upper = path_bound.upper.when_satisfied_by(db, builder, lower);
-                        if when_upper.is_never_satisfied(db) {
+                        let mut storage = builder.storage.borrow_mut();
+                        let (when_upper, source_order) =
+                            path_bound.upper.when_satisfied_by(db, &mut storage, lower);
+                        if when_upper.is_never_satisfied(db, &mut storage, source_order) {
                             // This path does not satisfy the accumulated upper bound, and is
                             // therefore not a valid specialization.
                             return Err(());
@@ -3968,14 +4042,16 @@ impl<'db> PathBounds<'db> {
                     // for upper-bound evidence.
                     let when_lower =
                         lower.when_constraint_set_assignable_to_owned(db, constraint_upper);
-                    let when_upper =
+                    let mut storage = builder.storage.borrow_mut();
+                    let (when_upper, upper_source_order) =
                         path_bound
                             .upper
-                            .when_satisfied_by(db, builder, constraint_lower);
-                    let when = builder
-                        .load(db, &when_lower)
-                        .and(db, builder, || when_upper);
-                    if when.is_never_satisfied(db) {
+                            .when_satisfied_by(db, &mut storage, constraint_lower);
+                    let (when_lower, lower_source_order) = storage.load(db, &when_lower);
+                    let when = when_lower.and(&mut storage, when_upper);
+                    let source_order =
+                        storage.ordered_source_order(lower_source_order, upper_source_order);
+                    if when.is_never_satisfied(db, &mut storage, source_order) {
                         continue;
                     }
 
@@ -4038,94 +4114,94 @@ impl InteriorNode {
         self.0
     }
 
-    fn negate(self, builder: &ConstraintSetBuilder<'_>) -> NodeId {
+    fn negate(self, storage: &mut ConstraintSetStorage<'_>) -> NodeId {
         let key = self.node();
-        let storage = builder.storage.borrow();
         if let Some(result) = storage.negate_cache.get(&key) {
             return *result;
         }
-        drop(storage);
 
         // negate(n ? C : U : D) = n ? negate(or(C, U)) : 0 : negate(or(D, U))
         //
         // The uncertain branch U is absorbed into C and D via union before negation. The result's
         // uncertain branch is always zero. When U = 0 (the common case), this degenerates to the
         // standard binary BDD leaf-swap: n ? negate(C) : 0 : negate(D).
-        let interior = builder.interior_node_data(self.node());
-        let not_true = interior.if_true.negate(builder);
-        let not_uncertain = interior.if_uncertain.negate(builder);
-        let not_false = interior.if_false.negate(builder);
-        let result = NodeId::new(
-            builder,
-            interior.constraint,
-            not_true.and(builder, not_uncertain),
-            not_false.and(builder, not_uncertain),
-        );
+        let interior = storage.interior_node_data(self.node());
+        let not_true = interior.if_true.negate(storage);
+        let not_uncertain = interior.if_uncertain.negate(storage);
+        let not_false = interior.if_false.negate(storage);
+        let if_true = not_true.and(storage, not_uncertain);
+        let if_false = not_false.and(storage, not_uncertain);
+        let result = NodeId::new(storage, interior.constraint, if_true, if_false);
 
-        let mut storage = builder.storage.borrow_mut();
         storage.negate_cache.insert(key, result);
         result
     }
 
-    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+    fn or(self, storage: &mut ConstraintSetStorage<'_>, other: Self) -> NodeId {
         let key = (self.node(), other.node());
-        let storage = builder.storage.borrow();
         if let Some(result) = storage.or_cache.get(&key) {
             return *result;
         }
-        drop(storage);
 
-        let self_interior = builder.interior_node_data(self.node());
+        let self_interior = storage.interior_node_data(self.node());
         let self_ordering = self_interior.constraint.ordering();
-        let other_interior = builder.interior_node_data(other.node());
+        let other_interior = storage.interior_node_data(other.node());
         let other_ordering = other_interior.constraint.ordering();
         let result = match self_ordering.cmp(&other_ordering) {
-            Ordering::Equal => NodeId::with_uncertain(
-                builder,
-                self_interior.constraint,
-                self_interior.if_true.or(builder, other_interior.if_true),
-                self_interior
+            Ordering::Equal => {
+                let if_true = self_interior.if_true.or(storage, other_interior.if_true);
+                let if_uncertain = self_interior
                     .if_uncertain
-                    .or(builder, other_interior.if_uncertain),
-                self_interior.if_false.or(builder, other_interior.if_false),
-            ),
+                    .or(storage, other_interior.if_uncertain);
+                let if_false = self_interior.if_false.or(storage, other_interior.if_false);
+                NodeId::with_uncertain(
+                    storage,
+                    self_interior.constraint,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                )
+            }
             // This is from Frisch's original description of TDDs. If self < other, we check self
             // first. Instead of distributing other into the if_true and if_false branches, we
             // "park" it in the if_uncertain branch. That causes us to only evaluate other "lazily"
             // when needed.
-            Ordering::Less => NodeId::with_uncertain(
-                builder,
-                self_interior.constraint,
-                self_interior.if_true,
-                self_interior.if_uncertain.or(builder, other.node()),
-                self_interior.if_false,
-            ),
+            Ordering::Less => {
+                let if_uncertain = self_interior.if_uncertain.or(storage, other.node());
+                NodeId::with_uncertain(
+                    storage,
+                    self_interior.constraint,
+                    self_interior.if_true,
+                    if_uncertain,
+                    self_interior.if_false,
+                )
+            }
             // Ditto above but for the other variable ordering
-            Ordering::Greater => NodeId::with_uncertain(
-                builder,
-                other_interior.constraint,
-                other_interior.if_true,
-                self.node().or(builder, other_interior.if_uncertain),
-                other_interior.if_false,
-            ),
+            Ordering::Greater => {
+                let if_uncertain = self.node().or(storage, other_interior.if_uncertain);
+                NodeId::with_uncertain(
+                    storage,
+                    other_interior.constraint,
+                    other_interior.if_true,
+                    if_uncertain,
+                    other_interior.if_false,
+                )
+            }
         };
 
-        let mut storage = builder.storage.borrow_mut();
         storage.or_cache.insert(key, result);
         result
     }
 
-    fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+    fn and(self, storage: &mut ConstraintSetStorage<'_>, other: Self) -> NodeId {
         let key = (self.node(), other.node());
-        let storage = builder.storage.borrow();
         if let Some(result) = storage.and_cache.get(&key) {
             return *result;
         }
-        drop(storage);
 
-        let self_interior = builder.interior_node_data(self.node());
+        let self_interior = storage.interior_node_data(self.node());
         let self_ordering = self_interior.constraint.ordering();
-        let other_interior = builder.interior_node_data(other.node());
+        let other_interior = storage.interior_node_data(other.node());
         let other_ordering = other_interior.constraint.ordering();
         let result = match self_ordering.cmp(&other_ordering) {
             // This is one of Duboc's optimizations over Frisch's original TDD operators. Frisch
@@ -4138,62 +4214,59 @@ impl InteriorNode {
             //
             // See [Duboc2026], §11.2 for more details.
             Ordering::Equal => {
-                let if_true = self_interior
+                let other_if_true = other_interior
                     .if_true
-                    .and(
-                        builder,
-                        other_interior
-                            .if_true
-                            .or(builder, other_interior.if_uncertain),
-                    )
-                    .or(
-                        builder,
-                        self_interior
-                            .if_uncertain
-                            .and(builder, other_interior.if_true),
-                    );
+                    .or(storage, other_interior.if_uncertain);
+                let true_from_true = self_interior.if_true.and(storage, other_if_true);
+                let true_from_uncertain = self_interior
+                    .if_uncertain
+                    .and(storage, other_interior.if_true);
+                let if_true = true_from_true.or(storage, true_from_uncertain);
                 let if_uncertain = self_interior
                     .if_uncertain
-                    .and(builder, other_interior.if_uncertain);
-                let if_false = self_interior
-                    .if_false
-                    .and(
-                        builder,
-                        other_interior
-                            .if_uncertain
-                            .or(builder, other_interior.if_false),
-                    )
-                    .or(
-                        builder,
-                        self_interior
-                            .if_uncertain
-                            .and(builder, other_interior.if_false),
-                    );
+                    .and(storage, other_interior.if_uncertain);
+                let other_if_false = other_interior
+                    .if_uncertain
+                    .or(storage, other_interior.if_false);
+                let false_from_false = self_interior.if_false.and(storage, other_if_false);
+                let false_from_uncertain = self_interior
+                    .if_uncertain
+                    .and(storage, other_interior.if_false);
+                let if_false = false_from_false.or(storage, false_from_uncertain);
                 NodeId::with_uncertain(
-                    builder,
+                    storage,
                     self_interior.constraint,
                     if_true,
                     if_uncertain,
                     if_false,
                 )
             }
-            Ordering::Less => NodeId::with_uncertain(
-                builder,
-                self_interior.constraint,
-                self_interior.if_true.and(builder, other.node()),
-                self_interior.if_uncertain.and(builder, other.node()),
-                self_interior.if_false.and(builder, other.node()),
-            ),
-            Ordering::Greater => NodeId::with_uncertain(
-                builder,
-                other_interior.constraint,
-                self.node().and(builder, other_interior.if_true),
-                self.node().and(builder, other_interior.if_uncertain),
-                self.node().and(builder, other_interior.if_false),
-            ),
+            Ordering::Less => {
+                let if_true = self_interior.if_true.and(storage, other.node());
+                let if_uncertain = self_interior.if_uncertain.and(storage, other.node());
+                let if_false = self_interior.if_false.and(storage, other.node());
+                NodeId::with_uncertain(
+                    storage,
+                    self_interior.constraint,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                )
+            }
+            Ordering::Greater => {
+                let if_true = self.node().and(storage, other_interior.if_true);
+                let if_uncertain = self.node().and(storage, other_interior.if_uncertain);
+                let if_false = self.node().and(storage, other_interior.if_false);
+                NodeId::with_uncertain(
+                    storage,
+                    other_interior.constraint,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                )
+            }
         };
 
-        let mut storage = builder.storage.borrow_mut();
         storage.and_cache.insert(key, result);
         result
     }
@@ -4201,24 +4274,24 @@ impl InteriorNode {
     fn exists_inner<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         bound_typevars: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
     ) -> (NodeId, Option<SourceOrderId>) {
-        let mentions_typevar = |ty: Type<'db>| match ty {
+        let mentions_typevar = |ty: Type<'_>| match ty {
             Type::TypeVar(typevar) => typevar.is_inferable(db, bound_typevars),
             _ => false,
         };
         self.abstract_inner(
             db,
-            builder,
+            storage,
             source_order,
             // Remove any node that constrains one of `bound_typevars`, or that has a lower/upper
             // bound that mentions one of them. Removed constraints are still added to `path`, so
             // the sequent map can propagate any derived constraints that do not mention the
             // quantified typevars.
-            &mut |constraint| {
-                let constraint = builder.constraint_data(constraint);
+            &mut |storage: &ConstraintSetStorage<'_>, constraint| {
+                let constraint = storage.constraint_data(constraint);
                 constraint.typevar.is_inferable(db, bound_typevars)
                     || constraint
                         .bounds
@@ -4235,17 +4308,17 @@ impl InteriorNode {
     fn remove_noninferable<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         inferable: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
     ) -> (NodeId, Option<SourceOrderId>) {
-        let is_bare_inferable_typevar = |ty: Type<'db>| {
+        let is_bare_inferable_typevar = |ty: Type<'_>| {
             ty.as_typevar()
                 .is_some_and(|bound_typevar| bound_typevar.is_inferable(db, inferable))
         };
         self.abstract_inner(
             db,
-            builder,
+            storage,
             source_order,
             // We only want to keep constraints on inferable typevars. If the constraint's typevar
             // is itself inferable, we keep it. We also need to keep some constraints in
@@ -4256,8 +4329,8 @@ impl InteriorNode {
             // either as `Never ≤ I ≤ N` or `I ≤ N ≤ object`, depending on typevar ordering. If we
             // only checked the inferability of the constrained typevar, we would keep the first
             // encoding but remove the second.
-            &mut |constraint| {
-                let constraint = builder.constraint_data(constraint);
+            &mut |storage: &ConstraintSetStorage<'_>, constraint| {
+                let constraint = storage.constraint_data(constraint);
                 !constraint.typevar.is_inferable(db, inferable)
                     && !constraint
                         .bounds
@@ -4274,12 +4347,12 @@ impl InteriorNode {
     fn abstract_inner<'db, F>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         source_order: Option<SourceOrderId>,
         should_remove: F,
     ) -> (NodeId, Option<SourceOrderId>)
     where
-        F: FnMut(ConstraintId) -> bool,
+        F: FnMut(&ConstraintSetStorage<'_>, ConstraintId) -> bool,
     {
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         enum Disposition {
@@ -4293,7 +4366,7 @@ impl InteriorNode {
 
         impl<F> PathVisitor for AbstractVisitor<F>
         where
-            F: FnMut(ConstraintId) -> bool,
+            F: FnMut(&ConstraintSetStorage<'_>, ConstraintId) -> bool,
         {
             type Result = (NodeId, Option<SourceOrderId>);
             type Interior = (Disposition, ConstraintId);
@@ -4302,7 +4375,7 @@ impl InteriorNode {
             fn visit_satisfied<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                _builder: &ConstraintSetBuilder<'db>,
+                _storage: &mut ConstraintSetStorage<'db>,
                 _path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
                 ControlFlow::Continue((ALWAYS_TRUE, None))
@@ -4311,7 +4384,7 @@ impl InteriorNode {
             fn visit_unsatisfied<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                _builder: &ConstraintSetBuilder<'db>,
+                _storage: &mut ConstraintSetStorage<'db>,
                 _path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
                 ControlFlow::Continue((ALWAYS_FALSE, None))
@@ -4320,7 +4393,7 @@ impl InteriorNode {
             fn visit_impossible<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                _builder: &ConstraintSetBuilder<'db>,
+                _storage: &mut ConstraintSetStorage<'db>,
                 _path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
                 ControlFlow::Continue((ALWAYS_FALSE, None))
@@ -4329,11 +4402,11 @@ impl InteriorNode {
             fn enter_interior<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                builder: &ConstraintSetBuilder<'db>,
+                storage: &mut ConstraintSetStorage<'db>,
                 interior: InteriorNode,
             ) -> ControlFlow<Self::Break, Self::Interior> {
-                let interior = builder.interior_node_data(interior.node());
-                let disposition = if (self.should_remove)(interior.constraint) {
+                let interior = storage.interior_node_data(interior.node());
+                let disposition = if (self.should_remove)(storage, interior.constraint) {
                     Disposition::Remove
                 } else {
                     Disposition::Keep
@@ -4344,7 +4417,7 @@ impl InteriorNode {
             fn visit_edge<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                builder: &ConstraintSetBuilder<'db>,
+                storage: &mut ConstraintSetStorage<'db>,
                 interior: &Self::Interior,
                 subtree: Self::Result,
                 path: &PathAssignments,
@@ -4360,29 +4433,20 @@ impl InteriorNode {
                     // that depend on the constraint we're about to remove. If so, we need to
                     // "remember" them by AND-ing them in with the corresponding branch.
                     Disposition::Remove => {
-                        ControlFlow::Continue(
-                            path.assignments[new_range]
-                                .iter()
-                                .filter(|(assignment, _)| {
-                                    // Don't add back any derived facts if they are ones that we would have
-                                    // removed!
-                                    !(self.should_remove)(assignment.constraint())
-                                })
-                                .fold(
-                                    subtree,
-                                    |(subtree, subtree_source_order), (assignment, _)| {
-                                        let (assignment, assignment_source_order) =
-                                            Node::new_satisfied_constraint(builder, *assignment);
-                                        (
-                                            subtree.and(builder, assignment),
-                                            builder.ordered_source_order(
-                                                subtree_source_order,
-                                                assignment_source_order,
-                                            ),
-                                        )
-                                    },
-                                ),
-                        )
+                        let (mut result, mut result_source_order) = subtree;
+                        for (assignment, _) in &path.assignments[new_range] {
+                            // Don't add back any derived facts if they are ones that we would have
+                            // removed!
+                            if (self.should_remove)(storage, assignment.constraint()) {
+                                continue;
+                            }
+                            let (assignment, assignment_source_order) =
+                                Node::new_satisfied_constraint(storage, *assignment);
+                            result = result.and(storage, assignment);
+                            result_source_order = storage
+                                .ordered_source_order(result_source_order, assignment_source_order);
+                        }
+                        ControlFlow::Continue((result, result_source_order))
                     }
                 }
             }
@@ -4390,7 +4454,7 @@ impl InteriorNode {
             fn leave_interior<'db>(
                 &mut self,
                 _db: &'db dyn Db,
-                builder: &ConstraintSetBuilder<'db>,
+                storage: &mut ConstraintSetStorage<'db>,
                 interior: &Self::Interior,
                 if_true: Self::Result,
                 if_uncertain: Self::Result,
@@ -4408,22 +4472,20 @@ impl InteriorNode {
                     // one in the BDD ordering.
                     Disposition::Keep => {
                         let (guard, guard_source_order) =
-                            Node::new_constraint(builder, *constraint);
+                            Node::new_constraint(storage, *constraint);
                         let (if_true, if_true_source_order) = if_true;
                         let (if_uncertain, if_uncertain_source_order) = if_uncertain;
                         let (if_false, if_false_source_order) = if_false;
-                        let node = guard.ite(
-                            builder,
-                            if_true.or(builder, if_uncertain),
-                            if_false.or(builder, if_uncertain),
-                        );
+                        let if_true = if_true.or(storage, if_uncertain);
+                        let if_false = if_false.or(storage, if_uncertain);
+                        let node = guard.ite(storage, if_true, if_false);
                         let left_source_order =
-                            builder.ordered_source_order(guard_source_order, if_true_source_order);
-                        let right_source_order = builder
+                            storage.ordered_source_order(guard_source_order, if_true_source_order);
+                        let right_source_order = storage
                             .ordered_source_order(if_uncertain_source_order, if_false_source_order);
                         ControlFlow::Continue((
                             node,
-                            builder.ordered_source_order(left_source_order, right_source_order),
+                            storage.ordered_source_order(left_source_order, right_source_order),
                         ))
                     }
 
@@ -4435,38 +4497,36 @@ impl InteriorNode {
                         let (if_true, if_true_source_order) = if_true;
                         let (if_uncertain, if_uncertain_source_order) = if_uncertain;
                         let (if_false, if_false_source_order) = if_false;
-                        let node = if_true.or(builder, if_uncertain).or(builder, if_false);
-                        let source_order = builder
+                        let node = if_true.or(storage, if_uncertain).or(storage, if_false);
+                        let source_order = storage
                             .ordered_source_order(if_true_source_order, if_uncertain_source_order);
                         ControlFlow::Continue((
                             node,
-                            builder.ordered_source_order(source_order, if_false_source_order),
+                            storage.ordered_source_order(source_order, if_false_source_order),
                         ))
                     }
                 }
             }
         }
 
-        let mut path = self.path_assignments(builder, source_order);
+        let mut path = self.path_assignments(storage, source_order);
         let mut visitor = AbstractVisitor { should_remove };
-        let ControlFlow::Continue(result) = path.visit(db, builder, self.node(), &mut visitor);
+        let ControlFlow::Continue(result) = path.visit(db, storage, self.node(), &mut visitor);
         result
     }
 
     fn restrict_one<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         assignment: ConstraintAssignment,
     ) -> (NodeId, bool) {
         let key = (self.node(), assignment);
-        let storage = builder.storage.borrow();
         if let Some(result) = storage.restrict_one_cache.get(&key) {
             return *result;
         }
-        drop(storage);
 
-        let self_interior = builder.interior_node_data(self.node());
+        let self_interior = storage.interior_node_data(self.node());
         let self_ordering = self_interior.constraint.ordering();
         let result = if assignment.constraint().ordering() < self_ordering {
             // If this node's variable is larger than the assignment's variable, then we have reached a
@@ -4482,7 +4542,7 @@ impl InteriorNode {
                 (
                     self_interior
                         .if_true
-                        .or(builder, self_interior.if_uncertain),
+                        .or(storage, self_interior.if_uncertain),
                     true,
                 )
             } else if assignment == self_interior.constraint.when_false() {
@@ -4490,7 +4550,7 @@ impl InteriorNode {
                 (
                     self_interior
                         .if_false
-                        .or(builder, self_interior.if_uncertain),
+                        .or(storage, self_interior.if_uncertain),
                     true,
                 )
             } else if assignment == self_interior.constraint.when_unconstrained() {
@@ -4498,21 +4558,21 @@ impl InteriorNode {
                 (
                     self_interior
                         .if_true
-                        .or(builder, self_interior.if_uncertain)
-                        .or(builder, self_interior.if_false),
+                        .or(storage, self_interior.if_uncertain)
+                        .or(storage, self_interior.if_false),
                     true,
                 )
             } else {
                 let (if_true, found_in_true) =
-                    self_interior.if_true.restrict_one(db, builder, assignment);
+                    self_interior.if_true.restrict_one(db, storage, assignment);
                 let (if_uncertain, found_in_uncertain) = self_interior
                     .if_uncertain
-                    .restrict_one(db, builder, assignment);
+                    .restrict_one(db, storage, assignment);
                 let (if_false, found_in_false) =
-                    self_interior.if_false.restrict_one(db, builder, assignment);
+                    self_interior.if_false.restrict_one(db, storage, assignment);
                 (
                     NodeId::with_uncertain(
-                        builder,
+                        storage,
                         self_interior.constraint,
                         if_true,
                         if_uncertain,
@@ -4523,22 +4583,21 @@ impl InteriorNode {
             }
         };
 
-        let mut storage = builder.storage.borrow_mut();
         storage.restrict_one_cache.insert(key, result);
         result
     }
 
     fn path_assignments(
         self,
-        builder: &ConstraintSetBuilder<'_>,
+        storage: &mut ConstraintSetStorage<'_>,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
         self.node()
-            .for_each_unique_constraint(builder, &mut |constraint| {
+            .for_each_unique_constraint(storage, &mut |constraint| {
                 constraints.push(constraint);
             });
-        let source_orders = builder.calculate_source_orders(source_order);
+        let source_orders = storage.calculate_source_orders(source_order);
         // `PathAssignments` seeds its insertion-ordered discovered-constraint map from this list,
         // and uses that order when constructing non-commutative sequent pairs. Do not replace this
         // with TDD traversal order: doing so can change inference and lose gradual constraints.
@@ -4557,13 +4616,11 @@ impl InteriorNode {
     /// This is calculated by looking at the relationships that exist between the constraints that
     /// are mentioned in the BDD. For instance, if one constraint implies another (`x → y`), then
     /// `x ∧ ¬y` is not a valid input, and we can rewrite any occurrences of `x ∨ y` into `y`.
-    fn simplify<'db>(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> NodeId {
+    fn simplify<'db>(self, db: &'db dyn Db, storage: &mut ConstraintSetStorage<'db>) -> NodeId {
         let key = self.node();
-        let storage = builder.storage.borrow();
         if let Some(result) = storage.simplify_cache.get(&key) {
             return *result;
         }
-        drop(storage);
 
         // To simplify a non-terminal BDD, we find all pairs of constraints that are mentioned in
         // the BDD. If any of those pairs can be simplified to some other BDD, we perform a
@@ -4582,7 +4639,7 @@ impl InteriorNode {
         // need to compare a constraint against itself, and because ordering doesn't matter.)
         let mut seen_constraints = FxHashSet::default();
         self.node()
-            .for_each_unique_constraint(builder, &mut |constraint| {
+            .for_each_unique_constraint(storage, &mut |constraint| {
                 seen_constraints.insert(constraint);
             });
         let mut to_visit: Vec<(_, _)> = (seen_constraints.iter().copied())
@@ -4596,9 +4653,9 @@ impl InteriorNode {
         while let Some((left_constraint, right_constraint)) = to_visit.pop() {
             // If the constraints refer to different typevars, the only simplifications we can make
             // are of the form `S ≤ T ∧ T ≤ int → S ≤ int`.
-            let left_constraint_data = builder.constraint_data(left_constraint);
+            let left_constraint_data = storage.constraint_data(left_constraint);
             let left_typevar = left_constraint_data.typevar;
-            let right_constraint_data = builder.constraint_data(right_constraint);
+            let right_constraint_data = storage.constraint_data(right_constraint);
             let right_typevar = right_constraint_data.typevar;
             if !left_typevar.is_same_typevar_as(db, right_typevar) {
                 // We've structured our constraints so that a typevar's upper/lower bound can only
@@ -4607,14 +4664,14 @@ impl InteriorNode {
                 // have to figure out which of the two typevars is constrained, and which one is
                 // the upper/lower bound.
                 let (bound_constraint, constrained_constraint) =
-                    if left_typevar.can_be_bound_for(db, builder, right_typevar) {
+                    if left_typevar.can_be_bound_for(db, storage, right_typevar) {
                         (left_constraint, right_constraint)
                     } else {
                         (right_constraint, left_constraint)
                     };
-                let bound_constraint_data = builder.constraint_data(bound_constraint);
+                let bound_constraint_data = storage.constraint_data(bound_constraint);
                 let bound_typevar = bound_constraint_data.typevar;
-                let constrained_constraint_data = builder.constraint_data(constrained_constraint);
+                let constrained_constraint_data = storage.constraint_data(constrained_constraint);
                 let constrained_typevar = constrained_constraint_data.typevar;
 
                 // We then look for cases where the "constrained" typevar's upper and/or lower
@@ -4657,7 +4714,7 @@ impl InteriorNode {
 
                 let new_constraint = ConstraintId::new_with_bounds(
                     db,
-                    builder,
+                    storage,
                     constrained_typevar,
                     new_lower,
                     new_upper,
@@ -4665,14 +4722,14 @@ impl InteriorNode {
                 if seen_constraints.contains(&new_constraint) {
                     continue;
                 }
-                let (new_node, _) = Node::new_constraint(builder, new_constraint);
+                let (new_node, _) = Node::new_constraint(storage, new_constraint);
                 let (positive_left_node, _) =
-                    Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                    Node::new_satisfied_constraint(storage, left_constraint.when_true());
                 let (positive_right_node, _) =
-                    Node::new_satisfied_constraint(builder, right_constraint.when_true());
-                let lhs = positive_left_node.and(builder, positive_right_node);
-                let intersection = new_node.ite(builder, lhs, ALWAYS_FALSE);
-                simplified = simplified.and(builder, intersection);
+                    Node::new_satisfied_constraint(storage, right_constraint.when_true());
+                let lhs = positive_left_node.and(storage, positive_right_node);
+                let intersection = new_node.ite(storage, lhs, ALWAYS_FALSE);
+                simplified = simplified.and(storage, intersection);
                 continue;
             }
 
@@ -4703,23 +4760,23 @@ impl InteriorNode {
 
             // Containment: The range of one constraint might completely contain the range of the
             // other. If so, there are several potential simplifications.
-            let larger_smaller = if left_constraint.implies(db, builder, right_constraint) {
+            let larger_smaller = if left_constraint.implies(db, storage, right_constraint) {
                 Some((right_constraint, left_constraint))
-            } else if right_constraint.implies(db, builder, left_constraint) {
+            } else if right_constraint.implies(db, storage, left_constraint) {
                 Some((left_constraint, right_constraint))
             } else {
                 None
             };
             if let Some((larger_constraint, smaller_constraint)) = larger_smaller {
                 let (positive_larger_node, _) =
-                    Node::new_satisfied_constraint(builder, larger_constraint.when_true());
+                    Node::new_satisfied_constraint(storage, larger_constraint.when_true());
                 let (negative_larger_node, _) =
-                    Node::new_satisfied_constraint(builder, larger_constraint.when_false());
+                    Node::new_satisfied_constraint(storage, larger_constraint.when_false());
 
                 // larger ∨ smaller = larger
                 simplified = simplified.substitute_union(
                     db,
-                    builder,
+                    storage,
                     larger_constraint.when_true(),
                     smaller_constraint.when_true(),
                     positive_larger_node,
@@ -4728,7 +4785,7 @@ impl InteriorNode {
                 // ¬larger ∧ ¬smaller = ¬larger
                 simplified = simplified.substitute_intersection(
                     db,
-                    builder,
+                    storage,
                     larger_constraint.when_false(),
                     smaller_constraint.when_false(),
                     negative_larger_node,
@@ -4738,7 +4795,7 @@ impl InteriorNode {
                 // (¬larger removes everything that's present in smaller)
                 simplified = simplified.substitute_intersection(
                     db,
-                    builder,
+                    storage,
                     larger_constraint.when_false(),
                     smaller_constraint.when_true(),
                     ALWAYS_FALSE,
@@ -4748,7 +4805,7 @@ impl InteriorNode {
                 // (larger fills in everything that's missing in ¬smaller)
                 simplified = simplified.substitute_union(
                     db,
-                    builder,
+                    storage,
                     larger_constraint.when_true(),
                     smaller_constraint.when_false(),
                     ALWAYS_TRUE,
@@ -4758,10 +4815,10 @@ impl InteriorNode {
             // There are some simplifications we can make when the intersection of the two
             // constraints is empty, and others that we can make when the intersection is
             // non-empty.
-            match left_constraint.intersect(db, builder, right_constraint) {
+            match left_constraint.intersect(db, storage, right_constraint) {
                 IntersectionResult::Simplified(intersection_constraint_data) => {
                     let intersection_constraint =
-                        builder.intern_constraint(db, intersection_constraint_data);
+                        storage.intern_constraint(db, intersection_constraint_data);
 
                     // If the intersection is non-empty, we need to create a new constraint to
                     // represent that intersection. We also need to add the new constraint to our
@@ -4774,28 +4831,28 @@ impl InteriorNode {
                         );
                     }
                     let (positive_intersection_node, _) = Node::new_satisfied_constraint(
-                        builder,
+                        storage,
                         intersection_constraint.when_true(),
                     );
                     let (negative_intersection_node, _) = Node::new_satisfied_constraint(
-                        builder,
+                        storage,
                         intersection_constraint.when_false(),
                     );
 
                     let (positive_left_node, _) =
-                        Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                        Node::new_satisfied_constraint(storage, left_constraint.when_true());
                     let (negative_left_node, _) =
-                        Node::new_satisfied_constraint(builder, left_constraint.when_false());
+                        Node::new_satisfied_constraint(storage, left_constraint.when_false());
 
                     let (positive_right_node, _) =
-                        Node::new_satisfied_constraint(builder, right_constraint.when_true());
+                        Node::new_satisfied_constraint(storage, right_constraint.when_true());
                     let (negative_right_node, _) =
-                        Node::new_satisfied_constraint(builder, right_constraint.when_false());
+                        Node::new_satisfied_constraint(storage, right_constraint.when_false());
 
                     // left ∧ right = intersection
                     simplified = simplified.substitute_intersection(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_true(),
                         right_constraint.when_true(),
                         positive_intersection_node,
@@ -4804,7 +4861,7 @@ impl InteriorNode {
                     // ¬left ∨ ¬right = ¬intersection
                     simplified = simplified.substitute_union(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_false(),
                         right_constraint.when_false(),
                         negative_intersection_node,
@@ -4813,43 +4870,47 @@ impl InteriorNode {
                     // left ∧ ¬right = left ∧ ¬intersection
                     // (clip the negative constraint to the smallest range that actually removes
                     // something from positive constraint)
+                    let replacement = positive_left_node.and(storage, negative_intersection_node);
                     simplified = simplified.substitute_intersection(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_true(),
                         right_constraint.when_false(),
-                        positive_left_node.and(builder, negative_intersection_node),
+                        replacement,
                     );
 
                     // ¬left ∧ right = ¬intersection ∧ right
                     // (save as above but reversed)
+                    let replacement = positive_right_node.and(storage, negative_intersection_node);
                     simplified = simplified.substitute_intersection(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_false(),
                         right_constraint.when_true(),
-                        positive_right_node.and(builder, negative_intersection_node),
+                        replacement,
                     );
 
                     // left ∨ ¬right = intersection ∨ ¬right
                     // (clip the positive constraint to the smallest range that actually adds
                     // something to the negative constraint)
+                    let replacement = negative_right_node.or(storage, positive_intersection_node);
                     simplified = simplified.substitute_union(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_true(),
                         right_constraint.when_false(),
-                        negative_right_node.or(builder, positive_intersection_node),
+                        replacement,
                     );
 
                     // ¬left ∨ right = ¬left ∨ intersection
                     // (save as above but reversed)
+                    let replacement = negative_left_node.or(storage, positive_intersection_node);
                     simplified = simplified.substitute_union(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_false(),
                         right_constraint.when_true(),
-                        negative_left_node.or(builder, positive_intersection_node),
+                        replacement,
                     );
                 }
 
@@ -4862,14 +4923,14 @@ impl InteriorNode {
                     // and right is empty.
 
                     let (positive_left_node, _) =
-                        Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                        Node::new_satisfied_constraint(storage, left_constraint.when_true());
                     let (positive_right_node, _) =
-                        Node::new_satisfied_constraint(builder, right_constraint.when_true());
+                        Node::new_satisfied_constraint(storage, right_constraint.when_true());
 
                     // left ∧ right = false
                     simplified = simplified.substitute_intersection(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_true(),
                         right_constraint.when_true(),
                         ALWAYS_FALSE,
@@ -4878,7 +4939,7 @@ impl InteriorNode {
                     // ¬left ∨ ¬right = true
                     simplified = simplified.substitute_union(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_false(),
                         right_constraint.when_false(),
                         ALWAYS_TRUE,
@@ -4888,7 +4949,7 @@ impl InteriorNode {
                     // (there is nothing in the hole of ¬right that overlaps with left)
                     simplified = simplified.substitute_intersection(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_true(),
                         right_constraint.when_false(),
                         positive_left_node,
@@ -4898,7 +4959,7 @@ impl InteriorNode {
                     // (save as above but reversed)
                     simplified = simplified.substitute_intersection(
                         db,
-                        builder,
+                        storage,
                         left_constraint.when_false(),
                         right_constraint.when_true(),
                         positive_right_node,
@@ -4907,7 +4968,6 @@ impl InteriorNode {
             }
         }
 
-        let mut storage = builder.storage.borrow_mut();
         storage.simplify_cache.insert(key, simplified);
         simplified
     }
@@ -4974,7 +5034,7 @@ impl ConstraintAssignment {
     fn implies<'db>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         other: Self,
     ) -> bool {
         match (self, other) {
@@ -4986,7 +5046,7 @@ impl ConstraintAssignment {
             (
                 ConstraintAssignment::Positive(self_constraint),
                 ConstraintAssignment::Positive(other_constraint),
-            ) => self_constraint.implies(db, builder, other_constraint),
+            ) => self_constraint.implies(db, storage, other_constraint),
 
             // For two negative constraints, one range has to fully contain the other; the ranges
             // represent "holes", though, so the constraint with the larger range implies the one
@@ -4997,7 +5057,7 @@ impl ConstraintAssignment {
             (
                 ConstraintAssignment::Negative(self_constraint),
                 ConstraintAssignment::Negative(other_constraint),
-            ) => other_constraint.implies(db, builder, self_constraint),
+            ) => other_constraint.implies(db, storage, self_constraint),
 
             // For a positive and negative constraint, the ranges have to be disjoint, and the
             // positive range implies the negative range.
@@ -5008,7 +5068,7 @@ impl ConstraintAssignment {
                 ConstraintAssignment::Positive(self_constraint),
                 ConstraintAssignment::Negative(other_constraint),
             ) => self_constraint
-                .intersect(db, builder, other_constraint)
+                .intersect(db, storage, other_constraint)
                 .is_disjoint(),
 
             // It's theoretically possible for a negative constraint to imply a positive constraint
@@ -5033,11 +5093,11 @@ impl ConstraintAssignment {
         }
     }
 
-    fn display<'db>(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> impl Display {
+    fn display<'db>(self, db: &'db dyn Db, storage: &ConstraintSetStorage<'db>) -> impl Display {
         struct DisplayConstraintAssignment<'db, 'c> {
             assignment: ConstraintAssignment,
             db: &'db dyn Db,
-            builder: &'c ConstraintSetBuilder<'db>,
+            storage: &'c ConstraintSetStorage<'db>,
         }
 
         impl DisplayConstraintAssignment<'_, '_> {
@@ -5060,7 +5120,7 @@ impl ConstraintAssignment {
 
         impl Display for DisplayConstraintAssignment<'_, '_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let constraint_data = self.builder.constraint_data(self.assignment.constraint());
+                let constraint_data = self.storage.constraint_data(self.assignment.constraint());
                 let lower = constraint_data.bounds.materialized_lower();
                 let upper = constraint_data.bounds.materialized_upper();
                 let typevar = constraint_data.typevar;
@@ -5113,7 +5173,7 @@ impl ConstraintAssignment {
         DisplayConstraintAssignment {
             assignment: self,
             db,
-            builder,
+            storage,
         }
     }
 }
@@ -5187,30 +5247,21 @@ impl SequentMap {
     /// constraint.
     fn for_constraint<'db, 'c>(
         db: &'db dyn Db,
-        builder: &'c ConstraintSetBuilder<'db>,
+        storage: &'c mut ConstraintSetStorage<'db>,
         constraint: ConstraintId,
-    ) -> Ref<'c, Self> {
+    ) -> &'c Self {
         let key = constraint;
-        let storage = builder.storage.borrow();
-        if let Ok(map) = Ref::filter_map(storage, |storage| storage.single_sequent_cache.get(&key))
-        {
-            return map;
+        if !storage.single_sequent_cache.contains_key(&key) {
+            tracing::trace!(
+                target: "ty_python_semantic::types::constraints::SequentMap",
+                constraint = %constraint.display(db, storage),
+                "add sequents for constraint",
+            );
+            let mut map = SequentMap::default();
+            map.add_sequents_for_single(db, storage, constraint);
+            storage.single_sequent_cache.insert(key, map);
         }
-
-        tracing::trace!(
-            target: "ty_python_semantic::types::constraints::SequentMap",
-            constraint = %constraint.display(db, builder),
-            "add sequents for constraint",
-        );
-        let mut map = SequentMap::default();
-        map.add_sequents_for_single(db, builder, constraint);
-
-        let mut storage = builder.storage.borrow_mut();
-        storage.single_sequent_cache.insert(key, map);
-        drop(storage);
-
-        let storage = builder.storage.borrow();
-        Ref::map(storage, |storage| &storage.single_sequent_cache[&key])
+        &storage.single_sequent_cache[&key]
     }
 
     /// Returns a sequent map containing the sequents that we can infer from a pair of constraints.
@@ -5221,31 +5272,23 @@ impl SequentMap {
     /// that retain that ordering.)
     fn for_constraint_pair<'db, 'c>(
         db: &'db dyn Db,
-        builder: &'c ConstraintSetBuilder<'db>,
+        storage: &'c mut ConstraintSetStorage<'db>,
         left: ConstraintId,
         right: ConstraintId,
-    ) -> Ref<'c, Self> {
+    ) -> &'c Self {
         let key = (left, right);
-        let storage = builder.storage.borrow();
-        if let Ok(map) = Ref::filter_map(storage, |storage| storage.pair_sequent_cache.get(&key)) {
-            return map;
+        if !storage.pair_sequent_cache.contains_key(&key) {
+            tracing::trace!(
+                target: "ty_python_semantic::types::constraints::SequentMap",
+                left = %left.display(db, storage),
+                right = %right.display(db, storage),
+                "add sequents for constraint pair",
+            );
+            let mut map = SequentMap::default();
+            map.add_sequents_for_pair(db, storage, left, right);
+            storage.pair_sequent_cache.insert(key, map);
         }
-
-        tracing::trace!(
-            target: "ty_python_semantic::types::constraints::SequentMap",
-            left = %left.display(db, builder),
-            right = %right.display(db, builder),
-            "add sequents for constraint pair",
-        );
-        let mut map = SequentMap::default();
-        map.add_sequents_for_pair(db, builder, left, right);
-
-        let mut storage = builder.storage.borrow_mut();
-        storage.pair_sequent_cache.insert(key, map);
-        drop(storage);
-
-        let storage = builder.storage.borrow();
-        Ref::map(storage, |storage| &storage.pair_sequent_cache[&key])
+        &storage.pair_sequent_cache[&key]
     }
 
     /// Quickly determines whether two constraints cannot possibly produce any sequents when passed
@@ -5253,7 +5296,7 @@ impl SequentMap {
     /// to skip calling `for_constraint_pair` for this pair of constraints.
     fn pair_cannot_produce_sequents<'db>(
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         left: ConstraintId,
         right: ConstraintId,
     ) -> bool {
@@ -5263,8 +5306,8 @@ impl SequentMap {
         // single constraint; we always break that apart into the two smaller constraints that we
         // started with.
 
-        let left = builder.constraint_data(left);
-        let right = builder.constraint_data(right);
+        let left = storage.constraint_data(left);
+        let right = storage.constraint_data(right);
         if !left.typevar.is_same_typevar_as(db, right.typevar) {
             return false;
         }
@@ -5283,8 +5326,11 @@ impl SequentMap {
             return false;
         };
 
+        // This call might need its own borrow of the builder's storage, so create a new builder
+        // that it can use.
+        let builder = ConstraintSetBuilder::new();
         left_lower
-            .when_trivially_disjoint_from(db, right_lower, builder, TypeVarSet::None)
+            .when_trivially_disjoint_from(db, right_lower, &builder, TypeVarSet::None)
             .is_trivially_always_satisfied()
     }
 
@@ -5300,27 +5346,27 @@ impl SequentMap {
     fn add_pair_implication<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         ante1: ConstraintId,
         ante2: ConstraintId,
         post: ConstraintId,
     ) {
         // If the post constraint is unsatisfiable, then the antecedents contradict each other.
-        let post_data = builder.constraint_data(post);
-        let when = builder.load(
+        let post_data = storage.constraint_data(post);
+        let (when, source_order) = storage.load(
             db,
             &post_data
                 .bounds
                 .materialized_lower()
                 .when_constraint_set_assignable_to_owned(db, post_data.bounds.materialized_upper()),
         );
-        if when.is_never_satisfied(db) {
+        if when.is_never_satisfied(db, storage, source_order) {
             self.add_pair_impossibility(ante1, ante2);
             return;
         }
 
         // If either antecedent implies the consequent on its own, this new sequent is redundant.
-        if ante1.implies(db, builder, post) || ante2.implies(db, builder, post) {
+        if ante1.implies(db, storage, post) || ante2.implies(db, storage, post) {
             return;
         }
 
@@ -5340,12 +5386,12 @@ impl SequentMap {
     fn add_sequents_for_single<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         constraint: ConstraintId,
     ) {
         // If this constraint binds its typevar to `Never ≤ T ≤ object`, then the typevar can take
         // on any type, and the constraint is always satisfied.
-        let constraint_data = builder.constraint_data(constraint);
+        let constraint_data = storage.constraint_data(constraint);
         let lower = constraint_data.bounds.materialized_lower();
         let upper = constraint_data.bounds.materialized_upper();
         if lower.is_never() && upper.is_object() {
@@ -5397,21 +5443,24 @@ impl SequentMap {
             return;
         }
 
-        let when = builder.load(
+        let (when, source_order) = storage.load(
             db,
             &lower.when_constraint_set_assignable_to_owned(db, upper),
         );
 
         // If L is _never_ assignable to U, this constraint would violate transitivity, and should
         // never have been added.
-        debug_assert!(!when.is_never_satisfied(db));
+        #[expect(clippy::debug_assert_with_mut_call)]
+        {
+            debug_assert!(!when.is_never_satisfied(db, storage, source_order));
+        }
 
         // Fast path: If L is trivially always assignable to U, there are no derived constraints
         // that we can infer. This would be handled correctly by the logic below, but this is a
         // useful early return. Since we only use this check as an early return happy path, we can
         // accept false negatives. That lets us use the simpler and cheaper check against
         // ALWAYS_TRUE, rather than a more expensive is_always_satisfiable call.
-        if when.node == ALWAYS_TRUE {
+        if when == ALWAYS_TRUE {
             return;
         }
 
@@ -5447,8 +5496,8 @@ impl SequentMap {
         // it once for _every_ root→always path in the BDD. (That would require resetting the
         // PathAssignments state for each of those paths, which is why the logic would have to
         // move.)
-        let mut node = when.node;
-        if !node.is_single_conjunction(builder) {
+        let mut node = when;
+        if !node.is_single_conjunction(storage) {
             return;
         }
 
@@ -5456,7 +5505,7 @@ impl SequentMap {
             match node.node() {
                 Node::AlwaysTrue | Node::AlwaysFalse => break,
                 Node::Interior(interior) => {
-                    let interior = builder.interior_node_data(interior.node());
+                    let interior = storage.interior_node_data(interior.node());
                     if interior.if_true != ALWAYS_FALSE {
                         self.add_single_implication(constraint, interior.constraint);
                         node = interior.if_true;
@@ -5472,7 +5521,7 @@ impl SequentMap {
     fn add_sequents_for_pair<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
     ) {
@@ -5497,19 +5546,19 @@ impl SequentMap {
         //
         // If all of the lower and upper bounds are concrete (i.e., not typevars), then there
         // several _other_ sequents that we can add, as handled by `add_concrete_sequents`.
-        let left_constraint_data = builder.constraint_data(left_constraint);
+        let left_constraint_data = storage.constraint_data(left_constraint);
         let left_typevar = left_constraint_data.typevar;
-        let right_constraint_data = builder.constraint_data(right_constraint);
+        let right_constraint_data = storage.constraint_data(right_constraint);
         let right_typevar = right_constraint_data.typevar;
 
         if !left_typevar.is_same_typevar_as(db, right_typevar) {
             self.add_mutual_sequents_for_different_typevars(
                 db,
-                builder,
+                storage,
                 left_constraint,
                 right_constraint,
             );
-            self.add_nested_typevar_sequents(db, builder, left_constraint, right_constraint);
+            self.add_nested_typevar_sequents(db, storage, left_constraint, right_constraint);
         } else if left_constraint_data
             .bounds
             .lower
@@ -5529,19 +5578,19 @@ impl SequentMap {
         {
             self.add_mutual_sequents_for_same_typevars(
                 db,
-                builder,
+                storage,
                 left_constraint,
                 right_constraint,
             );
         } else {
-            self.add_concrete_sequents(db, builder, left_constraint, right_constraint);
+            self.add_concrete_sequents(db, storage, left_constraint, right_constraint);
         }
     }
 
     fn add_mutual_sequents_for_different_typevars<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
     ) {
@@ -5550,12 +5599,12 @@ impl SequentMap {
         // we only have to check this pair of constraints in one direction — though we do
         // have to figure out which of the two typevars is constrained, and which one is
         // the upper/lower bound.
-        let left_constraint_data = builder.constraint_data(left_constraint);
+        let left_constraint_data = storage.constraint_data(left_constraint);
         let left_typevar = left_constraint_data.typevar;
-        let right_constraint_data = builder.constraint_data(right_constraint);
+        let right_constraint_data = storage.constraint_data(right_constraint);
         let right_typevar = right_constraint_data.typevar;
         let (bound_constraint, constrained_constraint) =
-            if left_typevar.can_be_bound_for(db, builder, right_typevar) {
+            if left_typevar.can_be_bound_for(db, storage, right_typevar) {
                 (left_constraint, right_constraint)
             } else {
                 (right_constraint, left_constraint)
@@ -5565,9 +5614,9 @@ impl SequentMap {
         // matches the "bound" typevar. If so, we're going to add an implication sequent that
         // replaces the upper/lower bound that matched with the bound constraint's corresponding
         // bound.
-        let bound_constraint_data = builder.constraint_data(bound_constraint);
+        let bound_constraint_data = storage.constraint_data(bound_constraint);
         let bound_typevar = bound_constraint_data.typevar;
-        let constrained_constraint_data = builder.constraint_data(constrained_constraint);
+        let constrained_constraint_data = storage.constraint_data(constrained_constraint);
         let constrained_typevar = constrained_constraint_data.typevar;
 
         // Transitive pivots require subtyping; classes with dynamic bases can be assignable to
@@ -5611,7 +5660,7 @@ impl SequentMap {
             (constrained_lower, Some(constrained_upper), Some(bound_lower), _)
                 if !constrained_upper.is_never()
                     && !constrained_upper.is_object()
-                    && builder.cached_is_constraint_set_subtype_of(
+                    && storage.cached_is_constraint_set_subtype_of(
                         db,
                         constrained_upper.top_materialization(db),
                         bound_lower.bottom_materialization(db),
@@ -5624,7 +5673,7 @@ impl SequentMap {
             (Some(constrained_lower), constrained_upper, _, Some(bound_upper))
                 if !constrained_lower.is_never()
                     && !constrained_lower.is_object()
-                    && builder.cached_is_constraint_set_subtype_of(
+                    && storage.cached_is_constraint_set_subtype_of(
                         db,
                         bound_upper.top_materialization(db),
                         constrained_lower.bottom_materialization(db),
@@ -5660,11 +5709,11 @@ impl SequentMap {
         //   `(Never ≤ [A] ≤ T)` and `(T ≤ [B] ≤ object)`.
         // This preserves the relationship while keeping all derived constraints canonical.
         if let Some(Type::TypeVar(lower_bound_typevar)) = new_lower
-            && !lower_bound_typevar.can_be_bound_for(db, builder, constrained_typevar)
+            && !lower_bound_typevar.can_be_bound_for(db, storage, constrained_typevar)
         {
             post_constraints.push(ConstraintId::new_with_bounds(
                 db,
-                builder,
+                storage,
                 lower_bound_typevar,
                 None,
                 Some(Type::TypeVar(constrained_typevar)),
@@ -5673,11 +5722,11 @@ impl SequentMap {
         }
 
         if let Some(Type::TypeVar(upper_bound_typevar)) = new_upper
-            && !upper_bound_typevar.can_be_bound_for(db, builder, constrained_typevar)
+            && !upper_bound_typevar.can_be_bound_for(db, storage, constrained_typevar)
         {
             post_constraints.push(ConstraintId::new_with_bounds(
                 db,
-                builder,
+                storage,
                 upper_bound_typevar,
                 Some(Type::TypeVar(constrained_typevar)),
                 None,
@@ -5690,7 +5739,7 @@ impl SequentMap {
         {
             post_constraints.push(ConstraintId::new_with_bounds(
                 db,
-                builder,
+                storage,
                 constrained_typevar,
                 constrained_lower,
                 constrained_upper,
@@ -5700,7 +5749,7 @@ impl SequentMap {
         for post_constraint in post_constraints {
             self.add_pair_implication(
                 db,
-                builder,
+                storage,
                 left_constraint,
                 right_constraint,
                 post_constraint,
@@ -5720,7 +5769,7 @@ impl SequentMap {
     fn add_nested_typevar_sequents<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
     ) {
@@ -5733,18 +5782,18 @@ impl SequentMap {
                     .upper
                     .is_some_and(|bound| any_over_type(db, bound, true, Type::is_type_var))
         };
-        if !has_typevar_bound(builder.constraint_data(left_constraint).bounds)
-            && !has_typevar_bound(builder.constraint_data(right_constraint).bounds)
+        if !has_typevar_bound(storage.constraint_data(left_constraint).bounds)
+            && !has_typevar_bound(storage.constraint_data(right_constraint).bounds)
         {
             return;
         }
 
         let mut try_tightening =
             |bound_constraint: ConstraintId, constrained_constraint: ConstraintId| {
-                let bound_data = builder.constraint_data(bound_constraint);
+                let bound_data = storage.constraint_data(bound_constraint);
                 let bound_typevar = bound_data.typevar;
                 let bound_identity = bound_typevar.identity(db);
-                let constrained_data = builder.constraint_data(constrained_constraint);
+                let constrained_data = storage.constraint_data(constrained_constraint);
                 let constrained_typevar = constrained_data.typevar;
                 let constrained_identity = constrained_typevar.identity(db);
                 let constrained_lower = constrained_data.bounds.materialized_lower();
@@ -5821,14 +5870,14 @@ impl SequentMap {
                     if new_upper != constrained_upper {
                         let post = ConstraintId::new_with_bounds(
                             db,
-                            builder,
+                            storage,
                             constrained_typevar,
                             constrained_data.bounds.lower,
                             Some(new_upper),
                         );
                         self.add_pair_implication(
                             db,
-                            builder,
+                            storage,
                             bound_constraint,
                             constrained_constraint,
                             post,
@@ -5882,14 +5931,14 @@ impl SequentMap {
                     if new_lower != constrained_lower {
                         let post = ConstraintId::new_with_bounds(
                             db,
-                            builder,
+                            storage,
                             constrained_typevar,
                             Some(new_lower),
                             constrained_data.bounds.upper,
                         );
                         self.add_pair_implication(
                             db,
-                            builder,
+                            storage,
                             bound_constraint,
                             constrained_constraint,
                             post,
@@ -5924,10 +5973,10 @@ impl SequentMap {
         // bound constraint's typevar.
         let mut try_weakening =
             |bound_constraint: ConstraintId, constrained_constraint: ConstraintId| {
-                let bound_data = builder.constraint_data(bound_constraint);
+                let bound_data = storage.constraint_data(bound_constraint);
                 let bound_typevar = bound_data.typevar;
                 let bound_lower = bound_data.bounds.materialized_lower();
-                let constrained_data = builder.constraint_data(constrained_constraint);
+                let constrained_data = storage.constraint_data(constrained_constraint);
                 let constrained_typevar = constrained_data.typevar;
                 let constrained_lower = constrained_data.bounds.materialized_lower();
                 let constrained_upper = constrained_data.bounds.materialized_upper();
@@ -5975,14 +6024,14 @@ impl SequentMap {
                         if new_upper != constrained_upper {
                             let post = ConstraintId::new_with_bounds(
                                 db,
-                                builder,
+                                storage,
                                 constrained_typevar,
                                 constrained_data.bounds.lower,
                                 Some(new_upper),
                             );
                             self.add_pair_implication(
                                 db,
-                                builder,
+                                storage,
                                 bound_constraint,
                                 constrained_constraint,
                                 post,
@@ -6013,14 +6062,14 @@ impl SequentMap {
                         if new_lower != constrained_lower {
                             let post = ConstraintId::new_with_bounds(
                                 db,
-                                builder,
+                                storage,
                                 constrained_typevar,
                                 Some(new_lower),
                                 constrained_data.bounds.upper,
                             );
                             self.add_pair_implication(
                                 db,
-                                builder,
+                                storage,
                                 bound_constraint,
                                 constrained_constraint,
                                 post,
@@ -6048,19 +6097,19 @@ impl SequentMap {
     fn add_mutual_sequents_for_same_typevars<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
     ) {
         let mut try_one_direction =
             |left_constraint: ConstraintId, right_constraint: ConstraintId| {
-                let left_constraint_data = builder.constraint_data(left_constraint);
+                let left_constraint_data = storage.constraint_data(left_constraint);
                 let left_lower = left_constraint_data.bounds.lower;
                 let left_upper = left_constraint_data.bounds.upper;
-                let right_constraint_data = builder.constraint_data(right_constraint);
+                let right_constraint_data = storage.constraint_data(right_constraint);
                 let right_lower = right_constraint_data.bounds.lower;
                 let right_upper = right_constraint_data.bounds.upper;
-                let new_constraints =
+                let mut new_constraints =
                     |bound_typevar: BoundTypeVarInstance<'db>,
                      mut right_lower: Option<Type<'db>>,
                      mut right_upper: Option<Type<'db>>| {
@@ -6088,11 +6137,11 @@ impl SequentMap {
                         let mut constrained_upper = right_upper.filter(|upper| !upper.is_object());
 
                         if let Some(Type::TypeVar(lower_bound_typevar)) = right_lower
-                            && !lower_bound_typevar.can_be_bound_for(db, builder, bound_typevar)
+                            && !lower_bound_typevar.can_be_bound_for(db, storage, bound_typevar)
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
                                 db,
-                                builder,
+                                storage,
                                 lower_bound_typevar,
                                 None,
                                 Some(Type::TypeVar(bound_typevar)),
@@ -6101,11 +6150,11 @@ impl SequentMap {
                         }
 
                         if let Some(Type::TypeVar(upper_bound_typevar)) = right_upper
-                            && !upper_bound_typevar.can_be_bound_for(db, builder, bound_typevar)
+                            && !upper_bound_typevar.can_be_bound_for(db, storage, bound_typevar)
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
                                 db,
-                                builder,
+                                storage,
                                 upper_bound_typevar,
                                 Some(Type::TypeVar(bound_typevar)),
                                 None,
@@ -6118,7 +6167,7 @@ impl SequentMap {
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
                                 db,
-                                builder,
+                                storage,
                                 bound_typevar,
                                 constrained_lower,
                                 constrained_upper,
@@ -6145,7 +6194,7 @@ impl SequentMap {
                 for post_constraint in post_constraints {
                     self.add_pair_implication(
                         db,
-                        builder,
+                        storage,
                         left_constraint,
                         right_constraint,
                         post_constraint,
@@ -6160,7 +6209,7 @@ impl SequentMap {
     fn add_concrete_sequents<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
     ) {
@@ -6169,39 +6218,39 @@ impl SequentMap {
         // identify constraints that are identical besides e.g. ordering of union/intersection
         // elements. (For instance, when processing `T ≤ τ₁ & τ₂` and `T ≤ τ₂ & τ₁`, these clauses
         // would add sequents for `(T ≤ τ₁ & τ₂) → (T ≤ τ₂ & τ₁)` and vice versa.)
-        if builder.cached_constraint_implies(db, left_constraint, right_constraint) {
+        if storage.cached_constraint_implies(db, left_constraint, right_constraint) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::SequentMap",
-                left = %left_constraint.display(db, builder),
-                right = %right_constraint.display(db, builder),
+                left = %left_constraint.display(db, storage),
+                right = %right_constraint.display(db, storage),
                 "left implies right",
             );
             self.add_single_implication(left_constraint, right_constraint);
         }
-        if builder.cached_constraint_implies(db, right_constraint, left_constraint) {
+        if storage.cached_constraint_implies(db, right_constraint, left_constraint) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::SequentMap",
-                left = %left_constraint.display(db, builder),
-                right = %right_constraint.display(db, builder),
+                left = %left_constraint.display(db, storage),
+                right = %right_constraint.display(db, storage),
                 "right implies left",
             );
             self.add_single_implication(right_constraint, left_constraint);
         }
 
-        match left_constraint.intersect(db, builder, right_constraint) {
+        match left_constraint.intersect(db, storage, right_constraint) {
             IntersectionResult::Simplified(intersection_constraint_data) => {
                 let intersection_constraint =
-                    builder.intern_constraint(db, intersection_constraint_data);
+                    storage.intern_constraint(db, intersection_constraint_data);
                 tracing::trace!(
                     target: "ty_python_semantic::types::constraints::SequentMap",
-                    left = %left_constraint.display(db, builder),
-                    right = %right_constraint.display(db, builder),
-                    intersection = %intersection_constraint.display(db, builder),
+                    left = %left_constraint.display(db, storage),
+                    right = %right_constraint.display(db, storage),
+                    intersection = %intersection_constraint.display(db, storage),
                     "left and right overlap",
                 );
                 self.add_pair_implication(
                     db,
-                    builder,
+                    storage,
                     left_constraint,
                     right_constraint,
                     intersection_constraint,
@@ -6218,8 +6267,8 @@ impl SequentMap {
             IntersectionResult::Disjoint => {
                 tracing::trace!(
                     target: "ty_python_semantic::types::constraints::SequentMap",
-                    left = %left_constraint.display(db, builder),
-                    right = %right_constraint.display(db, builder),
+                    left = %left_constraint.display(db, storage),
+                    right = %right_constraint.display(db, storage),
                     "left and right are disjoint",
                 );
                 self.add_pair_impossibility(left_constraint, right_constraint);
@@ -6231,14 +6280,14 @@ impl SequentMap {
     fn display<'db, 'a>(
         &'a self,
         db: &'db dyn Db,
-        builder: &'a ConstraintSetBuilder<'db>,
+        storage: &'a ConstraintSetStorage<'db>,
         prefix: &'a dyn Display,
     ) -> impl Display + 'a {
         struct DisplaySequentMap<'a, 'db> {
             map: &'a SequentMap,
             prefix: &'a dyn Display,
             db: &'db dyn Db,
-            builder: &'a ConstraintSetBuilder<'db>,
+            storage: &'a ConstraintSetStorage<'db>,
         }
 
         impl Display for DisplaySequentMap<'_, '_> {
@@ -6262,8 +6311,8 @@ impl SequentMap {
                             write!(
                                 f,
                                 "{} ∧ {} → false",
-                                ante1.display(self.db, self.builder),
-                                ante2.display(self.db, self.builder),
+                                ante1.display(self.db, self.storage),
+                                ante2.display(self.db, self.storage),
                             )?;
                         }
 
@@ -6272,9 +6321,9 @@ impl SequentMap {
                             write!(
                                 f,
                                 "{} ∧ {} → {}",
-                                ante1.display(self.db, self.builder),
-                                ante2.display(self.db, self.builder),
-                                post.display(self.db, self.builder),
+                                ante1.display(self.db, self.storage),
+                                ante2.display(self.db, self.storage),
+                                post.display(self.db, self.storage),
                             )?;
                         }
 
@@ -6283,8 +6332,8 @@ impl SequentMap {
                             write!(
                                 f,
                                 "{} → {}",
-                                ante.display(self.db, self.builder),
-                                post.display(self.db, self.builder)
+                                ante.display(self.db, self.storage),
+                                post.display(self.db, self.storage)
                             )?;
                         }
                     }
@@ -6301,7 +6350,7 @@ impl SequentMap {
             map: self,
             prefix,
             db,
-            builder,
+            storage,
         }
     }
 }
@@ -6350,7 +6399,7 @@ trait PathVisitor {
     fn visit_satisfied<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result>;
 
@@ -6360,7 +6409,7 @@ trait PathVisitor {
     fn visit_unsatisfied<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result>;
 
@@ -6371,7 +6420,7 @@ trait PathVisitor {
     fn visit_impossible<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result>;
 
@@ -6382,7 +6431,7 @@ trait PathVisitor {
     fn enter_interior<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         interior_node: InteriorNode,
     ) -> ControlFlow<Self::Break, Self::Interior>;
 
@@ -6392,7 +6441,7 @@ trait PathVisitor {
     fn visit_edge<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         interior_value: &Self::Interior,
         subtree: Self::Result,
         path: &PathAssignments,
@@ -6404,7 +6453,7 @@ trait PathVisitor {
     fn leave_interior<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         interior_value: &Self::Interior,
         if_true: Self::Result,
         if_uncertain: Self::Result,
@@ -6425,7 +6474,7 @@ trait PathFold {
     fn satisfied<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result>;
 
@@ -6433,7 +6482,7 @@ trait PathFold {
     fn unsatisfied<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result>;
 
@@ -6441,7 +6490,7 @@ trait PathFold {
     fn impossible<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result>;
 
@@ -6450,7 +6499,7 @@ trait PathFold {
     fn combine<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         if_true: Self::Result,
         if_uncertain: Self::Result,
         if_false: Self::Result,
@@ -6468,34 +6517,34 @@ where
     fn visit_satisfied<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result> {
-        PathFold::satisfied(self, db, builder, path)
+        PathFold::satisfied(self, db, storage, path)
     }
 
     fn visit_unsatisfied<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result> {
-        PathFold::unsatisfied(self, db, builder, path)
+        PathFold::unsatisfied(self, db, storage, path)
     }
 
     fn visit_impossible<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result> {
-        PathFold::impossible(self, db, builder, path)
+        PathFold::impossible(self, db, storage, path)
     }
 
     fn enter_interior<'db>(
         &mut self,
         _db: &'db dyn Db,
-        _builder: &ConstraintSetBuilder<'db>,
+        _storage: &mut ConstraintSetStorage<'db>,
         _interior_node: InteriorNode,
     ) -> ControlFlow<Self::Break, Self::Interior> {
         ControlFlow::Continue(())
@@ -6504,7 +6553,7 @@ where
     fn visit_edge<'db>(
         &mut self,
         _db: &'db dyn Db,
-        _builder: &ConstraintSetBuilder<'db>,
+        _storage: &mut ConstraintSetStorage<'db>,
         _interior_value: &Self::Interior,
         subtree: Self::Result,
         _path: &PathAssignments,
@@ -6516,13 +6565,13 @@ where
     fn leave_interior<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         _interior_value: &Self::Interior,
         if_true: Self::Result,
         if_uncertain: Self::Result,
         if_false: Self::Result,
     ) -> ControlFlow<Self::Break, Self::Result> {
-        PathFold::combine(self, db, builder, if_true, if_uncertain, if_false)
+        PathFold::combine(self, db, storage, if_true, if_uncertain, if_false)
     }
 }
 
@@ -6538,7 +6587,7 @@ impl PathFold for IsNeverSatisfiedVisitor {
     fn satisfied<'db>(
         &mut self,
         _db: &'db dyn Db,
-        _builder: &ConstraintSetBuilder<'db>,
+        _storage: &mut ConstraintSetStorage<'db>,
         _path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result> {
         ControlFlow::Break(())
@@ -6547,7 +6596,7 @@ impl PathFold for IsNeverSatisfiedVisitor {
     fn unsatisfied<'db>(
         &mut self,
         _db: &'db dyn Db,
-        _builder: &ConstraintSetBuilder<'db>,
+        _storage: &mut ConstraintSetStorage<'db>,
         _path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result> {
         ControlFlow::Continue(())
@@ -6556,7 +6605,7 @@ impl PathFold for IsNeverSatisfiedVisitor {
     fn impossible<'db>(
         &mut self,
         _db: &'db dyn Db,
-        _builder: &ConstraintSetBuilder<'db>,
+        _storage: &mut ConstraintSetStorage<'db>,
         _path: &PathAssignments,
     ) -> ControlFlow<Self::Break, Self::Result> {
         ControlFlow::Continue(())
@@ -6565,7 +6614,7 @@ impl PathFold for IsNeverSatisfiedVisitor {
     fn combine<'db>(
         &mut self,
         _db: &'db dyn Db,
-        _builder: &ConstraintSetBuilder<'db>,
+        _storage: &mut ConstraintSetStorage<'db>,
         _if_true: Self::Result,
         _if_uncertain: Self::Result,
         _if_false: Self::Result,
@@ -6705,34 +6754,34 @@ impl PathAssignments {
     fn visit<'db, V>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         node: NodeId,
         visitor: &mut V,
     ) -> ControlFlow<V::Break, V::Result>
     where
         V: PathVisitor,
     {
-        self.visit_inner(db, builder, node, visitor, false)
+        self.visit_inner(db, storage, node, visitor, false)
     }
 
     /// Visits the paths of the negation of `node`, without constructing that negation eagerly.
     fn visit_negated<'db, V>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         node: NodeId,
         visitor: &mut V,
     ) -> ControlFlow<V::Break, V::Result>
     where
         V: PathVisitor,
     {
-        self.visit_inner(db, builder, node, visitor, true)
+        self.visit_inner(db, storage, node, visitor, true)
     }
 
     fn visit_inner<'db, V>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         node: NodeId,
         visitor: &mut V,
         negated: bool,
@@ -6741,35 +6790,35 @@ impl PathAssignments {
         V: PathVisitor,
     {
         match node.node() {
-            Node::AlwaysTrue if negated => visitor.visit_unsatisfied(db, builder, self),
-            Node::AlwaysTrue => visitor.visit_satisfied(db, builder, self),
+            Node::AlwaysTrue if negated => visitor.visit_unsatisfied(db, storage, self),
+            Node::AlwaysTrue => visitor.visit_satisfied(db, storage, self),
 
-            Node::AlwaysFalse if negated => visitor.visit_satisfied(db, builder, self),
-            Node::AlwaysFalse => visitor.visit_unsatisfied(db, builder, self),
+            Node::AlwaysFalse if negated => visitor.visit_satisfied(db, storage, self),
+            Node::AlwaysFalse => visitor.visit_unsatisfied(db, storage, self),
 
             Node::Interior(interior) => {
-                let interior_value = visitor.enter_interior(db, builder, interior)?;
-                let interior = builder.interior_node_data(node);
+                let interior_value = visitor.enter_interior(db, storage, interior)?;
+                let interior = storage.interior_node_data(node);
 
                 let true_subtree = if negated {
-                    interior.if_true.or(builder, interior.if_uncertain)
+                    interior.if_true.or(storage, interior.if_uncertain)
                 } else {
                     interior.if_true
                 };
                 let if_true = self.walk_edge(
                     db,
-                    builder,
+                    storage,
                     interior.constraint.when_true(),
-                    |path, new_range, found_conflict| {
+                    |storage, path, new_range, found_conflict| {
                         let subtree = if found_conflict {
-                            visitor.visit_impossible(db, builder, path)
+                            visitor.visit_impossible(db, storage, path)
                         } else {
-                            path.visit_inner(db, builder, true_subtree, visitor, negated)
+                            path.visit_inner(db, storage, true_subtree, visitor, negated)
                         };
                         match subtree {
                             ControlFlow::Continue(subtree) => visitor.visit_edge(
                                 db,
-                                builder,
+                                storage,
                                 &interior_value,
                                 subtree,
                                 path,
@@ -6781,23 +6830,23 @@ impl PathAssignments {
                 )?;
 
                 let if_uncertain = if negated {
-                    let subtree = visitor.visit_impossible(db, builder, self)?;
-                    visitor.visit_edge(db, builder, &interior_value, subtree, self, 0..0)?
+                    let subtree = visitor.visit_impossible(db, storage, self)?;
+                    visitor.visit_edge(db, storage, &interior_value, subtree, self, 0..0)?
                 } else {
                     self.walk_edge(
                         db,
-                        builder,
+                        storage,
                         interior.constraint.when_unconstrained(),
-                        |path, new_range, found_conflict| {
+                        |storage, path, new_range, found_conflict| {
                             let subtree = if found_conflict {
-                                visitor.visit_impossible(db, builder, path)
+                                visitor.visit_impossible(db, storage, path)
                             } else {
-                                path.visit_inner(db, builder, interior.if_uncertain, visitor, false)
+                                path.visit_inner(db, storage, interior.if_uncertain, visitor, false)
                             };
                             match subtree {
                                 ControlFlow::Continue(subtree) => visitor.visit_edge(
                                     db,
-                                    builder,
+                                    storage,
                                     &interior_value,
                                     subtree,
                                     path,
@@ -6810,24 +6859,24 @@ impl PathAssignments {
                 };
 
                 let false_subtree = if negated {
-                    interior.if_false.or(builder, interior.if_uncertain)
+                    interior.if_false.or(storage, interior.if_uncertain)
                 } else {
                     interior.if_false
                 };
                 let if_false = self.walk_edge(
                     db,
-                    builder,
+                    storage,
                     interior.constraint.when_false(),
-                    |path, new_range, found_conflict| {
+                    |storage, path, new_range, found_conflict| {
                         let subtree = if found_conflict {
-                            visitor.visit_impossible(db, builder, path)
+                            visitor.visit_impossible(db, storage, path)
                         } else {
-                            path.visit_inner(db, builder, false_subtree, visitor, negated)
+                            path.visit_inner(db, storage, false_subtree, visitor, negated)
                         };
                         match subtree {
                             ControlFlow::Continue(subtree) => visitor.visit_edge(
                                 db,
-                                builder,
+                                storage,
                                 &interior_value,
                                 subtree,
                                 path,
@@ -6840,7 +6889,7 @@ impl PathAssignments {
 
                 visitor.leave_interior(
                     db,
-                    builder,
+                    storage,
                     &interior_value,
                     if_true,
                     if_uncertain,
@@ -6875,9 +6924,9 @@ impl PathAssignments {
     fn walk_edge<'db, R>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         assignment: ConstraintAssignment,
-        f: impl FnOnce(&mut Self, Range<usize>, bool) -> R,
+        f: impl FnOnce(&mut ConstraintSetStorage<'db>, &mut Self, Range<usize>, bool) -> R,
     ) -> R {
         // Record a snapshot of the assignments that we already knew held — both so that we can
         // pass along the range of which assignments are new, and so that we can reset back to this
@@ -6892,10 +6941,10 @@ impl PathAssignments {
             before = %format_args!(
                 "[{}]",
                 self.assignments[..start].iter().map(|(assignment, _)| {
-                    assignment.display(db, builder)
+                    assignment.display(db, storage)
                 }).format(", "),
             ),
-            edge = %assignment.display(db, builder),
+            edge = %assignment.display(db, storage),
             "walk edge",
         );
         debug_assert!(self.assignment_queue.is_empty());
@@ -6903,7 +6952,7 @@ impl PathAssignments {
             .push_back((assignment, AssignmentFuel::origin()));
         let source_constraint = assignment.constraint();
         let found_conflict = self
-            .drain_assignment_queue(db, builder, source_constraint)
+            .drain_assignment_queue(db, storage, source_constraint)
             .is_err();
         if !found_conflict {
             tracing::trace!(
@@ -6911,7 +6960,7 @@ impl PathAssignments {
                 new = %format_args!(
                     "[{}]",
                     self.assignments[start..].iter().map(|(assignment, _)| {
-                        assignment.display(db, builder)
+                        assignment.display(db, storage)
                     }).format(", "),
                 ),
                 "new assignments",
@@ -6923,7 +6972,7 @@ impl PathAssignments {
         // `add_assignment` call above — that is, the new assignment for this edge along with
         // the derived information we inferred from it.
         let end = self.assignments.len();
-        let result = f(self, start..end, found_conflict);
+        let result = f(storage, self, start..end, found_conflict);
 
         // Reset back to where we were before following this edge, so that the caller can reuse a
         // single instance for the entire BDD traversal.
@@ -6977,7 +7026,7 @@ impl PathAssignments {
     fn discover_constraint<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         constraint: ConstraintId,
     ) {
         // If we've already processed this constraint, we can skip it.
@@ -6987,16 +7036,15 @@ impl PathAssignments {
             return;
         }
 
-        let single_map = SequentMap::for_constraint(db, builder, constraint);
+        let single_map = SequentMap::for_constraint(db, storage, constraint);
         self.sequents.extend_from_slice(&single_map.sequents);
-        drop(single_map);
 
         for (existing_index, (existing, _)) in self.discovered.iter().enumerate() {
             if *existing == constraint {
                 continue;
             }
 
-            if SequentMap::pair_cannot_produce_sequents(db, builder, *existing, constraint) {
+            if SequentMap::pair_cannot_produce_sequents(db, storage, *existing, constraint) {
                 continue;
             }
 
@@ -7010,7 +7058,7 @@ impl PathAssignments {
                 continue;
             }
 
-            let pair_map = SequentMap::for_constraint_pair(db, builder, a, b);
+            let pair_map = SequentMap::for_constraint_pair(db, storage, a, b);
             self.sequents.extend_from_slice(&pair_map.sequents);
         }
     }
@@ -7018,11 +7066,11 @@ impl PathAssignments {
     fn drain_assignment_queue<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         source_constraint: ConstraintId,
     ) -> Result<(), PathAssignmentConflict> {
         while let Some((assignment, fuel)) = self.assignment_queue.pop_front() {
-            self.add_assignment(db, builder, assignment, source_constraint, fuel)?;
+            self.add_assignment(db, storage, assignment, source_constraint, fuel)?;
         }
         Ok(())
     }
@@ -7033,7 +7081,7 @@ impl PathAssignments {
     fn add_assignment<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         assignment: ConstraintAssignment,
         source_constraint: ConstraintId,
         fuel: AssignmentFuel,
@@ -7059,11 +7107,11 @@ impl PathAssignments {
         if self.assignments.contains_key(&assignment.negated()) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
-                assignment = %assignment.display(db, builder),
+                assignment = %assignment.display(db, storage),
                 facts = %format_args!(
                     "[{}]",
                     self.assignments.iter().map(|(assignment, _)| {
-                        assignment.display(db, builder)
+                        assignment.display(db, storage)
                     }).format(", "),
                 ),
                 "found contradiction",
@@ -7130,11 +7178,11 @@ impl PathAssignments {
         // brute-force search.
 
         self.new_assignments.clear();
-        self.discover_constraint(db, builder, assignment.constraint());
+        self.discover_constraint(db, storage, assignment.constraint());
 
         for i in 0..self.sequents.len() {
             let sequent = self.sequents[i];
-            self.check_sequent(db, builder, sequent)?;
+            self.check_sequent(db, storage, sequent)?;
         }
 
         // If we were able to derive any new assignments from this one, add them to the processing
@@ -7156,20 +7204,20 @@ impl PathAssignments {
     fn check_sequent<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         sequent: Sequent,
     ) -> Result<(), PathAssignmentConflict> {
         match sequent {
-            Sequent::SingleTautology { ante } => self.check_single_tautology(db, builder, ante),
+            Sequent::SingleTautology { ante } => self.check_single_tautology(db, storage, ante),
             Sequent::PairImpossibility { ante1, ante2 } => {
-                self.check_pair_impossibility(db, builder, ante1, ante2)
+                self.check_pair_impossibility(db, storage, ante1, ante2)
             }
             Sequent::PairImplication { ante1, ante2, post } => {
-                self.check_pair_implication(db, builder, ante1, ante2, post);
+                self.check_pair_implication(db, storage, ante1, ante2, post);
                 Ok(())
             }
             Sequent::SingleImplication { ante, post } => {
-                self.check_single_implication(db, builder, ante, post);
+                self.check_single_implication(db, storage, ante, post);
                 Ok(())
             }
         }
@@ -7178,7 +7226,7 @@ impl PathAssignments {
     fn check_single_tautology<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         ante: ConstraintId,
     ) -> Result<(), PathAssignmentConflict> {
         if self.assignment_holds(ante.when_false()) {
@@ -7186,11 +7234,11 @@ impl PathAssignments {
             // it's false.
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
-                ante = %ante.display(db, builder),
+                ante = %ante.display(db, storage),
                 facts = %format_args!(
                     "[{}]",
                     self.assignments.iter().map(|(assignment, _)| {
-                        assignment.display(db, builder)
+                        assignment.display(db, storage)
                     }).format(", "),
                 ),
                 "found contradiction",
@@ -7204,7 +7252,7 @@ impl PathAssignments {
     fn check_pair_impossibility<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         ante1: ConstraintId,
         ante2: ConstraintId,
     ) -> Result<(), PathAssignmentConflict> {
@@ -7213,12 +7261,12 @@ impl PathAssignments {
             // current path asserts that both are true.
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
-                ante1 = %ante1.display(db, builder),
-                ante2 = %ante2.display(db, builder),
+                ante1 = %ante1.display(db, storage),
+                ante2 = %ante2.display(db, storage),
                 facts = %format_args!(
                     "[{}]",
                     self.assignments.iter().map(|(assignment, _)| {
-                        assignment.display(db, builder)
+                        assignment.display(db, storage)
                     }).format(", "),
                 ),
                 "found contradiction",
@@ -7232,7 +7280,7 @@ impl PathAssignments {
     fn check_pair_implication<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         ante1: ConstraintId,
         ante2: ConstraintId,
         post: ConstraintId,
@@ -7244,10 +7292,10 @@ impl PathAssignments {
             return;
         };
         let available_fuel = ante1_fuel.min(ante2_fuel);
-        let (ante1_constructor_depth, _) = builder.cached_constraint_bound_depth(db, ante1);
-        let (ante2_constructor_depth, _) = builder.cached_constraint_bound_depth(db, ante2);
+        let (ante1_constructor_depth, _) = storage.cached_constraint_bound_depth(db, ante1);
+        let (ante2_constructor_depth, _) = storage.cached_constraint_bound_depth(db, ante2);
         let antecedent_constructor_depth = ante1_constructor_depth.max(ante2_constructor_depth);
-        let fuel_cost = builder.sequent_fuel_cost(db, post, antecedent_constructor_depth);
+        let fuel_cost = storage.sequent_fuel_cost(db, post, antecedent_constructor_depth);
         if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
             self.enqueue_assignment(
                 post.when_true(),
@@ -7259,20 +7307,20 @@ impl PathAssignments {
     fn check_single_implication<'db>(
         &mut self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         ante: ConstraintId,
         post: ConstraintId,
     ) {
         let Some(available_fuel) = self.max_remaining_fuel_for(ante.when_true()) else {
             return;
         };
-        let ante_data = builder.constraint_data(ante);
-        let (antecedent_constructor_depth, _) = builder.cached_constraint_bound_depth(db, ante);
-        let post_data = builder.constraint_data(post);
+        let ante_data = storage.constraint_data(ante);
+        let (antecedent_constructor_depth, _) = storage.cached_constraint_bound_depth(db, ante);
+        let post_data = storage.constraint_data(post);
         let fuel_cost = if post_data.is_bound_projection_of(db, ante_data) {
             1
         } else {
-            builder.sequent_fuel_cost(db, post, antecedent_constructor_depth)
+            storage.sequent_fuel_cost(db, post, antecedent_constructor_depth)
         };
         if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
             self.enqueue_assignment(
@@ -7330,7 +7378,7 @@ impl SatisfiedClause {
     /// want to remove the larger one and keep the smaller one.)
     ///
     /// Returns a boolean that indicates whether any simplifications were made.
-    fn simplify<'db>(&mut self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> bool {
+    fn simplify<'db>(&mut self, db: &'db dyn Db, storage: &mut ConstraintSetStorage<'db>) -> bool {
         let mut changes_made = false;
         let mut i = 0;
         // Loop through each constraint, comparing it with any constraints that appear later in the
@@ -7338,7 +7386,7 @@ impl SatisfiedClause {
         'outer: while i < self.constraints.len() {
             let mut j = i + 1;
             while j < self.constraints.len() {
-                if self.constraints[j].implies(db, builder, self.constraints[i]) {
+                if self.constraints[j].implies(db, storage, self.constraints[i]) {
                     // If constraint `i` is removed, then we don't need to compare it with any
                     // later constraints in the list. Note that we continue the outer loop, instead
                     // of breaking from the inner loop, so that we don't bump index `i` below.
@@ -7347,7 +7395,7 @@ impl SatisfiedClause {
                     self.constraints.swap_remove(i);
                     changes_made = true;
                     continue 'outer;
-                } else if self.constraints[i].implies(db, builder, self.constraints[j]) {
+                } else if self.constraints[i].implies(db, storage, self.constraints[j]) {
                     // If constraint `j` is removed, then we can continue the inner loop. We will
                     // swap a new element into place at index `j`, and will continue comparing the
                     // constraint at index `i` with later constraints.
@@ -7362,7 +7410,7 @@ impl SatisfiedClause {
         changes_made
     }
 
-    fn display<'db>(&self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> String {
+    fn display<'db>(&self, db: &'db dyn Db, storage: &ConstraintSetStorage<'db>) -> String {
         if self.constraints.is_empty() {
             return String::from("always");
         }
@@ -7373,7 +7421,7 @@ impl SatisfiedClause {
         let mut constraints: Vec<_> = self
             .constraints
             .iter()
-            .map(|constraint| constraint.display(db, builder).to_string())
+            .map(|constraint| constraint.display(db, storage).to_string())
             .collect();
         constraints.sort();
 
@@ -7409,11 +7457,11 @@ impl SatisfiedClauses {
     /// Simplifies the DNF representation, removing redundancies that do not change the underlying
     /// function. (This is used when displaying a BDD, to make sure that the representation that we
     /// show is as simple as possible while still producing the same results.)
-    fn simplify<'db>(&mut self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) {
+    fn simplify<'db>(&mut self, db: &'db dyn Db, storage: &mut ConstraintSetStorage<'db>) {
         // First simplify each clause individually, by removing constraints that are implied by
         // other constraints in the clause.
         for clause in &mut self.clauses {
-            clause.simplify(db, builder);
+            clause.simplify(db, storage);
         }
 
         while self.simplify_one_round() {
@@ -7485,7 +7533,7 @@ impl SatisfiedClauses {
         false
     }
 
-    fn display<'db>(&self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> String {
+    fn display<'db>(&self, db: &'db dyn Db, storage: &ConstraintSetStorage<'db>) -> String {
         // This is a bit heavy-handed, but we need to output the clauses in a consistent order
         // even though Salsa IDs are assigned non-deterministically. This Display output is only
         // used in test cases, so we don't need to over-optimize it.
@@ -7496,7 +7544,7 @@ impl SatisfiedClauses {
         let mut clauses: Vec<_> = self
             .clauses
             .iter()
-            .map(|clause| clause.display(db, builder))
+            .map(|clause| clause.display(db, storage))
             .collect();
         clauses.sort();
         clauses.join(" ∨ ")
@@ -7507,14 +7555,14 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// Returns the valid specializations of a typevar. This is used when checking a constraint set
     /// when this typevar is in inferable position, where we only need _some_ specialization to
     /// satisfy the constraint set.
-    fn valid_specializations<'c>(
+    fn valid_specializations(
         self,
         db: &'db dyn Db,
-        builder: &'c ConstraintSetBuilder<'db>,
-    ) -> ConstraintSet<'db, 'c> {
+        storage: &mut ConstraintSetStorage<'db>,
+    ) -> (NodeId, Option<SourceOrderId>) {
         if self.paramspec_attr(db).is_some() {
             // P.args and P.kwargs are variadic, and do not have an upper bound or constraints.
-            return ConstraintSet::always(builder);
+            return (ALWAYS_TRUE, None);
         }
 
         // For gradual upper bounds and constraints, we are free to choose any materialization that
@@ -7528,26 +7576,29 @@ impl<'db> BoundTypeVarInstance<'db> {
         // that _some_ valid specialization satisfies the constraint set, it's correct for us to
         // return the range of valid materializations that we can choose from.
         match self.typevar(db).bound_or_constraints(db) {
-            None => ConstraintSet::always(builder),
+            None => (ALWAYS_TRUE, None),
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 let bound = bound.top_materialization(db);
-                ConstraintSet::constrain_typevar_upper_bound(db, builder, self, bound)
+                Constraint::new_node_with_bounds(db, storage, self, None, Some(bound))
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                let mut specializations = ConstraintSet::never(builder);
+                let mut specializations = ALWAYS_FALSE;
+                let mut source_order = None;
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    let constraint = ConstraintSet::constrain_typevar(
+                    let (constraint, constraint_source_order) = Constraint::new_node_with_bounds(
                         db,
-                        builder,
+                        storage,
                         self,
-                        constraint_lower,
-                        constraint_upper,
+                        Some(constraint_lower),
+                        Some(constraint_upper),
                     );
-                    specializations.union(db, builder, constraint);
+                    specializations = specializations.or(storage, constraint);
+                    source_order =
+                        storage.ordered_source_order(source_order, constraint_source_order);
                 }
-                specializations
+                (specializations, source_order)
             }
         }
     }
@@ -7565,45 +7616,55 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// specifies the required specializations, and the iterator will be empty. For a constrained
     /// typevar, the primary result will include the fully static constraints, and the iterator
     /// will include an entry for each non-fully-static constraint.
-    fn required_specializations<'c>(
+    #[expect(clippy::type_complexity)]
+    fn required_specializations(
         self,
         db: &'db dyn Db,
-        builder: &'c ConstraintSetBuilder<'db>,
-    ) -> (ConstraintSet<'db, 'c>, Vec<ConstraintSet<'db, 'c>>) {
+        storage: &mut ConstraintSetStorage<'db>,
+    ) -> (
+        (NodeId, Option<SourceOrderId>),
+        Vec<(NodeId, Option<SourceOrderId>)>,
+    ) {
         // For upper bounds and constraints, we are free to choose any materialization that makes
         // the check succeed. In non-inferable positions, it is most helpful to choose a
         // materialization that is as restrictive as possible, since that minimizes the number of
         // valid specializations that must satisfy the check. We therefore take the bottom
         // materialization of the bound or constraints.
         match self.typevar(db).bound_or_constraints(db) {
-            None => (ConstraintSet::always(builder), Vec::new()),
+            None => ((ALWAYS_TRUE, None), Vec::new()),
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 let bound = bound.bottom_materialization(db);
                 (
-                    ConstraintSet::constrain_typevar_upper_bound(db, builder, self, bound),
+                    Constraint::new_node_with_bounds(db, storage, self, None, Some(bound)),
                     Vec::new(),
                 )
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                let mut non_gradual_constraints = ConstraintSet::never(builder);
+                let mut non_gradual_constraints = ALWAYS_FALSE;
+                let mut non_gradual_source_order = None;
                 let mut gradual_constraints = Vec::new();
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    let constraint = ConstraintSet::constrain_typevar(
+                    let constraint = Constraint::new_node_with_bounds(
                         db,
-                        builder,
+                        storage,
                         self,
-                        constraint_lower,
-                        constraint_upper,
+                        Some(constraint_lower),
+                        Some(constraint_upper),
                     );
                     if constraint_lower == constraint_upper {
-                        non_gradual_constraints.union(db, builder, constraint);
+                        non_gradual_constraints = non_gradual_constraints.or(storage, constraint.0);
+                        non_gradual_source_order =
+                            storage.ordered_source_order(non_gradual_source_order, constraint.1);
                     } else {
                         gradual_constraints.push(constraint);
                     }
                 }
-                (non_gradual_constraints, gradual_constraints)
+                (
+                    (non_gradual_constraints, non_gradual_source_order),
+                    gradual_constraints,
+                )
             }
         }
     }
@@ -7867,11 +7928,12 @@ mod tests {
             .map_bound_or_constraints(&db, |_| Some(TypeVarBoundOrConstraints::UpperBound(bool)));
         let type_of_u = SubclassOfType::from(&db, u);
         let bool_class = KnownClass::Bool.to_class_literal(&db);
-        let left = ConstraintId::new_with_bounds(&db, &builder, t, Some(type_of_u), None);
-        let right = ConstraintId::new_with_bounds(&db, &builder, t, Some(bool_class), None);
+        let mut storage = builder.storage.borrow_mut();
+        let left = ConstraintId::new_with_bounds(&db, &mut storage, t, Some(type_of_u), None);
+        let right = ConstraintId::new_with_bounds(&db, &mut storage, t, Some(bool_class), None);
 
         for (left, right) in [(left, right), (right, left)] {
-            let sequents = SequentMap::for_constraint_pair(&db, &builder, left, right);
+            let sequents = SequentMap::for_constraint_pair(&db, &mut storage, left, right);
 
             assert!(
                 sequents
@@ -7880,7 +7942,10 @@ mod tests {
                     .any(|sequent| matches!(sequent, Sequent::SingleImplication { .. }))
             );
             assert!(!SequentMap::pair_cannot_produce_sequents(
-                &db, &builder, left, right
+                &db,
+                &mut storage,
+                left,
+                right
             ));
         }
     }
@@ -8018,14 +8083,16 @@ mod tests {
         let bytearray = known_instance(&db, KnownClass::Bytearray);
         let int_or_str = UnionType::from_two_elements(&db, int, str);
         let bytes_or_bytearray = UnionType::from_two_elements(&db, bytes, bytearray);
-        let left = ConstraintId::new_with_bounds(&db, &builder, t, Some(int), Some(int_or_str));
-        let right = ConstraintId::new_with_bounds(&db, &builder, t, None, Some(bytes_or_bytearray));
+        let mut storage = builder.storage.borrow_mut();
+        let left = ConstraintId::new_with_bounds(&db, &mut storage, t, Some(int), Some(int_or_str));
+        let right =
+            ConstraintId::new_with_bounds(&db, &mut storage, t, None, Some(bytes_or_bytearray));
 
         // Check satisfiability against each upper clause before punting on the union-bearing
         // merged upper bound. The old size heuristic returned `CannotSimplify` here before
         // discovering that `int` cannot satisfy the second upper clause.
         assert!(matches!(
-            left.intersect(&db, &builder, right),
+            left.intersect(&db, &mut storage, right),
             IntersectionResult::Disjoint
         ));
     }
@@ -8035,23 +8102,25 @@ mod tests {
         let db = setup_db();
         let t = create_typevar(&db, "T");
         let builder = ConstraintSetBuilder::new();
+        let mut storage = builder.storage.borrow_mut();
         let t_int = ConstraintId::new(
             &db,
-            &builder,
+            &mut storage,
             t,
             Type::Never,
             KnownClass::Int.to_instance(&db),
         );
         let t_bool = ConstraintId::new(
             &db,
-            &builder,
+            &mut storage,
             t,
             Type::Never,
             KnownClass::Bool.to_instance(&db),
         );
 
-        assert!(builder.cached_constraint_implies(&db, t_bool, t_int));
-        assert!(builder.cached_constraint_implies(&db, t_bool, t_int));
+        assert!(storage.cached_constraint_implies(&db, t_bool, t_int));
+        assert!(storage.cached_constraint_implies(&db, t_bool, t_int));
+        drop(storage);
 
         {
             let storage = builder.storage.borrow();
@@ -8062,8 +8131,10 @@ mod tests {
             assert_eq!(storage.constraint_implication_cache.len(), 1);
         }
 
-        assert!(!builder.cached_constraint_implies(&db, t_int, t_bool));
-        assert!(!builder.cached_constraint_implies(&db, t_int, t_bool));
+        let mut storage = builder.storage.borrow_mut();
+        assert!(!storage.cached_constraint_implies(&db, t_int, t_bool));
+        assert!(!storage.cached_constraint_implies(&db, t_int, t_bool));
+        drop(storage);
 
         let storage = builder.storage.borrow();
         assert_eq!(
@@ -8223,14 +8294,8 @@ mod tests {
         owned.query(|builder, set| {
             assert!(!set.is_never_satisfied(&db));
             assert!(!set.is_never_satisfied(&db));
-            assert_eq!(
-                builder
-                    .storage
-                    .borrow()
-                    .never_satisfied_cache
-                    .get(&set.node),
-                Some(&false)
-            );
+            let storage = builder.storage.borrow();
+            assert_eq!(storage.never_satisfied_cache.get(&set.node), Some(&false));
         });
     }
 
@@ -8250,7 +8315,8 @@ mod tests {
         assert_ne!(first.source_order, second.source_order);
         assert!(!first.is_never_satisfied(&db));
         assert!(!second.is_never_satisfied(&db));
-        assert_eq!(builder.storage.borrow().never_satisfied_cache.len(), 1);
+        let storage = builder.storage.borrow();
+        assert_eq!(storage.never_satisfied_cache.len(), 1);
     }
 
     #[derive(Clone, Copy)]
@@ -8261,9 +8327,9 @@ mod tests {
     );
 
     impl<'db> PermutedConstraint<'db> {
-        fn node(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> NodeId {
+        fn node(self, db: &'db dyn Db, storage: &mut ConstraintSetStorage<'db>) -> NodeId {
             let PermutedConstraint(typevar, lower, upper) = self;
-            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper).0
+            Constraint::new_node_with_bounds(db, storage, typevar, lower, upper).0
         }
     }
 
@@ -8280,7 +8346,7 @@ mod tests {
         db: &'db dyn Db,
         typevars: &[BoundTypeVarInstance<'db>],
         atoms: &[PermutedConstraint<'db>],
-        build_bdd: impl Fn(&ConstraintSetBuilder<'db>) -> NodeId,
+        build_bdd: impl Fn(&mut ConstraintSetStorage<'db>) -> NodeId,
         expected: impl IntoIterator<Item = &'static str>,
     ) {
         let inferable = TypeVarSet::from_typevars(db, typevars.iter().copied());
@@ -8288,12 +8354,13 @@ mod tests {
 
         for constraint_order in (0..atoms.len()).permutations(atoms.len()) {
             let builder = ConstraintSetBuilder::new();
+            let mut storage = builder.storage.borrow_mut();
             for typevar in typevars {
-                builder.intern_typevar(db, *typevar);
+                storage.intern_typevar(db, *typevar);
             }
             for index in constraint_order {
                 let PermutedConstraint(typevar, lower, upper) = atoms[index];
-                builder.intern_constraint(
+                storage.intern_constraint(
                     db,
                     Constraint {
                         typevar,
@@ -8302,21 +8369,21 @@ mod tests {
                 );
             }
 
-            let node = build_bdd(&builder);
+            let node = build_bdd(&mut storage);
             let source_order = atoms.iter().fold(None, |source_order, atom| {
                 let PermutedConstraint(typevar, lower, upper) = *atom;
-                let constraint = builder.intern_constraint(
+                let constraint = storage.intern_constraint(
                     db,
                     Constraint {
                         typevar,
                         bounds: ConstraintBounds::new(lower, upper),
                     },
                 );
-                builder.ordered_source_order(
-                    source_order,
-                    Some(builder.constraint_source_order(constraint)),
-                )
+                let constraint_source_order = storage.constraint_source_order(constraint);
+                storage.ordered_source_order(source_order, Some(constraint_source_order))
             });
+            drop(storage);
+
             let set = ConstraintSet::from_node(&builder, node, source_order);
             let solutions = set.solutions(db, &builder, inferable);
             let mut merged = FxHashMap::default();
@@ -8385,9 +8452,9 @@ mod tests {
             &db,
             &[t],
             &atoms,
-            |builder| {
-                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
-                str_t.or(builder, int_t).and(builder, str_t)
+            |storage| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, storage));
+                str_t.or(storage, int_t).and(storage, str_t)
             },
             ["never=false always=false merged=[T=str] paths=[T=str]"],
         );
@@ -8396,9 +8463,9 @@ mod tests {
             &db,
             &[t],
             &atoms,
-            |builder| {
-                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
-                str_t.or(builder, int_t)
+            |storage| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, storage));
+                str_t.or(storage, int_t)
             },
             ["never=false always=false merged=[T=str | int] paths=[T=str; T=int]"],
         );
@@ -8422,10 +8489,10 @@ mod tests {
             &db,
             &[t, u],
             &atoms,
-            |builder| {
-                let [str_t, bytes_u, int_t] = atoms.map(|atom| atom.node(&db, builder));
-                let compound = str_t.and(builder, bytes_u);
-                compound.or(builder, int_t).and(builder, compound)
+            |storage| {
+                let [str_t, bytes_u, int_t] = atoms.map(|atom| atom.node(&db, storage));
+                let compound = str_t.and(storage, bytes_u);
+                compound.or(storage, int_t).and(storage, compound)
             },
             ["never=false always=false merged=[T=str, U=bytes] paths=[T=str, U=bytes]"],
         );
@@ -8450,11 +8517,11 @@ mod tests {
             &db,
             &[t, u, x],
             &atoms,
-            |builder| {
-                let [str_t, bytes_u, int_x] = atoms.map(|atom| atom.node(&db, builder));
-                let early = int_x.and(builder, str_t).and(builder, bytes_u);
-                let late = bytes_u.and(builder, str_t);
-                early.or(builder, late)
+            |storage| {
+                let [str_t, bytes_u, int_x] = atoms.map(|atom| atom.node(&db, storage));
+                let early = int_x.and(storage, str_t).and(storage, bytes_u);
+                let late = bytes_u.and(storage, str_t);
+                early.or(storage, late)
             },
             ["never=false always=false merged=[T=str, U=bytes] paths=[T=str, U=bytes]"],
         );
@@ -8475,11 +8542,11 @@ mod tests {
             &db,
             &[t],
             &atoms,
-            |builder| {
-                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
-                let true_path = int_t.and(builder, str_t);
-                let false_path = int_t.negate(builder).and(builder, str_t);
-                true_path.or(builder, false_path)
+            |storage| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, storage));
+                let true_path = int_t.and(storage, str_t);
+                let false_path = int_t.negate(storage).and(storage, str_t);
+                true_path.or(storage, false_path)
             },
             ["never=false always=false merged=[T=str] paths=[T=str]"],
         );
@@ -8506,13 +8573,13 @@ mod tests {
             &db,
             &[t, u, v],
             &atoms,
-            |builder| {
+            |storage| {
                 let [t_list_u, u_int, list_int_t, bytes_v] =
-                    atoms.map(|atom| atom.node(&db, builder));
+                    atoms.map(|atom| atom.node(&db, storage));
                 t_list_u
-                    .and(builder, u_int)
-                    .and(builder, list_int_t)
-                    .or(builder, bytes_v)
+                    .and(storage, u_int)
+                    .and(storage, list_int_t)
+                    .or(storage, bytes_v)
             },
             // TODO: All permutations should produce the first result. TDD traversal currently
             // leaks irrelevant positive constraints onto the `V = bytes` alternative.
@@ -8543,12 +8610,12 @@ mod tests {
             &db,
             &[t, u],
             &atoms,
-            |builder| {
-                let [t_int, t_str, bytes_u] = atoms.map(|atom| atom.node(&db, builder));
+            |storage| {
+                let [t_int, t_str, bytes_u] = atoms.map(|atom| atom.node(&db, storage));
                 t_int
-                    .or(builder, t_str)
-                    .negate(builder)
-                    .or(builder, bytes_u)
+                    .or(storage, t_str)
+                    .negate(storage)
+                    .or(storage, bytes_u)
             },
             // TODO: All permutations should produce the first result. A satisfied alternative
             // should not infer `T` from unrelated positive decisions made earlier in a BDD path.
@@ -8578,12 +8645,12 @@ mod tests {
             &db,
             &[t, u],
             &atoms,
-            |builder| {
-                let [t_int, t_str, int_t, u_int] = atoms.map(|atom| atom.node(&db, builder));
+            |storage| {
+                let [t_int, t_str, int_t, u_int] = atoms.map(|atom| atom.node(&db, storage));
                 t_int
-                    .or(builder, t_str)
-                    .and(builder, int_t)
-                    .and(builder, u_int)
+                    .or(storage, t_str)
+                    .and(storage, int_t)
+                    .and(storage, u_int)
             },
             // TODO: Constraint-ID permutations can still change which equivalent upper-bound
             // intersection is constructed first.
@@ -8601,8 +8668,9 @@ mod tests {
         set: ConstraintSet<'db, 'c>,
         expected: &str,
     ) {
+        let storage = builder.storage.borrow();
         let expected = expected.trim_end();
-        let actual = set.node.display_graph(db, builder, &"").to_string();
+        let actual = set.node.display_graph(db, &storage, &"").to_string();
         assert_eq!(expected, actual);
     }
 
@@ -8857,7 +8925,7 @@ mod tests {
         fn satisfied<'db>(
             &mut self,
             _db: &'db dyn Db,
-            builder: &ConstraintSetBuilder<'db>,
+            storage: &mut ConstraintSetStorage<'db>,
             path: &PathAssignments,
         ) -> ControlFlow<Self::Break, Self::Result> {
             let result =
@@ -8866,10 +8934,10 @@ mod tests {
                     .fold((ALWAYS_TRUE, None), |result, (assignment, _)| {
                         let (node, source_order) = result;
                         let (assignment, assignment_source_order) =
-                            Node::new_satisfied_constraint(builder, *assignment);
+                            Node::new_satisfied_constraint(storage, *assignment);
                         (
-                            node.and(builder, assignment),
-                            builder.ordered_source_order(source_order, assignment_source_order),
+                            node.and(storage, assignment),
+                            storage.ordered_source_order(source_order, assignment_source_order),
                         )
                     });
             self.result(PathFoldBreak::Satisfied, result)
@@ -8878,7 +8946,7 @@ mod tests {
         fn unsatisfied<'db>(
             &mut self,
             _db: &'db dyn Db,
-            _builder: &ConstraintSetBuilder<'db>,
+            _storage: &mut ConstraintSetStorage<'db>,
             _path: &PathAssignments,
         ) -> ControlFlow<Self::Break, Self::Result> {
             self.result(PathFoldBreak::Unsatisfied, (ALWAYS_FALSE, None))
@@ -8887,7 +8955,7 @@ mod tests {
         fn impossible<'db>(
             &mut self,
             _db: &'db dyn Db,
-            _builder: &ConstraintSetBuilder<'db>,
+            _storage: &mut ConstraintSetStorage<'db>,
             _path: &PathAssignments,
         ) -> ControlFlow<Self::Break, Self::Result> {
             self.result(PathFoldBreak::Impossible, (ALWAYS_FALSE, None))
@@ -8896,7 +8964,7 @@ mod tests {
         fn combine<'db>(
             &mut self,
             _db: &'db dyn Db,
-            builder: &ConstraintSetBuilder<'db>,
+            storage: &mut ConstraintSetStorage<'db>,
             if_true: Self::Result,
             if_uncertain: Self::Result,
             if_false: Self::Result,
@@ -8904,10 +8972,10 @@ mod tests {
             let (if_true, if_true_source_order) = if_true;
             let (if_uncertain, if_uncertain_source_order) = if_uncertain;
             let (if_false, if_false_source_order) = if_false;
-            let node = if_true.or(builder, if_uncertain).or(builder, if_false);
+            let node = if_true.or(storage, if_uncertain).or(storage, if_false);
             let source_order =
-                builder.ordered_source_order(if_true_source_order, if_uncertain_source_order);
-            let source_order = builder.ordered_source_order(source_order, if_false_source_order);
+                storage.ordered_source_order(if_true_source_order, if_uncertain_source_order);
+            let source_order = storage.ordered_source_order(source_order, if_false_source_order);
             self.result(PathFoldBreak::Combine, (node, source_order))
         }
     }
@@ -8919,7 +8987,10 @@ mod tests {
     ) -> PathAssignments {
         match node.node() {
             Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([]),
-            Node::Interior(interior) => interior.path_assignments(builder, source_order),
+            Node::Interior(interior) => {
+                let mut storage = builder.storage.borrow_mut();
+                interior.path_assignments(&mut storage, source_order)
+            }
         }
     }
 
@@ -8936,8 +9007,9 @@ mod tests {
         // initializer follows the sidecar rather than either TDD traversal or constraint IDs.
         let set = u_str.and(&db, &builder, || t_int);
         let path = path_assignments_for(&builder, set.node, set.source_order);
+        let storage = builder.storage.borrow();
         let expected =
-            [u_str.node, t_int.node].map(|node| builder.interior_node_data(node).constraint);
+            [u_str.node, t_int.node].map(|node| storage.interior_node_data(node).constraint);
         let actual: Vec<_> = path.discovered.keys().copied().collect();
 
         assert_eq!(actual, expected);
@@ -8989,11 +9061,13 @@ mod tests {
         ] {
             let mut path = path_assignments_for(&builder, set.node, set.source_order);
             let mut fold = ReconstructPathFold { break_at: None };
+            let mut storage = builder.storage.borrow_mut();
             let ControlFlow::Continue((reconstructed, reconstructed_source_order)) =
-                path.visit(&db, &builder, set.node, &mut fold)
+                path.visit(&db, &mut storage, set.node, &mut fold)
             else {
                 panic!("reconstruction unexpectedly aborted");
             };
+            drop(storage);
             let reconstructed =
                 ConstraintSet::from_node(&builder, reconstructed, reconstructed_source_order);
             assert!(
@@ -9026,17 +9100,19 @@ mod tests {
             let mut aborting_fold = ReconstructPathFold {
                 break_at: Some(break_at),
             };
+            let mut storage = builder.storage.borrow_mut();
             assert_eq!(
-                path.visit(&db, &builder, set.node, &mut aborting_fold),
+                path.visit(&db, &mut storage, set.node, &mut aborting_fold),
                 ControlFlow::Break(break_at)
             );
 
             let mut completing_fold = ReconstructPathFold { break_at: None };
             let ControlFlow::Continue((reconstructed, reconstructed_source_order)) =
-                path.visit(&db, &builder, set.node, &mut completing_fold)
+                path.visit(&db, &mut storage, set.node, &mut completing_fold)
             else {
                 panic!("reconstruction unexpectedly aborted after {break_at:?}");
             };
+            drop(storage);
             let reconstructed =
                 ConstraintSet::from_node(&builder, reconstructed, reconstructed_source_order);
             assert!(
@@ -9093,7 +9169,9 @@ mod tests {
         let combined = t_int.and(&db, &builder, || u_str);
 
         for original in [t_int, combined] {
-            let original_source_order_count = builder.storage.borrow().source_orders.len();
+            let storage = builder.storage.borrow();
+            let original_source_order_count = storage.source_orders.len();
+            drop(storage);
             let intersection = original.and(&db, &builder, || original);
             let union = original.or(&db, &builder, || original);
 
@@ -9101,10 +9179,8 @@ mod tests {
             assert_eq!(intersection.source_order, original.source_order);
             assert_eq!(union.node, original.node);
             assert_eq!(union.source_order, original.source_order);
-            assert_eq!(
-                builder.storage.borrow().source_orders.len(),
-                original_source_order_count
-            );
+            let storage = builder.storage.borrow();
+            assert_eq!(storage.source_orders.len(), original_source_order_count);
         }
     }
 
@@ -9220,22 +9296,26 @@ mod tests {
                 )
             };
 
-            let existing_constraint = builder.interior_node_data(set.node).constraint;
+            let mut storage = builder.storage.borrow_mut();
+            let existing_constraint = storage.interior_node_data(set.node).constraint;
             assert_eq!(
-                Some(builder.constraint_source_order(existing_constraint)),
+                Some(storage.constraint_source_order(existing_constraint)),
                 set.source_order
             );
+            drop(storage);
 
             let w = create_typevar(&db, "W");
             let w_str = create_constraint(&db, builder, w, KnownClass::Str);
+            let mut storage = builder.storage.borrow_mut();
             let new_constraint = w_str
                 .node
-                .root_constraint(builder)
+                .root_constraint(&storage)
                 .expect("new constraint should be nonterminal");
 
             assert!(w_str.node.index() >= node_split);
             assert!(new_constraint.index() >= constraint_split);
-            assert!(builder.typevar_id(&db, w).index() >= typevar_split);
+            assert!(storage.typevar_id(&db, w).index() >= typevar_split);
+            drop(storage);
             assert!(
                 w_str
                     .source_order


### PR DESCRIPTION
This is a mechanical change that updates the _internal_ constraint set APIs to take in `ConstraintSetStorage`, instead of the `RefCell`-carrying `ConstraintSetBuilder`. That means we only have to `borrow` or `borrow_mut` at the public API boundary, instead of multiple times throughout the internals.

I'm not sure if this will have a huge performance impact, but that's not the goal — rather it's to simplify the internal APIs.

Since this change is purely mechanical, I plan to merge it without review if CI / ecosystem pass.