### PR TITLE
[ty] Simplify numeric tower displays (e.g., `float` over `int | float`)

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -12,7 +12,7 @@ use ty_python_semantic::ProgramEnvironment;
 use ty_python_semantic::types::ide_support::{resolved_call_signature, typed_dict_key_hover};
 use ty_python_semantic::types::{KnownInstanceType, Type, TypeAliasType, TypeVarVariance};
 
-use ty_python_semantic::{DisplaySettings, SemanticModel, TypeQualifiers};
+use ty_python_semantic::{SemanticModel, TypeQualifiers};
 
 pub fn hover<'db>(
     db: &'db dyn Db,
@@ -340,13 +340,7 @@ impl<'db> DisplayHoverContent<'_, 'db> {
         let db = self.db;
         // Special types like `<special-form of whatever 'blahblah' with 'florps'>`
         // render poorly with python syntax-highlighting but well as xml
-        let ty_string = ty
-            .display_with(
-                db,
-                self.env,
-                DisplaySettings::from_possibly_ambiguous_types(db, self.env, [*ty]).multiline(),
-            )
-            .to_string();
+        let ty_string = ty.display(db, self.env).multiline().to_string();
         let syntax = if ty_string.starts_with('<') {
             "xml"
         } else {

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -6109,6 +6109,45 @@ def function():
     }
 
     #[test]
