### PR TITLE
[ty] Share inherited bound methods across union members

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -489,10 +489,10 @@ class Child(Parent):
         assert_type(self.create(), Self)
 ```
 
-## Inherited methods on union receivers
+## Inherited methods on a union
 
-A parameterless inherited method returning `Self` preserves every possible receiver when accessed
-through a union:
+If two classes inherit the same method, a union of their instances can share one bound method
+without losing either possible return type:
 
 ```py
 from typing import Self
@@ -506,50 +506,40 @@ class Original:
 
 class First(Original): ...
 class Second(Original): ...
+
+def shared_method(value: First | Second) -> None:
+    reveal_type(value.clone)  # revealed: bound method (First | Second).clone() -> First | Second
+```
+
+The bound method's `__func__` attribute is still the original function, so it also accepts another
+subclass of the declaring class:
+
+```py
 class Third(Original): ...
 
-def inherited(value: First | Second) -> None:
-    method = value.clone
-    reveal_type(method)  # revealed: bound method (First | Second).clone() -> First | Second
-    reveal_type(method.__self__)  # revealed: First | Second
-    reveal_type(method())  # revealed: First | Second
-    reveal_type(method.__func__(Third()))  # revealed: Third
+def declaring_function(value: First | Second) -> None:
+    reveal_type(value.clone.__func__(Third()))  # revealed: Third
+```
 
-    # An invariant container must retain the separate receiver specializations.
+A method that returns `list[Self]` must keep the two list types separate:
+
+```py
+def separate_list_types(value: First | Second) -> None:
     reveal_type(value.children())  # revealed: list[First] | list[Second]
 ```
 
-Combining a shared union-bound method with one concrete alternative must not discard the other
-possible receiver:
+Choosing between the shared method and a method bound to `First` must not remove `Second` from the
+return type:
 
 ```py
-def union_with_concrete_method(value: First | Second, first: First, flag: bool) -> None:
+def shared_or_first_method(value: First | Second, first: First, flag: bool) -> None:
     method = value.clone if flag else first.clone
-    reveal_type(method())  # revealed: First | Second
 
     # error: [invalid-assignment]
     result: First = method()
 ```
 
-The underlying function must retain its declaring class's original `Self` bound even when that class
-is generic:
-
-```py
-class GenericOriginal[T]:
-    def clone(self) -> Self:
-        return self
-
-class GenericFirst(GenericOriginal[int]): ...
-class GenericSecond(GenericOriginal[int]): ...
-class GenericThird(GenericOriginal[str]): ...
-
-def generic_declaring_function(value: GenericFirst | GenericSecond) -> None:
-    method = value.clone
-    reveal_type(method())  # revealed: GenericFirst | GenericSecond
-    reveal_type(method.__func__(GenericThird()))  # revealed: GenericThird
-```
-
-An override remains a separate bound method even when both implementations return `Self`:
+Methods with different implementations cannot be combined, even if both return `Self`:
 
 ```py
 class Overridden(Original):
@@ -559,7 +549,21 @@ class Overridden(Original):
 def overridden(value: First | Overridden) -> None:
     # revealed: (bound method First.clone() -> First) | (bound method Overridden.clone() -> Overridden)
     reveal_type(value.clone)
-    reveal_type(value.clone())  # revealed: First | Overridden
+```
+
+For a generic class, `__func__` must also accept a subclass with different type arguments:
+
+```py
+class GenericBase[T]:
+    def clone(self) -> Self:
+        return self
+
+class FirstInt(GenericBase[int]): ...
+class SecondInt(GenericBase[int]): ...
+class ThirdStr(GenericBase[str]): ...
+
+def generic_function(value: FirstInt | SecondInt) -> None:
+    reveal_type(value.clone.__func__(ThirdStr()))  # revealed: ThirdStr
 ```
 
 ## Attributes

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -489,6 +489,45 @@ class Child(Parent):
         assert_type(self.create(), Self)
 ```
 
