### PR TITLE
[ty] Treat bound method receivers covariantly

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1146,6 +1146,39 @@ c: Callable[[Any], str] = A().f
 c: Callable[[Any], str] = A().g
 ```
 
+A bound receiver is a captured value, so methods inherited by a subclass can be assigned to the same
+method bound to the parent class, but not the other way around:
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_assignable_to
+
+class Writer:
+    def write(self, data: bytes) -> None: ...
+
+class ChildWriter(Writer): ...
+
+writer = Writer()
+child = ChildWriter()
+
+static_assert(is_assignable_to(TypeOf[child.write], TypeOf[writer.write]))
+static_assert(not is_assignable_to(TypeOf[writer.write], TypeOf[child.write]))
+```
+
+Narrowing a receiver before storing its method must not make an otherwise valid assignment fail:
+
+```py
+class OtherWriter(Writer):
+    def write(self, data: bytes) -> None: ...
+
+class Copy:
+    def __init__(self, writer: Writer | None) -> None:
+        if not writer:
+            writer = OtherWriter()
+
+        self._write = writer.write
+```
+
 ### Generic method types with gradual class return types
 
 A generic receiver makes signature comparison lazy without changing whether gradual class types are

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -174,13 +174,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: BoundMethodType<'db>,
         target: BoundMethodType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // A bound method is a typically a subtype of itself. However, we must explicitly verify
-        // the subtyping of the underlying function signatures (since they might be specialized
-        // differently), and of the bound self parameter (taking care that parameters, including a
-        // bound self parameter, are contravariant.)
+        // The underlying function signature remains contravariant in its parameters, but the
+        // bound receiver is an already-captured value. A method bound to `A` is therefore a
+        // subtype of the same method bound to `A | B`, not the other way around.
         self.check_function_pair(db, source.function(db), target.function(db))
             .and(db, self.constraints, || {
-                self.check_type_pair(db, target.self_instance(db), source.self_instance(db))
+                self.check_type_pair(db, source.self_instance(db), target.self_instance(db))
             })
     }
 }


### PR DESCRIPTION
## Summary

A bound method captures its receiver as a value, so receiver types must be compared covariantly even though the underlying function's parameters remain contravariant. We currently compare both contravariantly, which rejects valid assignments after narrowing:

```python
class Writer:
    def write(self, data: bytes) -> None: ...

class OtherWriter(Writer):
    def write(self, data: bytes) -> None: ...

class Copy:
    def __init__(self, writer: Writer | None) -> None:
        if not writer:
            writer = OtherWriter()
        self._write = writer.write
```

Previously, the final assignment failed because a method bound to `Writer & ~AlwaysFalsy` was considered incompatible with the same method bound to `Writer`. The captured receiver is actually narrower, so the assignment is valid.

Compare captured receivers covariantly while preserving ordinary callable-parameter checks. Add direct relation tests for both variance directions and a focused reproduction of the two false positives removed from `psycopg`.

This is a prerequisite for #27417. The full semantic suite passes: 790 tests.
