### PR TITLE
Use `LinterSettings` builder methods in tests

### DIFF
--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -518,7 +518,7 @@ mod tests {
     use ruff_linter::settings::LinterSettings;
     use ruff_linter::settings::flags;
     use ruff_linter::settings::types::UnsafeFixes;
-    use ruff_python_ast::{PySourceType, PythonVersion};
+    use ruff_python_ast::PySourceType;
     use ruff_workspace::Settings;
 
     use crate::cache::{self, ChangeData, FileCache, FileCacheData, FileCacheKey};
@@ -536,10 +536,7 @@ mod tests {
 
         let settings = Settings {
             cache_dir,
-            linter: LinterSettings {
-                unresolved_target_version: PythonVersion::latest().into(),
-                ..LinterSettings::for_rule(Rule::UnusedVariable)
-            },
+            linter: LinterSettings::for_rule(Rule::UnusedVariable),
             ..Settings::default()
         };
 

--- a/crates/ruff_linter/src/rules/fastapi/mod.rs
+++ b/crates/ruff_linter/src/rules/fastapi/mod.rs
@@ -41,14 +41,8 @@ mod tests {
         assert_diagnostics_diff!(
             snapshot,
             Path::new("fastapi").join(path).as_path(),
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY313.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY314.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY313),
+            &LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY314),
         );
         Ok(())
     }
