### PR TITLE
[ty] Check property compatibility when matching class objects to protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/numpy.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/numpy.md
@@ -19,6 +19,16 @@ xs = np.array([1, 2, 3])
 reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[Unknown]]
 
 xs = np.array([1.0, 2.0, 3.0], dtype=np.float64)
-# TODO: should be `ndarray[tuple[Any, ...], dtype[float64]]`
-reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[Unknown]]
+reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[float64]]
+```
+
+An explicit integer dtype is also preserved through `array`, allowing `interp` to select its array
+overload. This is a regression test for <https://github.com/astral-sh/ty/issues/1429>:
+
+```py
+values = np.array([0, 1, 2], dtype=np.int64)
+reveal_type(values)  # revealed: ndarray[tuple[Any, ...], dtype[signedinteger[_64Bit]]]
+
+interpolated = np.interp(values, values, values)
+reveal_type(interpolated)  # revealed: ndarray[tuple[Any, ...], dtype[float64]]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/external/numpy.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/numpy.md
@@ -29,7 +29,10 @@ regression test for <https://github.com/astral-sh/ty/issues/3199>:
 def takes_float16(values: np.ndarray[tuple[int, ...], np.dtype[np.float16]]) -> None: ...
 
 float32_values = np.array([1, 2, 3], dtype=np.float32)
+reveal_type(float32_values)  # revealed: ndarray[tuple[Any, ...], dtype[floating[_32Bit]]]
+
 float16_values = np.array([1, 2, 3], dtype=np.float16)
+reveal_type(float16_values)  # revealed: ndarray[tuple[Any, ...], dtype[floating[_16Bit]]]
 
 takes_float16(float32_values)  # error: [invalid-argument-type]
 takes_float16(float16_values)

--- a/crates/ty_python_semantic/resources/mdtest/external/numpy.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/numpy.md
@@ -22,6 +22,19 @@ xs = np.array([1.0, 2.0, 3.0], dtype=np.float64)
 reveal_type(xs)  # revealed: ndarray[tuple[Any, ...], dtype[float64]]
 ```
 
+Explicit dtypes remain distinct when checking an array against a parameter annotation. This is a
+regression test for <https://github.com/astral-sh/ty/issues/3199>:
+
+```py
+def takes_float16(values: np.ndarray[tuple[int, ...], np.dtype[np.float16]]) -> None: ...
+
+float32_values = np.array([1, 2, 3], dtype=np.float32)
+float16_values = np.array([1, 2, 3], dtype=np.float16)
+
+takes_float16(float32_values)  # error: [invalid-argument-type]
+takes_float16(float16_values)
+```
+
 An explicit integer dtype is also preserved through `array`, allowing `interp` to select its array
 overload. This is a regression test for <https://github.com/astral-sh/ty/issues/1429>:
 

--- a/crates/ty_python_semantic/resources/mdtest/libraries/numpy.md
+++ b/crates/ty_python_semantic/resources/mdtest/libraries/numpy.md
@@ -49,9 +49,13 @@ _DTypeLike: TypeAlias = type[_ScalarT] | dtype[_ScalarT] | _SupportsDType[dtype[
 DTypeLike: TypeAlias = _DTypeLike[Any] | str | None
 ```
 
-Now we can make sure that a function which accepts `DTypeLike | None` works as expected:
+Now we can make sure that a function which accepts `DTypeLike | None` works as expected. A generic
+function accepting `_DTypeLike[_ScalarT]` should also infer the scalar type from a scalar class. The
+protocol union element describes instances with a `dtype` property, not the class object whose class
+access exposes that property descriptor:
 
 ```py
+from typing import TypeVar
 import mini_numpy as np
 
 def accepts_dtype(dtype: np.DTypeLike | None) -> None: ...
@@ -61,4 +65,11 @@ accepts_dtype(dtype=np.dtype[np.bool])
 accepts_dtype(dtype=object)
 accepts_dtype(dtype=np.object_)
 accepts_dtype(dtype="U")
+
+_ScalarT = TypeVar("_ScalarT", bound=np.generic)
+
+def from_dtype_like(value: np._DTypeLike[_ScalarT]) -> np.dtype[_ScalarT]:
+    raise NotImplementedError
+
+reveal_type(from_dtype_like(np.bool))  # revealed: dtype[bool[bool]]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2071,6 +2071,14 @@ static_assert(is_subtype_of(XImplicitFinal, HasXProperty))
 static_assert(is_assignable_to(XImplicitFinal, HasXProperty))
 ```
 
