### PR TITLE
Remove unused APIs from ruff_python_stdlib

### DIFF
--- a/crates/ruff_python_stdlib/src/path.rs
+++ b/crates/ruff_python_stdlib/src/path.rs
@@ -1,12 +1,6 @@
 use std::ffi::OsStr;
 use std::path::Path;
 
-/// Return `true` if the [`Path`] is named `pyproject.toml`.
-pub fn is_pyproject_toml(path: &Path) -> bool {
-    path.file_name()
-        .is_some_and(|name| name == "pyproject.toml")
-}
-
 /// Return `true` if a [`Path`] should use the name of its parent directory as its module name.
 pub fn is_module_file(path: &Path) -> bool {
     matches!(

--- a/crates/ruff_python_stdlib/src/str.rs
+++ b/crates/ruff_python_stdlib/src/str.rs
@@ -1,4 +1,5 @@
 /// Return `true` if a string is lowercase.
+/// Return `true` if a string is _cased_ as lowercase.
 ///
 /// A string is lowercase if all alphabetic characters in the string are lowercase.
 ///
@@ -35,44 +36,6 @@ pub fn is_lowercase(s: &str) -> bool {
     true
 }
 
-/// Return `true` if a string is uppercase.
-///
-/// A string is uppercase if all alphabetic characters in the string are uppercase.
-///
-/// ## Examples
-///
-/// ```rust
-/// use ruff_python_stdlib::str::is_uppercase;
-///
-/// assert!(is_uppercase("ABC"));
-/// assert!(is_uppercase("A_B_C"));
-/// assert!(is_uppercase("A2C"));
-/// assert!(!is_uppercase("aBc"));
-/// assert!(!is_uppercase("abc"));
-/// assert!(is_uppercase(""));
-/// assert!(is_uppercase("_"));
-/// assert!(is_uppercase("ΩBC"));
-/// assert!(!is_uppercase("Ωbc"));
-/// assert!(!is_uppercase("αBC"));
-/// ```
-pub fn is_uppercase(s: &str) -> bool {
-    for (i, &c) in s.as_bytes().iter().enumerate() {
-        match c {
-            // Match against ASCII lowercase characters.
-            b'a'..=b'z' => return false,
-            _ if c.is_ascii() => {}
-            // If the character is non-ASCII, fallback to slow path.
-            _ => {
-                return s[i..]
-                    .chars()
-                    .all(|c| c.is_uppercase() || !c.is_alphabetic());
-            }
-        }
-    }
-    true
-}
-
-/// Return `true` if a string is _cased_ as lowercase.
 ///
 /// A string is cased as lowercase if it contains at least one lowercase character and no uppercase
 /// characters.

--- a/crates/ruff_python_stdlib/src/str.rs
+++ b/crates/ruff_python_stdlib/src/str.rs
@@ -1,5 +1,4 @@
 /// Return `true` if a string is lowercase.
-/// Return `true` if a string is _cased_ as lowercase.
 ///
 /// A string is lowercase if all alphabetic characters in the string are lowercase.
 ///
@@ -36,6 +35,44 @@ pub fn is_lowercase(s: &str) -> bool {
     true
 }
 
+/// Return `true` if a string is uppercase.
+///
+/// A string is uppercase if all alphabetic characters in the string are uppercase.
+///
+/// ## Examples
+///
+/// ```rust
+/// use ruff_python_stdlib::str::is_uppercase;
+///
+/// assert!(is_uppercase("ABC"));
+/// assert!(is_uppercase("A_B_C"));
+/// assert!(is_uppercase("A2C"));
+/// assert!(!is_uppercase("aBc"));
+/// assert!(!is_uppercase("abc"));
+/// assert!(is_uppercase(""));
+/// assert!(is_uppercase("_"));
+/// assert!(is_uppercase("ΩBC"));
+/// assert!(!is_uppercase("Ωbc"));
+/// assert!(!is_uppercase("αBC"));
+/// ```
+pub fn is_uppercase(s: &str) -> bool {
+    for (i, &c) in s.as_bytes().iter().enumerate() {
+        match c {
+            // Match against ASCII lowercase characters.
+            b'a'..=b'z' => return false,
+            _ if c.is_ascii() => {}
+            // If the character is non-ASCII, fallback to slow path.
+            _ => {
+                return s[i..]
+                    .chars()
+                    .all(|c| c.is_uppercase() || !c.is_alphabetic());
+            }
+        }
+    }
+    true
+}
+
+/// Return `true` if a string is _cased_ as lowercase.
 ///
 /// A string is cased as lowercase if it contains at least one lowercase character and no uppercase
 /// characters.


### PR DESCRIPTION
## Summary

This PR removes an unused API from ruff_python_stdlib identified by Hawk 0.1.11. It is split from #27339 so the removal can be reviewed independently at the crate boundary.

- 6 net lines removed
- 6 deletions
- 1 file changed
