### PR TITLE
[ty] Use legacy ParamSpec syntax in legacy wrapper test

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -593,16 +593,13 @@ def _(concrete: Command[[str]], gradual: Command[...]) -> None:
 This avoids rejecting wrappers around callbacks that are safe to use with a positional-only callback
 protocol.
 
-```toml
-[environment]
-python-version = "3.12"
-```
-
 ```py
 from collections.abc import Callable
-from typing import Final
+from typing import Final, Generic, ParamSpec
 
-class Job[**P]:
+P = ParamSpec("P", contravariant=True)
+
+class Job(Generic[P]):
     target: Final[Callable[P, None]]
 
     def __init__(self, target: Callable[P, None]) -> None:


### PR DESCRIPTION
## Summary

Use legacy ParamSpec syntax in `legacy/paramspec.md`. Previously, this was just a verbatim copy of [this PEP 695 test](https://github.com/astral-sh/ruff/blob/4a437b093417a22abecc168cc186ef58ca48c0fc/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md?plain=1#L436-L463).
