### PR TITLE
[ty] Preserve TypeVarTuple context during Generic recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -126,6 +126,16 @@ error[shadowed-type-variable]: Generic class `InnerClass` uses ParamSpec `P` alr
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `P` used in class definition here
 ```
 
+A `TypeVarTuple` must be unpacked when used as an argument to `Generic`. Even though the base is
+invalid, ty still treats the `TypeVarTuple` as a type parameter of the class during error recovery,
+so correctly unpacked uses within the class do not produce cascading errors.
+
+```py
+# error: [invalid-generic-class] "`TypeVarTuple` must be unpacked"
+class BareTypeVarTuple(Generic[Ts]):
+    values: tuple[*Ts]
+```
+
 If you don't specialize a generic base class, we use the default specialization, which maps each
 typevar to its default value or `Any`. Since that base class is fully specialized, it does not make
 the inheriting class generic.

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -2328,7 +2328,10 @@ enum LegacyGenericContextError<'db> {
     /// A duplicate typevar was provided.
     DuplicateTypevar(&'db str),
     /// A `TypeVarTuple` was provided but not unpacked.
-    TypeVarTupleMustBeUnpacked,
+    ///
+    /// The generic context is available when the argument is a bound `TypeVarTuple` and is used
+    /// to avoid cascading errors during recovery.
+    TypeVarTupleMustBeUnpacked(Option<GenericContext<'db>>),
 }
 
 impl<'db> LegacyGenericContextError<'db> {
@@ -2337,7 +2340,7 @@ impl<'db> LegacyGenericContextError<'db> {
             LegacyGenericContextError::InvalidArgument(_)
             | LegacyGenericContextError::VariadicTupleArguments
             | LegacyGenericContextError::DuplicateTypevar(_)
-            | LegacyGenericContextError::TypeVarTupleMustBeUnpacked => Type::unknown(),
+            | LegacyGenericContextError::TypeVarTupleMustBeUnpacked(_) => Type::unknown(),
             LegacyGenericContextError::NotYetSupported => {
                 todo_type!("ParamSpecs and TypeVarTuples")
             }
@@ -2373,10 +2376,14 @@ fn infer_legacy_generic_subscript<'db>(
                 typevar_name,
             },
         )),
-        Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked) => Err(SubscriptError::new(
-            Type::unknown(),
-            SubscriptErrorKind::TypeVarTupleNotUnpacked { origin },
-        )),
+        Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked(generic_context)) => {
+            Err(SubscriptError::new(
+                generic_context.map_or(Type::unknown(), |generic_context| {
+                    Type::KnownInstance(wrap_ok(generic_context))
+                }),
+                SubscriptErrorKind::TypeVarTupleNotUnpacked { origin },
+            ))
+        }
         Err(
             error @ (LegacyGenericContextError::NotYetSupported
             | LegacyGenericContextError::VariadicTupleArguments),
@@ -2423,7 +2430,10 @@ fn legacy_generic_class_context<'db>(
             let bound = bind_typevar(db, index, file_scope_id, typevar_binding_context, typevar)
                 .ok_or(LegacyGenericContextError::InvalidArgument(argument_ty))?;
             if bound.is_typevartuple(db) {
-                return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
+                validated_typevars.insert(bound);
+                return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked(Some(
+                    GenericContext::from_typevar_instances(db, validated_typevars),
+                )));
             }
             if !validated_typevars.insert(bound) {
                 return Err(LegacyGenericContextError::DuplicateTypevar(
@@ -2442,7 +2452,7 @@ fn legacy_generic_class_context<'db>(
                 Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple)
             )
         {
-            return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
+            return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked(None));
         } else if any_over_type(db, argument_ty, true, |inner_ty| match inner_ty {
             Type::NominalInstance(nominal) => matches!(
                 nominal.known_class(db),


### PR DESCRIPTION
## Summary

Prior to this change, we recovered an invalid `Generic[Shape]` subscription as `Unknown`. That lost the class's generic context and caused a cascading diagnostic for a correctly unpacked use:

```py
Shape = TypeVarTuple("Shape")

class ClassA(Generic[Shape]):  # invalid-generic-class
    values: tuple[*Shape]  # Previously: unbound-type-variable
```

We now preserve the bound `TypeVarTuple` in the recovery type while still reporting the invalid bare argument. This removes only the spurious `unbound-type-variable` diagnostic and makes `generics_typevartuple_basic.py` fully conformant.
