### PR TITLE
[ty] Preserve generic class type variables in constructor inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -634,6 +634,34 @@ class C(Generic[T]):
         invalid: C[int] = C(value)
 ```
 
+### Constructing through a classmethod receiver
+
+A constructor call through a classmethod receiver keeps an enclosing `TypeVarTuple` when checking
+the constructor arguments. In particular, freshening the constructor must not replace the
+`TypeVarTuple` in the receiver with `Unknown`.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Generic, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Thunk(Generic[*Ts]):
+    def __init__(self, state: Unresolved[*Ts] | None) -> None: ...
+    @classmethod
+    def make(cls, *values: *Ts) -> Thunk[*Ts]:
+        return cls(Unresolved(values))
+
+class Unresolved(Generic[*Ts]):
+    def __init__(self, values: tuple[*Ts]) -> None: ...
+```
+
 ### Many invariant parameters with dynamic bounds
 
 Treating unrelated classes with `Any` in their MRO as transitive pivots caused inference time to

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -615,6 +615,25 @@ reveal_type(C(1))  # revealed: C[int]
 wrong_innards: C[int] = C("five")
 ```
 
+### Constructing the class from its own type variable
+
+A constructor call inside a generic class can use a value whose type is one of the class's type
+variables. The constructed instance keeps that type variable instead of falling back to `Unknown`,
+so an incompatible type context is rejected.
+
+```py
+from typing_extensions import Generic, TypeVar
+
+T = TypeVar("T")
+
+class C(Generic[T]):
+    def __init__(self, value: T) -> None:
+        reveal_type(C(value))  # revealed: C[T@C]
+
+        # error: [invalid-assignment] "Object of type `C[T@C]` is not assignable to `C[int]`"
+        invalid: C[int] = C(value)
+```
+
 ### Many invariant parameters with dynamic bounds
 
 Treating unrelated classes with `Any` in their MRO as transitive pivots caused inference time to

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -307,6 +307,35 @@ If a typevar does not provide a default, we use `Unknown`:
 reveal_type(C())  # revealed: C[Unknown]
 ```
 
+## Calls within the generic class
+
+A call to a generic class from one of its own methods creates an independent generic occurrence. The
+enclosing class's type variable does not constrain the new instance.
+
+```py
+class C[T]:
+    def __init__(self) -> None: ...
+    def method(self) -> None:
+        reveal_type(C())  # revealed: C[Unknown]
+        contextual: C[int] = C()
+```
+
+The same applies when an explicit `__new__` is followed by a downstream `__init__`. Both bound
+receivers refer to the new generic occurrence.
+
+```py
+from typing import Self
+
+class D[T]:
+    def __new__(cls) -> Self:
+        return super().__new__(cls)
+
+    def __init__(self) -> None: ...
+    def method(self) -> None:
+        reveal_type(D())  # revealed: D[Unknown]
+        contextual: D[int] = D()
+```
+
 ## Inferring generic class parameters from constructors
 
 If the type of a constructor parameter is a class typevar, we can use that to infer the type

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -365,6 +365,12 @@ class C[T]:
 
         # error: [invalid-assignment] "Object of type `C[T@C]` is not assignable to `C[int]`"
         invalid: C[int] = C(value)
+
+    def from_union(self, value: T | list[T]) -> None:
+        reveal_type(C(value))  # revealed: C[T@C | list[T@C]]
+
+        # error: [invalid-assignment] "Object of type `C[T@C | list[T@C]]` is not assignable to `C[list[T@C]]`"
+        invalid_union: C[list[T]] = C(value)
 ```
 
 A method's own type variable is independent of the class type variable and is preserved in the same

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -352,6 +352,31 @@ reveal_type(C(1))  # revealed: C[Literal[1]]
 wrong_innards: C[int] = C("five")
 ```
 
