### PR TITLE
Remove unused APIs from ruff_source_file

### DIFF
--- a/crates/ruff_source_file/src/lib.rs
+++ b/crates/ruff_source_file/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, OnceLock};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextSize};
 
 pub use crate::line_index::{LineIndex, OneIndexed, PositionEncoding};
 pub use crate::line_ranges::LineRanges;
@@ -55,19 +55,7 @@ impl<'src, 'index> SourceCode<'src, 'index> {
         self.index.line_index(offset)
     }
 
-    /// Take the source code up to the given [`TextSize`].
-    #[inline]
-    pub fn up_to(&self, offset: TextSize) -> &'src str {
-        &self.text[TextRange::up_to(offset)]
-    }
-
-    /// Take the source code after the given [`TextSize`].
-    #[inline]
-    pub fn after(&self, offset: TextSize) -> &'src str {
-        &self.text[usize::from(offset)..]
-    }
-
-    /// Take the source code between the given [`TextRange`].
+    /// Take the source code between the given [`ruff_text_size::TextRange`].
     pub fn slice<T: Ranged>(&self, ranged: T) -> &'src str {
         &self.text[ranged.range()]
     }
@@ -82,10 +70,6 @@ impl<'src, 'index> SourceCode<'src, 'index> {
 
     pub fn line_end_exclusive(&self, line: OneIndexed) -> TextSize {
         self.index.line_end_exclusive(line, self.text)
-    }
-
-    pub fn line_range(&self, line: OneIndexed) -> TextRange {
-        self.index.line_range(line, self.text)
     }
 
     /// Returns the source text of the line with the given index
@@ -132,16 +116,6 @@ impl SourceFileBuilder {
         }
     }
 
-    #[must_use]
-    pub fn line_index(mut self, index: LineIndex) -> Self {
-        self.index = Some(index);
-        self
-    }
-
-    pub fn set_line_index(&mut self, index: LineIndex) {
-        self.index = Some(index);
-    }
-
     /// Consumes `self` and returns the [`SourceFile`].
     pub fn finish(self) -> SourceFile {
         let index = if let Some(index) = self.index {
@@ -183,11 +157,6 @@ impl SourceFile {
     #[inline]
     pub fn name(&self) -> &str {
         &self.inner.name
-    }
-
-    #[inline]
-    pub fn slice(&self, range: TextRange) -> &str {
-        &self.source_text()[range]
     }
 
     pub fn to_source_code(&self) -> SourceCode<'_, '_> {


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ruff_source_file identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 31 net lines removed
- 33 deletions and 2 additions
- 1 files changed

This preserves the general-purpose OneIndexed checked arithmetic APIs called out in review.