### PR TITLE
[ty] Detect `__aenter__` and `__aexit__` that do not return awaitables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/async.md_-_Async_with_statement…_-_Context_expression_w…_(28ef812089a32e6a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/async.md_-_Async_with_statement…_-_Context_expression_w…_(28ef812089a32e6a).snap
@@ -14,10 +14,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/with/async.md
 
 ```
  1 | class Manager1:
- 2 |     def __aenter__(self) -> str:
+ 2 |     async def __aenter__(self) -> str:
  3 |         return "foo"
  4 | 
- 5 |     def __aexit__(self, exc_type, exc_value, traceback): ...
+ 5 |     async def __aexit__(self, exc_type, exc_value, traceback): ...
  6 | 
  7 | class NotAContextManager: ...
  8 | 

--- a/crates/ty_python_semantic/resources/mdtest/with/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/with/async.md
@@ -2,9 +2,7 @@
 
 ## Basic `async with` statement
 
-The type of the target variable in a `with` statement should be the return type from the context
-manager's `__aenter__` method. However, `async with` statements aren't supported yet. This test
-asserts that it doesn't emit any context manager-related errors.
+An `async with` statement awaits the return value of `__aenter__` and binds the result.
 
 ```py
 class Target: ...
@@ -104,6 +102,9 @@ async def main():
 
 <!-- snapshot-diagnostics -->
 
+A union can contain a valid context manager and an object with no context-manager methods. The valid
+manager still determines the type of the value bound by `async with`.
+
 ```py
 class Manager1:
     async def __aenter__(self) -> str:
@@ -119,40 +120,43 @@ async def _(context_expr: Manager1 | NotAContextManager):
         reveal_type(f)  # revealed: str
 ```
 
-## Possibly unbound non-awaitable context-manager methods
+## Missing and non-awaitable methods in a union
 
-When a union member lacks the async context-manager methods, the methods on the remaining member
-must still return awaitables:
+If one member of a union does not define the context-manager methods, still check the return values
+of the methods defined on the other member.
 
 ```py
-class Invalid:
+class Manager:
     def __aenter__(self) -> int:
         return 0
 
     def __aexit__(self, exc_type, exc, tb) -> bool:
         return False
 
-class Missing: ...
+class NotAManager: ...
 
-async def main(manager: Invalid | Missing):
+async def main(manager: Manager | NotAManager):
     # snapshot: invalid-context-manager
     async with manager as value:
         reveal_type(value)  # revealed: Unknown
 ```
 
 ```snapshot
-error[invalid-context-manager]: Object of type `Invalid | Missing` cannot be used with `async with` because `__aenter__` and `__aexit__` may be missing or return non-awaitables
+error[invalid-context-manager]: Object of type `Manager | NotAManager` cannot be used with `async with` because `__aenter__` and `__aexit__` may be missing or return non-awaitables
   --> src/mdtest_snippet.py:12:16
    |
 12 |     async with manager as value:
    |                ^^^^^^^
-info: `Missing` does not implement `__aenter__` or `__aexit__`
+info: `NotAManager` does not implement `__aenter__` or `__aexit__`
 info: `__aenter__` returns `int`, which is not awaitable
 info: `__aexit__` returns `bool`, which is not awaitable
 info: Consider declaring the methods with `async def`
 ```
 
-## Context expression with "sometimes" callable `__aenter__` method
+## Conditionally defined `__aenter__` method
+
+A conditionally defined `__aenter__` method may be missing. When it exists, its awaited return type
+still determines the type of the bound value.
 
 ```py
 async def _(flag: bool):
@@ -185,10 +189,10 @@ async def main():
         reveal_type(f)  # revealed: CoroutineType[Any, Any, str]
 ```
 
-## Accidental use of async `async with`
+## Synchronous context manager in `async with`
 
-If a asynchronous `async with` statement is used on a type with `__enter__` and `__exit__`, we show
-a diagnostic hint that the user might have intended to use `with` instead.
+An object that only defines `__enter__` and `__exit__` cannot be used with `async with`. Suggest
+using `with` instead.
 
 ```py
 class Manager:
@@ -244,9 +248,8 @@ async def main():
 
 ## Non-awaitable `__aenter__`
 
-`async with` awaits whatever `__aenter__` returns, so a method that is callable but returns a
-non-awaitable fails at runtime with
-`TypeError: 'async with' received an object from __aenter__ that does not implement __await__: int`:
+`async with` awaits the value returned by `__aenter__`. Returning an `int` therefore raises a
+`TypeError`.
 
 ```py
 class Manager:
@@ -273,8 +276,8 @@ info: Consider declaring the method with `async def`
 
 ## Non-awaitable `__aexit__`
 
-The same applies on the way out. Here `__aenter__` is correct, so the target still binds, but
-leaving the block would await a `bool`:
+`async with` also awaits the value returned by `__aexit__`. The value from `__aenter__` is still
+bound before the invalid exit method runs.
 
 ```py
 class Manager:
@@ -340,7 +343,7 @@ info: `__aexit__` returns `bool`, which is not awaitable
 info: Consider declaring the method with `async def`
 ```
 
-## Both methods non-awaitable
+## Non-awaitable `__aenter__` and `__aexit__`
 
 When neither method returns an awaitable, both are named in a single diagnostic:
 
@@ -358,76 +361,73 @@ async def main():
         pass
 ```
 
-## Awaitable returns that are not `async def`
+## Awaitable return from a regular method
 
-A method does not have to be `async` to satisfy `async with`; it only has to return something
-awaitable. None of these are errors:
+A context-manager method does not need to be declared with `async def`. A regular method can return
+an `Awaitable` instead.
 
 ```py
-from typing import Any, Awaitable, Coroutine, Generator
+from typing import Awaitable
 
-class ReturnsAwaitable:
+class Manager:
     def __aenter__(self) -> Awaitable[int]:
         raise NotImplementedError
 
     def __aexit__(self, exc_type, exc, tb) -> Awaitable[None]:
         raise NotImplementedError
 
-class Custom:
-    def __await__(self) -> Generator[Any, None, int]:
+async def main():
+    async with Manager() as value:
+        reveal_type(value)  # revealed: int
+```
+
+## Awaitable return from a custom `__await__` method
+
+An object is awaitable when its `__await__` method returns an iterator.
+
+```py
+from typing import Generator
+
+class AwaitableValue:
+    def __await__(self) -> Generator[None, None, int]:
         raise NotImplementedError
 
-class ReturnsCustomAwaitable:
-    def __aenter__(self) -> Custom:
+class Manager:
+    def __aenter__(self) -> AwaitableValue:
         raise NotImplementedError
 
-    def __aexit__(self, exc_type, exc, tb) -> Custom:
-        raise NotImplementedError
-
-class ReturnsCoroutine:
-    def __aenter__(self) -> Coroutine[Any, Any, int]:
-        raise NotImplementedError
-
-    def __aexit__(self, exc_type, exc, tb) -> Coroutine[Any, Any, None]:
+    def __aexit__(self, exc_type, exc, tb) -> AwaitableValue:
         raise NotImplementedError
 
 async def main():
-    async with ReturnsAwaitable() as a:
-        reveal_type(a)  # revealed: int
-    async with ReturnsCustomAwaitable() as b:
-        reveal_type(b)  # revealed: int
-    async with ReturnsCoroutine() as c:
-        reveal_type(c)  # revealed: int
+    async with Manager() as value:
+        reveal_type(value)  # revealed: int
 ```
 
-A union return type is awaitable when every member is, and `Never` is vacuously awaitable:
+## Union of awaitable return types
+
+When every possible return value is awaitable, the bound value includes the awaited result from each
+union member.
 
 ```py
 from typing import Awaitable
-from typing_extensions import Never
 
-class UnionOfAwaitables:
+class Manager:
     def __aenter__(self) -> Awaitable[int] | Awaitable[str]:
         raise NotImplementedError
 
     def __aexit__(self, exc_type, exc, tb) -> Awaitable[None]:
         raise NotImplementedError
 
-class NeverReturns:
-    def __aenter__(self) -> Never:
-        raise NotImplementedError
-
-    async def __aexit__(self, exc_type, exc, tb) -> None: ...
-
 async def main():
-    async with UnionOfAwaitables() as a:
-        reveal_type(a)  # revealed: int | str
-    async with NeverReturns() as b:
-        reveal_type(b)  # revealed: Never
+    async with Manager() as value:
+        reveal_type(value)  # revealed: int | str
 ```
 
-A union is only awaitable if every member is, so mixing an awaitable with a plain value is still an
-error:
+## Union containing a non-awaitable return type
+
+Every possible return value must be awaitable. A union containing `int` does not satisfy that
+requirement.
 
 ```py
 from typing import Awaitable
@@ -444,24 +444,34 @@ async def main():
         pass
 ```
 
-A method whose return type is not known does not produce a diagnostic either:
+## `Any` return type
+
+A return type of `Any` might be awaitable, so it must not produce an error.
 
 ```py
 from typing import Any
 
-class ReturnsAny:
+class Manager:
     def __aenter__(self) -> Any: ...
     def __aexit__(self, exc_type, exc, tb) -> Any: ...
 
-class Unannotated:
+async def main():
+    async with Manager():
+        pass
+```
+
+## Unknown return type
+
+An unannotated return type might also be awaitable, so it must not produce an error.
+
+```py
+class Manager:
     def __aenter__(self): ...
     def __aexit__(self, exc_type, exc, tb): ...
 
 async def main():
-    async with ReturnsAny() as a:
-        reveal_type(a)  # revealed: Any
-    async with Unannotated() as b:
-        reveal_type(b)  # revealed: Unknown
+    async with Manager():
+        pass
 ```
 
 ## `@asynccontextmanager`

--- a/crates/ty_python_semantic/resources/mdtest/with/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/with/async.md
@@ -106,10 +106,10 @@ async def main():
 
 ```py
 class Manager1:
-    def __aenter__(self) -> str:
+    async def __aenter__(self) -> str:
         return "foo"
 
-    def __aexit__(self, exc_type, exc_value, traceback): ...
+    async def __aexit__(self, exc_type, exc_value, traceback): ...
 
 class NotAContextManager: ...
 
@@ -117,6 +117,39 @@ async def _(context_expr: Manager1 | NotAContextManager):
     # error: [invalid-context-manager] "Object of type `Manager1 | NotAContextManager` cannot be used with `async with` because the methods `__aenter__` and `__aexit__` are possibly missing"
     async with context_expr as f:
         reveal_type(f)  # revealed: str
+```
+
+## Possibly unbound non-awaitable context-manager methods
+
+When a union member lacks the async context-manager methods, the methods on the remaining member
+must still return awaitables:
+
+```py
+class Invalid:
+    def __aenter__(self) -> int:
+        return 0
+
+    def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+class Missing: ...
+
+async def main(manager: Invalid | Missing):
+    # snapshot: invalid-context-manager
+    async with manager as value:
+        reveal_type(value)  # revealed: Unknown
+```
+
+```snapshot
+error[invalid-context-manager]: Object of type `Invalid | Missing` cannot be used with `async with` because `__aenter__` and `__aexit__` may be missing or return non-awaitables
+  --> src/mdtest_snippet.py:12:16
+   |
+12 |     async with manager as value:
+   |                ^^^^^^^
+info: `Missing` does not implement `__aenter__` or `__aexit__`
+info: `__aenter__` returns `int`, which is not awaitable
+info: `__aexit__` returns `bool`, which is not awaitable
+info: Consider declaring the methods with `async def`
 ```
 
 ## Context expression with "sometimes" callable `__aenter__` method
@@ -132,7 +165,7 @@ async def _(flag: bool):
 
     # error: [invalid-context-manager] "Object of type `Manager` cannot be used with `async with` because the method `__aenter__` may be missing"
     async with Manager() as f:
-        reveal_type(f)  # revealed: CoroutineType[Any, Any, str]
+        reveal_type(f)  # revealed: str
 ```
 
 ## Invalid `__aenter__` signature
@@ -212,7 +245,8 @@ async def main():
 ## Non-awaitable `__aenter__`
 
 `async with` awaits whatever `__aenter__` returns, so a method that is callable but returns a
-non-awaitable fails at runtime with `TypeError: object int can't be used in 'await' expression`:
+non-awaitable fails at runtime with
+`TypeError: 'async with' received an object from __aenter__ that does not implement __await__: int`:
 
 ```py
 class Manager:
@@ -254,6 +288,56 @@ async def main():
     # error: [invalid-context-manager] "Object of type `Manager` cannot be used with `async with` because `__aexit__` does not return an awaitable"
     async with Manager() as value:
         reveal_type(value)  # revealed: int
+```
+
+## Non-awaitable `__aenter__` with missing `__aexit__`
+
+A missing exit method does not excuse an entry method that returns a non-awaitable:
+
+```py
+class Manager:
+    def __aenter__(self) -> int:
+        return 0
+
+async def main():
+    # snapshot: invalid-context-manager
+    async with Manager():
+        pass
+```
+
+```snapshot
+error[invalid-context-manager]: Object of type `Manager` cannot be used with `async with` because it does not implement `__aexit__`, and `__aenter__` does not return an awaitable
+ --> src/mdtest_snippet.py:7:16
+  |
+7 |     async with Manager():
+  |                ^^^^^^^^^
+info: `__aenter__` returns `int`, which is not awaitable
+info: Consider declaring the method with `async def`
+```
+
+## Missing `__aenter__` with non-awaitable `__aexit__`
+
+An exit method must return an awaitable even when the entry method is missing:
+
+```py
+class Manager:
+    def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+async def main():
+    # snapshot: invalid-context-manager
+    async with Manager():
+        pass
+```
+
+```snapshot
+error[invalid-context-manager]: Object of type `Manager` cannot be used with `async with` because it does not implement `__aenter__`, and `__aexit__` does not return an awaitable
+ --> src/mdtest_snippet.py:7:16
+  |
+7 |     async with Manager():
+  |                ^^^^^^^^^
+info: `__aexit__` returns `bool`, which is not awaitable
+info: Consider declaring the method with `async def`
 ```
 
 ## Both methods non-awaitable

--- a/crates/ty_python_semantic/resources/mdtest/with/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/with/async.md
@@ -209,6 +209,177 @@ async def main():
         pass
 ```
 
+## Non-awaitable `__aenter__`
+
+`async with` awaits whatever `__aenter__` returns, so a method that is callable but returns a
+non-awaitable fails at runtime with `TypeError: object int can't be used in 'await' expression`:
+
+```py
+class Manager:
+    def __aenter__(self) -> int:
+        return 0
+
+    async def __aexit__(self, exc_type, exc, tb) -> None: ...
+
+async def main():
+    # snapshot: invalid-context-manager
+    async with Manager():
+        pass
+```
+
+```snapshot
+error[invalid-context-manager]: Object of type `Manager` cannot be used with `async with` because `__aenter__` does not return an awaitable
+ --> src/mdtest_snippet.py:9:16
+  |
+9 |     async with Manager():
+  |                ^^^^^^^^^
+info: `__aenter__` returns `int`, which is not awaitable
+info: Consider declaring the method with `async def`
+```
+
+## Non-awaitable `__aexit__`
+
+The same applies on the way out. Here `__aenter__` is correct, so the target still binds, but
+leaving the block would await a `bool`:
+
+```py
+class Manager:
+    async def __aenter__(self) -> int:
+        return 0
+
+    def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+async def main():
+    # error: [invalid-context-manager] "Object of type `Manager` cannot be used with `async with` because `__aexit__` does not return an awaitable"
+    async with Manager() as value:
+        reveal_type(value)  # revealed: int
+```
+
+## Both methods non-awaitable
+
+When neither method returns an awaitable, both are named in a single diagnostic:
+
+```py
+class Manager:
+    def __aenter__(self) -> int:
+        return 0
+
+    def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+async def main():
+    # error: [invalid-context-manager] "Object of type `Manager` cannot be used with `async with` because `__aenter__` and `__aexit__` do not return awaitables"
+    async with Manager():
+        pass
+```
+
+## Awaitable returns that are not `async def`
+
+A method does not have to be `async` to satisfy `async with`; it only has to return something
+awaitable. None of these are errors:
+
+```py
+from typing import Any, Awaitable, Coroutine, Generator
+
+class ReturnsAwaitable:
+    def __aenter__(self) -> Awaitable[int]:
+        raise NotImplementedError
+
+    def __aexit__(self, exc_type, exc, tb) -> Awaitable[None]:
+        raise NotImplementedError
+
+class Custom:
+    def __await__(self) -> Generator[Any, None, int]:
+        raise NotImplementedError
+
+class ReturnsCustomAwaitable:
+    def __aenter__(self) -> Custom:
+        raise NotImplementedError
+
+    def __aexit__(self, exc_type, exc, tb) -> Custom:
+        raise NotImplementedError
+
+class ReturnsCoroutine:
+    def __aenter__(self) -> Coroutine[Any, Any, int]:
+        raise NotImplementedError
+
+    def __aexit__(self, exc_type, exc, tb) -> Coroutine[Any, Any, None]:
+        raise NotImplementedError
+
+async def main():
+    async with ReturnsAwaitable() as a:
+        reveal_type(a)  # revealed: int
+    async with ReturnsCustomAwaitable() as b:
+        reveal_type(b)  # revealed: int
+    async with ReturnsCoroutine() as c:
+        reveal_type(c)  # revealed: int
+```
+
+A union return type is awaitable when every member is, and `Never` is vacuously awaitable:
+
+```py
+from typing import Awaitable
+from typing_extensions import Never
+
+class UnionOfAwaitables:
+    def __aenter__(self) -> Awaitable[int] | Awaitable[str]:
+        raise NotImplementedError
+
+    def __aexit__(self, exc_type, exc, tb) -> Awaitable[None]:
+        raise NotImplementedError
+
+class NeverReturns:
+    def __aenter__(self) -> Never:
+        raise NotImplementedError
+
+    async def __aexit__(self, exc_type, exc, tb) -> None: ...
+
+async def main():
+    async with UnionOfAwaitables() as a:
+        reveal_type(a)  # revealed: int | str
+    async with NeverReturns() as b:
+        reveal_type(b)  # revealed: Never
+```
+
+A union is only awaitable if every member is, so mixing an awaitable with a plain value is still an
+error:
+
+```py
+from typing import Awaitable
+
+class Manager:
+    def __aenter__(self) -> int | Awaitable[int]:
+        raise NotImplementedError
+
+    async def __aexit__(self, exc_type, exc, tb) -> None: ...
+
+async def main():
+    # error: [invalid-context-manager] "Object of type `Manager` cannot be used with `async with` because `__aenter__` does not return an awaitable"
+    async with Manager():
+        pass
+```
+
+A method whose return type is not known does not produce a diagnostic either:
+
+```py
+from typing import Any
+
+class ReturnsAny:
+    def __aenter__(self) -> Any: ...
+    def __aexit__(self, exc_type, exc, tb) -> Any: ...
+
+class Unannotated:
+    def __aenter__(self): ...
+    def __aexit__(self, exc_type, exc, tb): ...
+
+async def main():
+    async with ReturnsAny() as a:
+        reveal_type(a)  # revealed: Any
+    async with Unannotated() as b:
+        reveal_type(b)  # revealed: Unknown
+```
+
 ## `@asynccontextmanager`
 
 ```py

--- a/crates/ty_python_semantic/src/types/context_manager.rs
+++ b/crates/ty_python_semantic/src/types/context_manager.rs
@@ -60,13 +60,39 @@ impl<'db> Type<'db> {
 
         // TODO: Make use of Protocols when we support it (the manager be assignable to `contextlib.AbstractContextManager`).
         match (enter, exit) {
-            (Ok(enter), Ok(_)) => {
-                let ty = enter.return_type(db);
-                Ok(if mode.is_async() {
-                    ty.try_await(db).unwrap_or(Type::unknown())
-                } else {
-                    ty
-                })
+            (Ok(enter), Ok(exit)) => {
+                let enter_return_type = enter.return_type(db);
+
+                if !mode.is_async() {
+                    return Ok(enter_return_type);
+                }
+
+                // `async with` awaits whatever `__aenter__` and `__aexit__` return, so a method
+                // that is callable but returns a non-awaitable still fails at runtime:
+                //
+                // ```python
+                // class C:
+                //     def __aenter__(self) -> int: ...  # `await`ing an `int` raises `TypeError`
+                // ```
+                let (awaited_enter_type, non_awaitable_enter) =
+                    match enter_return_type.try_await(db) {
+                        Ok(awaited) => (awaited, None),
+                        Err(_) => (Type::unknown(), Some(enter_return_type)),
+                    };
+
+                let exit_return_type = exit.return_type(db);
+                let non_awaitable_exit = exit_return_type
+                    .try_await(db)
+                    .is_err()
+                    .then_some(exit_return_type);
+
+                match NonAwaitableMethods::from_parts(non_awaitable_enter, non_awaitable_exit) {
+                    None => Ok(awaited_enter_type),
+                    Some(non_awaitable) => Err(ContextManagerError::NotAwaitable {
+                        enter_return_type: awaited_enter_type,
+                        non_awaitable,
+                    }),
+                }
             }
             (Ok(enter), Err(exit_error)) => {
                 let ty = enter.return_type(db);
@@ -105,6 +131,56 @@ pub(super) enum ContextManagerError<'db> {
         exit_error: CallDunderError<'db>,
         mode: EvaluationMode,
     },