+    fn hover_shadowed_numeric_builtin_in_selected_signature() {
+        let test = hover_test(
+            r#"
+            import builtins
+            from typing import overload
+
+            class float: ...
+
+            @overload
+            def choose(value: builtins.float | float) -> None: ...
+            @overload
+            def choose(value: str) -> None: ...
+            def choose(value: object) -> None: ...
+
+            choose<CURSOR>(1.0)
+            "#,
+        );
+
+        assert_snapshot!(test.hover());
+    }
+
+    #[test]
+    fn hover_shadowed_numeric_builtin_in_keyword_parameter() {
+        let test = hover_test(
+            r#"
+            import builtins
+
+            class float: ...
+
+            def choose(*, value: builtins.float | float) -> None: ...
+
+            choose(value<CURSOR>=1.0)
+            "#,
+        );
+
+        assert_snapshot!(test.hover());
+    }
+
+    #[test]
     fn hover_bare_final_annotation() {
         let test = hover_test(
             r#"

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -341,7 +341,11 @@ impl<'db> DisplayHoverContent<'_, 'db> {
         // Special types like `<special-form of whatever 'blahblah' with 'florps'>`
         // render poorly with python syntax-highlighting but well as xml
         let ty_string = ty
-            .display_with(db, self.env, DisplaySettings::default().multiline())
+            .display_with(
+                db,
+                self.env,
+                DisplaySettings::from_possibly_ambiguous_types(db, self.env, [*ty]).multiline(),
+            )
             .to_string();
         let syntax = if ty_string.starts_with('<') {
             "xml"
@@ -6086,6 +6090,22 @@ def function():
           |    |
           |    source
         ");
+    }
+
+    #[test]
+    fn hover_shadowed_numeric_builtin() {
+        let test = hover_test(
+            r#"
+            import builtins
+
+            class float: ...
+
+            def f(x: builtins.float | float):
+                x<CURSOR>
+            "#,
+        );
+
+        assert_snapshot!(test.hover());
     }
 
     #[test]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -6067,13 +6067,13 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        int | float
+        float
         ---------------------------------------------
         Convert a string or number to a floating-point number, if possible.
 
         ---------------------------------------------
         ```python
-        int | float
+        float
         ```
         ---
         Convert a string or number to a floating-point number, if possible.

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -2442,7 +2442,7 @@ Source with applied edits:
         assert_snapshot!(test.inlay_hints(), @r#"
 
         a[: list[int]] = [1, 2]
-        b[: list[int | float]] = [1.0, 2.0]
+        b[: list[float]] = [1.0, 2.0]
         c[: list[bool]] = [True, False]
         d[: list[None | Unknown]] = [None, None]
         e[: list[str]] = ["hel", "lo"]
@@ -2450,8 +2450,8 @@ Source with applied edits:
         g[: list[str]] = [f"{ft}", f"{ft}"]
         h[: list[Template]] = [t"wow %d", t"wow %d"]
         i[: list[bytes]] = [b'/x01', b'/x02']
-        j[: list[int | float]] = [+1, +2.0]
-        k[: list[int | float]] = [-1, -2.0]
+        j[: list[float]] = [+1, +2.0]
+        k[: list[float]] = [-1, -2.0]
 
         ---------------------------------------------
         info[inlay-hint-location]: Inlay Hint Target
@@ -2484,19 +2484,8 @@ Source with applied edits:
         info: Source
           --> main2.py:LL:5
            |
-        LL | b[: list[int | float]] = [1.0, 2.0]
+        LL | b[: list[float]] = [1.0, 2.0]
            |     ^^^^
-
-        info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/builtins.pyi:LL:7
-           |
-        LL | class int:
-           |       ^^^
-        info: Source
-          --> main2.py:LL:10
-           |
-        LL | b[: list[int | float]] = [1.0, 2.0]
-           |          ^^^
 
         info[inlay-hint-location]: Inlay Hint Target
           --> stdlib/builtins.pyi:LL:7
@@ -2504,10 +2493,10 @@ Source with applied edits:
         LL | class float:
            |       ^^^^^
         info: Source
-          --> main2.py:LL:16
+          --> main2.py:LL:10
            |
-        LL | b[: list[int | float]] = [1.0, 2.0]
-           |                ^^^^^
+        LL | b[: list[float]] = [1.0, 2.0]
+           |          ^^^^^
 
         info[inlay-hint-location]: Inlay Hint Target
           --> stdlib/builtins.pyi:LL:7
@@ -2682,19 +2671,8 @@ Source with applied edits:
         info: Source
           --> main2.py:LL:5
            |
-        LL | j[: list[int | float]] = [+1, +2.0]
+        LL | j[: list[float]] = [+1, +2.0]
            |     ^^^^
-
-        info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/builtins.pyi:LL:7
-           |
-        LL | class int:
-           |       ^^^
-        info: Source
-          --> main2.py:LL:10
-           |
-        LL | j[: list[int | float]] = [+1, +2.0]
-           |          ^^^
 
         info[inlay-hint-location]: Inlay Hint Target
           --> stdlib/builtins.pyi:LL:7
@@ -2702,10 +2680,10 @@ Source with applied edits:
         LL | class float:
            |       ^^^^^
         info: Source
-          --> main2.py:LL:16
+          --> main2.py:LL:10
            |
-        LL | j[: list[int | float]] = [+1, +2.0]
-           |                ^^^^^
+        LL | j[: list[float]] = [+1, +2.0]
+           |          ^^^^^
 
         info[inlay-hint-location]: Inlay Hint Target
           --> stdlib/builtins.pyi:LL:7
@@ -2715,19 +2693,8 @@ Source with applied edits:
         info: Source
           --> main2.py:LL:5
            |
-        LL | k[: list[int | float]] = [-1, -2.0]
+        LL | k[: list[float]] = [-1, -2.0]
            |     ^^^^
-
-        info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/builtins.pyi:LL:7
-           |
-        LL | class int:
-           |       ^^^
-        info: Source
-          --> main2.py:LL:10
-           |
-        LL | k[: list[int | float]] = [-1, -2.0]
-           |          ^^^
 
         info[inlay-hint-location]: Inlay Hint Target
           --> stdlib/builtins.pyi:LL:7
@@ -2735,10 +2702,10 @@ Source with applied edits:
         LL | class float:
            |       ^^^^^
         info: Source
-          --> main2.py:LL:16
+          --> main2.py:LL:10
            |
-        LL | k[: list[int | float]] = [-1, -2.0]
-           |                ^^^^^
+        LL | k[: list[float]] = [-1, -2.0]
+           |          ^^^^^
 
         ---------------------------------------------
         info[inlay-hint-edit]: Inlay hint edits
@@ -2759,7 +2726,7 @@ Source with applied edits:
            - j = [+1, +2.0]
            - k = [-1, -2.0]
         4  + a: list[int] = [1, 2]
-        5  + b: list[int | float] = [1.0, 2.0]
+        5  + b: list[float] = [1.0, 2.0]
         6  + c: list[bool] = [True, False]
         7  + d: list[None | Unknown] = [None, None]
         8  + e: list[str] = ["hel", "lo"]
@@ -2767,8 +2734,8 @@ Source with applied edits:
         10 + g: list[str] = [f"{ft}", f"{ft}"]
         11 + h: list[Template] = [t"wow %d", t"wow %d"]
         12 + i: list[bytes] = [b'/x01', b'/x02']
-        13 + j: list[int | float] = [+1, +2.0]
-        14 + k: list[int | float] = [-1, -2.0]
+        13 + j: list[float] = [+1, +2.0]
+        14 + k: list[float] = [-1, -2.0]
            |
         "#);
     }

--- a/crates/ty_ide/src/snapshots/ty_ide__hover__tests__hover_shadowed_numeric_builtin.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__hover__tests__hover_shadowed_numeric_builtin.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ty_ide/src/hover.rs
+expression: test.hover()
+---
+builtins.float | main.float
+---------------------------------------------
+```python
+builtins.float | main.float
+```
+---------------------------------------------
+info[hover]: Hovered content is
+ --> main.py:7:5
+  |
+7 |     x
+  |     ^- Cursor offset
+  |     |
+  |     source

--- a/crates/ty_ide/src/snapshots/ty_ide__hover__tests__hover_shadowed_numeric_builtin_in_keyword_parameter.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__hover__tests__hover_shadowed_numeric_builtin_in_keyword_parameter.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ty_ide/src/hover.rs
+expression: test.hover()
+---
+(parameter) value: builtins.float | main.float
+---------------------------------------------
+```python
+(parameter) value: builtins.float | main.float
+```
+---------------------------------------------
+info[hover]: Hovered content is
+ --> main.py:8:8
+  |
+8 | choose(value=1.0)
+  |        ^^^^^- Cursor offset
+  |        |
+  |        source

--- a/crates/ty_ide/src/snapshots/ty_ide__hover__tests__hover_shadowed_numeric_builtin_in_selected_signature.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__hover__tests__hover_shadowed_numeric_builtin_in_selected_signature.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ty_ide/src/hover.rs
+expression: test.hover()
+---
+def choose(value: builtins.float | main.float) -> None
+---------------------------------------------
+```python
+def choose(value: builtins.float | main.float) -> None
+```
+---------------------------------------------
+info[hover]: Hovered content is
+  --> main.py:13:1
+   |
+13 | choose(1.0)
+   | ^^^^^^- Cursor offset
+   | |
+   | source

--- a/crates/ty_python_semantic/resources/mdtest/annotations/int_float_complex.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/int_float_complex.md
@@ -40,12 +40,20 @@ def assigns_float_to_int(x: float):
     y: int = x
 ```
 
-Unlike other type checkers, we choose not to obfuscate this special case by displaying `int | float`
-as just `float`; we display the actual type:
+Ty displays these numeric-tower unions using the canonical spellings `float` and `complex`. Exact
+runtime instances are displayed as `float*` and `complex*` to preserve the distinction. The starred
+spellings are only used in type displays; use `ty_extensions.JustFloat` or `JustComplex` to write
+the exact types in annotations.
 
 ```py
 def f(x: float):
-    reveal_type(x)  # revealed: int | float
+    reveal_type(x)  # revealed: float
+
+def returns_float() -> float:
+    return 1
+
+reveal_type(returns_float())  # revealed: float
+reveal_type(1.0)  # revealed: float*
 ```
 
 ## complex
@@ -86,7 +94,32 @@ def assigns_complex(x: complex):
     z: float = x
 
 def f(x: complex):
-    reveal_type(x)  # revealed: int | float | complex
+    reveal_type(x)  # revealed: complex
+
+reveal_type(1j)  # revealed: complex*
+```
+
+## Shadowed numeric builtins
+
+Canonical numeric names remain qualified when a module defines a class with the same name:
+
+```py
+import builtins
+
+class float: ...
+class complex: ...
+
+def reveal_shadowed_names(
+    x: builtins.float | float,
+    y: builtins.complex | complex,
+):
+    reveal_type(x)  # revealed: builtins.float | mdtest_snippet.float
+    reveal_type(y)  # revealed: builtins.complex | mdtest_snippet.complex
+
+def takes_custom_float(x: float): ...
+def pass_builtin_float(x: builtins.float):
+    # error: [invalid-argument-type] "Argument to function `takes_custom_float` is incorrect: Expected `mdtest_snippet.float`, found `builtins.float`"
+    takes_custom_float(x)
 ```
 
 ## Narrowing
@@ -99,14 +132,14 @@ from typing_extensions import assert_type
 from ty_extensions import JustFloat
 
 def f(x: complex):
-    reveal_type(x)  # revealed: int | float | complex
+    reveal_type(x)  # revealed: complex
 
     if isinstance(x, int):
         reveal_type(x)  # revealed: int
     elif isinstance(x, float):
-        reveal_type(x)  # revealed: float
+        reveal_type(x)  # revealed: float*
     else:
-        reveal_type(x)  # revealed: complex
+        reveal_type(x)  # revealed: complex*
 
     assert isinstance(x, float)
     assert_type(x, JustFloat)

--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -306,10 +306,10 @@ from ty_extensions._internal import is_assignable_to
 Foo = NewType("Foo", float)
 Foo(3.14)
 Foo(42)
-Foo("hello")  # error: [invalid-argument-type] "Argument is incorrect: Expected `int | float`, found `Literal["hello"]`"
+Foo("hello")  # error: [invalid-argument-type] "Argument is incorrect: Expected `float`, found `Literal["hello"]`"
 
-reveal_type(Foo(3.14).__class__)  # revealed: type[int | float]
-reveal_type(Foo(42).__class__)  # revealed: type[int | float]
+reveal_type(Foo(3.14).__class__)  # revealed: type[float]
+reveal_type(Foo(42).__class__)  # revealed: type[float]
 static_assert(is_assignable_to(Foo, float))
 static_assert(is_assignable_to(Foo, int | float))
 static_assert(is_assignable_to(Foo, int | float | None))
@@ -326,9 +326,9 @@ Bar(3.14)
 Bar(42)
 Bar("goodbye")  # error: [invalid-argument-type]
 
-reveal_type(Bar(1 + 2j).__class__)  # revealed: type[int | float | complex]
-reveal_type(Bar(3.14).__class__)  # revealed: type[int | float | complex]
-reveal_type(Bar(42).__class__)  # revealed: type[int | float | complex]
+reveal_type(Bar(1 + 2j).__class__)  # revealed: type[complex]
+reveal_type(Bar(3.14).__class__)  # revealed: type[complex]
+reveal_type(Bar(42).__class__)  # revealed: type[complex]
 static_assert(is_assignable_to(Bar, complex))
 static_assert(is_assignable_to(Bar, int | float | complex))
 static_assert(is_assignable_to(Bar, int | float | complex | None))
@@ -340,8 +340,8 @@ static_assert(is_assignable_to(Bar, Bar | None))
 
 ```py
 FooFoo = NewType("FooFoo", Foo)
-reveal_type(FooFoo(Foo(3.14)).__class__)  # revealed: type[int | float]
-reveal_type(FooFoo(Foo(42)).__class__)  # revealed: type[int | float]
+reveal_type(FooFoo(Foo(3.14)).__class__)  # revealed: type[float]
+reveal_type(FooFoo(Foo(42)).__class__)  # revealed: type[float]
 static_assert(is_assignable_to(FooFoo, float))
 static_assert(is_assignable_to(FooFoo, Foo))
 static_assert(is_assignable_to(FooFoo, int | float))
@@ -384,12 +384,12 @@ explicit `Union` on the left side:
 ```py
 reveal_type(Foo(3.14) < Foo(42))  # revealed: bool
 reveal_type(Foo(3.14) == Foo(42))  # revealed: bool
-reveal_type(Foo(3.14) + Foo(42))  # revealed: int | float
-reveal_type(Foo(3.14) / Foo(42))  # revealed: int | float
+reveal_type(Foo(3.14) + Foo(42))  # revealed: float
+reveal_type(Foo(3.14) / Foo(42))  # revealed: float
 reveal_type(FooFoo(Foo(3.14)) < FooFoo(Foo(42)))  # revealed: bool
 reveal_type(FooFoo(Foo(3.14)) == FooFoo(Foo(42)))  # revealed: bool
-reveal_type(FooFoo(Foo(3.14)) + FooFoo(Foo(42)))  # revealed: int | float
-reveal_type(FooFoo(Foo(3.14)) / FooFoo(Foo(42)))  # revealed: int | float
+reveal_type(FooFoo(Foo(3.14)) + FooFoo(Foo(42)))  # revealed: float
+reveal_type(FooFoo(Foo(3.14)) / FooFoo(Foo(42)))  # revealed: float
 ```
 
 But again as above, we can't _always_ lower `Foo` to `int | float`, because there are also binary
@@ -442,16 +442,16 @@ reveal_type(unknown * MyFloat(1.0))  # revealed: Unknown
 Unary operations take a different codepath and need their own test cases:
 
 ```py
-reveal_type(-Foo(3.14))  # revealed: int | float
-reveal_type(+Foo(3.14))  # revealed: int | float
+reveal_type(-Foo(3.14))  # revealed: float
+reveal_type(+Foo(3.14))  # revealed: float
 ~Foo(3.14)  # error: [unsupported-operator]
 reveal_type(not Foo(3.14))  # revealed: bool
-reveal_type(-Bar(1 + 2j))  # revealed: int | float | complex
-reveal_type(+Bar(1 + 2j))  # revealed: int | float | complex
+reveal_type(-Bar(1 + 2j))  # revealed: complex
+reveal_type(+Bar(1 + 2j))  # revealed: complex
 ~Bar(1 + 2j)  # error: [unsupported-operator]
 reveal_type(not Bar(1 + 2j))  # revealed: bool
-reveal_type(-FooFoo(Foo(3.14)))  # revealed: int | float
-reveal_type(+FooFoo(Foo(3.14)))  # revealed: int | float
+reveal_type(-FooFoo(Foo(3.14)))  # revealed: float
+reveal_type(+FooFoo(Foo(3.14)))  # revealed: float
 ~FooFoo(Foo(3.14))  # error: [unsupported-operator]
 reveal_type(not FooFoo(Foo(3.14)))  # revealed: bool
 
@@ -476,13 +476,13 @@ union:
 
 ```py
 def _(x: Foo | float, y: Bar | complex):
-    reveal_type(-x)  # revealed: int | float
-    reveal_type(+x)  # revealed: int | float
+    reveal_type(-x)  # revealed: float
+    reveal_type(+x)  # revealed: float
     ~x  # error: [unsupported-operator]
     reveal_type(not x)  # revealed: bool
 
-    reveal_type(-y)  # revealed: int | float | complex
-    reveal_type(+y)  # revealed: int | float | complex
+    reveal_type(-y)  # revealed: complex
+    reveal_type(+y)  # revealed: complex
     ~y  # error: [unsupported-operator]
     reveal_type(not y)  # revealed: bool
 ```

--- a/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
@@ -9,7 +9,7 @@ reveal_type(x)  # revealed: Literal[2]
 
 x = 1.0
 x /= 2
-reveal_type(x)  # revealed: int | float
+reveal_type(x)  # revealed: float
 
 x = (1, 2)
 x += (3, 4)
@@ -140,7 +140,7 @@ def _(flag1: bool, flag2: bool):
         f = 42.0
     f += 12
 
-    reveal_type(f)  # revealed: int | str | float
+    reveal_type(f)  # revealed: float | str
 ```
 
 ## Target union
@@ -184,7 +184,7 @@ def f(flag: bool, flag2: bool):
         f = Bar()
     f += 12
 
-    reveal_type(f)  # revealed: int | str | float
+    reveal_type(f)  # revealed: float | str
 ```
 
 ## Implicit dunder calls on class objects

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -4021,8 +4021,8 @@ reveal_type(C.a_int)  # revealed: int
 reveal_type(C.a_str)  # revealed: str
 reveal_type(C.a_bytes)  # revealed: bytes
 reveal_type(C.a_bool)  # revealed: bool
-reveal_type(C.a_float)  # revealed: int | float
-reveal_type(C.a_complex)  # revealed: int | float | complex
+reveal_type(C.a_float)  # revealed: float
+reveal_type(C.a_complex)  # revealed: complex
 reveal_type(C.a_tuple)  # revealed: tuple[int]
 reveal_type(C.a_range)  # revealed: range
 # TODO: revealed: slice[Any, Literal[1], Any]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -174,7 +174,7 @@ takes_float_sequence([1])
 
 mutable_floats = [1.0]
 mutable_floats.append(1)
-reveal_type(mutable_floats)  # revealed: list[int | float]
+reveal_type(mutable_floats)  # revealed: list[float]
 ```
 
 ### Exact complex types in covariant contexts
@@ -1906,7 +1906,7 @@ def overloaded_call(data: object, dtype: object) -> object:
 
 def _(dtype: FloatDtype):
     x = overloaded_call([1.0], dtype)
-    reveal_type(x)  # revealed: int | float
+    reveal_type(x)  # revealed: float
 ```
 
 ```py
@@ -2278,7 +2278,7 @@ def _() -> int:
 ```py
 x7 = []
 x7[:] = [1, "2", 3.0]
-reveal_type(x7)  # revealed: list[int | str | float]
+reveal_type(x7)  # revealed: list[float | str]
 ```
 
 ```py
@@ -2415,7 +2415,7 @@ x23 = [None, None, None]
 x23[0] = 1
 x23[1] = "2"
 x23[2] = 3.0
-reveal_type(x23)  # revealed: list[int | str | float | None]
+reveal_type(x23)  # revealed: list[float | str | None]
 ```
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/binary/booleans.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/booleans.md
@@ -35,8 +35,8 @@ reveal_type(b**a)  # revealed: Literal[0]
 reveal_type(b**b)  # revealed: Literal[1]
 
 # Division
-reveal_type(a / a)  # revealed: float
-reveal_type(b / a)  # revealed: float
+reveal_type(a / a)  # revealed: float*
+reveal_type(b / a)  # revealed: float*
 b / b  # error: [division-by-zero] "Cannot divide object of type `Literal[False]` by zero"
 a / b  # error: [division-by-zero] "Cannot divide object of type `Literal[True]` by zero"
 
@@ -89,7 +89,7 @@ def _(a: bool):
         reveal_type(x - a)  # revealed: int
         reveal_type(x * a)  # revealed: int
         reveal_type(x // a)  # revealed: int
-        reveal_type(x / a)  # revealed: int | float
+        reveal_type(x / a)  # revealed: float
         reveal_type(x % a)  # revealed: int
 
     def rhs_is_int(x: int):
@@ -97,7 +97,7 @@ def _(a: bool):
         reveal_type(a - x)  # revealed: int
         reveal_type(a * x)  # revealed: int
         reveal_type(a // x)  # revealed: int
-        reveal_type(a / x)  # revealed: int | float
+        reveal_type(a / x)  # revealed: float
         reveal_type(a % x)  # revealed: int
 
     def lhs_is_bool(x: bool):
@@ -105,7 +105,7 @@ def _(a: bool):
         reveal_type(x - a)  # revealed: int
         reveal_type(x * a)  # revealed: int
         reveal_type(x // a)  # revealed: int
-        reveal_type(x / a)  # revealed: int | float
+        reveal_type(x / a)  # revealed: float
         reveal_type(x % a)  # revealed: int
 
     def rhs_is_bool(x: bool):
@@ -113,7 +113,7 @@ def _(a: bool):
         reveal_type(a - x)  # revealed: int
         reveal_type(a * x)  # revealed: int
         reveal_type(a // x)  # revealed: int
-        reveal_type(a / x)  # revealed: int | float
+        reveal_type(a / x)  # revealed: float
         reveal_type(a % x)  # revealed: int
 
     def both_are_bool(x: bool, y: bool):
@@ -121,7 +121,7 @@ def _(a: bool):
         reveal_type(x - y)  # revealed: int
         reveal_type(x * y)  # revealed: int
         reveal_type(x // y)  # revealed: int
-        reveal_type(x / y)  # revealed: int | float
+        reveal_type(x / y)  # revealed: float
         reveal_type(x % y)  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/instances.md
@@ -405,17 +405,17 @@ dunder methods. Perhaps we could have a special-case on the special-case, to exc
 return annotations from the widening, and preserve a bit more precision here?
 
 ```py
-reveal_type(3j + 3.14)  # revealed: int | float | complex
-reveal_type(4.2 + 42)  # revealed: int | float
-reveal_type(3j + 3)  # revealed: int | float | complex
-reveal_type(3.14 + 3j)  # revealed: int | float | complex
-reveal_type(42 + 4.2)  # revealed: int | float
-reveal_type(3 + 3j)  # revealed: int | float | complex
+reveal_type(3j + 3.14)  # revealed: complex
+reveal_type(4.2 + 42)  # revealed: float
+reveal_type(3j + 3)  # revealed: complex
+reveal_type(3.14 + 3j)  # revealed: complex
+reveal_type(42 + 4.2)  # revealed: float
+reveal_type(3 + 3j)  # revealed: complex
 
 def _(x: bool, y: int):
     reveal_type(x + y)  # revealed: int
-    reveal_type(4.2 + x)  # revealed: int | float
-    reveal_type(y + 4.12)  # revealed: int | float
+    reveal_type(4.2 + x)  # revealed: float
+    reveal_type(y + 4.12)  # revealed: float
 ```
 
 ## With literal types

--- a/crates/ty_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/integers.md
@@ -7,7 +7,7 @@ reveal_type(2 + 1)  # revealed: Literal[3]
 reveal_type(3 - 4)  # revealed: Literal[-1]
 reveal_type(3 * -1)  # revealed: Literal[-3]
 reveal_type(-3 // 3)  # revealed: Literal[-1]
-reveal_type(-3 / 3)  # revealed: float
+reveal_type(-3 / 3)  # revealed: float*
 reveal_type(5 % 3)  # revealed: Literal[2]
 reveal_type(3 | 4)  # revealed: Literal[7]
 reveal_type(5 & 6)  # revealed: Literal[4]
@@ -21,7 +21,7 @@ def lhs(x: int):
     reveal_type(x - 4)  # revealed: int
     reveal_type(x * -1)  # revealed: int
     reveal_type(x // 3)  # revealed: int
-    reveal_type(x / 3)  # revealed: int | float
+    reveal_type(x / 3)  # revealed: float
     reveal_type(x % 3)  # revealed: int
 
 def rhs(x: int):
@@ -29,7 +29,7 @@ def rhs(x: int):
     reveal_type(3 - x)  # revealed: int
     reveal_type(3 * x)  # revealed: int
     reveal_type(-3 // x)  # revealed: int
-    reveal_type(-3 / x)  # revealed: int | float
+    reveal_type(-3 / x)  # revealed: float
     reveal_type(5 % x)  # revealed: int
 
 def both(x: int):
@@ -37,7 +37,7 @@ def both(x: int):
     reveal_type(x - x)  # revealed: int
     reveal_type(x * x)  # revealed: int
     reveal_type(x // x)  # revealed: int
-    reveal_type(x / x)  # revealed: int | float
+    reveal_type(x / x)  # revealed: float
     reveal_type(x % x)  # revealed: int
 
 # Edge case: the runtime value is 9223372036854775808,
@@ -70,8 +70,8 @@ reveal_type(1**0)  # revealed: Literal[1]
 reveal_type(0**1)  # revealed: Literal[0]
 reveal_type(0**0)  # revealed: Literal[1]
 reveal_type((-1) ** 2)  # revealed: Literal[1]
-reveal_type(2 ** (-1))  # revealed: float
-reveal_type((-1) ** (-1))  # revealed: float
+reveal_type(2 ** (-1))  # revealed: float*
+reveal_type((-1) ** (-1))  # revealed: float*
 ```
 
 ## Division and Modulus
@@ -117,7 +117,7 @@ subclass; we only emit the error if the LHS type is exactly `int` or `float`, no
 
 ```py
 a = 1 / 0  # error: "Cannot divide object of type `Literal[1]` by zero"
-reveal_type(a)  # revealed: float
+reveal_type(a)  # revealed: float*
 
 b = 2 // 0  # error: "Cannot floor divide object of type `Literal[2]` by zero"
 reveal_type(b)  # revealed: int
@@ -126,22 +126,22 @@ c = 3 % 0  # error: "Cannot reduce object of type `Literal[3]` modulo zero"
 reveal_type(c)  # revealed: int
 
 # error: "Cannot divide object of type `int` by zero"
-reveal_type(int() / 0)  # revealed: int | float
+reveal_type(int() / 0)  # revealed: float
 
 # error: "Cannot divide object of type `Literal[1]` by zero"
-reveal_type(1 / False)  # revealed: float
+reveal_type(1 / False)  # revealed: float*
 # error: [division-by-zero] "Cannot divide object of type `Literal[True]` by zero"
 True / False
 # error: [division-by-zero] "Cannot divide object of type `Literal[True]` by zero"
 bool(1) / False
 
-# error: "Cannot divide object of type `float` by zero"
-reveal_type(1.0 / 0)  # revealed: int | float
+# error: "Cannot divide object of type `float*` by zero"
+reveal_type(1.0 / 0)  # revealed: float
 
 class MyInt(int): ...
 
 # No error for a subclass of int
-reveal_type(MyInt(3) / 0)  # revealed: int | float
+reveal_type(MyInt(3) / 0)  # revealed: float
 ```
 
 ## Bit-shifting

--- a/crates/ty_python_semantic/resources/mdtest/binary/unions.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/unions.md
@@ -42,12 +42,12 @@ here:
 
 ```py
 def f4(x: float, y: float):
-    reveal_type(x + y)  # revealed: int | float
-    reveal_type(x - y)  # revealed: int | float
-    reveal_type(x * y)  # revealed: int | float
-    reveal_type(x / y)  # revealed: int | float
-    reveal_type(x // y)  # revealed: int | float
-    reveal_type(x % y)  # revealed: int | float
+    reveal_type(x + y)  # revealed: float
+    reveal_type(x - y)  # revealed: float
+    reveal_type(x * y)  # revealed: float
+    reveal_type(x / y)  # revealed: float
+    reveal_type(x // y)  # revealed: float
+    reveal_type(x % y)  # revealed: float
 ```
 
 If any of the union elements leads to a division by zero, we will report an error:

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1023,7 +1023,7 @@ def _(args: tuple[str, str]) -> None:
 
 # But, with a fixed-length tuple that is too long, we get the expected error.
 def _(args: tuple[str, str, str]) -> None:
-    # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int | float`, found `str`"
+    # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `float`, found `str`"
     # error: [parameter-already-assigned] "Multiple values provided for parameter `c` of function `f`"
     f(*args, c=1.0)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -57,7 +57,7 @@ def f(a: int, b: str, c: float) -> bool:
     return True
 
 p = partial(f, 1, c=3.14)
-reveal_type(p)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+reveal_type(p)  # revealed: partial[(b: str, *, c: float = ...) -> bool]
 ```
 
 ### All args bound
@@ -703,7 +703,7 @@ def f(a: int, b: str, c: float) -> bool:
 
 args: tuple[int, str] = (1, "hello")
 p = partial(f, *args)
-reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
+reveal_type(p)  # revealed: partial[(c: float) -> bool]
 ```
 
 ### Mixed positional and starred args
@@ -716,7 +716,7 @@ def f(a: int, b: str, c: float) -> bool:
 
 args: tuple[str] = ("hello",)
 p = partial(f, 1, *args)
-reveal_type(p)  # revealed: partial[(c: int | float) -> bool]
+reveal_type(p)  # revealed: partial[(c: float) -> bool]
 ```
 
 ### Fallback for starred args with variable-length tuple
@@ -922,10 +922,10 @@ def f(a: int, b: str, c: float) -> bool:
     return True
 
 p1 = partial(f, 1)
-reveal_type(p1)  # revealed: partial[(b: str, c: int | float) -> bool]
+reveal_type(p1)  # revealed: partial[(b: str, c: float) -> bool]
 
 p2 = partial(p1, "hello")
-reveal_type(p2)  # revealed: partial[(c: int | float) -> bool]
+reveal_type(p2)  # revealed: partial[(c: float) -> bool]
 ```
 
 ## Constructors and advanced signatures
@@ -1192,7 +1192,7 @@ def f(a: int, b: str = "default", c: float = 0.0) -> bool:
     return True
 
 p = partial(f, 1, "hello")
-reveal_type(p)  # revealed: partial[(c: int | float = ...) -> bool]
+reveal_type(p)  # revealed: partial[(c: float = ...) -> bool]
 ```
 
 ### Multiple keyword bindings
@@ -1204,7 +1204,7 @@ def f(a: int, b: str, c: float, d: bool) -> int:
     return 0
 
 p = partial(f, b="hello", d=True)
-reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float, d: bool = True) -> int]
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: float, d: bool = True) -> int]
 ```
 
 ### Mixed positional-only, regular, and keyword-only
@@ -1217,15 +1217,15 @@ def f(a: int, /, b: str, *, c: float) -> bool:
 
 # Bind the positional-only param
 p1 = partial(f, 1)
-reveal_type(p1)  # revealed: partial[(b: str, *, c: int | float) -> bool]
+reveal_type(p1)  # revealed: partial[(b: str, *, c: float) -> bool]
 
 # Bind a keyword-only param by keyword
 p2 = partial(f, c=3.14)
-reveal_type(p2)  # revealed: partial[(a: int, /, b: str, *, c: int | float = ...) -> bool]
+reveal_type(p2)  # revealed: partial[(a: int, /, b: str, *, c: float = ...) -> bool]
 
 # Bind both positional-only and keyword-only
 p3 = partial(f, 1, c=3.14)
-reveal_type(p3)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+reveal_type(p3)  # revealed: partial[(b: str, *, c: float = ...) -> bool]
 ```
 
 ### Starred args combined with keyword args
@@ -1238,7 +1238,7 @@ def f(a: int, b: str, c: float) -> bool:
 
 args: tuple[int] = (1,)
 p = partial(f, *args, c=3.14)
-reveal_type(p)  # revealed: partial[(b: str, *, c: int | float = ...) -> bool]
+reveal_type(p)  # revealed: partial[(b: str, *, c: float = ...) -> bool]
 ```
 
 ### Starred args with empty tuple
@@ -1331,7 +1331,7 @@ def f(a: int, b: str, c: float) -> bool:
     return True
 
 p = partial(f, b="hello")
-reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float) -> bool]
+reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: float) -> bool]
 
 # Override b at call time
 reveal_type(p(1, b="world", c=3.14))  # revealed: bool

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -174,8 +174,8 @@ class IntDiag(DeferredDiagBase[int]): ...
 class StrDiag(DeferredDiagBase[str]): ...
 
 def _(factory: type[IntDiag] | type[StrDiag]):
