### PR TITLE
[ty] Remove unused APIs from ty_module_resolver

### DIFF
--- a/crates/ty_module_resolver/src/lib.rs
+++ b/crates/ty_module_resolver/src/lib.rs
@@ -13,8 +13,6 @@ pub use resolve::{
 };
 pub use settings::{SearchPathSettings, SearchPathSettingsError};
 pub use strategy::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};
-#[expect(unused_imports)]
-pub(crate) use typeshed::vendored_typeshed_versions;
 pub use typeshed::{PyVersionRange, TypeshedVersions, TypeshedVersionsParseError};
 
 pub use list::{all_modules, list_modules};

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -760,7 +760,8 @@ impl SearchPaths {
     /// Returns a new `SearchPaths` with no search paths configured.
     ///
     /// This is primarily useful for testing.
-    pub fn empty(vendored: &VendoredFileSystem) -> Self {
+    #[cfg(test)]
+    pub(crate) fn empty(vendored: &VendoredFileSystem) -> Self {
         Self {
             static_paths: vec![],
             stdlib_path: Some(SearchPath::vendored_stdlib()),


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ty_module_resolver identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 1 net lines removed
- 2 deletions and 1 additions
- 2 files changed