+## Inherited methods on union receivers
+
+A parameterless inherited method returning `Self` preserves every possible receiver when accessed
+through a union:
+
+```py
+from typing import Self
+
+class Original:
+    def clone(self) -> Self:
+        return self
+
+    def children(self) -> list[Self]:
+        return [self]
+
+class First(Original): ...
+class Second(Original): ...
+
+def inherited(value: First | Second) -> None:
+    method = value.clone
+    reveal_type(method)  # revealed: bound method (First | Second).clone() -> First | Second
+    reveal_type(method.__self__)  # revealed: First | Second
+    reveal_type(method())  # revealed: First | Second
+
+    # An invariant container must retain the separate receiver specializations.
+    reveal_type(value.children())  # revealed: list[First] | list[Second]
+```
+
+An override remains a separate bound method even when both implementations return `Self`:
+
+```py
+class Overridden(Original):
+    def clone(self) -> Self:
+        return self
+
+def overridden(value: First | Overridden) -> None:
+    reveal_type(value.clone())  # revealed: First | Overridden
+```
+
 ## Attributes
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -527,6 +527,8 @@ class Overridden(Original):
         return self
 
 def overridden(value: First | Overridden) -> None:
+    # revealed: (bound method First.clone() -> First) | (bound method Overridden.clone() -> Overridden)
+    reveal_type(value.clone)
     reveal_type(value.clone())  # revealed: First | Overridden
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -506,12 +506,14 @@ class Original:
 
 class First(Original): ...
 class Second(Original): ...
+class Third(Original): ...
 
 def inherited(value: First | Second) -> None:
     method = value.clone
     reveal_type(method)  # revealed: bound method (First | Second).clone() -> First | Second
     reveal_type(method.__self__)  # revealed: First | Second
     reveal_type(method())  # revealed: First | Second
+    reveal_type(method.__func__(Third()))  # revealed: Third
 
     # An invariant container must retain the separate receiver specializations.
     reveal_type(value.children())  # revealed: list[First] | list[Second]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -519,6 +519,18 @@ def inherited(value: First | Second) -> None:
     reveal_type(value.children())  # revealed: list[First] | list[Second]
 ```
 
+Combining a shared union-bound method with one concrete alternative must not discard the other
+possible receiver:
+
+```py
+def union_with_concrete_method(value: First | Second, first: First, flag: bool) -> None:
+    method = value.clone if flag else first.clone
+    reveal_type(method())  # revealed: First | Second
+
+    # error: [invalid-assignment]
+    result: First = method()
+```
+
 An override remains a separate bound method even when both implementations return `Self`:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -531,6 +531,24 @@ def union_with_concrete_method(value: First | Second, first: First, flag: bool) 
     result: First = method()
 ```
 
+The underlying function must retain its declaring class's original `Self` bound even when that class
+is generic:
+
+```py
+class GenericOriginal[T]:
+    def clone(self) -> Self:
+        return self
+
+class GenericFirst(GenericOriginal[int]): ...
+class GenericSecond(GenericOriginal[int]): ...
+class GenericThird(GenericOriginal[str]): ...
+
+def generic_declaring_function(value: GenericFirst | GenericSecond) -> None:
+    method = value.clone
+    reveal_type(method())  # revealed: GenericFirst | GenericSecond
+    reveal_type(method.__func__(GenericThird()))  # revealed: GenericThird
+```
+
 An override remains a separate bound method even when both implementations return `Self`:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2589,6 +2589,13 @@ def copy_same_fallback(value: Left | Right) -> None:
     reveal_type(method.__self__)  # revealed: Left | Right
     reveal_type(method())  # revealed: Left | Right
 
