### PR TITLE
[ty] Expand aliases in generic TypedDict constructor inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1030,10 +1030,10 @@ def nested_unknown() -> None:
     reveal_type(Outer(inner=inner, marker=["x"]))  # revealed: Outer[Unknown]
 ```
 
-### Arguments with type aliases
+### Type aliases that contain unspecialized `TypedDict`s
 
-This initial implementation does not infer through PEP 695 type aliases. An alias can therefore not
-hide an unspecialized nested `TypedDict`:
+Following a PEP 695 type alias must not allow an unspecialized `Inner` value to be treated as
+`Inner[str]`:
 
 ```toml
 [environment]
@@ -1059,15 +1059,52 @@ def check_unspecialized_alias() -> None:
     reveal_type(Outer(inner=get_inner(), marker="x"))  # revealed: Outer[Unknown]
 ```
 
-As an intentional limitation, even an alias with explicit type arguments keeps the outer constructor
-unspecialized:
+### Aliases to ordinary types
+
+An ordinary type alias in one field does not prevent another field from determining the type
+argument:
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
-def get_int_inner() -> InnerAlias[int]:
+from typing import TypedDict
+
+class Outer[T](TypedDict):
+    marker: T
+    payload: object
+
+type Payload = int
+
+def get_payload() -> Payload:
     raise NotImplementedError
 
-def check_specialized_alias() -> None:
-    reveal_type(Outer(inner=get_int_inner(), marker=1))  # revealed: Outer[Unknown]
+reveal_type(Outer(marker=1, payload=get_payload()))  # revealed: Outer[int]
+```
+
+### Recursive aliases
+
+Checking an argument's aliases must terminate even when each recursive step changes the alias's type
+argument. If ty reaches the same alias again with a different argument, it stops and leaves the
+constructor unspecialized:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypedDict
+
+type Growing[T] = T | Growing[list[T]]
+
+class Box[T](TypedDict):
+    value: T
+
+def construct(value: Growing[int]) -> None:
+    reveal_type(Box(value=value))  # revealed: Box[Unknown]
 ```
 
 ### Unrelated protocol members

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -98,7 +98,7 @@ pub use crate::types::typevar::{
 use crate::types::typevar::{TypeVarInstance, TypeVarSet};
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
-use crate::types::visitor::any_over_type;
+use crate::types::visitor::{any_over_type, any_over_type_expanding_aliases};
 use crate::{Db, FxOrderSet, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -25,7 +25,7 @@ use crate::types::typed_dict::{
 };
 use crate::types::{
     ClassType, IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext,
-    TypeVarBoundOrConstraints, TypedDictModule, TypedDictType, any_over_type,
+    TypeVarBoundOrConstraints, TypedDictModule, TypedDictType, any_over_type_expanding_aliases,
 };
 use crate::{FxIndexMap, Program, TypeQualifiers};
 use ty_python_core::definition::Definition;
@@ -202,9 +202,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // without providing the precise context needed by an expression such as a lambda. Prefer
         // a valid expected specialization so ordinary constructor validation checks the expression
         // under that context.
-        if any_over_type(db, return_ty, false, |ty| {
-            ty.is_unknown() || matches!(ty, Type::TypeAlias(_))
-        }) && let Some(contextual_typed_dict) = contextual_typed_dict
+        if any_over_type_expanding_aliases(db, return_ty, |ty| ty.is_unknown())
+            && let Some(contextual_typed_dict) = contextual_typed_dict
         {
             return Some(Type::TypedDict(contextual_typed_dict));
         }
@@ -393,18 +392,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         matching.next().is_none().then_some(specialization)
     }
 
-    /// Return `true` if `ty` contains an opaque alias or a matching generic `TypedDict` with a
-    /// gradual type argument. If `class_literal` is `None`, any `TypedDict` class matches.
+    /// Return `true` if `ty`, after expanding aliases, contains a matching generic `TypedDict`
+    /// with an unknown type argument. If `class_literal` is `None`, any `TypedDict` class matches.
     fn type_contains_unknown_generic_typed_dict(
         &self,
         ty: Type<'db>,
         class_literal: Option<ClassLiteral<'db>>,
     ) -> bool {
         let db = self.db();
-        any_over_type(db, ty, false, |ty| {
-            if matches!(ty, Type::TypeAlias(_)) {
-                return true;
-            }
+        any_over_type_expanding_aliases(db, ty, |ty| {
             let Type::TypedDict(typed_dict) = ty else {
                 return false;
             };
@@ -417,9 +413,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 return false;
             }
             alias.specialization(db).types(db).iter().any(|argument| {
-                any_over_type(db, *argument, false, |nested| {
-                    nested.is_unknown() || matches!(nested, Type::TypeAlias(_))
-                })
+                any_over_type_expanding_aliases(db, *argument, |nested| nested.is_unknown())
             })
         })
     }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use smallvec::SmallVec;
+use ty_python_core::definition::Definition;
 
 use crate::{
     Db,
@@ -17,6 +18,7 @@ use crate::{
         class::walk_generic_alias,
         cyclic::ActiveRecursionDetector,
         function::{FunctionType, walk_function_type},
+        generics::walk_specialization,
         instance::{walk_nominal_instance_type, walk_protocol_instance_type},
         known_instance::walk_known_instance_type,
         method::{walk_bound_method_type, walk_method_wrapper_type},
@@ -481,11 +483,26 @@ pub(super) fn non_any_dynamic_content<'db>(db: &'db dyn Db, ty: Type<'db>) -> Dy
     visitor.content.get()
 }
 
+/// Controls which attributes that require deferred type inference are traversed.
+///
+/// The alias-only mode follows structural type composition without inspecting protocol members or
+/// type-variable metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LazyTypeAttributes {
+    /// Do not traverse any deferred attributes.
+    None,
+    /// Expand type aliases while otherwise remaining within the structural type.
+    TypeAliases,
+    /// Traverse all deferred attributes supported by [`TypeVisitor`].
+    All,
+}
+
 /// Implementation for `any_over_type` and `find_over_type`.
 fn any_over_type_impl<'db, F, T>(
     db: &'db dyn Db,
     ty: Type<'db>,
-    should_visit_lazy_type_attributes: bool,
+    lazy_type_attributes: LazyTypeAttributes,
+    recursive_alias_result: T,
     query: F,
 ) -> T
 where
@@ -495,8 +512,10 @@ where
     struct AnyOverTypeVisitor<'db, 'a, U> {
         query: &'a dyn Fn(Type<'db>) -> U,
         recursion_guard: TypeCollector<'db>,
+        active_type_aliases: ActiveRecursionDetector<Definition<'db>>,
         found_matching_type: Cell<U>,
-        should_visit_lazy_type_attributes: bool,
+        lazy_type_attributes: LazyTypeAttributes,
+        recursive_alias_result: U,
     }
 
     impl<'db, U> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_, U>
@@ -504,7 +523,7 @@ where
         U: Copy + Default + PartialEq,
     {
         fn should_visit_lazy_type_attributes(&self) -> bool {
-            self.should_visit_lazy_type_attributes
+            self.lazy_type_attributes == LazyTypeAttributes::All
         }
 
         fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
@@ -520,13 +539,62 @@ where
             }
             walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
         }
+
+        fn visit_bound_type_var_type(
+            &self,
+            db: &'db dyn Db,
+            bound_typevar: BoundTypeVarInstance<'db>,
+        ) {
+            if self.lazy_type_attributes != LazyTypeAttributes::TypeAliases {
+                walk_bound_type_var_type(db, bound_typevar, self);
+            }
+        }
+
+        fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+            if self.lazy_type_attributes != LazyTypeAttributes::TypeAliases {
+                walk_type_var_type(db, typevar, self);
+            }
+        }
+
+        fn visit_protocol_instance_type(
+            &self,
+            db: &'db dyn Db,
+            protocol: ProtocolInstanceType<'db>,
+        ) {
+            if self.lazy_type_attributes != LazyTypeAttributes::TypeAliases {
+                walk_protocol_instance_type(db, protocol, self);
+                return;
+            }
+
+            if let Some((_, Some(specialization))) = protocol
+                .class_origin(db)
+                .and_then(|class| class.static_class_literal(db))
+            {
+                walk_specialization(db, specialization, self);
+            }
+        }
+
+        fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
+            if self.lazy_type_attributes == LazyTypeAttributes::TypeAliases {
+                let definition = type_alias.definition(db);
+                self.active_type_aliases.visit(
+                    &definition,
+                    || self.found_matching_type.set(self.recursive_alias_result),
+                    || self.visit_type(db, type_alias.value_type(db)),
+                );
+            } else {
+                walk_type_alias_type(db, type_alias, self);
+            }
+        }
     }
 
     let visitor = AnyOverTypeVisitor {
         query: &query,
         recursion_guard: TypeCollector::default(),
+        active_type_aliases: ActiveRecursionDetector::default(),
         found_matching_type: Cell::default(),
-        should_visit_lazy_type_attributes,
+        lazy_type_attributes,
+        recursive_alias_result,
     };
     visitor.visit_type(db, ty);
     visitor.found_matching_type.get()
@@ -546,7 +614,29 @@ pub(super) fn any_over_type<'db>(
     should_visit_lazy_type_attributes: bool,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(
+        db,
+        ty,
+        if should_visit_lazy_type_attributes {
+            LazyTypeAttributes::All
+        } else {
+            LazyTypeAttributes::None
+        },
+        false,
+        query,
+    )
+}
+
+/// Return `true` if `ty`, or any structurally contained type, matches `query`.
+///
+/// This expands type alias values but does not inspect protocol members or type-variable metadata.
+/// A recursive alias whose specialization changes on each expansion conservatively matches.
+pub(super) fn any_over_type_expanding_aliases<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    query: impl Fn(Type<'db>) -> bool,
+) -> bool {
+    any_over_type_impl(db, ty, LazyTypeAttributes::TypeAliases, true, query)
 }
 
 /// Recurse into a type and calls the passed-in closure on every nested type
@@ -571,7 +661,17 @@ pub(super) fn find_over_type<'db, T>(
 where
     T: Copy + PartialEq,
 {
-    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(
+        db,
+        ty,
+        if should_visit_lazy_type_attributes {
+            LazyTypeAttributes::All
+        } else {
+            LazyTypeAttributes::None
+        },
+        None,
+        query,
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR expands on #27373 by inspecting PEP 695 aliases when deciding whether a constructor value contains an unspecialized generic `TypedDict`. This allows inference from other fields when an alias contains an ordinary type, while preserving the `Unknown` fallback when an alias hides an unspecialized `TypedDict`.