+Accessing an instance property on the class object exposes the property descriptor, not the value
+returned by its getter. A class object with only an instance property therefore does not satisfy the
+protocol:
+
+```py
+x_class: HasXProperty = XReadProperty  # error: [invalid-assignment]
+```
+
 But only if it has the correct type:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2015,7 +2015,7 @@ read/write property, a `Final` attribute, or a `ClassVar` attribute:
 ```py
 from typing import ClassVar, Final, Protocol, final
 from ty_extensions import static_assert
-from ty_extensions._internal import is_subtype_of, is_assignable_to, is_disjoint_from
+from ty_extensions._internal import TypeOf, is_subtype_of, is_assignable_to, is_disjoint_from
 
 class HasXProperty(Protocol):
     @property
@@ -2071,14 +2071,6 @@ static_assert(is_subtype_of(XImplicitFinal, HasXProperty))
 static_assert(is_assignable_to(XImplicitFinal, HasXProperty))
 ```
 
-Accessing an instance property on the class object exposes the property descriptor, not the value
-returned by its getter. A class object with only an instance property therefore does not satisfy the
-protocol:
-
-```py
-x_class: HasXProperty = XReadProperty  # error: [invalid-assignment]
-```
-
 But only if it has the correct type:
 
 ```py
@@ -2092,6 +2084,18 @@ class HasStrXProperty(Protocol):
 static_assert(not is_assignable_to(XAttrBad, HasXProperty))
 static_assert(not is_assignable_to(HasStrXProperty, HasXProperty))
 static_assert(not is_assignable_to(HasXProperty, HasStrXProperty))
+```
+
+Accessing an instance property on the class object exposes the property descriptor, not the value
+returned by its getter. A class object with only an instance property is therefore disjoint from the
+protocol:
+
+```py
+static_assert(not is_subtype_of(TypeOf[XReadProperty], HasXProperty))
+static_assert(not is_assignable_to(TypeOf[XReadProperty], HasXProperty))
+static_assert(is_disjoint_from(TypeOf[XReadProperty], HasXProperty))
+
+x_class: HasXProperty = XReadProperty  # error: [invalid-assignment]
 ```
 
 A read-only property on a protocol, unlike a mutable attribute, is covariant: `XSub` in the below

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2817,15 +2817,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 (implementation_self_binding_ty, protocol_self_binding_ty)
             };
 
-        // Checking a class object against a protocol's instance capabilities can expose the
-        // property descriptor itself rather than the value returned by its getter. Compatibility
-        // for properties on class objects is not yet modeled; retain the previous name-only
-        // behavior until generic upper-bound solving can handle the large recursive unions this
-        // otherwise creates.
-        if member.is_property() && matches!(attribute_type, Type::PropertyInstance(_)) {
-            return self.always();
-        }
-
         if member.is_method() && access == ProtocolMemberAccessMode::Instance {
             let Some(required_ty) = required_ty.resolve(db, env) else {
                 return self.never();

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -3319,11 +3319,6 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         member: &ProtocolMember<'_, 'db>,
         ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // An unbound property descriptor does not establish that the value returned by its
-        // getter is disjoint from the required property type.
-        if member.is_property() && matches!(ty, Type::PropertyInstance(_)) {
-            return self.never();
-        }
         let env = self.env;
         let access = member.access(db, env, ProtocolMemberAccessMode::Instance);
         if !member.is_method() {


### PR DESCRIPTION
## Summary

When matching a class object against a protocol, we previously treated any `property` descriptor as an unconditional match for a protocol property. This reduced compatibility to a name-only check even though accessing an instance property on the class exposes the descriptor, not the value returned by its getter:

```py
class HasValue(Protocol):
    @property
    def value(self) -> str: ...

class Value:
    @property
    def value(self) -> str: ...

target: HasValue = Value  # error
```

This removes the stale shortcut so the class attribute and protocol member are compared using the normal type relation.

That shortcut also interfered with generic inference for unions, like in NumPy's `_DTypeLike[T]`, where it allowed a scalar class such as `np.int64` to match `_SupportsDType[dtype[T]]` without constraining `T`, overriding the useful `type[T]` match and producing `Unknown`. With normal property compatibility, the class-object branch binds `T`, so explicit dtypes remain specialized through downstream calls:

```py
values = np.array([0, 1, 2], dtype=np.int64)
reveal_type(values)  # ndarray[..., dtype[signedinteger[_64Bit]]]
reveal_type(np.interp(values, values, values))  # ndarray[..., dtype[float64]]
```

Closes https://github.com/astral-sh/ty/issues/3199.