+def copy_union_with_concrete_method(value: Left | Right, left: Left, flag: bool) -> None:
+    method = value.copy if flag else left.copy
+    reveal_type(method())  # revealed: Left | Right
+
+    # error: [invalid-assignment]
+    result: Left = method()
+
 def copy_mixed_fallback(value: Left | Extension) -> None:
     method = value.copy
     reveal_type(method.__self__)  # revealed: Left | Extension

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2565,6 +2565,39 @@ def _(u: IntX | StrX) -> None:
     reveal_type(u.setdefault("x", 1))  # revealed: int | str
 ```
 
+## Copying a union of `TypedDict` instances
+
+The copied value retains every possible receiver, including when the union combines `TypedDict`
+classes from different fallback implementations:
+
+```py
+from typing import TypedDict
+from typing_extensions import TypedDict as ExtensionTypedDict
+
+class Left(TypedDict):
+    left: int
+
+class Right(TypedDict):
+    right: str
+
+class Extension(ExtensionTypedDict):
+    extension: bytes
+
+def copy_same_fallback(value: Left | Right) -> None:
+    method = value.copy
+    reveal_type(method)  # revealed: bound method (Left | Right).copy() -> Left | Right
+    reveal_type(method.__self__)  # revealed: Left | Right
+    reveal_type(method())  # revealed: Left | Right
+
+def copy_mixed_fallback(value: Left | Extension) -> None:
+    method = value.copy
+    reveal_type(method.__self__)  # revealed: Left | Extension
+    reveal_type(method())  # revealed: Left | Extension
+
+def copy_mixed_receiver(value: Left | dict[str, int]) -> None:
+    reveal_type(value.copy())  # revealed: Left | dict[str, int]
+```
+
 ## Unlike normal classes
 
 `TypedDict` types do not act like normal classes. For example, calling `type(..)` on an inhabitant

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2567,12 +2567,11 @@ def _(u: IntX | StrX) -> None:
 
 ## Copying a union of `TypedDict` instances
 
-The copied value retains every possible receiver, including when the union combines `TypedDict`
-classes from different fallback implementations:
+Two `TypedDict` classes from `typing` inherit the same `copy` method. A union of their instances
+therefore has one bound method that preserves both classes:
 
 ```py
 from typing import TypedDict
-from typing_extensions import TypedDict as ExtensionTypedDict
 
 class Left(TypedDict):
     left: int
@@ -2580,29 +2579,32 @@ class Left(TypedDict):
 class Right(TypedDict):
     right: str
 
-class Extension(ExtensionTypedDict):
-    extension: bytes
+def copy_union(value: Left | Right) -> None:
+    reveal_type(value.copy)  # revealed: bound method (Left | Right).copy() -> Left | Right
+```
 
-def copy_same_fallback(value: Left | Right) -> None:
-    method = value.copy
-    reveal_type(method)  # revealed: bound method (Left | Right).copy() -> Left | Right
-    reveal_type(method.__self__)  # revealed: Left | Right
-    reveal_type(method())  # revealed: Left | Right
+Choosing between this method and one bound to `Left` must not remove `Right` from the return type:
 
-def copy_union_with_concrete_method(value: Left | Right, left: Left, flag: bool) -> None:
+```py
+def copy_union_or_left(value: Left | Right, left: Left, flag: bool) -> None:
     method = value.copy if flag else left.copy
-    reveal_type(method())  # revealed: Left | Right
 
     # error: [invalid-assignment]
     result: Left = method()
