### PR TITLE
Run Hawk in CI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>astral-sh/renovate-config"],
+  extends: [
+    "github>astral-sh/renovate-config",
+    "customManagers:githubActionsVersions",
+  ],
   schedule: ["before 4am on Wednesday"],
   enabledManagers: ["github-actions", "pre-commit", "cargo", "pep621", "pip_requirements", "npm", "custom.regex"],
   pep621: {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   # renovate: datasource=github-releases depName=astral-sh/hawk
-  HAWK_VERSION: 0.1.11
+  HAWK_VERSION: 0.1.12
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.14"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ env:
   CARGO_PROFILE_DEV_OPT_LEVEL: 0
   CARGO_TERM_COLOR: always
   # renovate: datasource=github-releases depName=astral-sh/hawk
-  HAWK_VERSION: 0.1.12
+  HAWK_VERSION: 0.1.13
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.14"
@@ -344,13 +344,13 @@ jobs:
           cache-workspace-crates: "false"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: "Install Rust toolchain"
-        run: rustup toolchain install 1.97.1
+        run: rustup toolchain install 1.98.0
       - name: "Install Hawk"
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
       - name: "Hawk"
-        run: cargo +1.97.1 hawk check --target-dir target/hawk -D warnings
+        run: cargo +1.98.0 hawk check --target-dir target/hawk -D warnings
 
   cargo-publish-dry-run:
     name: "cargo publish dry-run"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
+  # renovate: datasource=github-releases depName=astral-sh/hawk
+  HAWK_VERSION: 0.1.11
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.14"
@@ -300,6 +302,30 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
       - name: "Clippy (wasm)"
         run: cargo clippy -p ruff_wasm -p ty_wasm --target wasm32-unknown-unknown --all-features --locked -- -D warnings
+
+  hawk:
+    name: "cargo hawk"
+    runs-on: ubuntu-latest
+    needs: determine_changes
+    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: ". -> target/hawk"
+          cache-workspace-crates: "false"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Install Rust toolchain"
+        run: rustup toolchain install 1.97.1
+      - name: "Install Hawk"
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
+      - name: "Hawk"
+        run: cargo +1.97.1 hawk check --target-dir target/hawk -D warnings
 
   cargo-publish-dry-run:
     name: "cargo publish dry-run"
@@ -1315,6 +1341,7 @@ jobs:
     needs:
       - cargo-fmt
       - cargo-clippy
+      - hawk
       - cargo-test-linux
       - cargo-test-wasm
       - cargo-build-msrv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ env:
   CARGO_PROFILE_DEV_LTO: "false"
   CARGO_PROFILE_DEV_OPT_LEVEL: 0
   CARGO_TERM_COLOR: always
+  # renovate: datasource=github-releases depName=astral-sh/hawk
+  HAWK_VERSION: 0.1.11
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.14"
@@ -325,6 +327,30 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
       - name: "Clippy (wasm)"
         run: cargo clippy -p ruff_wasm -p ty_wasm --target wasm32-unknown-unknown --all-features --locked -- -D warnings
+
+  hawk:
+    name: "cargo hawk"
+    runs-on: ubuntu-latest
+    needs: determine_changes
+    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: ". -> target/hawk"
+          cache-workspace-crates: "false"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Install Rust toolchain"
+        run: rustup toolchain install 1.97.1
+      - name: "Install Hawk"
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
+      - name: "Hawk"
+        run: cargo +1.97.1 hawk check --target-dir target/hawk -D warnings
 
   cargo-publish-dry-run:
     name: "cargo publish dry-run"
@@ -1397,6 +1423,7 @@ jobs:
     needs:
       - cargo-fmt
       - cargo-clippy
+      - hawk
       - cargo-test-linux
       - cargo-test-wasm
       - cargo-build-msrv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ env:
   CARGO_PROFILE_DEV_OPT_LEVEL: 0
   CARGO_TERM_COLOR: always
   # renovate: datasource=github-releases depName=astral-sh/hawk
-  HAWK_VERSION: 0.1.11
+  HAWK_VERSION: 0.1.12
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
   PYTHON_VERSION: "3.14"

--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -5,7 +5,7 @@ use ruff_benchmark::criterion::{
 };
 
 use ruff_benchmark::{
-    LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestCase, UNICODE_PYPINYIN,
+    LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestFile, UNICODE_PYPINYIN,
 };
 use ruff_python_formatter::{PreviewMode, PyFormatOptions, format_module_ast};
 use ruff_python_parser::{Mode, ParseOptions, parse};
@@ -28,13 +28,13 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-fn create_test_cases() -> Vec<TestCase> {
+fn create_test_cases() -> Vec<TestFile> {
     vec![
-        TestCase::fast(NUMPY_GLOBALS.clone()),
-        TestCase::fast(UNICODE_PYPINYIN.clone()),
-        TestCase::normal(PYDANTIC_TYPES.clone()),
-        TestCase::normal(NUMPY_CTYPESLIB.clone()),
-        TestCase::slow(LARGE_DATASET.clone()),
+        NUMPY_GLOBALS.clone(),
+        UNICODE_PYPINYIN.clone(),
+        PYDANTIC_TYPES.clone(),
+        NUMPY_CTYPESLIB.clone(),
+        LARGE_DATASET.clone(),
     ]
 }
 

--- a/crates/ruff_benchmark/benches/lexer.rs
+++ b/crates/ruff_benchmark/benches/lexer.rs
@@ -4,7 +4,7 @@ use criterion::{
     BenchmarkId, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use ruff_benchmark::{
-    LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestCase, UNICODE_PYPINYIN,
+    LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestFile, UNICODE_PYPINYIN,
 };
 use ruff_python_ast::token::TokenKind;
 use ruff_python_parser::{Mode, lexer};
@@ -26,13 +26,13 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-fn create_test_cases() -> Vec<TestCase> {
+fn create_test_cases() -> Vec<TestFile> {
     vec![
-        TestCase::fast(NUMPY_GLOBALS.clone()),
-        TestCase::fast(UNICODE_PYPINYIN.clone()),
-        TestCase::normal(PYDANTIC_TYPES.clone()),
-        TestCase::normal(NUMPY_CTYPESLIB.clone()),
-        TestCase::slow(LARGE_DATASET.clone()),
+        NUMPY_GLOBALS.clone(),
+        UNICODE_PYPINYIN.clone(),
+        PYDANTIC_TYPES.clone(),
+        NUMPY_CTYPESLIB.clone(),
+        LARGE_DATASET.clone(),
     ]
 }
 

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -4,7 +4,7 @@ use criterion::{
     BenchmarkGroup, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
 };
 use ruff_benchmark::{
-    LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestCase, UNICODE_PYPINYIN,
+    LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestFile, UNICODE_PYPINYIN,
 };
 use ruff_linter::linter::{ParseSource, lint_only};
 use ruff_linter::rule_selector::PreviewOptions;
@@ -52,13 +52,13 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[expect(unsafe_code)]
 pub static _rjem_malloc_conf: &[u8] = b"dirty_decay_ms:-1,muzzy_decay_ms:-1\0";
 
-fn create_test_cases() -> Vec<TestCase> {
+fn create_test_cases() -> Vec<TestFile> {
     vec![
-        TestCase::fast(NUMPY_GLOBALS.clone()),
-        TestCase::fast(UNICODE_PYPINYIN.clone()),
-        TestCase::normal(PYDANTIC_TYPES.clone()),
-        TestCase::normal(NUMPY_CTYPESLIB.clone()),
-        TestCase::slow(LARGE_DATASET.clone()),
+        NUMPY_GLOBALS.clone(),
+        UNICODE_PYPINYIN.clone(),
+        PYDANTIC_TYPES.clone(),
+        NUMPY_CTYPESLIB.clone(),
+        LARGE_DATASET.clone(),
     ]
 }
 

--- a/crates/ruff_benchmark/benches/parser.rs
+++ b/crates/ruff_benchmark/benches/parser.rs
@@ -4,7 +4,7 @@ use criterion::{
     BenchmarkId, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use ruff_benchmark::{
-    LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestCase, UNICODE_PYPINYIN,
+    LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestFile, UNICODE_PYPINYIN,
 };
 use ruff_python_parser::parse_module;
 
@@ -25,13 +25,13 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-fn create_test_cases() -> Vec<TestCase> {
+fn create_test_cases() -> Vec<TestFile> {
     vec![
-        TestCase::fast(NUMPY_GLOBALS.clone()),
-        TestCase::fast(UNICODE_PYPINYIN.clone()),
-        TestCase::normal(PYDANTIC_TYPES.clone()),
-        TestCase::normal(NUMPY_CTYPESLIB.clone()),
-        TestCase::slow(LARGE_DATASET.clone()),
+        NUMPY_GLOBALS.clone(),
+        UNICODE_PYPINYIN.clone(),
+        PYDANTIC_TYPES.clone(),
+        NUMPY_CTYPESLIB.clone(),
+        LARGE_DATASET.clone(),
     ]
 }
 

--- a/crates/ruff_benchmark/src/lib.rs
+++ b/crates/ruff_benchmark/src/lib.rs
@@ -32,43 +32,6 @@ pub static LARGE_DATASET: TestFile = TestFile::new(
 );
 
 #[derive(Debug, Clone)]
-pub struct TestCase {
-    file: TestFile,
-}
-
-impl TestCase {
-    pub const fn fast(file: TestFile) -> Self {
-        Self { file }
-    }
-
-    pub const fn normal(file: TestFile) -> Self {
-        Self { file }
-    }
-
-    pub const fn slow(file: TestFile) -> Self {
-        Self { file }
-    }
-
-    pub fn code(&self) -> &str {
-        self.file.code
-    }
-
-    pub fn name(&self) -> &str {
-        self.file.name
-    }
-
-    pub fn path(&self) -> PathBuf {
-        PathBuf::from(file!())
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("resources")
-            .join(self.name())
-    }
-}
-
-#[derive(Debug, Clone)]
 pub struct TestFile {
     name: &'static str,
     code: &'static str,
@@ -85,5 +48,15 @@ impl TestFile {
 
     pub fn name(&self) -> &str {
         self.name
+    }
+
+    pub fn path(&self) -> PathBuf {
+        PathBuf::from(file!())
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("resources")
+            .join(self.name())
     }
 }

--- a/crates/ruff_benchmark/src/lib.rs
+++ b/crates/ruff_benchmark/src/lib.rs
@@ -31,45 +31,22 @@ pub static LARGE_DATASET: TestFile = TestFile::new(
     include_str!("../resources/large/dataset.py"),
 );
 
-/// Relative size of a test case. Benchmarks can use it to configure the time for how long a benchmark should run to get stable results.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum TestCaseSpeed {
-    /// A test case that is fast to run
-    Fast,
-
-    /// A normal test case
-    Normal,
-
-    /// A slow test case
-    Slow,
-}
-
 #[derive(Debug, Clone)]
 pub struct TestCase {
     file: TestFile,
-    speed: TestCaseSpeed,
 }
 
 impl TestCase {
     pub const fn fast(file: TestFile) -> Self {
-        Self {
-            file,
-            speed: TestCaseSpeed::Fast,
-        }
+        Self { file }
     }
 
     pub const fn normal(file: TestFile) -> Self {
-        Self {
-            file,
-            speed: TestCaseSpeed::Normal,
-        }
+        Self { file }
     }
 
     pub const fn slow(file: TestFile) -> Self {
-        Self {
-            file,
-            speed: TestCaseSpeed::Slow,
-        }
+        Self { file }
     }
 
     pub fn code(&self) -> &str {
@@ -78,10 +55,6 @@ impl TestCase {
 
     pub fn name(&self) -> &str {
         self.file.name
-    }
-
-    pub fn speed(&self) -> TestCaseSpeed {
-        self.speed
     }
 
     pub fn path(&self) -> PathBuf {

--- a/crates/ruff_benchmark/src/real_world_projects.rs
+++ b/crates/ruff_benchmark/src/real_world_projects.rs
@@ -122,19 +122,9 @@ pub struct InstalledProject<'a> {
 }
 
 impl<'a> InstalledProject<'a> {
-    /// Get the project configuration
-    pub fn config(&self) -> &RealWorldProject<'a> {
-        &self.config
-    }
-
     /// Get the benchmark paths
     pub fn check_paths(&self) -> &[&str] {
         self.config.paths
-    }
-
-    /// Get the virtual environment path
-    pub fn venv_path(&self) -> PathBuf {
-        self.path.join(".venv")
     }
 
     /// Copies the entire project to a memory file system.

--- a/crates/ruff_benchmark/src/real_world_projects.rs
+++ b/crates/ruff_benchmark/src/real_world_projects.rs
@@ -121,7 +121,7 @@ pub struct InstalledProject<'a> {
     pub config: RealWorldProject<'a>,
 }
 
-impl<'a> InstalledProject<'a> {
+impl InstalledProject<'_> {
     /// Get the benchmark paths
     pub fn check_paths(&self) -> &[&str] {
         self.config.paths

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -402,7 +402,7 @@ impl File {
     ///
     /// Reading the same file multiple times isn't guaranteed to return the same content. It's possible
     /// that the file has been modified in between the reads.
-    pub fn read_to_string(&self, db: &dyn Db) -> crate::system::Result<String> {
+    pub(crate) fn read_to_string(&self, db: &dyn Db) -> crate::system::Result<String> {
         let path = self.path(db);
 
         match path {

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -117,7 +117,7 @@ pub struct ParsedModule {
 }
 
 impl ParsedModule {
-    pub fn new(file: File, python_version: PythonVersion, parsed: Parsed<ModModule>) -> Self {
+    fn new(file: File, python_version: PythonVersion, parsed: Parsed<ModModule>) -> Self {
         Self {
             file,
             python_version,

--- a/crates/ruff_python_ast/src/script.rs
+++ b/crates/ruff_python_ast/src/script.rs
@@ -163,7 +163,7 @@ pub struct ScriptSourceMap {
 
 impl ScriptSourceMap {
     /// Maps a metadata offset to the corresponding offset in the Python source.
-    pub fn map_offset(&self, offset: TextSize) -> TextSize {
+    fn map_offset(&self, offset: TextSize) -> TextSize {
         let Some(index) = self
             .markers
             .partition_point(|marker| marker.metadata_offset <= offset)

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -56,7 +56,7 @@ impl<'db> Module<'db> {
     }
 
     /// The resolver environment used to resolve this module.
-    pub fn resolver_environment(self, db: &'db dyn Database) -> ResolverEnvironment<'db> {
+    fn resolver_environment(self, db: &'db dyn Database) -> ResolverEnvironment<'db> {
         match self {
             Module::File(module) => module.resolver_environment(db),
             Module::Namespace(module) => module.resolver_environment(db),

--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -507,7 +507,7 @@ impl<'db> ImportingFile<'db> {
         }
     }
 
-    pub fn resolver_environment(self, db: &'db dyn Db) -> ResolverEnvironment<'db> {
+    pub(crate) fn resolver_environment(self, db: &'db dyn Db) -> ResolverEnvironment<'db> {
         match self {
             Self::ResolverFile(file) => file.environment(db),
             Self::File(_, resolver_environment) => resolver_environment,

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -102,7 +102,7 @@ impl ProjectMetadata {
     }
 
     /// Loads a project from a configuration file using the explicitly configured uv integrations.
-    pub fn from_config_file_with_uv(
+    fn from_config_file_with_uv(
         path: SystemPathBuf,
         root: &SystemPath,
         system: &dyn System,
@@ -198,7 +198,7 @@ impl ProjectMetadata {
     }
 
     /// Discovers the closest project using the explicitly configured uv integrations.
-    pub fn discover_with_uv(
+    fn discover_with_uv(
         path: &SystemPath,
         system: &dyn System,
         use_uv: UseUv,
@@ -403,7 +403,7 @@ impl ProjectMetadata {
 
     /// Configures which uv integrations are enabled for this project.
     #[must_use]
-    pub fn with_use_uv(mut self, use_uv: UseUv) -> Self {
+    pub(crate) fn with_use_uv(mut self, use_uv: UseUv) -> Self {
         self.use_uv = use_uv;
         self
     }

--- a/crates/ty_project/src/metadata/pyproject.rs
+++ b/crates/ty_project/src/metadata/pyproject.rs
@@ -141,7 +141,7 @@ pub enum ResolveRequiresPythonError {
 
 impl ResolveRequiresPythonError {
     /// Returns the error without its optional recovery guidance.
-    pub fn message(&self) -> String {
+    pub(crate) fn message(&self) -> String {
         match self {
             Self::TooLargeMajor(version) => {
                 format!(
@@ -163,7 +163,7 @@ impl ResolveRequiresPythonError {
     }
 
     /// Returns guidance for fixing the invalid Python requirement, when available.
-    pub fn hint(&self) -> Option<&'static str> {
+    pub(crate) fn hint(&self) -> Option<&'static str> {
         match self {
             Self::NoLowerBound(_) => Some(
                 "Add a lower bound to indicate the minimum compatible Python version (e.g., `>=3.13`) or specify a version in `environment.python-version`.",

--- a/crates/ty_project/src/metadata/settings.rs
+++ b/crates/ty_project/src/metadata/settings.rs
@@ -58,7 +58,7 @@ impl Settings {
         &self.overrides
     }
 
-    pub(crate) fn analysis(&self) -> &AnalysisSettings {
+    fn analysis(&self) -> &AnalysisSettings {
         &self.analysis
     }
 }

--- a/crates/ty_project/src/script/environment.rs
+++ b/crates/ty_project/src/script/environment.rs
@@ -187,7 +187,7 @@ impl ScriptEnvironments {
     }
 
     /// Returns whether `file`'s environment is [`Pending`](ScriptEnvironmentAvailability::Pending).
-    pub fn is_initialization_pending(&self, db: &dyn Db, file: File) -> bool {
+    pub(crate) fn is_initialization_pending(&self, db: &dyn Db, file: File) -> bool {
         if !self.is_enabled() || script_tag(db, file).is_none() {
             return false;
         }

--- a/crates/ty_project/src/uv.rs
+++ b/crates/ty_project/src/uv.rs
@@ -41,7 +41,7 @@ pub enum UseUv {
 
 impl UseUv {
     /// Resolves the mode configured by the `TY_UV` environment variable.
-    pub fn from_system(system: &dyn System) -> Self {
+    pub(crate) fn from_system(system: &dyn System) -> Self {
         match system.env_var(EnvVars::TY_UV).as_deref() {
             Ok("1" | "true") => Self::On,
             Ok("scripts") => Self::Scripts,
@@ -97,7 +97,7 @@ impl Uv {
     /// This operation only requires a detached command executor, so it can run on a background
     /// worker.
     #[tracing::instrument(name = "Uv::execute", level = "debug", skip(self, executor))]
-    pub(crate) fn execute(
+    fn execute(
         &self,
         executor: &dyn CommandExecutor,
         target: MetadataTarget<'_>,

--- a/crates/ty_project/src/uv/sync.rs
+++ b/crates/ty_project/src/uv/sync.rs
@@ -225,7 +225,7 @@ impl ScriptSyncRequest {
     }
 
     /// The `--python` argument
-    pub(crate) fn python(&self) -> Option<&ruff_db::system::SystemPath> {
+    fn python(&self) -> Option<&ruff_db::system::SystemPath> {
         self.0.python.as_deref()
     }
 

--- a/crates/ty_python_core/src/scope.rs
+++ b/crates/ty_python_core/src/scope.rs
@@ -60,7 +60,7 @@ impl<'db> ScopeId<'db> {
     }
 
     /// Returns the class definition for the enclosing class if this scope is a method body.
-    pub fn class_definition_of_method(self, db: &'db dyn Db) -> Option<Definition<'db>> {
+    fn class_definition_of_method(self, db: &'db dyn Db) -> Option<Definition<'db>> {
         semantic_index(db, self.program_file(db)).class_definition_of_method(self.file_scope_id(db))
     }
 

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -62,7 +62,7 @@ impl ScopedDefinitionId {
     /// unbound or undeclared at a given usage site.
     /// When creating a use-def-map builder, we always add an empty `DefinitionState::Undefined` definition
     /// at index 0, so this ID is always present.
-    pub(crate) const UNBOUND: ScopedDefinitionId = ScopedDefinitionId::from_u32(0);
+    const UNBOUND: ScopedDefinitionId = ScopedDefinitionId::from_u32(0);
 
     pub(crate) fn is_unbound(self) -> bool {
         self == Self::UNBOUND

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -309,7 +309,7 @@ impl<'db> Place<'db> {
     }
 
     #[must_use]
-    pub(crate) fn map_type(self, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Place<'db> {
+    fn map_type(self, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Place<'db> {
         match self {
             Place::Defined(defined) => Place::Defined(DefinedPlace {
                 ty: f(defined.ty),

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -786,7 +786,7 @@ pub trait HasDefinition {
     fn definition<'db>(&self, model: &SemanticModel<'db>) -> Definition<'db>;
 }
 
-pub(crate) trait HasOptionalDefinition {
+trait HasOptionalDefinition {
     /// Returns the definition of `self`, if it has one.
     ///
     /// ## Panics

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -681,7 +681,7 @@ pub trait HasDefinition {
     fn definition<'db>(&self, model: &SemanticModel<'db>) -> Definition<'db>;
 }
 
-pub(crate) trait HasOptionalDefinition {
+trait HasOptionalDefinition {
     /// Returns the definition of `self`, if it has one.
     ///
     /// ## Panics

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -100,11 +100,11 @@ use crate::types::tuple::TupleSpec;
 pub use crate::types::type_alias::TypeAliasType;
 pub use crate::types::type_form::TypeFormType;
 pub(crate) use crate::types::typed_dict::TypedDictType;
-pub(crate) use crate::types::typevar::TypeVarBoundOrConstraints;
-pub use crate::types::typevar::{
-    BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance, ParamSpecAttrKind, TypeVarKind,
+pub(crate) use crate::types::typevar::{
+    BindingContext, BoundTypeVarIdentity, ParamSpecAttrKind, TypeVarBoundOrConstraints,
     TypeVarNonce,
 };
+pub use crate::types::typevar::{BoundTypeVarInstance, TypeVarKind};
 use crate::types::typevar::{TypeVarInstance, TypeVarSet};
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
@@ -1880,7 +1880,7 @@ impl<'db> Type<'db> {
         })
     }
 
-    pub(crate) fn is_fully_static(self, db: &'db dyn Db, env: &ProgramEnvironment) -> bool {
+    fn is_fully_static(self, db: &'db dyn Db, env: &ProgramEnvironment) -> bool {
         dynamic_content(db, env, self).is_absent()
     }
 
@@ -1978,7 +1978,7 @@ impl<'db> Type<'db> {
         self.cycle_normalized_impl(db, env, previous, cycle)
     }
 
-    pub(super) fn cycle_normalized_impl(
+    fn cycle_normalized_impl(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -4794,7 +4794,7 @@ impl<'db> Type<'db> {
     /// See also: [`Type::static_member`]
     ///
     #[must_use]
-    pub(crate) fn member(
+    fn member(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3390,7 +3390,7 @@ impl<'db> ClassMetaclass<'db> {
         }
     }
 
-    pub(super) fn to_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
+    fn to_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         match self {
             Self::Selected(metaclass) => metaclass,
             Self::ProtocolFallback => KnownClass::ABCMeta.to_class_literal(db, env),

--- a/crates/ty_python_semantic/src/types/class/slots.rs
+++ b/crates/ty_python_semantic/src/types/class/slots.rs
@@ -498,7 +498,7 @@ impl<'db> StaticClassLiteral<'db> {
     }
 
     /// Returns whether instance dictionary storage exists or cannot be ruled out.
-    pub(crate) fn has_instance_dictionary(self, db: &'db dyn Db) -> bool {
+    fn has_instance_dictionary(self, db: &'db dyn Db) -> bool {
         if !self.has_explicit_slots(db) && !self.has_generated_slots(db) && self.known(db).is_none()
         {
             return true;

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -505,7 +505,7 @@ impl<'db> StaticClassLiteral<'db> {
     }
 
     /// Returns the generic context that should be inherited by any constructor methods of this class.
-    pub(super) fn inherited_generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
+    fn inherited_generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         self.generic_context(db)
     }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1857,15 +1857,15 @@ pub(crate) enum ConstraintBound<'db> {
 }
 
 impl<'db> ConstraintBound<'db> {
-    pub(crate) const fn missing_lower() -> Self {
+    const fn missing_lower() -> Self {
         Self::Validity(Type::Never)
     }
 
-    pub(crate) const fn missing_upper() -> Self {
+    const fn missing_upper() -> Self {
         Self::Validity(Type::object())
     }
 
-    pub(crate) fn ty(self) -> Type<'db> {
+    fn ty(self) -> Type<'db> {
         match self {
             Self::Validity(ty) | Self::Evidence(ty) => ty,
         }
@@ -2011,11 +2011,11 @@ impl<'db> ConstraintBounds<'db> {
         )
     }
 
-    pub(crate) fn lower_bound(self) -> ConstraintBound<'db> {
+    fn lower_bound(self) -> ConstraintBound<'db> {
         self.lower.unwrap_or_else(ConstraintBound::missing_lower)
     }
 
-    pub(crate) fn upper_bound(self) -> ConstraintBound<'db> {
+    fn upper_bound(self) -> ConstraintBound<'db> {
         self.upper.unwrap_or_else(ConstraintBound::missing_upper)
     }
 
@@ -2078,7 +2078,7 @@ impl<'db> UpperBound<'db> {
         self.validity.iter().copied().map(ConstraintBound::Validity)
     }
 
-    pub(crate) fn iter_clauses(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
+    fn iter_clauses(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
         iter::chain(self.iter_evidence(), self.iter_validity())
     }
 
@@ -3764,7 +3764,7 @@ impl<'db> PathBoundSolution<'db> {
 pub(crate) struct PathBound<'db> {
     pub(crate) bound_typevar: BoundTypeVarInstance<'db>,
     pub(crate) evidence_lower: Option<Type<'db>>,
-    pub(crate) validity_lower: Type<'db>,
+    validity_lower: Type<'db>,
     pub(crate) upper: UpperBound<'db>,
     /// Whether the path contains gradual evidence and no static evidence.
     has_only_gradual_evidence: bool,
@@ -3781,11 +3781,7 @@ impl<'db> PathBound<'db> {
         }
     }
 
-    pub(crate) fn effective_lower(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Type<'db> {
+    fn effective_lower(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         let Some(evidence_lower) = self.evidence_lower else {
             return self.validity_lower;
         };

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -47,7 +47,7 @@ impl<'db> ProgramEnvironment<'db> {
     }
 
     /// Creates an environment that lazily obtains its program from `definition`.
-    pub fn from_definition(definition: Definition<'db>) -> Self {
+    pub(crate) fn from_definition(definition: Definition<'db>) -> Self {
         Self {
             environment: Cell::new(ProgramSource::Definition(definition.as_id())),
             lifetime: PhantomData,
@@ -55,7 +55,7 @@ impl<'db> ProgramEnvironment<'db> {
     }
 
     /// Creates an environment that lazily obtains its program from `scope`.
-    pub fn from_scope(scope: ScopeId<'db>) -> Self {
+    pub(crate) fn from_scope(scope: ScopeId<'db>) -> Self {
         Self {
             environment: Cell::new(ProgramSource::Scope(scope.as_id())),
             lifetime: PhantomData,
@@ -102,13 +102,13 @@ impl<'db> ProgramEnvironment<'db> {
 
     /// Returns the Python version used by this operation.
     #[inline]
-    pub fn python_version(&self, db: &'db dyn Db) -> PythonVersion {
+    pub(crate) fn python_version(&self, db: &'db dyn Db) -> PythonVersion {
         self.program(db).python_version(db)
     }
 
     /// Returns the resolver environment used by this operation.
     #[inline]
-    pub fn resolver_environment(&self, db: &'db dyn Db) -> ResolverEnvironment<'db> {
+    pub(crate) fn resolver_environment(&self, db: &'db dyn Db) -> ResolverEnvironment<'db> {
         self.program(db).resolver_environment(db)
     }
 }
@@ -185,7 +185,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         self.file
     }
 
-    pub(crate) fn python_file(&self) -> PythonFile<'db> {
+    fn python_file(&self) -> PythonFile<'db> {
         self.program_file.python_file(self.db())
     }
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -146,7 +146,7 @@ pub struct DisplaySettings<'db> {
 
 impl<'db> DisplaySettings<'db> {
     #[must_use]
-    pub fn multiline(&self) -> Self {
+    fn multiline(&self) -> Self {
         Self {
             multiline: true,
             ..self.clone()
@@ -162,7 +162,7 @@ impl<'db> DisplaySettings<'db> {
     }
 
     #[must_use]
-    pub(crate) fn preserve_long_unions(self) -> Self {
+    fn preserve_long_unions(self) -> Self {
         Self {
             preserve_full_unions: true,
             ..self
@@ -182,7 +182,7 @@ impl<'db> DisplaySettings<'db> {
     }
 
     #[must_use]
-    pub(crate) fn disallow_signature_name(&self) -> Self {
+    fn disallow_signature_name(&self) -> Self {
         Self {
             signature_name_display: SignatureNameDisplay::Disallow,
             ..self.clone()
@@ -198,7 +198,7 @@ impl<'db> DisplaySettings<'db> {
     }
 
     #[must_use]
-    pub(crate) fn hide_return_type(&self) -> Self {
+    fn hide_return_type(&self) -> Self {
         Self {
             hide_return_type: true,
             ..self.clone()
@@ -652,7 +652,7 @@ impl<'db> Type<'db> {
         }
     }
 
-    pub fn display_with<'env>(
+    pub(crate) fn display_with<'env>(
         self,
         db: &'db dyn Db,
         env: &'env ProgramEnvironment<'db>,
@@ -2376,7 +2376,7 @@ impl<'db> Signature<'db> {
         )
     }
 
-    pub(crate) fn display_with<'a>(
+    fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
         env: &'a ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -336,7 +336,7 @@ impl<'db> OverloadLiteral<'db> {
         self.body_scope(db).python_file(db)
     }
 
-    pub(crate) fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+    fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
         self.body_scope(db).program_file(db)
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -213,9 +213,6 @@ impl<'db> NominalInstanceType<'db> {
     ///
     /// For example, for an instance of `builtins.str`, this returns `"str"`.
     ///
-    /// As of 2026-02-16, this method is not used in any crates in the Ruff
-    /// repo, but is exposed as a public API for external users of
-    /// `ty_python_semantic`.
     pub fn class_name(&self, db: &'db dyn Db) -> &'db Name {
         self.class(db).name(db)
     }
@@ -227,9 +224,6 @@ impl<'db> NominalInstanceType<'db> {
     /// `Some("pathlib")`. Returns `None` if the class's file cannot be resolved
     /// to a known module (e.g. for classes defined in scripts or notebooks).
     ///
-    /// As of 2026-02-16, this method is not used in any crates in the Ruff
-    /// repo, but is exposed as a public API for external users of
-    /// `ty_python_semantic`.
     pub fn class_module_name(&self, db: &'db dyn Db) -> Option<&'db ModuleName> {
         let file = self.class(db).class_literal(db).file(db);
         file_to_module(db, file).map(|module| module.name(db))

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -6,9 +6,6 @@ use std::cell::Cell;
 use std::debug_assert_matches;
 use std::marker::PhantomData;
 
-use ruff_python_ast::name::Name;
-use ty_module_resolver::{ModuleName, file_to_module};
-
 use super::protocol_class::{ProtocolInterface, ProtocolInterfaceView, StructuralMemberPriority};
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, ClassType, DivergentType, KnownClass,
@@ -231,30 +228,6 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::NonTuple(class) => class.inherits_from_explicit_any(),
             _ => false,
         }
-    }
-
-    /// Returns the name of the class this is an instance of.
-    ///
-    /// For example, for an instance of `builtins.str`, this returns `"str"`.
-    ///
-    pub fn class_name(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> &'db Name {
-        self.class(db, env).name(db)
-    }
-
-    /// Returns the fully qualified module name of the module in which the class
-    /// is defined, if it can be resolved.
-    ///
-    /// For example, for an instance of `pathlib.Path`, this returns
-    /// `Some("pathlib")`. Returns `None` if the class's file cannot be resolved
-    /// to a known module (e.g. for classes defined in scripts or notebooks).
-    ///
-    pub fn class_module_name(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Option<&'db ModuleName> {
-        let class = self.class(db, env).class_literal(db);
-        file_to_module(db, class.program_file(db).resolver_file(db)).map(|module| module.name(db))
     }
 
     pub(super) fn class(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> ClassType<'db> {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -237,9 +237,6 @@ impl<'db> NominalInstanceType<'db> {
     ///
     /// For example, for an instance of `builtins.str`, this returns `"str"`.
     ///
-    /// As of 2026-02-16, this method is not used in any crates in the Ruff
-    /// repo, but is exposed as a public API for external users of
-    /// `ty_python_semantic`.
     pub fn class_name(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> &'db Name {
         self.class(db, env).name(db)
     }
@@ -251,9 +248,6 @@ impl<'db> NominalInstanceType<'db> {
     /// `Some("pathlib")`. Returns `None` if the class's file cannot be resolved
     /// to a known module (e.g. for classes defined in scripts or notebooks).
     ///
-    /// As of 2026-02-16, this method is not used in any crates in the Ruff
-    /// repo, but is exposed as a public API for external users of
-    /// `ty_python_semantic`.
     pub fn class_module_name(
         &self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -439,7 +439,7 @@ impl<'db> Type<'db> {
     ///
     /// This is a separate method so that we can skip this expensive check when diagnostics
     /// are suppressed.
-    pub(crate) fn relation_error_context(
+    fn relation_error_context(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -2769,7 +2769,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 }
 
 pub(super) struct EquivalenceChecker<'a, 'c, 'db> {
-    pub(super) env: &'a ProgramEnvironment<'db>,
+    env: &'a ProgramEnvironment<'db>,
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     given: ConstraintSet<'db, 'c>,
     perform_expensive_checks: bool,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -819,7 +819,7 @@ impl<'db> TypeVarInstance<'db> {
 /// `0` is reserved for source-level, non-freshened typevars. Positive values identify fresh
 /// occurrences.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct TypeVarNonce(u32);
+pub(crate) struct TypeVarNonce(u32);
 
 // This type does not have any heap storage.
 impl get_size2::GetSize for TypeVarNonce {}
@@ -1694,7 +1694,7 @@ impl<'db> BindingContext<'db> {
         }
     }
 
-    pub(crate) fn program(self, db: &'db dyn Db) -> Program<'db> {
+    fn program(self, db: &'db dyn Db) -> Program<'db> {
         match self {
             Self::Definition(definition) => definition.program(db),
             Self::Synthetic(program) => program,
@@ -1707,7 +1707,7 @@ impl<'db> BindingContext<'db> {
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, get_size2::GetSize)]
-pub enum ParamSpecAttrKind {
+pub(crate) enum ParamSpecAttrKind {
     Args,
     Kwargs,
 }
@@ -2139,7 +2139,7 @@ pub enum TypeVarBoundOrConstraints<'db> {
     Constraints(TypeVarConstraints<'db>),
 }
 
-pub(super) fn walk_type_var_bounds<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+fn walk_type_var_bounds<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     bounds: TypeVarBoundOrConstraints<'db>,
     visitor: &V,

--- a/hawk.toml
+++ b/hawk.toml
@@ -967,49 +967,9 @@ level = "expect"
 reason = "semantic ingredients expose consistent file, scope, and program accessors"
 
 [[override]]
-lint = "hawk::unnecessary_public"
-crate = "ty_python_semantic"
-item = "FixtureBinding"
-kind = "reexport"
-level = "expect"
-reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
-
-[[override]]
-lint = "hawk::unnecessary_public"
-crate = "ty_python_semantic"
-item = "fixture_bindings_for_parameter"
-kind = "reexport"
-level = "expect"
-reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
-
-[[override]]
-lint = "hawk::unnecessary_public"
-crate = "ty_python_semantic"
-item = "types::FixtureBinding"
-kind = "reexport"
-level = "expect"
-reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
-
-[[override]]
-lint = "hawk::unnecessary_public"
-crate = "ty_python_semantic"
-item = "types::fixture_bindings_for_parameter"
-kind = "reexport"
-level = "expect"
-reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
-
-[[override]]
 lint = "hawk::dead_public"
 crate = "ty_python_semantic"
 item = "types::dedicated::pytest::FixtureBinding::<'db>::request"
-kind = "inherent_method"
-level = "expect"
-reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
-
-[[override]]
-lint = "hawk::unnecessary_public"
-crate = "ty_python_semantic"
-item = "types::dedicated::pytest::FixtureBinding::<'db>::fixture"
 kind = "inherent_method"
 level = "expect"
 reason = "the public pytest fixture lookup API exposes both request and fixture definitions"

--- a/hawk.toml
+++ b/hawk.toml
@@ -496,22 +496,6 @@ reason = "the public semantic model exposes its file identity and source locatio
 
 [[override]]
 lint = "hawk::dead_public"
-crate = "ty_python_semantic"
-item = "types::instance::NominalInstanceType::<'db>::class_name"
-kind = "inherent_method"
-level = "expect"
-reason = "unused in the Ruff workspace but retained for external ty_python_semantic consumers"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "ty_python_semantic"
-item = "types::instance::NominalInstanceType::<'db>::class_module_name"
-kind = "inherent_method"
-level = "expect"
-reason = "unused in the Ruff workspace but retained for external ty_python_semantic consumers"
-
-[[override]]
-lint = "hawk::dead_public"
 crate = "ruff_formatter"
 item = "formatter::Formatter::<'_, Context>::state_snapshot"
 kind = "inherent_method"

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,1046 @@
+# Keep intentional uniform field visibility audited instead of excluding whole files.
+
+preserve-uniform-field-visibility = true
+
+[[production]]
+package = "ruff"
+bin = "ruff"
+reason = "shipped Ruff binary"
+
+[[production]]
+package = "ty"
+bin = "ty"
+reason = "shipped ty type checker binary"
+
+[[production]]
+package = "ruff_python_formatter"
+bin = "ruff_python_formatter"
+reason = "workspace formatter development binary"
+
+[[production]]
+package = "ruff_dev"
+bin = "ruff_dev"
+reason = "workspace development binary"
+
+[[production]]
+package = "ty_completion_bench"
+bin = "ty_completion_bench"
+reason = "workspace completion benchmark binary"
+
+[[production]]
+package = "ty_completion_eval"
+bin = "ty_completion_eval"
+reason = "workspace completion evaluation binary"
+
+# Keep this list in sync with workspace packages that define doctests.
+
+[[doctest]]
+package = "ruff_annotate_snippets"
+
+[[doctest]]
+package = "ruff_cache"
+
+[[doctest]]
+package = "ruff_db"
+
+[[doctest]]
+package = "ruff_formatter"
+
+[[doctest]]
+package = "ruff_linter"
+
+[[doctest]]
+package = "ruff_notebook"
+
+[[doctest]]
+package = "ruff_options_metadata"
+
+[[doctest]]
+package = "ruff_python_ast"
+
+[[doctest]]
+package = "ruff_python_parser"
+
+[[doctest]]
+package = "ruff_python_stdlib"
+
+[[doctest]]
+package = "ruff_python_trivia"
+
+[[doctest]]
+package = "ruff_source_file"
+
+[[doctest]]
+package = "ruff_text_size"
+
+[[doctest]]
+package = "ruff_workspace"
+
+[[doctest]]
+package = "ty_module_resolver"
+
+[[doctest]]
+package = "ty_python_semantic"
+
+# Keep APIs used by targets outside Hawk's workspace analysis.
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_codegen"
+item = "generator::Generator::<'a>::unparse_suite"
+kind = "inherent_method"
+level = "expect"
+reason = "the standalone fuzz crate uses this method"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_trivia"
+item = "cursor::EOF_CHAR"
+kind = "constant"
+level = "expect"
+reason = "public cursor documentation links to this end-of-file sentinel"
+
+# Keep APIs referenced by public documentation or paired with sibling APIs.
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "format_element::BestFittingVariants::most_expanded"
+kind = "inherent_method"
+level = "expect"
+reason = "public best-fitting macro documentation links to this variant accessor"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "printer::printer_options::LineEnding::as_str"
+kind = "inherent_method"
+level = "expect"
+reason = "public line-ending settings documentation links to this representation accessor"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "settings::TargetVersion::linter_version"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the public parser and linter target-version accessor pair"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_parser"
+item = "Parsed::<T>::has_no_syntax_errors"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the public syntax-validity predicate API"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_parser"
+item = "parser::options::ParseOptions::with_max_recursion_depth"
+kind = "inherent_method"
+level = "expect"
+reason = "public parser options support configuring the documented recursion limit"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_parser"
+item = "parser::options::ParseOptions::max_recursion_depth"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the public recursion-limit builder and accessor pair"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_workspace"
+item = "settings::FormatterSettings::resolve_target_version"
+kind = "inherent_method"
+level = "expect"
+reason = "public formatter settings fields direct callers to this resolver"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_python_semantic"
+item = "semantic_model::SemanticModel::<'db>::scope"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the documented semantic-model scope navigation API"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_python_semantic"
+item = "types::set_theoretic::UnionType::<'db>::from_two_elements"
+kind = "inherent_method"
+level = "expect"
+reason = "public union construction documentation recommends this optimized constructor"
+
+# Keep the code component accessor API symmetric.
+
+[[override]]
+lint = "hawk::unnecessary_restricted_visibility"
+crate = "ruff_linter"
+item = "codes::NoqaCode::prefix"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric prefix and suffix accessor API"
+
+# Keep the symmetric edit-operation predicate APIs, including currently unused variants.
+
+[[override]]
+lint = "hawk::unnecessary_restricted_visibility"
+crate = "ruff_diagnostics"
+item = "edit::Edit::is_deletion"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric edit-operation predicate API"
+
+[[override]]
+lint = "hawk::unnecessary_restricted_visibility"
+crate = "ruff_diagnostics"
+item = "edit::Edit::is_replacement"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric edit-operation predicate API"
+
+[[override]]
+lint = "hawk::unnecessary_restricted_visibility"
+crate = "ruff_diagnostics"
+item = "edit::EditOperationKind::is_insertion"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric edit-operation predicate API"
+
+[[override]]
+lint = "hawk::unnecessary_restricted_visibility"
+crate = "ruff_diagnostics"
+item = "edit::EditOperationKind::is_deletion"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric edit-operation predicate API"
+
+[[override]]
+lint = "hawk::unnecessary_restricted_visibility"
+crate = "ruff_diagnostics"
+item = "edit::EditOperationKind::is_replacement"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric edit-operation predicate API"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "IndentStyle::is_space"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric indent-style predicate API"
+
+# Keep the public printer-options builder API uniform.
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "printer::printer_options::PrinterOptions::with_line_width"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional uniform printer-options builder API"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "printer::printer_options::PrinterOptions::with_indent"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional uniform printer-options builder API"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "printer::printer_options::PrinterOptions::with_tab_width"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional uniform printer-options builder API"
+
+# Keep public APIs retained during cleanup review.
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "formatter::Formatter::<'_, Context>::state_snapshot"
+kind = "inherent_method"
+level = "expect"
+reason = "formatter clients use snapshots to restore state after speculative formatting"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "formatter::Formatter::<'_, Context>::restore_state_snapshot"
+kind = "inherent_method"
+level = "expect"
+reason = "formatter clients use snapshots to restore state after speculative formatting"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "formatter::FormatterSnapshot"
+kind = "struct"
+level = "expect"
+reason = "formatter clients use snapshots to restore state after speculative formatting"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "binding::Binding::<'a>::is_deferred_type_alias"
+kind = "inherent_method"
+level = "expect"
+reason = "binding predicates intentionally expose the distinct type-alias classifications"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "binding::Binding::<'a>::is_type_alias"
+kind = "inherent_method"
+level = "expect"
+reason = "binding predicates intentionally expose the distinct type-alias classifications"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_source_file"
+item = "line_index::OneIndexed::checked_add"
+kind = "inherent_method"
+level = "expect"
+reason = "one-indexed arithmetic intentionally provides checked and saturating operations"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_source_file"
+item = "line_index::OneIndexed::checked_sub"
+kind = "inherent_method"
+level = "expect"
+reason = "one-indexed arithmetic intentionally provides checked and saturating operations"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_ast"
+item = "expression::StringLikePart::<'a>::as_string_literal"
+kind = "inherent_method"
+level = "expect"
+reason = "string-like AST parts intentionally expose consistent typed accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_ast"
+item = "name::Name::join"
+kind = "inherent_method"
+level = "expect"
+reason = "the AST name wrapper intentionally mirrors common string operations"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_ast"
+item = "token::TokenKind::is_non_soft_keyword"
+kind = "inherent_method"
+level = "expect"
+reason = "token kind predicates intentionally cover every keyword classification"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_ast"
+item = "token::tokens::TokenIterWithContext::<'a>::nesting"
+kind = "inherent_method"
+level = "expect"
+reason = "token iterator context intentionally exposes all tracked parser state"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_ide"
+item = "symbols::FlatSymbols::get"
+kind = "inherent_method"
+level = "expect"
+reason = "flat and hierarchical symbol collections intentionally share lookup APIs"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_ide"
+item = "symbols::FlatSymbols::len"
+kind = "inherent_method"
+level = "expect"
+reason = "flat and hierarchical symbol collections intentionally share collection APIs"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_ide"
+item = "symbols::HierarchicalSymbols::get"
+kind = "inherent_method"
+level = "expect"
+reason = "flat and hierarchical symbol collections intentionally share lookup APIs"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_ide"
+item = "symbols::HierarchicalSymbols::len"
+kind = "inherent_method"
+level = "expect"
+reason = "flat and hierarchical symbol collections intentionally share collection APIs"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_module_resolver"
+item = "module_glob::ModuleNameMatch::is_none"
+kind = "inherent_method"
+level = "expect"
+reason = "module glob match predicates intentionally cover every result variant"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::Level::is_error"
+kind = "inherent_method"
+level = "expect"
+reason = "lint level predicates intentionally cover every severity"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::Level::is_warn"
+kind = "inherent_method"
+level = "expect"
+reason = "lint level predicates intentionally cover every severity"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::Level::is_ignore"
+kind = "inherent_method"
+level = "expect"
+reason = "lint level predicates intentionally cover every severity"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::LintStatus::deprecated"
+kind = "inherent_method"
+level = "expect"
+reason = "lint status constructors intentionally cover every lifecycle state"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::LintRegistryBuilder::register_alias"
+kind = "inherent_method"
+level = "expect"
+reason = "the lint registry intentionally supports aliases before the first alias is added"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::LintRegistry::aliases"
+kind = "inherent_method"
+level = "expect"
+reason = "lint registry queries intentionally cover aliases and removed rules"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::LintRegistry::removed"
+kind = "inherent_method"
+level = "expect"
+reason = "lint registry queries intentionally cover aliases and removed rules"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::RuleSelection::enabled"
+kind = "inherent_method"
+level = "expect"
+reason = "rule selections intentionally support iteration with and without severity"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "lint::RuleSelection::iter"
+kind = "inherent_method"
+level = "expect"
+reason = "rule selections intentionally support iteration with and without severity"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "frozen::FrozenMap::<K, V>::iter_mut"
+kind = "inherent_method"
+level = "expect"
+reason = "the frozen map intentionally mirrors standard map iteration APIs"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "frozen::FrozenMap::<K, V>::values"
+kind = "inherent_method"
+level = "expect"
+reason = "the frozen map intentionally mirrors standard map iteration APIs"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "rank::RankBitBox::is_empty"
+kind = "inherent_method"
+level = "expect"
+reason = "the rank bit collection intentionally provides matching len and is_empty APIs"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_graph"
+item = "ModuleImports::is_empty"
+kind = "inherent_method"
+level = "expect"
+reason = "module import collections intentionally provide matching len and is_empty APIs"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "line_width::LineLengthFromIntError::0"
+kind = "field"
+level = "expect"
+reason = "the conversion error exposes the rejected line length to callers"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "rules::pep8_naming::settings::IgnoreNames::matches"
+kind = "inherent_method"
+level = "expect"
+reason = "public settings support downstream configuration and validation"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "rules::pep8_naming::settings::IgnoreNames::from_patterns"
+kind = "inherent_method"
+level = "expect"
+reason = "public settings support downstream configuration and validation"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "settings::LinterSettings::with_target_version"
+kind = "inherent_method"
+level = "expect"
+reason = "public test helpers use this builder from downstream crates"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "settings::LinterSettings::with_preview_mode"
+kind = "inherent_method"
+level = "expect"
+reason = "public test helpers use this builder from downstream crates"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "settings::LinterSettings::with_external_rules"
+kind = "inherent_method"
+level = "expect"
+reason = "public test helpers use this builder from downstream crates"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_workspace"
+item = "configuration::FormatConfiguration::from_options"
+kind = "inherent_method"
+level = "expect"
+reason = "workspace configuration types retain public constructors for downstream integrations"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_workspace"
+item = "configuration::AnalyzeConfiguration::from_options"
+kind = "inherent_method"
+level = "expect"
+reason = "workspace configuration types retain public constructors for downstream integrations"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_project"
+item = "db::testing::TestDb::take_salsa_events"
+kind = "inherent_method"
+level = "expect"
+reason = "the testing feature exposes database event assertions to downstream tests"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_benchmark"
+item = "TestCase::speed"
+kind = "inherent_method"
+level = "expect"
+reason = "benchmark support types retain their complete harness interface"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_benchmark"
+item = "real_world_projects::InstalledProject::<'a>::config"
+kind = "inherent_method"
+level = "expect"
+reason = "benchmark support types retain their complete harness interface"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_benchmark"
+item = "real_world_projects::InstalledProject::<'a>::venv_path"
+kind = "inherent_method"
+level = "expect"
+reason = "benchmark support types retain their complete harness interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "completion::Completion::builtin"
+kind = "field"
+level = "expect"
+reason = "completion metadata remains visible to downstream test and protocol adapters"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "completion::Completion::is_type_check_only"
+kind = "field"
+level = "expect"
+reason = "completion metadata remains visible to downstream test and protocol adapters"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "completion::Completion::is_context_specific"
+kind = "field"
+level = "expect"
+reason = "completion metadata remains visible to downstream test and protocol adapters"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "symbols::HierarchicalSymbols::is_empty"
+kind = "inherent_method"
+level = "expect"
+reason = "symbol collections intentionally provide matching len and is_empty APIs"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "symbols::SymbolKind::to_string"
+kind = "inherent_method"
+level = "expect"
+reason = "symbol kinds expose their protocol-facing names to downstream adapters"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_static"
+item = "env_vars::EnvVars::XDG_CONFIG_HOME"
+kind = "inherent_associated_constant"
+level = "expect"
+reason = "consumed by the generated environment-variable reference"
+
+# Keep public APIs whose narrower visibility would break a uniform interface or
+# activate compiler lints that Rust intentionally suppresses for public APIs.
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "format_element::PrintMode::is_flat"
+kind = "inherent_method"
+level = "expect"
+reason = "print mode predicates intentionally expose a consistent public interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "format_element::PrintMode::is_expanded"
+kind = "inherent_method"
+level = "expect"
+reason = "print mode predicates intentionally expose a consistent public interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "format_element::tag::GroupMode::is_flat"
+kind = "inherent_method"
+level = "expect"
+reason = "group mode predicates intentionally expose a consistent public interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "formatter::Formatter::<'buf, Context>::intern_vec"
+kind = "inherent_method"
+level = "expect"
+reason = "the public formatter API supports interning prebuilt format elements"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "IndentStyle::as_str"
+kind = "inherent_method"
+level = "expect"
+reason = "public indentation settings expose their stable string representation"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "registry::<impl codes::Rule>::url"
+kind = "inherent_method"
+level = "expect"
+reason = "public rule metadata includes its documentation URL"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "settings::types::PythonVersion::as_tuple"
+kind = "inherent_method"
+level = "expect"
+reason = "public Python version settings expose their numeric representation"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_codegen"
+item = "generator::Generator::<'a>::with_mode"
+kind = "inherent_method"
+level = "expect"
+reason = "the public generator builder intentionally exposes its output mode"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_codegen"
+item = "stylist::Indentation::new"
+kind = "inherent_method"
+level = "expect"
+reason = "the public indentation wrapper retains its explicit constructor"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_formatter"
+item = "AsFormat"
+kind = "reexport"
+level = "expect"
+reason = "generated formatter implementations expose this public extension trait"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_formatter"
+item = "FormattedIter"
+kind = "reexport"
+level = "expect"
+reason = "generated formatter implementations expose this public iterator adapter"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_formatter"
+item = "FormattedIterExt"
+kind = "reexport"
+level = "expect"
+reason = "generated formatter implementations expose this public extension trait"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_formatter"
+item = "IntoFormat"
+kind = "reexport"
+level = "expect"
+reason = "generated formatter implementations expose this public extension trait"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_formatter"
+item = "options::QuoteStyle::as_str"
+kind = "inherent_method"
+level = "expect"
+reason = "public quote-style settings expose their stable string representation"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_parser"
+item = "semantic_errors::YieldOutsideFunctionKind::is_await"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic error variants intentionally expose their classification predicate"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_semantic"
+item = "cfg::visualize::draw_cfg"
+kind = "function"
+level = "expect"
+reason = "the control-flow graph visualizer remains available to downstream debugging tools"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_semantic"
+item = "cfg::visualize::MermaidNode::with_content"
+kind = "inherent_method"
+level = "expect"
+reason = "the public control-flow graph visualization API retains its node constructor"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_semantic"
+item = "cfg::visualize::DirectedGraph"
+kind = "trait"
+level = "expect"
+reason = "the control-flow graph visualizer remains available to downstream debugging tools"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_source_file"
+item = "newlines::LineEnding::len"
+kind = "inherent_method"
+level = "expect"
+reason = "line-ending values expose consistent byte and text length APIs"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_source_file"
+item = "newlines::LineEnding::text_len"
+kind = "inherent_method"
+level = "expect"
+reason = "line-ending values expose consistent byte and text length APIs"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "all_symbols::AllSymbolInfo::<'db>::name_in_file"
+kind = "inherent_method"
+level = "expect"
+reason = "auto-import symbol results intentionally expose their complete metadata interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "all_symbols::AllSymbolInfo::<'db>::qualified"
+kind = "inherent_method"
+level = "expect"
+reason = "auto-import symbol results intentionally expose their complete metadata interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "all_symbols::AllSymbolInfo::<'db>::kind"
+kind = "inherent_method"
+level = "expect"
+reason = "auto-import symbol results intentionally expose their complete metadata interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "all_symbols::AllSymbolInfo::<'db>::deprecated"
+kind = "inherent_method"
+level = "expect"
+reason = "auto-import symbol results intentionally expose their complete metadata interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "all_symbols::AllSymbolInfo::<'db>::module"
+kind = "inherent_method"
+level = "expect"
+reason = "auto-import symbol results intentionally expose their complete metadata interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "all_symbols::AllSymbolInfo::<'db>::file"
+kind = "inherent_method"
+level = "expect"
+reason = "auto-import symbol results intentionally expose their complete metadata interface"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "AllSymbolInfo"
+kind = "reexport"
+level = "expect"
+reason = "the public auto-import API re-exports its result type"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_ide"
+item = "all_symbols"
+kind = "reexport"
+level = "expect"
+reason = "the public auto-import API re-exports its query function"
+
+# Keep the generated AST and its hand-written companion APIs consistent across
+# node types, visitors, and string literal kinds.
+
+[[exclude]]
+crate = "ruff_python_ast"
+file = "crates/ruff_python_ast/src/generated.rs"
+reason = "generated from crates/ruff_python_ast/ast.toml"
+
+[[exclude]]
+crate = "ruff_python_ast"
+file = "crates/ruff_python_ast/src/nodes.rs"
+reason = "AST node APIs intentionally provide a consistent interface across node types"
+
+[[exclude]]
+crate = "ruff_python_ast"
+file = "crates/ruff_python_ast/src/comparable.rs"
+reason = "the comparable AST intentionally mirrors the full AST hierarchy"
+
+[[exclude]]
+crate = "ruff_python_ast"
+file = "crates/ruff_python_ast/src/statement_visitor.rs"
+reason = "AST walk functions intentionally provide a consistent interface across node types"
+
+[[exclude]]
+crate = "ruff_python_ast"
+file = "crates/ruff_python_ast/src/visitor.rs"
+reason = "AST walk functions intentionally provide a consistent interface across node types"
+
+[[exclude]]
+crate = "ruff_python_ast"
+file = "crates/ruff_python_ast/src/visitor/source_order.rs"
+reason = "AST walk functions intentionally provide a consistent interface across node types"
+
+[[exclude]]
+crate = "ruff_python_ast"
+file = "crates/ruff_python_ast/src/visitor/transformer.rs"
+reason = "AST walk functions intentionally provide a consistent interface across node types"
+
+[[exclude]]
+crate = "ruff_python_ast"
+file = "crates/ruff_python_ast/src/str_prefix.rs"
+reason = "string prefix APIs intentionally provide a consistent interface across literal kinds"
+
+[[exclude]]
+crate = "ruff_python_literal"
+file = "crates/ruff_python_literal/src/escape.rs"
+reason = "string and bytes escape APIs intentionally provide a consistent interface"
+
+[[exclude]]
+crate = "ruff_python_literal"
+file = "crates/ruff_python_literal/src/cformat.rs"
+reason = "C-style string and bytes format APIs intentionally provide a consistent interface"
+
+# Preserve complete wrapper and DSL interfaces whose methods intentionally
+# mirror their underlying abstractions.
+
+[[exclude]]
+crate = "ruff_db"
+file = "crates/ruff_db/src/files/path.rs"
+reason = "file path variant accessors intentionally cover every backing path type"
+
+[[exclude]]
+crate = "ruff_db"
+file = "crates/ruff_db/src/system/path.rs"
+reason = "system path wrappers intentionally mirror the supported UTF-8 path API"
+
+[[exclude]]
+crate = "ruff_db"
+file = "crates/ruff_db/src/vendored/path.rs"
+reason = "vendored path wrappers intentionally mirror the supported UTF-8 path API"
+
+[[exclude]]
+crate = "ruff_db"
+file = "crates/ruff_db/src/system.rs"
+reason = "system abstractions intentionally expose a consistent interface across backends"
+
+[[exclude]]
+crate = "ruff_db"
+file = "crates/ruff_db/src/system/memory_fs.rs"
+reason = "the in-memory system intentionally mirrors the public filesystem interface"
+
+[[exclude]]
+crate = "ruff_db"
+file = "crates/ruff_db/src/system/walk_directory.rs"
+reason = "directory walking intentionally exposes a complete backend-neutral interface"
+
+[[exclude]]
+crate = "ruff_db"
+file = "crates/ruff_db/src/testing.rs"
+reason = "public test helpers are consumed by downstream crates with the testing feature"
+
+[[exclude]]
+crate = "ruff_db"
+file = "crates/ruff_db/src/vendored.rs"
+reason = "the vendored filesystem intentionally mirrors the public filesystem interface"
+
+[[exclude]]
+crate = "ruff_index"
+file = "crates/ruff_index/src/slice.rs"
+reason = "indexed slices intentionally mirror the supported slice API"
+
+[[exclude]]
+crate = "ruff_index"
+file = "crates/ruff_index/src/vec.rs"
+reason = "indexed vectors intentionally mirror the supported vector API"
+
+[[exclude]]
+crate = "ruff_formatter"
+file = "crates/ruff_formatter/src/builders.rs"
+reason = "the public formatter DSL intentionally exposes a complete builder vocabulary"
+
+[[exclude]]
+crate = "ruff_linter"
+file = "crates/ruff_linter/src/source_kind.rs"
+reason = "source kind accessors intentionally cover every source representation"
+
+[[exclude]]
+crate = "ruff_linter"
+file = "crates/ruff_linter/src/test.rs"
+reason = "public test helpers are consumed by downstream crates with the testing feature"
+
+# Preserve interfaces that are consumed outside the native Rust workspace.
+
+[[exclude]]
+crate = "ruff_wasm"
+file = "crates/ruff_wasm/src/lib.rs"
+reason = "public exports are consumed by JavaScript"
+
+[[exclude]]
+crate = "ty_wasm"
+file = "crates/ty_wasm/src/lib.rs"
+reason = "public exports are consumed by JavaScript"
+
+# Keep generated and upstream-compatible APIs in sync with their sources.
+
+[[exclude]]
+crate = "ruff_notebook"
+file = "crates/ruff_notebook/src/schema.rs"
+reason = "generated from the Jupyter Notebook schema"
+
+[[exclude]]
+crate = "ruff_formatter"
+file = "crates/ruff_formatter/src/prelude.rs"
+reason = "the public formatter prelude intentionally provides a complete downstream import surface"
+
+[[exclude]]
+crate = "annotate_snippets"
+file = "crates/ruff_annotate_snippets/src/lib.rs"
+reason = "kept compatible with the upstream annotate-snippets crate"
+
+[[exclude]]
+crate = "annotate_snippets"
+file = "crates/ruff_annotate_snippets/src/level.rs"
+reason = "kept compatible with the upstream annotate-snippets crate"
+
+[[exclude]]
+crate = "annotate_snippets"
+file = "crates/ruff_annotate_snippets/src/renderer/mod.rs"
+reason = "kept compatible with the upstream annotate-snippets crate"
+
+[[exclude]]
+crate = "annotate_snippets"
+module = "renderer::render"
+reason = "kept compatible with the upstream annotate-snippets crate"
+
+[[exclude]]
+crate = "annotate_snippets"
+module = "renderer::source_map"
+reason = "kept compatible with the upstream annotate-snippets crate"
+
+[[exclude]]
+crate = "annotate_snippets"
+module = "renderer::styled_buffer"
+reason = "kept compatible with the upstream annotate-snippets crate"
+
+[[exclude]]
+crate = "annotate_snippets"
+file = "crates/ruff_annotate_snippets/src/snippet.rs"
+reason = "kept compatible with the upstream annotate-snippets crate"

--- a/hawk.toml
+++ b/hawk.toml
@@ -136,22 +136,6 @@ reason = "preserves the public syntax-validity predicate API"
 
 [[override]]
 lint = "hawk::unnecessary_public"
-crate = "ruff_python_parser"
-item = "parser::options::ParseOptions::with_max_recursion_depth"
-kind = "inherent_method"
-level = "expect"
-reason = "public parser options support configuring the documented recursion limit"
-
-[[override]]
-lint = "hawk::unnecessary_public"
-crate = "ruff_python_parser"
-item = "parser::options::ParseOptions::max_recursion_depth"
-kind = "inherent_method"
-level = "expect"
-reason = "preserves the public recursion-limit builder and accessor pair"
-
-[[override]]
-lint = "hawk::unnecessary_public"
 crate = "ruff_workspace"
 item = "settings::FormatterSettings::resolve_target_version"
 kind = "inherent_method"
@@ -893,6 +877,158 @@ item = "env_vars::EnvVars::XDG_CONFIG_HOME"
 kind = "inherent_associated_constant"
 level = "expect"
 reason = "consumed by the generated environment-variable reference"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_db"
+item = "system::command::Command::arg"
+kind = "inherent_method"
+level = "expect"
+reason = "command descriptions expose a complete argument builder and inspection API"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_db"
+item = "system::command::Command::get_current_dir"
+kind = "inherent_method"
+level = "expect"
+reason = "command descriptions expose a complete argument builder and inspection API"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "expression::Expression::<'db>::python_file"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "expression::Expression::<'db>::program"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "predicate::PatternPredicate::<'db>::file"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "predicate::PatternPredicate::<'db>::python_file"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "predicate::PatternPredicate::<'db>::program"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "statement::StatementInner::<'db>::file"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "statement::StatementInner::<'db>::python_file"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "statement::StatementInner::<'db>::program"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "unpack::Unpack::<'db>::file"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "unpack::Unpack::<'db>::python_file"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_core"
+item = "unpack::Unpack::<'db>::program"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic ingredients expose consistent file, scope, and program accessors"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_python_semantic"
+item = "FixtureBinding"
+kind = "reexport"
+level = "expect"
+reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_python_semantic"
+item = "fixture_bindings_for_parameter"
+kind = "reexport"
+level = "expect"
+reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_python_semantic"
+item = "types::FixtureBinding"
+kind = "reexport"
+level = "expect"
+reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_python_semantic"
+item = "types::fixture_bindings_for_parameter"
+kind = "reexport"
+level = "expect"
+reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "types::dedicated::pytest::FixtureBinding::<'db>::request"
+kind = "inherent_method"
+level = "expect"
+reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ty_python_semantic"
+item = "types::dedicated::pytest::FixtureBinding::<'db>::fixture"
+kind = "inherent_method"
+level = "expect"
+reason = "the public pytest fixture lookup API exposes both request and fixture definitions"
 
 # Keep public APIs whose narrower visibility would break a uniform interface or
 # activate compiler lints that Rust intentionally suppresses for public APIs.

--- a/hawk.toml
+++ b/hawk.toml
@@ -174,20 +174,28 @@ kind = "inherent_method"
 level = "expect"
 reason = "public union construction documentation recommends this optimized constructor"
 
-# Keep the code component accessor API symmetric.
+# Keep the public code-component accessor API symmetric.
 
 [[override]]
-lint = "hawk::unnecessary_restricted_visibility"
+lint = "hawk::dead_public"
 crate = "ruff_linter"
 item = "codes::NoqaCode::prefix"
 kind = "inherent_method"
 level = "expect"
 reason = "preserves the intentional symmetric prefix and suffix accessor API"
 
-# Keep the symmetric edit-operation predicate APIs, including currently unused variants.
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_linter"
+item = "codes::NoqaCode::suffix"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric prefix and suffix accessor API"
+
+# Keep the public edit-operation predicate API symmetric.
 
 [[override]]
-lint = "hawk::unnecessary_restricted_visibility"
+lint = "hawk::dead_public"
 crate = "ruff_diagnostics"
 item = "edit::Edit::is_deletion"
 kind = "inherent_method"
@@ -195,33 +203,17 @@ level = "expect"
 reason = "preserves the intentional symmetric edit-operation predicate API"
 
 [[override]]
-lint = "hawk::unnecessary_restricted_visibility"
+lint = "hawk::unnecessary_public"
+crate = "ruff_diagnostics"
+item = "edit::Edit::is_insertion"
+kind = "inherent_method"
+level = "expect"
+reason = "preserves the intentional symmetric edit-operation predicate API"
+
+[[override]]
+lint = "hawk::dead_public"
 crate = "ruff_diagnostics"
 item = "edit::Edit::is_replacement"
-kind = "inherent_method"
-level = "expect"
-reason = "preserves the intentional symmetric edit-operation predicate API"
-
-[[override]]
-lint = "hawk::unnecessary_restricted_visibility"
-crate = "ruff_diagnostics"
-item = "edit::EditOperationKind::is_insertion"
-kind = "inherent_method"
-level = "expect"
-reason = "preserves the intentional symmetric edit-operation predicate API"
-
-[[override]]
-lint = "hawk::unnecessary_restricted_visibility"
-crate = "ruff_diagnostics"
-item = "edit::EditOperationKind::is_deletion"
-kind = "inherent_method"
-level = "expect"
-reason = "preserves the intentional symmetric edit-operation predicate API"
-
-[[override]]
-lint = "hawk::unnecessary_restricted_visibility"
-crate = "ruff_diagnostics"
-item = "edit::EditOperationKind::is_replacement"
 kind = "inherent_method"
 level = "expect"
 reason = "preserves the intentional symmetric edit-operation predicate API"
@@ -261,6 +253,278 @@ level = "expect"
 reason = "preserves the intentional uniform printer-options builder API"
 
 # Keep public APIs retained during cleanup review.
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "buffer::VecBuffer::<'a, Context>::take_vec"
+kind = "inherent_method"
+level = "expect"
+reason = "formatter buffers support both consuming and reusable element extraction"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "format_element::LineMode::is_hard"
+kind = "inherent_method"
+level = "expect"
+reason = "public line modes retain their classification predicate"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "format_element::FormatElement::is_tag"
+kind = "inherent_method"
+level = "expect"
+reason = "public format elements retain their tag inspection API"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "format_element::FormatElement::is_start_tag"
+kind = "inherent_method"
+level = "expect"
+reason = "public format elements retain their tag inspection API"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "format_element::tag::Condition::if_fits_on_line"
+kind = "inherent_method"
+level = "expect"
+reason = "conditional formatting constructors intentionally cover fits and breaks variants"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "format_element::tag::VerbatimKind::is_bogus"
+kind = "inherent_method"
+level = "expect"
+reason = "public verbatim kinds retain their classification predicate"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_formatter"
+item = "SimpleFormatContext::with_source_code"
+kind = "inherent_method"
+level = "expect"
+reason = "the public simple formatting context supports source-backed downstream tests and examples"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "Printed::new_empty"
+kind = "inherent_method"
+level = "expect"
+reason = "public formatter results retain their empty constructor"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "Printed::range"
+kind = "inherent_method"
+level = "expect"
+reason = "public formatter results expose their covered source range"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "Printed::into_sourcemap"
+kind = "inherent_method"
+level = "expect"
+reason = "formatter results expose borrowed, owned, and take-based source map access"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "Printed::take_sourcemap"
+kind = "inherent_method"
+level = "expect"
+reason = "formatter results expose borrowed, owned, and take-based source map access"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "Printed::verbatim"
+kind = "inherent_method"
+level = "expect"
+reason = "public formatter results expose verbatim text and range metadata"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "Printed::verbatim_ranges"
+kind = "inherent_method"
+level = "expect"
+reason = "formatter results expose borrowed and take-based verbatim range access"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "Printed::take_verbatim_ranges"
+kind = "inherent_method"
+level = "expect"
+reason = "formatter results expose borrowed and take-based verbatim range access"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "FormatOwnedWithRule::<T, R, C>::with_item"
+kind = "inherent_method"
+level = "expect"
+reason = "the public owned-format adapter retains its builder API"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "FormatOwnedWithRule::<T, R, C>::with_options"
+kind = "inherent_method"
+level = "expect"
+reason = "the public owned-format adapter retains its builder API"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "printer::printer_options::PrintWidth::new"
+kind = "inherent_method"
+level = "expect"
+reason = "the public print-width wrapper retains its explicit constructor"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_formatter"
+item = "printer::printer_options::SourceMapGeneration::is_disabled"
+kind = "inherent_method"
+level = "expect"
+reason = "source map generation exposes symmetric enabled and disabled predicates"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_ast"
+item = "helpers::map_starred"
+kind = "function"
+level = "expect"
+reason = "AST helpers consistently unwrap callable, subscripted, and starred expressions"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_parser"
+item = "error::ParseError::error"
+kind = "inherent_method"
+level = "expect"
+reason = "downstream parser clients can consume a parse error into its error kind"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_parser"
+item = "Parsed::<T>::as_result"
+kind = "inherent_method"
+level = "expect"
+reason = "downstream parser clients retain borrowed result conversion"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_parser"
+item = "Parsed::<ruff_python_ast::ModExpression>::into_expr"
+kind = "inherent_method"
+level = "expect"
+reason = "parsed expressions retain borrowed and consuming accessors"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "binding::Binding::<'a>::is_deleted"
+kind = "inherent_method"
+level = "expect"
+reason = "the public binding API retains its deleted-state query"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "cfg::graph::ControlFlowGraph::<'stmt>::predecessors"
+kind = "inherent_method"
+level = "expect"
+reason = "the public control-flow graph supports downstream predecessor inspection"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "model::SemanticModel::<'a>::node"
+kind = "inherent_method"
+level = "expect"
+reason = "the public semantic model retains node navigation for downstream analyses"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "model::SemanticModel::<'a>::in_runtime_required_annotation"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic model predicates intentionally expose each annotation context"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "model::SemanticModel::<'a>::in_simple_string_type_definition"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic model predicates intentionally expose each string type context"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "model::SemanticModel::<'a>::in_dunder_all_definition"
+kind = "inherent_method"
+level = "expect"
+reason = "semantic model predicates retain the documented dunder-all context query"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "model::TypingOnlyBindingsStatus::is_allowed"
+kind = "inherent_method"
+level = "expect"
+reason = "typing-only binding status exposes symmetric allowed and disallowed predicates"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_python_semantic"
+item = "reference::ResolvedReference::in_annotated_type_alias_value"
+kind = "inherent_method"
+level = "expect"
+reason = "resolved references expose their complete semantic context interface"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "semantic_model::SemanticModel::<'db>::file_path"
+kind = "inherent_method"
+level = "expect"
+reason = "the public semantic model exposes its file identity and source locations"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "semantic_model::SemanticModel::<'db>::line_index"
+kind = "inherent_method"
+level = "expect"
+reason = "the public semantic model exposes its file identity and source locations"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "types::instance::NominalInstanceType::<'db>::class_name"
+kind = "inherent_method"
+level = "expect"
+reason = "unused in the Ruff workspace but retained for external ty_python_semantic consumers"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_python_semantic"
+item = "types::instance::NominalInstanceType::<'db>::class_module_name"
+kind = "inherent_method"
+level = "expect"
+reason = "unused in the Ruff workspace but retained for external ty_python_semantic consumers"
 
 [[override]]
 lint = "hawk::dead_public"
@@ -581,30 +845,6 @@ item = "db::testing::TestDb::take_salsa_events"
 kind = "inherent_method"
 level = "expect"
 reason = "the testing feature exposes database event assertions to downstream tests"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "ruff_benchmark"
-item = "TestCase::speed"
-kind = "inherent_method"
-level = "expect"
-reason = "benchmark support types retain their complete harness interface"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "ruff_benchmark"
-item = "real_world_projects::InstalledProject::<'a>::config"
-kind = "inherent_method"
-level = "expect"
-reason = "benchmark support types retain their complete harness interface"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "ruff_benchmark"
-item = "real_world_projects::InstalledProject::<'a>::venv_path"
-kind = "inherent_method"
-level = "expect"
-reason = "benchmark support types retain their complete harness interface"
 
 [[override]]
 lint = "hawk::unnecessary_public"
@@ -986,11 +1226,6 @@ reason = "indexed slices intentionally mirror the supported slice API"
 crate = "ruff_index"
 file = "crates/ruff_index/src/vec.rs"
 reason = "indexed vectors intentionally mirror the supported vector API"
-
-[[exclude]]
-crate = "ruff_formatter"
-file = "crates/ruff_formatter/src/builders.rs"
-reason = "the public formatter DSL intentionally exposes a complete builder vocabulary"
 
 [[exclude]]
 crate = "ruff_linter"

--- a/hawk.toml
+++ b/hawk.toml
@@ -320,6 +320,22 @@ reason = "one-indexed arithmetic intentionally provides checked and saturating o
 
 [[override]]
 lint = "hawk::dead_public"
+crate = "ty_project"
+item = "db::changes::ChangeResult::custom_stdlib_changed"
+kind = "inherent_method"
+level = "expect"
+reason = "change results expose both project and custom-stdlib invalidation state"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ty_project"
+item = "watch::ChangeEvent::is_created"
+kind = "inherent_method"
+level = "expect"
+reason = "change event predicates intentionally cover created, changed, deleted, and rescan events"
+
+[[override]]
+lint = "hawk::dead_public"
 crate = "ruff_python_ast"
 item = "expression::StringLikePart::<'a>::as_string_literal"
 kind = "inherent_method"


### PR DESCRIPTION
## Summary

We now run Hawk 0.1.13 with Rust 1.98.0 in CI, following the pattern used by uv. The configuration preserves intentional public APIs and generated interfaces while checking all configured production binaries and workspace non-production targets with `-D warnings`.

The accompanying cleanup narrows internal visibility, removes unused benchmark classification state and accessors, and records intentional public interfaces as audited Hawk expectations. The resulting configuration reports zero Hawk findings across the configured targets.
