### PR TITLE
[ty] Hide stub-only helpers from implicit builtin lookup

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3573,9 +3573,17 @@ _private_type_alias = type[int]
 
 def make_union() -> UnionType: ...
 def make_typevar() -> TypeVar: ...
+def make_callback() -> Callable[[int], int]: ...
+def make_class() -> type[int]: ...
+def decorate(callback: Callable[[int], int]) -> Callable[[int], int]: ...
 
 _private_runtime_union = make_union()
 _private_runtime_typevar = make_typevar()
+_private_runtime_callback = make_callback()
+_private_runtime_class = make_class()
+
+@decorate
+def _private_runtime_decorated(value: int) -> int: ...
 
 class PublicProtocol(Protocol):
     def method(self) -> None: ...
@@ -3622,6 +3630,9 @@ class _PrivateTypeOnlyProtocol(Protocol):
         test.not_contains("_private_reexported_alias");
         test.contains("_private_runtime_union");
         test.contains("_private_runtime_typevar");
+        test.contains("_private_runtime_callback");
+        test.contains("_private_runtime_class");
+        test.contains("_private_runtime_decorated");
         test.contains("PublicProtocol");
         test.contains("_PrivateProtocol");
         test.contains("_PrivateRuntimeCheckableProtocol");

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3393,6 +3393,23 @@ mod tests {
     }
 
     #[test]
+    fn private_builtin_helpers_are_not_scoped_completions() {
+        let builder = completion_test_builder("_O<CURSOR>").skip_auto_import();
+        let test = builder.build();
+
+        test.not_contains("_Opener");
+    }
+
+    #[test]
+    fn explicitly_imported_private_builtin_helpers_are_scoped_completions() {
+        let builder =
+            completion_test_builder("from builtins import _Opener\n_Op<CURSOR>").skip_auto_import();
+        let test = builder.build();
+
+        test.contains("_Opener");
+    }
+
+    #[test]
     fn keywords() {
         let test = completion_test_builder(
             "\

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3410,6 +3410,18 @@ mod tests {
     }
 
     #[test]
+    fn private_project_builtin_shadows_type_checking_only_builtin_completion() {
+        let builder = CursorTest::builder()
+            .source("__builtins__.pyi", "_Opener: int")
+            .source("main.py", "_O<CURSOR>")
+            .completion_test_builder()
+            .skip_auto_import();
+        let test = builder.build();
+
+        test.contains("_Opener");
+    }
+
+    #[test]
     fn keywords() {
         let test = completion_test_builder(
             "\
@@ -3558,10 +3570,7 @@ re.<CURSOR>
             .source(
                 "package/__init__.pyi",
                 r#"\
-from types import UnionType
-from typing import TYPE_CHECKING, Callable, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, TypeVarTuple, runtime_checkable, type_check_only
-
-from .helpers import _private_reexported_alias as _private_reexported_alias
+from typing import TypeAlias, Literal, TypeVar, ParamSpec, TypeVarTuple, Protocol
 
 public_name = 1
 _private_name = 1
@@ -3580,50 +3589,16 @@ _private_type_var_tuple = TypeVarTuple("_private_type_var_tuple")
 
 public_explicit_type_alias: TypeAlias = Literal[1]
 _private_explicit_type_alias: TypeAlias = Literal[1]
-_private_simple_type_alias: TypeAlias = int
 
 public_implicit_union_alias = int | str
 _private_implicit_union_alias = int | str
-_private_generic_alias = list[int]
-_private_callable_alias = Callable[[int], str]
-_private_type_alias = type[int]
-
-def make_union() -> UnionType: ...
-def make_typevar() -> TypeVar: ...
-def make_callback() -> Callable[[int], int]: ...
-def make_class() -> type[int]: ...
-def decorate(callback: Callable[[int], int]) -> Callable[[int], int]: ...
-
-_private_runtime_union = make_union()
-_private_runtime_typevar = make_typevar()
-_private_runtime_callback = make_callback()
-_private_runtime_class = make_class()
-
-@decorate
-def _private_runtime_decorated(value: int) -> int: ...
 
 class PublicProtocol(Protocol):
     def method(self) -> None: ...
 
 class _PrivateProtocol(Protocol):
     def method(self) -> None: ...
-
-@runtime_checkable
-class _PrivateRuntimeCheckableProtocol(Protocol):
-    def method(self) -> None: ...
-
-@type_check_only
-class _PrivateTypeOnlyProtocol(Protocol):
-    def method(self) -> None: ...
-
-if TYPE_CHECKING:
-    class _PrivateTypeCheckingProtocol(Protocol):
-        def method(self) -> None: ...
 "#,
-            )
-            .source(
-                "package/helpers.pyi",
-                "from typing import TypeAlias\n_private_reexported_alias: TypeAlias = int\n",
             )
             .source("main.py", "import package; package.<CURSOR>")
             .completion_test_builder();
@@ -3642,23 +3617,10 @@ if TYPE_CHECKING:
         test.not_contains("_private_type_var_tuple");
         test.contains("public_explicit_type_alias");
         test.not_contains("_private_explicit_type_alias");
-        test.not_contains("_private_simple_type_alias");
         test.contains("public_implicit_union_alias");
         test.not_contains("_private_implicit_union_alias");
-        test.not_contains("_private_generic_alias");
-        test.not_contains("_private_callable_alias");
-        test.not_contains("_private_type_alias");
-        test.not_contains("_private_reexported_alias");
-        test.contains("_private_runtime_union");
-        test.contains("_private_runtime_typevar");
-        test.contains("_private_runtime_callback");
-        test.contains("_private_runtime_class");
-        test.contains("_private_runtime_decorated");
         test.contains("PublicProtocol");
-        test.contains("_PrivateProtocol");
-        test.contains("_PrivateRuntimeCheckableProtocol");
-        test.not_contains("_PrivateTypeOnlyProtocol");
-        test.not_contains("_PrivateTypeCheckingProtocol");
+        test.not_contains("_PrivateProtocol");
     }
 
     /// Unlike [`private_symbols_in_stub`], this test doesn't use a `.pyi` file so all of the names

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3570,7 +3570,8 @@ re.<CURSOR>
             .source(
                 "package/__init__.pyi",
                 r#"\
-from typing import TypeAlias, Literal, TypeVar, ParamSpec, TypeVarTuple, Protocol
+from types import UnionType
+from typing import TYPE_CHECKING, Callable, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, TypeVarTuple, type_check_only
 
 public_name = 1
 _private_name = 1
@@ -3592,12 +3593,37 @@ _private_explicit_type_alias: TypeAlias = Literal[1]
 
 public_implicit_union_alias = int | str
 _private_implicit_union_alias = int | str
+_private_generic_alias = list[int]
+_private_callable_alias = Callable[[int], str]
+_private_type_alias = type[int]
+
+def make_union() -> UnionType: ...
+def make_typevar() -> TypeVar: ...
+def identity[T](value: T) -> T: ...
+
+_private_runtime_union = make_union()
+_private_runtime_typevar = make_typevar()
+_private_precise_runtime_union = identity(int | str)
+
+callbacks: list[Callable[[int], str]]
+_private_indexed_callback = callbacks[0]
+
+classes: list[type[int]]
+_private_indexed_class = classes[0]
 
 class PublicProtocol(Protocol):
     def method(self) -> None: ...
 
 class _PrivateProtocol(Protocol):
     def method(self) -> None: ...
+
+@type_check_only
+class _PrivateTypeOnlyProtocol(Protocol):
+    def method(self) -> None: ...
+
+if TYPE_CHECKING:
+    class _PrivateTypeCheckingProtocol(Protocol):
+        def method(self) -> None: ...
 "#,
             )
             .source("main.py", "import package; package.<CURSOR>")
@@ -3619,8 +3645,18 @@ class _PrivateProtocol(Protocol):
         test.not_contains("_private_explicit_type_alias");
         test.contains("public_implicit_union_alias");
         test.not_contains("_private_implicit_union_alias");
+        test.not_contains("_private_generic_alias");
+        test.not_contains("_private_callable_alias");
+        test.not_contains("_private_type_alias");
+        test.contains("_private_runtime_union");
+        test.contains("_private_runtime_typevar");
+        test.contains("_private_precise_runtime_union");
+        test.contains("_private_indexed_callback");
+        test.contains("_private_indexed_class");
         test.contains("PublicProtocol");
-        test.not_contains("_PrivateProtocol");
+        test.contains("_PrivateProtocol");
+        test.not_contains("_PrivateTypeOnlyProtocol");
+        test.not_contains("_PrivateTypeCheckingProtocol");
     }
 
     /// Unlike [`private_symbols_in_stub`], this test doesn't use a `.pyi` file so all of the names

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3393,35 +3393,6 @@ mod tests {
     }
 
     #[test]
-    fn private_builtin_helpers_are_not_scoped_completions() {
-        let builder = completion_test_builder("_O<CURSOR>").skip_auto_import();
-        let test = builder.build();
-
-        test.not_contains("_Opener");
-    }
-
-    #[test]
-    fn explicitly_imported_private_builtin_helpers_are_scoped_completions() {
-        let builder =
-            completion_test_builder("from builtins import _Opener\n_Op<CURSOR>").skip_auto_import();
-        let test = builder.build();
-
-        test.contains("_Opener");
-    }
-
-    #[test]
-    fn private_project_builtin_shadows_type_checking_only_builtin_completion() {
-        let builder = CursorTest::builder()
-            .source("__builtins__.pyi", "_Opener: int")
-            .source("main.py", "_O<CURSOR>")
-            .completion_test_builder()
-            .skip_auto_import();
-        let test = builder.build();
-
-        test.contains("_Opener");
-    }
-
-    #[test]
     fn keywords() {
         let test = completion_test_builder(
             "\
@@ -3618,10 +3589,17 @@ class _PrivateProtocol(Protocol):
     def method(self) -> None: ...
 
 @type_check_only
+class PublicTypeOnlyProtocol(Protocol):
+    def method(self) -> None: ...
+
+@type_check_only
 class _PrivateTypeOnlyProtocol(Protocol):
     def method(self) -> None: ...
 
 if TYPE_CHECKING:
+    class PublicTypeCheckingProtocol(Protocol):
+        def method(self) -> None: ...
+
     class _PrivateTypeCheckingProtocol(Protocol):
         def method(self) -> None: ...
 "#,
@@ -3655,7 +3633,9 @@ if TYPE_CHECKING:
         test.contains("_private_indexed_class");
         test.contains("PublicProtocol");
         test.contains("_PrivateProtocol");
+        test.not_contains("PublicTypeOnlyProtocol");
         test.not_contains("_PrivateTypeOnlyProtocol");
+        test.not_contains("PublicTypeCheckingProtocol");
         test.not_contains("_PrivateTypeCheckingProtocol");
     }
 

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3541,7 +3541,10 @@ re.<CURSOR>
             .source(
                 "package/__init__.pyi",
                 r#"\
-from typing import TypeAlias, Literal, TypeVar, ParamSpec, TypeVarTuple, Protocol
+from types import UnionType
+from typing import Callable, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, TypeVarTuple, runtime_checkable, type_check_only
+
+from .helpers import _private_reexported_alias as _private_reexported_alias
 
 public_name = 1
 _private_name = 1
@@ -3560,16 +3563,38 @@ _private_type_var_tuple = TypeVarTuple("_private_type_var_tuple")
 
 public_explicit_type_alias: TypeAlias = Literal[1]
 _private_explicit_type_alias: TypeAlias = Literal[1]
+_private_simple_type_alias: TypeAlias = int
 
 public_implicit_union_alias = int | str
 _private_implicit_union_alias = int | str
+_private_generic_alias = list[int]
+_private_callable_alias = Callable[[int], str]
+_private_type_alias = type[int]
+
+def make_union() -> UnionType: ...
+def make_typevar() -> TypeVar: ...
+
+_private_runtime_union = make_union()
+_private_runtime_typevar = make_typevar()
 
 class PublicProtocol(Protocol):
     def method(self) -> None: ...
 
 class _PrivateProtocol(Protocol):
     def method(self) -> None: ...
+
+@runtime_checkable
+class _PrivateRuntimeCheckableProtocol(Protocol):
+    def method(self) -> None: ...
+
+@type_check_only
+class _PrivateTypeOnlyProtocol(Protocol):
+    def method(self) -> None: ...
 "#,
+            )
+            .source(
+                "package/helpers.pyi",
+                "from typing import TypeAlias\n_private_reexported_alias: TypeAlias = int\n",
             )
             .source("main.py", "import package; package.<CURSOR>")
             .completion_test_builder();
@@ -3588,10 +3613,19 @@ class _PrivateProtocol(Protocol):
         test.not_contains("_private_type_var_tuple");
         test.contains("public_explicit_type_alias");
         test.not_contains("_private_explicit_type_alias");
+        test.not_contains("_private_simple_type_alias");
         test.contains("public_implicit_union_alias");
         test.not_contains("_private_implicit_union_alias");
+        test.not_contains("_private_generic_alias");
+        test.not_contains("_private_callable_alias");
+        test.not_contains("_private_type_alias");
+        test.not_contains("_private_reexported_alias");
+        test.contains("_private_runtime_union");
+        test.contains("_private_runtime_typevar");
         test.contains("PublicProtocol");
-        test.not_contains("_PrivateProtocol");
+        test.contains("_PrivateProtocol");
+        test.contains("_PrivateRuntimeCheckableProtocol");
+        test.not_contains("_PrivateTypeOnlyProtocol");
     }
 
     /// Unlike [`private_symbols_in_stub`], this test doesn't use a `.pyi` file so all of the names

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3542,7 +3542,7 @@ re.<CURSOR>
                 "package/__init__.pyi",
                 r#"\
 from types import UnionType
-from typing import TYPE_CHECKING, Callable, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, TypeVarTuple, type_check_only
+from typing import TYPE_CHECKING, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, TypeVarTuple, type_check_only
 
 public_name = 1
 _private_name = 1
@@ -3564,9 +3564,6 @@ _private_explicit_type_alias: TypeAlias = Literal[1]
 
 public_implicit_union_alias = int | str
 _private_implicit_union_alias = int | str
-_private_generic_alias = list[int]
-_private_callable_alias = Callable[[int], str]
-_private_type_alias = type[int]
 
 def make_union() -> UnionType: ...
 def make_typevar() -> TypeVar: ...
@@ -3575,12 +3572,6 @@ def identity[T](value: T) -> T: ...
 _private_runtime_union = make_union()
 _private_runtime_typevar = make_typevar()
 _private_precise_runtime_union = identity(int | str)
-
-callbacks: list[Callable[[int], str]]
-_private_indexed_callback = callbacks[0]
-
-classes: list[type[int]]
-_private_indexed_class = classes[0]
 
 class PublicProtocol(Protocol):
     def method(self) -> None: ...
@@ -3623,14 +3614,9 @@ if TYPE_CHECKING:
         test.not_contains("_private_explicit_type_alias");
         test.contains("public_implicit_union_alias");
         test.not_contains("_private_implicit_union_alias");
-        test.not_contains("_private_generic_alias");
-        test.not_contains("_private_callable_alias");
-        test.not_contains("_private_type_alias");
         test.contains("_private_runtime_union");
         test.contains("_private_runtime_typevar");
         test.contains("_private_precise_runtime_union");
-        test.contains("_private_indexed_callback");
-        test.contains("_private_indexed_class");
         test.contains("PublicProtocol");
         test.contains("_PrivateProtocol");
         test.not_contains("PublicTypeOnlyProtocol");

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3542,7 +3542,7 @@ re.<CURSOR>
                 "package/__init__.pyi",
                 r#"\
 from types import UnionType
-from typing import Callable, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, TypeVarTuple, runtime_checkable, type_check_only
+from typing import TYPE_CHECKING, Callable, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, TypeVarTuple, runtime_checkable, type_check_only
 
 from .helpers import _private_reexported_alias as _private_reexported_alias
 
@@ -3598,6 +3598,10 @@ class _PrivateRuntimeCheckableProtocol(Protocol):
 @type_check_only
 class _PrivateTypeOnlyProtocol(Protocol):
     def method(self) -> None: ...
+
+if TYPE_CHECKING:
+    class _PrivateTypeCheckingProtocol(Protocol):
+        def method(self) -> None: ...
 "#,
             )
             .source(
@@ -3637,6 +3641,7 @@ class _PrivateTypeOnlyProtocol(Protocol):
         test.contains("_PrivateProtocol");
         test.contains("_PrivateRuntimeCheckableProtocol");
         test.not_contains("_PrivateTypeOnlyProtocol");
+        test.not_contains("_PrivateTypeCheckingProtocol");
     }
 
     /// Unlike [`private_symbols_in_stub`], this test doesn't use a `.pyi` file so all of the names

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -1216,6 +1216,16 @@ def convert_to_number(value):
     }
 
     #[test]
