### PR TITLE
DOC align S603 rule name and description

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -863,7 +863,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 flake8_bandit::rules::weak_cryptographic_key(checker, call);
             }
             if checker.any_rule_enabled(&[
-                Rule::SubprocessWithoutShellEqualsTrue,
+                Rule::SubprocessCallWithUntrustedInput,
                 Rule::SubprocessPopenWithShellEqualsTrue,
                 Rule::CallWithShellEqualsTrue,
                 Rule::StartProcessWithAShell,

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -728,7 +728,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Bandit, "509") => rules::flake8_bandit::rules::SnmpWeakCryptography,
         (Flake8Bandit, "601") => rules::flake8_bandit::rules::ParamikoCall,
         (Flake8Bandit, "602") => rules::flake8_bandit::rules::SubprocessPopenWithShellEqualsTrue,
-        (Flake8Bandit, "603") => rules::flake8_bandit::rules::SubprocessWithoutShellEqualsTrue,
+        (Flake8Bandit, "603") => rules::flake8_bandit::rules::SubprocessCallWithUntrustedInput,
         (Flake8Bandit, "604") => rules::flake8_bandit::rules::CallWithShellEqualsTrue,
         (Flake8Bandit, "605") => rules::flake8_bandit::rules::StartProcessWithAShell,
         (Flake8Bandit, "606") => rules::flake8_bandit::rules::StartProcessWithNoShell,

--- a/crates/ruff_linter/src/rules/flake8_bandit/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/mod.rs
@@ -44,7 +44,7 @@ mod tests {
     #[test_case(Rule::StartProcessWithNoShell, Path::new("S606.py"))]
     #[test_case(Rule::StartProcessWithPartialPath, Path::new("S607.py"))]
     #[test_case(Rule::SubprocessPopenWithShellEqualsTrue, Path::new("S602.py"))]
-    #[test_case(Rule::SubprocessWithoutShellEqualsTrue, Path::new("S603.py"))]
+    #[test_case(Rule::SubprocessCallWithUntrustedInput, Path::new("S603.py"))]
     #[test_case(Rule::SuspiciousPickleUsage, Path::new("S301.py"))]
     #[test_case(Rule::SuspiciousEvalUsage, Path::new("S307.py"))]
     #[test_case(Rule::SuspiciousMarkSafeUsage, Path::new("S308.py"))]

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -56,12 +56,12 @@ impl Violation for SubprocessPopenWithShellEqualsTrue {
 }
 
 /// ## What it does
-/// Check for method calls that initiate a subprocess without a shell.
+/// Check for subprocess calls whose input may be untrusted.
 ///
 /// ## Why is this bad?
-/// Starting a subprocess without a shell can prevent attackers from executing
-/// arbitrary shell commands; however, it is still error-prone. Consider
-/// validating the input.
+/// A subprocess call with untrusted input can allow attackers to influence
+/// the command that is executed. Validate or otherwise constrain the input
+/// before passing it to the subprocess.
 ///
 /// ## Known problems
 /// Prone to false positives as it is difficult to determine whether the
@@ -81,9 +81,9 @@ impl Violation for SubprocessPopenWithShellEqualsTrue {
 /// [#4045]: https://github.com/astral-sh/ruff/issues/4045
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.262")]
-pub(crate) struct SubprocessWithoutShellEqualsTrue;
+pub(crate) struct SubprocessCallWithUntrustedInput;
 
-impl Violation for SubprocessWithoutShellEqualsTrue {
+impl Violation for SubprocessCallWithUntrustedInput {
     #[derive_message_formats]
     fn message(&self) -> String {
         "`subprocess` call: check for execution of untrusted input".to_string()
@@ -342,7 +342,7 @@ pub(crate) fn shell_injection(checker: &Checker, call: &ast::ExprCall) {
                 _ => {
                     if !is_trusted_input(arg, checker.semantic()) {
                         checker.report_diagnostic_if_enabled(
-                            SubprocessWithoutShellEqualsTrue,
+                            SubprocessCallWithUntrustedInput,
                             call.func.range(),
                         );
                     }


### PR DESCRIPTION
Fixes #27322.

Align S603 metadata with the diagnostic message by renaming the violation type and updating its generated documentation description.