### PR TITLE
Remove unused APIs from ruff_linter

### DIFF
--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -10,7 +10,6 @@ use unicode_width::UnicodeWidthChar;
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_macros::CacheKey;
 use ruff_python_trivia::tab_offset;
-use ruff_text_size::TextSize;
 
 /// The length of a line of text that is considered too long.
 ///
@@ -26,10 +25,6 @@ impl LineLength {
     /// Return the numeric value for this [`LineLength`]
     pub fn value(&self) -> u16 {
         self.0.get()
-    }
-
-    pub fn text_len(&self) -> TextSize {
-        TextSize::from(u32::from(self.value()))
     }
 }
 

--- a/crates/ruff_linter/src/locator.rs
+++ b/crates/ruff_linter/src/locator.rs
@@ -19,13 +19,6 @@ impl<'a> Locator<'a> {
         }
     }
 
-    pub fn with_index(contents: &'a str, index: LineIndex) -> Self {
-        Self {
-            contents,
-            index: OnceCell::from(index),
-        }
-    }
-
     #[deprecated(
         note = "This is expensive, avoid using outside of the diagnostic phase. Prefer the other `Locator` methods instead."
     )]
@@ -43,10 +36,6 @@ impl<'a> Locator<'a> {
     pub fn to_index(&self) -> &LineIndex {
         self.index
             .get_or_init(|| LineIndex::from_source_text(self.contents))
-    }
-
-    pub fn line_index(&self) -> Option<&LineIndex> {
-        self.index.get()
     }
 
     pub fn to_source_code(&self) -> SourceCode<'_, '_> {
@@ -126,11 +115,6 @@ impl<'a> Locator<'a> {
     pub(crate) fn text_len(&self) -> TextSize {
         self.contents.text_len()
     }
-
-    /// Return `true` if the source code is empty.
-    pub const fn is_empty(&self) -> bool {
-        self.contents.is_empty()
-    }
 }
 
 // Override the `_str` methods from [`LineRanges`] to extend the lifetime to `'a`.
@@ -154,13 +138,6 @@ impl<'a> Locator<'a> {
     /// See [`LineRanges::lines_str`].
     pub(crate) fn lines_str(&self, range: TextRange) -> &'a str {
         self.contents.lines_str(range)
-    }
-
-    /// Returns the text of all lines that include `range`.
-    ///
-    /// See [`LineRanges::full_lines_str`].
-    pub fn full_lines_str(&self, range: TextRange) -> &'a str {
-        self.contents.full_lines_str(range)
     }
 }
 

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -175,7 +175,7 @@ pub(crate) trait Emitter {
     ) -> anyhow::Result<()>;
 }
 
-/// Context passed to diagnostic emitters.
+/// Context used while rendering diagnostics.
 pub struct EmitterContext<'a> {
     notebook_indexes: &'a FxHashMap<String, NotebookIndex>,
 }
@@ -183,11 +183,6 @@ pub struct EmitterContext<'a> {
 impl<'a> EmitterContext<'a> {
     pub fn new(notebook_indexes: &'a FxHashMap<String, NotebookIndex>) -> Self {
         Self { notebook_indexes }
-    }
-
-    /// Tests if the file with `name` is a jupyter notebook.
-    pub fn is_notebook(&self, name: &str) -> bool {
-        self.notebook_indexes.contains_key(name)
     }
 
     fn notebook_index(&self, name: &str) -> Option<&NotebookIndex> {

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -12,10 +12,6 @@ use crate::codes::{self};
 
 mod rule_set;
 
-pub trait AsRule {
-    fn rule(&self) -> Rule;
-}
-
 impl Rule {
     pub fn from_code(code: &str) -> Result<Self, FromCodeError> {
         let (linter, code) = Linter::parse_code(code).ok_or(FromCodeError::Unknown)?;

--- a/crates/ruff_linter/src/registry/rule_set.rs
+++ b/crates/ruff_linter/src/registry/rule_set.rs
@@ -24,10 +24,6 @@ impl RuleSet {
         Self(Self::EMPTY)
     }
 
-    pub fn clear(&mut self) {
-        self.0 = Self::EMPTY;
-    }
-
     #[inline]
     pub const fn from_rule(rule: Rule) -> Self {
         let rule = rule as u16;

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -438,7 +438,8 @@ impl RuleSelector {
     }
 
     /// Parse [`RuleSelector`] from a string; but do not follow redirects.
-    pub fn parse_no_redirect(s: &str) -> Result<Self, ParseError> {
+    #[cfg(feature = "schemars")]
+    fn parse_no_redirect(s: &str) -> Result<Self, ParseError> {
         // **Changes should be reflected in `from_str` as well**
         match s {
             "ALL" => Ok(Self::All),

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -410,20 +410,6 @@ impl KnownModules {
         };
         Some((section, reason))
     }
-
-    /// Return the list of user-defined modules, indexed by section.
-    pub fn user_defined(&self) -> FxHashMap<&str, Vec<&IdentifierPattern>> {
-        let mut user_defined: FxHashMap<&str, Vec<&IdentifierPattern>> = FxHashMap::default();
-        for (module, section) in &self.known {
-            if let ImportSection::UserDefined(section_name) = section {
-                user_defined
-                    .entry(section_name.as_str())
-                    .or_default()
-                    .push(module);
-            }
-        }
-        user_defined
-    }
 }
 
 impl fmt::Display for KnownModules {

--- a/crates/ruff_linter/src/settings/fix_safety_table.rs
+++ b/crates/ruff_linter/src/settings/fix_safety_table.rs
@@ -41,10 +41,6 @@ impl FixSafetyTable {
         }
     }
 
-    pub const fn is_empty(&self) -> bool {
-        self.forced_safe.is_empty() && self.forced_unsafe.is_empty()
-    }
-
     pub fn from_rule_selectors(
         extend_safe_fixes: &[UnresolvedRuleSelector],
         extend_unsafe_fixes: &[UnresolvedRuleSelector],

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -184,10 +184,6 @@ impl GlobPath {
         let absolute = fs::normalize_path_to(path, escaped);
         Self { path: absolute }
     }
-
-    pub fn into_inner(self) -> PathBuf {
-        self.path
-    }
 }
 
 impl Deref for GlobPath {


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ruff_linter identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 62 net lines removed
- 64 deletions and 2 additions
- 9 files changed