### PR TITLE
Remove unused APIs from ruff_db

### DIFF
--- a/crates/ruff_db/src/cancellation.rs
+++ b/crates/ruff_db/src/cancellation.rs
@@ -21,10 +21,6 @@ impl CancellationTokenSource {
         }
     }
 
-    pub fn is_cancellation_requested(&self) -> bool {
-        self.cancelled.load(std::sync::atomic::Ordering::Relaxed)
-    }
-
     /// Creates a new token that uses this source.
     pub fn token(&self) -> CancellationToken {
         CancellationToken {

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -385,13 +385,8 @@ impl Diagnostic {
         Arc::make_mut(&mut self.inner).fix = None;
     }
 
-    /// Returns `true` if the diagnostic contains a [`Fix`].
-    pub fn fixable(&self) -> bool {
-        self.fix().is_some()
-    }
-
-    /// Returns `true` if the diagnostic is [`fixable`](Diagnostic::fixable) and applies at the
-    /// configured applicability level.
+    /// Returns `true` if the diagnostic has a fix that applies at the configured applicability
+    /// level.
     pub fn has_applicable_fix(&self, fix_applicability: Applicability) -> bool {
         self.fix().is_some_and(|fix| fix.applies(fix_applicability))
     }
@@ -419,6 +414,7 @@ impl Diagnostic {
     /// Returns the remapped offset for a suppression comment if it exists.
     ///
     /// Like [`Diagnostic::parent`], this is used for noqa code suppression comments in Ruff.
+    #[cfg(feature = "serde")]
     fn noqa_offset(&self) -> Option<TextSize> {
         self.inner.noqa_offset
     }
@@ -902,19 +898,6 @@ impl Annotation {
     /// Sets the span on this annotation.
     pub fn set_span(&mut self, span: Span) {
         self.span = span;
-    }
-
-    /// Returns the tags associated with this annotation.
-    pub fn get_tags(&self) -> &[DiagnosticTag] {
-        &self.tags
-    }
-
-    /// Attaches this tag to this annotation.
-    ///
-    /// It will not replace any existing tags.
-    pub fn tag(mut self, tag: DiagnosticTag) -> Annotation {
-        self.tags.push(tag);
-        self
     }
 
     /// Attaches an additional tag to this annotation.
@@ -1519,7 +1502,8 @@ impl DisplayDiagnosticConfig {
     ///
     /// Nearby annotations or fix edits are rendered in a single source frame even when their
     /// configured context windows would not otherwise overlap.
-    pub fn merge_window(self, lines: usize) -> DisplayDiagnosticConfig {
+    #[cfg(test)]
+    fn merge_window(self, lines: usize) -> DisplayDiagnosticConfig {
         DisplayDiagnosticConfig {
             merge_window: lines,
             ..self

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -901,12 +901,6 @@ pub struct Input {
     pub(crate) line_index: LineIndex,
 }
 
-impl Input {
-    pub fn line_index(&self) -> &LineIndex {
-        &self.line_index
-    }
-}
-
 /// Returns the line number accounting for the given `len`
 /// number of preceding context lines.
 ///

--- a/crates/ruff_db/src/display.rs
+++ b/crates/ruff_db/src/display.rs
@@ -35,17 +35,6 @@ impl Join<'_, '_> {
         self
     }
 
-    pub fn entries<I, F>(&mut self, items: I) -> &mut Self
-    where
-        I: IntoIterator<Item = F>,
-        F: Display,
-    {
-        for item in items {
-            self.entry(&item);
-        }
-        self
-    }
-
     pub fn finish(&mut self) -> fmt::Result {
         self.result
     }

--- a/crates/ruff_db/src/file_revision.rs
+++ b/crates/ruff_db/src/file_revision.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use crate::system::file_time_now;
 
 /// A number representing the revision of a file.
@@ -15,10 +16,6 @@ pub struct FileRevision(u128);
 impl FileRevision {
     pub fn new(value: u128) -> Self {
         Self(value)
-    }
-
-    pub fn now() -> Self {
-        Self::from(file_time_now())
     }
 
     pub(crate) const fn zero() -> Self {

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -4,8 +4,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use dashmap::mapref::entry::Entry;
-#[expect(unused_imports)]
-pub(crate) use directory::system_path_to_directory;
 pub use directory::{DirectoryListing, DirectoryListingError, directory_listing};
 pub use file_root::{FileRoot, FileRootKind};
 pub use path::FilePath;
@@ -566,11 +564,6 @@ impl File {
     /// Returns `true` if the file should be analyzed as a type stub.
     pub fn is_stub(self, db: &dyn Db) -> bool {
         self.source_type(db).is_stub()
-    }
-
-    /// Returns `true` if the file is an `__init__.pyi`
-    pub fn is_package_stub(self, db: &dyn Db) -> bool {
-        self.path(db).as_str().ends_with("__init__.pyi")
     }
 
     /// Returns `true` if the file is an `__init__.pyi`

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -32,8 +32,6 @@ pub use std::time::{Instant, SystemTime, SystemTimeError};
 pub use web_time::{Instant, SystemTime, SystemTimeError};
 
 pub type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;
-pub type FxDashSet<K> = dashmap::DashSet<K, BuildHasherDefault<FxHasher>>;
-
 static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
 /// Returns the version of the executing program if set.

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -333,13 +333,6 @@ pub struct InMemorySystem {
 }
 
 impl InMemorySystem {
-    pub fn new(cwd: SystemPathBuf) -> Self {
-        Self {
-            user_config_directory: Mutex::new(None).into(),
-            memory_fs: MemoryFileSystem::with_current_directory(cwd),
-        }
-    }
-
     pub fn from_memory_fs(memory_fs: MemoryFileSystem) -> Self {
         Self {
             user_config_directory: Mutex::new(None).into(),


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ruff_db identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 56 net lines removed
- 61 deletions and 5 additions
- 8 files changed