### PR TITLE
[ty] Fix stack overflow on recursive `__call__` attributes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callable_instance.md
@@ -58,6 +58,76 @@ a = NonCallable()
 reveal_type(a())  # revealed: Unknown
 ```
 
+## Recursive non-callable `__call__`
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+A `__call__` chain that never reaches a callable signature is not callable:
+
+```py
+from typing import Callable
+
+class Direct:
+    __call__: "Direct"
+
+Direct()()  # error: [call-non-callable] "Object of type `Direct` is not callable"
+
+class IndirectA:
+    __call__: "IndirectB"
+
+class IndirectB:
+    __call__: IndirectA
+
+IndirectA()()  # error: [call-non-callable] "Object of type `IndirectA` is not callable"
+```
+
+Only the cyclic union variant is non-callable:
+
+```py
+class Mixed:
+    __call__: "Mixed | Callable[[], int]"
+
+result = Mixed()()  # error: [call-non-callable] "Object of type `Mixed` is not callable"
+reveal_type(result)  # revealed: Unknown | int
+```
+
+Callable assignability follows the same chain without a call expression:
+
+```py
+class Cyclic:
+    __call__: "Cyclic"
+
+def takes_callable(f: Callable[[], int]) -> None: ...
+def _(x: Cyclic, y: Cyclic | Callable[[], int]) -> None:
+    takes_callable(x)  # error: [invalid-argument-type]
+    reveal_type(y)  # revealed: Cyclic | (() -> int)
+```
+
+Exact-cycle detection cannot stop a chain whose specialization grows at every step:
+
+```py
+class Growing[T]:
+    __call__: "Growing[list[T]]"
+
+def _(x: Growing[int]) -> None:
+    takes_callable(x)  # error: [invalid-argument-type]
+    x()  # error: [call-non-callable] "Object of type `Growing[int]` is not callable"
+```
+
+Finite specialization chains still resolve:
+
+```py
+class Wrapper[T]:
+    __call__: "T"
+
+def _(x: Wrapper[Wrapper[Callable[[], int]]]) -> None:
+    takes_callable(x)
+    reveal_type(x())  # revealed: int
+```
+
 ## Possibly non-callable `__call__`
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -23,6 +23,7 @@ use smallvec::smallvec_inline;
 use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
+use self::cyclic::ActiveRecursionDetector;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
 pub(crate) use self::diagnostic::TypeCheckDiagnostics;
@@ -171,6 +172,10 @@ mod definition;
 #[cfg(test)]
 mod property_tests;
 mod subscript;
+
+/// Bounds type-growing `__call__` chains such as `C[T].__call__: C[list[T]]`.
+/// Matches `MAX_TUPLE_EXPANSION` in `type_expansion`.
+const MAX_DUNDER_CALL_EXPANSION: usize = 64;
 
 pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
     let _span = tracing::trace_span!("check_types", ?file).entered();
@@ -4545,8 +4550,16 @@ impl<'db> Type<'db> {
     /// elements. It's usually best to only worry about "callability" relative to a particular
     /// argument list, via [`try_call`][Self::try_call] and [`CallErrorKind::NotCallable`].
     fn bindings(self, db: &'db dyn Db) -> Bindings<'db> {
+        self.bindings_impl(db, &ActiveRecursionDetector::default())
+    }
+
+    fn bindings_impl(
+        self,
+        db: &'db dyn Db,
+        recursion_guard: &ActiveRecursionDetector<Type<'db>>,
+    ) -> Bindings<'db> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.bindings(db);
+            return fallback.bindings_impl(db, recursion_guard);
         }
 
         match self {
@@ -4558,11 +4571,16 @@ impl<'db> Type<'db> {
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => CallableBinding::not_callable(self).into(),
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.bindings(db),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        bound.bindings_impl(db, recursion_guard)
+                    }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Bindings::from_union(
                             self,
-                            constraints.elements(db).iter().map(|ty| ty.bindings(db)),
+                            constraints
+                                .elements(db)
+                                .iter()
+                                .map(|ty| ty.bindings_impl(db, recursion_guard)),
                         )
                     }
                 }
@@ -4785,17 +4803,18 @@ impl<'db> Type<'db> {
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
                     let bindings = match tvar.typevar(db).bound_or_constraints(db) {
-                        None => KnownClass::Type.to_instance(db).bindings(db),
+                        None => KnownClass::Type
+                            .to_instance(db)
+                            .bindings_impl(db, recursion_guard),
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            bound.to_meta_type(db).bindings(db)
+                            bound.to_meta_type(db).bindings_impl(db, recursion_guard)
                         }
                         Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                             Bindings::from_union(
                                 self,
-                                constraints
-                                    .elements(db)
-                                    .iter()
-                                    .map(|ty| ty.to_meta_type(db).bindings(db)),
+                                constraints.elements(db).iter().map(|ty| {
+                                    ty.to_meta_type(db).bindings_impl(db, recursion_guard)
+                                }),
                             )
                         }
                     };
@@ -4844,12 +4863,21 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
-                        let mut bindings = dunder_callable.bindings(db);
-                        bindings.replace_callable_type(dunder_callable, self);
-                        if boundness == Definedness::PossiblyUndefined {
-                            bindings.set_dunder_call_is_possibly_unbound();
-                        }
-                        bindings
+                        // Stop cyclic or excessively deep `__call__` expansion before it overflows.
+                        recursion_guard.visit_bounded(
+                            &self,
+                            MAX_DUNDER_CALL_EXPANSION,
+                            || CallableBinding::not_callable(self).into(),
+                            || {
+                                let mut bindings =
+                                    dunder_callable.bindings_impl(db, recursion_guard);
+                                bindings.replace_callable_type(dunder_callable, self);
+                                if boundness == Definedness::PossiblyUndefined {
+                                    bindings.set_dunder_call_is_possibly_unbound();
+                                }
+                                bindings
+                            },
+                        )
                     }
                     Place::Undefined => CallableBinding::not_callable(self).into(),
                 }
@@ -4867,17 +4895,19 @@ impl<'db> Type<'db> {
                 union
                     .elements(db)
                     .iter()
-                    .map(|element| element.bindings(db)),
+                    .map(|element| element.bindings_impl(db, recursion_guard)),
             ),
 
             Type::Intersection(intersection) => Bindings::from_intersection(
                 self,
                 intersection
                     .positive_elements_or_object(db)
-                    .map(|element| element.bindings(db)),
+                    .map(|element| element.bindings_impl(db, recursion_guard)),
             ),
 
-            Type::EnumComplement(complement) => complement.to_intersection(db).bindings(db),
+            Type::EnumComplement(complement) => complement
+                .to_intersection(db)
+                .bindings_impl(db, recursion_guard),
 
             Type::DataclassDecorator(_) => {
                 let typevar = BoundTypeVarInstance::synthetic(
@@ -4904,9 +4934,9 @@ impl<'db> Type<'db> {
             Type::SpecialForm(_) => CallableBinding::not_callable(self).into(),
 
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Enum(enum_literal) => {
-                    enum_literal.enum_class_instance(db).bindings(db)
-                }
+                LiteralValueTypeKind::Enum(enum_literal) => enum_literal
+                    .enum_class_instance(db)
+                    .bindings_impl(db, recursion_guard),
                 _ => CallableBinding::not_callable(self).into(),
             },
 
@@ -4923,13 +4953,13 @@ impl<'db> Type<'db> {
             Type::KnownInstance(
                 KnownInstanceType::FunctoolsPartial(partial)
                 | KnownInstanceType::FunctoolsPartialCall(partial),
-            ) => Type::Callable(partial.partial(db)).bindings(db),
+            ) => Type::Callable(partial.partial(db)).bindings_impl(db, recursion_guard),
 
-            Type::KnownInstance(known_instance) => {
-                known_instance.instance_fallback(db).bindings(db)
-            }
+            Type::KnownInstance(known_instance) => known_instance
+                .instance_fallback(db)
+                .bindings_impl(db, recursion_guard),
 
-            Type::TypeAlias(alias) => alias.value_type(db).bindings(db),
+            Type::TypeAlias(alias) => alias.value_type(db).bindings_impl(db, recursion_guard),
 
             Type::PropertyInstance(_)
             | Type::AlwaysFalsy

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -7,9 +7,11 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
         FunctionType, InternedType, KnownBoundMethodType, KnownClass, KnownInstanceType,
-        LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters, Signature,
-        SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionType,
+        LiteralValueTypeKind, MAX_DUNDER_CALL_EXPANSION, MemberLookupPolicy, Parameter, Parameters,
+        Signature, SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
+        UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
+        cyclic::ActiveRecursionDetector,
         known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
         signatures::{CallableSignature, PartialSignatureApplication},
@@ -54,6 +56,7 @@ impl<'db> Type<'db> {
             UpcastPolicy::default(),
             CallableUpcastContext {
                 recursive_definition,
+                active_dunder_calls: &ActiveRecursionDetector::default(),
             },
         )
     }
@@ -66,7 +69,10 @@ impl<'db> Type<'db> {
         self.try_upcast_to_callable_with_policy_and_context(
             db,
             policy,
-            CallableUpcastContext::default(),
+            CallableUpcastContext {
+                recursive_definition: None,
+                active_dunder_calls: &ActiveRecursionDetector::default(),
+            },
         )
     }
 
@@ -74,7 +80,7 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         policy: UpcastPolicy,
-        context: CallableUpcastContext<'db>,
+        context: CallableUpcastContext<'_, 'db>,
     ) -> Option<CallableTypes<'db>> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
             return fallback.try_upcast_to_callable_with_policy_and_context(db, policy, context);
@@ -121,12 +127,21 @@ impl<'db> Type<'db> {
                 if let Place::Defined(place) = call_symbol
                     && place.is_definitely_defined()
                 {
-                    place
-                        .ty
-                        .try_upcast_to_callable_with_policy_and_context(db, policy, context)
-                        // The callable instance itself doesn't inherit the descriptor behavior of
-                        // its `__call__` method.
-                        .map(|callables| callables.map(|callable| callable.into_regular(db)))
+                    context.active_dunder_calls.visit_bounded(
+                        &self,
+                        MAX_DUNDER_CALL_EXPANSION,
+                        || None,
+                        || {
+                            place
+                                .ty
+                                .try_upcast_to_callable_with_policy_and_context(db, policy, context)
+                                // The callable instance itself doesn't inherit the descriptor
+                                // behavior of its `__call__` method.
+                                .map(|callables| {
+                                    callables.map(|callable| callable.into_regular(db))
+                                })
+                        },
+                    )
                 } else {
                     None
                 }
@@ -305,12 +320,14 @@ impl<'db> Type<'db> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-struct CallableUpcastContext<'db> {
+#[derive(Clone, Copy, Debug)]
+struct CallableUpcastContext<'a, 'db> {
     recursive_definition: Option<Definition<'db>>,
+    /// Active `__call__` expansions.
+    active_dunder_calls: &'a ActiveRecursionDetector<Type<'db>>,
 }
 
-impl<'db> CallableUpcastContext<'db> {
+impl<'db> CallableUpcastContext<'_, 'db> {
     fn is_recursive_reference(self, db: &'db dyn Db, function: FunctionType<'db>) -> bool {
         self.recursive_definition
             .is_some_and(|definition| function.contains_definition(db, definition))

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -661,6 +661,21 @@ impl<T: Hash + Eq + Clone> ActiveRecursionDetector<T> {
 
         func()
     }
+
+    /// Calls `on_limit` when `item` is active or `max_depth` items are already active.
+    pub(crate) fn visit_bounded<R>(
+        &self,
+        item: &T,
+        max_depth: usize,
+        on_limit: impl FnOnce() -> R,
+        func: impl FnOnce() -> R,
+    ) -> R {
+        if self.seen.borrow().len() >= max_depth {
+            return on_limit();
+        }
+
+        self.visit(item, on_limit, func)
+    }
 }
 
 struct ActiveRecursionGuard<'a, T: Hash + Eq> {


### PR DESCRIPTION
Fixes astral-sh/ty#4148.

## Summary

ty determines whether an instance is callable by following its annotated `__call__` attribute.
Recursive annotations such as `class C: __call__: "C"` could therefore recurse until the process
overflowed its stack.

This happened through two independent paths: `Type::bindings` during call inference, and
`Type::try_upcast_to_callable_with_policy_and_context` during callable-relation checks. The latter
does not require a call expression; checking `C <: Callable[[], int]` also follows `__call__`.

Both paths now detect active `__call__` expansions. A repeated type is treated as not callable
because the cycle never reaches a callable signature. The expansion is also bounded because a
generic chain such as `C[int]`, `C[list[int]]`, and so on never repeats the same type. The detector
remains keyed by the full type so valid finite chains with different specializations still resolve.

## Test Plan

Added mdtests for direct and mutual cycles, a mixed union, the relation-only path, a growing generic
specialization, and a finite nested-generic chain that must still resolve to `int`.

Validated with:

- `cargo test -p ty_python_semantic`
- `cargo fmt --all -- --check`
- `cargo clippy -p ty_python_semantic --all-targets --all-features -- -D warnings`
- `ty check --python-version 3.14` on the original report and the focused reproductions
