### PR TITLE
fix(flake8-executable): only treat leading comments as shebangs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_executable/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/mod.rs
@@ -46,4 +46,28 @@ mod tests {
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
     }
+
+    /// Regression test for <https://github.com/astral-sh/ruff/issues/27028>.
+    ///
+    /// A `#!` comment later in the file is an ordinary comment, so EXE001 and
+    /// EXE003 should not be reported; only EXE005 should be.
+    #[test]
+    fn comment_not_shebang() -> Result<()> {
+        if super::helpers::is_wsl() {
+            // EXE001 is always ignored on WSL, so skip testing it in a WSL
+            // environment.
+            return Ok(());
+        }
+
+        let diagnostics = test_path(
+            Path::new("flake8_executable/comment_not_shebang.py"),
+            &settings::LinterSettings::for_rules(vec![
+                Rule::ShebangNotExecutable,
+                Rule::ShebangMissingPython,
+                Rule::ShebangNotFirstLine,
+            ]),
+        )?;
+        assert_diagnostics!(Path::new("comment_not_shebang.py"), diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use ruff_python_trivia::CommentRanges;
+use ruff_python_trivia::{CommentRanges, is_python_whitespace};
 pub(crate) use shebang_leading_whitespace::*;
 pub(crate) use shebang_missing_executable_file::*;
 pub(crate) use shebang_missing_python::*;
@@ -28,15 +28,26 @@ pub(crate) fn from_tokens(
     for range in comment_ranges {
         let comment = locator.slice(range);
         if let Some(shebang) = ShebangDirective::try_extract(comment) {
-            has_any_shebang = true;
+            // A shebang is only recognized at the beginning of the file,
+            // ignoring whitespace. A `#!` comment later in the file is an
+            // ordinary comment, and should only be reported by EXE005
+            // (`ShebangNotFirstLine`).
+            let is_leading = locator
+                .up_to(range.start())
+                .chars()
+                .all(|c| is_python_whitespace(c) || matches!(c, '\r' | '\n'));
 
-            shebang_missing_python(range, &shebang, context);
+            if is_leading {
+                has_any_shebang = true;
 
-            if context.is_rule_enabled(Rule::ShebangNotExecutable) {
-                shebang_not_executable(path, range, context);
+                shebang_missing_python(range, &shebang, context);
+
+                if context.is_rule_enabled(Rule::ShebangNotExecutable) {
+                    shebang_not_executable(path, range, context);
+                }
+
+                shebang_leading_whitespace(context, range, locator);
             }
-
-            shebang_leading_whitespace(context, range, locator);
 
             shebang_not_first_line(range, locator, context);
         }

--- a/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__comment_not_shebang.snap
+++ b/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__comment_not_shebang.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_linter/src/rules/flake8_executable/mod.rs
+---
+EXE005 Shebang should be at the beginning of the file
+ --> comment_not_shebang.py:2:5
+  |
+1 | def f():
+2 |     #! regular comment
+  |     ^^^^^^^^^^^^^^^^^^
+3 |     return 1
+  |


### PR DESCRIPTION
Fixes #27028

## Problem

`EXE001` (and the other "shebang is present" rules, `EXE003` and `EXE004`) treat any comment beginning with `#!` as a shebang, even when it appears later in the file as an ordinary comment:

```python
def f():
    #! regular comment
    return 1
```

```console
$ ruff check --isolated --select EXE001 test.py
EXE001 Shebang is present but file is not executable
```

## Fix

In `flake8_executable::rules::from_tokens`, only treat a comment as a shebang for the "shebang is present" rules (`EXE001`/`EXE003`/`EXE004`) and for `EXE002`'s `has_any_shebang` tracking when it appears at the beginning of the file (ignoring whitespace). A `#!` comment later in the file is an ordinary comment; `EXE005` (`ShebangNotFirstLine`) continues to report it as a misplaced shebang, matching upstream `flake8-executable` behavior.

## Test

New fixture `comment_not_shebang.py` exercises `EXE001`/`EXE003`/`EXE005` together: only `EXE005` is reported for the in-function `#!` comment.