### PR TITLE
Remove unused APIs from ruff_python_parser

### DIFF
--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -49,12 +49,6 @@ impl Ranged for ParseError {
     }
 }
 
-impl ParseError {
-    pub fn error(self) -> ParseErrorType {
-        self.error
-    }
-}
-
 /// Represents the different types of errors that can occur during parsing of an f-string or t-string.
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
 pub enum InterpolatedStringErrorType {

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -456,19 +456,6 @@ impl<T> Parsed<T> {
         !self.has_no_syntax_errors()
     }
 
-    /// Returns the [`Parsed`] output as a [`Result`], returning [`Ok`] if it has no syntax errors,
-    /// or [`Err`] containing the first [`ParseError`] encountered.
-    ///
-    /// Note that any [`unsupported_syntax_errors`](Parsed::unsupported_syntax_errors) will not
-    /// cause [`Err`] to be returned.
-    pub fn as_result(&self) -> Result<&Parsed<T>, &[ParseError]> {
-        if self.has_valid_syntax() {
-            Ok(self)
-        } else {
-            Err(&self.errors)
-        }
-    }
-
     /// Consumes the [`Parsed`] output and returns a [`Result`] which is [`Ok`] if it has no syntax
     /// errors, or [`Err`] containing the first [`ParseError`] encountered.
     ///
@@ -544,11 +531,6 @@ impl Parsed<ModExpression> {
     /// Returns a mutable reference to the expression contained in this parsed output.
     fn expr_mut(&mut self) -> &mut Expr {
         &mut self.syntax.body
-    }
-
-    /// Consumes the [`Parsed`] output and returns the contained [`Expr`].
-    pub fn into_expr(self) -> Expr {
-        *self.syntax.body
     }
 }
 


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ruff_python_parser identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 24 net lines removed
- 24 deletions and 0 additions
- 2 files changed

This downstream-facing crate is intentionally isolated for focused API review.