@@ -62,10 +56,7 @@ mod tests {
         let snapshot = format!("{}_{}_py38", rule_code.name(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("fastapi").join(path).as_path(),
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY38.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY38),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_async/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/mod.rs
@@ -47,10 +47,8 @@ mod tests {
     fn async109_python_310_or_older(path: &Path) -> Result<()> {
         let diagnostics = test_path(
             Path::new("flake8_async").join(path),
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY310.into(),
-                ..LinterSettings::for_rule(Rule::AsyncFunctionWithTimeout)
-            },
+            &LinterSettings::for_rule(Rule::AsyncFunctionWithTimeout)
+                .with_target_version(PythonVersion::PY310),
         )?;
         assert_diagnostics!(path.file_name().unwrap().to_str().unwrap(), diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_bandit/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/mod.rs
@@ -12,7 +12,6 @@ mod tests {
 
     use crate::registry::Rule;
     use crate::settings::LinterSettings;
-    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_diagnostics, assert_diagnostics_diff};
 
@@ -116,14 +115,8 @@ mod tests {
         assert_diagnostics_diff!(
             snapshot,
             Path::new("flake8_bandit").join(path).as_path(),
-            &LinterSettings {
-                preview: PreviewMode::Disabled,
-                ..LinterSettings::for_rule(rule_code)
-            },
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(rule_code)
-            }
+            &LinterSettings::for_rule(rule_code),
+            &LinterSettings::for_rule(rule_code).with_preview_mode()
         );
         Ok(())
     }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -144,10 +144,7 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("flake8_bugbear").join(path).as_path(),
-            &LinterSettings {
-                unresolved_target_version: target_version.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code).with_target_version(target_version),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -17,7 +17,6 @@ mod tests {
     use crate::settings::LinterSettings;
     use crate::test::{test_path, test_snippet};
 
-    use crate::settings::types::PreviewMode;
     use ruff_python_ast::PythonVersion;
 
     #[test_case(Rule::AbstractBaseClassWithoutAbstractMethod, Path::new("B024.py"))]
@@ -105,11 +104,9 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("flake8_bugbear").join(path).as_path(),
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                unresolved_target_version: PythonVersion::PY314.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code)
+                .with_preview_mode()
+                .with_target_version(PythonVersion::PY314),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_builtins/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/mod.rs
@@ -73,14 +73,8 @@ mod tests {
         assert_diagnostics_diff!(
             snapshot,
             Path::new("flake8_builtins").join(path).as_path(),
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY313.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY314.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY313),
+            &LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY314),
         );
         Ok(())
     }
@@ -238,10 +232,7 @@ mod tests {
         let snapshot = format!("{}_{}_py38", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("flake8_builtins").join(path).as_path(),
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY38.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY38),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
@@ -15,7 +15,6 @@ mod tests {
     use crate::assert_diagnostics;
     use crate::registry::Rule;
     use crate::settings::LinterSettings;
-    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
 
     #[test_case(Rule::UnnecessaryCallAroundSorted, Path::new("C413.py"))]
@@ -78,10 +77,7 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("flake8_comprehensions").join(path).as_path(),
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code).with_preview_mode(),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
@@ -29,10 +29,8 @@ mod tests {
         let snapshot = path.to_string_lossy().into_owned();
         let diagnostics = test_path(
             Path::new("flake8_future_annotations").join(path).as_path(),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY37.into(),
-                ..settings::LinterSettings::for_rule(Rule::FutureRewritableTypeAnnotation)
-            },
+            &settings::LinterSettings::for_rule(Rule::FutureRewritableTypeAnnotation)
+                .with_target_version(PythonVersion::PY37),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
@@ -49,10 +47,8 @@ mod tests {
         let snapshot = format!("fa102_{}", path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("flake8_future_annotations").join(path).as_path(),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY37.into(),
-                ..settings::LinterSettings::for_rule(Rule::FutureRequiredTypeAnnotation)
-            },
+            &settings::LinterSettings::for_rule(Rule::FutureRequiredTypeAnnotation)
+                .with_target_version(PythonVersion::PY37),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
@@ -71,7 +71,6 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::Rule;
-    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_diagnostics, settings};
 
@@ -95,10 +94,7 @@ mod tests {
         let snapshot = format!("preview__{}_{}", rule_code.name(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("flake8_gettext").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code).with_preview_mode(),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
@@ -188,10 +188,7 @@ mod tests {
         let snapshot = format!("py38_{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("flake8_pyi").join(path).as_path(),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY38.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY38),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
@@ -11,7 +11,6 @@ mod tests {
 
     use crate::registry::Rule;
     use crate::rules::pep8_naming;
-    use crate::settings::types::PreviewMode;
     use crate::source_kind::SourceKind;
     use crate::test::{test_contents, test_path};
     use crate::{assert_diagnostics, assert_diagnostics_diff, settings};
@@ -156,14 +155,8 @@ mod tests {
         assert_diagnostics_diff!(
             snapshot,
             Path::new("flake8_pyi").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Disabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code),
+            &settings::LinterSettings::for_rule(rule_code).with_preview_mode(),
         );
         Ok(())
     }

--- a/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
@@ -11,7 +11,6 @@ mod tests {
 
     use crate::registry::Rule;
     use crate::settings::LinterSettings;
-    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_diagnostics, assert_diagnostics_diff, settings};
 
@@ -69,10 +68,7 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("flake8_simplify").join(path).as_path(),
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code).with_preview_mode(),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -164,10 +164,7 @@ mod tests {
         let snapshot = format!("pre_py310_{}_{}", rule_code.name(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("flake8_type_checking").join(path).as_path(),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY39.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY39),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -643,10 +643,8 @@ mod tests {
     fn contents_preview(contents: &str, snapshot: &str) {
         let diagnostics = test_snippet(
             contents,
-            &settings::LinterSettings {
-                preview: settings::types::PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rules(Linter::Flake8TypeChecking.rules())
-            },
+            &settings::LinterSettings::for_rules(Linter::Flake8TypeChecking.rules())
+                .with_preview_mode(),
         );
         assert_diagnostics!(snapshot, diagnostics);
     }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
@@ -162,10 +162,7 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("flake8_use_pathlib").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code).with_preview_mode(),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
@@ -93,14 +93,10 @@ mod tests {
         assert_diagnostics_diff!(
             snapshot,
             Path::new("flake8_use_pathlib").join(path).as_path(),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY313.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY314.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code)
+                .with_target_version(PythonVersion::PY313),
+            &settings::LinterSettings::for_rule(rule_code)
+                .with_target_version(PythonVersion::PY314),
         );
         Ok(())
     }
@@ -177,10 +173,8 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("flake8_use_pathlib").join(path).as_path(),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY314.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code)
+                .with_target_version(PythonVersion::PY314),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/perflint/mod.rs
+++ b/crates/ruff_linter/src/rules/perflint/mod.rs
@@ -12,7 +12,6 @@ mod tests {
     use crate::assert_diagnostics;
     use crate::registry::Rule;
     use crate::settings::LinterSettings;
-    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
 
     #[test_case(Rule::UnnecessaryListCast, Path::new("PERF101.py"))]
@@ -43,11 +42,9 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("perflint").join(path).as_path(),
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                unresolved_target_version: PythonVersion::PY310.into(),
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code)
+                .with_preview_mode()
+                .with_target_version(PythonVersion::PY310),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -107,10 +107,7 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("pycodestyle").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code).with_preview_mode(),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
@@ -126,10 +123,8 @@ mod tests {
         let tested_notebook = assert_notebook_path(
             &actual,
             &expected,
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(Rule::TooManyNewlinesAtEndOfFile)
-            },
+            &settings::LinterSettings::for_rule(Rule::TooManyNewlinesAtEndOfFile)
+                .with_preview_mode(),
         )?;
 
         assert_eq!(tested_notebook.diagnostics.len(), 3);

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -223,10 +223,8 @@ mod tests {
     fn f821_with_builtin_added_on_new_py_version_but_old_target_version_specified() {
         let diagnostics = test_snippet(
             "PythonFinalizationError",
-            &LinterSettings {
-                unresolved_target_version: ruff_python_ast::PythonVersion::PY312.into(),
-                ..LinterSettings::for_rule(Rule::UndefinedName)
-            },
+            &LinterSettings::for_rule(Rule::UndefinedName)
+                .with_target_version(ruff_python_ast::PythonVersion::PY312),
         );
         assert_diagnostics!(diagnostics);
     }
@@ -236,10 +234,8 @@ mod tests {
         // frozendict is available starting in Python 3.15.
         let diagnostics = test_snippet(
             "frozendict",
-            &LinterSettings {
-                unresolved_target_version: ruff_python_ast::PythonVersion::PY315.into(),
-                ..LinterSettings::for_rule(Rule::UndefinedName)
-            },
+            &LinterSettings::for_rule(Rule::UndefinedName)
+                .with_target_version(ruff_python_ast::PythonVersion::PY315),
         );
         assert!(diagnostics.is_empty());
     }
@@ -249,10 +245,8 @@ mod tests {
         // frozendict is not available before Python 3.15.
         let diagnostics = test_snippet(
             "frozendict",
-            &LinterSettings {
-                unresolved_target_version: ruff_python_ast::PythonVersion::PY314.into(),
-                ..LinterSettings::for_rule(Rule::UndefinedName)
-            },
+            &LinterSettings::for_rule(Rule::UndefinedName)
+                .with_target_version(ruff_python_ast::PythonVersion::PY314),
         );
         assert_diagnostics!(diagnostics);
     }

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -274,10 +274,7 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("pyflakes").join(path).as_path(),
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(rule_code)
-            },
+            &LinterSettings::for_rule(rule_code).with_preview_mode(),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
@@ -471,10 +468,7 @@ mod tests {
             snapshot,
             Path::new("pyflakes").join(path).as_path(),
             &LinterSettings::for_rule(rule_code),
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(rule_code)
-            }
+            &LinterSettings::for_rule(rule_code).with_preview_mode()
         );
         Ok(())
     }
@@ -612,10 +606,7 @@ mod tests {
                 is_stub: false,
             },
             Path::new("f401_preview_submodule.py"),
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(Rule::UnusedImport)
-            },
+            &LinterSettings::for_rule(Rule::UnusedImport).with_preview_mode(),
         )
         .0;
         assert_diagnostics!(snapshot, diagnostics);
@@ -757,10 +748,7 @@ mod tests {
     fn f811_annotated_assignment_redefinition() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyflakes/F811_34.py"),
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(Rule::RedefinedWhileUnused)
-            },
+            &LinterSettings::for_rule(Rule::RedefinedWhileUnused).with_preview_mode(),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/pygrep_hooks/mod.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/mod.rs
@@ -11,7 +11,6 @@ mod tests {
     use crate::registry::Rule;
 
     use crate::settings::LinterSettings;
-    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_diagnostics, assert_diagnostics_diff, settings};
 
@@ -43,14 +42,8 @@ mod tests {
         assert_diagnostics_diff!(
             snapshot,
             Path::new("pygrep_hooks").join(path).as_path(),
-            &LinterSettings {
-                preview: PreviewMode::Disabled,
-                ..LinterSettings::for_rule(rule_code)
-            },
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(rule_code)
-            }
+            &LinterSettings::for_rule(rule_code),
+            &LinterSettings::for_rule(rule_code).with_preview_mode()
         );
         Ok(())
     }

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -275,14 +275,8 @@ mod tests {
         assert_diagnostics_diff!(
             snapshot,
             Path::new("pylint").join(path).as_path(),
-            &LinterSettings {
-                preview: PreviewMode::Disabled,
-                ..LinterSettings::for_rule(rule_code)
-            },
-            &LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..LinterSettings::for_rule(rule_code)
-            }
+            &LinterSettings::for_rule(rule_code),
+            &LinterSettings::for_rule(rule_code).with_preview_mode()
         );
         Ok(())
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -239,10 +239,7 @@ mod tests {
         let snapshot = format!("{}__preview", path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("pyupgrade").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code).with_preview_mode(),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
@@ -272,14 +269,8 @@ mod tests {
         assert_diagnostics_diff!(
             snapshot,
             Path::new("pyupgrade").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Disabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code),
+            &settings::LinterSettings::for_rule(rule_code).with_preview_mode(),
         );
         Ok(())
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -224,11 +224,9 @@ mod tests {
         let snapshot = path.to_string_lossy().to_string();
         let diagnostics = test_path(
             Path::new("pyupgrade").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                unresolved_target_version: PythonVersion::PY312.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code)
+                .with_preview_mode()
+                .with_target_version(PythonVersion::PY312),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -250,10 +250,8 @@ mod tests {
         let snapshot = format!("rules_py313__{}", path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("pyupgrade").join(path).as_path(),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY313.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code)
+                .with_target_version(PythonVersion::PY313),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
@@ -295,10 +293,8 @@ mod tests {
     fn async_timeout_error_alias_not_applied_py310() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP041.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY310.into(),
-                ..settings::LinterSettings::for_rule(Rule::TimeoutErrorAlias)
-            },
+            &settings::LinterSettings::for_rule(Rule::TimeoutErrorAlias)
+                .with_target_version(PythonVersion::PY310),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
@@ -308,10 +304,8 @@ mod tests {
     fn non_pep695_type_alias_not_applied_py311() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP040.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY311.into(),
-                ..settings::LinterSettings::for_rule(Rule::NonPEP695TypeAlias)
-            },
+            &settings::LinterSettings::for_rule(Rule::NonPEP695TypeAlias)
+                .with_target_version(PythonVersion::PY311),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
@@ -353,10 +347,8 @@ mod tests {
     fn future_annotations_pep_585_p37() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyupgrade/future_annotations.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY37.into(),
-                ..settings::LinterSettings::for_rule(Rule::NonPEP585Annotation)
-            },
+            &settings::LinterSettings::for_rule(Rule::NonPEP585Annotation)
+                .with_target_version(PythonVersion::PY37),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
@@ -366,10 +358,8 @@ mod tests {
     fn future_annotations_pep_585_py310() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyupgrade/future_annotations.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY310.into(),
-                ..settings::LinterSettings::for_rule(Rule::NonPEP585Annotation)
-            },
+            &settings::LinterSettings::for_rule(Rule::NonPEP585Annotation)
+                .with_target_version(PythonVersion::PY310),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
@@ -411,10 +401,8 @@ mod tests {
     fn datetime_utc_alias_py311() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP017.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY311.into(),
-                ..settings::LinterSettings::for_rule(Rule::DatetimeTimezoneUTC)
-            },
+            &settings::LinterSettings::for_rule(Rule::DatetimeTimezoneUTC)
+                .with_target_version(PythonVersion::PY311),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
@@ -424,10 +412,8 @@ mod tests {
     fn unpack_pep_646_py311() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP044.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY311.into(),
-                ..settings::LinterSettings::for_rule(Rule::NonPEP646Unpack)
-            },
+            &settings::LinterSettings::for_rule(Rule::NonPEP646Unpack)
+                .with_target_version(PythonVersion::PY311),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
@@ -529,10 +515,8 @@ mod tests {
         let snapshot = "UP043.pyi";
         let diagnostics = test_path(
             Path::new("pyupgrade/UP043.pyi"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY312.into(),
-                ..settings::LinterSettings::for_rule(Rule::UnnecessaryDefaultTypeArgs)
-            },
+            &settings::LinterSettings::for_rule(Rule::UnnecessaryDefaultTypeArgs)
+                .with_target_version(PythonVersion::PY312),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
@@ -542,10 +526,8 @@ mod tests {
     fn up045_future_annotations_py39() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyupgrade/UP045_py39.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY39.into(),
-                ..settings::LinterSettings::for_rule(Rule::NonPEP604AnnotationOptional)
-            },
+            &settings::LinterSettings::for_rule(Rule::NonPEP604AnnotationOptional)
+                .with_target_version(PythonVersion::PY39),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -819,11 +819,9 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("ruff").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                unresolved_target_version: PythonVersion::PY37.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code)
+                .with_preview_mode()
+                .with_target_version(PythonVersion::PY37),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
@@ -838,11 +836,9 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("ruff").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                unresolved_target_version: PythonVersion::PY38.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code)
+                .with_preview_mode()
+                .with_target_version(PythonVersion::PY38),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -243,14 +243,10 @@ mod tests {
     fn missing_fstring_syntax_backslash_py311() -> Result<()> {
         assert_diagnostics_diff!(
             Path::new("ruff/RUF027_0.py"),
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY312.into(),
-                ..LinterSettings::for_rule(Rule::MissingFStringSyntax)
-            },
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY311.into(),
-                ..LinterSettings::for_rule(Rule::MissingFStringSyntax)
-            },
+            &LinterSettings::for_rule(Rule::MissingFStringSyntax)
+                .with_target_version(PythonVersion::PY312),
+            &LinterSettings::for_rule(Rule::MissingFStringSyntax)
+                .with_target_version(PythonVersion::PY311),
         );
         Ok(())
     }
@@ -353,10 +349,8 @@ mod tests {
 
             print(None | (int)and 2)
             ",
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY313.into(),
-                ..settings::LinterSettings::for_rule(Rule::NoneNotAtEndOfUnion)
-            },
+            &settings::LinterSettings::for_rule(Rule::NoneNotAtEndOfUnion)
+                .with_target_version(PythonVersion::PY313),
         );
         assert_diagnostics!("PY313_RUF036_runtime_evaluated", diagnostics);
     }
