### PR TITLE
[ty] Allow compatible function reassignment

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/shadowing/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/shadowing/function.md
@@ -20,8 +20,8 @@ f = 1  # error: [invalid-assignment]
 
 ## Compatible function reassignment
 
-A function declaration constrains later assignments by its callable signature, not by the identity
-of the original function.
+A function declaration constrains later assignments by its callable signature and descriptor
+behavior, not by the identity of the original function.
 
 ```py
 def original(value: int) -> int:
@@ -31,6 +31,70 @@ def replacement(value: int) -> int:
     return value
 
 original = replacement
+```
+
+## Reassigned functions expose their current identity across modules
+
+A function that replaces another function remains a descriptor. Imports must see the replacement
+function rather than preserving the original function's identity.
+
+`implementation.py`:
+
+```py
+def original(instance: object, value: int) -> int:
+    return value
+
+def replacement(instance: object, value: int) -> int:
+    return value
+
+before = original
+original = replacement
+```
+
+`main.py`:
+
+```py
+from implementation import before, original, replacement
+
+reveal_type(original is before)  # revealed: Literal[False]
+reveal_type(original is replacement)  # revealed: Literal[True]
+
+class Container:
+    method = original
+
+reveal_type(Container().method(1))  # revealed: int
+```
+
+## Conditionally reassigned functions preserve both public identities
+
+When reassignment depends on a condition, an imported function can still refer to either compatible
+function. Its identity must not be narrowed to either possibility.
+
+`implementation.py`:
+
+```py
+def condition() -> bool:
+    return True
+
+def original(value: int) -> int:
+    return value
+
+def replacement(value: int) -> int:
+    return value
+
+before = original
+
+if condition():
+    original = replacement
+```
+
+`main.py`:
+
+```py
+from implementation import before, original, replacement
+
+reveal_type(original is before)  # revealed: bool
+reveal_type(original is replacement)  # revealed: bool
 ```
 
 ## Imported compatible function reassignment
@@ -53,18 +117,60 @@ def imported(value: int) -> int:
 from implementation import imported
 ```
 
-## Compatible callable-class reassignment
+## Callable objects do not preserve function descriptor behavior
 
-Class objects are also compatible when their constructor satisfies the declared callable signature.
+A class object or callable instance cannot replace a function, even when its call signature matches.
+Unlike ordinary functions, these objects do not bind an instance when assigned to a class attribute.
 
 ```py
 class Factory:
     def __init__(self, value: int) -> None: ...
 
+class CallableObject:
+    def __call__(self, value: int) -> object:
+        return value
+
 def factory(value: int) -> object:
     return value
 
-factory = Factory
+factory = Factory  # error: [invalid-assignment]
+
+def callback(value: int) -> object:
+    return value
+
+callback = CallableObject()  # error: [invalid-assignment]
+```
+
+## Type-checking-only function declarations describe callable signatures
+
+A function defined only under `TYPE_CHECKING` does not exist at runtime, so its declaration does not
+promise function descriptor behavior. A compatible callable object can provide its implementation,
+but importing that object must not incorrectly turn it into a binding descriptor.
+
+`implementation.py`:
+
+```py
+from typing import TYPE_CHECKING
+
+class CallableObject:
+    def __call__(self, instance: object, value: int) -> int:
+        return value
+
+if TYPE_CHECKING:
+    def callback(instance: object, value: int) -> int: ...
+
+callback = CallableObject()
+```
+
+`main.py`:
+
+```py
+from implementation import callback
+
+class Container:
+    method = callback
+
+Container().method(1)  # error: [missing-argument]
 ```
 
 ## Incompatible function reassignment

--- a/crates/ty_python_semantic/resources/mdtest/shadowing/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/shadowing/function.md
@@ -18,6 +18,98 @@ def f(): ...
 f = 1  # error: [invalid-assignment]
 ```
 
