### PR TITLE
[ty] Prevent stack overflow from occurring in large inference dependencies

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1567,17 +1567,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let kind = definition.kind(self.db);
         let is_loop_header = kind.is_loop_header();
         let category = kind.category(self.source_type.is_stub(), self.module);
-        let is_name_dependency_root = matches!(
-            kind,
-            DefinitionKind::NamedExpression(_)
-                | DefinitionKind::Assignment(_)
-                | DefinitionKind::AnnotatedAssignment(_)
-                | DefinitionKind::AugmentedAssignment(_)
-        );
-        let name_dependencies = if place.is_symbol() && is_name_dependency_root {
-            self.name_dependencies(kind)
+        let definition_id = self.current_use_def_map().next_definition_id();
+        let name_dependencies = if place.is_symbol() {
+            self.name_dependencies(kind, definition_id)
         } else {
-            SmallVec::new()
+            None
         };
 
         // We need to avoid marking places as bound as soon as we encounter a loop header
@@ -1596,7 +1590,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             self.mark_place_declared(place);
         }
 
-        let definition_id = self.current_use_def_map().next_definition_id();
         let use_def = self.current_use_def_map_mut();
         match category {
             DefinitionCategory::DeclarationAndBinding => {
@@ -1622,12 +1615,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
         }
 
-        if place.is_symbol() {
-            self.current_use_def_map_mut().record_name_dependencies(
-                definition,
-                name_dependencies,
-                is_name_dependency_root,
-            );
+        if let Some(name_dependencies) = name_dependencies {
+            self.current_use_def_map_mut()
+                .record_name_dependencies(definition, name_dependencies);
         }
 
         if category.is_binding()
@@ -1643,48 +1633,68 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     }
 
     /// Returns prior ordinary variable definitions used by eager value expressions.
-    fn name_dependencies(&mut self, kind: &DefinitionKind<'db>) -> SmallVec<[Definition<'db>; 2]> {
+    ///
+    /// Returns `None` if inference could follow a synthetic or forward binding. Such a definition
+    /// must be left to source-order inference instead of being moved by dependency sorting.
+    fn name_dependencies(
+        &self,
+        kind: &DefinitionKind<'db>,
+        definition_id: ScopedDefinitionId,
+    ) -> Option<SmallVec<[Definition<'db>; 2]>> {
         let mut dependencies = SmallVec::new();
 
-        match kind {
+        let is_safe = match kind {
             DefinitionKind::NamedExpression(named) => {
                 let named = named.node(self.module);
                 if named.target.is_name_expr() {
-                    self.extend_name_dependencies(&named.value, &mut dependencies);
+                    self.extend_name_dependencies(&named.value, definition_id, &mut dependencies)
+                } else {
+                    false
                 }
             }
             DefinitionKind::Assignment(assignment)
                 if assignment.unpack().is_none()
                     && assignment.target(self.module).is_name_expr() =>
             {
-                self.extend_name_dependencies(assignment.value(self.module), &mut dependencies);
+                self.extend_name_dependencies(
+                    assignment.value(self.module),
+                    definition_id,
+                    &mut dependencies,
+                )
             }
             DefinitionKind::AnnotatedAssignment(assignment)
                 if assignment.target(self.module).is_name_expr() =>
             {
                 if let Some(value) = assignment.value(self.module) {
-                    self.extend_name_dependencies(value, &mut dependencies);
+                    self.extend_name_dependencies(value, definition_id, &mut dependencies)
+                } else {
+                    false
                 }
             }
             DefinitionKind::AugmentedAssignment(assignment)
                 if assignment.node(self.module).target.is_name_expr() =>
             {
                 let assignment = assignment.node(self.module);
-                self.extend_name_dependencies(&assignment.target, &mut dependencies);
-                self.extend_name_dependencies(&assignment.value, &mut dependencies);
+                self.extend_name_dependencies(&assignment.target, definition_id, &mut dependencies)
+                    && self.extend_name_dependencies(
+                        &assignment.value,
+                        definition_id,
+                        &mut dependencies,
+                    )
             }
-            _ => {}
-        }
+            _ => false,
+        };
 
-        dependencies
+        is_safe.then_some(dependencies)
     }
 
     fn extend_name_dependencies(
         &self,
         expression: &ast::Expr,
+        definition_id: ScopedDefinitionId,
         dependencies: &mut SmallVec<[Definition<'db>; 2]>,
-    ) {
-        any_over_expr(expression, |expression| {
+    ) -> bool {
+        !any_over_expr(expression, |expression| {
             if !expression.is_name_expr() {
                 return false;
             }
@@ -1693,39 +1703,53 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 return false;
             };
 
-            self.extend_live_binding_dependencies(
+            !self.extend_live_binding_dependencies(
                 self.current_use_def_map().bindings_at_use(use_id).copied(),
+                definition_id,
                 dependencies,
-            );
-
-            false
-        });
+            )
+        })
     }
 
     fn extend_live_binding_dependencies(
         &self,
         live_bindings: impl IntoIterator<Item = LiveBinding>,
+        definition_id: ScopedDefinitionId,
         dependencies: &mut SmallVec<[Definition<'db>; 2]>,
-    ) {
+    ) -> bool {
         for live_binding in live_bindings {
+            let binding_id = live_binding.binding();
             let Some(dependency) = self
                 .current_use_def_map()
-                .definition(live_binding.binding())
+                .definition(binding_id)
                 .definition()
             else {
                 continue;
             };
-            if matches!(
+            let is_ordinary_variable = matches!(
                 dependency.kind(self.db),
                 DefinitionKind::NamedExpression(_)
                     | DefinitionKind::Assignment(_)
                     | DefinitionKind::AnnotatedAssignment(_)
                     | DefinitionKind::AugmentedAssignment(_)
-            ) && !dependencies.contains(&dependency)
+            );
+
+            if binding_id >= definition_id
+                || !dependency.kind(self.db).is_user_visible()
+                || (is_ordinary_variable
+                    && !self
+                        .current_use_def_map()
+                        .is_name_dependency_eligible(dependency))
             {
+                return false;
+            }
+
+            if is_ordinary_variable && !dependencies.contains(&dependency) {
                 dependencies.push(dependency);
             }
         }
+
+        true
     }
 
     // Creates a definition for each key-value assignment in the dictionary.

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -67,7 +67,8 @@ use crate::use_def::{
 use crate::{Db, Statement, StatementNodeKey};
 use crate::{
     DefinitionsByNode, EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopHeaderId,
-    NarrowingAliasPredicate, PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter,
+    NameDependencies, NarrowingAliasPredicate, PossiblyNarrowedPlaces, SemanticIndex,
+    VisibleAncestorsIter,
 };
 
 use super::place::PlaceExprRef;
@@ -3029,6 +3030,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 .map(|(definition, uses)| (definition, uses.into_boxed_slice()))
                 .collect(),
         );
+        let mut use_def_maps = IndexVec::new();
+        let mut name_dependencies = FxHashMap::default();
+        for builder in self.use_def_maps {
+            let (use_def_map, scope_name_dependencies) = builder.finish();
+            use_def_maps.push(Arc::new(use_def_map));
+            name_dependencies.extend(scope_name_dependencies);
+        }
 
         SemanticIndex {
             place_tables: self
@@ -3045,11 +3053,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast_ids,
             scopes_by_expression: self.scopes_by_expression.build(),
             scopes_by_node: self.scopes_by_node,
-            use_def_maps: self
-                .use_def_maps
-                .into_iter()
-                .map(|builder| Arc::new(builder.finish()))
-                .collect(),
+            use_def_maps: use_def_maps.into(),
+            name_dependencies: NameDependencies::from_map(name_dependencies),
             enclosing_lambda_statements: FrozenMap::from(self.enclosing_lambda_statements),
             collections_by_use: FrozenMap::from(self.collections_by_use),
             uses_by_collection,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1563,6 +1563,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let kind = definition.kind(self.db);
         let is_loop_header = kind.is_loop_header();
         let category = kind.category(self.source_type.is_stub(), self.module);
+        let is_name_dependency_root = matches!(
+            kind,
+            DefinitionKind::NamedExpression(_)
+                | DefinitionKind::Assignment(_)
+                | DefinitionKind::AnnotatedAssignment(_)
+                | DefinitionKind::AugmentedAssignment(_)
+        );
+        let name_dependencies = if place.is_symbol() {
+            self.name_dependencies(kind)
+        } else {
+            SmallVec::new()
+        };
 
         // We need to avoid marking places as bound as soon as we encounter a loop header
         // definition for them, because that would lead to false-positive semantic syntax errors in
@@ -1606,6 +1618,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
         }
 
+        if place.is_symbol() {
+            self.current_use_def_map_mut().record_name_dependencies(
+                definition,
+                name_dependencies,
+                is_name_dependency_root,
+            );
+        }
+
         if category.is_binding()
             && let Some(id) = place.as_symbol()
         {
@@ -1616,6 +1636,204 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let mut try_node_stack_manager = std::mem::take(&mut self.try_node_context_stack_manager);
         try_node_stack_manager.record_definition(self);
         self.try_node_context_stack_manager = try_node_stack_manager;
+    }
+
+    /// Returns the ordinary variable definitions needed to infer this definition.
+    fn name_dependencies(&mut self, kind: &DefinitionKind<'db>) -> SmallVec<[Definition<'db>; 2]> {
+        let mut dependencies = SmallVec::new();
+
+        match kind {
+            DefinitionKind::NamedExpression(named) => {
+                let named = named.node(self.module);
+                if named.target.is_name_expr() {
+                    self.extend_name_dependencies(&named.value, &mut dependencies);
+                }
+            }
+            DefinitionKind::Assignment(assignment)
+                if assignment.unpack().is_none()
+                    && assignment.target(self.module).is_name_expr() =>
+            {
+                self.extend_name_dependencies(assignment.value(self.module), &mut dependencies);
+            }
+            DefinitionKind::AnnotatedAssignment(assignment)
+                if assignment.target(self.module).is_name_expr() =>
+            {
+                self.extend_name_dependencies(
+                    assignment.annotation(self.module),
+                    &mut dependencies,
+                );
+                if let Some(value) = assignment.value(self.module) {
+                    self.extend_name_dependencies(value, &mut dependencies);
+                }
+            }
+            DefinitionKind::AugmentedAssignment(assignment)
+                if assignment.node(self.module).target.is_name_expr() =>
+            {
+                let assignment = assignment.node(self.module);
+                self.extend_name_dependencies(&assignment.target, &mut dependencies);
+                self.extend_name_dependencies(&assignment.value, &mut dependencies);
+            }
+            DefinitionKind::Function(function) => {
+                let function = function.node(self.module);
+                for decorator in &function.decorator_list {
+                    self.extend_name_dependencies(&decorator.expression, &mut dependencies);
+                }
+                for parameter in &function.parameters {
+                    if let Some(default) = parameter.default() {
+                        self.extend_name_dependencies(default, &mut dependencies);
+                    }
+                    if let Some(annotation) = parameter.annotation() {
+                        self.extend_name_dependencies(annotation, &mut dependencies);
+                    }
+                }
+                if let Some(returns) = &function.returns {
+                    self.extend_name_dependencies(returns, &mut dependencies);
+                }
+                self.extend_type_parameter_dependencies(
+                    function.type_params.as_deref(),
+                    &mut dependencies,
+                );
+            }
+            DefinitionKind::Class(class) => {
+                let class = class.node(self.module);
+                for decorator in &class.decorator_list {
+                    self.extend_name_dependencies(&decorator.expression, &mut dependencies);
+                }
+                if let Some(arguments) = &class.arguments {
+                    for argument in &arguments.args {
+                        self.extend_name_dependencies(argument, &mut dependencies);
+                    }
+                    for keyword in &arguments.keywords {
+                        self.extend_name_dependencies(&keyword.value, &mut dependencies);
+                    }
+                }
+                self.extend_type_parameter_dependencies(
+                    class.type_params.as_deref(),
+                    &mut dependencies,
+                );
+            }
+            _ => {}
+        }
+
+        dependencies
+    }
+
+    fn extend_type_parameter_dependencies(
+        &mut self,
+        type_params: Option<&ast::TypeParams>,
+        dependencies: &mut SmallVec<[Definition<'db>; 2]>,
+    ) {
+        let Some(type_params) = type_params else {
+            return;
+        };
+        let names = type_params
+            .type_params
+            .iter()
+            .map(ast::TypeParam::name)
+            .collect::<SmallVec<[_; 4]>>();
+
+        for type_param in &type_params.type_params {
+            match type_param {
+                ast::TypeParam::TypeVar(type_var) => {
+                    if let Some(bound) = &type_var.bound {
+                        self.extend_enclosing_name_dependencies(bound, &names, dependencies);
+                    }
+                    if let Some(default) = &type_var.default {
+                        self.extend_enclosing_name_dependencies(default, &names, dependencies);
+                    }
+                }
+                ast::TypeParam::ParamSpec(param_spec) => {
+                    if let Some(default) = &param_spec.default {
+                        self.extend_enclosing_name_dependencies(default, &names, dependencies);
+                    }
+                }
+                ast::TypeParam::TypeVarTuple(type_var_tuple) => {
+                    if let Some(default) = &type_var_tuple.default {
+                        self.extend_enclosing_name_dependencies(default, &names, dependencies);
+                    }
+                }
+            }
+        }
+    }
+
+    // Type-parameter expressions use a child scope, so resolve their free names against the
+    // enclosing definition scope instead of looking up their use IDs.
+    fn extend_enclosing_name_dependencies(
+        &mut self,
+        expression: &ast::Expr,
+        type_parameter_names: &[&ast::Identifier],
+        dependencies: &mut SmallVec<[Definition<'db>; 2]>,
+    ) {
+        any_over_expr(expression, |expression| {
+            let Some(name) = expression.as_name_expr() else {
+                return false;
+            };
+            if type_parameter_names
+                .iter()
+                .any(|type_parameter| type_parameter.id == name.id)
+            {
+                return false;
+            }
+
+            let Some(symbol) = self.current_place_table().symbol_id(name.id.as_str()) else {
+                return false;
+            };
+            let live_bindings = self
+                .current_use_def_map_mut()
+                .current_bindings(symbol.into())
+                .collect::<SmallVec<[_; 2]>>();
+            self.extend_live_binding_dependencies(live_bindings, dependencies);
+            false
+        });
+    }
+
+    fn extend_name_dependencies(
+        &self,
+        expression: &ast::Expr,
+        dependencies: &mut SmallVec<[Definition<'db>; 2]>,
+    ) {
+        any_over_expr(expression, |expression| {
+            if !expression.is_name_expr() {
+                return false;
+            }
+
+            let Some(use_id) = self.current_ast_ids().try_use_id(expression) else {
+                return false;
+            };
+
+            self.extend_live_binding_dependencies(
+                self.current_use_def_map().bindings_at_use(use_id).copied(),
+                dependencies,
+            );
+
+            false
+        });
+    }
+
+    fn extend_live_binding_dependencies(
+        &self,
+        live_bindings: impl IntoIterator<Item = LiveBinding>,
+        dependencies: &mut SmallVec<[Definition<'db>; 2]>,
+    ) {
+        for live_binding in live_bindings {
+            let Some(dependency) = self
+                .current_use_def_map()
+                .definition(live_binding.binding())
+                .definition()
+            else {
+                continue;
+            };
+            if matches!(
+                dependency.kind(self.db),
+                DefinitionKind::NamedExpression(_)
+                    | DefinitionKind::Assignment(_)
+                    | DefinitionKind::AnnotatedAssignment(_)
+                    | DefinitionKind::AugmentedAssignment(_)
+            ) && !dependencies.contains(&dependency)
+            {
+                dependencies.push(dependency);
+            }
+        }
     }
 
     // Creates a definition for each key-value assignment in the dictionary.

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1570,7 +1570,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 | DefinitionKind::AnnotatedAssignment(_)
                 | DefinitionKind::AugmentedAssignment(_)
         );
-        let name_dependencies = if place.is_symbol() {
+        let name_dependencies = if place.is_symbol() && is_name_dependency_root {
             self.name_dependencies(kind)
         } else {
             SmallVec::new()
@@ -1638,7 +1638,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.try_node_context_stack_manager = try_node_stack_manager;
     }
 
-    /// Returns the ordinary variable definitions needed to infer this definition.
+    /// Returns prior ordinary variable definitions used by eager value expressions.
     fn name_dependencies(&mut self, kind: &DefinitionKind<'db>) -> SmallVec<[Definition<'db>; 2]> {
         let mut dependencies = SmallVec::new();
 
@@ -1658,10 +1658,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             DefinitionKind::AnnotatedAssignment(assignment)
                 if assignment.target(self.module).is_name_expr() =>
             {
-                self.extend_name_dependencies(
-                    assignment.annotation(self.module),
-                    &mut dependencies,
-                );
                 if let Some(value) = assignment.value(self.module) {
                     self.extend_name_dependencies(value, &mut dependencies);
                 }
@@ -1673,118 +1669,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 self.extend_name_dependencies(&assignment.target, &mut dependencies);
                 self.extend_name_dependencies(&assignment.value, &mut dependencies);
             }
-            DefinitionKind::Function(function) => {
-                let function = function.node(self.module);
-                for decorator in &function.decorator_list {
-                    self.extend_name_dependencies(&decorator.expression, &mut dependencies);
-                }
-                for parameter in &function.parameters {
-                    if let Some(default) = parameter.default() {
-                        self.extend_name_dependencies(default, &mut dependencies);
-                    }
-                    if let Some(annotation) = parameter.annotation() {
-                        self.extend_name_dependencies(annotation, &mut dependencies);
-                    }
-                }
-                if let Some(returns) = &function.returns {
-                    self.extend_name_dependencies(returns, &mut dependencies);
-                }
-                self.extend_type_parameter_dependencies(
-                    function.type_params.as_deref(),
-                    &mut dependencies,
-                );
-            }
-            DefinitionKind::Class(class) => {
-                let class = class.node(self.module);
-                for decorator in &class.decorator_list {
-                    self.extend_name_dependencies(&decorator.expression, &mut dependencies);
-                }
-                if let Some(arguments) = &class.arguments {
-                    for argument in &arguments.args {
-                        self.extend_name_dependencies(argument, &mut dependencies);
-                    }
-                    for keyword in &arguments.keywords {
-                        self.extend_name_dependencies(&keyword.value, &mut dependencies);
-                    }
-                }
-                self.extend_type_parameter_dependencies(
-                    class.type_params.as_deref(),
-                    &mut dependencies,
-                );
-            }
             _ => {}
         }
 
         dependencies
-    }
-
-    fn extend_type_parameter_dependencies(
-        &mut self,
-        type_params: Option<&ast::TypeParams>,
-        dependencies: &mut SmallVec<[Definition<'db>; 2]>,
-    ) {
-        let Some(type_params) = type_params else {
-            return;
-        };
-        let names = type_params
-            .type_params
-            .iter()
-            .map(ast::TypeParam::name)
-            .collect::<SmallVec<[_; 4]>>();
-
-        for type_param in &type_params.type_params {
-            match type_param {
-                ast::TypeParam::TypeVar(type_var) => {
-                    if let Some(bound) = &type_var.bound {
-                        self.extend_enclosing_name_dependencies(bound, &names, dependencies);
-                    }
-                    if let Some(default) = &type_var.default {
-                        self.extend_enclosing_name_dependencies(default, &names, dependencies);
-                    }
-                }
-                ast::TypeParam::ParamSpec(param_spec) => {
-                    if let Some(default) = &param_spec.default {
-                        self.extend_enclosing_name_dependencies(default, &names, dependencies);
-                    }
-                }
-                ast::TypeParam::TypeVarTuple(type_var_tuple) => {
-                    if let Some(default) = &type_var_tuple.default {
-                        self.extend_enclosing_name_dependencies(default, &names, dependencies);
-                    }
-                }
-            }
-        }
-    }
-
-    // Type-parameter expressions use a child scope, so resolve their free names against the
-    // enclosing definition scope instead of looking up their use IDs.
-    fn extend_enclosing_name_dependencies(
-        &mut self,
-        expression: &ast::Expr,
-        type_parameter_names: &[&ast::Identifier],
-        dependencies: &mut SmallVec<[Definition<'db>; 2]>,
-    ) {
-        any_over_expr(expression, |expression| {
-            let Some(name) = expression.as_name_expr() else {
-                return false;
-            };
-            if type_parameter_names
-                .iter()
-                .any(|type_parameter| type_parameter.id == name.id)
-            {
-                return false;
-            }
-
-            let Some(symbol) = self.current_place_table().symbol_id(name.id.as_str()) else {
-                return false;
-            };
-            let live_bindings = self
-                .current_use_def_map_mut()
-                .current_bindings(symbol.into())
-                .collect::<SmallVec<[_; 2]>>();
-            self.extend_live_binding_dependencies(live_bindings, dependencies);
-            false
-        });
     }
 
     fn extend_name_dependencies(

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -16,6 +16,7 @@ use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::plumbing::AsId;
 use smallvec::SmallVec;
+use thin_vec::ThinVec;
 use ty_module_resolver::ModuleName;
 
 // FIXME: Replace this temporary alias once semantic query keys can use the environment-bearing
@@ -279,6 +280,50 @@ impl<'db> DefinitionsByNode<'db> {
     }
 }
 
+/// Prior ordinary variable definitions used by eager value expressions in one file.
+#[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+struct NameDependencies<'db> {
+    definitions: ThinVec<(Definition<'db>, usize)>,
+    dependencies: ThinVec<Definition<'db>>,
+}
+
+impl<'db> NameDependencies<'db> {
+    fn from_map(
+        dependencies_by_definition: FxHashMap<Definition<'db>, Box<[Definition<'db>]>>,
+    ) -> Self {
+        let dependency_count = dependencies_by_definition
+            .values()
+            .map(|dependencies| dependencies.len())
+            .sum();
+        let mut entries = dependencies_by_definition.into_iter().collect::<Vec<_>>();
+        entries.sort_unstable_by_key(|(definition, _)| *definition);
+
+        let mut definitions = ThinVec::with_capacity(entries.len());
+        let mut dependencies = ThinVec::with_capacity(dependency_count);
+        for (definition, definition_dependencies) in entries {
+            dependencies.extend(definition_dependencies);
+            definitions.push((definition, dependencies.len()));
+        }
+
+        Self {
+            definitions,
+            dependencies,
+        }
+    }
+
+    fn get(&self, definition: Definition<'db>) -> Option<&[Definition<'db>]> {
+        let index = self
+            .definitions
+            .binary_search_by_key(&definition, |(candidate, _)| *candidate)
+            .ok()?;
+        let start = index
+            .checked_sub(1)
+            .map_or(0, |previous| self.definitions[previous].1);
+        let end = self.definitions[index].1;
+        Some(&self.dependencies[start..end])
+    }
+}
+
 /// The place tables and use-def maps for all scopes in a file.
 #[derive(Debug, get_size2::GetSize, salsa::SalsaValue)]
 pub struct SemanticIndex<'db> {
@@ -320,6 +365,9 @@ pub struct SemanticIndex<'db> {
 
     /// Use-def map for each scope in this file.
     use_def_maps: FrozenIndexVec<FileScopeId, Arc<UseDefMap<'db>>>,
+
+    /// Eager value dependencies for definitions that have them.
+    name_dependencies: NameDependencies<'db>,
 
     /// Lookup table to map between node ids and ast nodes.
     ///
@@ -382,6 +430,64 @@ impl<'db> SemanticIndex<'db> {
     #[track_caller]
     pub fn use_def_map(&self, scope_id: FileScopeId) -> &UseDefMap<'db> {
         &self.use_def_maps[scope_id]
+    }
+
+    /// Returns prior ordinary variable definitions used by `definition`'s eager value expression.
+    pub fn name_dependencies(&self, definition: Definition<'db>) -> &[Definition<'db>] {
+        self.name_dependencies.get(definition).unwrap_or_default()
+    }
+
+    /// Returns every definition in a scope's eager value dependency graph in dependency order.
+    pub fn all_name_dependencies_in_order(&self, scope_id: FileScopeId) -> Vec<Definition<'db>> {
+        let roots = self
+            .use_def_map(scope_id)
+            .all_definitions_with_usage()
+            .filter_map(|(_, state, _)| state.definition())
+            .filter(|definition| self.name_dependencies.get(*definition).is_some());
+        Self::name_dependency_order(&self.name_dependencies, roots)
+    }
+
+    /// Returns `definition`'s eager value dependencies in dependency order.
+    pub fn name_dependencies_in_order(&self, definition: Definition<'db>) -> Vec<Definition<'db>> {
+        Self::name_dependency_order(
+            &self.name_dependencies,
+            self.name_dependencies(definition).iter().copied(),
+        )
+    }
+
+    fn name_dependency_order(
+        dependencies: &NameDependencies<'db>,
+        roots: impl IntoIterator<Item = Definition<'db>>,
+    ) -> Vec<Definition<'db>> {
+        let mut pending = Vec::new();
+        let mut visited = FxHashSet::default();
+        let mut ordered = Vec::new();
+
+        for root in roots {
+            pending.push((root, false));
+
+            while let Some((definition, expanded)) = pending.pop() {
+                if expanded {
+                    ordered.push(definition);
+                    continue;
+                }
+                if !visited.insert(definition) {
+                    continue;
+                }
+
+                pending.push((definition, true));
+                if let Some(definition_dependencies) = dependencies.get(definition) {
+                    pending.extend(
+                        definition_dependencies
+                            .iter()
+                            .rev()
+                            .map(|dependency| (*dependency, false)),
+                    );
+                }
+            }
+        }
+
+        ordered
     }
 
     /// Returns the set of modules that are imported anywhere in this file.

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -283,7 +283,8 @@ impl<'db> DefinitionsByNode<'db> {
 /// Prior ordinary variable definitions used by eager value expressions in one file.
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 struct NameDependencies<'db> {
-    definitions: ThinVec<(Definition<'db>, usize)>,
+    /// The definition and exclusive dependency end offset for each graph node.
+    definitions: ThinVec<(Definition<'db>, u32)>,
     dependencies: ThinVec<Definition<'db>>,
 }
 
@@ -302,7 +303,9 @@ impl<'db> NameDependencies<'db> {
         let mut dependencies = ThinVec::with_capacity(dependency_count);
         for (definition, definition_dependencies) in entries {
             dependencies.extend(definition_dependencies);
-            definitions.push((definition, dependencies.len()));
+            let end = u32::try_from(dependencies.len())
+                .expect("Expected name-dependency length to fit into a u32");
+            definitions.push((definition, end));
         }
 
         Self {
@@ -320,7 +323,7 @@ impl<'db> NameDependencies<'db> {
             .checked_sub(1)
             .map_or(0, |previous| self.definitions[previous].1);
         let end = self.definitions[index].1;
-        Some(&self.dependencies[start..end])
+        Some(&self.dependencies[start as usize..end as usize])
     }
 }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -246,7 +246,7 @@ use std::sync::LazyLock;
 
 use ruff_index::{FrozenIndexVec, Idx, IndexVec, newtype_index};
 use ruff_text_size::TextRange;
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHasher};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
 use smallvec::SmallVec;
 use thin_vec::ThinVec;
 
@@ -780,6 +780,14 @@ pub struct UseDefMap<'db> {
         DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
     >,
 
+    /// Ordinary variable definitions directly needed to infer a definition.
+    ///
+    /// Type inference traverses this graph iteratively before inferring a requested definition.
+    name_dependencies: FrozenMap<Definition<'db>, Box<[Definition<'db>]>>,
+
+    /// Ordinary variable definitions that have entries in `name_dependencies`.
+    name_dependency_roots: FrozenMap<Definition<'db>, ()>,
+
     /// Retained [`PlaceState`] values for each symbol.
     symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<InternedPlaceStateId>>,
 
@@ -1073,6 +1081,62 @@ impl<'db> UseDefMap<'db> {
             |definitions| &self.interned_bindings[definitions.bindings],
         );
         self.bindings_iterator(bindings, BoundnessAnalysis::BasedOnUnboundVisibility)
+    }
+
+    /// Returns the ordinary variable definitions directly referenced by `definition`.
+    pub fn name_dependencies(&self, definition: Definition<'db>) -> &[Definition<'db>] {
+        self.name_dependencies
+            .get(&definition)
+            .map(AsRef::as_ref)
+            .unwrap_or_default()
+    }
+
+    /// Returns every ordinary variable definition in the dependency graph in dependency order.
+    pub fn all_name_dependencies_in_order(&self) -> Vec<Definition<'db>> {
+        let roots = self
+            .all_definitions
+            .iter_enumerated()
+            .filter_map(|(_, state)| state.state().definition())
+            .filter(|definition| self.name_dependency_roots.get(definition).is_some());
+        self.name_dependency_order(roots)
+    }
+
+    /// Returns the ordinary variable dependencies of `definition` in dependency order.
+    pub fn name_dependencies_in_order(&self, definition: Definition<'db>) -> Vec<Definition<'db>> {
+        self.name_dependency_order(self.name_dependencies(definition).iter().copied())
+    }
+
+    fn name_dependency_order(
+        &self,
+        roots: impl IntoIterator<Item = Definition<'db>>,
+    ) -> Vec<Definition<'db>> {
+        let mut pending = Vec::new();
+        let mut visited = FxHashSet::default();
+        let mut ordered = Vec::new();
+
+        for root in roots {
+            pending.push((root, false));
+
+            while let Some((definition, expanded)) = pending.pop() {
+                if expanded {
+                    ordered.push(definition);
+                    continue;
+                }
+                if !visited.insert(definition) {
+                    continue;
+                }
+
+                pending.push((definition, true));
+                pending.extend(
+                    self.name_dependencies(definition)
+                        .iter()
+                        .rev()
+                        .map(|dependency| (*dependency, false)),
+                );
+            }
+        }
+
+        ordered
     }
 
     pub fn declarations_at_binding(
@@ -1799,6 +1863,12 @@ pub(super) struct UseDefMapBuilder<'db> {
     definitions_by_definition:
         FxHashMap<Definition<'db>, DefinitionsAtDefinition<Bindings, Declarations>>,
 
+    /// Ordinary variable definitions directly needed to infer a definition.
+    name_dependencies: FxHashMap<Definition<'db>, Box<[Definition<'db>]>>,
+
+    /// Ordinary variable definitions that have entries in `name_dependencies`.
+    name_dependency_roots: FxHashSet<Definition<'db>>,
+
     /// Currently live bindings and declarations for each place.
     symbol_states: IndexVec<ScopedSymbolId, PendingPlaceState>,
 
@@ -1837,6 +1907,8 @@ impl<'db> UseDefMapBuilder<'db> {
             reachability: ScopedReachabilityConstraintId::ALWAYS_TRUE,
             range_reachability: Vec::new(),
             definitions_by_definition: FxHashMap::default(),
+            name_dependencies: FxHashMap::default(),
+            name_dependency_roots: FxHashSet::default(),
             symbol_states: IndexVec::new(),
             member_states: IndexVec::new(),
             pending_reachability: PendingReachability::default(),
@@ -1865,6 +1937,23 @@ impl<'db> UseDefMapBuilder<'db> {
 
     pub(super) fn definition(&self, def_id: ScopedDefinitionId) -> DefinitionState<'db> {
         self.all_definitions[def_id]
+    }
+
+    /// Records the ordinary variable definitions directly referenced by `binding`.
+    pub(super) fn record_name_dependencies(
+        &mut self,
+        binding: Definition<'db>,
+        dependencies: impl IntoIterator<Item = Definition<'db>>,
+        is_root: bool,
+    ) {
+        let dependencies = dependencies.into_iter().collect::<Vec<_>>();
+        if !dependencies.is_empty() {
+            self.name_dependencies
+                .insert(binding, dependencies.into_boxed_slice());
+            if is_root {
+                self.name_dependency_roots.insert(binding);
+            }
+        }
     }
 
     pub(super) fn mark_unreachable(&mut self) {
@@ -2902,6 +2991,12 @@ impl<'db> UseDefMapBuilder<'db> {
             range_reachability: self.range_reachability.into_boxed_slice(),
             symbol_states,
             definitions_by_definition,
+            name_dependencies: FrozenMap::from(self.name_dependencies),
+            name_dependency_roots: self
+                .name_dependency_roots
+                .into_iter()
+                .map(|definition| (definition, ()))
+                .collect(),
             extra,
             end_of_scope_reachability: self.reachability,
         }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -780,14 +780,6 @@ pub struct UseDefMap<'db> {
         DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
     >,
 
-    /// Prior ordinary variable definitions used by eager value expressions.
-    ///
-    /// Type inference traverses this graph iteratively before inferring a requested definition.
-    name_dependencies: FrozenMap<Definition<'db>, Box<[Definition<'db>]>>,
-
-    /// Ordinary variable definitions whose eager value expressions have dependency entries.
-    name_dependency_roots: FrozenMap<Definition<'db>, ()>,
-
     /// Retained [`PlaceState`] values for each symbol.
     symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<InternedPlaceStateId>>,
 
@@ -1081,62 +1073,6 @@ impl<'db> UseDefMap<'db> {
             |definitions| &self.interned_bindings[definitions.bindings],
         );
         self.bindings_iterator(bindings, BoundnessAnalysis::BasedOnUnboundVisibility)
-    }
-
-    /// Returns prior ordinary variable definitions used by `definition`'s eager value expression.
-    pub fn name_dependencies(&self, definition: Definition<'db>) -> &[Definition<'db>] {
-        self.name_dependencies
-            .get(&definition)
-            .map(AsRef::as_ref)
-            .unwrap_or_default()
-    }
-
-    /// Returns every definition in the eager value dependency graph in dependency order.
-    pub fn all_name_dependencies_in_order(&self) -> Vec<Definition<'db>> {
-        let roots = self
-            .all_definitions
-            .iter_enumerated()
-            .filter_map(|(_, state)| state.state().definition())
-            .filter(|definition| self.name_dependency_roots.get(definition).is_some());
-        self.name_dependency_order(roots)
-    }
-
-    /// Returns `definition`'s eager value dependencies in dependency order.
-    pub fn name_dependencies_in_order(&self, definition: Definition<'db>) -> Vec<Definition<'db>> {
-        self.name_dependency_order(self.name_dependencies(definition).iter().copied())
-    }
-
-    fn name_dependency_order(
-        &self,
-        roots: impl IntoIterator<Item = Definition<'db>>,
-    ) -> Vec<Definition<'db>> {
-        let mut pending = Vec::new();
-        let mut visited = FxHashSet::default();
-        let mut ordered = Vec::new();
-
-        for root in roots {
-            pending.push((root, false));
-
-            while let Some((definition, expanded)) = pending.pop() {
-                if expanded {
-                    ordered.push(definition);
-                    continue;
-                }
-                if !visited.insert(definition) {
-                    continue;
-                }
-
-                pending.push((definition, true));
-                pending.extend(
-                    self.name_dependencies(definition)
-                        .iter()
-                        .rev()
-                        .map(|dependency| (*dependency, false)),
-                );
-            }
-        }
-
-        ordered
     }
 
     pub fn declarations_at_binding(
@@ -1866,9 +1802,6 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Ordinary variable definitions directly needed to infer a definition.
     name_dependencies: FxHashMap<Definition<'db>, Box<[Definition<'db>]>>,
 
-    /// Ordinary variable definitions that have entries in `name_dependencies`.
-    name_dependency_roots: FxHashSet<Definition<'db>>,
-
     /// Ordinary variable definitions that are safe to infer before their source-order visit.
     name_dependency_eligible: FxHashSet<Definition<'db>>,
 
@@ -1911,7 +1844,6 @@ impl<'db> UseDefMapBuilder<'db> {
             range_reachability: Vec::new(),
             definitions_by_definition: FxHashMap::default(),
             name_dependencies: FxHashMap::default(),
-            name_dependency_roots: FxHashSet::default(),
             name_dependency_eligible: FxHashSet::default(),
             symbol_states: IndexVec::new(),
             member_states: IndexVec::new(),
@@ -1954,7 +1886,6 @@ impl<'db> UseDefMapBuilder<'db> {
         if !dependencies.is_empty() {
             self.name_dependencies
                 .insert(binding, dependencies.into_boxed_slice());
-            self.name_dependency_roots.insert(binding);
         }
     }
 
@@ -2848,7 +2779,12 @@ impl<'db> UseDefMapBuilder<'db> {
             .add_or_constraint(self.reachability, snapshot.reachability);
     }
 
-    pub(super) fn finish(mut self: Box<Self>) -> UseDefMap<'db> {
+    pub(super) fn finish(
+        mut self: Box<Self>,
+    ) -> (
+        UseDefMap<'db>,
+        FxHashMap<Definition<'db>, Box<[Definition<'db>]>>,
+    ) {
         let pending = self.pending_reachability.current;
         for state in self
             .symbol_states
@@ -2988,25 +2924,23 @@ impl<'db> UseDefMapBuilder<'db> {
                 narrowing_constraints,
             })
         });
+        let name_dependencies = std::mem::take(&mut self.name_dependencies);
         let all_definitions = RetainedDefinitions::new(self.all_definitions, self.used_bindings);
 
-        UseDefMap {
-            all_definitions,
-            constraint_tables,
-            interned_bindings,
-            interned_declarations,
-            range_reachability: self.range_reachability.into_boxed_slice(),
-            symbol_states,
-            definitions_by_definition,
-            name_dependencies: FrozenMap::from(self.name_dependencies),
-            name_dependency_roots: self
-                .name_dependency_roots
-                .into_iter()
-                .map(|definition| (definition, ()))
-                .collect(),
-            extra,
-            end_of_scope_reachability: self.reachability,
-        }
+        (
+            UseDefMap {
+                all_definitions,
+                constraint_tables,
+                interned_bindings,
+                interned_declarations,
+                range_reachability: self.range_reachability.into_boxed_slice(),
+                symbol_states,
+                definitions_by_definition,
+                extra,
+                end_of_scope_reachability: self.reachability,
+            },
+            name_dependencies,
+        )
     }
 
     fn zip_place_states<I: Idx, T>(

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -780,12 +780,12 @@ pub struct UseDefMap<'db> {
         DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
     >,
 
-    /// Ordinary variable definitions directly needed to infer a definition.
+    /// Prior ordinary variable definitions used by eager value expressions.
     ///
     /// Type inference traverses this graph iteratively before inferring a requested definition.
     name_dependencies: FrozenMap<Definition<'db>, Box<[Definition<'db>]>>,
 
-    /// Ordinary variable definitions that have entries in `name_dependencies`.
+    /// Ordinary variable definitions whose eager value expressions have dependency entries.
     name_dependency_roots: FrozenMap<Definition<'db>, ()>,
 
     /// Retained [`PlaceState`] values for each symbol.
@@ -1083,7 +1083,7 @@ impl<'db> UseDefMap<'db> {
         self.bindings_iterator(bindings, BoundnessAnalysis::BasedOnUnboundVisibility)
     }
 
-    /// Returns the ordinary variable definitions directly referenced by `definition`.
+    /// Returns prior ordinary variable definitions used by `definition`'s eager value expression.
     pub fn name_dependencies(&self, definition: Definition<'db>) -> &[Definition<'db>] {
         self.name_dependencies
             .get(&definition)
@@ -1091,7 +1091,7 @@ impl<'db> UseDefMap<'db> {
             .unwrap_or_default()
     }
 
-    /// Returns every ordinary variable definition in the dependency graph in dependency order.
+    /// Returns every definition in the eager value dependency graph in dependency order.
     pub fn all_name_dependencies_in_order(&self) -> Vec<Definition<'db>> {
         let roots = self
             .all_definitions
@@ -1101,7 +1101,7 @@ impl<'db> UseDefMap<'db> {
         self.name_dependency_order(roots)
     }
 
-    /// Returns the ordinary variable dependencies of `definition` in dependency order.
+    /// Returns `definition`'s eager value dependencies in dependency order.
     pub fn name_dependencies_in_order(&self, definition: Definition<'db>) -> Vec<Definition<'db>> {
         self.name_dependency_order(self.name_dependencies(definition).iter().copied())
     }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1869,6 +1869,9 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Ordinary variable definitions that have entries in `name_dependencies`.
     name_dependency_roots: FxHashSet<Definition<'db>>,
 
+    /// Ordinary variable definitions that are safe to infer before their source-order visit.
+    name_dependency_eligible: FxHashSet<Definition<'db>>,
+
     /// Currently live bindings and declarations for each place.
     symbol_states: IndexVec<ScopedSymbolId, PendingPlaceState>,
 
@@ -1909,6 +1912,7 @@ impl<'db> UseDefMapBuilder<'db> {
             definitions_by_definition: FxHashMap::default(),
             name_dependencies: FxHashMap::default(),
             name_dependency_roots: FxHashSet::default(),
+            name_dependency_eligible: FxHashSet::default(),
             symbol_states: IndexVec::new(),
             member_states: IndexVec::new(),
             pending_reachability: PendingReachability::default(),
@@ -1939,21 +1943,24 @@ impl<'db> UseDefMapBuilder<'db> {
         self.all_definitions[def_id]
     }
 
-    /// Records the ordinary variable definitions directly referenced by `binding`.
+    /// Marks `binding` as eligible for dependency sorting and records its direct dependencies.
     pub(super) fn record_name_dependencies(
         &mut self,
         binding: Definition<'db>,
         dependencies: impl IntoIterator<Item = Definition<'db>>,
-        is_root: bool,
     ) {
+        self.name_dependency_eligible.insert(binding);
         let dependencies = dependencies.into_iter().collect::<Vec<_>>();
         if !dependencies.is_empty() {
             self.name_dependencies
                 .insert(binding, dependencies.into_boxed_slice());
-            if is_root {
-                self.name_dependency_roots.insert(binding);
-            }
+            self.name_dependency_roots.insert(binding);
         }
+    }
+
+    /// Returns whether `definition` can be moved before its source-order inference.
+    pub(super) fn is_name_dependency_eligible(&self, definition: Definition<'db>) -> bool {
+        self.name_dependency_eligible.contains(&definition)
     }
 
     pub(super) fn mark_unreachable(&mut self) {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -13,7 +13,8 @@ use crate::reachability::{
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
     DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
-    UnionBuilder, UnionType, binding_type, inferred_declaration, is_discarded_dict_key_assignment,
+    UnionBuilder, UnionType, binding_type, binding_type_with_prepared_dependencies,
+    inferred_declaration, is_discarded_dict_key_assignment,
 };
 use crate::{Db, FxIndexSet, FxOrderSet, Program};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
@@ -673,10 +674,13 @@ pub(super) fn place_from_bindings<'db>(
         bindings_with_constraints,
         RequiresExplicitReExport::No,
         None,
+        binding_type,
     )
 }
 
-pub(super) fn place_from_bindings_with_reachability_cache<'db>(
+/// Builds a place with a reachability cache after every binding's ordinary variable dependencies
+/// have been inferred in dependency order.
+pub(super) fn place_from_bindings_with_prepared_dependencies_and_reachability_cache<'db>(
     db: &'db dyn Db,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
     reachability_cache: &ReachabilityEvaluationCache<'db>,
@@ -686,6 +690,22 @@ pub(super) fn place_from_bindings_with_reachability_cache<'db>(
         bindings_with_constraints,
         RequiresExplicitReExport::No,
         Some(reachability_cache),
+        binding_type_with_prepared_dependencies,
+    )
+}
+
+/// Builds a place after the ordinary variable dependencies of every binding have been inferred in
+/// dependency order.
+pub(super) fn place_from_bindings_with_prepared_dependencies<'db>(
+    db: &'db dyn Db,
+    bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
+) -> PlaceWithDefinition<'db> {
+    place_from_bindings_impl(
+        db,
+        bindings_with_constraints,
+        RequiresExplicitReExport::No,
+        None,
+        binding_type_with_prepared_dependencies,
     )
 }
 