@@ -365,10 +359,8 @@ mod tests {
     fn quadratic_list_summation_py315() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/RUF017_0.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY315.into(),
-                ..settings::LinterSettings::for_rule(Rule::QuadraticListSummation)
-            },
+            &settings::LinterSettings::for_rule(Rule::QuadraticListSummation)
+                .with_target_version(PythonVersion::PY315),
         )?;
         assert_diagnostics!("PY315_RUF017_RUF017_0.py", diagnostics);
         Ok(())
@@ -378,12 +370,8 @@ mod tests {
     fn unnecessary_iterable_allocation_for_first_element_py315() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/RUF015_py315.py"),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY315.into(),
-                ..settings::LinterSettings::for_rule(
-                    Rule::UnnecessaryIterableAllocationForFirstElement,
-                )
-            },
+            &settings::LinterSettings::for_rule(Rule::UnnecessaryIterableAllocationForFirstElement)
+                .with_target_version(PythonVersion::PY315),
         )?;
         assert_diagnostics!("PY315_RUF015_RUF015_py315.py", diagnostics);
         Ok(())
@@ -393,10 +381,8 @@ mod tests {
     fn access_annotations_from_class_dict_py310() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/RUF063.py"),
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY310.into(),
-                ..LinterSettings::for_rule(Rule::AccessAnnotationsFromClassDict)
-            },
+            &LinterSettings::for_rule(Rule::AccessAnnotationsFromClassDict)
+                .with_target_version(PythonVersion::PY310),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
@@ -406,10 +392,8 @@ mod tests {
     fn access_annotations_from_class_dict_py314() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/RUF063.py"),
-            &LinterSettings {
-                unresolved_target_version: PythonVersion::PY314.into(),
-                ..LinterSettings::for_rule(Rule::AccessAnnotationsFromClassDict)
-            },
+            &LinterSettings::for_rule(Rule::AccessAnnotationsFromClassDict)
+                .with_target_version(PythonVersion::PY314),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())
@@ -901,10 +885,8 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("ruff").join(path).as_path(),
-            &settings::LinterSettings {
-                unresolved_target_version: PythonVersion::PY314.into(),
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code)
+                .with_target_version(PythonVersion::PY314),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -820,10 +820,7 @@ mod tests {
         );
         let diagnostics = test_path(
             Path::new("ruff").join(path).as_path(),
-            &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
-                ..settings::LinterSettings::for_rule(rule_code)
-            },
+            &settings::LinterSettings::for_rule(rule_code).with_preview_mode(),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())


### PR DESCRIPTION
## Summary

Hello! Refactored `LinterSettings` to reuse `.with_target_version()` and `.with_preview_mode()` builder methods in simple cases.

It works the best when there are two similar `LinterSettings` lines next to each other, as the difference is very apparent even from a glance:

https://github.com/astral-sh/ruff/blob/2742f956d87314cf1522c69c9a95a71d972bd76c/crates/ruff_linter/src/rules/flake8_bandit/mod.rs#L116-L127

->

https://github.com/astral-sh/ruff/blob/3bcd1aaba01855055d94754739e6c14c723c2375/crates/ruff_linter/src/rules/flake8_bandit/mod.rs#L115-L120

I've cleaned up the ones that were redefining just 1 member (either `preview` or `unresolved_target_version`) and some of the cases that use both, since it read more cleanly. Commits are grouped by the types of the change.

Haven't touched the cases where multiple members of `LinterSettings` are redefined, as the builder methods either don't improve readability there or make it worse.

## Test Plan

No functional changes - all tests pass.