### PR TITLE
[ty] Improve error context for incompatible callable signatures

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -286,6 +286,7 @@ error[invalid-assignment]: Object of type `(int, str, /) -> bool` is not assigna
    |             |
    |             Declared type
 info: unexpected extra parameter
+help: The parameter must have a default value
 ```
 
 Assigning a function with an extra required parameter to a `Callable`:
@@ -306,6 +307,7 @@ error[invalid-assignment]: Object of type `def source(x: int, extra: str) -> boo
    |         |
    |         Declared type
 info: unexpected extra parameter `extra`
+help: Parameter `extra` must have a default value
 ```
 
 Assigning a class to a `Callable`
@@ -350,6 +352,7 @@ error[invalid-argument-type]: Argument to function `accepts_callable` is incorre
    |                  ^^^ Expected `(Any, /) -> Any`, found `<class 'Foo'>`
 info: type `<class 'Foo'>` has inferred callable type `(x: Any, y: Any) -> Foo`
 info: └── unexpected extra parameter `y`
+help: Parameter `y` must have a default value
 info: Function defined here
   --> src/mdtest_snippet.py:23:5
    |
@@ -421,6 +424,134 @@ error[invalid-assignment]: Object of type `partial[(y: str) -> bool]` is not ass
    |                 |
    |                 Declared type
 info: the first parameter has an incompatible type: `bytes` is not assignable to `str`
+```
+
+## Missing unnamed callable parameters
+
+Parameters in a `Callable` type do not have names, so a missing parameter is identified by its
+position.
+
+```py
+from typing import Callable
+
+def assign(source: Callable[[], None]) -> None:
+    target: Callable[[int], None] = source  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `() -> None` is not assignable to `(int, /) -> None`
+ --> src/mdtest_snippet.py:4:37
+  |
+4 |     target: Callable[[int], None] = source  # snapshot: invalid-assignment
+  |             ---------------------   ^^^^^^ Incompatible value of type `() -> None`
+  |             |
+  |             Declared type
+info: the first parameter is missing
+```
+
+## Missing parameters in nested generic calls involving `TypeVarTuple`s and `ParamSpec`s
+
+In the following example, the signature of the `callback` function does not satisfy the `fn`
+parameter of `wrapper` in the `accept()` call, because the arguments provided to `accept()`
+following `fn` indicate that it must accept the value `1` as a positional argument, and it does not.
+
+We don't currently add error context in this code path, but we could add it in the future:
+
+```py
+from collections.abc import Callable
+
+def wrapper1[**P](fn: Callable[P, None]) -> Callable[P, None]:
+    return fn
+
+def accept1[**P](fn: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+def callback1() -> None: ...
+
+accept1(wrapper1(callback1), 1)  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper1` is incorrect
+ --> src/mdtest_snippet.py:9:18
+  |
+9 | accept1(wrapper1(callback1), 1)  # snapshot: invalid-argument-type
+  |                  ^^^^^^^^^ Expected `(**P@accept1) -> None`, found `def callback1() -> None`
+info: Function defined here
+ --> src/mdtest_snippet.py:3:5
+  |
+3 | def wrapper1[**P](fn: Callable[P, None]) -> Callable[P, None]:
+  |     ^^^^^^^^      --------------------- Parameter declared here
+```
+
+The following case is similar, but exercises a different code path. Here, we could also add error
+context to improve the diagnostic in the future:
+
+```py
+def wrapper2[**P](fn: Callable[P, None]) -> Callable[P, None]:
+    return fn
+
+def accept2[**P](fn: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+def callback2(**kwargs: int) -> None: ...
+
+accept2(wrapper2(callback2), 1)  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper2` is incorrect
+  --> src/mdtest_snippet.py:16:18
+   |
+16 | accept2(wrapper2(callback2), 1)  # snapshot: invalid-argument-type
+   |                  ^^^^^^^^^ Expected `(**P@accept2) -> None`, found `def callback2(**kwargs: int) -> None`
+info: Function defined here
+  --> src/mdtest_snippet.py:10:5
+   |
+10 | def wrapper2[**P](fn: Callable[P, None]) -> Callable[P, None]:
+   |     ^^^^^^^^      --------------------- Parameter declared here
+```
+
+And the same applies to the following two examples too, which both use a `TypeVarTuple` instead of a
+`ParamSpec`:
+
+```py
+def wrapper3[*Ts](fn: Callable[[*Ts], None]) -> Callable[[*Ts], None]:
+    return fn
+
+def accept3[*Ts](fn: Callable[[*Ts], None], *args: *Ts) -> None: ...
+def callback3(value: int) -> None: ...
+
+accept3(wrapper3(callback3))  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper3` is incorrect
+  --> src/mdtest_snippet.py:23:18
+   |
+23 | accept3(wrapper3(callback3))  # snapshot: invalid-argument-type
+   |                  ^^^^^^^^^ Expected `(*int) -> None`, found `def callback3(value: int) -> None`
+info: Function defined here
+  --> src/mdtest_snippet.py:17:5
+   |
+17 | def wrapper3[*Ts](fn: Callable[[*Ts], None]) -> Callable[[*Ts], None]:
+   |     ^^^^^^^^      ------------------------- Parameter declared here
+```
+
+```py
+def accepts4[*Ts](fn: Callable[[*Ts, int], None]) -> None: ...
+def callback4() -> None: ...
+
+accepts4(callback4)  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `accepts4` is incorrect
+  --> src/mdtest_snippet.py:27:10
+   |
+27 | accepts4(callback4)  # snapshot: invalid-argument-type
+   |          ^^^^^^^^^ Expected `(*args: Unknown, int, /) -> None`, found `def callback4() -> None`
+info: Function defined here
+  --> src/mdtest_snippet.py:24:5
+   |
+24 | def accepts4[*Ts](fn: Callable[[*Ts, int], None]) -> None: ...
+   |     ^^^^^^^^      ------------------------------ Parameter declared here
 ```
 
 ## Function assignability and overrides
@@ -529,6 +660,31 @@ error[invalid-method-override]: Invalid override of method `method`
    |         ---------------------------- `Parent.method` defined here
 info: the parameter named `y` does not match `x` (and can be used as a keyword parameter)
 info: This violates the Liskov Substitution Principle
+```
+
+## Uncallable top signatures
+
+A top callable represents every possible callable signature, so no specific call is guaranteed to be
+accepted. It therefore cannot be assigned to a callable that promises to accept an integer.
+
+```py
+from typing import Callable
+from ty_extensions import Top
+
+def assign(source: Top[Callable[..., int]]) -> None:
+    target: Callable[[int], int] = source  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Top[(...) -> int]` is not assignable to `(int, /) -> int`
+ --> src/mdtest_snippet.py:5:36
+  |
+5 |     target: Callable[[int], int] = source  # snapshot: invalid-assignment
+  |             --------------------   ^^^^^^ Incompatible value of type `Top[(...) -> int]`
+  |             |
+  |             Declared type
+info: Object of type `Top[(...) -> int]` is not safe to call; its signature is not known
+help: This type includes all possible parameter sets, so it cannot safely be called because there is no valid set of arguments for it
 ```
 
 ## `TypedDict`
@@ -1652,5 +1808,6 @@ info:     └── incompatible return types: `WrongIterator` is not assignable
 info:         └── type `WrongIterator` is not assignable to protocol `Iterator[Unknown]`
 info:             └── protocol member `__next__` is incompatible
 info:                 └── unexpected extra parameter `wrong`
+help: Parameter `wrong` must have a default value
 info: Expected signature for `__next__` is `def __next__(self): ...`
 ```

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -169,6 +169,7 @@ error[invalid-method-override]: Invalid override of method `method`
    |
  2 |     def method(self, x: int, /): ...
    |         ----------------------- `Super.method` defined here
+info: parameter `x` is missing
 info: This violates the Liskov Substitution Principle
 ```
 
@@ -191,6 +192,7 @@ error[invalid-method-override]: Invalid override of method `method`
  2 |     def method(self, x: int, /): ...
    |         ----------------------- `Super.method` defined here
 info: unexpected extra parameter `y`
+help: Parameter `y` must have a default value
 info: This violates the Liskov Substitution Principle
 ```
 
@@ -314,6 +316,7 @@ error[invalid-method-override]: Invalid override of method `method3`
 54 | class Sub19(Super3):
 55 |     def method3(self, x, /): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super3.method3`
+info: parameter `x` is positional-only but must also accept keyword arguments
 info: This violates the Liskov Substitution Principle
 ```
 
@@ -346,6 +349,7 @@ error[invalid-method-override]: Invalid override of method `method`
 61 | class Sub21(Super4):
 62 |     def method(self, *args): ...  # snapshot: invalid-method-override
    |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Super4.method`
+info: the signature must accept arbitrary keyword arguments
 info: This violates the Liskov Substitution Principle
 ```
 
@@ -367,6 +371,7 @@ error[invalid-method-override]: Invalid override of method `method`
    |
 57 |     def method(self, *args: int, **kwargs: str): ...
    |         --------------------------------------- `Super4.method` defined here
+info: the signature must accept arbitrary positional arguments
 info: This violates the Liskov Substitution Principle
 ```
 
@@ -377,6 +382,274 @@ superclass.
 ```pyi
 class Sub23(Super4):
     def method(self, x, *args, y, **kwargs): ...
+```
+
+## Variadic keyword parameters cannot replace positional parameters
+
+A method that accepts only keyword arguments cannot accept a positional argument required by the
+superclass method.
+
+```pyi
+class Parent:
+    def method(self, value: int, /) -> None: ...
+
+class Child(Parent):
+    def method(self, **kwargs: int) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+ --> src/mdtest_snippet.pyi:5:9
+  |
+2 |     def method(self, value: int, /) -> None: ...
+  |         ----------------------------------- `Parent.method` defined here
+3 |
+4 | class Child(Parent):
+5 |     def method(self, **kwargs: int) -> None: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
+info: parameter `value` is missing
+info: This violates the Liskov Substitution Principle
+```
+
+## Signatures with variadic positional arguments cannot add additional required arguments
+
+A method that accepts any number of positional arguments can be called with no arguments. An
+override must not introduce a required positional argument before its variadic parameter.
+
+```pyi
+class Parent:
+    def method(self, *args: int) -> None: ...
+
+class Child(Parent):
+    def method(self, first: int, *args: int) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+ --> src/mdtest_snippet.pyi:5:9
+  |
+2 |     def method(self, *args: int) -> None: ...
+  |         -------------------------------- `Parent.method` defined here
+3 |
+4 | class Child(Parent):
+5 |     def method(self, first: int, *args: int) -> None: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
+info: unexpected extra parameter `first`
+help: Parameter `first` must have a default value
+info: This violates the Liskov Substitution Principle
+```
+
+Adding a positional parameter with a default is valid because callers can omit it.
+
+```pyi
+class OptionalChild(Parent):
+    # TODO: this is a false-positive error that should be fixed.
+    def method(self, first: int = 0, *args: int) -> None: ...  # error: [invalid-method-override]
+```
+
+## Variadic keyword parameters cannot be overridden with a limited set of keyword-only parameters
+
+A method that accepts arbitrary keyword arguments cannot be overridden by a method that accepts only
+one named keyword argument, even when that argument is optional.
+
+```pyi
+class Parent:
+    def method(self, **kwargs: int) -> None: ...
+
+class Child(Parent):
+    def method(self, *, value: int = 0) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+ --> src/mdtest_snippet.pyi:5:9
+  |
+2 |     def method(self, **kwargs: int) -> None: ...
+  |         ----------------------------------- `Parent.method` defined here
+3 |
+4 | class Child(Parent):
+5 |     def method(self, *, value: int = 0) -> None: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
+info: the signature must accept arbitrary keyword arguments
+info: This violates the Liskov Substitution Principle
+```
+
+## Optional parameters must remain optional on subclass overrides
+
+A positional-only parameter that callers may omit on the superclass cannot become required on the
+subclass.
+
+```pyi
+class ParentPositionalOnly:
+    def method(self, parent_value: int = 0, /) -> None: ...
+
+class ChildPositionalOnly(ParentPositionalOnly):
+    def method(self, child_value: int, /) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+ --> src/mdtest_snippet.pyi:5:9
+  |
+2 |     def method(self, parent_value: int = 0, /) -> None: ...
+  |         ---------------------------------------------- `ParentPositionalOnly.method` defined here
+3 |
+4 | class ChildPositionalOnly(ParentPositionalOnly):
+5 |     def method(self, child_value: int, /) -> None: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `ParentPositionalOnly.method`
+info: parameter `child_value` must have a default value
+info: This violates the Liskov Substitution Principle
+```
+
+The same rule applies when the optional parameter is positional-or-keyword:
+
+```pyi
+class ParentPositionalOrKeyword:
+    def method(self, value: int = 0) -> None: ...
+
+class ChildPositionalOrKeyword(ParentPositionalOrKeyword):
+    def method(self, value: int) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+  --> src/mdtest_snippet.pyi:10:9
+   |
+ 7 |     def method(self, value: int = 0) -> None: ...
+   |         ------------------------------------ `ParentPositionalOrKeyword.method` defined here
+ 8 |
+ 9 | class ChildPositionalOrKeyword(ParentPositionalOrKeyword):
+10 |     def method(self, value: int) -> None: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `ParentPositionalOrKeyword.method`
+info: parameter `value` must have a default value
+info: This violates the Liskov Substitution Principle
+```
+
+And if the parameter is keyword-only:
+
+```pyi
+class ParentKeywordOnly:
+    def method(self, *, value: int = 0) -> None: ...
+
+class ChildKeywordOnly(ParentKeywordOnly):
+    def method(self, *, value: int) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+  --> src/mdtest_snippet.pyi:15:9
+   |
+12 |     def method(self, *, value: int = 0) -> None: ...
+   |         --------------------------------------- `ParentKeywordOnly.method` defined here
+13 |
+14 | class ChildKeywordOnly(ParentKeywordOnly):
+15 |     def method(self, *, value: int) -> None: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `ParentKeywordOnly.method`
+info: parameter `value` must have a default value
+info: This violates the Liskov Substitution Principle
+```
+
+## Subclass overrides may not add additional positional-only parameters without default values
+
+This is true if the new parameter is positional-only:
+
+```pyi
+class PositionalOnlyParent:
+    def method(self, *, value: int) -> None: ...
+
+class PositionalOnlyChild(PositionalOnlyParent):
+    def method(self, extra: int, /, *, value: int) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+ --> src/mdtest_snippet.pyi:5:9
+  |
+2 |     def method(self, *, value: int) -> None: ...
+  |         ----------------------------------- `PositionalOnlyParent.method` defined here
+3 |
+4 | class PositionalOnlyChild(PositionalOnlyParent):
+5 |     def method(self, extra: int, /, *, value: int) -> None: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `PositionalOnlyParent.method`
+info: unexpected extra parameter `extra`
+help: Parameter `extra` must have a default value
+info: This violates the Liskov Substitution Principle
+```
+
+And if the new parameter is keyword-only:
+
+```pyi
+class KeywordOnlyParent:
+    def method(self, *, value: int) -> None: ...
+
+class KeywordOnlyChild(KeywordOnlyParent):
+    def method(self, *, value: int, extra: int) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+  --> src/mdtest_snippet.pyi:10:9
+   |
+ 7 |     def method(self, *, value: int) -> None: ...
+   |         ----------------------------------- `KeywordOnlyParent.method` defined here
+ 8 |
+ 9 | class KeywordOnlyChild(KeywordOnlyParent):
+10 |     def method(self, *, value: int, extra: int) -> None: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `KeywordOnlyParent.method`
+info: unexpected extra parameter `extra`
+help: Parameter `extra` must have a default value
+info: This violates the Liskov Substitution Principle
+```
+
+## Keyword-only parameters cannot be removed
+
+Removing a keyword-only parameter means that the overriding method no longer accepts the
+corresponding keyword argument.
+
+```pyi
+class Parent:
+    def method(self, *, value: int) -> None: ...
+
+class Child(Parent):
+    def method(self) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+ --> src/mdtest_snippet.pyi:5:9
+  |
+2 |     def method(self, *, value: int) -> None: ...
+  |         ----------------------------------- `Parent.method` defined here
+3 |
+4 | class Child(Parent):
+5 |     def method(self) -> None: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
+info: parameter `value` is missing
+info: This violates the Liskov Substitution Principle
+```
+
+Replacing the parameter with a differently named optional keyword also prevents callers from
+providing the original argument.
+
+```pyi
+class ChildWithDifferentKeyword(Parent):
+    def method(self, *, other: int = 0) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+ --> src/mdtest_snippet.pyi:7:9
+  |
+2 |     def method(self, *, value: int) -> None: ...
+  |         ----------------------------------- `Parent.method` defined here
+3 |
+4 | class Child(Parent):
+5 |     def method(self) -> None: ...  # snapshot: invalid-method-override
+6 | class ChildWithDifferentKeyword(Parent):
+7 |     def method(self, *, other: int = 0) -> None: ...  # snapshot: invalid-method-override
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Parent.method`
+info: parameter `value` is missing
+info: This violates the Liskov Substitution Principle
 ```
 
 ## `ClassVar` and instance variables

--- a/crates/ty_python_semantic/resources/mdtest/loops/async_for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/async_for.md
@@ -219,6 +219,7 @@ info: Its `__aiter__` method has an invalid signature
 info: type `AsyncIterable` is not assignable to protocol `AsyncIterable[Unknown]`
 info: └── protocol member `__aiter__` is incompatible
 info:     └── unexpected extra parameter `arg`
+help: Parameter `arg` must have a default value
 info: Expected signature `def __aiter__(self): ...`
 ```
 
@@ -252,5 +253,6 @@ info:     └── incompatible return types: `AsyncIterator` is not assignable
 info:         └── type `AsyncIterator` is not assignable to protocol `AsyncIterator[Unknown]`
 info:             └── protocol member `__anext__` is incompatible
 info:                 └── unexpected extra parameter `arg`
+help: Parameter `arg` must have a default value
 info: Expected signature for `__anext__` is `def __anext__(self): ...`
 ```

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -892,6 +892,7 @@ info: Its `__iter__` method has an invalid signature
 info: type `Iterable` is not assignable to protocol `Iterable[Unknown]`
 info: └── protocol member `__iter__` is incompatible
 info:     └── unexpected extra parameter `extra_arg`
+help: Parameter `extra_arg` must have a default value
 info: Expected signature `def __iter__(self): ...`
 ```
 
@@ -970,6 +971,7 @@ info:     └── incompatible return types: `Iterator1` is not assignable to 
 info:         └── type `Iterator1` is not assignable to protocol `Iterator[Unknown]`
 info:             └── protocol member `__next__` is incompatible
 info:                 └── unexpected extra parameter `extra_arg`
+help: Parameter `extra_arg` must have a default value
 info: Expected signature for `__next__` is `def __next__(self): ...`
 ```
 
@@ -1233,6 +1235,7 @@ info: Its `__iter__` method may have an invalid signature
 info: type `Iterable1` is not assignable to protocol `Iterable[Unknown]`
 info: └── protocol member `__iter__` is incompatible
 info:     └── unexpected extra parameter `invalid_extra_arg`
+help: Parameter `invalid_extra_arg` must have a default value
 info: Type of `__iter__` is `(bound method Iterable1.__iter__() -> Iterator) | (bound method Iterable1.__iter__(invalid_extra_arg) -> Iterator)`
 info: Expected signature for `__iter__` is `def __iter__(self): ...`
 ```
@@ -1308,6 +1311,7 @@ info:     └── incompatible return types: `Iterator1` is not assignable to 
 info:         └── type `Iterator1` is not assignable to protocol `Iterator[Unknown]`
 info:             └── protocol member `__next__` is incompatible
 info:                 └── unexpected extra parameter `invalid_extra_arg`
+help: Parameter `invalid_extra_arg` must have a default value
 info: Expected signature for `__next__` is `def __next__(self): ...`
 ```
 

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -107,6 +107,17 @@ pub(crate) enum ErrorContext<'db> {
     ExtraRequiredParameter {
         parameter: ParameterDescription,
     },
+    MissingParameter {
+        parameter: ParameterDescription,
+    },
+    RequiredParameterMustHaveDefault {
+        parameter: ParameterDescription,
+    },
+    MissingVariadicPositionalParameter,
+    MissingVariadicKeywordParameter,
+    TopCallableAssignedToNonTop {
+        return_type: Type<'db>,
+    },
     ParameterNameMismatch {
         source_name: Name,
         target_name: Name,
@@ -287,9 +298,36 @@ impl<'db> ErrorContext<'db> {
                 callable.display(db),
             ),
             Self::ExtraRequiredParameter { parameter } => match parameter {
-                ParameterDescription::Named(name) => format!("unexpected extra parameter `{name}`"),
-                ParameterDescription::Index(_) => "unexpected extra parameter".to_string(),
+                ParameterDescription::Named(name) => {
+                    help_messages.insert(HelpMessages::ConsiderAddingADefaultValue {
+                        parameter_name: Some(name.clone()),
+                    });
+                    format!("unexpected extra parameter `{name}`")
+                }
+                ParameterDescription::Index(_) => {
+                    help_messages.insert(HelpMessages::ConsiderAddingADefaultValue {
+                        parameter_name: None,
+                    });
+                    "unexpected extra parameter".to_string()
+                }
             },
+            Self::MissingParameter { parameter } => format!("{parameter} is missing"),
+            Self::RequiredParameterMustHaveDefault { parameter } => {
+                format!("{parameter} must have a default value")
+            }
+            Self::MissingVariadicPositionalParameter => {
+                "the signature must accept arbitrary positional arguments".to_string()
+            }
+            Self::MissingVariadicKeywordParameter => {
+                "the signature must accept arbitrary keyword arguments".to_string()
+            }
+            Self::TopCallableAssignedToNonTop { return_type } => {
+                help_messages.insert(HelpMessages::TopCallableExplanation);
+                format!(
+                    "Object of type `Top[(...) -> {}]` is not safe to call; its signature is not known",
+                    return_type.display(db)
+                )
+            }
             Self::ParameterNameMismatch {
                 source_name,
                 target_name,
@@ -382,6 +420,8 @@ enum HelpMessages {
     RequiredFieldCouldBeRemoved,
     TypedDictNotAssignableToDict,
     ConsiderUsingMappingInsteadOfDict,
+    TopCallableExplanation,
+    ConsiderAddingADefaultValue { parameter_name: Option<Name> },
 }
 
 impl std::fmt::Display for HelpMessages {
@@ -396,6 +436,14 @@ impl std::fmt::Display for HelpMessages {
             HelpMessages::ConsiderUsingMappingInsteadOfDict => {
                 f.write_str("Consider using `Mapping[..]` instead of `dict[..]`.")
             }
+            HelpMessages::TopCallableExplanation => f.write_str(
+                "This type includes all possible parameter sets, \
+                so it cannot safely be called because there is no valid set of arguments for it",
+            ),
+            HelpMessages::ConsiderAddingADefaultValue { parameter_name } => match parameter_name {
+                Some(name) => write!(f, "Parameter `{name}` must have a default value"),
+                None => f.write_str("The parameter must have a default value"),
+            },
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2314,21 +2314,71 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         {
             let source_positional = source.parameters.positional().count();
             let target_positional = target.parameters.positional().count();
+            let target_variadic = target.parameters.variadic();
+
+            // A subdiagnostic telling the user that `source` is missing a `*args` parameter
+            // is only guaranteed to be correct when `target` has a plain, open-ended variadic tail.
+            // (Well: we might be able to do better here in the future, but we simplify the logic here
+            // for now.)
+            //
+            // An unpacked annotation may represent a fixed-length tuple, and a variadic parameter
+            // followed by positional parameters may represent an unpacked tuple with a required suffix
+            // instead of an open-ended tail.
+            let target_has_open_ended_variadic = || {
+                target_variadic.is_some_and(|(index, parameter)| {
+                    !parameter.has_starred_annotation()
+                        && !target
+                            .parameters
+                            .iter()
+                            .skip(index)
+                            .any(Parameter::is_positional)
+                })
+            };
+
             let target_accepts_extra_positionals =
-                target_positional > source_positional || target.parameters.variadic().is_some();
+                target_positional > source_positional || target_variadic.is_some();
 
             if target_accepts_extra_positionals {
                 if let Some(context) = self.report_context()
-                    && target_positional > source_positional
-                    && let Some(ParameterKind::KeywordOnly { name, .. }) = source
-                        .parameters
-                        .iter()
-                        .nth(source_positional)
-                        .map(Parameter::kind)
+                    && (target_positional > source_positional || target_has_open_ended_variadic())
                 {
-                    context.push(ErrorContext::ParameterMustAcceptPositionalArguments {
-                        name: name.clone(),
-                    });
+                    let error_context = if target_positional > source_positional {
+                        let source_parameter_kind = source
+                            .parameters
+                            .get(source_positional)
+                            .map(Parameter::kind);
+
+                        match source_parameter_kind {
+                            Some(ParameterKind::KeywordOnly { name, .. }) => {
+                                ErrorContext::ParameterMustAcceptPositionalArguments {
+                                    name: name.clone(),
+                                }
+                            }
+                            Some(ParameterKind::KeywordVariadic { .. }) | None => {
+                                let parameter = target
+                                    .parameters
+                                    .get_positional(source_positional)
+                                    .and_then(Parameter::name);
+                                ErrorContext::MissingParameter {
+                                    parameter: ParameterDescription::new(
+                                        source_positional,
+                                        parameter,
+                                    ),
+                                }
+                            }
+                            Some(
+                                ParameterKind::PositionalOnly { .. }
+                                | ParameterKind::PositionalOrKeyword { .. }
+                                | ParameterKind::Variadic { .. },
+                            ) => unreachable!(
+                                "the first parameter after the positional prefix \
+                                cannot be positional or variadic"
+                            ),
+                        }
+                    } else {
+                        ErrorContext::MissingVariadicPositionalParameter
+                    };
+                    context.push(error_context);
                 }
 
                 return self.never();
@@ -2396,6 +2446,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             !result
                 .intersect(db, self.constraints, constraint_set)
                 .is_never_satisfied(db)
+        };
+        let parameter_must_have_default = |parameter: &Parameter<'db>, index: usize| {
+            ErrorContext::RequiredParameterMustHaveDefault {
+                parameter: ParameterDescription::new(index, parameter.name()),
+            }
         };
 
         if self.typevar_evaluation == TypeVarEvaluation::Lazy {
@@ -3000,6 +3055,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         if target.parameters.is_top() {
             return self.always();
         } else if source.parameters.is_top() && !target.parameters.is_gradual() {
+            if let Some(context) = self.report_context() {
+                context.push(ErrorContext::TopCallableAssignedToNonTop {
+                    return_type: source.return_ty,
+                });
+            }
             return self.never();
         }
 
@@ -3344,9 +3404,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
                 EitherOrBoth::Right(target_parameter) => {
                     if let Some(source_parameter_count) = as_target_typevartuple(target_parameter) {
-                        if source_parameter_count > 0 {
-                            return self.never();
-                        }
+                        assert_eq!(
+                            source_parameter_count, 0,
+                            "an exhausted source signature cannot provide parameters \
+                            to a TypeVarTuple"
+                        );
                         if !check_types(
                             &mut result,
                             target_parameter.annotated_type(),
@@ -3362,6 +3424,34 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
                     // If there are more parameters in `target` than in `source`, then `source` is
                     // not a subtype of `target`.
+                    if let Some(context) = self.report_context()
+                        && target.parameters.as_paramspec_with_prefix().is_none()
+                    {
+                        let error_context = match target_parameter.kind() {
+                            ParameterKind::PositionalOnly { .. }
+                            | ParameterKind::PositionalOrKeyword { .. } => unreachable!(
+                                "unmatched target positional parameters \
+                                are rejected by the positional fast path"
+                            ),
+                            ParameterKind::Variadic { .. } => {
+                                unreachable!(
+                                    "an unmatched target `*args` is impossible: \
+                                    a source without `*args` is rejected by the positional fast path, \
+                                    while a source with `*args` consumes the target during matching"
+                                )
+                            }
+                            ParameterKind::KeywordOnly { .. } => ErrorContext::MissingParameter {
+                                parameter: ParameterDescription::new(
+                                    target_index,
+                                    target_parameter.name(),
+                                ),
+                            },
+                            ParameterKind::KeywordVariadic { .. } => {
+                                ErrorContext::MissingVariadicKeywordParameter
+                            }
+                        };
+                        context.push(error_context);
+                    }
                     return self.never();
                 }
 
@@ -3382,6 +3472,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             },
                         ) => {
                             if source_default.is_none() && target_default.is_some() {
+                                if let Some(context) = self.report_context() {
+                                    context.push(parameter_must_have_default(
+                                        source_param,
+                                        target_index,
+                                    ));
+                                }
                                 return self.never();
                             }
                             if !check_types(
@@ -3416,6 +3512,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             }
                             // The following checks are the same as positional-only parameters.
                             if source_default.is_none() && target_default.is_some() {
+                                if let Some(context) = self.report_context() {
+                                    context.push(parameter_must_have_default(
+                                        source_param,
+                                        target_index,
+                                    ));
+                                }
                                 return self.never();
                             }
                             if !check_types(
@@ -3560,6 +3662,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             }
 
                             if !source_param.is_variadic() {
+                                if let Some(context) = self.report_context()
+                                    && target.parameters.as_paramspec_with_prefix().is_none()
+                                {
+                                    let parameter = ParameterDescription::new(
+                                        target_index,
+                                        source_param.name(),
+                                    );
+                                    context
+                                        .push(ErrorContext::ExtraRequiredParameter { parameter });
+                                }
                                 return self.never();
                             }
                             if !check_types(
@@ -3649,6 +3761,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     // only contains keyword-only and keyword-variadic parameters. However, if the
                     // parameter has a default, it's valid because callers don't need to provide it.
                     if default_type.is_none() {
+                        if let Some(context) = self.report_context() {
+                            if let Some(source_name) = source_param.name()
+                                && target
+                                    .parameters
+                                    .iter()
+                                    .any(|target_param| target_param.name() == Some(source_name))
+                            {
+                                context.push(ErrorContext::ParameterMustAcceptKeywordArguments {
+                                    source_name: Some(source_name.clone()),
+                                    target_name: source_name.clone(),
+                                });
+                            } else {
+                                let parameter =
+                                    ParameterDescription::new(target_index, source_param.name());
+                                context.push(ErrorContext::ExtraRequiredParameter { parameter });
+                            }
+                        }
                         return self.never();
                     }
                 }
@@ -3677,6 +3806,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 ..
                             } => {
                                 if source_default.is_none() && target_default.is_some() {
+                                    if let Some(context) = self.report_context() {
+                                        context.push(parameter_must_have_default(
+                                            source_param,
+                                            target_index,
+                                        ));
+                                    }
                                     return self.never();
                                 }
                                 if !check_types(
@@ -3704,6 +3839,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             return result;
                         }
                     } else {
+                        if let Some(context) = self.report_context() {
+                            let parameter =
+                                ParameterDescription::new(target_index, target_param.name());
+                            context.push(ErrorContext::MissingParameter { parameter });
+                        }
                         return self.never();
                     }
                 }
@@ -3711,6 +3851,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let Some(source_keyword_variadic) = source_keyword_variadic else {
                         // For a `source <: target` relationship, if `target` has a keyword variadic
                         // parameter, `source` must also have a keyword variadic parameter.
+                        if let Some(context) = self.report_context()
+                            && target.parameters.as_paramspec_with_prefix().is_none()
+                        {
+                            context.push(ErrorContext::MissingVariadicKeywordParameter);
+                        }
                         return self.never();
                     };
                     if !check_types(
@@ -3738,6 +3883,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         )]
         for (_, source_param) in source_keywords {
             if source_param.default_type().is_none() {
+                if let Some(context) = self.report_context() {
+                    let parameter = ParameterDescription::new(target_index, source_param.name());
+                    context.push(ErrorContext::ExtraRequiredParameter { parameter });
+                }
                 return self.never();
             }
         }


### PR DESCRIPTION
## Summary

We had a lot of branches in `signatures.rs` where we were failing to add error context, which often made our diagnostics less comprehensible than they could have been. This PR adds context to lots of these branches, and adds snapshots to cover the new code paths.

There are still lots of `return self.never();` branches, even on this PR branch, that don't have any error context attached to them. I was too scared to touch the `ParamSpec`- and `TypeVarTuple`-specific branches in this PR 🙈 so left them out of scope for now.