+    fn cannot_rename_private_builtin_helper() {
+        let test = CursorTest::builder()
+            .source("other.py", "_T_co\n")
+            .source("main.py", "<CURSOR>_T_co\n")
+            .build();
+
+        assert_snapshot!(test.prepare_rename(), @"Cannot rename");
+    }
+
+    #[test]
     fn rename_keyword_argument() {
         // Test renaming a keyword argument and its corresponding parameter
         let test = cursor_test(

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -1217,6 +1217,8 @@ def convert_to_number(value):
 
     #[test]
     fn cannot_rename_private_builtin_helper() {
+        // Unresolved references must not resolve to a private typeshed helper or rename matching
+        // unresolved references in other files.
         let test = CursorTest::builder()
             .source("other.py", "_T_co\n")
             .source("main.py", "<CURSOR>_T_co\n")

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -1217,8 +1217,8 @@ def convert_to_number(value):
 
     #[test]
     fn cannot_rename_private_builtin_helper() {
-        // Unresolved references must not resolve to a private typeshed helper or rename matching
-        // unresolved references in other files.
+        // Unresolved references must not resolve to a private typeshed helper that likely does not
+        // exist at runtime or rename matching unresolved references in other files.
         let test = CursorTest::builder()
             .source("other.py", "_T_co\n")
             .source("main.py", "<CURSOR>_T_co\n")

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -4656,6 +4656,14 @@ def f():
     }
 
     #[test]
+    fn private_builtin_helpers_do_not_receive_semantic_tokens() {
+        let test = SemanticTokenTest::new("_T_co\n_P\n");
+
+        let tokens = test.highlight_file();
+        assert_snapshot!(test.to_snapshot(&tokens), @"");
+    }
+
+    #[test]
     fn unresolved_attributes_do_not_receive_semantic_tokens() {
         let test = SemanticTokenTest::new(
             r#"

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -4657,6 +4657,8 @@ def f():
 
     #[test]
     fn private_builtin_helpers_do_not_receive_semantic_tokens() {
+        // Private helpers excluded from implicit builtin lookup must remain unresolved for IDE
+        // highlighting instead of receiving tokens from their typeshed definitions.
         let test = SemanticTokenTest::new("_T_co\n_P\n");
 
         let tokens = test.highlight_file();

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -170,6 +170,28 @@ _ReassignedAlias: int
 _ReassignedAlias: TypeAlias = str
 ```
 
+## Private runtime protocols in custom builtins
+
+Protocol classes are real runtime objects unless their definitions are marked as type-check-only.
+
+```py
+_RuntimeProtocol
+_RuntimeCheckableProtocol
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from typing import Protocol, runtime_checkable
+
+class _RuntimeProtocol(Protocol):
+    def method(self) -> int: ...
+
+@runtime_checkable
+class _RuntimeCheckableProtocol(Protocol):
+    def method(self) -> int: ...
+```
+
 ## Conditionally defined private runtime values
 
 A private name remains available when any reachable definition represents a real runtime value.

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -19,6 +19,182 @@ reveal_type(chr)  # revealed: def chr(i: SupportsIndex, /) -> str
 reveal_type(str)  # revealed: <class 'str'>
 ```
 
+## Stub-only symbols are not implicit builtins
+
+Private type variables, parameter specifications, type aliases, and protocols in `builtins.pyi` are
+implementation details of the stub. They must not be available without an explicit import.
+
+```py
+_T_co  # error: [unresolved-reference]
+_P  # error: [unresolved-reference]
+_PositiveInteger  # error: [unresolved-reference]
+_Opener  # error: [unresolved-reference]
+_SupportsSynchronousAnext  # error: [unresolved-reference]
+```
+
+## Explicitly importing stub-only builtin symbols
+
+An explicit import can still access private helpers from `builtins.pyi`, just as it can access
+private symbols from any other stub.
+
+```py
+from builtins import _Opener, _P, _PositiveInteger, _SupportsSynchronousAnext, _T_co
+
+_Opener
+_P
+_PositiveInteger
+_SupportsSynchronousAnext
+_T_co
+```
+
+## Private names in custom builtins
+
+A private runtime value defined by a project-level builtins stub remains available implicitly.
+Private generic helpers in the same stub do not.
+
+```py
+reveal_type(_private_value)  # revealed: int
+reveal_type(_private_type)  # revealed: <class 'int'>
+
+_private_union
+_private_typevar
+
+_PrivateTypeVar  # error: [unresolved-reference]
+_PrivateParamSpec  # error: [unresolved-reference]
+_PrivateTypeVarTuple  # error: [unresolved-reference]
+_PrivateAlias  # error: [unresolved-reference]
+_PrivateImplicitAlias  # error: [unresolved-reference]
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from types import UnionType
+from typing import ParamSpec, TypeAlias, TypeVar
+from typing_extensions import TypeVarTuple
+
+_private_value: int
+_private_type = int
+_private_union: UnionType
+_private_typevar: TypeVar
+
+_PrivateTypeVar = TypeVar("_PrivateTypeVar")
+_PrivateParamSpec = ParamSpec("_PrivateParamSpec")
+_PrivateTypeVarTuple = TypeVarTuple("_PrivateTypeVarTuple")
+_PrivateAlias: TypeAlias = int
+_PrivateImplicitAlias = int | str
+```
+
+## Conditionally defined private aliases
+
+A private type alias remains unavailable even when its possible definitions come from separate
+control-flow branches.
+
+```py
+_ConditionalAlias  # error: [unresolved-reference]
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from typing import TypeAlias
+
+flag: bool
+
+if flag:
+    _ConditionalAlias: TypeAlias = int
+else:
+    _ConditionalAlias: TypeAlias = str
+```
+
+## Conditionally defined private protocols
+
+All reachable private protocol definitions must be excluded from implicit builtin lookup.
+
+```py
+_ConditionalProtocol  # error: [unresolved-reference]
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from typing import Protocol, type_check_only
+
+flag: bool
+
+if flag:
+    @type_check_only
+    class _ConditionalProtocol(Protocol):
+        def method(self) -> int: ...
+
+else:
+    @type_check_only
+    class _ConditionalProtocol(Protocol):
+        def method(self) -> str: ...
+```
+
+## Re-exported private aliases
+
+Re-exporting a private type alias does not make its original stub-only definition a runtime builtin.
+
+```py
+_ImportedAlias  # error: [unresolved-reference]
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from helpers import _ImportedAlias as _ImportedAlias
+```
+
+`helpers.pyi`:
+
+```pyi
+from typing import TypeAlias
+
+_ImportedAlias: TypeAlias = int
+```
+
+## Conditionally defined private runtime values
+
+A private name remains available when any reachable definition represents a real runtime value.
+
+```py
+_ConditionalValue
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from typing import TypeAlias
+
+flag: bool
+
+if flag:
+    _ConditionalValue: TypeAlias = int
+else:
+    _ConditionalValue: int
+```
+
+## Explicitly writing private builtin aliases
+
+Writing to the builtin module is explicit attribute access, so it must not apply implicit builtin
+visibility rules.
+
+```py
+import builtins
+
+builtins._PrivateAlias = int
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from typing import TypeAlias
+
+_PrivateAlias: TypeAlias = int
+```
+
 ## Builtin symbol from custom typeshed
 
 If we specify a custom typeshed, we can use the builtin symbol from it, and no longer access the

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -213,6 +213,36 @@ else:
     _ConditionalValue: int
 ```
 
+## Runtime typing-object values in custom builtins
+
+A runtime factory can produce objects whose classes are also used for stub-only typing helpers.
+Those values must remain available as real builtins.
+
+```py
+_runtime_union
+_runtime_typevar
+_runtime_paramspec
+_runtime_typevartuple
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from types import UnionType
+from typing import ParamSpec, TypeVar
+from typing_extensions import TypeVarTuple
+
+def make_union() -> UnionType: ...
+def make_typevar() -> TypeVar: ...
+def make_paramspec() -> ParamSpec: ...
+def make_typevartuple() -> TypeVarTuple: ...
+
+_runtime_union = make_union()
+_runtime_typevar = make_typevar()
+_runtime_paramspec = make_paramspec()
+_runtime_typevartuple = make_typevartuple()
+```
+
 ## Explicitly writing private builtin aliases
 
 Writing to the builtin module is explicit attribute access, so it must not apply implicit builtin

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -90,6 +90,32 @@ def make_typevar() -> TypeVar: ...
 _runtime_typevar = make_typevar()
 ```
 
+## Private type-checking-only builtins with stacked decorators
+
+An outer decorator can change the inferred type of a private function or class, but it does not make
+an inner `@type_check_only` definition available at runtime.
+
+```py
+_PrivateFunction  # error: [unresolved-reference]
+_PrivateClass  # error: [unresolved-reference]
+```
+
+`__builtins__.pyi`:
+
+```pyi
+from typing import Callable, type_check_only
+
+def decorate_function(callback: Callable[[int], int]) -> Callable[[int], int]: ...
+def decorate_class(cls: type[object]) -> type[object]: ...
+@decorate_function
+@type_check_only
+def _PrivateFunction(value: int) -> int: ...
+
+@decorate_class
+@type_check_only
+class _PrivateClass: ...
+```
+
 ## Private runtime standard builtins
 
 A private class declared by the standard `builtins` stub remains available when it represents a real

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -223,24 +223,35 @@ _runtime_union
 _runtime_typevar
 _runtime_paramspec
 _runtime_typevartuple
+_runtime_callback
+_runtime_class
+_runtime_decorated
 ```
 
 `__builtins__.pyi`:
 
 ```pyi
 from types import UnionType
-from typing import ParamSpec, TypeVar
+from typing import Callable, ParamSpec, TypeVar
 from typing_extensions import TypeVarTuple
 
 def make_union() -> UnionType: ...
 def make_typevar() -> TypeVar: ...
 def make_paramspec() -> ParamSpec: ...
 def make_typevartuple() -> TypeVarTuple: ...
+def make_callback() -> Callable[[int], int]: ...
+def make_class() -> type[int]: ...
+def decorate(callback: Callable[[int], int]) -> Callable[[int], int]: ...
 
 _runtime_union = make_union()
 _runtime_typevar = make_typevar()
 _runtime_paramspec = make_paramspec()
 _runtime_typevartuple = make_typevartuple()
+_runtime_callback = make_callback()
+_runtime_class = make_class()
+
+@decorate
+def _runtime_decorated(value: int) -> int: ...
 ```
 
 ## Explicitly writing private builtin aliases

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -53,12 +53,10 @@ from typing import ParamSpec, Protocol, TypeAlias, TypeVar, type_check_only
 
 class object: ...
 class int: ...
-class str: ...
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 _PrivateAlias: TypeAlias = int
-_PrivateUnion = int | str
 
 @type_check_only
 class _PrivateProtocol(Protocol): ...
@@ -70,11 +68,12 @@ class PublicTypeOnlyClass: ...
 def public_type_only_function(): ...
 ```
 
+`module.py`:
+
 ```py
 _T  # error: [unresolved-reference]
 _P  # error: [unresolved-reference]
 _PrivateAlias  # error: [unresolved-reference]
-_PrivateUnion  # error: [unresolved-reference]
 _PrivateProtocol  # error: [unresolved-reference]
 PublicTypeOnlyClass  # error: [unresolved-reference]
 public_type_only_function  # error: [unresolved-reference]
@@ -120,6 +119,8 @@ class _PrivateProtocol(Protocol): ...
 @type_check_only
 class PublicTypeOnlyClass: ...
 ```
+
+`module.py`:
 
 ```py
 from builtins import PublicTypeOnlyClass, _PrivateAlias, _PrivateProtocol, _T
@@ -214,6 +215,8 @@ typeshed = "/typeshed"
 class object: ...
 class _IncompleteInputError: ...
 ```
+
+`module.py`:
 
 ```py
 _IncompleteInputError

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -64,13 +64,17 @@ _PrivateParamSpec  # error: [unresolved-reference]
 _PrivateTypeVarTuple  # error: [unresolved-reference]
 _PrivateAlias  # error: [unresolved-reference]
 _PrivateImplicitAlias  # error: [unresolved-reference]
+_PrivateListAlias  # error: [unresolved-reference]
+_PrivateTupleAlias  # error: [unresolved-reference]
+_PrivateCallableAlias  # error: [unresolved-reference]
+_PrivateTypeAlias  # error: [unresolved-reference]
 ```
 
 `__builtins__.pyi`:
 
 ```pyi
 from types import UnionType
-from typing import ParamSpec, TypeAlias, TypeVar
+from typing import Callable, ParamSpec, TypeAlias, TypeVar
 from typing_extensions import TypeVarTuple
 
 _private_value: int
@@ -83,6 +87,10 @@ _PrivateParamSpec = ParamSpec("_PrivateParamSpec")
 _PrivateTypeVarTuple = TypeVarTuple("_PrivateTypeVarTuple")
 _PrivateAlias: TypeAlias = int
 _PrivateImplicitAlias = int | str
+_PrivateListAlias = list[int]
+_PrivateTupleAlias = tuple[int, str]
+_PrivateCallableAlias = Callable[[int], str]
+_PrivateTypeAlias = type[int]
 ```
 
 ## Conditionally defined private aliases

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -147,12 +147,13 @@ Re-exporting a private type alias does not make its original stub-only definitio
 
 ```py
 _ImportedAlias  # error: [unresolved-reference]
+_ReassignedAlias  # error: [unresolved-reference]
 ```
 
 `__builtins__.pyi`:
 
 ```pyi
-from helpers import _ImportedAlias as _ImportedAlias
+from helpers import _ImportedAlias as _ImportedAlias, _ReassignedAlias as _ReassignedAlias
 ```
 
 `helpers.pyi`:
@@ -160,7 +161,13 @@ from helpers import _ImportedAlias as _ImportedAlias
 ```pyi
 from typing import TypeAlias
 
-_ImportedAlias: TypeAlias = int
+if False:
+    _ImportedAlias: int
+else:
+    _ImportedAlias: TypeAlias = int
+
+_ReassignedAlias: int
+_ReassignedAlias: TypeAlias = str
 ```
 
 ## Conditionally defined private runtime values

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -21,31 +21,113 @@ reveal_type(str)  # revealed: <class 'str'>
 
 ## Private type-checking-only builtin helpers are not implicit builtins
 
-Private type variables, type aliases, and type-checking-only protocols in the standard `builtins`
-stub are implementation details. They must not be available without an explicit import.
+Private type variables, type aliases, and type-checking-only definitions in a `builtins` stub are
+implementation details. They must not be available without an explicit import.
+
+```toml
+[environment]
+typeshed = "/typeshed"
+```
+
+`/typeshed/stdlib/typing.pyi`:
+
+```pyi
+class TypeVar:
+    def __new__(cls, name): ...
+
+class ParamSpec:
+    def __new__(cls, name): ...
+
+class Protocol: ...
+class _SpecialForm: ...
+
+TypeAlias: _SpecialForm
+
+def type_check_only(obj): ...
+```
+
+`/typeshed/stdlib/builtins.pyi`:
+
+```pyi
+from typing import ParamSpec, Protocol, TypeAlias, TypeVar, type_check_only
+
+class object: ...
+class int: ...
+class str: ...
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+_PrivateAlias: TypeAlias = int
+_PrivateUnion = int | str
+
+@type_check_only
+class _PrivateProtocol(Protocol): ...
+
+@type_check_only
+class PublicTypeOnlyClass: ...
+
+@type_check_only
+def public_type_only_function(): ...
+```
 
 ```py
-_T_co  # error: [unresolved-reference]
+_T  # error: [unresolved-reference]
 _P  # error: [unresolved-reference]
-_PositiveInteger  # error: [unresolved-reference]
-_LiteralInteger  # error: [unresolved-reference]
-_Opener  # error: [unresolved-reference]
-_SupportsSynchronousAnext  # error: [unresolved-reference]
+_PrivateAlias  # error: [unresolved-reference]
+_PrivateUnion  # error: [unresolved-reference]
+_PrivateProtocol  # error: [unresolved-reference]
+PublicTypeOnlyClass  # error: [unresolved-reference]
+public_type_only_function  # error: [unresolved-reference]
 ```
 
 ## Explicitly importing private builtin helpers
 
-Filtering implicit builtin fallback does not change explicit imports from the `builtins` module.
+We still allow users to explicitly import implementation details from the `builtins` module.
+
+```toml
+[environment]
+typeshed = "/typeshed"
+```
+
+`/typeshed/stdlib/typing.pyi`:
+
+```pyi
+class TypeVar:
+    def __new__(cls, name): ...
+
+class Protocol: ...
+class _SpecialForm: ...
+
+TypeAlias: _SpecialForm
+
+def type_check_only(obj): ...
+```
+
+`/typeshed/stdlib/builtins.pyi`:
+
+```pyi
+from typing import Protocol, TypeAlias, TypeVar, type_check_only
+
+class object: ...
+class int: ...
+
+_T = TypeVar("_T")
+_PrivateAlias: TypeAlias = int
+
+@type_check_only
+class _PrivateProtocol(Protocol): ...
+
+@type_check_only
+class PublicTypeOnlyClass: ...
+```
 
 ```py
-from builtins import _LiteralInteger, _Opener, _P, _PositiveInteger, _SupportsSynchronousAnext, _T_co
+from builtins import PublicTypeOnlyClass, _PrivateAlias, _PrivateProtocol, _T
 
-_LiteralInteger
-_Opener
-_P
-_PositiveInteger
-_SupportsSynchronousAnext
-_T_co
+_T
+_PrivateAlias
+_PrivateProtocol
+PublicTypeOnlyClass
 ```
 
 ## Private project-level builtins

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -19,10 +19,10 @@ reveal_type(chr)  # revealed: def chr(i: SupportsIndex, /) -> str
 reveal_type(str)  # revealed: <class 'str'>
 ```
 
-## Stub-only symbols are not implicit builtins
+## Private type-checking-only builtin helpers are not implicit builtins
 
-Private type variables, parameter specifications, type aliases, and protocols in `builtins.pyi` are
-implementation details of the stub. They must not be available without an explicit import.
+Private type variables, type aliases, and type-checking-only protocols in the standard `builtins`
+stub are implementation details. They must not be available without an explicit import.
 
 ```py
 _T_co  # error: [unresolved-reference]
@@ -32,10 +32,9 @@ _Opener  # error: [unresolved-reference]
 _SupportsSynchronousAnext  # error: [unresolved-reference]
 ```
 
-## Explicitly importing stub-only builtin symbols
+## Explicitly importing private builtin helpers
 
-An explicit import can still access private helpers from `builtins.pyi`, just as it can access
-private symbols from any other stub.
+Filtering implicit builtin fallback does not change explicit imports from the `builtins` module.
 
 ```py
 from builtins import _Opener, _P, _PositiveInteger, _SupportsSynchronousAnext, _T_co
@@ -47,255 +46,42 @@ _SupportsSynchronousAnext
 _T_co
 ```
 
-## Private names in custom builtins
+## Private project-level builtins
 
-A private runtime value defined by a project-level builtins stub remains available implicitly.
-Private generic helpers in the same stub do not.
+A project-level `__builtins__.pyi` can deliberately provide private runtime names, including names
+that overlap with private helpers in the standard `builtins` stub.
 
 ```py
 reveal_type(_private_value)  # revealed: int
-reveal_type(_private_type)  # revealed: <class 'int'>
-
-_private_union
-_private_typevar
-
-_PrivateTypeVar  # error: [unresolved-reference]
-_PrivateParamSpec  # error: [unresolved-reference]
-_PrivateTypeVarTuple  # error: [unresolved-reference]
-_PrivateAlias  # error: [unresolved-reference]
-_PrivateImplicitAlias  # error: [unresolved-reference]
-_PrivateListAlias  # error: [unresolved-reference]
-_PrivateTupleAlias  # error: [unresolved-reference]
-_PrivateCallableAlias  # error: [unresolved-reference]
-_PrivateTypeAlias  # error: [unresolved-reference]
+reveal_type(_T_co)  # revealed: int
 ```
 
 `__builtins__.pyi`:
 
 ```pyi
-from types import UnionType
-from typing import Callable, ParamSpec, TypeAlias, TypeVar
-from typing_extensions import TypeVarTuple
-
 _private_value: int
-_private_type = int
-_private_union: UnionType
-_private_typevar: TypeVar
-
-_PrivateTypeVar = TypeVar("_PrivateTypeVar")
-_PrivateParamSpec = ParamSpec("_PrivateParamSpec")
-_PrivateTypeVarTuple = TypeVarTuple("_PrivateTypeVarTuple")
-_PrivateAlias: TypeAlias = int
-_PrivateImplicitAlias = int | str
-_PrivateListAlias = list[int]
-_PrivateTupleAlias = tuple[int, str]
-_PrivateCallableAlias = Callable[[int], str]
-_PrivateTypeAlias = type[int]
+_T_co: int
 ```
 
-## Conditionally defined private aliases
+## Private runtime standard builtins
 
-A private type alias remains unavailable even when its possible definitions come from separate
-control-flow branches.
+A private class declared by the standard `builtins` stub remains available when it represents a real
+runtime builtin, rather than a type-checking-only helper.
+
+```toml
+[environment]
+typeshed = "/typeshed"
+```
+
+`/typeshed/stdlib/builtins.pyi`:
+
+```pyi
+class object: ...
+class _IncompleteInputError: ...
+```
 
 ```py
-_ConditionalAlias  # error: [unresolved-reference]
-```
-
-`__builtins__.pyi`:
-
-```pyi
-from typing import TypeAlias
-
-flag: bool
-
-if flag:
-    _ConditionalAlias: TypeAlias = int
-else:
-    _ConditionalAlias: TypeAlias = str
-```
-
-## Conditionally defined private protocols
-
-All reachable private protocol definitions must be excluded from implicit builtin lookup.
-
-```py
-_ConditionalProtocol  # error: [unresolved-reference]
-```
-
-`__builtins__.pyi`:
-
-```pyi
-from typing import Protocol, type_check_only
-
-flag: bool
-
-if flag:
-    @type_check_only
-    class _ConditionalProtocol(Protocol):
-        def method(self) -> int: ...
-
-else:
-    @type_check_only
-    class _ConditionalProtocol(Protocol):
-        def method(self) -> str: ...
-```
-
-## Re-exported private aliases
-
-Re-exporting a private type alias does not make its original stub-only definition a runtime builtin.
-
-```py
-_ImportedAlias  # error: [unresolved-reference]
-_ReassignedAlias  # error: [unresolved-reference]
-```
-
-`__builtins__.pyi`:
-
-```pyi
-from helpers import _ImportedAlias as _ImportedAlias, _ReassignedAlias as _ReassignedAlias
-```
-
-`helpers.pyi`:
-
-```pyi
-from typing import TypeAlias
-
-if False:
-    _ImportedAlias: int
-else:
-    _ImportedAlias: TypeAlias = int
-
-_ReassignedAlias: int
-_ReassignedAlias: TypeAlias = str
-```
-
-## Private runtime protocols in custom builtins
-
-Protocol classes are real runtime objects unless their definitions are marked as type-check-only.
-
-```py
-_RuntimeProtocol
-_RuntimeCheckableProtocol
-```
-
-`__builtins__.pyi`:
-
-```pyi
-from typing import Protocol, runtime_checkable
-
-class _RuntimeProtocol(Protocol):
-    def method(self) -> int: ...
-
-@runtime_checkable
-class _RuntimeCheckableProtocol(Protocol):
-    def method(self) -> int: ...
-```
-
-## Conditionally defined private runtime values
-
-A private name remains available when any reachable definition represents a real runtime value.
-
-```py
-_ConditionalValue
-```
-
-`__builtins__.pyi`:
-
-```pyi
-from typing import TypeAlias
-
-flag: bool
-
-if flag:
-    _ConditionalValue: TypeAlias = int
-else:
-    _ConditionalValue: int
-```
-
-## Private protocols guarded by TYPE_CHECKING
-
-Protocols defined only inside type-checking blocks do not exist at runtime, including when the guard
-is accessed through the `typing` module.
-
-```py
-_TypeCheckingProtocol  # error: [unresolved-reference]
-_QualifiedTypeCheckingProtocol  # error: [unresolved-reference]
-```
-
-`__builtins__.pyi`:
-
-```pyi
-import typing
-from typing import TYPE_CHECKING, Protocol
-
-if TYPE_CHECKING:
-    class _TypeCheckingProtocol(Protocol):
-        def method(self) -> int: ...
-
-if typing.TYPE_CHECKING:
-    class _QualifiedTypeCheckingProtocol(Protocol):
-        def method(self) -> int: ...
-```
-
-## Runtime typing-object values in custom builtins
-
-A runtime factory can produce objects whose classes are also used for stub-only typing helpers.
-Those values must remain available as real builtins.
-
-```py
-_runtime_union
-_runtime_typevar
-_runtime_paramspec
-_runtime_typevartuple
-_runtime_callback
-_runtime_class
-_runtime_decorated
-```
-
-`__builtins__.pyi`:
-
-```pyi
-from types import UnionType
-from typing import Callable, ParamSpec, TypeVar
-from typing_extensions import TypeVarTuple
-
-def make_union() -> UnionType: ...
-def make_typevar() -> TypeVar: ...
-def make_paramspec() -> ParamSpec: ...
-def make_typevartuple() -> TypeVarTuple: ...
-def make_callback() -> Callable[[int], int]: ...
-def make_class() -> type[int]: ...
-def decorate(callback: Callable[[int], int]) -> Callable[[int], int]: ...
-
-_runtime_union = make_union()
-_runtime_typevar = make_typevar()
-_runtime_paramspec = make_paramspec()
-_runtime_typevartuple = make_typevartuple()
-_runtime_callback = make_callback()
-_runtime_class = make_class()
-
-@decorate
-def _runtime_decorated(value: int) -> int: ...
-```
-
-## Explicitly writing private builtin aliases
-
-Writing to the builtin module is explicit attribute access, so it must not apply implicit builtin
-visibility rules.
-
-```py
-import builtins
-
-builtins._PrivateAlias = int
-```
-
-`__builtins__.pyi`:
-
-```pyi
-from typing import TypeAlias
-
-_PrivateAlias: TypeAlias = int
+_IncompleteInputError
 ```
 
 ## Builtin symbol from custom typeshed

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -28,6 +28,7 @@ stub are implementation details. They must not be available without an explicit 
 _T_co  # error: [unresolved-reference]
 _P  # error: [unresolved-reference]
 _PositiveInteger  # error: [unresolved-reference]
+_LiteralInteger  # error: [unresolved-reference]
 _Opener  # error: [unresolved-reference]
 _SupportsSynchronousAnext  # error: [unresolved-reference]
 ```
@@ -37,8 +38,9 @@ _SupportsSynchronousAnext  # error: [unresolved-reference]
 Filtering implicit builtin fallback does not change explicit imports from the `builtins` module.
 
 ```py
-from builtins import _Opener, _P, _PositiveInteger, _SupportsSynchronousAnext, _T_co
+from builtins import _LiteralInteger, _Opener, _P, _PositiveInteger, _SupportsSynchronousAnext, _T_co
 
+_LiteralInteger
 _Opener
 _P
 _PositiveInteger
@@ -54,13 +56,38 @@ that overlap with private helpers in the standard `builtins` stub.
 ```py
 reveal_type(_private_value)  # revealed: int
 reveal_type(_T_co)  # revealed: int
+
+_PrivateTypeVar  # error: [unresolved-reference]
+_PrivateAlias  # error: [unresolved-reference]
+_PrivateTypeOnlyProtocol  # error: [unresolved-reference]
+_PrivateTypeCheckingProtocol  # error: [unresolved-reference]
+
+_RuntimeProtocol
+_runtime_typevar
 ```
 
 `__builtins__.pyi`:
 
 ```pyi
+from typing import TYPE_CHECKING, Protocol, TypeAlias, TypeVar, type_check_only
+
 _private_value: int
 _T_co: int
+
+_PrivateTypeVar = TypeVar("_PrivateTypeVar")
+_PrivateAlias: TypeAlias = int
+
+@type_check_only
+class _PrivateTypeOnlyProtocol(Protocol): ...
+
+if TYPE_CHECKING:
+    class _PrivateTypeCheckingProtocol(Protocol): ...
+
+class _RuntimeProtocol(Protocol): ...
+
+def make_typevar() -> TypeVar: ...
+
+_runtime_typevar = make_typevar()
 ```
 
 ## Private runtime standard builtins

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -213,6 +213,31 @@ else:
     _ConditionalValue: int
 ```
 
+## Private protocols guarded by TYPE_CHECKING
+
+Protocols defined only inside type-checking blocks do not exist at runtime, including when the guard
+is accessed through the `typing` module.
+
+```py
+_TypeCheckingProtocol  # error: [unresolved-reference]
+_QualifiedTypeCheckingProtocol  # error: [unresolved-reference]
+```
+
+`__builtins__.pyi`:
+
+```pyi
+import typing
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    class _TypeCheckingProtocol(Protocol):
+        def method(self) -> int: ...
+
+if typing.TYPE_CHECKING:
+    class _QualifiedTypeCheckingProtocol(Protocol):
+        def method(self) -> int: ...
+```
+
 ## Runtime typing-object values in custom builtins
 
 A runtime factory can produce objects whose classes are also used for stub-only typing helpers.

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -618,6 +618,14 @@ pub(crate) fn builtins_symbol<'db>(
 ///
 /// Private type-checking-only definitions are implementation details, but private runtime
 /// definitions from either the standard or project-level builtins remain available.
+///
+/// ```python
+/// # builtins.pyi
+/// _T = TypeVar("_T")  # Not available as an implicit builtin.
+///
+/// # __builtins__.pyi
+/// _custom: int  # Available as an implicit builtin.
+/// ```
 pub(crate) fn implicit_builtins_symbol<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -629,6 +637,9 @@ pub(crate) fn implicit_builtins_symbol<'db>(
 }
 
 /// Returns the module scope that supplies `symbol` through implicit builtin fallback.
+///
+/// Uses the same visibility rules as [`implicit_builtins_symbol`] so IDE definition lookup cannot
+/// resolve a private typing-only helper that type inference considers undefined.
 pub(crate) fn implicit_builtins_symbol_scope<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -637,6 +648,10 @@ pub(crate) fn implicit_builtins_symbol_scope<'db>(
     builtins_symbol_impl(db, env, symbol, true).map(|(scope, _)| scope)
 }
 
+/// Resolves project-level builtins before standard builtins and optionally hides typing-only names.
+///
+/// Returns the supplying module's scope together with the symbol so inference and IDE lookups can
+/// share the same resolution and visibility policy.
 fn builtins_symbol_impl<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -13,10 +13,11 @@ use crate::reachability::{
 };
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
-    DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
-    UnionBuilder, UnionType, binding_type, inferred_declaration, is_discarded_dict_key_assignment,
+    DynamicType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeAndQualifiers,
+    TypeQualifiers, UnionBuilder, UnionType, binding_type, inferred_declaration,
+    is_discarded_dict_key_assignment,
 };
-use crate::{Db, FxIndexSet, FxOrderSet};
+use crate::{Db, FxIndexSet, FxOrderSet, NameKind, SemanticModel};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
 use ty_python_core::place::ScopedPlaceId;
@@ -608,12 +609,47 @@ pub(crate) fn builtins_symbol<'db>(
     env: &ProgramEnvironment<'db>,
     symbol: &str,
 ) -> PlaceAndQualifiers<'db> {
+    builtins_symbol_impl(db, env, symbol, false)
+        .map(|(_, symbol)| symbol)
+        .unwrap_or_default()
+}
+
+/// Looks up `symbol` for implicit builtin fallback.
+///
+/// Private type-checking-only definitions in the standard `builtins` stub are implementation
+/// details, but private runtime builtins and project-level `__builtins__` names remain available.
+pub(crate) fn implicit_builtins_symbol<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    symbol: &str,
+) -> PlaceAndQualifiers<'db> {
+    builtins_symbol_impl(db, env, symbol, true)
+        .map(|(_, symbol)| symbol)
+        .unwrap_or_default()
+}
+
+/// Returns the module scope that supplies `symbol` through implicit builtin fallback.
+pub(crate) fn implicit_builtins_symbol_scope<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    symbol: &str,
+) -> Option<ScopeId<'db>> {
+    builtins_symbol_impl(db, env, symbol, true).map(|(scope, _)| scope)
+}
+
+fn builtins_symbol_impl<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    symbol: &str,
+    exclude_type_checking_only_builtins: bool,
+) -> Option<(ScopeId<'db>, PlaceAndQualifiers<'db>)> {
     let python_version = env.python_version(db);
     let resolver = |module: Module<'db>| {
         let python_file = module.python_file(db)?;
+        let scope = global_scope(db, python_file);
         let found_symbol = symbol_impl(
             db,
-            global_scope(db, python_file),
+            scope,
             symbol,
             RequiresExplicitReExport::Yes,
             ConsideredDefinitions::EndOfScope,
@@ -627,7 +663,7 @@ pub(crate) fn builtins_symbol<'db>(
         // If this symbol is not present in project-level builtins, search in the default ones.
         found_symbol
             .ignore_possibly_undefined()
-            .map(|_| found_symbol)
+            .map(|_| (scope, found_symbol))
     };
     resolve_module_confident(
         db,
@@ -636,10 +672,37 @@ pub(crate) fn builtins_symbol<'db>(
     )
     .and_then(&resolver)
     .or_else(|| {
-        resolve_module_confident(db, python_version, &KnownModule::Builtins.name())
-            .and_then(resolver)
+        let (scope, found_symbol) =
+            resolve_module_confident(db, python_version, &KnownModule::Builtins.name())
+                .and_then(resolver)?;
+
+        if exclude_type_checking_only_builtins
+            && matches!(NameKind::classify(symbol), NameKind::Sunder)
+            && let Place::Defined(defined) = found_symbol.place
+            && let Some(definition) = defined.provenance.definition()
+            && is_type_checking_only_builtin_definition(db, definition)
+        {
+            return None;
+        }
+
+        Some((scope, found_symbol))
     })
-    .unwrap_or_default()
+}
+
+#[salsa::tracked(returns(copy))]
+fn is_type_checking_only_builtin_definition<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+) -> bool {
+    let ty = binding_type(db, definition);
+
+    ty.is_type_check_only(db)
+        || matches!(
+            ty,
+            Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
+                if typevar.definition(db) == Some(definition)
+        )
+        || SemanticModel::new(db, definition.python_file(db)).is_type_alias_definition(definition)
 }
 
 /// Lookup the type of `symbol` in a given known module.

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -13,11 +13,11 @@ use crate::reachability::{
 };
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
-    DynamicType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeAndQualifiers,
-    TypeQualifiers, UnionBuilder, UnionType, binding_type, inferred_declaration,
+    DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
+    UnionBuilder, UnionType, binding_type, exists_at_runtime, inferred_declaration,
     is_discarded_dict_key_assignment,
 };
