### PR TITLE
Remove unused APIs from ruff_notebook

### DIFF
--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -443,10 +443,6 @@ impl Notebook {
         &self.raw.cells
     }
 
-    pub fn metadata(&self) -> &RawNotebookMetadata {
-        &self.raw.metadata
-    }
-
     /// Check if it's a Python notebook.
     ///
     /// This is determined by checking the `language_info` or `kernelspec` in the notebook


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ruff_notebook identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 4 net lines removed
- 4 deletions and 0 additions
- 1 files changed