### PR TITLE
[ty] Remove unused APIs from ty_server

### DIFF
--- a/crates/ty_server/src/document/text_document.rs
+++ b/crates/ty_server/src/document/text_document.rs
@@ -70,10 +70,6 @@ impl TextDocument {
         self
     }
 
-    pub fn into_contents(self) -> String {
-        self.contents
-    }
-
     pub(crate) fn uri(&self) -> &Uri {
         &self.uri
     }


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ty_server identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 4 net lines removed
- 4 deletions and 0 additions
- 1 files changed