### PR TITLE
[ty] Remove unused APIs from ty_site_packages

### DIFF
--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -399,14 +399,6 @@ impl PythonEnvironment {
         }
     }
 
-    /// Returns the `pyvenv.cfg` path for virtual environments.
-    pub fn pyvenv_cfg_path(&self) -> Option<SystemPathBuf> {
-        match self {
-            Self::Virtual(env) => Some(env.root_path.join("pyvenv.cfg")),
-            Self::System(_) => None,
-        }
-    }
-
     /// Returns `true` if this is a virtual environment (has a `pyvenv.cfg` file).
     pub fn is_virtual(&self) -> bool {
         matches!(self, Self::Virtual(_))

--- a/crates/ty_site_packages/src/version.rs
+++ b/crates/ty_site_packages/src/version.rs
@@ -60,16 +60,6 @@ impl PythonVersionFileSource {
         Self { path, range }
     }
 
-    /// Returns the path to the configuration file.
-    pub fn path(&self) -> &SystemPathBuf {
-        &self.path
-    }
-
-    /// Returns the range of the configuration setting.
-    pub fn range(&self) -> Option<TextRange> {
-        self.range
-    }
-
     /// Attempt to resolve a [`Span`] that corresponds to the location of
     /// the configuration setting that specified the Python version.
     ///


### PR DESCRIPTION
## Summary

This PR removes unused APIs from ty_site_packages identified by Hawk 0.1.11. It is split from #27339 so the removals can be reviewed independently at the crate boundary.

- 18 net lines removed
- 18 deletions and 0 additions
- 2 files changed