-use crate::{Db, FxIndexSet, FxOrderSet, NameKind, SemanticModel};
+use crate::{Db, FxIndexSet, FxOrderSet, NameKind};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
 use ty_python_core::place::ScopedPlaceId;
@@ -616,8 +616,8 @@ pub(crate) fn builtins_symbol<'db>(
 
 /// Looks up `symbol` for implicit builtin fallback.
 ///
-/// Private type-checking-only definitions in the standard `builtins` stub are implementation
-/// details, but private runtime builtins and project-level `__builtins__` names remain available.
+/// Private type-checking-only definitions are implementation details, but private runtime
+/// definitions from either the standard or project-level builtins remain available.
 pub(crate) fn implicit_builtins_symbol<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -660,11 +660,20 @@ fn builtins_symbol_impl<'db>(
             // `imported_symbol`.
             module_type_implicit_global_symbol(db, python_file, symbol)
         });
-        // If this symbol is not present in project-level builtins, search in the default ones.
-        found_symbol
-            .ignore_possibly_undefined()
-            .map(|_| (scope, found_symbol))
+        found_symbol.ignore_possibly_undefined()?;
+
+        if exclude_type_checking_only_builtins
+            && matches!(NameKind::classify(symbol), NameKind::Sunder)
+            && let Place::Defined(defined) = found_symbol.place
+            && let Some(definition) = defined.provenance.definition()
+            && !exists_at_runtime(db, definition)
+        {
+            return None;
+        }
+
+        Some((scope, found_symbol))
     };