+```
 
-def copy_mixed_fallback(value: Left | Extension) -> None:
-    method = value.copy
-    reveal_type(method.__self__)  # revealed: Left | Extension
-    reveal_type(method())  # revealed: Left | Extension
+A `TypedDict` created with `typing_extensions.TypedDict` does not share the same `copy` definition,
+so its bound method must remain separate:
 
-def copy_mixed_receiver(value: Left | dict[str, int]) -> None:
-    reveal_type(value.copy())  # revealed: Left | dict[str, int]
+```py
+from typing_extensions import TypedDict as ExtensionTypedDict
+
+class Extension(ExtensionTypedDict):
+    extension: bytes
+
+def separate_copy_methods(value: Left | Extension) -> None:
+    # revealed: (bound method Left.copy() -> Left) | (bound method Extension.copy() -> Extension)
+    reveal_type(value.copy)
 ```
 
 ## Unlike normal classes

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3871,6 +3871,29 @@ impl<'db> Type<'db> {
                 policy: MemberLookupPolicy,
             ) -> Option<Vec<PlaceAndQualifiers<'db>>> {
                 let receiver = Type::Union(union);
+                let mut shared_function_literal = None;
+
+                for element in union.elements(db) {
+                    let member =
+                        element.member_lookup_with_policy_and_receiver(db, name, policy, None);
+                    let Place::Defined(DefinedPlace {
+                        ty: Type::BoundMethod(method),
+                        definedness: Definedness::AlwaysDefined,
+                        ..
+                    }) = member.place
+                    else {
+                        return None;
+                    };
+
+                    let function_literal = method.function(db).literal(db);
+                    if shared_function_literal.is_some_and(|shared_function_literal| {
+                        shared_function_literal != function_literal
+                    }) {
+                        return None;
+                    }
+                    shared_function_literal = Some(function_literal);
+                }
+
                 let mut methods = Vec::with_capacity(union.elements(db).len());
                 let mut shared_function: Option<FunctionType<'db>> = None;
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3893,15 +3893,22 @@ impl<'db> Type<'db> {
                         return None;
                     }
 
-                    let mapping = TypeMapping::ReplaceSelf {
-                        new_upper_bound: receiver,
+                    let original_function = method.function(db);
+                    let unspecialized_function =
+                        FunctionType::new(db, original_function.literal(db), None);
+                    let function = if original_function == unspecialized_function {
+                        original_function
+                    } else {
+                        let mapping = TypeMapping::ReplaceSelf {
+                            new_upper_bound: receiver,
+                        };
+                        original_function.apply_type_mapping_impl(
+                            db,
+                            &mapping,
+                            TypeContext::default(),
+                            &ApplyTypeMappingVisitor::default(),
+                        )
                     };
-                    let function = method.function(db).apply_type_mapping_impl(
-                        db,
-                        &mapping,
-                        TypeContext::default(),
-                        &ApplyTypeMappingVisitor::default(),
-                    );
                     let method = BoundMethodType::new(db, function, receiver);
                     let [signature] = method.bound_signatures(db).overloads.as_slice() else {
                         return None;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3859,6 +3859,67 @@ impl<'db> Type<'db> {
                 promote_inferred_attribute_class_literals(db, result)
             }
 
+            /// Collapse separately bound instances of the same receiver-returning method.
+            ///
+            /// This is only sound for parameterless methods whose return type is exactly the
+            /// receiver: method arguments or a return such as `list[Self]` can retain
+            /// correlations that would be lost by replacing each receiver with their union.
+            fn shared_receiver_returning_methods<'db>(
+                db: &'db dyn Db,
+                union: UnionType<'db>,
+                name: &str,
+                policy: MemberLookupPolicy,
+            ) -> Option<Vec<PlaceAndQualifiers<'db>>> {
+                let receiver = Type::Union(union);
+                let mut methods = Vec::with_capacity(union.elements(db).len());
+                let mut shared_function: Option<FunctionType<'db>> = None;
+
+                for element in union.elements(db) {
+                    let member =
+                        element.member_lookup_with_policy_and_receiver(db, name, policy, None);
+                    let Place::Defined(DefinedPlace {
+                        ty: Type::BoundMethod(method),
+                        definedness: Definedness::AlwaysDefined,
+                        ..
+                    }) = member.place
+                    else {
+                        return None;
+                    };
+
+                    let [signature] = method.bound_signatures(db).overloads.as_slice() else {
+                        return None;
+                    };
+                    if signature.parameters().len() != 0 || signature.return_ty != *element {
+                        return None;
+                    }
+
+                    let mapping = TypeMapping::ReplaceSelf {
+                        new_upper_bound: receiver,
+                    };
+                    let function = method.function(db).apply_type_mapping_impl(
+                        db,
+                        &mapping,
+                        TypeContext::default(),
+                        &ApplyTypeMappingVisitor::default(),
+                    );
+                    let method = BoundMethodType::new(db, function, receiver);
+                    let [signature] = method.bound_signatures(db).overloads.as_slice() else {
+                        return None;
+                    };
+                    if signature.parameters().len() != 0 || signature.return_ty != receiver {
+                        return None;
+                    }
+
+                    if shared_function.is_some_and(|shared_function| shared_function != function) {
+                        return None;
+                    }
+                    shared_function = Some(function);
+                    methods.push(member.map_type(|_| Type::BoundMethod(method)));
+                }
+
+                Some(methods)
+            }
+
             let this = key.ty(db);
             let name = key.name(db);
             let name_str = name.as_str();
@@ -3871,9 +3932,23 @@ impl<'db> Type<'db> {
             }
 
             match this {
-                Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
-                    elem.member_lookup_with_policy_and_receiver(db, name_str, policy, receiver)
-                }),
+                Type::Union(union) => {
+                    let mut shared_methods = receiver
+                        .is_none()
+                        .then(|| shared_receiver_returning_methods(db, union, name_str, policy))
+                        .flatten()
+                        .map(Vec::into_iter);
+                    union.map_with_boundness_and_qualifiers(db, |element| {
+                        shared_methods
+                            .as_mut()
+                            .and_then(Iterator::next)
+                            .unwrap_or_else(|| {
+                                element.member_lookup_with_policy_and_receiver(
+                                    db, name_str, policy, receiver,
+                                )
+                            })
+                    })
+                }
 
                 Type::Intersection(intersection) => {
                     if let Some(complement) = intersection.enum_complement(db) {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3922,15 +3922,43 @@ impl<'db> Type<'db> {
                     let function = if original_function == unspecialized_function {
                         original_function
                     } else {
-                        let mapping = TypeMapping::ReplaceSelf {
-                            new_upper_bound: receiver,
+                        let original_signature = original_function.signature(db);
+                        let [signature] = original_signature.overloads.as_slice() else {
+                            return None;
                         };
-                        original_function.apply_type_mapping_impl(
-                            db,
-                            &mapping,
-                            TypeContext::default(),
-                            &ApplyTypeMappingVisitor::default(),
-                        )
+
+                        // A generic declaring class bounds `Self` by its class, not by any
+                        // particular specialization of that class.
+                        let receiver_satisfies_original_self_bound = match signature.return_ty {
+                            Type::TypeVar(typevar)
+                                if typevar.typevar(db).is_self(db)
+                                    && let Some(declaring_class) = typevar
+                                        .typevar(db)
+                                        .upper_bound(db)
+                                        .and_then(|upper_bound| upper_bound.nominal_class(db))
+                                    && let Some(receiver_class) = element.nominal_class(db) =>
+                            {
+                                receiver_class.is_subtype_of_class_literal(
+                                    db,
+                                    declaring_class.class_literal(db),
+                                )
+                            }
+                            _ => false,
+                        };
+
+                        if receiver_satisfies_original_self_bound {
+                            original_function
+                        } else {
+                            let mapping = TypeMapping::ReplaceSelf {
+                                new_upper_bound: receiver,
+                            };
+                            original_function.apply_type_mapping_impl(
+                                db,
+                                &mapping,
+                                TypeContext::default(),
+                                &ApplyTypeMappingVisitor::default(),
+                            )
+                        }
                     };
                     let method = BoundMethodType::new(db, function, receiver);
                     let [signature] = method.bound_signatures(db).overloads.as_slice() else {


### PR DESCRIPTION
## Summary

Built on #27421, which fixes bound-method receiver variance independently.

Generalize the optimization explored in #27413 from `TypedDict.copy()` to any inherited, parameterless method whose return type is exactly `Self`.

```python
from typing import Self

class Base:
    def clone(self) -> Self: ...

class A(Base): ...
class B(Base): ...

def clone(value: A | B) -> None:
    reveal_type(value.clone)
    # Before: (bound method A.clone() -> A) | (bound method B.clone() -> B)
    # After: bound method (A | B).clone() -> A | B
```

When every union member resolves to the same function, bind that function to the entire receiver union instead of constructing and comparing a separate bound method for each member. This also covers `TypedDict.copy()` without adding a `TypedDict`-specific lookup path.

Preserve the original function exposed through `__func__`, including its declaring-class bound for generic classes; reject overridden or otherwise distinct functions before interning candidates; and avoid combining methods with correlated return types such as `list[Self]`.

On nine alternating, single-threaded Pydantic runs with identical diagnostics, this reduces CPU time by a median of 5.6% per paired run. Synthetic unions of 192 and 256 `TypedDict` classes improve by 24.6% and 16.7%, respectively, and a 96-class inherited-method union improves by 6.3%. The complete semantic and IDE suites pass: 2,592 tests.