-    # error: [invalid-argument-type] "Argument to `DeferredDiagBase.__init__` is incorrect: Expected `int`, found `float`"
-    # error: [invalid-argument-type] "Argument to `DeferredDiagBase.__init__` is incorrect: Expected `str`, found `float`"
+    # error: [invalid-argument-type] "Argument to `DeferredDiagBase.__init__` is incorrect: Expected `int`, found `float*`"
+    # error: [invalid-argument-type] "Argument to `DeferredDiagBase.__init__` is incorrect: Expected `str`, found `float*`"
     factory(1.2)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
@@ -329,13 +329,13 @@ reveal_type(1 >= 1.0)  # revealed: bool
 reveal_type(1 == 2j)  # revealed: bool
 reveal_type(1 != 2j)  # revealed: bool
 
-# error: [unsupported-operator] "Operator `<` is not supported between objects of type `Literal[1]` and `complex`"
+# error: [unsupported-operator] "Operator `<` is not supported between objects of type `Literal[1]` and `complex*`"
 reveal_type(1 < 2j)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `<=` is not supported between objects of type `Literal[1]` and `complex`"
+# error: [unsupported-operator] "Operator `<=` is not supported between objects of type `Literal[1]` and `complex*`"
 reveal_type(1 <= 2j)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `>` is not supported between objects of type `Literal[1]` and `complex`"
+# error: [unsupported-operator] "Operator `>` is not supported between objects of type `Literal[1]` and `complex*`"
 reveal_type(1 > 2j)  # revealed: Unknown
-# error: [unsupported-operator] "Operator `>=` is not supported between objects of type `Literal[1]` and `complex`"
+# error: [unsupported-operator] "Operator `>=` is not supported between objects of type `Literal[1]` and `complex*`"
 reveal_type(1 >= 2j)  # revealed: Unknown
 
 def f(x: bool, y: int):

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -164,7 +164,7 @@ JSONPrimitive = Union[str, int, float, bool, None]
 JSONValue = TypeAliasType("JSONValue", 'Union[JSONPrimitive, Sequence["JSONValue"], Mapping[str, "JSONValue"]]')
 
 def _(x: JSONValue):
-    reveal_type(x)  # revealed: Sequence[JSONValue] | int | float | None | Mapping[str, JSONValue]
+    reveal_type(x)  # revealed: Sequence[JSONValue] | float | None | Mapping[str, JSONValue]
 ```
 
 ## Self-referential legacy type variables

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -2072,7 +2072,7 @@ WithClassConverter("1", "2.5")
 
 with_class_converter = WithClassConverter("1", "2.5")
 reveal_type(with_class_converter.a)  # revealed: PermissiveNumber
-reveal_type(with_class_converter.b)  # revealed: int | float
+reveal_type(with_class_converter.b)  # revealed: float
 
 with_class_converter.a = "2"
 with_class_converter.a = 1.5  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -771,7 +771,7 @@ class Derived(Base):
 
     @other.setter
     def other(self, v: float) -> None:
-        reveal_type(self.value)  # revealed: int | float
+        reveal_type(self.value)  # revealed: float
         self.value = v
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_argument_type.md
@@ -580,8 +580,8 @@ error[invalid-argument-type]: Argument to function `f` is incorrect
  --> src/mdtest_snippet.py:8:7
   |
 8 |     f(x)  # snapshot: invalid-argument-type
-  |       ^ Expected `Number`, found `int | float`
-info: element `int` of union `int | float` is not assignable to `Number`
+  |       ^ Expected `Number`, found `float`
+info: element `int` of union `int | float*` is not assignable to `Number`
 info: Function defined here
  --> src/mdtest_snippet.py:3:5
   |

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -2992,8 +2992,8 @@ reveal_type(StringyNames.A.value)  # revealed: Literal["1"]
 reveal_type(StringyNames.B.value)  # revealed: Literal["2"]
 reveal_type(BytesyNames.A.value)  # revealed: bytes
 reveal_type(BytesyNames.B.value)  # revealed: bytes
-reveal_type(FloatyNames.A.value)  # revealed: float
-reveal_type(FloatyNames.B.value)  # revealed: float
+reveal_type(FloatyNames.A.value)  # revealed: float*
+reveal_type(FloatyNames.B.value)  # revealed: float*
 
 # revealed: tuple[Literal["A"], Literal["B"]]
 reveal_type(enum_members(StringyNames))

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -876,7 +876,7 @@ def test_seq(x: Sequence[T]) -> Sequence[T]:
     return x
 
 def func8(t1: tuple[complex, list[int]], t2: tuple[int, *tuple[str, ...]], t3: tuple[()]):
-    reveal_type(test_seq(t1))  # revealed: Sequence[int | float | complex | list[int]]
+    reveal_type(test_seq(t1))  # revealed: Sequence[complex | list[int]]
     reveal_type(test_seq(t2))  # revealed: Sequence[int | str]
     reveal_type(test_seq(t3))  # revealed: Sequence[Never]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -58,7 +58,7 @@ def f(x: T) -> T:
     return x
 
 reveal_type(f(1))  # revealed: Literal[1]
-reveal_type(f(1.0))  # revealed: float
+reveal_type(f(1.0))  # revealed: float*
 reveal_type(f(True))  # revealed: Literal[True]
 reveal_type(f("string"))  # revealed: Literal["string"]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -442,7 +442,7 @@ T3 = TypeVar("T3", bound=str)
 # and the upper bound of `T` (`int`) is assignable to `int | float`
 S = TypeVar("S", default=T1, bound=float)
 
-# error: [invalid-type-variable-default] "Default `T3` of TypeVar `U` is not assignable to upper bound `int | float` of `U` because its upper bound `str` is not assignable to `int | float`"
+# error: [invalid-type-variable-default] "Default `T3` of TypeVar `U` is not assignable to upper bound `float` of `U` because its upper bound `str` is not assignable to `float`"
 U = TypeVar("U", default=T3, bound=float)
 ```
 
@@ -576,7 +576,7 @@ T = TypeVar("T", int, bool)
 reveal_type(T.__constraints__)  # revealed: tuple[int, bool]
 
 S = TypeVar("S", float, str)
-reveal_type(S.__constraints__)  # revealed: tuple[int | float, str]
+reveal_type(S.__constraints__)  # revealed: tuple[float, str]
 ```
 
 ### Cannot have only one constraint

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -590,7 +590,7 @@ def test_seq[T](x: Sequence[T]) -> Sequence[T]:
     return x
 
 def func8(t1: tuple[complex, list[int]], t2: tuple[int, *tuple[str, ...]], t3: tuple[()]):
-    reveal_type(test_seq(t1))  # revealed: Sequence[int | float | complex | list[int]]
+    reveal_type(test_seq(t1))  # revealed: Sequence[complex | list[int]]
     reveal_type(test_seq(t2))  # revealed: Sequence[int | str]
     reveal_type(test_seq(t3))  # revealed: Sequence[Never]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -450,7 +450,7 @@ def my_handler(env: str, x: int, y: float) -> bool:
     return True
 
 m = Middleware(my_handler)
-reveal_type(m)  # revealed: Middleware[(x: int, y: int | float), bool]
+reveal_type(m)  # revealed: Middleware[(x: int, y: float), bool]
 ```
 
 ### Specializing `ParamSpec` with `Concatenate`

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -77,7 +77,7 @@ def f[T](x: T) -> T:
     return x
 
 reveal_type(f(1))  # revealed: Literal[1]
