### PR TITLE
fix(flake8-bandit): clarify S603 diagnostic message for subprocess without shell=True

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -86,7 +86,7 @@ pub(crate) struct SubprocessWithoutShellEqualsTrue;
 impl Violation for SubprocessWithoutShellEqualsTrue {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "`subprocess` call: check for execution of untrusted input".to_string()
+        "`subprocess` call without `shell=True`: check for execution of untrusted input".to_string()
     }
 }
 


### PR DESCRIPTION
Updates the violation message for SubprocessWithoutShellEqualsTrue (S603) in shell_injection.rs to include without shell=True, aligning the diagnostic output with the rule description and name (fixes #27322).