+    // If this symbol is not present in project-level builtins, search in the default ones.
     resolve_module_confident(
         db,
         python_version,
@@ -672,37 +681,9 @@ fn builtins_symbol_impl<'db>(
     )
     .and_then(&resolver)
     .or_else(|| {
-        let (scope, found_symbol) =
-            resolve_module_confident(db, python_version, &KnownModule::Builtins.name())
-                .and_then(resolver)?;
-
-        if exclude_type_checking_only_builtins
-            && matches!(NameKind::classify(symbol), NameKind::Sunder)
-            && let Place::Defined(defined) = found_symbol.place
-            && let Some(definition) = defined.provenance.definition()
-            && is_type_checking_only_builtin_definition(db, definition)
-        {
-            return None;
-        }
-
-        Some((scope, found_symbol))
+        resolve_module_confident(db, python_version, &KnownModule::Builtins.name())
+            .and_then(resolver)
     })
-}
-
-#[salsa::tracked(returns(copy))]
-fn is_type_checking_only_builtin_definition<'db>(
-    db: &'db dyn Db,
-    definition: Definition<'db>,
-) -> bool {
-    let ty = binding_type(db, definition);
-
-    ty.is_type_check_only(db)
-        || matches!(
-            ty,
-            Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
-                if typevar.definition(db) == Some(definition)
-        )
-        || SemanticModel::new(db, definition.python_file(db)).is_type_alias_definition(definition)
 }
 
 /// Lookup the type of `symbol` in a given known module.

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -17,7 +17,7 @@ use crate::types::{
     UnionBuilder, UnionType, binding_type, exists_at_runtime, inferred_declaration,
     is_discarded_dict_key_assignment,
 };
-use crate::{Db, FxIndexSet, FxOrderSet, NameKind};
+use crate::{Db, FxIndexSet, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
 use ty_python_core::place::ScopedPlaceId;
@@ -609,7 +609,7 @@ pub(crate) fn builtins_symbol<'db>(
     env: &ProgramEnvironment<'db>,
     symbol: &str,
 ) -> PlaceAndQualifiers<'db> {
-    builtins_symbol_impl(db, env, symbol, false)
+    builtins_symbol_impl(db, env, symbol, BuiltinVisibility::All)
         .map(|(_, symbol)| symbol)
         .unwrap_or_default()
 }
@@ -631,7 +631,7 @@ pub(crate) fn implicit_builtins_symbol<'db>(
     env: &ProgramEnvironment<'db>,
     symbol: &str,
 ) -> PlaceAndQualifiers<'db> {
-    builtins_symbol_impl(db, env, symbol, true)
+    builtins_symbol_impl(db, env, symbol, BuiltinVisibility::RuntimeOnly)
         .map(|(_, symbol)| symbol)
         .unwrap_or_default()
 }
@@ -645,7 +645,13 @@ pub(crate) fn implicit_builtins_symbol_scope<'db>(
     env: &ProgramEnvironment<'db>,
     symbol: &str,
 ) -> Option<ScopeId<'db>> {