-reveal_type(f(1.0))  # revealed: float
+reveal_type(f(1.0))  # revealed: float*
 reveal_type(f(True))  # revealed: Literal[True]
 reveal_type(f("string"))  # revealed: Literal["string"]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1457,7 +1457,7 @@ reveal_type(identity(1))  # revealed: Literal[1]
 reveal_type(identity("hello"))  # revealed: Literal["hello"]
 
 reveal_type(pair(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
-reveal_type(pair("x", 2.5))  # revealed: tuple[Literal["x"], float]
+reveal_type(pair("x", 2.5))  # revealed: tuple[Literal["x"], float*]
 ```
 
 ### Chained decorators with generic functions

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -124,7 +124,7 @@ When the default is a TypeVar, its upper bound must be assignable to the outer T
 def f[T1: int, S: float = T1](): ...
 
 # `T3` has bound `str`, which is not assignable to `int | float`
-# error: [invalid-type-variable-default] "Default `T3` of TypeVar `U` is not assignable to upper bound `int | float` of `U` because its upper bound `str` is not assignable to `int | float`"
+# error: [invalid-type-variable-default] "Default `T3` of TypeVar `U` is not assignable to upper bound `float` of `U` because its upper bound `str` is not assignable to `float`"
 def g[T3: str, U: float = T3](): ...
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/import/stub_packages.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/stub_packages.md
@@ -126,7 +126,7 @@ from shapes.polygons.hexagon import Hexagon
 from shapes.polygons.pentagon import Pentagon
 
 reveal_type(Pentagon().sides)  # revealed: int
-reveal_type(Hexagon().area)  # revealed: int | float
+reveal_type(Hexagon().area)  # revealed: float
 ```
 
 ## Manual overrides from extra paths
@@ -606,7 +606,7 @@ from shapes.polygons.pentagon import Pentagon
 from shapes.polygons.hexagon import Hexagon
 
 reveal_type(Pentagon().sides)  # revealed: int
-reveal_type(Hexagon().area)  # revealed: int | float
+reveal_type(Hexagon().area)  # revealed: float
 ```
 
 ## Stub package using `__init__.py` over `.pyi`
@@ -644,7 +644,7 @@ class Hexagon: ...
 from shapes import Hexagon, Pentagon
 
 reveal_type(Pentagon().sides)  # revealed: int
-reveal_type(Hexagon().area)  # revealed: int | float
+reveal_type(Hexagon().area)  # revealed: float
 ```
 
 ## Relative import in stub package

--- a/crates/ty_python_semantic/resources/mdtest/libraries/numpy.md
+++ b/crates/ty_python_semantic/resources/mdtest/libraries/numpy.md
@@ -71,5 +71,5 @@ _ScalarT = TypeVar("_ScalarT", bound=np.generic)
 def from_dtype_like(value: np._DTypeLike[_ScalarT]) -> np.dtype[_ScalarT]:
     raise NotImplementedError
 
-reveal_type(from_dtype_like(np.bool))  # revealed: dtype[bool[bool]]
+reveal_type(from_dtype_like(np.bool))  # revealed: dtype[mini_numpy.bool[builtins.bool]]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -240,7 +240,7 @@ def _(x: dict[str, dict[str, float | str]]):
     # A rejected dictionary assignment does not establish known key types.
     # error: [invalid-assignment]
     x["kwargs"] = {"nested": {"a": 1}}
-    reveal_type(x["kwargs"]["nested"])  # revealed: int | float | str
+    reveal_type(x["kwargs"]["nested"])  # revealed: float | str
     # error: [invalid-argument-type]
     f1(**x["kwargs"])
 
@@ -251,13 +251,13 @@ def _(x: dict[str, dict[str, float | str]]):
     # A rejected replacement also invalidates a prior known-key type.
     # error: [invalid-assignment]
     x["kwargs"] = {"nested": {"a": 1}}
-    reveal_type(x["kwargs"]["nested"])  # revealed: int | float | str
+    reveal_type(x["kwargs"]["nested"])  # revealed: float | str
 
 def accepts_value(**kwargs: object): ...
 def _(x: dict[str, dict[str, float | str]]):
     # error: [invalid-assignment]
     x = {"kwargs": {"nested": {"a": object()}}}
-    reveal_type(x["kwargs"]["nested"])  # revealed: int | float | str
+    reveal_type(x["kwargs"]["nested"])  # revealed: float | str
     # error: [invalid-argument-type]
     accepts_value(**x["kwargs"]["nested"])
 

--- a/crates/ty_python_semantic/resources/mdtest/literal/complex.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/complex.md
@@ -3,5 +3,5 @@
 ## Complex numbers
 
 ```py
-reveal_type(2j)  # revealed: complex
+reveal_type(2j)  # revealed: complex*
 ```

--- a/crates/ty_python_semantic/resources/mdtest/literal/float.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/float.md
@@ -3,5 +3,5 @@
 ## Basic
 
 ```py
-reveal_type(1.0)  # revealed: float
+reveal_type(1.0)  # revealed: float*
 ```

--- a/crates/ty_python_semantic/resources/mdtest/literal/integer.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/integer.md
@@ -46,11 +46,11 @@ reveal_type(z)  # revealed: Literal[987]
 ## Floats
 
 ```py
-reveal_type(1.0)  # revealed: float
+reveal_type(1.0)  # revealed: float*
 ```
 
 ## Complex
 
 ```py
-reveal_type(2j)  # revealed: complex
+reveal_type(2j)  # revealed: complex*
 ```

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -211,7 +211,7 @@ class Point(NamedTuple("Point", [("x", int), ("y", int)])):
 p = Point(3, 4)
 reveal_type(p.x)  # revealed: int
 reveal_type(p.y)  # revealed: int
-reveal_type(p.magnitude())  # revealed: int | float
+reveal_type(p.magnitude())  # revealed: float
 ```
 
 String annotations in dangling calls work correctly for forward references to classes defined in the
@@ -1197,11 +1197,11 @@ class Property[T](NamedTuple):
     name: str
     value: T
 
-reveal_type(Property("height", 3.4))  # revealed: Property[float]
+reveal_type(Property("height", 3.4))  # revealed: Property[float*]
 reveal_type(Property.value)  # revealed: property
 reveal_type(Property.value.fget)  # revealed: (self, /) -> Unknown
 reveal_type(Property[str].value.fget)  # revealed: (self, /) -> str
-reveal_type(Property("height", 3.4).value)  # revealed: float
+reveal_type(Property("height", 3.4).value)  # revealed: float*
 
 T = TypeVar("T")
 
@@ -1213,7 +1213,7 @@ reveal_type(LegacyProperty("height", 42))  # revealed: LegacyProperty[int]
 reveal_type(LegacyProperty.value)  # revealed: property
 reveal_type(LegacyProperty.value.fget)  # revealed: (self, /) -> Unknown
 reveal_type(LegacyProperty[str].value.fget)  # revealed: (self, /) -> str
-reveal_type(LegacyProperty("height", 3.4).value)  # revealed: int | float
+reveal_type(LegacyProperty("height", 3.4).value)  # revealed: float
 ```
 
 ### Functional syntax with generics
@@ -2030,5 +2030,5 @@ class GenericChild(GenericBase[T]):
         reveal_type(instance)  # revealed: Self@__new__
         return instance
 
-reveal_type(GenericChild(x=3.14))  # revealed: GenericChild[int | float]
+reveal_type(GenericChild(x=3.14))  # revealed: GenericChild[float]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -3079,17 +3079,17 @@ class C:
 def _(x: Literal["foo", "bar", 42, b"foo"] | bool | complex):
     match x:
         case "foo":
-            reveal_type(x)  # revealed: Literal["foo"] | float | complex
+            reveal_type(x)  # revealed: Literal["foo"] | float* | complex*
         case 42:
-            reveal_type(x)  # revealed: Literal[42] | float | complex
+            reveal_type(x)  # revealed: Literal[42] | float* | complex*
         case 6.0:
-            reveal_type(x)  # revealed: Literal["bar", b"foo"] | (int & ~Literal[42]) | float | complex
+            reveal_type(x)  # revealed: Literal["bar", b"foo"] | (int & ~Literal[42]) | float* | complex*
         case 1j:
-            reveal_type(x)  # revealed: Literal["bar", b"foo"] | (int & ~Literal[42]) | float | complex
+            reveal_type(x)  # revealed: Literal["bar", b"foo"] | (int & ~Literal[42]) | float* | complex*
         case b"foo":
-            reveal_type(x)  # revealed: Literal[b"foo"] | float | complex
+            reveal_type(x)  # revealed: Literal[b"foo"] | float* | complex*
         case _:
-            reveal_type(x)  # revealed: Literal["bar"] | (int & ~Literal[42]) | float | complex
+            reveal_type(x)  # revealed: Literal["bar"] | (int & ~Literal[42]) | float* | complex*
 ```
 
 The same limitation applies inside a sequence. Matching a literal proves only that the element

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -141,7 +141,7 @@ def bar(world: str, *args, **kwargs) -> float:
 x = foo if flag() else bar
 
 if x:
-    reveal_type(x)  # revealed: (def foo(hello: int) -> bytes) | (def bar(world: str, *args, **kwargs) -> int | float)
+    reveal_type(x)  # revealed: (def foo(hello: int) -> bytes) | (def bar(world: str, *args, **kwargs) -> float)
 else:
     reveal_type(x)  # revealed: Never
 ```
@@ -589,7 +589,7 @@ def f(floaty: FloatNewType, complexy: ComplexNewType):
 
     if complexy:
         reveal_type(complexy)  # revealed: ComplexNewType & ~AlwaysFalsy
-        reveal_type(complexy.real)  # revealed: int | float
+        reveal_type(complexy.real)  # revealed: float
         expects_complex(complexy)  # fine
         expects_float(complexy)  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -248,7 +248,7 @@ def _(a: object, flag: bool) -> TypeGuard[str]:
 # error: [invalid-return-type] "Function can implicitly return `None`, which is not assignable to return type `TypeIs[str]`"
 def f(a: object, flag: bool) -> TypeIs[str]:
     if flag:
-        # error: [invalid-return-type] "Return type does not match returned value: expected `TypeIs[str]`, found `float`"
+        # error: [invalid-return-type] "Return type does not match returned value: expected `TypeIs[str]`, found `float*`"
         return 1.2
 
 def g(a: Literal["foo", "bar"]) -> TypeIs[Literal["foo"]]:

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -55,12 +55,12 @@ reveal_type(x4)  # revealed: Literal[MyEnum.A]
 reveal_type(promote(x4))  # revealed: list[MyEnum]
 
 x5 = 3.14
-reveal_type(x5)  # revealed: float
-reveal_type(promote(x5))  # revealed: list[int | float]
+reveal_type(x5)  # revealed: float*
+reveal_type(promote(x5))  # revealed: list[float]
 
 x6 = 3.14j
-reveal_type(x6)  # revealed: complex
-reveal_type(promote(x6))  # revealed: list[int | float | complex]
+reveal_type(x6)  # revealed: complex*
+reveal_type(promote(x6))  # revealed: list[complex]
 
 def _(source: Literal["foo", "bar"]):
     x7 = f"hello"

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2434,7 +2434,7 @@ class ReadClass(Protocol[JustT_co]):
     def __class__(self, /) -> type[JustT_co]: ...
 
 def takes_read_class(value: ReadClass[float]) -> None:
-    reveal_type(value)  # revealed: ReadClass[int | float]
+    reveal_type(value)  # revealed: ReadClass[float]
 
 takes_read_class(1)
 takes_read_class(1.0)
@@ -2446,7 +2446,7 @@ class WritableValue(Protocol[JustT]):
     def value(self, value: type[JustT], /) -> None: ...
 
 def takes_writable_value(value: WritableValue[float]) -> None:
-    reveal_type(value)  # revealed: WritableValue[int | float]
+    reveal_type(value)  # revealed: WritableValue[float]
 ```
 
 A read/write property on a protocol, where the setter accepts a subtype of the type returned by the

--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -495,7 +495,7 @@ def _(maybe_float: float | None, certain_int: int, flag: bool) -> None:
         if flag:
             x = certain_int
         assert x is not None
-        reveal_type(x)  # revealed: int | float
+        reveal_type(x)  # revealed: float
         +x
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Wrong_value_type_for…_(ffe39a3bae68cfe4).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Wrong_value_type_for…_(ffe39a3bae68cfe4).snap
@@ -22,25 +22,25 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 # Diagnostics
 
 ```
-error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["retries"]` and value of type `float` on object of type `dict[str, int]`
+error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["retries"]` and value of type `float*` on object of type `dict[str, int]`
  --> src/mdtest_snippet.py:4:5
   |
 4 |     config["retries"] = 3.0
   |     ^^^^^^^^^^^^^^^^^^^^---
   |                         |
-  |                         Expected value of type `int`, got `float`
+  |                         Expected value of type `int`, got `float*`
 info: The full type of the subscripted object is `dict[str, int] | dict[str, str]`
 
 ```
 
 ```
-error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["retries"]` and value of type `float` on object of type `dict[str, str]`
+error[invalid-assignment]: Invalid subscript assignment with key of type `Literal["retries"]` and value of type `float*` on object of type `dict[str, str]`
  --> src/mdtest_snippet.py:4:5
   |
 4 |     config["retries"] = 3.0
   |     ^^^^^^^^^^^^^^^^^^^^---
   |                         |
-  |                         Expected value of type `str`, got `float`
+  |                         Expected value of type `str`, got `float*`
 info: The full type of the subscripted object is `dict[str, int] | dict[str, str]`
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(dd80c593d9136f35).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(dd80c593d9136f35).snap
@@ -87,19 +87,19 @@ info:   (a: str, b: str, c: int) -> Unknown
 info:   (a: int, b: str, c: str) -> Unknown
 info:   (a: str, b: str, c: str) -> Unknown
 info:   (a: int, b: int, c: int) -> Unknown
-info:   (a: int | float, b: int, c: int) -> Unknown
-info:   (a: int, b: int | float, c: int) -> Unknown
-info:   (a: int, b: int, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int) -> Unknown
-info:   (a: int, b: int | float, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int | float) -> Unknown
+info:   (a: float, b: int, c: int) -> Unknown
+info:   (a: int, b: float, c: int) -> Unknown
+info:   (a: int, b: int, c: float) -> Unknown
+info:   (a: float, b: float, c: int) -> Unknown
+info:   (a: int, b: float, c: float) -> Unknown
+info:   (a: float, b: float, c: float) -> Unknown
 info:   (a: str, b: str, c: str) -> Unknown
-info:   (a: int | float, b: str, c: str) -> Unknown
-info:   (a: str, b: int | float, c: str) -> Unknown
-info:   (a: str, b: str, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: str) -> Unknown
-info:   (a: str, b: int | float, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int | float) -> Unknown
+info:   (a: float, b: str, c: str) -> Unknown
+info:   (a: str, b: float, c: str) -> Unknown
+info:   (a: str, b: str, c: float) -> Unknown
+info:   (a: float, b: float, c: str) -> Unknown
+info:   (a: str, b: float, c: float) -> Unknown
+info:   (a: float, b: float, c: float) -> Unknown
 info: Overload implementation defined here
   --> src/mdtest_snippet.py:47:5
    |

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(f66e3a8a3977c472).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/no_matching_overload…_-_No_matching_overload…_-_Call_to_function_wit…_(f66e3a8a3977c472).snap
@@ -167,19 +167,19 @@ info:   (a: str, b: str, c: int) -> Unknown
 info:   (a: int, b: str, c: str) -> Unknown
 info:   (a: str, b: str, c: str) -> Unknown
 info:   (a: int, b: int, c: int) -> Unknown
-info:   (a: int | float, b: int, c: int) -> Unknown
-info:   (a: int, b: int | float, c: int) -> Unknown
-info:   (a: int, b: int, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int) -> Unknown
-info:   (a: int, b: int | float, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int | float) -> Unknown
+info:   (a: float, b: int, c: int) -> Unknown
+info:   (a: int, b: float, c: int) -> Unknown
+info:   (a: int, b: int, c: float) -> Unknown
+info:   (a: float, b: float, c: int) -> Unknown
+info:   (a: int, b: float, c: float) -> Unknown
+info:   (a: float, b: float, c: float) -> Unknown
 info:   (a: str, b: str, c: str) -> Unknown
-info:   (a: int | float, b: str, c: str) -> Unknown
-info:   (a: str, b: int | float, c: str) -> Unknown
-info:   (a: str, b: str, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: str) -> Unknown
-info:   (a: str, b: int | float, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int | float) -> Unknown
+info:   (a: float, b: str, c: str) -> Unknown
+info:   (a: str, b: float, c: str) -> Unknown
+info:   (a: str, b: str, c: float) -> Unknown
+info:   (a: float, b: float, c: str) -> Unknown
+info:   (a: str, b: float, c: float) -> Unknown
+info:   (a: float, b: float, c: float) -> Unknown
 info:   (a: list[int], b: list[int], c: list[int]) -> Unknown
 info:   (a: list[str], b: list[int], c: list[int]) -> Unknown
 info:   (a: list[int], b: list[str], c: list[int]) -> Unknown
@@ -188,19 +188,19 @@ info:   (a: list[str], b: list[str], c: list[int]) -> Unknown
 info:   (a: list[int], b: list[str], c: list[str]) -> Unknown
 info:   (a: list[str], b: list[str], c: list[str]) -> Unknown
 info:   (a: list[int], b: list[int], c: list[int]) -> Unknown
-info:   (a: list[int | float], b: list[int], c: list[int]) -> Unknown
-info:   (a: list[int], b: list[int | float], c: list[int]) -> Unknown
-info:   (a: list[int], b: list[int], c: list[int | float]) -> Unknown
-info:   (a: list[int | float], b: list[int | float], c: list[int]) -> Unknown
-info:   (a: list[int], b: list[int | float], c: list[int | float]) -> Unknown
-info:   (a: list[int | float], b: list[int | float], c: list[int | float]) -> Unknown
+info:   (a: list[float], b: list[int], c: list[int]) -> Unknown
+info:   (a: list[int], b: list[float], c: list[int]) -> Unknown
+info:   (a: list[int], b: list[int], c: list[float]) -> Unknown
+info:   (a: list[float], b: list[float], c: list[int]) -> Unknown
+info:   (a: list[int], b: list[float], c: list[float]) -> Unknown
+info:   (a: list[float], b: list[float], c: list[float]) -> Unknown
 info:   (a: list[str], b: list[str], c: list[str]) -> Unknown
-info:   (a: list[int | float], b: list[str], c: list[str]) -> Unknown
-info:   (a: list[str], b: list[int | float], c: list[str]) -> Unknown
-info:   (a: list[str], b: list[str], c: list[int | float]) -> Unknown
-info:   (a: list[int | float], b: list[int | float], c: list[str]) -> Unknown
-info:   (a: list[str], b: list[int | float], c: list[int | float]) -> Unknown
-info:   (a: list[int | float], b: list[int | float], c: list[int | float]) -> Unknown
+info:   (a: list[float], b: list[str], c: list[str]) -> Unknown
+info:   (a: list[str], b: list[float], c: list[str]) -> Unknown
+info:   (a: list[str], b: list[str], c: list[float]) -> Unknown
+info:   (a: list[float], b: list[float], c: list[str]) -> Unknown
+info:   (a: list[str], b: list[float], c: list[float]) -> Unknown
+info:   (a: list[float], b: list[float], c: list[float]) -> Unknown
 info:   (a: bool, b: bool, c: bool) -> Unknown
 info:   (a: str, b: bool, c: bool) -> Unknown
 info:   (a: bool, b: str, c: bool) -> Unknown

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/single_matching_over…_-_Single_matching_over…_-_Call_to_function_wit…_(8fdf5a06afc7d4fe).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/single_matching_over…_-_Single_matching_over…_-_Call_to_function_wit…_(8fdf5a06afc7d4fe).snap
@@ -173,19 +173,19 @@ info:   (a: str, b: str, c: int) -> Unknown
 info:   (a: int, b: str, c: str) -> Unknown
 info:   (a: str, b: str, c: str) -> Unknown
 info:   (a: int, b: int, c: int) -> Unknown
-info:   (a: int | float, b: int, c: int) -> Unknown
-info:   (a: int, b: int | float, c: int) -> Unknown
-info:   (a: int, b: int, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int) -> Unknown
-info:   (a: int, b: int | float, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int | float) -> Unknown
+info:   (a: float, b: int, c: int) -> Unknown
+info:   (a: int, b: float, c: int) -> Unknown
+info:   (a: int, b: int, c: float) -> Unknown
+info:   (a: float, b: float, c: int) -> Unknown
+info:   (a: int, b: float, c: float) -> Unknown
+info:   (a: float, b: float, c: float) -> Unknown
 info:   (a: str, b: str, c: str) -> Unknown
-info:   (a: int | float, b: str, c: str) -> Unknown
-info:   (a: str, b: int | float, c: str) -> Unknown
-info:   (a: str, b: str, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: str) -> Unknown
-info:   (a: str, b: int | float, c: int | float) -> Unknown
-info:   (a: int | float, b: int | float, c: int | float) -> Unknown
+info:   (a: float, b: str, c: str) -> Unknown
+info:   (a: str, b: float, c: str) -> Unknown
+info:   (a: str, b: str, c: float) -> Unknown
+info:   (a: float, b: float, c: str) -> Unknown
+info:   (a: str, b: float, c: float) -> Unknown
+info:   (a: float, b: float, c: float) -> Unknown
 info:   (a: list[int], b: list[int], c: list[int]) -> Unknown
 info:   (a: list[str], b: list[int], c: list[int]) -> Unknown
 info:   (a: list[int], b: list[str], c: list[int]) -> Unknown
@@ -194,19 +194,19 @@ info:   (a: list[str], b: list[str], c: list[int]) -> Unknown
 info:   (a: list[int], b: list[str], c: list[str]) -> Unknown
 info:   (a: list[str], b: list[str], c: list[str]) -> Unknown
 info:   (a: list[int], b: list[int], c: list[int]) -> Unknown
-info:   (a: list[int | float], b: list[int], c: list[int]) -> Unknown
-info:   (a: list[int], b: list[int | float], c: list[int]) -> Unknown
-info:   (a: list[int], b: list[int], c: list[int | float]) -> Unknown
-info:   (a: list[int | float], b: list[int | float], c: list[int]) -> Unknown
-info:   (a: list[int], b: list[int | float], c: list[int | float]) -> Unknown
-info:   (a: list[int | float], b: list[int | float], c: list[int | float]) -> Unknown
+info:   (a: list[float], b: list[int], c: list[int]) -> Unknown
+info:   (a: list[int], b: list[float], c: list[int]) -> Unknown
+info:   (a: list[int], b: list[int], c: list[float]) -> Unknown
+info:   (a: list[float], b: list[float], c: list[int]) -> Unknown
+info:   (a: list[int], b: list[float], c: list[float]) -> Unknown
+info:   (a: list[float], b: list[float], c: list[float]) -> Unknown
 info:   (a: list[str], b: list[str], c: list[str]) -> Unknown
-info:   (a: list[int | float], b: list[str], c: list[str]) -> Unknown
-info:   (a: list[str], b: list[int | float], c: list[str]) -> Unknown
-info:   (a: list[str], b: list[str], c: list[int | float]) -> Unknown
-info:   (a: list[int | float], b: list[int | float], c: list[str]) -> Unknown
-info:   (a: list[str], b: list[int | float], c: list[int | float]) -> Unknown
-info:   (a: list[int | float], b: list[int | float], c: list[int | float]) -> Unknown
+info:   (a: list[float], b: list[str], c: list[str]) -> Unknown
+info:   (a: list[str], b: list[float], c: list[str]) -> Unknown
+info:   (a: list[str], b: list[str], c: list[float]) -> Unknown
+info:   (a: list[float], b: list[float], c: list[str]) -> Unknown
+info:   (a: list[str], b: list[float], c: list[float]) -> Unknown
+info:   (a: list[float], b: list[float], c: list[float]) -> Unknown
 info:   (a: bool, b: bool, c: bool) -> Unknown
 info:   (a: str, b: bool, c: bool) -> Unknown
 info:   (a: bool, b: str, c: bool) -> Unknown

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_Default_TypeVar's_bo…_(fcd7ad5416c91629).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/variables.md_-_Legacy_type_variable…_-_Type_variables_-_Invalid_defaults_-_Default_TypeVar's_bo…_(fcd7ad5416c91629).snap
@@ -23,7 +23,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/legacy/variable
  8 | # and the upper bound of `T` (`int`) is assignable to `int | float`
  9 | S = TypeVar("S", default=T1, bound=float)
 10 | 
-11 | # error: [invalid-type-variable-default] "Default `T3` of TypeVar `U` is not assignable to upper bound `int | float` of `U` because its upper bound `str` is not assignable to `int | float`"
+11 | # error: [invalid-type-variable-default] "Default `T3` of TypeVar `U` is not assignable to upper bound `float` of `U` because its upper bound `str` is not assignable to `float`"
 12 | U = TypeVar("U", default=T3, bound=float)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/struct_unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/struct_unpack.md
@@ -20,15 +20,15 @@ def _(buf: bytes):
     reveal_type(unpack("0c", buf))  # revealed: tuple[()]
     reveal_type(unpack("1s", buf))  # revealed: tuple[bytes]
     reveal_type(unpack("255s", buf))  # revealed: tuple[bytes]
-    reveal_type(unpack("e", buf))  # revealed: tuple[float]
-    reveal_type(unpack("2e", buf))  # revealed: tuple[float, float]
-    reveal_type(unpack("e4x", buf))  # revealed: tuple[float]
-    reveal_type(unpack("3eH", buf))  # revealed: tuple[float, float, float, int]
+    reveal_type(unpack("e", buf))  # revealed: tuple[float*]
+    reveal_type(unpack("2e", buf))  # revealed: tuple[float*, float*]
+    reveal_type(unpack("e4x", buf))  # revealed: tuple[float*]
+    reveal_type(unpack("3eH", buf))  # revealed: tuple[float*, float*, float*, int]
     reveal_type(unpack("?x?", buf))  # revealed: tuple[bool, bool]
     reveal_type(unpack("2?", buf))  # revealed: tuple[bool, bool]
     reveal_type(unpack("?2xI", buf))  # revealed: tuple[bool, int]
-    reveal_type(unpack("fd4x", buf))  # revealed: tuple[float, float]
-    reveal_type(unpack("d2xH", buf))  # revealed: tuple[float, int]
+    reveal_type(unpack("fd4x", buf))  # revealed: tuple[float*, float*]
+    reveal_type(unpack("d2xH", buf))  # revealed: tuple[float*, int]
     reveal_type(unpack("2i4x2h", buf))  # revealed: tuple[int, int, int, int]
     reveal_type(unpack("iP", buf))  # revealed: tuple[int, int]
     reveal_type(unpack("@n2xN", buf))  # revealed: tuple[int, int]
@@ -46,8 +46,8 @@ python-version = "3.14"
 from struct import *
 
 def _(buf: bytes):
-    reveal_type(unpack("2F", buf))  # revealed: tuple[complex, complex]
-    reveal_type(unpack("3D", buf))  # revealed: tuple[complex, complex, complex]
+    reveal_type(unpack("2F", buf))  # revealed: tuple[complex*, complex*]
+    reveal_type(unpack("3D", buf))  # revealed: tuple[complex*, complex*, complex*]
 ```
 
 ## Escape Large Repetition Counts

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -129,9 +129,9 @@ from ty_extensions._internal import reveal_mro
 
 reveal_type(os.stat("my_file.txt"))  # revealed: stat_result
 reveal_type(os.stat("my_file.txt")[stat.ST_MODE])  # revealed: int
-reveal_type(os.stat("my_file.txt")[stat.ST_ATIME])  # revealed: int | float
+reveal_type(os.stat("my_file.txt")[stat.ST_ATIME])  # revealed: float
 
-# revealed: (<class 'stat_result'>, <class 'structseq[int | float]'>, <class 'tuple[int, int, int, int, int, int, int, int | float, int | float, int | float]'>, <class 'Sequence[int | float]'>, <class 'Reversible[int | float]'>, <class 'Collection[int | float]'>, <class 'Iterable[int | float]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
+# revealed: (<class 'stat_result'>, <class 'structseq[float]'>, <class 'tuple[int, int, int, int, int, int, int, float, float, float]'>, <class 'Sequence[float]'>, <class 'Reversible[float]'>, <class 'Collection[float]'>, <class 'Iterable[float]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)
 reveal_mro(os.stat_result)
 
 # There are no specific overloads for the `float` elements in `os.stat_result`,
@@ -139,7 +139,7 @@ reveal_mro(os.stat_result)
 # gives the right result for those elements in the tuple, and we aim to synthesize
 # the minimum number of overloads for any given tuple
 #
-# revealed: Overload[(self, index: Literal[-10, -9, -8, -7, -6, -5, -4, 0, 1, 2, 3, 4, 5, 6], /) -> int, (self, index: SupportsIndex, /) -> int | float, (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[int | float, ...]]
+# revealed: Overload[(self, index: Literal[-10, -9, -8, -7, -6, -5, -4, 0, 1, 2, 3, 4, 5, 6], /) -> int, (self, index: SupportsIndex, /) -> float, (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[float, ...]]
 reveal_type(os.stat_result.__getitem__)
 ```
 
@@ -496,7 +496,7 @@ def test(val: tuple[str] | tuple[int]):
     reveal_type(val[0])  # revealed: str | int
 
 def test2(val: tuple[str, None] | list[int | float]):
-    reveal_type(val[0])  # revealed: str | int | float
+    reveal_type(val[0])  # revealed: str | float
 ```
 
 ## Union subscript access with non-indexable type

--- a/crates/ty_python_semantic/resources/mdtest/unary/invert_add_usub.md
+++ b/crates/ty_python_semantic/resources/mdtest/unary/invert_add_usub.md
@@ -47,11 +47,11 @@ from typing import TypeVar
 T = TypeVar("T", bound=float)
 
 def neg_float_bound(a: T) -> float:
-    reveal_type(-a)  # revealed: int | float
+    reveal_type(-a)  # revealed: float
     return -a
 
 def pos_float_bound(a: T) -> float:
-    reveal_type(+a)  # revealed: int | float
+    reveal_type(+a)  # revealed: float
     return +a
 ```
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -105,10 +105,13 @@ impl SignatureNameDisplay {
     }
 }
 
+/// Controls whether numeric-tower unions use annotation spelling or expose their exact members.
 #[derive(Debug, Clone, Copy, Default)]
 enum NumericTowerDisplay {
+    /// Display `int | float*` as the annotation `float`.
     #[default]
     Canonical,
+    /// Display every exact member, such as `int | float*`.
     Expanded,
 }
 
@@ -166,6 +169,10 @@ impl<'db> DisplaySettings<'db> {
         }
     }
 
+    /// Expands numeric-tower unions so explanations can refer to their individual members.
+    ///
+    /// For example, a relation error that discusses the `int` member of a `float` annotation
+    /// displays the union as `int | float*` instead of hiding that member behind `float`.
     #[must_use]
     pub(crate) fn expand_numeric_tower_unions(&self) -> Self {
         Self {
@@ -225,9 +232,8 @@ impl<'db> DisplaySettings<'db> {
         }
     }
 
-    /// Creates settings that qualify otherwise ambiguous names across `types`.
     #[must_use]
-    pub fn from_possibly_ambiguous_types<I, T>(
+    pub(crate) fn from_possibly_ambiguous_types<I, T>(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         types: I,
@@ -683,6 +689,23 @@ pub struct DisplayType<'env, 'db> {
 }
 
 impl<'db> DisplayType<'_, 'db> {
+    /// Allows this type display to span multiple lines while preserving inferred qualification.
+    #[must_use]
+    pub fn multiline(self) -> Self {
+        Self {
+            settings: self.settings.multiline(),
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn preserve_long_unions(self) -> Self {
+        Self {
+            settings: self.settings.preserve_long_unions(),
+            ..self
+        }
+    }
+
     pub fn to_string_parts(&self) -> TypeDisplayDetails<'db> {
         let mut f = TypeWriter::Details(TypeDetailsWriter::new());
         self.fmt_detailed(&mut f).unwrap();
@@ -2298,26 +2321,34 @@ impl Display for DisplayCallableType<'_, '_> {
 }
 
 impl<'db> Signature<'db> {
+    /// Displays this signature with qualification inferred across all parameter and return types.
+    ///
+    /// For example, considering the annotations together keeps the two `float` classes distinct:
+    ///
+    /// ```python
+    /// import builtins
+    ///
+    /// class float: ...
+    ///
+    /// def f(value: builtins.float | float) -> None: ...
+    /// ```
     pub(crate) fn display<'a>(
         &'a self,
         db: &'db dyn Db,
         env: &'a ProgramEnvironment<'db>,
     ) -> DisplaySignature<'a, 'db> {
-        Self::display_with(self, db, env, self.display_settings(db, env))
-    }
-
-    pub(crate) fn display_settings(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> DisplaySettings<'db> {
-        DisplaySettings::from_possibly_ambiguous_types(
+        Self::display_with(
+            self,
             db,
             env,
-            self.parameters()
-                .iter()
-                .map(Parameter::annotated_type)
-                .chain(std::iter::once(self.return_ty)),
+            DisplaySettings::from_possibly_ambiguous_types(
+                db,
+                env,
+                self.parameters()
+                    .iter()
+                    .map(Parameter::annotated_type)
+                    .chain(std::iter::once(self.return_ty)),
+            ),
         )
     }
 
@@ -2349,7 +2380,31 @@ pub(crate) struct DisplaySignature<'a, 'db> {
     settings: DisplaySettings<'db>,
 }
 
-impl DisplaySignature<'_, '_> {
+impl<'db> DisplaySignature<'_, 'db> {
+    #[must_use]
+    pub(crate) fn multiline(self) -> Self {
+        Self {
+            settings: self.settings.multiline(),
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn disallow_name(self) -> Self {
+        Self {
+            settings: self.settings.disallow_signature_name(),
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn hide_return_type(self) -> Self {
+        Self {
+            settings: self.settings.hide_return_type(),
+            ..self
+        }
+    }
+
     /// Get detailed display information including component ranges
     pub(crate) fn to_string_parts(&self) -> SignatureDisplayDetails {
         let mut f = TypeWriter::Details(TypeDetailsWriter::new());
@@ -2859,6 +2914,13 @@ const UNION_POLICY: TruncationPolicy = TruncationPolicy {
     max_when_elided: 3,
 };
 
+/// Finds the largest numeric-tower group among the given classes.
+///
+/// Unrelated classes are ignored so a mixed annotation can still use canonical spelling:
+///
+/// ```python
+/// def f(value: str | float) -> None: ...
+/// ```
 fn numeric_tower_group(known_classes: impl IntoIterator<Item = KnownClass>) -> Option<KnownUnion> {
     let mut has_int = false;
     let mut has_float = false;
@@ -2885,18 +2947,6 @@ fn subclass_of_known_class(db: &dyn Db, subclass_of: SubclassOfType<'_>) -> Opti
         SubclassOfInner::Class(class) => class.known(db),
         _ => None,
     }
-}
-
-enum UnionDisplayEntry<'db> {
-    NumericTower(KnownUnion),
-    Literals(Vec<Type<'db>>),
-    Subclasses(Vec<SubclassOfType<'db>>),
-    Type(Type<'db>),
-}
-
-enum SubclassDisplayEntry<'db> {
-    NumericTower(KnownUnion),
-    Type(SubclassOfType<'db>),
 }
 
 impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
@@ -2927,7 +2977,7 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
         let db = self.db;
 
         let elements = self.ty.elements(db);
-        let numeric_tower_group = matches!(
+        let numeric_tower = matches!(
             self.settings.numeric_tower_display,
             NumericTowerDisplay::Canonical
         )
@@ -2939,11 +2989,32 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
             }))
         })
         .flatten();
+        let is_numeric_tower_element = |element: Type<'db>| {
+            numeric_tower.is_some_and(|group| {
+                element
+                    .as_nominal_instance()
+                    .and_then(|instance| instance.known_class(db))
+                    .is_some_and(|known_class| group.contains(known_class))
+            })
+        };
         let mut condensed_types = vec![];
+        let mut condensed_element_count = 0usize;
         let mut subclass_of_types = vec![];
+        let element_labels: Vec<_> = elements
+            .iter()
+            .copied()
+            .map(|element| {
+                (self.condensable_literals(element).is_none()
+                    && !element.is_subclass_of()
+                    && !is_numeric_tower_element(element))
+                .then(|| singleline_union_element_label(db, self.env, element, &self.settings))
+            })
+            .collect();
+        let duplicate_ambiguous_labels = duplicate_ambiguous_labels(&element_labels);
 
         for element in elements.iter().copied() {
             if let Some(literals) = self.condensable_literals(element) {
+                condensed_element_count += 1;
                 for literal in literals {
                     if !condensed_types.contains(&literal) {
                         condensed_types.push(literal);
@@ -2954,50 +3025,18 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
             }
         }
 
-        let mut pending_numeric_tower_group = numeric_tower_group;
-        let mut condensed_types = (!condensed_types.is_empty()).then_some(condensed_types);
-        let mut subclass_of_types = (!subclass_of_types.is_empty()).then_some(subclass_of_types);
-        let mut display_entries = Vec::with_capacity(elements.len());
-
-        for element in elements.iter().copied() {
-            if numeric_tower_group.is_some_and(|group| {
-                element
-                    .as_nominal_instance()
-                    .and_then(|instance| instance.known_class(db))
-                    .is_some_and(|known_class| group.contains(known_class))
-            }) {
-                if let Some(group) = pending_numeric_tower_group.take() {
-                    display_entries.push(UnionDisplayEntry::NumericTower(group));
-                }
-            } else if self.condensable_literals(element).is_some() {
-                if let Some(literals) = condensed_types.take() {
-                    display_entries.push(UnionDisplayEntry::Literals(literals));
-                }
-            } else if element.is_subclass_of() {
-                if let Some(subclasses) = subclass_of_types.take() {
-                    display_entries.push(UnionDisplayEntry::Subclasses(subclasses));
-                }
-            } else {
-                display_entries.push(UnionDisplayEntry::Type(element));
-            }
-        }
-
-        let element_labels: Vec<_> = display_entries
+        let numeric_tower_element_count = elements
             .iter()
-            .map(|entry| match entry {
-                UnionDisplayEntry::Type(ty) => Some(singleline_union_element_label(
-                    db,
-                    self.env,
-                    *ty,
-                    &self.settings,
-                )),
-                UnionDisplayEntry::NumericTower(_)
-                | UnionDisplayEntry::Literals(_)
-                | UnionDisplayEntry::Subclasses(_) => None,
-            })
-            .collect();
-        let duplicate_ambiguous_labels = duplicate_ambiguous_labels(&element_labels);
-        let total_entries = display_entries.len();
+            .copied()
+            .filter(|element| is_numeric_tower_element(*element))
+            .count();
+        let total_entries = elements.len()
+            - numeric_tower_element_count
+            - condensed_element_count
+            - subclass_of_types.len()
+            + usize::from(numeric_tower.is_some())
+            + usize::from(!condensed_types.is_empty())
+            + usize::from(!subclass_of_types.is_empty());
 
         assert_ne!(total_entries, 0);
 
@@ -3007,13 +3046,19 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
         let display_limit =
             UNION_POLICY.display_limit(total_entries, self.settings.preserve_full_unions);
 
-        for (entry, label) in display_entries
-            .into_iter()
-            .zip(&element_labels)
-            .take(display_limit)
-        {
-            match entry {
-                UnionDisplayEntry::NumericTower(union) => {
+        let mut numeric_tower = numeric_tower;
+        let mut condensed_types = Some(condensed_types);
+        let mut subclass_of_types = Some(subclass_of_types);
+        let mut displayed_entries = 0usize;
+
+        for (element, label) in elements.iter().zip(&element_labels) {
+            if displayed_entries >= display_limit {
+                break;
+            }
+
+            if is_numeric_tower_element(*element) {
+                if let Some(union) = numeric_tower.take() {
+                    displayed_entries += 1;
                     join.entry(&DisplayKnownUnion {
                         union,
                         db,
@@ -3021,7 +3066,9 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                         settings: self.settings.singleline(),
                     });
                 }
-                UnionDisplayEntry::Literals(literals) => {
+            } else if self.condensable_literals(*element).is_some() {
+                if let Some(literals) = condensed_types.take() {
+                    displayed_entries += 1;
                     join.entry(&DisplayLiteralGroup {
                         literals,
                         db,
@@ -3029,7 +3076,9 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                         settings: self.settings.singleline(),
                     });
                 }
-                UnionDisplayEntry::Subclasses(types) => {
+            } else if element.is_subclass_of() {
+                if let Some(types) = subclass_of_types.take() {
+                    displayed_entries += 1;
                     join.entry(&DisplaySubclassOfGroup {
                         types,
                         db,
@@ -3037,27 +3086,27 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                         settings: self.settings.singleline(),
                     });
                 }
-                UnionDisplayEntry::Type(ty) => {
-                    let settings = if label
-                        .as_deref()
-                        .is_some_and(|label| duplicate_ambiguous_labels.contains(label))
-                    {
-                        self.settings.singleline().force_signature_name()
-                    } else {
-                        self.settings.singleline()
-                    };
-                    join.entry(&DisplayMaybeParenthesizedType {
-                        ty,
-                        db,
-                        env: self.env,
-                        settings,
-                    });
-                }
+            } else {
+                displayed_entries += 1;
+                let settings = if label
+                    .as_deref()
+                    .is_some_and(|label| duplicate_ambiguous_labels.contains(label))
+                {
+                    self.settings.singleline().force_signature_name()
+                } else {
+                    self.settings.singleline()
+                };
+                join.entry(&DisplayMaybeParenthesizedType {
+                    ty: *element,
+                    db,
+                    env: self.env,
+                    settings,
+                });
             }
         }
 
         if !self.settings.preserve_full_unions {
-            let omitted_entries = total_entries.saturating_sub(display_limit);
+            let omitted_entries = total_entries.saturating_sub(displayed_entries);
             if omitted_entries > 0 {
                 join.entry(&DisplayOmitted {
                     count: omitted_entries,
@@ -3070,6 +3119,9 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
     }
 }
 
+/// Displays a numeric-tower union through its canonical annotation class.
+///
+/// Delegating to the class display preserves qualification and IDE navigation metadata.
 struct DisplayKnownUnion<'env, 'db> {
     union: KnownUnion,
     db: &'db dyn Db,
@@ -3086,7 +3138,7 @@ impl<'db> FmtDetailed<'db> for DisplayKnownUnion<'_, 'db> {
                 .fmt_detailed(f)
         } else {
             f.with_type(class.to_instance(self.db, self.env))
-                .write_str(class.name(self.db))
+                .write_str(class.name(self.env.python_version(self.db)))
         }
     }
 }
@@ -3114,7 +3166,7 @@ impl<'db> FmtDetailed<'db> for DisplaySubclassOfGroup<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
         let db = self.db;
         f.write_str("type[")?;
-        let numeric_tower_group = matches!(
+        let numeric_tower = matches!(
             self.settings.numeric_tower_display,
             NumericTowerDisplay::Canonical
         )
@@ -3126,40 +3178,45 @@ impl<'db> FmtDetailed<'db> for DisplaySubclassOfGroup<'_, 'db> {
             )
         })
         .flatten();
-        let mut pending_numeric_tower_group = numeric_tower_group;
-        let mut display_entries = Vec::with_capacity(self.types.len());
-
-        for subclass_of in &self.types {
-            if numeric_tower_group.is_some_and(|group| {
-                subclass_of_known_class(self.db, *subclass_of)
+        let is_numeric_tower_subclass = |subclass_of: SubclassOfType<'db>| {
+            numeric_tower.is_some_and(|group| {
+                subclass_of_known_class(self.db, subclass_of)
                     .is_some_and(|known_class| group.contains(known_class))
-            }) {
-                if let Some(group) = pending_numeric_tower_group.take() {
-                    display_entries.push(SubclassDisplayEntry::NumericTower(group));
-                }
-            } else {
-                display_entries.push(SubclassDisplayEntry::Type(*subclass_of));
-            }
-        }
-
-        let total_entries = display_entries.len();
+            })
+        };
+        let numeric_tower_element_count = self
+            .types
+            .iter()
+            .copied()
+            .filter(|subclass_of| is_numeric_tower_subclass(*subclass_of))
+            .count();
+        let total_entries =
+            self.types.len() - numeric_tower_element_count + usize::from(numeric_tower.is_some());
         let display_limit =
             UNION_POLICY.display_limit(total_entries, self.settings.preserve_full_unions);
         let mut join = f.join(" | ");
+        let mut numeric_tower = numeric_tower;
+        let mut displayed_entries = 0usize;
 
-        for entry in display_entries.into_iter().take(display_limit) {
-            let subclass_of = match entry {
-                SubclassDisplayEntry::NumericTower(union) => {
+        for subclass_of in &self.types {
+            if displayed_entries >= display_limit {
+                break;
+            }
+
+            if is_numeric_tower_subclass(*subclass_of) {
+                if let Some(union) = numeric_tower.take() {
+                    displayed_entries += 1;
                     join.entry(&DisplayKnownUnion {
                         union,
                         db,
                         env: self.env,
                         settings: self.settings.singleline(),
                     });
-                    continue;
                 }
-                SubclassDisplayEntry::Type(subclass_of) => subclass_of,
-            };
+                continue;
+            }
+
+            displayed_entries += 1;
 
             match subclass_of.subclass_of() {
                 SubclassOfInner::Class(ClassType::NonGeneric(class)) => {
@@ -3195,7 +3252,7 @@ impl<'db> FmtDetailed<'db> for DisplaySubclassOfGroup<'_, 'db> {
             }
         }
         if !self.settings.preserve_full_unions {
-            let omitted_entries = total_entries.saturating_sub(display_limit);
+            let omitted_entries = total_entries.saturating_sub(displayed_entries);
             if omitted_entries > 0 {
                 join.entry(&DisplayOmitted {
                     count: omitted_entries,

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -33,9 +33,10 @@ use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::visitor::TypeVisitor;
 use crate::types::{
     CallableType, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
-    LiteralValueType, LiteralValueTypeKind, MaterializationKind, PropertyInstanceType, Protocol,
-    SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType, Type, TypeAliasType,
-    TypeGuardLike, TypedDictModule, TypedDictType, UnionType, WrapperDescriptorKind, visitor,
+    KnownUnion, LiteralValueType, LiteralValueTypeKind, MaterializationKind, PropertyInstanceType,
+    Protocol, SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType, Type,
+    TypeAliasType, TypeGuardLike, TypedDictModule, TypedDictType, UnionType, WrapperDescriptorKind,
+    visitor,
 };
 use ty_python_core::ProgramFile;
 use ty_python_core::definition::Definition;
@@ -104,6 +105,13 @@ impl SignatureNameDisplay {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+enum NumericTowerDisplay {
+    #[default]
+    Canonical,
+    Expanded,
+}
+
 /// Settings for displaying types and signatures
 #[derive(Debug, Clone, Default)]
 pub struct DisplaySettings<'db> {
@@ -119,6 +127,8 @@ pub struct DisplaySettings<'db> {
     qualified_type_aliases: Rc<FxHashMap<&'db str, QualificationLevel>>,
     /// Whether long unions and literals are displayed in full
     preserve_full_unions: bool,
+    /// How numeric-tower unions should be displayed.
+    numeric_tower_display: NumericTowerDisplay,
     /// Scopes that are currently active in the display context (e.g. function scopes
     /// whose type parameters are currently being displayed).
     /// Used to suppress redundant `@{scope}` suffixes for type variables.
@@ -153,6 +163,14 @@ impl<'db> DisplaySettings<'db> {
         Self {
             preserve_full_unions: true,
             ..self
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn expand_numeric_tower_unions(&self) -> Self {
+        Self {
+            numeric_tower_display: NumericTowerDisplay::Expanded,
+            ..self.clone()
         }
     }
 
@@ -1003,6 +1021,14 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                 match (class, class.known(db)) {
                     (_, Some(KnownClass::NoneType)) => f.with_type(self.ty).write_str("None"),
                     (_, Some(KnownClass::NoDefaultType)) => f.with_type(self.ty).write_str("NoDefault"),
+                    (_, Some(KnownClass::Float | KnownClass::Complex)) => {
+                        f.set_invalid_type_annotation();
+                        class
+                            .class_literal(self.db)
+                            .display_with(self.db, self.settings.clone())
+                            .fmt_detailed(f)?;
+                        f.write_char('*')
+                    }
                     (ClassType::Generic(alias), Some(KnownClass::Tuple)) => alias
                         .specialization(db)
                         .tuple(db)
@@ -2817,6 +2843,46 @@ const UNION_POLICY: TruncationPolicy = TruncationPolicy {
     max_when_elided: 3,
 };
 
+fn numeric_tower_group(known_classes: impl IntoIterator<Item = KnownClass>) -> Option<KnownUnion> {
+    let mut has_int = false;
+    let mut has_float = false;
+    let mut has_complex = false;
+
+    for known_class in known_classes {
+        match known_class {
+            KnownClass::Int => has_int = true,
+            KnownClass::Float => has_float = true,
+            KnownClass::Complex => has_complex = true,
+            _ => {}
+        }
+    }
+
+    match (has_int, has_float, has_complex) {
+        (true, true, true) => Some(KnownUnion::Complex),
+        (true, true, false) => Some(KnownUnion::Float),
+        _ => None,
+    }
+}
+
+fn subclass_of_known_class(db: &dyn Db, subclass_of: SubclassOfType<'_>) -> Option<KnownClass> {
+    match subclass_of.subclass_of() {
+        SubclassOfInner::Class(class) => class.known(db),
+        _ => None,
+    }
+}
+
+enum UnionDisplayEntry<'db> {
+    NumericTower(KnownUnion),
+    Literals(Vec<Type<'db>>),
+    Subclasses(Vec<SubclassOfType<'db>>),
+    Type(Type<'db>),
+}
+
+enum SubclassDisplayEntry<'db> {
+    NumericTower(KnownUnion),
+    Type(SubclassOfType<'db>),
+}
+
 impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
         fn singleline_union_element_label<'db>(
@@ -2845,22 +2911,23 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
         let db = self.db;
 
         let elements = self.ty.elements(db);
+        let numeric_tower_group = matches!(
+            self.settings.numeric_tower_display,
+            NumericTowerDisplay::Canonical
+        )
+        .then(|| {
+            numeric_tower_group(elements.iter().filter_map(|element| {
+                element
+                    .as_nominal_instance()
+                    .and_then(|instance| instance.known_class(db))
+            }))
+        })
+        .flatten();
         let mut condensed_types = vec![];
-        let mut condensed_element_count = 0usize;
         let mut subclass_of_types = vec![];
-        let element_labels: Vec<_> = elements
-            .iter()
-            .copied()
-            .map(|element| {
-                (self.condensable_literals(element).is_none() && !element.is_subclass_of())
-                    .then(|| singleline_union_element_label(db, self.env, element, &self.settings))
-            })
-            .collect();
-        let duplicate_ambiguous_labels = duplicate_ambiguous_labels(&element_labels);
 
         for element in elements.iter().copied() {
             if let Some(literals) = self.condensable_literals(element) {
-                condensed_element_count += 1;
                 for literal in literals {
                     if !condensed_types.contains(&literal) {
                         condensed_types.push(literal);
@@ -2871,9 +2938,50 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
             }
         }
 
-        let total_entries = elements.len() - condensed_element_count - subclass_of_types.len()
-            + usize::from(!condensed_types.is_empty())
-            + usize::from(!subclass_of_types.is_empty());
+        let mut pending_numeric_tower_group = numeric_tower_group;
+        let mut condensed_types = (!condensed_types.is_empty()).then_some(condensed_types);
+        let mut subclass_of_types = (!subclass_of_types.is_empty()).then_some(subclass_of_types);
+        let mut display_entries = Vec::with_capacity(elements.len());
+
+        for element in elements.iter().copied() {
+            if numeric_tower_group.is_some_and(|group| {
+                element
+                    .as_nominal_instance()
+                    .and_then(|instance| instance.known_class(db))
+                    .is_some_and(|known_class| group.contains(known_class))
+            }) {
+                if let Some(group) = pending_numeric_tower_group.take() {
+                    display_entries.push(UnionDisplayEntry::NumericTower(group));
+                }
+            } else if self.condensable_literals(element).is_some() {
+                if let Some(literals) = condensed_types.take() {
+                    display_entries.push(UnionDisplayEntry::Literals(literals));
+                }
+            } else if element.is_subclass_of() {
+                if let Some(subclasses) = subclass_of_types.take() {
+                    display_entries.push(UnionDisplayEntry::Subclasses(subclasses));
+                }
+            } else {
+                display_entries.push(UnionDisplayEntry::Type(element));
+            }
+        }
+
+        let element_labels: Vec<_> = display_entries
+            .iter()
+            .map(|entry| match entry {
+                UnionDisplayEntry::Type(ty) => Some(singleline_union_element_label(
+                    db,
+                    self.env,
+                    *ty,
+                    &self.settings,
+                )),
+                UnionDisplayEntry::NumericTower(_)
+                | UnionDisplayEntry::Literals(_)
+                | UnionDisplayEntry::Subclasses(_) => None,
+            })
+            .collect();
+        let duplicate_ambiguous_labels = duplicate_ambiguous_labels(&element_labels);
+        let total_entries = display_entries.len();
 
         assert_ne!(total_entries, 0);
 
@@ -2883,56 +2991,57 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
         let display_limit =
             UNION_POLICY.display_limit(total_entries, self.settings.preserve_full_unions);
 
-        let mut condensed_types = Some(condensed_types);
-        let mut subclass_of_types = Some(subclass_of_types);
-        let mut displayed_entries = 0usize;
-
-        for (element, label) in elements.iter().zip(&element_labels) {
-            if displayed_entries >= display_limit {
-                break;
-            }
-
-            if self.condensable_literals(*element).is_some() {
-                if let Some(condensed_types) = condensed_types.take() {
-                    displayed_entries += 1;
+        for (entry, label) in display_entries
+            .into_iter()
+            .zip(&element_labels)
+            .take(display_limit)
+        {
+            match entry {
+                UnionDisplayEntry::NumericTower(union) => {
+                    join.entry(&DisplayKnownUnion {
+                        union,
+                        db,
+                        env: self.env,
+                        settings: self.settings.singleline(),
+                    });
+                }
+                UnionDisplayEntry::Literals(literals) => {
                     join.entry(&DisplayLiteralGroup {
-                        literals: condensed_types,
+                        literals,
                         db,
                         env: self.env,
                         settings: self.settings.singleline(),
                     });
                 }
-            } else if element.is_subclass_of() {
-                if let Some(subclass_of_types) = subclass_of_types.take() {
-                    displayed_entries += 1;
+                UnionDisplayEntry::Subclasses(types) => {
                     join.entry(&DisplaySubclassOfGroup {
-                        types: subclass_of_types,
+                        types,
                         db,
                         env: self.env,
                         settings: self.settings.singleline(),
                     });
                 }
-            } else {
-                displayed_entries += 1;
-                let settings = if label
-                    .as_deref()
-                    .is_some_and(|label| duplicate_ambiguous_labels.contains(label))
-                {
-                    self.settings.singleline().force_signature_name()
-                } else {
-                    self.settings.singleline()
-                };
-                join.entry(&DisplayMaybeParenthesizedType {
-                    ty: *element,
-                    db,
-                    env: self.env,
-                    settings,
-                });
+                UnionDisplayEntry::Type(ty) => {
+                    let settings = if label
+                        .as_deref()
+                        .is_some_and(|label| duplicate_ambiguous_labels.contains(label))
+                    {
+                        self.settings.singleline().force_signature_name()
+                    } else {
+                        self.settings.singleline()
+                    };
+                    join.entry(&DisplayMaybeParenthesizedType {
+                        ty,
+                        db,
+                        env: self.env,
+                        settings,
+                    });
+                }
             }
         }
 
         if !self.settings.preserve_full_unions {
-            let omitted_entries = total_entries.saturating_sub(displayed_entries);
+            let omitted_entries = total_entries.saturating_sub(display_limit);
             if omitted_entries > 0 {
                 join.entry(&DisplayOmitted {
                     count: omitted_entries,
@@ -2942,6 +3051,27 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
             }
         }
         join.finish()
+    }
+}
+
+struct DisplayKnownUnion<'env, 'db> {
+    union: KnownUnion,
+    db: &'db dyn Db,
+    env: &'env ProgramEnvironment<'db>,
+    settings: DisplaySettings<'db>,
+}
+
+impl<'db> FmtDetailed<'db> for DisplayKnownUnion<'_, 'db> {
+    fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let class = self.union.annotation_class();
+        if let Some(class_literal) = class.try_to_class_literal(self.db, self.env) {
+            ClassLiteral::Static(class_literal)
+                .display_with(self.db, self.settings.clone())
+                .fmt_detailed(f)
+        } else {
+            f.with_type(class.to_instance(self.db, self.env))
+                .write_str(class.name(self.db))
+        }
     }
 }
 
@@ -2968,11 +3098,53 @@ impl<'db> FmtDetailed<'db> for DisplaySubclassOfGroup<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
         let db = self.db;
         f.write_str("type[")?;
-        let total_entries = self.types.len();
+        let numeric_tower_group = matches!(
+            self.settings.numeric_tower_display,
+            NumericTowerDisplay::Canonical
+        )
+        .then(|| {
+            numeric_tower_group(
+                self.types
+                    .iter()
+                    .filter_map(|subclass_of| subclass_of_known_class(self.db, *subclass_of)),
+            )
+        })
+        .flatten();
+        let mut pending_numeric_tower_group = numeric_tower_group;
+        let mut display_entries = Vec::with_capacity(self.types.len());
+
+        for subclass_of in &self.types {
+            if numeric_tower_group.is_some_and(|group| {
+                subclass_of_known_class(self.db, *subclass_of)
+                    .is_some_and(|known_class| group.contains(known_class))
+            }) {
+                if let Some(group) = pending_numeric_tower_group.take() {
+                    display_entries.push(SubclassDisplayEntry::NumericTower(group));
+                }
+            } else {
+                display_entries.push(SubclassDisplayEntry::Type(*subclass_of));
+            }
+        }
+
+        let total_entries = display_entries.len();
         let display_limit =
             UNION_POLICY.display_limit(total_entries, self.settings.preserve_full_unions);
         let mut join = f.join(" | ");
-        for subclass_of in self.types.iter().take(display_limit) {
+
+        for entry in display_entries.into_iter().take(display_limit) {
+            let subclass_of = match entry {
+                SubclassDisplayEntry::NumericTower(union) => {
+                    join.entry(&DisplayKnownUnion {
+                        union,
+                        db,
+                        env: self.env,
+                        settings: self.settings.singleline(),
+                    });
+                    continue;
+                }
+                SubclassDisplayEntry::Type(subclass_of) => subclass_of,
+            };
+
             match subclass_of.subclass_of() {
                 SubclassOfInner::Class(ClassType::NonGeneric(class)) => {
                     join.entry(&class.display_with(db, self.settings.singleline()));
@@ -3213,10 +3385,17 @@ impl<'db> FmtDetailed<'db> for DisplayMaybeParenthesizedType<'_, 'db> {
         };
         match self.ty {
             ty if should_parenthesize_callable_type(ty, db) => write_parentheses(f),
-            Type::KnownBoundMethod(_)
-            | Type::FunctionLiteral(_)
-            | Type::BoundMethod(_)
-            | Type::Union(_) => write_parentheses(f),
+            Type::KnownBoundMethod(_) | Type::FunctionLiteral(_) | Type::BoundMethod(_) => {
+                write_parentheses(f)
+            }
+            Type::Union(union)
+                if matches!(
+                    self.settings.numeric_tower_display,
+                    NumericTowerDisplay::Expanded
+                ) || union.known(db).is_none() =>
+            {
+                write_parentheses(f)
+            }
             Type::Intersection(intersection) if !intersection.has_one_element(db) => {
                 write_parentheses(f)
             }
@@ -3569,7 +3748,10 @@ mod tests {
     use ruff_python_ast::name::Name;
 
     use crate::db::tests::{TestDb, setup_db};
-    use crate::types::{KnownClass, Parameter, Parameters, Signature, Type};
+    use crate::types::{
+        DisplaySettings, KnownClass, KnownUnion, Parameter, Parameters, Signature, Type,
+        TypeDetail, UnionType,
+    };
 
     #[test]
     fn string_literal_display() {
@@ -3593,6 +3775,77 @@ mod tests {
                 .to_string(),
             r#"Literal["\""]"#
         );
+    }
+
+    #[test]
+    fn numeric_tower_display() {
+        let db = setup_db();
+        let env = db.program_environment();
+
+        let exact_float = KnownClass::Float.to_instance(&db, &env);
+        let exact_complex = KnownClass::Complex.to_instance(&db, &env);
+        let float_annotation = KnownUnion::Float.to_type(&db, &env);
+        let complex_annotation = KnownUnion::Complex.to_type(&db, &env);
+
+        assert_snapshot!(exact_float.display(&db, &env), @"float*");
+        assert_snapshot!(exact_complex.display(&db, &env), @"complex*");
+        assert_snapshot!(float_annotation.display(&db, &env), @"float");
+        assert_snapshot!(complex_annotation.display(&db, &env), @"complex");
+        assert_eq!(
+            float_annotation
+                .display_with(
+                    &db,
+                    &env,
+                    DisplaySettings::default().expand_numeric_tower_unions(),
+                )
+                .to_string(),
+            "int | float*"
+        );
+        assert_eq!(
+            complex_annotation
+                .display_with(
+                    &db,
+                    &env,
+                    DisplaySettings::default().expand_numeric_tower_unions(),
+                )
+                .to_string(),
+            "int | float* | complex*"
+        );
+        assert_snapshot!(float_annotation.to_meta_type(&db, &env).display(&db, &env), @"type[float]");
+        assert_snapshot!(complex_annotation.to_meta_type(&db, &env).display(&db, &env), @"type[complex]");
+
+        let list_of_float =
+            KnownClass::List.to_specialized_instance(&db, &env, &[float_annotation]);
+        assert_snapshot!(list_of_float.display(&db, &env), @"list[float]");
+
+        let string_or_float = UnionType::from_elements(
+            &db,
+            &env,
+            [KnownClass::Str.to_instance(&db, &env), float_annotation],
+        );
+        assert_snapshot!(string_or_float.display(&db, &env), @"str | float");
+
+        assert!(
+            !exact_float
+                .display(&db, &env)
+                .to_string_parts()
+                .is_valid_syntax
+        );
+        assert!(
+            float_annotation
+                .display(&db, &env)
+                .to_string_parts()
+                .is_valid_syntax
+        );
+        assert!(matches!(
+            float_annotation
+                .display(&db, &env)
+                .to_string_parts()
+                .details
+                .as_slice(),
+            [TypeDetail::Type(Type::ClassLiteral(class))]
+                if class.known(&db) == Some(KnownClass::Float)
+        ));
     }
 
     fn display_signature<'db>(

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -225,8 +225,9 @@ impl<'db> DisplaySettings<'db> {
         }
     }
 
+    /// Creates settings that qualify otherwise ambiguous names across `types`.
     #[must_use]
-    pub(crate) fn from_possibly_ambiguous_types<I, T>(
+    pub fn from_possibly_ambiguous_types<I, T>(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         types: I,

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -2380,7 +2380,7 @@ pub(crate) struct DisplaySignature<'a, 'db> {
     settings: DisplaySettings<'db>,
 }
 
-impl<'db> DisplaySignature<'_, 'db> {
+impl DisplaySignature<'_, '_> {
     #[must_use]
     pub(crate) fn multiline(self) -> Self {
         Self {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -2303,7 +2303,22 @@ impl<'db> Signature<'db> {
         db: &'db dyn Db,
         env: &'a ProgramEnvironment<'db>,
     ) -> DisplaySignature<'a, 'db> {
-        Self::display_with(self, db, env, DisplaySettings::default())
+        Self::display_with(self, db, env, self.display_settings(db, env))
+    }
+
+    pub(crate) fn display_settings(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> DisplaySettings<'db> {
+        DisplaySettings::from_possibly_ambiguous_types(
+            db,
+            env,
+            self.parameters()
+                .iter()
+                .map(Parameter::annotated_type)
+                .chain(std::iter::once(self.return_ty)),
+        )
     }
 
     pub(crate) fn display_with<'a>(

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2965,7 +2965,8 @@ pub(super) fn report_revealed_type<'db>(
                 revealed_type.display_with(
                     db,
                     env,
-                    DisplaySettings::default().preserve_long_unions()
+                    DisplaySettings::from_possibly_ambiguous_types(db, env, [revealed_type])
+                        .preserve_long_unions()
                 )
             )),
         );

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2962,12 +2962,7 @@ pub(super) fn report_revealed_type<'db>(
         diag.annotate(
             Annotation::primary(context.span(argument_node)).message(format_args!(
                 "`{}`",
-                revealed_type.display_with(
-                    db,
-                    env,
-                    DisplaySettings::from_possibly_ambiguous_types(db, env, [revealed_type])
-                        .preserve_long_unions()
-                )
+                revealed_type.display(db, env).preserve_long_unions()
             )),
         );
     }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1773,11 +1773,7 @@ pub fn call_type_simplified_by_overloads(
     }
 
     let signature = resolve_single_overload(model, callable_type, call_expr)?;
-    Some(
-        signature
-            .display_with(db, env, signature.display_settings(db, env).multiline())
-            .to_string(),
-    )
+    Some(signature.display(db, env).multiline().to_string())
 }
 
 /// Returns the definitions of the binary operation along with its callable type.
@@ -3069,15 +3065,10 @@ pub fn constructor_signature(model: &SemanticModel, call_expr: &ast::ExprCall) -
     let env = &model.program_environment();
     let display_sig = |signature: &Signature| {
         let params = signature
-            .display_with(
-                db,
-                env,
-                signature
-                    .display_settings(db, env)
-                    .multiline()
-                    .disallow_signature_name()
-                    .hide_return_type(),
-            )
+            .display(db, env)
+            .multiline()
+            .disallow_name()
+            .hide_return_type()
             .to_string();
 
         format!("class {class_name}{params}")

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -13,7 +13,7 @@ use crate::types::{
     KnownUnion, PropertyAccessorRole, SubclassOfInner, Type, TypeContext,
     TypeVarBoundOrConstraints, binding_type,
 };
-use crate::{Db, DisplaySettings, HasDefinition, HasType, ProgramEnvironment, SemanticModel};
+use crate::{Db, HasDefinition, HasType, ProgramEnvironment, SemanticModel};
 use itertools::Either;
 use ruff_db::files::FileRange;
 use ruff_db::parsed::parsed_module;
@@ -1775,7 +1775,7 @@ pub fn call_type_simplified_by_overloads(
     let signature = resolve_single_overload(model, callable_type, call_expr)?;
     Some(
         signature
-            .display_with(db, env, DisplaySettings::default().multiline())
+            .display_with(db, env, signature.display_settings(db, env).multiline())
             .to_string(),
     )
 }
@@ -3072,7 +3072,8 @@ pub fn constructor_signature(model: &SemanticModel, call_expr: &ast::ExprCall) -
             .display_with(
                 db,
                 env,
-                DisplaySettings::default()
+                signature
+                    .display_settings(db, env)
                     .multiline()
                     .disallow_signature_name()
                     .hide_return_type(),

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -8,7 +8,7 @@ use ruff_python_ast::name::Name;
 
 use crate::types::context::LintDiagnosticGuard;
 use crate::types::tuple::TupleLength;
-use crate::types::{Type, TypedDictType};
+use crate::types::{DisplaySettings, Type, TypedDictType};
 use crate::{FxOrderSet, ProgramEnvironment};
 
 /// Identifies a parameter, either by name or by position.
@@ -188,17 +188,28 @@ impl<'db> ErrorContext<'db> {
                 element,
                 union,
                 target,
-            } => format!(
-                "element `{}` of union `{}` is not assignable to `{}`",
-                element.display(db, env),
-                union.display(db, env),
-                target.display(db, env),
-            ),
-            Self::NotAssignableToAnyUnionElement { source, union } => format!(
-                "type `{}` is not assignable to any element of the union `{}`",
-                source.display(db, env),
-                union.display(db, env),
-            ),
+            } => {
+                let settings = DisplaySettings::from_possibly_ambiguous_types(
+                    db,
+                    env,
+                    [*element, *union, *target],
+                );
+                format!(
+                    "element `{}` of union `{}` is not assignable to `{}`",
+                    element.display_with(db, env, settings.clone()),
+                    union.display_with(db, env, settings.expand_numeric_tower_unions()),
+                    target.display_with(db, env, settings),
+                )
+            }
+            Self::NotAssignableToAnyUnionElement { source, union } => {
+                let settings =
+                    DisplaySettings::from_possibly_ambiguous_types(db, env, [*source, *union]);
+                format!(
+                    "type `{}` is not assignable to any element of the union `{}`",
+                    source.display_with(db, env, settings.clone()),
+                    union.display_with(db, env, settings.expand_numeric_tower_unions()),
+                )
+            }
             Self::NotAssignableToNOtherUnionElements { n } => format!(
                 "... omitted {n} union element{} without additional context",
                 if *n == 1 { "" } else { "s" }

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -504,6 +504,7 @@ pub(crate) enum KnownUnion {
 }
 
 impl KnownUnion {
+    /// Returns the class whose annotation denotes this numeric-tower union.
     pub(crate) const fn annotation_class(self) -> KnownClass {
         match self {
             Self::Float => KnownClass::Float,
@@ -511,6 +512,7 @@ impl KnownUnion {
         }
     }
 
+    /// Returns whether this union contains exact instances of `class`.
     pub(crate) const fn contains(self, class: KnownClass) -> bool {
         match self {
             Self::Float => matches!(class, KnownClass::Int | KnownClass::Float),

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -504,6 +504,23 @@ pub(crate) enum KnownUnion {
 }
 
 impl KnownUnion {
+    pub(crate) const fn annotation_class(self) -> KnownClass {
+        match self {
+            Self::Float => KnownClass::Float,
+            Self::Complex => KnownClass::Complex,
+        }
+    }
+
+    pub(crate) const fn contains(self, class: KnownClass) -> bool {
+        match self {
+            Self::Float => matches!(class, KnownClass::Int | KnownClass::Float),
+            Self::Complex => matches!(
+                class,
+                KnownClass::Int | KnownClass::Float | KnownClass::Complex
+            ),
+        }
+    }
+
     pub(crate) fn to_type<'db>(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         match self {
             KnownUnion::Float => UnionType::from_two_elements(


### PR DESCRIPTION
## Summary

PEP 484's numeric tower means we represent a `float` annotation as the semantic union `int | float*` and `complex` as `int | float* | complex*`. We previously rendered those internal unions directly, which exposed an implementation detail in user-facing output:

```python
def f() -> float:
    return 1

reveal_type(f())  # Before: int | float; after: float
```

This change recognizes complete numeric-tower unions during display and renders them using their canonical annotation spelling, `float` or `complex`.

The implementation does _not_ preserve explicit unions, e.g., if the user writes out `int | float`, we still collapse that rather than trying to preserve it, mostly for simplicity (as per https://github.com/astral-sh/ty/issues/2184#issuecomment-4345219164).

Closes https://github.com/astral-sh/ty/issues/2184.
