### PR TITLE
Remove unused APIs from ruff_workspace

### DIFF
--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -33,17 +33,6 @@ pub struct Pyproject {
     project: Option<Project>,
 }
 
-impl Pyproject {
-    pub const fn new(options: Options) -> Self {
-        Self {
-            tool: Some(Tools {
-                ruff: Some(options),
-            }),
-            project: None,
-        }
-    }
-}
-
 fn parse_toml<P: AsRef<Path>, T: DeserializeOwned>(path: P, table_path: &[&str]) -> Result<T> {
     let path = path.as_ref();
 

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -68,11 +68,6 @@ pub enum PyprojectDiscoveryStrategy {
 
 impl PyprojectDiscoveryStrategy {
     #[inline]
-    pub const fn is_fixed(self) -> bool {
-        matches!(self, PyprojectDiscoveryStrategy::Fixed)
-    }
-
-    #[inline]
     const fn is_hierarchical(self) -> bool {
         matches!(self, PyprojectDiscoveryStrategy::Hierarchical)
     }


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ruff_workspace identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 16 net lines removed
- 16 deletions and 0 additions
- 2 files changed