-    builtins_symbol_impl(db, env, symbol, true).map(|(scope, _)| scope)
+    builtins_symbol_impl(db, env, symbol, BuiltinVisibility::RuntimeOnly).map(|(scope, _)| scope)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BuiltinVisibility {
+    All,
+    RuntimeOnly,
 }
 
 /// Resolves project-level builtins before standard builtins and optionally hides typing-only names.
@@ -656,7 +662,7 @@ fn builtins_symbol_impl<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     symbol: &str,
-    exclude_type_checking_only_builtins: bool,
+    visibility: BuiltinVisibility,
 ) -> Option<(ScopeId<'db>, PlaceAndQualifiers<'db>)> {
     let python_version = env.python_version(db);
     let resolver = |module: Module<'db>| {
@@ -677,8 +683,7 @@ fn builtins_symbol_impl<'db>(
         });
         found_symbol.ignore_possibly_undefined()?;
 
-        if exclude_type_checking_only_builtins
-            && matches!(NameKind::classify(symbol), NameKind::Sunder)
+        if matches!(visibility, BuiltinVisibility::RuntimeOnly)
             && let Place::Defined(defined) = found_symbol.place
             && let Some(definition) = defined.provenance.definition()
             && !exists_at_runtime(db, definition)

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -15,7 +15,6 @@ use ty_module_resolver::{
 };
 
 use crate::Db;
-use crate::place::implicit_builtins_symbol_scope;
 use crate::place::implicit_globals::all_implicit_module_globals;
 use crate::types::ide_support::{ImportAliasResolution, definition_for_name};
 use crate::types::list_members::{Member, all_members, all_reachable_members};
@@ -285,16 +284,20 @@ impl<'db> SemanticModel<'db> {
             }),
         );
 
+        // Project-level builtins take precedence over the standard builtins.
+        let project_builtins = ModuleName::new_static("__builtins__").expect("valid module name");
+        if resolve_module(self.db, self.file, &project_builtins).is_some() {
+            completions.extend(self.module_completions(&project_builtins).into_iter().map(
+                |mut completion| {
+                    completion.builtin = true;
+                    completion
+                },
+            ));
+        }
+
         // Builtins are available in all scopes.
         let builtins = ModuleName::new_static("builtins").expect("valid module name");
-        completions.extend(
-            self.module_completions(&builtins)
-                .into_iter()
-                .filter(|completion| {
-                    !matches!(NameKind::classify(&completion.name), NameKind::Sunder)
-                        || implicit_builtins_symbol_scope(self.db, &completion.name).is_some()
-                }),
-        );
+        completions.extend(self.module_completions(&builtins));
 
         // The above can sometimes result in duplicates. Get rid of them.
         completions.sort_by(|c1, c2| c1.name.cmp(&c2.name));

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -285,7 +285,7 @@ impl<'db> SemanticModel<'db> {
         );
 
         // Project-level builtins take precedence over the standard builtins.
-        let project_builtins = ModuleName::new_static("__builtins__").expect("valid module name");
+        let project_builtins = ModuleName::new_static("__builtins__").unwrap();
         if resolve_module(self.db, self.file, &project_builtins).is_some() {
             completions.extend(self.module_completions(&project_builtins).into_iter().map(
                 |mut completion| {
@@ -296,7 +296,7 @@ impl<'db> SemanticModel<'db> {
         }
 
         // Builtins are available in all scopes.
-        let builtins = ModuleName::new_static("builtins").expect("valid module name");
+        let builtins = KnownModule::Builtins.name();
         completions.extend(self.module_completions(&builtins));
 
         // The above can sometimes result in duplicates. Get rid of them.

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -15,6 +15,7 @@ use ty_module_resolver::{
 };
 
 use crate::Db;
+use crate::place::implicit_builtins_symbol_scope;
 use crate::place::implicit_globals::all_implicit_module_globals;
 use crate::types::ide_support::{ImportAliasResolution, definition_for_name};
 use crate::types::list_members::{Member, all_members, all_reachable_members};
@@ -291,6 +292,7 @@ impl<'db> SemanticModel<'db> {
                 .into_iter()
                 .filter(|completion| {
                     !matches!(NameKind::classify(&completion.name), NameKind::Sunder)
+                        || implicit_builtins_symbol_scope(self.db, &completion.name).is_some()
                 }),
         );
 

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -286,7 +286,13 @@ impl<'db> SemanticModel<'db> {
 
         // Builtins are available in all scopes.
         let builtins = ModuleName::new_static("builtins").expect("valid module name");
-        completions.extend(self.module_completions(&builtins));
+        completions.extend(
+            self.module_completions(&builtins)
+                .into_iter()
+                .filter(|completion| {
+                    !matches!(NameKind::classify(&completion.name), NameKind::Sunder)
+                }),
+        );
 
         // The above can sometimes result in duplicates. Get rid of them.
         completions.sort_by(|c1, c2| c1.name.cmp(&c2.name));

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -228,8 +228,17 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
 /// In addition to explicit aliases and `@type_check_only` definitions, this recognizes direct
 /// type-variable declarations and implicit aliases without confusing runtime factory results or
 /// indexing operations with typing-only definitions.
+///
+/// ```python
+/// _T = TypeVar("_T")  # Typing-only helper.
+/// _Alias = list[int]  # Typing-only alias.
+/// _runtime_typevar = make_typevar()  # Runtime value.
+/// _runtime_callback = callbacks[0]  # Runtime value.
+/// ```
 #[salsa::tracked(returns(copy))]
 pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
+    let file = definition.file(db);
+    let model = SemanticModel::new(db, file);
     let inference = infer_definition_types(db, definition);
     let ty = inference.binding_type(definition);
 
@@ -242,12 +251,11 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
             Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
                 if typevar.definition(db) == Some(definition)
         )
-        || SemanticModel::new(db, definition.file(db)).is_type_alias_definition(definition)
+        || model.is_type_alias_definition(definition)
     {
         return false;
     }
 
-    let file = definition.file(db);
     let parsed = parsed_module(db, file);
     let module = parsed.load(db);
 
@@ -262,9 +270,7 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
         return true;
     };
 
-    let value = assignment.value(&module);
-
-    match (ty, value) {
+    match (ty, assignment.value(&module)) {
         (
             Type::KnownInstance(KnownInstanceType::UnionType(_)),
             ast::Expr::BinOp(ast::ExprBinOp {
@@ -283,13 +289,10 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
             | Type::Callable(_)
             | Type::SubclassOf(_),
             ast::Expr::Subscript(subscript),
-        ) => {
-            let model = SemanticModel::new(db, definition.file(db));
-            !matches!(
-                subscript.value.inferred_type(&model),
-                Some(Type::SpecialForm(_) | Type::ClassLiteral(_) | Type::GenericAlias(_))
-            )
-        }
+        ) => !matches!(
+            subscript.value.inferred_type(&model),
+            Some(Type::SpecialForm(_) | Type::ClassLiteral(_) | Type::GenericAlias(_))
+        ),
         _ => true,
     }
 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -223,25 +223,25 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
     inference.binding_type(definition)
 }
 
-/// Returns whether a stub definition represents a value that exists at runtime.
+/// Returns whether a definition represents a value that exists at runtime.
 ///
 /// Type-checking-only decorators and guards never represent runtime values. Private type-variable
-/// declarations and aliases are also stub-only, while public aliases and genuine runtime values
-/// remain visible.
+/// declarations, explicit aliases, and unambiguous typing aliases in stub files are also
+/// typing-only, while public aliases and genuine runtime values remain visible.
 ///
 /// ```python
 /// _T = TypeVar("_T")  # Typing-only helper.
-/// _Alias = list[int]  # Typing-only alias.
+/// _Alias: TypeAlias = list[int]  # Typing-only alias.
 /// _runtime_typevar = make_typevar()  # Runtime value.
 /// _runtime_callback = callbacks[0]  # Runtime value.
 /// ```
 #[salsa::tracked(returns(copy))]
 pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
     let file = definition.python_file(db);
-    let model = SemanticModel::new(db, file);
     let inference = infer_definition_types(db, definition);
     let ty = inference.binding_type(definition);
 
+    // A class or function decorated with `@type_check_only` never exists at runtime.
     if ty.is_type_check_only(db)
         || inference
             .undecorated_type()
@@ -253,11 +253,17 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
     let parsed = parsed_module(db, file);
     let module = parsed.load(db);
 
+    // Definitions inside an `if TYPE_CHECKING` block are never available at runtime.
     if semantic_index(db, file).is_in_type_checking_block(
         definition.file_scope(db),
         definition.full_range(db, &module).range(),
     ) {
         return false;
+    }
+
+    // The remaining heuristics only apply to stub definitions.
+    if !file.file(db).is_stub(db) {
+        return true;
     }
 
     let is_private = definition.place(db).as_symbol().is_some_and(|symbol| {
@@ -271,12 +277,17 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
         return true;
     }
 
-    if matches!(
-        ty,
-        Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
-            if typevar.definition(db) == Some(definition)
-    ) || model.is_type_alias_definition(definition)
+    // Private type variables, parameter specifications, and type-variable tuples in stubs are
+    // implementation details rather than runtime values.
+    if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
+        && typevar.definition(db) == Some(definition)
     {
+        return false;
+    }
+
+    // Explicit PEP 613 and PEP 695 type aliases in stubs are also typing-only helpers.
+    let model = SemanticModel::new(db, file);
+    if model.is_type_alias_definition(definition) {
         return false;
     }
 
@@ -284,6 +295,8 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
         return true;
     };
 
+    // Preserve the existing narrow heuristics for private union, `Literal`, and `Annotated`
+    // aliases without mistaking runtime calls or indexing for type-alias definitions.
     match (ty, assignment.value(&module)) {
         (
             Type::KnownInstance(KnownInstanceType::UnionType(_)),
@@ -293,15 +306,7 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
             }),
         ) => false,
         (
-            Type::KnownInstance(
-                KnownInstanceType::Literal(_)
-                | KnownInstanceType::Annotated(_)
-                | KnownInstanceType::Callable(_)
-                | KnownInstanceType::TypeGenericAlias(_),
-            )
-            | Type::GenericAlias(_)
-            | Type::Callable(_)
-            | Type::SubclassOf(_),
+            Type::KnownInstance(KnownInstanceType::Literal(_) | KnownInstanceType::Annotated(_)),
             ast::Expr::Subscript(subscript),
         ) => !matches!(
             subscript.value.inferred_type(&model),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -101,7 +101,7 @@ use crate::types::typevar::{TypeVarInstance, TypeVarSet};
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::any_over_type;
-use crate::{Db, FxOrderSet, HasType, Program, SemanticModel};
+use crate::{Db, FxOrderSet, HasType, NameKind, Program, SemanticModel};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};
 use instance::Protocol;
@@ -225,9 +225,9 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
 
 /// Returns whether a stub definition represents a value that exists at runtime.
 ///
-/// In addition to explicit aliases and `@type_check_only` definitions, this recognizes direct
-/// type-variable declarations and implicit aliases without confusing runtime factory results or
-/// indexing operations with typing-only definitions.
+/// Type-checking-only decorators and guards never represent runtime values. Private type-variable
+/// declarations and aliases are also stub-only, while public aliases and genuine runtime values
+/// remain visible.
 ///
 /// ```python
 /// _T = TypeVar("_T")  # Typing-only helper.
@@ -237,7 +237,7 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
 /// ```
 #[salsa::tracked(returns(copy))]
 pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
-    let file = definition.file(db);
+    let file = definition.python_file(db);
     let model = SemanticModel::new(db, file);
     let inference = infer_definition_types(db, definition);
     let ty = inference.binding_type(definition);
@@ -246,12 +246,6 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
         || inference
             .undecorated_type()
             .is_some_and(|ty| ty.is_type_check_only(db))
-        || matches!(
-            ty,
-            Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
-                if typevar.definition(db) == Some(definition)
-        )
-        || model.is_type_alias_definition(definition)
     {
         return false;
     }
@@ -263,6 +257,26 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
         definition.file_scope(db),
         definition.full_range(db, &module).range(),
     ) {
+        return false;
+    }
+
+    let is_private = definition.place(db).as_symbol().is_some_and(|symbol| {
+        matches!(
+            NameKind::classify(place_table(db, definition.scope(db)).symbol(symbol).name()),
+            NameKind::Sunder
+        )
+    });
+
+    if !is_private {
+        return true;
+    }
+
+    if matches!(
+        ty,
+        Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
+            if typevar.definition(db) == Some(definition)
+    ) || model.is_type_alias_definition(definition)
+    {
         return false;
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -101,7 +101,7 @@ use crate::types::typevar::{TypeVarInstance, TypeVarSet};
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::any_over_type;
-use crate::{Db, FxOrderSet, Program};
+use crate::{Db, FxOrderSet, HasType, Program, SemanticModel};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};
 use instance::Protocol;
@@ -111,7 +111,7 @@ pub(crate) use literal::{
 };
 pub use special_form::SpecialFormType;
 pub(crate) use special_form::TypedDictModule;
-use ty_python_core::definition::Definition;
+use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{Truthiness, place_table, semantic_index, use_def_map};
@@ -221,6 +221,73 @@ pub fn check_types(db: &dyn Db, file: PythonFile<'_>) -> Vec<Diagnostic> {
 pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
     inference.binding_type(definition)
+}
+
+/// Returns whether a stub definition represents a value that exists at runtime.
+///
+/// In addition to explicit aliases and `@type_check_only` definitions, this recognizes direct
+/// type-variable declarations and implicit aliases without confusing runtime factory results or
+/// indexing operations with typing-only definitions.
+#[salsa::tracked(returns(copy))]
+pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
+    let ty = binding_type(db, definition);
+
+    if ty.is_type_check_only(db)
+        || matches!(
+            ty,
+            Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
+                if typevar.definition(db) == Some(definition)
+        )
+        || SemanticModel::new(db, definition.file(db)).is_type_alias_definition(definition)
+    {
+        return false;
+    }
+
+    let file = definition.file(db);
+    let parsed = parsed_module(db, file);
+    let module = parsed.load(db);
+
+    if semantic_index(db, file).is_in_type_checking_block(
+        definition.file_scope(db),
+        definition.full_range(db, &module).range(),
+    ) {
+        return false;
+    }
+
+    let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
+        return true;
+    };
+
+    let value = assignment.value(&module);
+
+    match (ty, value) {
+        (
+            Type::KnownInstance(KnownInstanceType::UnionType(_)),
+            ast::Expr::BinOp(ast::ExprBinOp {
+                op: ast::Operator::BitOr,
+                ..
+            }),
+        ) => false,
+        (
+            Type::KnownInstance(
+                KnownInstanceType::Literal(_)
+                | KnownInstanceType::Annotated(_)
+                | KnownInstanceType::Callable(_)
+                | KnownInstanceType::TypeGenericAlias(_),
+            )
+            | Type::GenericAlias(_)
+            | Type::Callable(_)
+            | Type::SubclassOf(_),
+            ast::Expr::Subscript(subscript),
+        ) => {
+            let model = SemanticModel::new(db, definition.file(db));
+            !matches!(
+                subscript.value.inferred_type(&model),
+                Some(Type::SpecialForm(_) | Type::ClassLiteral(_) | Type::GenericAlias(_))
+            )
+        }
+        _ => true,
+    }
 }
 
 /// Infer the type of a declaration, returning `Rejected` if it is not valid.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -295,8 +295,9 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
         return true;
     };
 