+    /// `__aenter__` and `__aexit__` are both callable, but at least one of them returns a value
+    /// that cannot be awaited. This can only happen in [`EvaluationMode::Async`], since `with`
+    /// does not await what `__enter__` and `__exit__` return.
+    NotAwaitable {
+        /// The type bound to the `as` target, already awaited when `__aenter__` allowed it.
+        enter_return_type: Type<'db>,
+        non_awaitable: NonAwaitableMethods<'db>,
+    },
+}
+
+/// Which of `__aenter__` and `__aexit__` returned a value that cannot be awaited, and what each
+/// of them returned.
+///
+/// At least one method must be at fault for the enclosing error to exist, which is why this is an
+/// enum rather than a pair of `Option`s or a collection that could be empty.
+#[derive(Debug)]
+pub(super) enum NonAwaitableMethods<'db> {
+    Enter(Type<'db>),
+    Exit(Type<'db>),
+    Both { enter: Type<'db>, exit: Type<'db> },
+}
+
+impl<'db> NonAwaitableMethods<'db> {
+    /// Builds the error description from whichever methods are at fault, or `None` if both
+    /// returned awaitables and there is nothing to report.
+    fn from_parts(enter: Option<Type<'db>>, exit: Option<Type<'db>>) -> Option<Self> {
+        match (enter, exit) {
+            (Some(enter), Some(exit)) => Some(Self::Both { enter, exit }),
+            (Some(enter), None) => Some(Self::Enter(enter)),
+            (None, Some(exit)) => Some(Self::Exit(exit)),
+            (None, None) => None,
+        }
+    }
+
+    /// The offending return types, paired with the name of the method that returned each one.
+    fn named_return_types(
+        &self,
+        enter_method: &'static str,
+        exit_method: &'static str,
+    ) -> Vec<(&'static str, Type<'db>)> {
+        match self {
+            Self::Enter(enter) => vec![(enter_method, *enter)],
+            Self::Exit(exit) => vec![(exit_method, *exit)],
+            Self::Both { enter, exit } => vec![(enter_method, *enter), (exit_method, *exit)],
+        }
+    }
+
+    const fn is_both(&self) -> bool {
+        matches!(self, Self::Both { .. })
+    }
 }
 
 impl<'db> ContextManagerError<'db> {
@@ -120,6 +196,10 @@ impl<'db> ContextManagerError<'db> {
                 enter_return_type,
                 exit_error: _,
                 mode: _,
+            }
+            | Self::NotAwaitable {
+                enter_return_type,
+                non_awaitable: _,
             } => Some(*enter_return_type),
             Self::Enter(enter_error, _)
             | Self::EnterAndExit {
@@ -160,6 +240,8 @@ impl<'db> ContextManagerError<'db> {
             Self::Exit { mode, .. } | Self::Enter(_, mode) | Self::EnterAndExit { mode, .. } => {
                 *mode
             }
+            // `NotAwaitable` is only ever constructed for `async with`.
+            Self::NotAwaitable { .. } => EvaluationMode::Async,
         };
 
         let (enter_method, exit_method) = match mode {
@@ -218,6 +300,19 @@ impl<'db> ContextManagerError<'db> {
                 exit_error,
                 mode: _,
             } => format_call_dunder_errors(enter_error, enter_method, exit_error, exit_method),
+            Self::NotAwaitable { non_awaitable, .. } => {
+                let methods = non_awaitable
+                    .named_return_types(enter_method, exit_method)
+                    .iter()
+                    .map(|(name, _)| format!("`{name}`"))
+                    .collect::<Vec<_>>()
+                    .join(" and ");
+                if non_awaitable.is_both() {
+                    format!("{methods} do not return awaitables")
+                } else {
+                    format!("{methods} does not return an awaitable")
+                }
+            }
         };
 
         // Suggest using `async with` if only async methods are available in a sync context,
@@ -284,6 +379,28 @@ impl<'db> ContextManagerError<'db> {
                     }
                 }
             }
+            Self::NotAwaitable { non_awaitable, .. } => {
+                for (method, return_type) in
+                    non_awaitable.named_return_types(enter_method, exit_method)
+                {
+                    diag.info(format_args!(
+                        "`{method}` returns `{}`, which is not awaitable",
+                        return_type.display(db)
+                    ));
+                }
+                if non_awaitable.is_both() {
+                    diag.info("Consider declaring the methods with `async def`");
+                } else {
+                    diag.info("Consider declaring the method with `async def`");
+                }
+            }
+        }
+
+        // The remaining hint suggests switching between `with` and `async with`. That is not the
+        // problem here: the object already implements the methods for the mode it was used in,
+        // they just return values that cannot be awaited.
+        if matches!(self, Self::NotAwaitable { .. }) {
+            return;
         }
 
         let (alt_mode, alt_enter_method, alt_exit_method, alt_with_kw) = match mode {

--- a/crates/ty_python_semantic/src/types/context_manager.rs
+++ b/crates/ty_python_semantic/src/types/context_manager.rs
@@ -68,11 +68,13 @@ impl<'db> Type<'db> {
             };
 
             let enter_return_type = return_type(&enter);
+            let exit_return_type = return_type(&exit);
             let awaited_enter_type =
                 enter_return_type.and_then(|return_type| return_type.try_await(db).ok());
+            let awaited_exit_type =
+                exit_return_type.and_then(|return_type| return_type.try_await(db).ok());
             let non_awaitable_enter = enter_return_type.filter(|_| awaited_enter_type.is_none());
-            let non_awaitable_exit =
-                return_type(&exit).filter(|return_type| return_type.try_await(db).is_err());
+            let non_awaitable_exit = exit_return_type.filter(|_| awaited_exit_type.is_none());
 
             if let Some(non_awaitable) =
                 NonAwaitableMethods::from_parts(non_awaitable_enter, non_awaitable_exit)
@@ -101,12 +103,12 @@ impl<'db> Type<'db> {
                 })
             }
             (Ok(enter), Err(exit_error)) => {
-                let ty = enter.return_type(db);
+                let return_type = enter.return_type(db);
                 Err(ContextManagerError::Exit {
                     enter_return_type: if mode.is_async() {
-                        ty.try_await(db).unwrap_or(Type::unknown())
+                        awaited_enter_type.unwrap_or(Type::unknown())
                     } else {
-                        ty
+                        return_type
                     },
                     exit_error,
                     mode,

--- a/crates/ty_python_semantic/src/types/context_manager.rs
+++ b/crates/ty_python_semantic/src/types/context_manager.rs
@@ -478,9 +478,7 @@ impl<'db> ContextManagerError<'db> {
             }
         }
 
-        // The remaining hint suggests switching between `with` and `async with`. That is not the
-        // problem here: the object already implements the methods for the mode it was used in,
-        // they just return values that cannot be awaited.
+        // Do not suggest switching between `with` and `async with` for a non-awaitable return.
         if matches!(self, Self::NotAwaitable { .. }) {
             return;
         }

--- a/crates/ty_python_semantic/src/types/context_manager.rs
+++ b/crates/ty_python_semantic/src/types/context_manager.rs
@@ -1,7 +1,7 @@
 use crate::{
     Db, FxOrderSet,
     types::{
-        CallArguments, CallDunderError, Type, TypeContext, call::CallErrorKind,
+        Bindings, CallArguments, CallDunderError, Type, TypeContext, call::CallErrorKind,
         context::InferContext, diagnostic::INVALID_CONTEXT_MANAGER,
     },
 };
@@ -58,41 +58,47 @@ impl<'db> Type<'db> {
             TypeContext::default(),
         );
 
+        let awaited_enter_type = if mode.is_async() {
+            let return_type = |call: &Result<Bindings<'db>, CallDunderError<'db>>| match call {
+                Ok(bindings) => Some(bindings.return_type(db)),
+                Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
+                    Some(bindings.return_type(db))
+                }
+                Err(CallDunderError::MethodNotAvailable | CallDunderError::CallError(..)) => None,
+            };
+
+            let enter_return_type = return_type(&enter);
+            let awaited_enter_type =
+                enter_return_type.and_then(|return_type| return_type.try_await(db).ok());
+            let non_awaitable_enter = enter_return_type.filter(|_| awaited_enter_type.is_none());
+            let non_awaitable_exit =
+                return_type(&exit).filter(|return_type| return_type.try_await(db).is_err());
+
+            if let Some(non_awaitable) =
+                NonAwaitableMethods::from_parts(non_awaitable_enter, non_awaitable_exit)
+            {
+                return Err(ContextManagerError::NotAwaitable {
+                    enter_return_type: awaited_enter_type.unwrap_or(Type::unknown()),
+                    non_awaitable,
+                    enter_error: enter.err().map(Box::new),
+                    exit_error: exit.err().map(Box::new),
+                });
+            }
+
+            awaited_enter_type
+        } else {
+            None
+        };
+
         // TODO: Make use of Protocols when we support it (the manager be assignable to `contextlib.AbstractContextManager`).
         match (enter, exit) {
-            (Ok(enter), Ok(exit)) => {
-                let enter_return_type = enter.return_type(db);
-
-                if !mode.is_async() {
-                    return Ok(enter_return_type);
-                }
-
-                // `async with` awaits whatever `__aenter__` and `__aexit__` return, so a method
-                // that is callable but returns a non-awaitable still fails at runtime:
-                //
-                // ```python
-                // class C:
-                //     def __aenter__(self) -> int: ...  # `await`ing an `int` raises `TypeError`
-                // ```
-                let (awaited_enter_type, non_awaitable_enter) =
-                    match enter_return_type.try_await(db) {
-                        Ok(awaited) => (awaited, None),
-                        Err(_) => (Type::unknown(), Some(enter_return_type)),
-                    };
-
-                let exit_return_type = exit.return_type(db);
-                let non_awaitable_exit = exit_return_type
-                    .try_await(db)
-                    .is_err()
-                    .then_some(exit_return_type);
-
-                match NonAwaitableMethods::from_parts(non_awaitable_enter, non_awaitable_exit) {
-                    None => Ok(awaited_enter_type),
-                    Some(non_awaitable) => Err(ContextManagerError::NotAwaitable {
-                        enter_return_type: awaited_enter_type,
-                        non_awaitable,
-                    }),
-                }
+            (Ok(enter), Ok(_)) => {
+                let return_type = enter.return_type(db);
+                Ok(if mode.is_async() {
+                    awaited_enter_type.unwrap_or(Type::unknown())
+                } else {
+                    return_type
+                })
             }
             (Ok(enter), Err(exit_error)) => {
                 let ty = enter.return_type(db);
@@ -131,13 +137,14 @@ pub(super) enum ContextManagerError<'db> {
         exit_error: CallDunderError<'db>,
         mode: EvaluationMode,
     },
-    /// `__aenter__` and `__aexit__` are both callable, but at least one of them returns a value
-    /// that cannot be awaited. This can only happen in [`EvaluationMode::Async`], since `with`
-    /// does not await what `__enter__` and `__exit__` return.
+    /// At least one async context-manager method returns a non-awaitable, possibly in addition to
+    /// a missing or invalid method.
     NotAwaitable {
         /// The type bound to the `as` target, already awaited when `__aenter__` allowed it.
         enter_return_type: Type<'db>,
         non_awaitable: NonAwaitableMethods<'db>,
+        enter_error: Option<Box<CallDunderError<'db>>>,
+        exit_error: Option<Box<CallDunderError<'db>>>,
     },
 }
 
@@ -198,16 +205,22 @@ impl<'db> ContextManagerError<'db> {
                 mode: _,
             }
             | Self::NotAwaitable {
-                enter_return_type,
-                non_awaitable: _,
+                enter_return_type, ..
             } => Some(*enter_return_type),
-            Self::Enter(enter_error, _)
+            Self::Enter(enter_error, mode)
             | Self::EnterAndExit {
                 enter_error,
                 exit_error: _,
-                mode: _,
+                mode,
             } => match enter_error {
-                CallDunderError::PossiblyUnbound { bindings, .. } => Some(bindings.return_type(db)),
+                CallDunderError::PossiblyUnbound { bindings, .. } => {
+                    let return_type = bindings.return_type(db);
+                    Some(if mode.is_async() {
+                        return_type.try_await(db).unwrap_or(Type::unknown())
+                    } else {
+                        return_type
+                    })
+                }
                 CallDunderError::CallError(CallErrorKind::NotCallable, _, _) => None,
                 CallDunderError::CallError(_, bindings, _) => Some(bindings.return_type(db)),
                 CallDunderError::MethodNotAvailable => None,
@@ -300,17 +313,51 @@ impl<'db> ContextManagerError<'db> {
                 exit_error,
                 mode: _,
             } => format_call_dunder_errors(enter_error, enter_method, exit_error, exit_method),
-            Self::NotAwaitable { non_awaitable, .. } => {
+            Self::NotAwaitable {
+                non_awaitable,
+                enter_error,
+                exit_error,
+                ..
+            } => {
                 let methods = non_awaitable
                     .named_return_types(enter_method, exit_method)
                     .iter()
                     .map(|(name, _)| format!("`{name}`"))
                     .collect::<Vec<_>>()
                     .join(" and ");
-                if non_awaitable.is_both() {
+                let await_error = if non_awaitable.is_both() {
                     format!("{methods} do not return awaitables")
                 } else {
                     format!("{methods} does not return an awaitable")
+                };
+
+                match (enter_error.as_deref(), exit_error.as_deref()) {
+                    (
+                        Some(CallDunderError::PossiblyUnbound { .. }),
+                        Some(CallDunderError::PossiblyUnbound { .. }),
+                    ) if non_awaitable.is_both() => {
+                        format!(
+                            "`{enter_method}` and `{exit_method}` may be missing or return non-awaitables"
+                        )
+                    }
+                    (Some(enter_error), Some(exit_error)) => format!(
+                        "{}, and {await_error}",
+                        format_call_dunder_errors(
+                            enter_error,
+                            enter_method,
+                            exit_error,
+                            exit_method
+                        )
+                    ),
+                    (Some(enter_error), None) => format!(
+                        "{}, and {await_error}",
+                        format_call_dunder_error(enter_error, enter_method)
+                    ),
+                    (None, Some(exit_error)) => format!(
+                        "{}, and {await_error}",
+                        format_call_dunder_error(exit_error, exit_method)
+                    ),
+                    (None, None) => await_error,
                 }
             }
         };
@@ -379,7 +426,42 @@ impl<'db> ContextManagerError<'db> {
                     }
                 }
             }
-            Self::NotAwaitable { non_awaitable, .. } => {
+            Self::NotAwaitable {
+                non_awaitable,
+                enter_error,
+                exit_error,
+                ..
+            } => {
+                let enter_unbound_on = enter_error
+                    .as_deref()
+                    .map_or_else(FxOrderSet::default, unbound_on);
+                let exit_unbound_on = exit_error
+                    .as_deref()
+                    .map_or_else(FxOrderSet::default, unbound_on);
+
+                for ty in &enter_unbound_on {
+                    if exit_unbound_on.contains(ty) {
+                        diag.info(format_args!(
+                            "`{}` does not implement `{enter_method}` or `{exit_method}`",
+                            ty.display(db)
+                        ));
+                    } else {
+                        diag.info(format_args!(
+                            "`{}` does not implement `{enter_method}`",
+                            ty.display(db)
+                        ));
+                    }
+                }
+
+                for ty in &exit_unbound_on {
+                    if !enter_unbound_on.contains(ty) {
+                        diag.info(format_args!(
+                            "`{}` does not implement `{exit_method}`",
+                            ty.display(db)
+                        ));
+                    }
+                }
+
                 for (method, return_type) in
                     non_awaitable.named_return_types(enter_method, exit_method)
                 {


### PR DESCRIPTION
## Summary

`async with` awaits whatever `__aenter__` and `__aexit__` return, so a method that is callable but returns a non-awaitable still fails at runtime:

```python
class C:
    def __aenter__(self) -> int:
        return 0

    async def __aexit__(self, exc_type, exc, tb) -> None: ...

async def f() -> None:
    async with C() as x:  # TypeError: object int can't be used in 'await' expression
        ...
```

ty accepted both of these. `try_enter_with_mode` awaited the `__aenter__` return type with `try_await(db).unwrap_or(Type::unknown())`, discarding the failure and silently binding the target to `Unknown`, and it ignored the `__aexit__` return type entirely.

Both return types are now awaited in async mode, and a new `ContextManagerError::NotAwaitable` variant reports the methods at fault along with the offending return type:

```
error[invalid-context-manager]: Object of type `C` cannot be used with `async with` because `__aenter__` does not return an awaitable
  --> example.py:14:16
   |
14 |     async with C() as x:
   |                ^^^
info: `__aenter__` returns `int`, which is not awaitable
info: Consider declaring the method with `async def`
```

`NonAwaitableMethods` is an enum rather than a collection so that "at least one method is at fault" cannot be represented as an empty set.

The hint suggesting a switch between `with` and `async with` is suppressed for this variant. The object does implement the methods for the mode it was used in, so that suggestion would be misleading.

Sync `with` is unaffected, since it does not await what `__enter__` and `__exit__` return.

Closes astral-sh/ty#4124

## Test Plan

New cases in `with/async.md` cover a non-awaitable `__aenter__` (with a snapshot of the full diagnostic), a non-awaitable `__aexit__`, and both failing together.

Since the risk here is false positives on valid context managers, the following are asserted to remain clean:

- methods that return an awaitable without being `async def`, spelled as `Awaitable[T]`, as `Coroutine[...]`, and as a custom class implementing `__await__`
- union return types where every member is awaitable, and `Never`
- return types that are `Any` or unannotated

A mixed union (`int | Awaitable[int]`) is asserted to still be an error, since awaiting the non-awaitable arm fails.

Also verified manually, unchanged by this PR: `asyncio.timeout`, `asyncio.TaskGroup`, `@asynccontextmanager`, protocol-typed context managers, inherited `__aenter__`/`__aexit__`, and sync `with`. A possibly-unbound `__aenter__` continues to report the pre-existing diagnostic rather than double-reporting.

Checks run:

- `cargo test -p ty_python_semantic`: 297 + 14 unit tests and 479 mdtests pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `uv run --only-group dev --locked prek run --files ...`: passes
- `cargo dev generate-all`: no changes (this reuses the existing `invalid-context-manager` rule)
