### PR TITLE
[ty] Remove unused TypeVarVariance bounds

### DIFF
--- a/crates/ty_python_semantic/src/types/variance.rs
+++ b/crates/ty_python_semantic/src/types/variance.rs
@@ -9,14 +9,6 @@ pub enum TypeVarVariance {
 }
 
 impl TypeVarVariance {
-    pub const fn bottom() -> Self {
-        TypeVarVariance::Bivariant
-    }
-
-    pub const fn top() -> Self {
-        TypeVarVariance::Invariant
-    }
-
     // supremum
     #[must_use]
     pub(crate) const fn join(self, other: Self) -> Self {


### PR DESCRIPTION
## Summary

This PR removes the unused TypeVarVariance bottom and top constructors identified by Hawk 0.1.11. The variance lattice is implemented through the internal join operation, and no Ruff or ty code calls these public constructors.

- 2 unused public methods removed
- 8 lines removed
- 1 file changed