-    // Preserve the existing narrow heuristics for private union, `Literal`, and `Annotated`
-    // aliases without mistaking runtime calls or indexing for type-alias definitions.
+    // Treat only unambiguous union, `Literal`, and `Annotated` expressions as implicit aliases.
+    // Other expressions may also be aliases, but a false negative is preferable to incorrectly
+    // hiding a value that exists at runtime.
     match (ty, assignment.value(&module)) {
         (
             Type::KnownInstance(KnownInstanceType::UnionType(_)),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -230,9 +230,13 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
 /// indexing operations with typing-only definitions.
 #[salsa::tracked(returns(copy))]
 pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
-    let ty = binding_type(db, definition);
+    let inference = infer_definition_types(db, definition);
+    let ty = inference.binding_type(definition);
 
     if ty.is_type_check_only(db)
+        || inference
+            .undecorated_type()
+            .is_some_and(|ty| ty.is_type_check_only(db))
         || matches!(
             ty,
             Type::KnownInstance(KnownInstanceType::TypeVar(typevar))

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -173,7 +173,10 @@ fn is_stub_only_builtin_definition<'db>(
         DefinitionKind::AnnotatedAssignment(_) => {
             SemanticModel::new(db, definition.file(db)).is_type_alias_definition(definition)
         }
-        DefinitionKind::Assignment(_) | DefinitionKind::Class(_) | DefinitionKind::Function(_) => {
+        DefinitionKind::Class(_) | DefinitionKind::Function(_) => {
+            binding_type(db, definition).is_type_check_only(db)
+        }
+        DefinitionKind::Assignment(assignment) => {
             let ty = binding_type(db, definition);
 
             if ty.is_type_check_only(db) {
@@ -196,9 +199,6 @@ fn is_stub_only_builtin_definition<'db>(
                         return false;
                     }
 
-                    let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
-                        return false;
-                    };
                     let parsed = parsed_module(db, definition.file(db)).load(db);
                     let ast::Expr::Call(call) = assignment.value(&parsed) else {
                         return false;
@@ -223,8 +223,14 @@ fn is_stub_only_builtin_definition<'db>(
                 Type::Callable(_)
                 | Type::GenericAlias(_)
                 | Type::SpecialForm(_)
-                | Type::SubclassOf(_)
-                | Type::TypeAlias(_)
+                | Type::SubclassOf(_) => {
+                    let parsed = parsed_module(db, definition.file(db)).load(db);
+                    matches!(
+                        assignment.value(&parsed),
+                        ast::Expr::Subscript(_) | ast::Expr::BinOp(_)
+                    )
+                }
+                Type::TypeAlias(_)
                 | Type::KnownInstance(
                     KnownInstanceType::TypeVar(_)
                     | KnownInstanceType::TypeAliasType(_)

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -22,7 +22,9 @@ use ruff_db::source::source_text;
 use ruff_python_ast::{self as ast, AnyNodeRef, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module_confident};
+use ty_module_resolver::{
+    KnownModule, Module, ModuleName, resolve_module, resolve_module_confident,
+};
 use ty_python_core::definition::{Definition, DefinitionKind, NestedBindingExecution};
 use ty_python_core::{attribute_scopes, global_scope, place_table, semantic_index, use_def_map};
 
@@ -62,6 +64,15 @@ pub(crate) fn is_stub_only_builtin_symbol<'db>(db: &'db dyn Db, name: Name) -> b
 
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
 fn is_stub_only_builtin_symbol_in_file<'db>(db: &'db dyn Db, file: File, name: Name) -> bool {
+    is_stub_only_builtin_symbol_in_file_recursive(db, file, &name, &mut FxHashSet::default())
+}
+
+fn is_stub_only_builtin_symbol_in_file_recursive<'db>(
+    db: &'db dyn Db,
+    file: File,
+    name: &str,
+    visiting: &mut FxHashSet<Definition<'db>>,
+) -> bool {
     if !file.is_stub(db) {
         return false;
     }
@@ -82,33 +93,67 @@ fn is_stub_only_builtin_symbol_in_file<'db>(db: &'db dyn Db, file: File, name: N
             continue;
         };
 
-        let resolved = resolve_definition(
-            db,
-            definition,
-            Some(&name),
-            ImportAliasResolution::ResolveAliases,
-        );
+        if !visiting.insert(definition) {
+            return false;
+        }
 
-        for resolved in resolved {
-            let Some(definition) = resolved.definition() else {
-                return false;
-            };
-            has_definition = true;
-            if !is_stub_only_builtin_definition(db, definition) {
-                return false;
-            }
+        has_definition = true;
+        let is_stub_only = is_stub_only_builtin_definition(db, definition, name, visiting);
+        visiting.remove(&definition);
+        if !is_stub_only {
+            return false;
         }
     }
 
     has_definition
 }
 
-fn is_stub_only_builtin_definition<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
+fn is_stub_only_builtin_definition<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    name: &str,
+    visiting: &mut FxHashSet<Definition<'db>>,
+) -> bool {
     if !definition.file(db).is_stub(db) {
         return false;
     }
 
     match definition.kind(db) {
+        DefinitionKind::ImportFrom(import) => {
+            let file = definition.file(db);
+            let parsed = parsed_module(db, file).load(db);
+            let import_node = import.import(&parsed);
+            let imported_name = &import.alias(&parsed).name;
+
+            let Some(module_name) = ModuleName::from_import_statement(db, file, import_node).ok()
+            else {
+                return false;
+            };
+            let Some(file) =
+                resolve_module(db, file, &module_name).and_then(|module| module.file(db))
+            else {
+                return false;
+            };
+
+            is_stub_only_builtin_symbol_in_file_recursive(db, file, imported_name, visiting)
+        }
+        DefinitionKind::StarImport(import) => {
+            let file = definition.file(db);
+            let parsed = parsed_module(db, file).load(db);
+            let import_node = import.import(&parsed);
+
+            let Some(module_name) = ModuleName::from_import_statement(db, file, import_node).ok()
+            else {
+                return false;
+            };
+            let Some(file) =
+                resolve_module(db, file, &module_name).and_then(|module| module.file(db))
+            else {
+                return false;
+            };
+
+            is_stub_only_builtin_symbol_in_file_recursive(db, file, name, visiting)
+        }
         DefinitionKind::TypeAlias(_)
         | DefinitionKind::TypeVar(_)
         | DefinitionKind::ParamSpec(_)

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -13,7 +13,9 @@ use crate::types::{
     KnownInstanceType, KnownUnion, PropertyAccessorRole, SubclassOfInner, Type, TypeContext,
     TypeVarBoundOrConstraints, binding_type,
 };
-use crate::{Db, DisplaySettings, HasDefinition, HasType, ProgramEnvironment, SemanticModel};
+use crate::{
+    Db, DisplaySettings, HasDefinition, HasType, NameKind, ProgramEnvironment, SemanticModel,
+};
 use itertools::Either;
 use ruff_db::PythonFile;
 use ruff_db::files::FileRange;
@@ -59,7 +61,17 @@ pub(crate) fn is_stub_only_builtin_symbol<'db>(db: &'db dyn Db, name: Name) -> b
         return false;
     };
 
-    is_stub_only_builtin_symbol_in_file(db, file, name)
+    is_private_stub_symbol(db, file, &name)
+}
+
+/// Returns whether a privately named stub symbol exists only to support type checking.
+///
+/// Implicit builtin lookup and module completion must apply the same definition-aware visibility
+/// policy, including re-export resolution, reachable bindings, and actual runtime values.
+pub(crate) fn is_private_stub_symbol<'db>(db: &'db dyn Db, file: File, name: &Name) -> bool {
+    file.is_stub(db)
+        && matches!(NameKind::classify(name), NameKind::Sunder)
+        && is_stub_only_builtin_symbol_in_file(db, file, name.clone())
 }
 
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -179,7 +179,6 @@ fn is_stub_only_builtin_definition<'db>(
                             | KnownClass::UnionType
                     )
                 ),
