### PR TITLE
Remove unused ClassMemberBoundness predicates

### DIFF
--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -157,16 +157,6 @@ pub enum ClassMemberBoundness {
     Bound,
 }
 
-impl ClassMemberBoundness {
-    pub const fn is_bound(self) -> bool {
-        matches!(self, Self::Bound)
-    }
-
-    pub const fn is_possibly_unbound(self) -> bool {
-        matches!(self, Self::PossiblyUnbound)
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 pub enum ClassMemberKind<'a> {
     Assign(&'a ast::StmtAssign),


### PR DESCRIPTION
## Summary

This PR removes the unused `ClassMemberBoundness::{is_bound, is_possibly_unbound}` predicates identified by Hawk 0.1.11. The other APIs and CFG visualization support considered in #27339 remain unchanged.

- 2 unused public methods removed
- 10 deletions
- 1 file changed