+## Compatible function reassignment
+
+A function declaration constrains later assignments by its callable signature, not by the identity
+of the original function.
+
+```py
+def original(value: int) -> int:
+    return value
+
+def replacement(value: int) -> int:
+    return value
+
+original = replacement
+```
+
+## Imported compatible function reassignment
+
+An imported function with the same signature can replace an existing function declaration.
+
+`implementation.py`:
+
+```py
+def imported(value: int) -> int:
+    return value
+```
+
+`main.py`:
+
+```py
+def imported(value: int) -> int:
+    return value
+
+from implementation import imported
+```
+
+## Compatible callable-class reassignment
+
+Class objects are also compatible when their constructor satisfies the declared callable signature.
+
+```py
+class Factory:
+    def __init__(self, value: int) -> None: ...
+
+def factory(value: int) -> object:
+    return value
+
+factory = Factory
+```
+
+## Incompatible function reassignment
+
+A replacement function must accept the original function's arguments and return a compatible type.
+
+```py
+def original(value: int) -> int:
+    return value
+
+def different_type(value: str) -> str:
+    return value
+
+original = different_type  # error: [invalid-assignment]
+```
+
+Parameter names remain significant when callers may pass them by keyword.
+
+```py
+def accepts_value(value: int) -> int:
+    return value
+
+def accepts_number(number: int) -> int:
+    return number
+
+accepts_value = accepts_number  # error: [invalid-assignment]
+```
+
+## Class methods preserve descriptor behavior
+
+A callable instance does not bind an instance argument when accessed as a class attribute, so it
+cannot replace a function-like method even when their call signatures otherwise match.
+
+```py
+class CallableObject:
+    def __call__(this, self: object, value: int) -> int:
+        return value
+
+class Container:
+    def method(self, value: int) -> int:
+        return value
+
+    method = CallableObject()  # error: [invalid-assignment]
+```
+
 ## Explicit shadowing
 
 ```py

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1063,7 +1063,35 @@ pub(crate) fn place_by_id<'db>(
                 .with_qualifiers(qualifiers),
             }
         }
-        // Place is declared, trust the declared type
+        // A function declaration identifies its original function object, while a compatible
+        // reassignment can replace that object. Once a different binding is visible, expose the
+        // current binding so imports and other public lookups do not retain its stale identity.
+        PlaceAndQualifiers {
+            place:
+                Place::Defined(
+                    declared @ DefinedPlace {
+                        ty: Type::FunctionLiteral(_),
+                        definedness: Definedness::AlwaysDefined,
+                        provenance: Provenance::SingleDefinition(declaration),
+                        ..
+                    },
+                ),
+            qualifiers,
+        } if place_id.as_symbol().is_some()
+            && all_considered_bindings().any(|binding| {
+                matches!(binding.binding, DefinitionState::Defined(binding) if binding != declaration)
+            }) =>
+        {
+            let bindings = all_considered_bindings();
+            match place_from_bindings_impl(db, bindings, requires_explicit_reexport, None).place {
+                Place::Defined(inferred) => {
+                    Place::Defined(inferred.with_origin(TypeOrigin::Declared))
+                        .with_qualifiers(qualifiers)
+                }
+                Place::Undefined => Place::Defined(declared).with_qualifiers(qualifiers),
+            }
+        }
+        // Place is declared, trust the declared type.
         place_and_quals @ PlaceAndQualifiers {
             place:
                 Place::Defined(DefinedPlace {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1448,8 +1448,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
         .or_else(|| resolved_place.ignore_possibly_undefined());
 
+        let assignment_ty = match (place, declared_ty) {
+            (PlaceExprRef::Symbol(_), Some(Type::FunctionLiteral(function))) => {
+                let callable = function.into_callable_type(db);
+                Type::Callable(if function.has_implicit_receiver(db) {
+                    callable
+                } else {
+                    callable.into_regular(db)
+                })
+            }
+            _ => declared_ty.unwrap_or(Type::unknown()),
+        };
+
         AddBinding {
             declared_ty,
+            assignment_ty,
             binding,
             node,
             qualifiers,
@@ -4155,8 +4168,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             let node = target.into();
+            let declared_ty = self.fallback_member_declared_type(node);
             let add = AddBinding {
-                declared_ty: self.fallback_member_declared_type(node),
+                declared_ty,
+                assignment_ty: declared_ty.unwrap_or(Type::unknown()),
                 binding: definition,
                 node,
                 qualifiers: TypeQualifiers::empty(),
@@ -11975,7 +11990,10 @@ impl<V> IntoIterator for VecSet<V> {
 
 #[must_use]
 struct AddBinding<'db, 'ast> {
+    /// The declared value type, retained for inference context and diagnostics.
     declared_ty: Option<Type<'db>>,
+    /// The contract a new binding must satisfy; function names use their callable signature.
+    assignment_ty: Type<'db>,
     binding: Definition<'db>,
     node: AnyNodeRef<'ast>,
     qualifiers: TypeQualifiers,
@@ -12053,7 +12071,7 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
             }
         }
 
-        if !bound_ty.is_assignable_to(db, declared_ty) {
+        if !bound_ty.is_assignable_to(db, self.assignment_ty) {
             builder.discard_dict_key_assignments_for(self.binding);
             report_invalid_assignment(
                 &builder.context,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1451,11 +1451,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let assignment_ty = match (place, declared_ty) {
             (PlaceExprRef::Symbol(_), Some(Type::FunctionLiteral(function))) => {
                 let callable = function.into_callable_type(db);
-                Type::Callable(if function.has_implicit_receiver(db) {
-                    callable
-                } else {
+                let callable = if function.file(db) == self.file()
+                    && self.is_in_type_checking_block(
+                        self.scope(),
+                        function.node(db, self.file(), self.module()),
+                    ) {
+                    // A type-checking-only definition describes a callable signature, but never
+                    // creates a function object whose descriptor behavior must be preserved.
                     callable.into_regular(db)
-                })
+                } else {
+                    callable
+                };
+                Type::Callable(callable)
             }
             _ => declared_ty.unwrap_or(Type::unknown()),
         };


### PR DESCRIPTION
## Summary

When a function is defined, we currently treat its name as being declared with the type of that exact function object. This makes an ordinary reassignment fail even when the replacement accepts the same arguments and returns the same type:

```py
def original(value: int) -> int:
    return value