-                Type::ClassLiteral(class) => class.is_protocol(db),
                 Type::Callable(_)
                 | Type::GenericAlias(_)
                 | Type::SpecialForm(_)

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -126,8 +126,17 @@ fn is_stub_only_builtin_definition<'db>(
     name: &str,
     visiting: &mut FxHashSet<Definition<'db>>,
 ) -> bool {
-    if !definition.file(db).is_stub(db) {
+    let file = definition.file(db);
+    if !file.is_stub(db) {
         return false;
+    }
+
+    let parsed = parsed_module(db, file).load(db);
+    if semantic_index(db, file).is_in_type_checking_block(
+        definition.file_scope(db),
+        definition.full_range(db, &parsed).range(),
+    ) {
+        return true;
     }
 
     match definition.kind(db) {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, VecDeque};
 
 use crate::FxIndexSet;
-use crate::place::builtins_module_scope;
-use crate::reachability::is_range_reachable;
+use crate::place::{RequiresExplicitReExport, builtins_module_scope, imported_symbol};
+use crate::reachability::{evaluate_reachability, is_range_reachable};
 use crate::types::call::bind::CheckTypesMode;
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
 use crate::types::class::{DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor};
@@ -10,7 +10,7 @@ use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::signatures::{ParametersKind, Signature};
 use crate::types::{
     CallDunderError, CallableTypes, ClassBase, ClassLiteral, ClassType, KnownClass, KnownFunction,
-    KnownUnion, PropertyAccessorRole, SubclassOfInner, Type, TypeContext,
+    KnownInstanceType, KnownUnion, PropertyAccessorRole, SubclassOfInner, Type, TypeContext,
     TypeVarBoundOrConstraints, binding_type,
 };
 use crate::{Db, DisplaySettings, HasDefinition, HasType, ProgramEnvironment, SemanticModel};
@@ -22,9 +22,9 @@ use ruff_db::source::source_text;
 use ruff_python_ast::{self as ast, AnyNodeRef, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::Module;
+use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module_confident};
 use ty_python_core::definition::{Definition, DefinitionKind, NestedBindingExecution};
-use ty_python_core::{attribute_scopes, global_scope, semantic_index, use_def_map};
+use ty_python_core::{attribute_scopes, global_scope, place_table, semantic_index, use_def_map};
 
 mod unreachable_code;
 #[path = "ide_support/unused_bindings.rs"]
@@ -34,6 +34,121 @@ pub use resolve_definition::{ImportAliasResolution, ResolvedDefinition, map_stub
 use resolve_definition::{find_symbol_in_scope, resolve_definition};
 pub use unreachable_code::{UnreachableKind, UnreachableRange, unreachable_ranges};
 pub use unused_binding_support::{UnusedBinding, unused_bindings};
+
+/// Returns whether every reachable definition of a private builtin is a stub-only typing helper.
+///
+/// Builtin stubs contain type variables, aliases, and protocol classes that do not exist in the
+/// runtime builtins namespace. Imported helpers must be classified at their original definitions,
+/// while ordinary runtime values must remain visible even when their types are typing objects.
+pub(crate) fn is_stub_only_builtin_symbol<'db>(db: &'db dyn Db, name: Name) -> bool {
+    let custom_file = ModuleName::new_static("__builtins__")
+        .and_then(|module_name| resolve_module_confident(db, &module_name))
+        .and_then(|module| module.file(db))
+        .filter(|file| {
+            imported_symbol(db, Some(*file), &name, Some(RequiresExplicitReExport::Yes))
+                .ignore_possibly_undefined()
+                .is_some()
+        });
+
+    let Some(file) = custom_file.or_else(|| {
+        resolve_module_confident(db, &KnownModule::Builtins.name())
+            .and_then(|module| module.file(db))
+    }) else {
+        return false;
+    };
+
+    is_stub_only_builtin_symbol_in_file(db, file, name)
+}
+
+#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+fn is_stub_only_builtin_symbol_in_file<'db>(db: &'db dyn Db, file: File, name: Name) -> bool {
+    if !file.is_stub(db) {
+        return false;
+    }
+
+    let scope = global_scope(db, file);
+    let Some(symbol_id) = place_table(db, scope).symbol_id(&name) else {
+        return false;
+    };
+    let use_def = use_def_map(db, scope);
+    let mut has_definition = false;
+
+    for binding in use_def.end_of_scope_symbol_bindings(symbol_id) {
+        if evaluate_reachability(db, use_def, binding.reachability_constraint).is_always_false() {
+            continue;
+        }
+
+        let Some(definition) = binding.binding.definition() else {
+            continue;
+        };
+
+        let resolved = resolve_definition(
+            db,
+            definition,
+            Some(&name),
+            ImportAliasResolution::ResolveAliases,
+        );
+
+        for resolved in resolved {
+            let Some(definition) = resolved.definition() else {
+                return false;
+            };
+            has_definition = true;
+            if !is_stub_only_builtin_definition(db, definition) {
+                return false;
+            }
+        }
+    }
+
+    has_definition
+}
+
+fn is_stub_only_builtin_definition<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
+    if !definition.file(db).is_stub(db) {
+        return false;
+    }
+
+    match definition.kind(db) {
+        DefinitionKind::TypeAlias(_)
+        | DefinitionKind::TypeVar(_)
+        | DefinitionKind::ParamSpec(_)
+        | DefinitionKind::TypeVarTuple(_) => true,
+        DefinitionKind::AnnotatedAssignment(_) => {
+            SemanticModel::new(db, definition.file(db)).is_type_alias_definition(definition)
+        }
+        DefinitionKind::Assignment(_) | DefinitionKind::Class(_) | DefinitionKind::Function(_) => {
+            let ty = binding_type(db, definition);
+
+            if ty.is_type_check_only(db) {
+                return true;
+            }
+
+            match ty {
+                Type::NominalInstance(instance) => matches!(
+                    instance.known_class(db),
+                    Some(
+                        KnownClass::TypeVar
+                            | KnownClass::TypeVarTuple
+                            | KnownClass::ExtensionsTypeVarTuple
+                            | KnownClass::ParamSpec
+                            | KnownClass::UnionType
+                    )
+                ),
+                Type::ClassLiteral(class) => class.is_protocol(db),
+                Type::TypeAlias(_)
+                | Type::KnownInstance(
+                    KnownInstanceType::TypeVar(_)
+                    | KnownInstanceType::TypeAliasType(_)
+                    | KnownInstanceType::UnionType(_)
+                    | KnownInstanceType::Literal(_)
+                    | KnownInstanceType::Annotated(_),
+                ) => true,
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
 
 /// Get the primary definition kind for a name expression within a specific file.
 /// Returns the first definition kind that is reachable for this name in its scope.

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, VecDeque};
 
 use crate::FxIndexSet;
-use crate::place::{RequiresExplicitReExport, builtins_module_scope, imported_symbol};
-use crate::reachability::{evaluate_reachability, is_range_reachable};
+use crate::place::implicit_builtins_symbol_scope;
+use crate::reachability::is_range_reachable;
 use crate::types::call::bind::CheckTypesMode;
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
 use crate::types::class::{DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor};
@@ -10,12 +10,10 @@ use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::signatures::{ParametersKind, Signature};
 use crate::types::{
     CallDunderError, CallableTypes, ClassBase, ClassLiteral, ClassType, KnownClass, KnownFunction,
-    KnownInstanceType, KnownUnion, PropertyAccessorRole, SubclassOfInner, Type, TypeContext,
+    KnownUnion, PropertyAccessorRole, SubclassOfInner, Type, TypeContext,
     TypeVarBoundOrConstraints, binding_type,
 };
-use crate::{
-    Db, DisplaySettings, HasDefinition, HasType, NameKind, ProgramEnvironment, SemanticModel,
-};
+use crate::{Db, DisplaySettings, HasDefinition, HasType, ProgramEnvironment, SemanticModel};
 use itertools::Either;
 use ruff_db::PythonFile;
 use ruff_db::files::FileRange;
@@ -24,11 +22,9 @@ use ruff_db::source::source_text;
 use ruff_python_ast::{self as ast, AnyNodeRef, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{
-    KnownModule, Module, ModuleName, resolve_module, resolve_module_confident,
-};
+use ty_module_resolver::Module;
 use ty_python_core::definition::{Definition, DefinitionKind, NestedBindingExecution};
-use ty_python_core::{attribute_scopes, global_scope, place_table, semantic_index, use_def_map};
+use ty_python_core::{attribute_scopes, global_scope, semantic_index, use_def_map};
 
 mod unreachable_code;
 #[path = "ide_support/unused_bindings.rs"]
@@ -38,223 +34,6 @@ pub use resolve_definition::{ImportAliasResolution, ResolvedDefinition, map_stub
 use resolve_definition::{find_symbol_in_scope, resolve_definition};
 pub use unreachable_code::{UnreachableKind, UnreachableRange, unreachable_ranges};
 pub use unused_binding_support::{UnusedBinding, unused_bindings};
-
-/// Returns whether every reachable definition of a private builtin is a stub-only typing helper.
-///
-/// Builtin stubs contain type variables, aliases, and protocol classes that do not exist in the
-/// runtime builtins namespace. Imported helpers must be classified at their original definitions,
-/// while ordinary runtime values must remain visible even when their types are typing objects.
-pub(crate) fn is_stub_only_builtin_symbol<'db>(db: &'db dyn Db, name: Name) -> bool {
-    let custom_file = ModuleName::new_static("__builtins__")
-        .and_then(|module_name| resolve_module_confident(db, &module_name))
-        .and_then(|module| module.file(db))
-        .filter(|file| {
-            imported_symbol(db, Some(*file), &name, Some(RequiresExplicitReExport::Yes))
-                .ignore_possibly_undefined()
-                .is_some()
-        });
-
-    let Some(file) = custom_file.or_else(|| {
-        resolve_module_confident(db, &KnownModule::Builtins.name())
-            .and_then(|module| module.file(db))
-    }) else {
-        return false;
-    };
-
-    is_private_stub_symbol(db, file, &name)
-}
-
-/// Returns whether a privately named stub symbol exists only to support type checking.
-///
-/// Implicit builtin lookup and module completion must apply the same definition-aware visibility
-/// policy, including re-export resolution, reachable bindings, and actual runtime values.
-pub(crate) fn is_private_stub_symbol<'db>(db: &'db dyn Db, file: File, name: &Name) -> bool {
-    file.is_stub(db)
-        && matches!(NameKind::classify(name), NameKind::Sunder)
-        && is_stub_only_builtin_symbol_in_file(db, file, name.clone())
-}
-
-#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-fn is_stub_only_builtin_symbol_in_file<'db>(db: &'db dyn Db, file: File, name: Name) -> bool {
-    is_stub_only_builtin_symbol_in_file_recursive(db, file, &name, &mut FxHashSet::default())
-}
-
-fn is_stub_only_builtin_symbol_in_file_recursive<'db>(
-    db: &'db dyn Db,
-    file: File,
-    name: &str,
-    visiting: &mut FxHashSet<Definition<'db>>,
-) -> bool {
-    if !file.is_stub(db) {
-        return false;
-    }
-
-    let scope = global_scope(db, file);
-    let Some(symbol_id) = place_table(db, scope).symbol_id(&name) else {
-        return false;
-    };
-    let use_def = use_def_map(db, scope);
-    let mut has_definition = false;
-
-    for binding in use_def.end_of_scope_symbol_bindings(symbol_id) {
-        if evaluate_reachability(db, use_def, binding.reachability_constraint).is_always_false() {
-            continue;
-        }
-
-        let Some(definition) = binding.binding.definition() else {
-            continue;
-        };
-
-        if !visiting.insert(definition) {
-            return false;
-        }
-
-        has_definition = true;
-        let is_stub_only = is_stub_only_builtin_definition(db, definition, name, visiting);
-        visiting.remove(&definition);
-        if !is_stub_only {
-            return false;
-        }
-    }
-
-    has_definition
-}
-
-fn is_stub_only_builtin_definition<'db>(
-    db: &'db dyn Db,
-    definition: Definition<'db>,
-    name: &str,
-    visiting: &mut FxHashSet<Definition<'db>>,
-) -> bool {
-    let file = definition.file(db);
-    if !file.is_stub(db) {
-        return false;
-    }
-
-    let parsed = parsed_module(db, file).load(db);
-    if semantic_index(db, file).is_in_type_checking_block(
-        definition.file_scope(db),
-        definition.full_range(db, &parsed).range(),
-    ) {
-        return true;
-    }
-
-    match definition.kind(db) {
-        DefinitionKind::ImportFrom(import) => {
-            let file = definition.file(db);
-            let parsed = parsed_module(db, file).load(db);
-            let import_node = import.import(&parsed);
-            let imported_name = &import.alias(&parsed).name;
-
-            let Some(module_name) = ModuleName::from_import_statement(db, file, import_node).ok()
-            else {
-                return false;
-            };
-            let Some(file) =
-                resolve_module(db, file, &module_name).and_then(|module| module.file(db))
-            else {
-                return false;
-            };
-
-            is_stub_only_builtin_symbol_in_file_recursive(db, file, imported_name, visiting)
-        }
-        DefinitionKind::StarImport(import) => {
-            let file = definition.file(db);
-            let parsed = parsed_module(db, file).load(db);
-            let import_node = import.import(&parsed);
-
-            let Some(module_name) = ModuleName::from_import_statement(db, file, import_node).ok()
-            else {
-                return false;
-            };
-            let Some(file) =
-                resolve_module(db, file, &module_name).and_then(|module| module.file(db))
-            else {
-                return false;
-            };
-
-            is_stub_only_builtin_symbol_in_file_recursive(db, file, name, visiting)
-        }
-        DefinitionKind::TypeAlias(_)
-        | DefinitionKind::TypeVar(_)
-        | DefinitionKind::ParamSpec(_)
-        | DefinitionKind::TypeVarTuple(_) => true,
-        DefinitionKind::AnnotatedAssignment(_) => {
-            SemanticModel::new(db, definition.file(db)).is_type_alias_definition(definition)
-        }
-        DefinitionKind::Class(_) | DefinitionKind::Function(_) => {
-            binding_type(db, definition).is_type_check_only(db)
-        }
-        DefinitionKind::Assignment(assignment) => {
-            let ty = binding_type(db, definition);
-
-            if ty.is_type_check_only(db) {
-                return true;
-            }
-
-            match ty {
-                Type::NominalInstance(instance) => {
-                    if !matches!(
-                        instance.known_class(db),
-                        Some(
-                            KnownClass::TypeVar
-                                | KnownClass::ExtensionsTypeVar
-                                | KnownClass::TypeVarTuple
-                                | KnownClass::ExtensionsTypeVarTuple
-                                | KnownClass::ParamSpec
-                                | KnownClass::ExtensionsParamSpec
-                        )
-                    ) {
-                        return false;
-                    }
-
-                    let parsed = parsed_module(db, definition.file(db)).load(db);
-                    let ast::Expr::Call(call) = assignment.value(&parsed) else {
-                        return false;
-                    };
-                    let model = SemanticModel::new(db, definition.file(db));
-
-                    matches!(
-                        call.func
-                            .inferred_type(&model)
-                            .and_then(Type::as_class_literal)
-                            .and_then(|class| class.known(db)),
-                        Some(
-                            KnownClass::TypeVar
-                                | KnownClass::ExtensionsTypeVar
-                                | KnownClass::TypeVarTuple
-                                | KnownClass::ExtensionsTypeVarTuple
-                                | KnownClass::ParamSpec
-                                | KnownClass::ExtensionsParamSpec
-                        )
-                    )
-                }
-                Type::Callable(_)
-                | Type::GenericAlias(_)
-                | Type::SpecialForm(_)
-                | Type::SubclassOf(_) => {
-                    let parsed = parsed_module(db, definition.file(db)).load(db);
-                    matches!(
-                        assignment.value(&parsed),
-                        ast::Expr::Subscript(_) | ast::Expr::BinOp(_)
-                    )
-                }
-                Type::TypeAlias(_)
-                | Type::KnownInstance(
-                    KnownInstanceType::TypeVar(_)
-                    | KnownInstanceType::TypeAliasType(_)
-                    | KnownInstanceType::UnionType(_)
-                    | KnownInstanceType::Literal(_)
-                    | KnownInstanceType::Annotated(_)
-                    | KnownInstanceType::TypeGenericAlias(_)
-                    | KnownInstanceType::Callable(_),
-                ) => true,
-                _ => false,
-            }
-        }
-        _ => false,
-    }
-}
 
 /// Get the primary definition kind for a name expression within a specific file.
 /// Returns the first definition kind that is reachable for this name in its scope.
@@ -393,7 +172,7 @@ pub fn definitions_for_name<'db>(
     // If we didn't find any definitions in scopes, fallback to builtins
     let env = model.program_environment();
     if resolved_definitions.is_empty()
-        && let Some(builtins_scope) = builtins_module_scope(db, &env)
+        && let Some(builtins_scope) = implicit_builtins_symbol_scope(db, &env, name_str)
     {
         // Special cases for `float` and `complex` in type annotation positions.
         // We don't know whether we're in a type annotation position, so we'll just ask `Name`'s type,

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -135,13 +135,19 @@ fn is_stub_only_builtin_definition<'db>(db: &'db dyn Db, definition: Definition<
                     )
                 ),
                 Type::ClassLiteral(class) => class.is_protocol(db),
