### PR TITLE
[`flake8-logging-format`] Avoid behavior changes and syntax errors in fixes (`G004`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-logging-format/logging-f-string.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-logging-format/logging-f-string.md
@@ -1,0 +1,346 @@
+# `logging-f-string` (`G004`)
+
+```toml
+lint.preview = true
+lint.select = ["G004"]
+```
+
+The fix rewrites the message into `%`-style formatting so that it is only interpolated when the
+record is actually emitted. That must not change what the program logs, so each section below
+either checks that the rewrite is equivalent at runtime, or that no fix is offered because no
+faithful `%`-style equivalent exists.
+
+## Basic example
+
+Nothing unusual here, so the fix applies.
+
+```py
+import logging
+
+value = "a"
+
+logging.info(f"plain {value}")  # snapshot: logging-f-string
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:5:14
+  |
+5 | logging.info(f"plain {value}")  # snapshot: logging-f-string
+  |              ^^^^^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+4 |
+  - logging.info(f"plain {value}")  # snapshot: logging-f-string
+5 + logging.info("plain %s", value)  # snapshot: logging-f-string
+  |
+```
+
+## Escape sequences
+
+The literal parts of an f-string reach the rule already decoded, so a source `\n` arrives as a real
+newline. They need re-escaping when they are emitted back into a plain (non-raw) string literal.
+
+```py
+import logging
+
+value = "a"
+
+logging.warning(f"\n{value}")  # snapshot: logging-f-string
+logging.warning(f"C:\\{value}")  # snapshot: logging-f-string
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:5:17
+  |
+5 | logging.warning(f"\n{value}")  # snapshot: logging-f-string
+  |                 ^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+4 |
+  - logging.warning(f"\n{value}")  # snapshot: logging-f-string
+5 + logging.warning("\n%s", value)  # snapshot: logging-f-string
+6 | logging.warning(f"C:\\{value}")  # snapshot: logging-f-string
+  |
+
+
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:6:17
+  |
+6 | logging.warning(f"C:\\{value}")  # snapshot: logging-f-string
+  |                 ^^^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+5 | logging.warning(f"\n{value}")  # snapshot: logging-f-string
+  - logging.warning(f"C:\\{value}")  # snapshot: logging-f-string
+6 + logging.warning("C:\\%s", value)  # snapshot: logging-f-string
+  |
+```
+
+## Raw f-strings
+
+A raw prefix means the backslash is part of the text rather than the start of an escape. The
+replacement is a plain literal, so those backslashes have to be escaped to keep the same characters.
+
+```py
+import logging
+
+value = "a"
+
+logging.warning(rf"\'{value}")  # snapshot: logging-f-string
+logging.warning(Rf"\d+ {value}")  # snapshot: logging-f-string
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:5:17
+  |
+5 | logging.warning(rf"\'{value}")  # snapshot: logging-f-string
+  |                 ^^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+4 |
+  - logging.warning(rf"\'{value}")  # snapshot: logging-f-string
+5 + logging.warning("\\'%s", value)  # snapshot: logging-f-string
+6 | logging.warning(Rf"\d+ {value}")  # snapshot: logging-f-string
+  |
+
+
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:6:17
+  |
+6 | logging.warning(Rf"\d+ {value}")  # snapshot: logging-f-string
+  |                 ^^^^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+5 | logging.warning(rf"\'{value}")  # snapshot: logging-f-string
+  - logging.warning(Rf"\d+ {value}")  # snapshot: logging-f-string
+6 + logging.warning("\\d+ %s", value)  # snapshot: logging-f-string
+  |
+```
+
+## Quote style
+
+The replacement picks the quote style that avoids escaping, rather than reusing the quotes of the
+original f-string.
+
+```py
+import logging
+
+value = "a"
+
+logging.warning(f'"{value}"')  # snapshot: logging-f-string
+logging.warning(f"'{value}'")  # snapshot: logging-f-string
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:5:17
+  |
+5 | logging.warning(f'"{value}"')  # snapshot: logging-f-string
+  |                 ^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+4 |
+  - logging.warning(f'"{value}"')  # snapshot: logging-f-string
+5 + logging.warning('"%s"', value)  # snapshot: logging-f-string
+6 | logging.warning(f"'{value}'")  # snapshot: logging-f-string
+  |
+
+
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:6:17
+  |
+6 | logging.warning(f"'{value}'")  # snapshot: logging-f-string
+  |                 ^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+5 | logging.warning(f'"{value}"')  # snapshot: logging-f-string
+  - logging.warning(f"'{value}'")  # snapshot: logging-f-string
+6 + logging.warning("'%s'", value)  # snapshot: logging-f-string
+  |
+```
+
+## Parenthesized messages
+
+The fix replaces any parentheses around the message along with the message itself. Rewriting only
+the f-string would leave the parentheses wrapped around the new argument list, silently turning the
+message into a tuple.
+
+```py
+import logging
+
+value = "a"
+
+logging.warning((f"{value}"))  # snapshot: logging-f-string
+logging.warning(((f"{value}")))  # snapshot: logging-f-string
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:5:18
+  |
+5 | logging.warning((f"{value}"))  # snapshot: logging-f-string
+  |                  ^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+4 |
+  - logging.warning((f"{value}"))  # snapshot: logging-f-string
+5 + logging.warning("%s", value)  # snapshot: logging-f-string
+6 | logging.warning(((f"{value}")))  # snapshot: logging-f-string
+  |
+
+
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:6:19
+  |
+6 | logging.warning(((f"{value}")))  # snapshot: logging-f-string
+  |                   ^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+5 | logging.warning((f"{value}"))  # snapshot: logging-f-string
+  - logging.warning(((f"{value}")))  # snapshot: logging-f-string
+6 + logging.warning("%s", value)  # snapshot: logging-f-string
+  |
+```
+
+## Self-documenting interpolations
+
+`f"{value=}"` renders `value=` followed by `repr(value)`, whereas `%s` renders `str(value)`. Those
+differ for most types -- on a string, `repr` shows the surrounding quotes -- so no fix is offered.
+
+```py
+import logging
+
+value = "a"
+
+logging.info(f"{value=}")  # snapshot: logging-f-string
+logging.info(f"{value = }")  # snapshot: logging-f-string
+logging.info(f"prefix {value=} suffix")  # snapshot: logging-f-string
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:5:14
+  |
+5 | logging.info(f"{value=}")  # snapshot: logging-f-string
+  |              ^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+
+
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:6:14
+  |
+6 | logging.info(f"{value = }")  # snapshot: logging-f-string
+  |              ^^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+
+
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:7:14
+  |
+7 | logging.info(f"prefix {value=} suffix")  # snapshot: logging-f-string
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Convert to lazy `%` formatting
+```
+
+## Messages passed by keyword
+
+The interpolated values become positional arguments that follow the message, which is impossible
+when the message itself is passed by keyword, so no fix is offered. Passing a tuple instead
+(`msg=("%s", value)`) would log the tuple rather than the formatted message, because `logging` only
+applies `%` formatting when `args` is non-empty.
+
+```py
+import logging
+
+value = "a"
+
+logging.warning(msg=f"{value}")  # snapshot: logging-f-string
+logging.warning(msg=(f"{value}"))  # snapshot: logging-f-string
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:5:21
+  |
+5 | logging.warning(msg=f"{value}")  # snapshot: logging-f-string
+  |                     ^^^^^^^^^^
+help: Convert to lazy `%` formatting
+
+
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:6:22
+  |
+6 | logging.warning(msg=(f"{value}"))  # snapshot: logging-f-string
+  |                      ^^^^^^^^^^
+help: Convert to lazy `%` formatting
+```
+
+## Comments in the replaced range
+
+Everything in the replaced range is discarded, so the fix is marked unsafe when it would delete a
+comment.
+
+```py
+import logging
+
+value = "a"
+
+logging.warning(
+    (  # Important explanation
+        f"{value}"  # snapshot: logging-f-string
+        # Another important explanation
+    )
+)
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:7:9
+  |
+7 |         f"{value}"  # snapshot: logging-f-string
+  |         ^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+5 | logging.warning(
+  -     (  # Important explanation
+  -         f"{value}"  # snapshot: logging-f-string
+  -         # Another important explanation
+  -     )
+6 +     "%s", value
+7 | )
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Comments outside the replaced range
+
+Only the message and the parentheses around it are replaced, so a comment elsewhere in the call
+leaves the fix safe.
+
+```py
+import logging
+
+value = "a"
+
+logging.warning(  # Important explanation
+    f"{value}"  # snapshot: logging-f-string
+)
+```
+
+```snapshot
+error[G004]: Logging statement uses f-string
+ --> src/mdtest_snippet.py:6:5
+  |
+6 |     f"{value}"  # snapshot: logging-f-string
+  |     ^^^^^^^^^^
+help: Convert to lazy `%` formatting
+  |
+5 | logging.warning(  # Important explanation
+  -     f"{value}"  # snapshot: logging-f-string
+6 +     "%s", value  # snapshot: logging-f-string
+7 | )
+  |
+```

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -1,5 +1,6 @@
 use ruff_python_ast::InterpolatedStringElement;
-use ruff_python_ast::{self as ast, Arguments, Expr, Keyword, Operator, StringFlags};
+use ruff_python_ast::token::parenthesized_range;
+use ruff_python_ast::{self as ast, Arguments, AtomicNodeIndex, Expr, Keyword, Operator};
 
 use ruff_python_semantic::analyze::logging;
 use ruff_python_stdlib::logging::LoggingLevel;
@@ -12,7 +13,7 @@ use crate::rules::flake8_logging_format::violations::{
     LoggingExcInfo, LoggingExtraAttrClash, LoggingFString, LoggingPercentFormat,
     LoggingRedundantExcInfo, LoggingStringConcat, LoggingStringFormat, LoggingWarn,
 };
-use crate::{Edit, Fix};
+use crate::{Applicability, Edit, Fix};
 
 fn logging_f_string(
     checker: &Checker,
@@ -35,20 +36,19 @@ fn logging_f_string(
         return;
     }
 
+    // The interpolated values become positional arguments
+    // that follow the message, so the message itself has to be positional too.
+    // Rewriting `logging.warning(msg=f"{x}")` in place would produce
+    // `logging.warning(msg="%s", x)`, which is a syntax error,
+    // and passing a tuple instead (`msg=("%s", x)`) would log the tuple
+    // rather than the formatted message, since `%`-formatting only runs when
+    // `args` is non-empty.
+    if arguments.find_keyword("msg").is_some() {
+        return;
+    }
+
     let mut format_string = String::new();
     let mut args: Vec<&str> = Vec::new();
-
-    // Try to reuse the first part's quote style when building the replacement.
-    // Default to double quotes if we can't determine it.
-    let quote_str = f_string
-        .value
-        .iter()
-        .map(|part| match part {
-            ast::FStringPart::Literal(literal) => literal.flags.quote_str(),
-            ast::FStringPart::FString(f) => f.flags.quote_str(),
-        })
-        .next()
-        .unwrap_or("\"");
 
     for part in &f_string.value {
         match part {
@@ -72,7 +72,12 @@ fn logging_f_string(
                             format_string.push_str(lit.value.as_ref());
                         }
                         InterpolatedStringElement::Interpolation(interpolated) => {
-                            if interpolated.format_spec.is_some()
+                            // A self-documenting interpolation such as `f"{x=}"` renders `x=`
+                            // followed by `repr(x)`, whereas `%s` renders `str(x)`. Those differ
+                            // for most types -- `f"{s=}"` on a string shows the surrounding
+                            // quotes -- so there is no faithful `%`-style equivalent.
+                            if interpolated.debug_text.is_some()
+                                || interpolated.format_spec.is_some()
                                 || !matches!(
                                     interpolated.conversion,
                                     ruff_python_ast::ConversionFlag::None
@@ -98,15 +103,45 @@ fn logging_f_string(
         return;
     }
 
-    let replacement = format!(
-        "{q}{format_string}{q}, {args}",
-        q = quote_str,
-        format_string = format_string,
-        args = args.join(", ")
-    );
+    // Emit the format string through the code generator rather than pasting the collected text
+    // between quotes. The literal parts gathered above are *decoded*, so a source `f"\n{x}"`
+    // leaves a real newline in `format_string`, and re-emitting that verbatim produced an
+    // unterminated literal. The generator escapes the contents for a plain (non-raw) literal,
+    // which also stops raw-prefixed sources such as `fr"\'{x}"` from losing their backslash.
+    let format_string = checker
+        .generator()
+        .expr(&Expr::StringLiteral(ast::ExprStringLiteral {
+            value: ast::StringLiteralValue::single(ast::StringLiteral {
+                value: Box::from(format_string),
+                range: TextRange::default(),
+                node_index: AtomicNodeIndex::NONE,
+                flags: checker.default_string_flags(),
+            }),
+            range: TextRange::default(),
+            node_index: AtomicNodeIndex::NONE,
+        }));
 
-    let fix = Fix::safe_edit(Edit::range_replacement(replacement, msg.range()));
-    diagnostic.set_fix(fix);
+    // Replace any enclosing parentheses along with the f-string.
+    // Rewriting only the f-string in `logging.warning((f"{x}"))`
+    // would leave the parentheses wrapped around the new argument
+    // list, silently turning the message into a tuple.
+    let target =
+        parenthesized_range(msg.into(), arguments.into(), checker.tokens()).unwrap_or(msg.range());
+
+    let replacement = format!("{format_string}, {}", args.join(", "));
+
+    // Everything in the replaced range is discarded, so a comment
+    // written between the parentheses and the message would be lost.
+    let applicability = if checker.comment_ranges().intersects(target) {
+        Applicability::Unsafe
+    } else {
+        Applicability::Safe
+    };
+
+    diagnostic.set_fix(Fix::applicable_edit(
+        Edit::range_replacement(replacement, target),
+        applicability,
+    ));
 }
 
 /// Returns `true` if the attribute is a reserved attribute on the `logging` module's `LogRecord`

--- a/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
@@ -320,6 +320,11 @@ impl Violation for LoggingStringConcat {
 /// logging.info("%s - Something happened", user)
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe if the message,
+/// or the parentheses around it, contain comments,
+/// since the rewrite replaces that whole range and would delete them.
+///
 /// ## Options
 /// - `lint.logger-objects`
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fixes #20151

I authored the original fix in #19303. This improves that implementation.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added a new fixture that covers multiple cases from the issue.

```
crates/ruff_linter/resources/test/fixtures/flake8_logging_format/G004_fix_semantics.py
```

<!-- How was it tested? -->