def replacement(value: int) -> int:
    return value

original = replacement
```

We should allow this assignment: `original` does not need to keep pointing to the same function forever. But checking only that the replacement is callable would be too permissive.

### Why callable signatures are not enough

Functions are descriptors. When a function is placed on a class, accessing it through an instance automatically supplies that instance as the first argument. Ordinary callable objects and class objects do not generally behave this way.

```py
class Callback:
    def __call__(self, instance: object, value: int) -> int:
        return value

def callback(instance: object, value: int) -> int:
    return value

callback = Callback()

class Container:
    method = callback

Container().method(1)  # Fails at runtime: `value` was not provided.
```

Even though `callback` was originally defined at module scope, it can later become a class attribute. Replacing it with an arbitrary callable would let us incorrectly assume that the replacement still binds an instance.

### Resulting model

We separate the type of the current value from the contract used to check reassignment:

1. A newly defined function keeps its precise function-literal type and identity.
2. Reassignment is checked against a function-like callable with the same signature and descriptor behavior.
3. After a valid reassignment, the name refers to the actual replacement, not the original function.
4. Public lookups and imports use the current live binding, preserving exact identity for unconditional replacements and both possibilities for conditional replacements.

```py
# provider.py
before = original
original = replacement

# consumer.py
from provider import before, original

reveal_type(original is before)  # Literal[False], not Literal[True].
```

Therefore compatible functions are accepted, while callable objects, class objects, incompatible signatures, and mismatched keyword parameter names remain rejected. This is the same descriptor-preserving assignment model used for compatible method replacements in #26158.

### Type-checking-only declarations

A function defined only under `TYPE_CHECKING` never creates a function object at runtime, so it does not promise descriptor behavior:

```py
from functools import partial
from typing import TYPE_CHECKING

def implementation(prefix: str, value: int) -> int:
    return value

if TYPE_CHECKING:
    def callback(value: int) -> int: ...

callback = partial(implementation, "prefix")
```

Here the definition is just a convenient way to declare a callable signature. A compatible callable object remains valid, and imports see the actual callable object instead of incorrectly treating it as a function descriptor.