-                Type::TypeAlias(_)
+                Type::Callable(_)
+                | Type::GenericAlias(_)
+                | Type::SpecialForm(_)
+                | Type::SubclassOf(_)
+                | Type::TypeAlias(_)
                 | Type::KnownInstance(
                     KnownInstanceType::TypeVar(_)
                     | KnownInstanceType::TypeAliasType(_)
                     | KnownInstanceType::UnionType(_)
                     | KnownInstanceType::Literal(_)
-                    | KnownInstanceType::Annotated(_),
+                    | KnownInstanceType::Annotated(_)
+                    | KnownInstanceType::TypeGenericAlias(_)
+                    | KnownInstanceType::Callable(_),
                 ) => true,
                 _ => false,
             }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -169,16 +169,45 @@ fn is_stub_only_builtin_definition<'db>(
             }
 
             match ty {
-                Type::NominalInstance(instance) => matches!(
-                    instance.known_class(db),
-                    Some(
-                        KnownClass::TypeVar
-                            | KnownClass::TypeVarTuple
-                            | KnownClass::ExtensionsTypeVarTuple
-                            | KnownClass::ParamSpec
-                            | KnownClass::UnionType
+                Type::NominalInstance(instance) => {
+                    if !matches!(
+                        instance.known_class(db),
+                        Some(
+                            KnownClass::TypeVar
+                                | KnownClass::ExtensionsTypeVar
+                                | KnownClass::TypeVarTuple
+                                | KnownClass::ExtensionsTypeVarTuple
+                                | KnownClass::ParamSpec
+                                | KnownClass::ExtensionsParamSpec
+                        )
+                    ) {
+                        return false;
+                    }
+
+                    let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
+                        return false;
+                    };
+                    let parsed = parsed_module(db, definition.file(db)).load(db);
+                    let ast::Expr::Call(call) = assignment.value(&parsed) else {
+                        return false;
+                    };
+                    let model = SemanticModel::new(db, definition.file(db));
+
+                    matches!(
+                        call.func
+                            .inferred_type(&model)
+                            .and_then(Type::as_class_literal)
+                            .and_then(|class| class.known(db)),
+                        Some(
+                            KnownClass::TypeVar
+                                | KnownClass::ExtensionsTypeVar
+                                | KnownClass::TypeVarTuple
+                                | KnownClass::ExtensionsTypeVarTuple
+                                | KnownClass::ParamSpec
+                                | KnownClass::ExtensionsParamSpec
+                        )
                     )
-                ),
+                }
                 Type::Callable(_)
                 | Type::GenericAlias(_)
                 | Type::SpecialForm(_)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -35,8 +35,8 @@ use super::{
 use crate::diagnostic::format_enumeration;
 use crate::place::{
     ConsideredDefinitions, DefinedPlace, Definedness, LookupError, Place, PlaceAndQualifiers,
-    RequiresExplicitReExport, TypeOrigin, builtins_module_scope, builtins_symbol,
-    class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
+    RequiresExplicitReExport, TypeOrigin, builtins_module_scope, class_body_implicit_symbol,
+    explicit_global_symbol, implicit_builtins_symbol, loop_header_reachability,
     module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
     place_from_bindings_with_reachability_cache, place_from_declarations_with_reachability_cache,
     typing_extensions_symbol,
@@ -86,7 +86,6 @@ use crate::types::function::{
 use crate::types::generics::{
     GenericContext, Specialization, SpecializationBuilder, bind_typevar, enclosing_binding_contexts,
 };
-use crate::types::ide_support::is_stub_only_builtin_symbol;
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
 use crate::types::infer::builder::paramspec_validation::validate_paramspec_components;
 use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
@@ -122,7 +121,7 @@ use crate::types::{
     UnionType, any_over_type, binding_type, extract_fixed_length_iterable_element_types,
     infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
-use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet, NameKind};
+use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet};
 use ty_python_core::ast_ids::ScopedUseId;
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
@@ -9637,12 +9636,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .or_fall_back_to(db, env, || {
                 if Some(self.scope()) == builtins_module_scope(db, env) {
                     Place::Undefined.into()
-                } else if matches!(NameKind::classify(symbol_name), NameKind::Sunder)
-                    && is_stub_only_builtin_symbol(db, symbol_name.clone())
-                {
-                    Place::Undefined.into()
                 } else {
-                    builtins_symbol(db, env, symbol_name)
+                    implicit_builtins_symbol(db, env, symbol_name)
                 }
             })
             // Still not found? It might be `reveal_type`...

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -86,6 +86,7 @@ use crate::types::function::{
 use crate::types::generics::{
     GenericContext, Specialization, SpecializationBuilder, bind_typevar, enclosing_binding_contexts,
 };
+use crate::types::ide_support::is_stub_only_builtin_symbol;
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
 use crate::types::infer::builder::paramspec_validation::validate_paramspec_components;
 use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
@@ -121,7 +122,7 @@ use crate::types::{
     UnionType, any_over_type, binding_type, extract_fixed_length_iterable_element_types,
     infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
-use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet};
+use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet, NameKind};
 use ty_python_core::ast_ids::ScopedUseId;
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
@@ -9635,6 +9636,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // (without infinite recursion if we're already in builtins.)
             .or_fall_back_to(db, env, || {
                 if Some(self.scope()) == builtins_module_scope(db, env) {
+                    Place::Undefined.into()
+                } else if matches!(NameKind::classify(symbol_name), NameKind::Sunder)
+                    && is_stub_only_builtin_symbol(db, symbol_name.clone())
+                {
                     Place::Undefined.into()
                 } else {
                     builtins_symbol(db, env, symbol_name)

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -11,15 +11,15 @@ use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    Db,
+    Db, NameKind,
     place::{
         DefinedPlace, Place, PlaceWithDefinition, imported_symbol, place_from_bindings,
         place_from_declarations,
     },
     types::{
-        ClassBase, ClassLiteral, KnownClass, ProgramEnvironment, StaticClassLiteral,
-        SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
-        ide_support::is_private_stub_symbol,
+        ClassBase, ClassLiteral, KnownClass, KnownInstanceType, ProgramEnvironment,
+        StaticClassLiteral, SubclassOfInner, Type, TypeVarBoundOrConstraints,
+        class::CodeGeneratorKind,
     },
 };
 use ty_python_core::{
@@ -440,8 +440,38 @@ impl<'db> AllMembers<'db> {
                         continue;
                     };
 
-                    if is_private_stub_symbol(db, file, symbol_name) {
-                        continue;
+                    // Filter private symbols from stubs if they appear to be internal types
+                    let is_stub_file = file.path(db).extension() == Some("pyi");
+                    let is_private_symbol = match NameKind::classify(symbol_name) {
+                        NameKind::Dunder | NameKind::Normal => false,
+                        NameKind::Sunder => true,
+                    };
+                    if is_private_symbol && is_stub_file {
+                        match ty {
+                            Type::NominalInstance(instance)
+                                if matches!(
+                                    instance.known_class(db),
+                                    Some(
+                                        KnownClass::TypeVar
+                                            | KnownClass::TypeVarTuple
+                                            | KnownClass::ExtensionsTypeVarTuple
+                                            | KnownClass::ParamSpec
+                                            | KnownClass::UnionType
+                                    )
+                                ) =>
+                            {
+                                continue;
+                            }
+                            Type::ClassLiteral(class) if class.is_protocol(db) => continue,
+                            Type::KnownInstance(
+                                KnownInstanceType::TypeVar(_)
+                                | KnownInstanceType::TypeAliasType(_)
+                                | KnownInstanceType::UnionType(_)
+                                | KnownInstanceType::Literal(_)
+                                | KnownInstanceType::Annotated(_),
+                            ) => continue,
+                            _ => {}
+                        }
                     }
 
                     self.members.insert(Member {

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -17,9 +17,9 @@ use crate::{
         place_from_declarations,
     },
     types::{
-        ClassBase, ClassLiteral, KnownClass, KnownInstanceType, ProgramEnvironment,
-        StaticClassLiteral, SubclassOfInner, Type, TypeVarBoundOrConstraints,
-        class::CodeGeneratorKind,
+        ClassBase, ClassLiteral, KnownClass, ProgramEnvironment, StaticClassLiteral,
+        SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
+        exists_at_runtime,
     },
 };
 use ty_python_core::{
@@ -434,49 +434,23 @@ impl<'db> AllMembers<'db> {
 
                 for (symbol_id, _) in use_def_map.all_end_of_scope_symbol_declarations() {
                     let symbol_name = place_table.symbol(symbol_id).name();
-                    let Place::Defined(DefinedPlace { ty, .. }) =
+                    let Place::Defined(defined) =
                         imported_symbol(db, env, Some(python_file), symbol_name, None).place
                     else {
                         continue;
                     };
 
-                    // Filter private symbols from stubs if they appear to be internal types
-                    let is_stub_file = file.path(db).extension() == Some("pyi");
-                    let is_private_symbol = match NameKind::classify(symbol_name) {
-                        NameKind::Dunder | NameKind::Normal => false,
-                        NameKind::Sunder => true,
-                    };
-                    if is_private_symbol && is_stub_file {
-                        match ty {
-                            Type::NominalInstance(instance)
-                                if matches!(
-                                    instance.known_class(db),
-                                    Some(
-                                        KnownClass::TypeVar
-                                            | KnownClass::TypeVarTuple
-                                            | KnownClass::ExtensionsTypeVarTuple
-                                            | KnownClass::ParamSpec
-                                            | KnownClass::UnionType
-                                    )
-                                ) =>
-                            {
-                                continue;
-                            }
-                            Type::ClassLiteral(class) if class.is_protocol(db) => continue,
-                            Type::KnownInstance(
-                                KnownInstanceType::TypeVar(_)
-                                | KnownInstanceType::TypeAliasType(_)
-                                | KnownInstanceType::UnionType(_)
-                                | KnownInstanceType::Literal(_)
-                                | KnownInstanceType::Annotated(_),
-                            ) => continue,
-                            _ => {}
-                        }
+                    if file.is_stub(db)
+                        && matches!(NameKind::classify(symbol_name), NameKind::Sunder)
+                        && let Some(definition) = defined.provenance.definition()
+                        && !exists_at_runtime(db, definition)
+                    {
+                        continue;
                     }
 
                     self.members.insert(Member {
                         name: symbol_name.clone(),
-                        ty,
+                        ty: defined.ty,
                     });
                 }
 

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -11,13 +11,13 @@ use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    Db, NameKind,
+    Db,
     place::{
         DefinedPlace, Place, PlaceWithDefinition, imported_symbol, place_from_bindings,
         place_from_declarations,
     },
     types::{
-        ClassBase, ClassLiteral, KnownClass, ProgramEnvironment, StaticClassLiteral,
+        ClassBase, ClassLiteral, KnownClass, KnownFunction, ProgramEnvironment, StaticClassLiteral,
         SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
         exists_at_runtime,
     },
@@ -441,9 +441,15 @@ impl<'db> AllMembers<'db> {
                     };
 
                     if file.is_stub(db)
-                        && matches!(NameKind::classify(symbol_name), NameKind::Sunder)
                         && let Some(definition) = defined.provenance.definition()
                         && !exists_at_runtime(db, definition)
+                        // The decorator itself is typing-only, but users must still be able to
+                        // import it when defining typing-only classes and functions.
+                        && !matches!(
+                            defined.ty,
+                            Type::FunctionLiteral(function)
+                                if function.known(db) == Some(KnownFunction::TypeCheckOnly)
+                        )
                     {
                         continue;
                     }

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -11,15 +11,15 @@ use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    Db, NameKind,
+    Db,
     place::{
         DefinedPlace, Place, PlaceWithDefinition, imported_symbol, place_from_bindings,
         place_from_declarations,
     },
     types::{
-        ClassBase, ClassLiteral, KnownClass, KnownInstanceType, ProgramEnvironment,
-        StaticClassLiteral, SubclassOfInner, Type, TypeVarBoundOrConstraints,
-        class::CodeGeneratorKind,
+        ClassBase, ClassLiteral, KnownClass, ProgramEnvironment, StaticClassLiteral,
+        SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
+        ide_support::is_private_stub_symbol,
     },
 };
 use ty_python_core::{
@@ -440,38 +440,8 @@ impl<'db> AllMembers<'db> {
                         continue;
                     };
 
-                    // Filter private symbols from stubs if they appear to be internal types
-                    let is_stub_file = file.path(db).extension() == Some("pyi");
-                    let is_private_symbol = match NameKind::classify(symbol_name) {
-                        NameKind::Dunder | NameKind::Normal => false,
-                        NameKind::Sunder => true,
-                    };
-                    if is_private_symbol && is_stub_file {
-                        match ty {
-                            Type::NominalInstance(instance)
-                                if matches!(
-                                    instance.known_class(db),
-                                    Some(
-                                        KnownClass::TypeVar
-                                            | KnownClass::TypeVarTuple
-                                            | KnownClass::ExtensionsTypeVarTuple
-                                            | KnownClass::ParamSpec
-                                            | KnownClass::UnionType
-                                    )
-                                ) =>
-                            {
-                                continue;
-                            }
-                            Type::ClassLiteral(class) if class.is_protocol(db) => continue,
-                            Type::KnownInstance(
-                                KnownInstanceType::TypeVar(_)
-                                | KnownInstanceType::TypeAliasType(_)
-                                | KnownInstanceType::UnionType(_)
-                                | KnownInstanceType::Literal(_)
-                                | KnownInstanceType::Annotated(_),
-                            ) => continue,
-                            _ => {}
-                        }
+                    if is_private_stub_symbol(db, file, symbol_name) {
+                        continue;
                     }
 
                     self.members.insert(Member {

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -426,7 +426,6 @@ impl<'db> AllMembers<'db> {
                 let Some(python_file) = module.python_file(db) else {
                     return;
                 };
-                let file = python_file.file(db);
 
                 let module_scope = global_scope(db, python_file);
                 let use_def_map = use_def_map(db, module_scope);
@@ -440,9 +439,11 @@ impl<'db> AllMembers<'db> {
                         continue;
                     };
 
-                    if file.is_stub(db)
-                        && let Some(definition) = defined.provenance.definition()
+                    if let Some(definition) = defined.provenance.definition()
                         && !exists_at_runtime(db, definition)
+                        // Source-module completions retain `@type_check_only` symbols and rank them
+                        // lower.
+                        && (python_file.file(db).is_stub(db) || !defined.ty.is_type_check_only(db))
                         // The decorator itself is typing-only, but users must still be able to
                         // import it when defining typing-only classes and functions.
                         && !matches!(


### PR DESCRIPTION
## Summary

Typeshed's `builtins.pyi` defines private type variables, aliases, and protocols that do not exist in the runtime builtins namespace. Previously, implicit builtin fallback treated those stub-only helpers as ordinary builtins, so undefined names such as `_T_co` silently resolved (this should fail -- `_T_co` doesn't exist!):

```python
class SupportsNext:
    def __next__(self) -> _T_co:  # error: [unresolved-reference]
        raise NotImplementedError
```

This PR adds a shared `exists_at_runtime()` predicate for stub definitions and applies it consistently to implicit builtin resolution. Specifically, it excludes private type variables, aliases, and type-checking-only definitions, while preserving explicit imports, real private runtime builtins, and project-level `__builtins__.pyi` overrides.

As a result, like mypy, Pyright, and Pyrefly, we reject implicit references to private typing-only builtin helpers. And like mypy and Pyrefly (but unlike Pyright), we still allow explicit imports, like `from builtins import _T_co`.

Closes https://github.com/astral-sh/ty/issues/1483.
