### PR TITLE
Remove unused APIs from ruff_ranged_value

### DIFF
--- a/crates/ruff_ranged_value/src/lib.rs
+++ b/crates/ruff_ranged_value/src/lib.rs
@@ -43,10 +43,6 @@ impl ValueSource {
             ValueSource::UvWorkspace => None,
         }
     }
-
-    pub const fn is_cli(&self) -> bool {
-        matches!(self, ValueSource::Cli)
-    }
 }
 
 thread_local! {
@@ -169,12 +165,6 @@ impl<T> RangedValue<T> {
 
     pub fn source(&self) -> &ValueSource {
         &self.source
-    }
-
-    #[must_use]
-    pub fn with_source(mut self, source: ValueSource) -> Self {
-        self.source = source;
-        self
     }
 
     #[must_use]


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ruff_ranged_value identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 10 net lines removed
- 10 deletions and 0 additions
- 1 files changed