### PR TITLE
Restore symmetric public APIs

### DIFF
--- a/crates/ruff_diagnostics/src/edit.rs
+++ b/crates/ruff_diagnostics/src/edit.rs
@@ -77,22 +77,20 @@ impl Edit {
     }
 
     /// Returns `true` if this edit deletes content from the source document.
-    #[expect(dead_code)]
     #[inline]
-    pub(crate) fn is_deletion(&self) -> bool {
+    pub fn is_deletion(&self) -> bool {
         self.kind().is_deletion()
     }
 
     /// Returns `true` if this edit inserts new content into the source document.
     #[inline]
-    pub(crate) fn is_insertion(&self) -> bool {
+    pub fn is_insertion(&self) -> bool {
         self.kind().is_insertion()
     }
 
     /// Returns `true` if this edit replaces some existing content with new content.
-    #[expect(dead_code)]
     #[inline]
-    pub(crate) fn is_replacement(&self) -> bool {
+    pub fn is_replacement(&self) -> bool {
         self.kind().is_replacement()
     }
 }
@@ -131,15 +129,15 @@ enum EditOperationKind {
 }
 
 impl EditOperationKind {
-    pub(crate) const fn is_insertion(self) -> bool {
+    const fn is_insertion(self) -> bool {
         matches!(self, EditOperationKind::Insertion)
     }
 
-    pub(crate) const fn is_deletion(self) -> bool {
+    const fn is_deletion(self) -> bool {
         matches!(self, EditOperationKind::Deletion)
     }
 
-    pub(crate) const fn is_replacement(self) -> bool {
+    const fn is_replacement(self) -> bool {
         matches!(self, EditOperationKind::Replacement)
     }
 }

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -50,8 +50,6 @@ pub use builders::BestFitting;
 pub use source_code::{SourceCode, SourceCodeSlice};
 
 pub use crate::diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
-#[expect(unused_imports)]
-pub(crate) use format_element::LINE_TERMINATORS;
 pub use format_element::{FormatElement, normalize_newlines};
 pub use group_id::GroupId;
 use ruff_macros::CacheKey;

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -16,13 +16,12 @@ pub struct NoqaCode(&'static str, &'static str);
 
 impl NoqaCode {
     /// Return the prefix for the [`NoqaCode`], e.g., `SIM` for `SIM101`.
-    #[expect(dead_code)]
-    pub(crate) fn prefix(&self) -> &str {
+    pub fn prefix(&self) -> &str {
         self.0
     }
 
     /// Return the suffix for the [`NoqaCode`], e.g., `101` for `SIM101`.
-    pub(crate) fn suffix(&self) -> &str {
+    pub fn suffix(&self) -> &str {
         self.1
     }
 

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -17,8 +17,6 @@ use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::{SourceTextError, source_text};
 use rustc_hash::FxHasher;
-#[expect(unused_imports)]
-pub(crate) use semantic_model::HasOptionalDefinition;
 pub use semantic_model::{
     Completion, ExpectedStringLiteralCompletion, HasDefinition, HasType, MemberDefinition,
     NameKind, SemanticModel,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -44,14 +44,11 @@ pub(crate) use self::match_pattern::{
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;
+use self::set_theoretic::NegativeIntersectionElements;
 pub(crate) use self::set_theoretic::builder::{
     IntersectionBuilder, UnionAccumulator, UnionBuilder,
 };
 pub use self::set_theoretic::{IntersectionType, UnionType};
-#[expect(unused_imports)]
-pub(crate) use self::set_theoretic::{
-    NegativeIntersectionElements, NegativeIntersectionElementsIterator,
-};
 pub use self::signatures::ParameterKind;
 pub(crate) use self::signatures::Signature;
 pub(crate) use self::subclass_of::{SubclassOfInner, SubclassOfType};


### PR DESCRIPTION
## Summary

This follows up on #27339 based on review feedback.

- Remove internal re-exports instead of retaining them with `#[expect(unused_imports)]`.
- Restore the symmetric `Edit` and `NoqaCode` accessors to public visibility.
- Keep `EditOperationKind`'s helper methods private along with their containing type.

The public accessors are retained as coherent downstream-facing APIs even when individual methods are not used within the workspace. Hawk will document those intentional exceptions in the separate CI/configuration PR.
