### PR TITLE
[`flake8-pyi`] Avoid false positives on `singledispatch` functions (`PYI041`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-pyi/redundant-numeric-union.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-pyi/redundant-numeric-union.md
@@ -30,6 +30,21 @@ def dispatch(value: object) -> None: ...
 def _(value: int | float) -> None: ...
 ```
 
+## Generic single-dispatch functions
+
+The generic function's annotation does not register concrete types, so its numeric union remains
+redundant even when a registered implementation needs the same union.
+
+```py
+import functools
+
+@functools.singledispatch
+def dispatch(value: int | float) -> None: ...  # error: [redundant-numeric-union]
+
+@dispatch.register
+def _(value: int | float) -> None: ...
+```
+
 ## Other parameters of registered functions
 
 Numeric unions remain redundant for parameters that do not determine dispatch registration.

--- a/crates/ruff_linter/resources/mdtest/flake8-pyi/redundant-numeric-union.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-pyi/redundant-numeric-union.md
@@ -1,0 +1,102 @@
+# `redundant-numeric-union` (`PYI041`)
+
+```toml
+target-version = "py311"
+
+[lint]
+select = ["PYI041"]
+```
+
+## Ordinary parameter annotations
+
+Numeric unions are redundant when they are used only for static typing.
+
+```py
+def function(value: int | float) -> None: ...  # error: [redundant-numeric-union]
+```
+
+## Single-dispatch registrations
+
+The first annotated parameter determines the concrete types registered at runtime, so its numeric
+union is not redundant.
+
+```py
+import functools
+
+@functools.singledispatch
+def dispatch(value: object) -> None: ...
+
+@dispatch.register
+def _(value: int | float) -> None: ...
+```
+
+## Other parameters of registered functions
+
+Numeric unions remain redundant for parameters that do not determine dispatch registration.
+
+```py
+import functools
+
+@functools.singledispatch
+def dispatch(value: object) -> None: ...
+
+@dispatch.register
+def _(value: float | complex, other: int | float) -> None: ...  # snapshot: redundant-numeric-union
+```
+
+```snapshot
+error[PYI041]: Use `float` instead of `int | float`
+ --> src/mdtest_snippet.py:7:38
+  |
+7 | def _(value: float | complex, other: int | float) -> None: ...  # snapshot: redundant-numeric-union
+  |                                      ^^^^^^^^^^^
+help: Remove redundant type
+  |
+6 | @dispatch.register
+  - def _(value: float | complex, other: int | float) -> None: ...  # snapshot: redundant-numeric-union
+7 + def _(value: float | complex, other: float) -> None: ...  # snapshot: redundant-numeric-union
+  |
+```
+
+## Single-dispatch method registrations
+
+The dispatch parameter comes after the unannotated instance parameter.
+
+```py
+import functools
+
+class Dispatch:
+    @functools.singledispatchmethod
+    def dispatch(self, value: object) -> None: ...
+
+    @dispatch.register
+    def _(self, value: int | float) -> None: ...
+```
+
+## Explicit single-dispatch registrations
+
+An explicit registration does not inspect the implementation's parameter annotation.
+
+```py
+import functools
+
+@functools.singledispatch
+def dispatch(value: object) -> None: ...
+
+@dispatch.register(int | float)
+def _(value: int | float) -> None: ...  # error: [redundant-numeric-union]
+```
+
+## Stub annotations
+
+Registered dispatch implementations retain their numeric unions in stub files as well.
+
+```pyi
+import functools
+
+@functools.singledispatch
+def dispatch(value: object) -> None: ...
+
+@dispatch.register
+def _(value: int | float) -> None: ...
+```

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -152,7 +152,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 flake8_pyi::rules::bad_exit_annotation(checker, function_def);
             }
             if checker.is_rule_enabled(Rule::RedundantNumericUnion) {
-                flake8_pyi::rules::redundant_numeric_union(checker, parameters);
+                flake8_pyi::rules::redundant_numeric_union(checker, function_def);
             }
             if checker.is_rule_enabled(Rule::Pep484StylePositionalOnlyParameter) {
                 flake8_pyi::rules::pep_484_positional_parameter(checker, function_def);

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -1,12 +1,13 @@
 use bitflags::bitflags;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{AnyParameterRef, Expr, ExprBinOp, Operator, Parameters, PythonVersion};
+use ruff_python_ast::{AnyParameterRef, Expr, ExprBinOp, Operator, PythonVersion, StmtFunctionDef};
 use ruff_python_semantic::analyze::typing::traverse_union;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_resolve_string_annotation_pyi041_enabled;
+use crate::rules::flake8_type_checking::helpers::is_singledispatch_implementation;
 use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 
 use super::generate_union_fix;
@@ -80,8 +81,16 @@ impl Violation for RedundantNumericUnion {
 }
 
 /// PYI041
-pub(crate) fn redundant_numeric_union(checker: &Checker, parameters: &Parameters) {
-    for annotation in parameters.iter().filter_map(AnyParameterRef::annotation) {
+pub(crate) fn redundant_numeric_union(checker: &Checker, function_def: &StmtFunctionDef) {
+    let skip_dispatch_annotation =
+        is_singledispatch_implementation(function_def, checker.semantic());
+
+    for annotation in function_def
+        .parameters
+        .iter()
+        .filter_map(AnyParameterRef::annotation)
+        .skip(usize::from(skip_dispatch_annotation))
+    {
         check_annotation(checker, annotation);
     }
 }


### PR DESCRIPTION
Summary
--

Fixes #27333. The fixed annotation isn't actually equivalent in this case.

```pycon
>>> import functools
...
... @functools.singledispatch
... def int_or_float(value: object) -> str:
...     return False
...
... @int_or_float.register
... def _(value: int | float):
...     return True
...
... assert int_or_float(3)
...
>>> import functools
...
... @functools.singledispatch
... def int_or_float(value: object) -> str:
...     return False
...
... @int_or_float.register
... def _(value: float):
...     return True
...
... assert int_or_float(3)
...
Traceback (most recent call last):
  File "<python-input-1>", line 11, in <module>
    assert int_or_float(3)
           ~~~~~~~~~~~~^^^
AssertionError
```

We had an existing helper for testing for `singledispatch` functions, which we use to skip the first
parameter of such functions since this is the dispatching parameter.

Test Plan
--

New mdtests
