### PR TITLE
[ty] Remove unused APIs from ty_python_core

### DIFF
--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -271,12 +271,6 @@ pub struct Definitions<'db> {
 }
 
 impl<'db> Definitions<'db> {
-    pub fn single(definition: Definition<'db>) -> Self {
-        Self {
-            definitions: smallvec::smallvec_inline![definition],
-        }
-    }
-
     pub(crate) fn push(&mut self, definition: Definition<'db>) {
         self.definitions.push(definition);
     }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -869,10 +869,6 @@ impl<'db> UseDefMap<'db> {
         &self.constraint_tables().reachability_constraints
     }
 
-    pub fn narrowing_constraints(&self) -> &NarrowingConstraints {
-        &self.constraint_tables().narrowing_constraints
-    }
-
     pub fn predicates(&self) -> &Predicates<'db> {
         &self.constraint_tables().predicates
     }


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ty_python_core identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 10 net lines removed
- 10 deletions and 0 additions
- 2 files changed