+### Constructing the class from its own type variable
+
+A constructor call inside a generic class can use a value whose type is one of the class's type
+variables. The constructed instance keeps that type variable instead of falling back to `Unknown`,
+so an incompatible type context is rejected.
+
+```py
+class C[T]:
+    def __init__(self, value: T) -> None:
+        reveal_type(C(value))  # revealed: C[T@C]
+
+        # error: [invalid-assignment] "Object of type `C[T@C]` is not assignable to `C[int]`"
+        invalid: C[int] = C(value)
+```
+
+A method's own type variable is independent of the class type variable and is preserved in the same
+way.
+
+```py
+class D[T]:
+    def __init__(self, value: T) -> None: ...
+    def method[S](self, value: S) -> None:
+        reveal_type(D(value))  # revealed: D[S@method]
+```
+
 ### Identical `__new__` and `__init__` signatures
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -355,7 +355,7 @@ impl<'db> CallableItem<'db> {
                 binding.freshen_generic_contexts_in_place(db, env, nonce_generator);
             }
             CallableItem::Constructor(binding) => {
-                binding.freshen_generic_contexts_in_place(db, nonce_generator);
+                binding.freshen_generic_contexts_in_place(db, env, nonce_generator);
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -354,9 +354,9 @@ impl<'db> CallableItem<'db> {
             CallableItem::Regular(binding) => {
                 binding.freshen_generic_contexts_in_place(db, env, nonce_generator);
             }
-            // TODO: Constructor freshening also has to keep constructor instance context in sync
-            // with `__new__`/`__init__` signatures.
-            CallableItem::Constructor(_) => {}
+            CallableItem::Constructor(binding) => {
+                binding.freshen_generic_contexts_in_place(db, nonce_generator);
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -74,10 +74,11 @@ impl<'db> ConstructorBinding<'db> {
     pub(super) fn freshen_generic_contexts_in_place(
         &mut self,
         db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
         nonce_generator: &TypeVarNonceGenerator<'db>,
     ) {
         let instance_type = self.constructed_instance_type();
-        let Some((_, specialization)) = instance_type.class_specialization(db) else {
+        let Some((_, specialization)) = instance_type.class_specialization(db, env) else {
             return;
         };
         let generic_context = specialization.generic_context(db);
@@ -93,13 +94,21 @@ impl<'db> ConstructorBinding<'db> {
             delta,
         };
         let fresh_instance_type =
-            instance_type.apply_type_mapping(db, &type_mapping, TypeContext::default());
-        self.freshen_class_typevars(db, generic_context, delta, fresh_instance_type);
+            instance_type.apply_type_mapping(db, env, &type_mapping, TypeContext::default());
+        // Only freshen a generic context that belongs to the constructed instance itself.
+        // `class_specialization` can also find a context through a class-object type variable's
+        // bound, but freshening that context would detach the constructor parameters from the
+        // receiver.
+        if fresh_instance_type == instance_type {
+            return;
+        }
+        self.freshen_class_typevars(db, env, generic_context, delta, fresh_instance_type);
     }
 
     fn freshen_class_typevars(
         &mut self,
         db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
         generic_context: GenericContext<'db>,
         delta: u32,
         fresh_instance_type: Type<'db>,
@@ -113,7 +122,7 @@ impl<'db> ConstructorBinding<'db> {
         // the inferred specialization to that instance. Only the per-overload context is
         // call-local, so its instance must use the same fresh type variables as the signature.
         let constructor_context = self.context().with_instance_type(fresh_instance_type);
-        let visitor = ApplyTypeMappingVisitor::default();
+        let visitor = ApplyTypeMappingVisitor::new(env);
         self.entry.bound_type = self.entry.bound_type.map(|bound_type| {
             bound_type.apply_type_mapping_impl(db, &type_mapping, TypeContext::default(), &visitor)
         });
@@ -134,6 +143,7 @@ impl<'db> ConstructorBinding<'db> {
             {
                 downstream_binding.freshen_class_typevars(
                     db,
+                    env,
                     generic_context,
                     delta,
                     fresh_instance_type,

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -1,11 +1,17 @@
-use super::{Binding, Bindings, CallableBinding, CallableItem, CheckTypesMode};
+use super::{
+    Binding, Bindings, CallableBinding, CallableItem, CheckTypesMode, generic_context_has_paramspec,
+};
 use crate::Db;
 use crate::ProgramEnvironment;
 use crate::types::call::arguments::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
-use crate::types::generics::Specialization;
+use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::Parameter;
-use crate::types::{BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext};
+use crate::types::typevar::TypeVarNonceGenerator;
+use crate::types::{
+    ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext,
+    TypeMapping,
+};
 
 /// Bindings for a constructor call.
 ///
@@ -63,6 +69,73 @@ impl<'db> ConstructorBinding<'db> {
 
     pub(super) fn set_downstream_constructor(&mut self, bindings: Bindings<'db>) {
         self.downstream_constructor = Some(Box::new(bindings));
+    }
+
+    pub(super) fn freshen_generic_contexts_in_place(
+        &mut self,
+        db: &'db dyn Db,
+        nonce_generator: &TypeVarNonceGenerator<'db>,
+    ) {
+        let instance_type = self.constructed_instance_type();
+        let Some((_, specialization)) = instance_type.class_specialization(db) else {
+            return;
+        };
+        let generic_context = specialization.generic_context(db);
+        if generic_context_has_paramspec(db, generic_context)
+            || !nonce_generator.should_freshen(db, generic_context)
+        {
+            return;
+        }
+
+        let delta = nonce_generator.next().value();
+        let type_mapping = TypeMapping::FreshenBoundTypeVars {
+            generic_context,
+            delta,
+        };
+        let fresh_instance_type =
+            instance_type.apply_type_mapping(db, &type_mapping, TypeContext::default());
+        self.freshen_class_typevars(db, generic_context, delta, fresh_instance_type);
+    }
+
+    fn freshen_class_typevars(
+        &mut self,
+        db: &'db dyn Db,
+        generic_context: GenericContext<'db>,
+        delta: u32,
+        fresh_instance_type: Type<'db>,
+    ) {
+        let type_mapping = TypeMapping::FreshenBoundTypeVars {
+            generic_context,
+            delta,
+        };
+
+        // Keep the source-level instance on `ConstructorBinding`; the final return type applies
+        // the inferred specialization to that instance. Only the per-overload context is
+        // call-local, so its instance must use the same fresh type variables as the signature.
+        let constructor_context = self.context().with_instance_type(fresh_instance_type);
+        for overload in &mut self.entry.overloads {
+            overload.signature = overload.signature.apply_type_mapping_impl(
+                db,
+                &type_mapping,
+                TypeContext::default(),
+                &ApplyTypeMappingVisitor::default(),
+            );
+            overload.set_constructor_context(db, constructor_context);
+        }
+
+        if let Some(downstream) = self.downstream_constructor_mut() {
+            for downstream_binding in downstream
+                .iter_callable_items_mut()
+                .filter_map(CallableItem::as_constructor_mut)
+            {
+                downstream_binding.freshen_class_typevars(
+                    db,
+                    generic_context,
+                    delta,
+                    fresh_instance_type,
+                );
+            }
+        }
     }
 
     /// Match parameters for this constructor method and downstream constructors.

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -113,12 +113,16 @@ impl<'db> ConstructorBinding<'db> {
         // the inferred specialization to that instance. Only the per-overload context is
         // call-local, so its instance must use the same fresh type variables as the signature.
         let constructor_context = self.context().with_instance_type(fresh_instance_type);
+        let visitor = ApplyTypeMappingVisitor::default();
+        self.entry.bound_type = self.entry.bound_type.map(|bound_type| {
+            bound_type.apply_type_mapping_impl(db, &type_mapping, TypeContext::default(), &visitor)
+        });
         for overload in &mut self.entry.overloads {
             overload.signature = overload.signature.apply_type_mapping_impl(
                 db,
                 &type_mapping,
                 TypeContext::default(),
-                &ApplyTypeMappingVisitor::default(),
+                &visitor,
             );
             overload.set_constructor_context(db, constructor_context);
         }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2704,13 +2704,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     ) -> bool {
         let db = self.db;
         let target_context = target.binding_context(db);
+        let target_freshness = target.freshness(db);
         ty.as_typevar().is_some_and(|typevar| {
             // Relationships across binding contexts can intentionally remap one generic context
-            // onto another, as with constructor `self` annotations. Synthetic contexts do not
-            // identify a single source-level binding, so they are not safe to project either.
+            // onto another, as with constructor `self` annotations. Relationships across fresh
+            // occurrences preserve an outer generic value through a recursive call. Synthetic
+            // contexts do not identify a single source-level binding, so they are not safe to
+            // project either.
             !matches!(target_context, BindingContext::Synthetic(_))
                 && typevar.is_inferable(db, self.inferable)
                 && typevar.binding_context(db) == target_context
+                && typevar.freshness(db) == target_freshness
         })
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -970,7 +970,7 @@ impl<'db> Signature<'db> {
         })
     }
 
-    fn apply_type_mapping_impl<'a>(
+    pub(super) fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'a, 'db>,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -983,7 +983,7 @@ impl<'db> BoundTypeVarInstance<'db> {
         self.identity(db).paramspec_attr
     }
 
-    fn freshness(self, db: &'db dyn Db) -> TypeVarNonce {
+    pub(super) fn freshness(self, db: &'db dyn Db) -> TypeVarNonce {
         self.identity(db).freshness
     }
 


### PR DESCRIPTION
## Summary

Constructing a generic class from one of its own type variables currently loses that type variable and produces `C[Unknown]`. We now freshen the constructor-specific generic context while preserving the source-level return template, so `C(value)` within `C[T]` retains `C[T]`.

We also keep bound constructor receivers and downstream `__init__` bindings on the same fresh occurrence, and distinguish that occurrence from outer type variables during inference.

Closes https://github.com/astral-sh/ty/issues/4132.

Closes https://github.com/astral-sh/ty/issues/3963.
