### PR TITLE
[ty] Restore frozen-collection APIs

### DIFF
--- a/crates/ty_python_core/src/frozen.rs
+++ b/crates/ty_python_core/src/frozen.rs
@@ -86,6 +86,15 @@ impl<K: Ord, V> std::ops::Index<&K> for FrozenMap<K, V> {
     }
 }
 
+impl<K, V> IntoIterator for FrozenMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<(K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_vec().into_iter()
+    }
+}
+
 impl<'a, K, V> IntoIterator for &'a FrozenMap<K, V> {
     type Item = &'a (K, V);
     type IntoIter = std::slice::Iter<'a, (K, V)>;


### PR DESCRIPTION
## Summary

Revert #27347 and restore the consuming `IntoIterator` implementation for `FrozenMap`.

See comment by Micha [here](https://github.com/astral-sh/ruff/pull/27347#discussion_r3689046712).