@@ -1015,9 +1035,15 @@ pub(crate) fn place_by_id<'db>(
     // inferred type, without unioning with `Unknown`, because it cannot be modified.
     if let Some(qualifiers) = declared.is_bare_final() {
         let bindings = all_considered_bindings();
-        return place_from_bindings_impl(db, bindings, requires_explicit_reexport, None)
-            .place
-            .with_qualifiers(qualifiers);
+        return place_from_bindings_impl(
+            db,
+            bindings,
+            requires_explicit_reexport,
+            None,
+            binding_type,
+        )
+        .place
+        .with_qualifiers(qualifiers);
     }
 
     match declared {
@@ -1035,7 +1061,15 @@ pub(crate) fn place_by_id<'db>(
             qualifiers,
         } if qualifiers.contains(TypeQualifiers::CLASS_VAR) => {
             let bindings = all_considered_bindings();
-            match place_from_bindings_impl(db, bindings, requires_explicit_reexport, None).place {
+            match place_from_bindings_impl(
+                db,
+                bindings,
+                requires_explicit_reexport,
+                None,
+                binding_type,
+            )
+            .place
+            {
                 Place::Defined(DefinedPlace {
                     ty: inferred,
                     origin,
@@ -1083,7 +1117,13 @@ pub(crate) fn place_by_id<'db>(
         } => {
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
-            let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport, None);
+            let inferred = place_from_bindings_impl(
+                db,
+                bindings,
+                requires_explicit_reexport,
+                None,
+                binding_type,
+            );
 
             let place = match inferred.place {
                 // Place is possibly undeclared and definitely unbound
@@ -1128,8 +1168,14 @@ pub(crate) fn place_by_id<'db>(
         } => {
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
-            let mut inferred =
-                place_from_bindings_impl(db, bindings, requires_explicit_reexport, None).place;
+            let mut inferred = place_from_bindings_impl(
+                db,
+                bindings,
+                requires_explicit_reexport,
+                None,
+                binding_type,
+            )
+            .place;
 
             if boundness_analysis == BoundnessAnalysis::AssumeBound {
                 if let Place::Defined(defined) = inferred {
@@ -1469,6 +1515,7 @@ fn place_from_bindings_impl<'db>(
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
     requires_explicit_reexport: RequiresExplicitReExport,
     reachability_cache: Option<&ReachabilityEvaluationCache<'db>>,
+    binding_type: impl Fn(&'db dyn Db, Definition<'db>) -> Type<'db> + Copy,
 ) -> PlaceWithDefinition<'db> {
     let predicates = bindings_with_constraints.predicates();
     let reachability_constraints = bindings_with_constraints.reachability_constraints();

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -31,7 +31,8 @@ pub use self::diagnostic::{UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{
     InferredDeclaration, TypeContext, infer_complete_scope_types, infer_deferred_types,
     infer_definition_types, infer_expression_type, infer_expression_types,
-    infer_same_file_expression_type, infer_scope_types, is_discarded_dict_key_assignment,
+    infer_name_dependencies_for_scope, infer_same_file_expression_type, infer_scope_types,
+    is_discarded_dict_key_assignment,
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
@@ -219,6 +220,16 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
     inference.binding_type(definition)
+}
+
+/// Infer the type of a binding whose ordinary variable dependencies have already been inferred in
+/// dependency order.
+pub(crate) fn binding_type_with_prepared_dependencies<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+) -> Type<'db> {
+    infer::infer_definition_types_with_prepared_dependencies(db, definition)
+        .binding_type(definition)
 }
 
 /// Infer the type of a declaration, returning `Rejected` if it is not valid.

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -127,10 +127,9 @@ pub(crate) fn infer_definition_types<'db>(
 ) -> &'db DefinitionInference<'db> {
     let python_file = definition.python_file(db);
     let index = semantic_index(db, python_file);
-    let use_def_map = index.use_def_map(definition.file_scope(db));
 
-    if !use_def_map.name_dependencies(definition).is_empty() {
-        for dependency in use_def_map.name_dependencies_in_order(definition) {
+    if !index.name_dependencies(definition).is_empty() {
+        for dependency in index.name_dependencies_in_order(definition) {
             infer_definition_types_with_prepared_dependencies(db, dependency);
         }
     }
@@ -141,10 +140,7 @@ pub(crate) fn infer_definition_types<'db>(
 /// Infers every ordinary variable dependency in `scope` in dependency order.
 pub(crate) fn infer_name_dependencies_for_scope<'db>(db: &'db dyn Db, scope: ScopeId<'db>) {
     let index = semantic_index(db, scope.python_file(db));
-    for definition in index
-        .use_def_map(scope.file_scope_id(db))
-        .all_name_dependencies_in_order()
-    {
+    for definition in index.all_name_dependencies_in_order(scope.file_scope_id(db)) {
         infer_definition_types_with_prepared_dependencies(db, definition);
     }
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -120,6 +120,38 @@ fn extend_collection_use_constraints<'db>(
 
 /// Infer all types for a [`Definition`] (including sub-expressions).
 /// Use when resolving a place use or public type of a place.
+pub(crate) fn infer_definition_types<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+) -> &'db DefinitionInference<'db> {
+    let file = definition.file(db);
+    let index = semantic_index(db, file);
+    let use_def_map = index.use_def_map(definition.file_scope(db));
+
+    if !use_def_map.name_dependencies(definition).is_empty() {
+        for dependency in use_def_map.name_dependencies_in_order(definition) {
+            infer_definition_types_with_prepared_dependencies(db, dependency);
+        }
+    }
+
+    infer_definition_types_with_prepared_dependencies(db, definition)
+}
+
+/// Infers every ordinary variable dependency in `scope` in dependency order.
+pub(crate) fn infer_name_dependencies_for_scope<'db>(db: &'db dyn Db, scope: ScopeId<'db>) {
+    let index = semantic_index(db, scope.file(db));
+    for definition in index
+        .use_def_map(scope.file_scope_id(db))
+        .all_name_dependencies_in_order()
+    {
+        infer_definition_types_with_prepared_dependencies(db, definition);
+    }
+}
+
+/// Infers one definition whose ordinary variable dependencies have already been inferred in
+/// dependency order.
+///
+/// Scope inference may also use this query because it visits definitions in source order.
 #[salsa::tracked(
     returns(ref),
     cycle_initial=|db, id, definition: Definition<'db>| {
@@ -130,7 +162,7 @@ fn extend_collection_use_constraints<'db>(
     },
     heap_size=ruff_memory_usage::heap_size
 )]
-pub(crate) fn infer_definition_types<'db>(
+pub(super) fn infer_definition_types_with_prepared_dependencies<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> DefinitionInference<'db> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -28,8 +28,8 @@ use super::{
     DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
     FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference, InferenceRegion,
     OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra, infer_deferred_types,
-    infer_definition_types, infer_expression_types, infer_same_file_expression_type,
-    infer_unpack_types,
+    infer_definition_types_with_prepared_dependencies, infer_expression_types,
+    infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -37,8 +37,8 @@ use crate::place::{
     RequiresExplicitReExport, TypeOrigin, builtins_module_scope, builtins_symbol,
     class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
     module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
-    place_from_bindings_with_reachability_cache, place_from_declarations_with_reachability_cache,
-    typing_extensions_symbol,
+    place_from_bindings_with_prepared_dependencies_and_reachability_cache,
+    place_from_declarations_with_reachability_cache, typing_extensions_symbol,
 };
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
@@ -117,8 +117,9 @@ use crate::types::{
     Parameters, SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
     TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
     TypeVarVariance, TypedDictModule, TypedDictType, UnionAccumulator, UnionBuilder, UnionType,
-    any_over_type, binding_type, extract_fixed_length_iterable_element_types,
-    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
+    any_over_type, binding_type_with_prepared_dependencies,
+    extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
+    is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -223,11 +224,12 @@ const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 /// a single AST node and are called as part of this AST visit.
 ///
 /// When the visit encounters a node which creates a [`Definition`], we look up the definition in
-/// the semantic index and call the [`infer_definition_types()`] query on it, which creates another
-/// [`TypeInferenceBuilder`] just for that definition, and we merge the returned inference result
-/// into the one we are currently building for the entire scope. Using the query in this way
-/// ensures that if we first infer types for some scattered definitions in a scope, and later for
-/// the entire scope, we don't re-infer any types, we reuse the cached inference for those
+/// the semantic index and call [`infer_definition_types()`][super::infer_definition_types] on it.
+/// This prepares ordinary variable dependencies and invokes a tracked query that creates another
+/// [`TypeInferenceBuilder`] just for that definition. We merge the returned inference result into
+/// the one we are currently building for the entire scope. Using a tracked query for each
+/// definition ensures that if we first infer types for some scattered definitions in a scope, and
+/// later for the entire scope, we don't re-infer any types; we reuse the cached inference for those
 /// definitions and their sub-expressions.
 ///
 /// Functions with a name like `infer_*_definition` take both a node and a [`Definition`], and are
@@ -239,8 +241,8 @@ const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 /// [`infer_function_definition`](TypeInferenceBuilder::infer_function_definition), which takes
 /// both the node and the [`Definition`] id. The former is called as part of walking the AST, and
 /// it just looks up the [`Definition`] for that function in the semantic index and calls
-/// [`infer_definition_types()`] on it, which will create a new [`TypeInferenceBuilder`] with
-/// [`InferenceRegion::Definition`], and in that builder
+/// [`infer_definition_types()`][super::infer_definition_types] on it, which will create a new
+/// [`TypeInferenceBuilder`] with [`InferenceRegion::Definition`], and in that builder
 /// [`infer_region_definition`](TypeInferenceBuilder::infer_region_definition) will call
 /// [`infer_function_definition`](TypeInferenceBuilder::infer_function_definition) to actually
 /// infer a type for the definition.
@@ -1594,7 +1596,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let use_def = self.index.use_def_map(declaration.file_scope(self.db()));
         let prior_bindings = use_def.bindings_at_definition(declaration);
         // unbound_ty is Never because for this check we don't care about unbound
-        let inferred_ty = place_from_bindings_with_reachability_cache(
+        let inferred_ty = place_from_bindings_with_prepared_dependencies_and_reachability_cache(
             self.db(),
             prior_bindings,
             self.reachability_cache(),
@@ -1896,7 +1898,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn function_type(&self, function: &ast::StmtFunctionDef) -> Option<FunctionType<'db>> {
         let definition = self.index.expect_single_definition(function);
-        infer_definition_types(self.db(), definition).function_type(definition)
+        infer_definition_types_with_prepared_dependencies(self.db(), definition)
+            .function_type(definition)
     }
 
     fn current_function_type(&self) -> Option<FunctionType<'db>> {
@@ -1909,7 +1912,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> impl Iterator<Item = Type<'db>> + 'a {
         let definition = self.index.expect_single_definition(function);
 
-        let definition_types = infer_definition_types(self.db(), definition);
+        let definition_types =
+            infer_definition_types_with_prepared_dependencies(self.db(), definition);
 
         function
             .decorator_list
@@ -2013,7 +2017,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_definition(&mut self, node: impl Into<DefinitionNodeKey> + std::fmt::Debug + Copy) {
         let definition = self.index.expect_single_definition(node);
-        let result = infer_definition_types(self.db(), definition);
+        let result = infer_definition_types_with_prepared_dependencies(self.db(), definition);
         self.extend_definition(definition, result);
     }
 
@@ -2424,7 +2428,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
 
         for reachable_binding in &loop_header.reachable_bindings {
-            let binding_ty = binding_type(db, reachable_binding.definition);
+            let binding_ty =
+                binding_type_with_prepared_dependencies(db, reachable_binding.definition);
             let narrowed_ty = use_def
                 .narrowing_evaluator(reachable_binding.narrowing_constraint)
                 .narrow(db, binding_ty, place);
@@ -2476,7 +2481,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let DefinitionState::Defined(source) = binding.binding else {
                         continue;
                     };
-                    let ty = binding_type(db, source);
+                    let ty = binding_type_with_prepared_dependencies(db, source);
                     union.add_in_place(binding.narrowing_constraint.narrow(
                         db,
                         ty,
@@ -2486,7 +2491,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 continue;
             }
 
-            let Some(ty) = place_from_bindings_with_reachability_cache(
+            let Some(ty) = place_from_bindings_with_prepared_dependencies_and_reachability_cache(
                 db,
                 bindings,
                 self.reachability_cache(),
@@ -4706,7 +4711,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         assignment: Definition<'db>,
         definition: Definition<'db>,
     ) {
-        let value_ty = infer_definition_types(self.db(), assignment).expression_type(value);
+        let value_ty = infer_definition_types_with_prepared_dependencies(self.db(), assignment)
+            .expression_type(value);
         self.add_binding(key.into(), definition)
             .insert(self, value_ty);
     }
@@ -7928,7 +7934,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // See https://peps.python.org/pep-0572/#differences-between-assignment-expressions-and-assignment-statements
         if named.target.is_name_expr() {
             let definition = self.index.expect_single_definition(named);
-            let result = infer_definition_types(self.db(), definition);
+            let result = infer_definition_types_with_prepared_dependencies(self.db(), definition);
             self.extend_definition(definition, result);
             result.binding_type(definition)
         } else {
@@ -8194,7 +8200,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut elements: Vec<(&str, Type<'db>)> = Vec::new();
 
         for bindings in use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.file())) {
-            let place = place_from_bindings_with_reachability_cache(
+            let place = place_from_bindings_with_prepared_dependencies_and_reachability_cache(
                 db,
                 bindings.clone(),
                 self.reachability_cache(),
@@ -9302,7 +9308,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             DefinitionState::Defined(definition)
                                 if !is_discarded_dict_key_assignment(db, definition) =>
                             {
-                                let binding_ty = binding_type(db, definition);
+                                let binding_ty =
+                                    binding_type_with_prepared_dependencies(db, definition);
                                 union = union.add(
                                     binding.narrowing_constraint.narrow(db, binding_ty, place),
                                 );
@@ -9459,7 +9466,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // If we're inferring types of deferred expressions, look them up from end-of-scope.
         if self.is_deferred() {
             let place = if let Some(place_id) = place_table.place_id(expr) {
-                place_from_bindings_with_reachability_cache(
+                place_from_bindings_with_prepared_dependencies_and_reachability_cache(
                     db,
                     use_def.reachable_bindings(place_id),
                     self.reachability_cache(),
@@ -9487,7 +9494,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let ast::ExprRef::Named(named) = expr_ref {
                 let place = if named.target.is_name_expr() {
                     let definition = self.index.expect_single_definition(named);
-                    Place::bound(binding_type(db, definition)).with_definition(definition)
+                    Place::bound(binding_type_with_prepared_dependencies(db, definition))
+                        .with_definition(definition)
                 } else {
                     Place::Undefined
                 };
@@ -9495,7 +9503,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             let use_id = expr_ref.scoped_use_id(db, self.file());
-            let place = place_from_bindings_with_reachability_cache(
+            let place = place_from_bindings_with_prepared_dependencies_and_reachability_cache(
                 db,
                 use_def.bindings_at_use(use_id),
                 self.reachability_cache(),
@@ -9549,11 +9557,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return Place::Undefined.into();
                 }
                 EnclosingSnapshotResult::FoundBindings(bindings) => {
-                    let mut place_and_qualifiers = place_from_bindings_with_reachability_cache(
-                        db,
-                        bindings,
-                        self.reachability_cache(),
-                    );
+                    let mut place_and_qualifiers =
+                        place_from_bindings_with_prepared_dependencies_and_reachability_cache(
+                            db,
+                            bindings,
+                            self.reachability_cache(),
+                        );
                     if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place {
                         place_and_qualifiers.place =
                             Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
@@ -9765,7 +9774,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             }
                         }
                         EnclosingSnapshotResult::FoundBindings(bindings) => {
-                            let place = place_from_bindings_with_reachability_cache(
+                            let place =
+                                place_from_bindings_with_prepared_dependencies_and_reachability_cache(
                                 db,
                                 bindings,
                                 self.reachability_cache(),

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1,3 +1,4 @@
+use crate::types::infer::infer_definition_types_with_prepared_dependencies;
 use crate::{
     Db,
     reachability::ReachabilityConstraintsExtension,
@@ -26,7 +27,7 @@ use crate::{
             function_known_decorators, infer_statement_types, nearest_enclosing_function,
             original_class_type,
         },
-        infer_definition_types, infer_scope_types,
+        infer_scope_types,
         signatures::ReturnCallableTypeVarScope,
         tuple::{TupleSpecBuilder, TupleType},
         typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation,
@@ -1050,7 +1051,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let function_name = &function_node.name;
 
         let mut is_classmethod = is_implicit_classmethod(function_name);
-        let inference = infer_definition_types(db, method_definition);
+        let inference = infer_definition_types_with_prepared_dependencies(db, method_definition);
         for decorator in &function_node.decorator_list {
             let decorator_ty = inference.expression_type(&decorator.expression);
             if let Some(known_class) = decorator_ty

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -4,6 +4,7 @@ use ty_module_resolver::{
     ModuleName, ModuleNameResolutionError, ModuleResolveMode, resolve_module, search_paths,
 };
 
+use crate::types::infer::infer_definition_types_with_prepared_dependencies;
 use crate::{
     Program, TypeQualifiers, add_inferred_python_version_hint_to_diagnostic,
     place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin},
@@ -15,7 +16,6 @@ use crate::{
             hint_if_stdlib_submodule_exists_on_other_versions,
         },
         infer::{TypeInferenceBuilder, builder::DeclaredAndInferredType},
-        infer_definition_types,
     },
 };
 use ty_python_core::definition::Definition;
@@ -235,7 +235,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         for alias in names {
             for definition in self.index.definitions(alias) {
-                let inferred = infer_definition_types(db, *definition);
+                let inferred = infer_definition_types_with_prepared_dependencies(db, *definition);
                 // Check non-star imports for deprecations
                 if definition.kind(db).as_star_import().is_none() {
                     // In the initial cycle, `declaration_types()` is empty, so no deprecation check is performed.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
@@ -1,5 +1,5 @@
 use crate::types::{
-    ClassLiteral, Type, binding_type,
+    ClassLiteral, Type, binding_type_with_prepared_dependencies,
     class::{DynamicClassAnchor, DynamicMetaclassConflict, dynamic_class_bases_argument},
     context::InferContext,
     diagnostic::{
@@ -24,7 +24,7 @@ pub(crate) fn check_dynamic_class_definition<'db>(
         return;
     };
 
-    let ty = binding_type(db, definition);
+    let ty = binding_type_with_prepared_dependencies(db, definition);
 
     // Check if it's a dynamic class with a Definition anchor.
     let Type::ClassLiteral(ClassLiteral::Dynamic(dynamic_class)) = ty else {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/final_variable.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/final_variable.rs
@@ -1,6 +1,6 @@
 use crate::{
     TypeQualifiers,
-    place::{place_from_bindings, place_from_declarations},
+    place::{place_from_bindings_with_prepared_dependencies, place_from_declarations},
     types::{context::InferContext, diagnostic::FINAL_WITHOUT_VALUE},
 };
 use ty_python_core::SemanticIndex;
@@ -46,7 +46,7 @@ pub(crate) fn check_final_without_value<'db>(
 
         // Check if the symbol has any bindings in the current scope.
         let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-        let binding_place = place_from_bindings(db, bindings);
+        let binding_place = place_from_bindings_with_prepared_dependencies(db, bindings);
 
         if !binding_place.place.is_undefined() {
             continue;

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -1,3 +1,4 @@
+use crate::types::infer::infer_definition_types_with_prepared_dependencies;
 use crate::{
     diagnostic::format_enumeration,
     types::{
@@ -9,7 +10,6 @@ use crate::{
         },
         function::{FunctionDecorators, OverloadLiteral},
         generics::GenericContext,
-        infer_definition_types,
         signatures::ReturnCallableTypeVarScope,
         typevar::TypeVarInstance,
         visitor::find_over_type,
@@ -31,7 +31,8 @@ pub(crate) fn check_function_definition<'db>(
 ) {
     let db = context.db();
 
-    let Some(function_type) = infer_definition_types(db, definition).function_type(definition)
+    let Some(function_type) =
+        infer_definition_types_with_prepared_dependencies(db, definition).function_type(definition)
     else {
         return;
     };

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     Db,
-    place::{DefinedPlace, Definedness, Place, place_from_bindings},
+    place::{DefinedPlace, Definedness, Place, place_from_bindings_with_prepared_dependencies},
     types::{
         CallableType, KnownClass, Type,
         context::InferContext,
@@ -65,7 +65,7 @@ pub(crate) fn check_overloaded_function<'db>(
         ty: Type::FunctionLiteral(function),
         definedness: Definedness::AlwaysDefined,
         ..
-    }) = place_from_bindings(
+    }) = place_from_bindings_with_prepared_dependencies(
         db,
         use_def.end_of_scope_symbol_bindings(place.as_symbol().unwrap()),
     )

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -8,14 +8,19 @@ use ruff_python_ast::{self as ast, PythonVersion, name::Name};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashSet;
 
+use crate::types::infer::infer_definition_types_with_prepared_dependencies;
 use crate::{
     Db, Program, TypeQualifiers,
     diagnostic::format_enumeration,
-    place::{DefinedPlace, Place, TypeOrigin, place_from_bindings, place_from_declarations},
+    place::{
+        DefinedPlace, Place, TypeOrigin, place_from_bindings_with_prepared_dependencies,
+        place_from_declarations,
+    },
     types::{
         CallArguments, ClassBase, ClassLiteral, ClassType, DataclassFlags, KnownClass,
         KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters, Signature,
-        SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypedDictModule, binding_type,
+        SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypedDictModule,
+        binding_type_with_prepared_dependencies,
         call::Argument,
         class::{
             AbstractMethod, CodeGeneratorKind, Field, FieldKind, MetaclassErrorKind,
@@ -45,7 +50,6 @@ use crate::{
         function::KnownFunction,
         generics::enclosing_generic_contexts,
         infer::builder::post_inference::typed_dict::validate_typed_dict_class,
-        infer_definition_types,
         mro::StaticMroErrorKind,
         overrides,
         special_form::TypeQualifier,
@@ -1223,7 +1227,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
                     continue;
                 }
 
-                let assigned_ty = binding_type(db, definition);
+                let assigned_ty = binding_type_with_prepared_dependencies(db, definition);
                 if !assigned_ty.is_assignable_to(db, metaclass_member_ty) {
                     reported_incompatible_binding = true;
                     report_invalid_attribute_assignment(
@@ -1342,7 +1346,8 @@ fn check_final_class_abstract_methods<'db>(
         "Final class `{class_name}` has unimplemented abstract methods",
     ));
 
-    let definition_types = infer_definition_types(db, class.definition(db));
+    let definition_types =
+        infer_definition_types_with_prepared_dependencies(db, class.definition(db));
 
     if let Some(class_node) = class.body_scope(db).node(db).as_class()
         && let Some(decorator) = class_node
@@ -1406,7 +1411,9 @@ fn check_final_class_abstract_methods<'db>(
 
     let defining_class_name = defining_class.name(db);
 
-    if let Type::FunctionLiteral(function) = binding_type(db, *definition) {
+    if let Type::FunctionLiteral(function) =
+        binding_type_with_prepared_dependencies(db, *definition)
+    {
         let policy = if kind.is_explicit() {
             AbstractMethodAnnotationPolicy::ExcludeVerboseBody
         } else {
@@ -1443,9 +1450,10 @@ fn check_final_class_abstract_methods<'db>(
         // and the return type is assignable to `None`, they may not have intended
         // for it to be implicitly abstract; add a clarificatory note:
         if kind.is_implicit_due_to_stub_body() && db.should_check_file(definition.file(db)) {
-            let function_type_as_callable = infer_definition_types(db, *definition)
-                .binding_type(*definition)
-                .try_upcast_to_callable(db);
+            let function_type_as_callable =
+                infer_definition_types_with_prepared_dependencies(db, *definition)
+                    .binding_type(*definition)
+                    .try_upcast_to_callable(db);
 
             if let Some(callables) = function_type_as_callable
                 && Type::function_like_callable(
@@ -1500,7 +1508,7 @@ fn check_class_final_without_value<'db>(
 
         // Check if the symbol has any bindings at class level.
         let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-        let binding_place = place_from_bindings(db, bindings);
+        let binding_place = place_from_bindings_with_prepared_dependencies(db, bindings);
 
         if !binding_place.place.is_undefined() {
             continue;

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -496,29 +496,6 @@ fn large_branching_name_dependency_graph_does_not_overflow_stack() -> anyhow::Re
 }
 
 #[test]
-fn large_function_default_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()> {
-    run_name_dependency_stack_test("function-default-name-dependency-stack-test", |db| {
-        let mut module = String::from(
-            "def seed() -> int:\n    return 0\n\ndef add(left: int, right: int) -> int:\n    return left + right\n\nn0 = seed()\n",
-        );
-        for index in 1..=LONG_NAME_CHAIN {
-            writeln!(module, "n{index} = add(n{}, n0)", index - 1)?;
-        }
-        writeln!(
-            module,
-            "\ndef target(value: int = n{LONG_NAME_CHAIN}) -> int:\n    return value"
-        )?;
-        db.write_file("/src/lazy_boundary.py", module)?;
-        db.write_file(
-            "/src/lazy_boundary_main.py",
-            "from typing_extensions import reveal_type\nfrom lazy_boundary import target\n\nreveal_type(target())\n",
-        )?;
-        assert_revealed_type(db, "/src/lazy_boundary_main.py", "int");
-        Ok(())
-    })
-}
-
-#[test]
 fn large_name_dependency_chain_is_incrementally_invalidated() -> anyhow::Result<()> {
     run_name_dependency_stack_test("incremental-name-dependency-stack-test", |db| {
         let mut module = String::from("def seed() -> int:\n    return 0\n\nn0 = seed()\n");
@@ -541,46 +518,6 @@ fn large_name_dependency_chain_is_incrementally_invalidated() -> anyhow::Result<
         );
         db.write_file("/src/incremental.py", module)?;
         assert_revealed_type(db, "/src/incremental_main.py", "str");
-        Ok(())
-    })
-}
-
-#[test]
-fn large_annotation_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()> {
-    run_name_dependency_stack_test("annotation-name-dependency-stack-test", |db| {
-        let mut module = String::from("T0 = int\n");
-        for index in 1..=LONG_NAME_CHAIN {
-            writeln!(module, "T{index} = T{}", index - 1)?;
-        }
-        writeln!(module, "\nx: T{LONG_NAME_CHAIN}")?;
-        db.write_file("/src/annotation_boundary.py", module)?;
-        db.write_file(
-            "/src/annotation_boundary_main.py",
-            "from typing_extensions import reveal_type\nfrom annotation_boundary import x\n\nreveal_type(x)\n",
-        )?;
-        assert_revealed_type(db, "/src/annotation_boundary_main.py", "int");
-        Ok(())
-    })
-}
-
-#[test]
-fn large_type_parameter_bound_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()>
-{
-    run_name_dependency_stack_test("type-parameter-name-dependency-stack-test", |db| {
-        let mut module = String::from("T0 = int\n");
-        for index in 1..=LONG_NAME_CHAIN {
-            writeln!(module, "T{index} = T{}", index - 1)?;
-        }
-        writeln!(
-            module,
-            "\ndef target[T: T{LONG_NAME_CHAIN}]() -> int:\n    return 1"
-        )?;
-        db.write_file("/src/type_parameter_boundary.py", module)?;
-        db.write_file(
-            "/src/type_parameter_boundary_main.py",
-            "from typing_extensions import reveal_type\nfrom type_parameter_boundary import target\n\nreveal_type(target())\n",
-        )?;
-        assert_revealed_type(db, "/src/type_parameter_boundary_main.py", "int");
         Ok(())
     })
 }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+
 use super::builder::TypeInferenceBuilder;
 use crate::db::tests::{TestDb, setup_db};
 use crate::place::symbol;
@@ -403,6 +405,185 @@ fn unbound_symbol_no_reachability_constraint_check() {
 const MANY_WIDGETS: usize = 400;
 const MANY_NON_TERMINAL_CALLS: usize = 1_100;
 const FEW_NON_TERMINAL_CALLS: usize = 80;
+const LONG_NAME_CHAIN: usize = 4_000;
+const LARGE_BRANCHING_NAME_GRAPH: usize = 1_000;
+
+fn run_name_dependency_stack_test(
+    thread_name: &str,
+    test: impl FnOnce(&mut TestDb) -> anyhow::Result<()> + Send + 'static,
+) -> anyhow::Result<()> {
+    let handle = std::thread::Builder::new()
+        .name(thread_name.into())
+        // Match the stack size used by ty's production worker threads.
+        .stack_size(ruff_db::STACK_SIZE)
+        .spawn(move || {
+            let mut db = setup_db();
+            test(&mut db)
+        })?;
+
+    handle.join().expect("regression test thread panicked")
+}
+
+#[test]
+fn large_augmented_assignment_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()>
+{
+    run_name_dependency_stack_test("augmented-assignment-name-dependency-stack-test", |db| {
+        let mut module =
+            String::from("from typing_extensions import reveal_type\n\nclass C:\n    n = 0\n");
+        for _ in 0..LONG_NAME_CHAIN {
+            module.push_str("    n += 1\n");
+        }
+        module.push_str("reveal_type(C.n)\n");
+
+        let path = "/src/augmented.py";
+        db.write_file(path, module)?;
+        assert_revealed_type(db, path, "int");
+        Ok(())
+    })
+}
+
+#[test]
+fn large_binary_expression_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()> {
+    run_name_dependency_stack_test("binary-expression-name-dependency-stack-test", |db| {
+        let mut module =
+            String::from("from typing_extensions import reveal_type\n\nclass C:\n    n = 0\n");
+        for _ in 0..LONG_NAME_CHAIN {
+            module.push_str("    n = n + 1\n");
+        }
+        module.push_str("reveal_type(C.n)\n");
+
+        let path = "/src/binary.py";
+        db.write_file(path, module)?;
+        assert_revealed_type(db, path, "int");
+        Ok(())
+    })
+}
+
+#[test]
+fn large_call_expression_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()> {
+    run_name_dependency_stack_test("call-expression-name-dependency-stack-test", |db| {
+        let mut module = String::from(
+            "from typing_extensions import reveal_type\n\ndef increment(value: int) -> int:\n    return value + 1\n\nclass C:\n    n = 0\n",
+        );
+        for _ in 0..LONG_NAME_CHAIN {
+            module.push_str("    n = increment(n)\n");
+        }
+        module.push_str("reveal_type(C.n)\n");
+
+        let path = "/src/call.py";
+        db.write_file(path, module)?;
+        assert_revealed_type(db, path, "int");
+        Ok(())
+    })
+}
+
+#[test]
+fn large_branching_name_dependency_graph_does_not_overflow_stack() -> anyhow::Result<()> {
+    run_name_dependency_stack_test("branching-name-dependency-stack-test", |db| {
+        let mut module = String::from(
+            "from typing_extensions import reveal_type\n\ndef seed() -> int:\n    return 0\n\ndef add(left: int, right: int) -> int:\n    return left + right\n\nclass C:\n    n0 = seed()\n    n1 = add(n0, n0)\n",
+        );
+        for index in 2..=LARGE_BRANCHING_NAME_GRAPH {
+            writeln!(module, "    n{index} = add(n{}, n{})", index - 1, index - 2)?;
+        }
+        writeln!(module, "reveal_type(C.n{LARGE_BRANCHING_NAME_GRAPH})")?;
+
+        let path = "/src/branching.py";
+        db.write_file(path, module)?;
+        assert_revealed_type(db, path, "int");
+        Ok(())
+    })
+}
+
+#[test]
+fn large_function_default_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()> {
+    run_name_dependency_stack_test("function-default-name-dependency-stack-test", |db| {
+        let mut module = String::from(
+            "def seed() -> int:\n    return 0\n\ndef add(left: int, right: int) -> int:\n    return left + right\n\nn0 = seed()\n",
+        );
+        for index in 1..=LONG_NAME_CHAIN {
+            writeln!(module, "n{index} = add(n{}, n0)", index - 1)?;
+        }
+        writeln!(
+            module,
+            "\ndef target(value: int = n{LONG_NAME_CHAIN}) -> int:\n    return value"
+        )?;
+        db.write_file("/src/lazy_boundary.py", module)?;
+        db.write_file(
+            "/src/lazy_boundary_main.py",
+            "from typing_extensions import reveal_type\nfrom lazy_boundary import target\n\nreveal_type(target())\n",
+        )?;
+        assert_revealed_type(db, "/src/lazy_boundary_main.py", "int");
+        Ok(())
+    })
+}
+
+#[test]
+fn large_name_dependency_chain_is_incrementally_invalidated() -> anyhow::Result<()> {
+    run_name_dependency_stack_test("incremental-name-dependency-stack-test", |db| {
+        let mut module = String::from("def seed() -> int:\n    return 0\n\nn0 = seed()\n");
+        for index in 1..=LONG_NAME_CHAIN {
+            writeln!(module, "n{index} = n{}", index - 1)?;
+        }
+        db.write_file("/src/incremental.py", module.clone())?;
+        db.write_file(
+            "/src/incremental_main.py",
+            format!(
+                "from typing_extensions import reveal_type\nfrom incremental import n{LONG_NAME_CHAIN}\n\nreveal_type(n{LONG_NAME_CHAIN})\n"
+            ),
+        )?;
+        assert_revealed_type(db, "/src/incremental_main.py", "int");
+
+        let module = module.replacen(
+            "def seed() -> int:\n    return 0",
+            "def seed() -> str:\n    return ''",
+            1,
+        );
+        db.write_file("/src/incremental.py", module)?;
+        assert_revealed_type(db, "/src/incremental_main.py", "str");
+        Ok(())
+    })
+}
+
+#[test]
+fn large_annotation_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()> {
+    run_name_dependency_stack_test("annotation-name-dependency-stack-test", |db| {
+        let mut module = String::from("T0 = int\n");
+        for index in 1..=LONG_NAME_CHAIN {
+            writeln!(module, "T{index} = T{}", index - 1)?;
+        }
+        writeln!(module, "\nx: T{LONG_NAME_CHAIN}")?;
+        db.write_file("/src/annotation_boundary.py", module)?;
+        db.write_file(
+            "/src/annotation_boundary_main.py",
+            "from typing_extensions import reveal_type\nfrom annotation_boundary import x\n\nreveal_type(x)\n",
+        )?;
+        assert_revealed_type(db, "/src/annotation_boundary_main.py", "int");
+        Ok(())
+    })
+}
+
+#[test]
+fn large_type_parameter_bound_name_dependency_chain_does_not_overflow_stack() -> anyhow::Result<()>
+{
+    run_name_dependency_stack_test("type-parameter-name-dependency-stack-test", |db| {
+        let mut module = String::from("T0 = int\n");
+        for index in 1..=LONG_NAME_CHAIN {
+            writeln!(module, "T{index} = T{}", index - 1)?;
+        }
+        writeln!(
+            module,
+            "\ndef target[T: T{LONG_NAME_CHAIN}]() -> int:\n    return 1"
+        )?;
+        db.write_file("/src/type_parameter_boundary.py", module)?;
+        db.write_file(
+            "/src/type_parameter_boundary_main.py",
+            "from typing_extensions import reveal_type\nfrom type_parameter_boundary import target\n\nreveal_type(target())\n",
+        )?;
+        assert_revealed_type(db, "/src/type_parameter_boundary_main.py", "int");
+        Ok(())
+    })
+}
 
 #[test]
 fn implicit_attribute_after_many_non_terminal_calls() -> anyhow::Result<()> {

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -13,12 +13,13 @@ use rustc_hash::FxHashSet;
 use crate::{
     Db, NameKind,
     place::{
-        DefinedPlace, Place, PlaceWithDefinition, imported_symbol, place_from_bindings,
-        place_from_declarations,
+        DefinedPlace, Place, PlaceWithDefinition, imported_symbol,
+        place_from_bindings_with_prepared_dependencies, place_from_declarations,
     },
     types::{
         ClassBase, ClassLiteral, KnownClass, KnownInstanceType, StaticClassLiteral,
         SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
+        infer_name_dependencies_for_scope,
     },
 };
 use ty_python_core::{
@@ -32,6 +33,7 @@ pub(crate) fn all_end_of_scope_members<'db>(
     db: &'db dyn Db,
     scope_id: ScopeId<'db>,
 ) -> impl Iterator<Item = MemberWithDefinition<'db>> + 'db {
+    infer_name_dependencies_for_scope(db, scope_id);
     let use_def_map = use_def_map(db, scope_id);
     let table = place_table(db, scope_id);
 
@@ -59,7 +61,7 @@ pub(crate) fn all_end_of_scope_members<'db>(
                 let PlaceWithDefinition {
                     place,
                     first_definition,
-                } = place_from_bindings(db, bindings);
+                } = place_from_bindings_with_prepared_dependencies(db, bindings);
 
                 let first_reachable_definition = first_definition?;
                 let ty = place.ignore_possibly_undefined()?;
@@ -83,6 +85,7 @@ pub(crate) fn all_reachable_members<'db>(
     db: &'db dyn Db,
     scope_id: ScopeId<'db>,
 ) -> impl Iterator<Item = MemberWithDefinition<'db>> + 'db {
+    infer_name_dependencies_for_scope(db, scope_id);
     let use_def_map = use_def_map(db, scope_id);
     let table = place_table(db, scope_id);
 
@@ -110,7 +113,8 @@ pub(crate) fn all_reachable_members<'db>(
                         })
                     });
 
-            let place_with_definition = place_from_bindings(db, bindings);
+            let place_with_definition =
+                place_from_bindings_with_prepared_dependencies(db, bindings);
             let binding =
                 place_with_definition
                     .first_definition


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#96

In this PR, instead of taking a solution to the astral-sh/ty#96 problem (stack overflow for large chain of inter-dependent definitions) such as adjusting the stack size or moving to a heap, we use `SemanticIndexBuilder` to analyze such dependencies in advance and reverse the dependencies linearly.

For example, suppose we have a set of definitions `x1 = 0; x2 = x1; ...; xn = x{n-1}` in a module `foo`, and `xn` is imported via `from foo import xn`. `infer_definition_types(Definition(xn))` calls `infer_definition_types(Definition(x{n-1}))` to infer the type of `xn`, which in turn calls `infer_definition_types(Definition(x{n-2}))`, and so on, causing the call stack to grow.

To address this, we analyze these dependencies in advance before calling the type inference query, and reorder the calls to `infer_definition_types` starting from the root of the dependencies. Conceptually:

```rust
for dependency in use_def.name_dependencies_in_order(definition) {
    infer_definition_types(dependency);
}
```

In this case, `infer_definition_types(Definition(x1))` is called first, followed by `infer_definition_types(x2)`, ..., and finally `infer_definition_types(Definition(xn))`.

Since `infer_definition_types(x{n-1})`, which is required for the computation of `infer_definition_types(xn)`, has already completed and is cached, performance does not degrade.

## Test Plan

regression test added