### PR TITLE
[`ruff_python_ast`] Fix double visit / missing elif visit

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -436,10 +436,7 @@ impl<'a> Visitor<'a> for LoopMutationsVisitor<'a> {
                 // Handle the `elif` and `else` branches.
                 for clause in elif_else_clauses {
                     self.enter_new_branch();
-                    if let Some(test) = &clause.test {
-                        self.visit_expr(test);
-                    }
-                    self.visit_body(&clause.body);
+                    self.visit_elif_else_clause(clause);
                     self.merge_branch_into(saved_branch);
                 }
             }

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -265,9 +265,6 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             visitor.visit_expr(test);
             visitor.visit_body(body);
             for clause in elif_else_clauses {
-                if let Some(test) = &clause.test {
-                    visitor.visit_expr(test);
-                }
                 walk_elif_else_clause(visitor, clause);
             }
         }

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -265,7 +265,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             visitor.visit_expr(test);
             visitor.visit_body(body);
             for clause in elif_else_clauses {
-                walk_elif_else_clause(visitor, clause);
+                visitor.visit_elif_else_clause(clause);
             }
         }
         Stmt::With(ast::StmtWith { items, body, .. }) => {

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -252,7 +252,7 @@ pub fn walk_stmt<V: Transformer + ?Sized>(visitor: &V, stmt: &mut Stmt) {
             visitor.visit_expr(test);
             visitor.visit_body(body);
             for clause in elif_else_clauses {
-                walk_elif_else_clause(visitor, clause);
+                visitor.visit_elif_else_clause(clause);
             }
         }
         Stmt::With(ast::StmtWith { items, body, .. }) => {


### PR DESCRIPTION
## Summary

Hi! Fiddling with ast I've stumbled upon some issues:
- `Visitor.walk_stmt` visits `test` expression for each `elif` branch twice (e.g. causing minor performance overhead and double diagnostics in some cases, see below).
- `Visitor.walk_stmt` never calls `visit_elif_else_clause`, instead it calls `walk_elif_else_clause` directly. 
- `Transformer.walk_stmt` is also never calling `visit_elif_else_clause`
- `loop_iterator_mutation` is reimplementing `walk_elif_else_clause` instead of using `visit_elif_else_clause` - a minor thing, just a refactor opportunity found trying to find if `Visitor`/`Transformer` pattern was applicable anywhere else in the codebase.

Example where first issue causes double diagnostics:
```python
# ruff check --select TRY401 test.py
# https://docs.astral.sh/ruff/rules/verbose-log-message/
import logging

logger = logging.getLogger(__name__)

def f():
    try:
        pass
    except Exception as e:
        if False:
            pass
        elif logger.exception("uh oh", e):
            pass
```


Those issues are not new, I believe they sneaked when elifs where separated from ifs in  https://github.com/astral-sh/ruff/pull/5459. I've also found that double visit was present in the `Transformer` also, but then was fixed (https://github.com/astral-sh/ruff/pull/18064).

## Test Plan

Tested locally - all previous tests pass, duplicated diagnostic from the example above is resolved.
