### PR TITLE
[ty] Move Unknown into ty_extensions._internal

### DIFF
--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -898,7 +898,7 @@ mod tests {
         LL | a: "MyClass |" = 1
            |    ^^^^^^^^^^^ Clicking here
         info: Found 1 type definition
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | -------
@@ -948,7 +948,7 @@ mod tests {
         LL | a: "MyClass | No" = 1
            |               ^^ Clicking here
         info: Found 1 type definition
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | -------
@@ -970,7 +970,7 @@ mod tests {
         LL | ab: "ab"
            |      ^^ Clicking here
         info: Found 1 type definition
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | -------
@@ -992,7 +992,7 @@ mod tests {
         LL | x: "foobar"
            |     ^^^^^^ Clicking here
         info: Found 1 type definition
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | -------
@@ -1142,7 +1142,7 @@ mod tests {
         LL | x: """'list["MyClass" | "str"]' | None"""
            |             ^^^^^^^^^ Clicking here
         info: Found 1 type definition
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | -------
@@ -1902,7 +1902,7 @@ def function():
         LL | x = submod
            |     ^^^^^^ Clicking here
         info: Found 1 type definition
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | -------

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -1975,7 +1975,7 @@ Source with applied edits:
 
         ---------------------------------------------
         info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | ^^^^^^^
@@ -2000,7 +2000,7 @@ Source with applied edits:
         info[inlay-hint-edit]: Inlay hint edits
         --> main.py:1:1
           |
-        1 + from ty_extensions import Unknown
+        1 + from ty_extensions._internal import Unknown
         2 |
         3 | class A:
         4 |     def __init__(self, y):
@@ -2541,7 +2541,7 @@ Source with applied edits:
            |          ^^^^
 
         info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | ^^^^^^^
@@ -2731,7 +2731,7 @@ Source with applied edits:
         info[inlay-hint-edit]: Inlay hint edits
         --> main.py:1:1
            |
-        1  + from ty_extensions import Unknown
+        1  + from ty_extensions._internal import Unknown
         2  + from string.templatelib import Template
         3  |
            - a = [1, 2]
@@ -5067,7 +5067,7 @@ Source with applied edits:
         bar([a=]1, [b=]2)
         ---------------------------------------------
         info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | ^^^^^^^
@@ -5078,7 +5078,7 @@ Source with applied edits:
            |              ^^^^^^^
 
         info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | ^^^^^^^
@@ -6103,7 +6103,7 @@ Source with applied edits:
            |                                                      ^^^
 
         info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/ty_extensions/__init__.pyi:LL:1
+          --> stdlib/ty_extensions/_internal.pyi:LL:1
            |
         LL | Unknown: _SpecialForm
            | ^^^^^^^

--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -406,7 +406,7 @@ result to `Sized` or `object`; ideally the element type would remain `Unknown`, 
 return type would still be used where possible.
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _(xs: Unknown):
     # TODO: should be `list[Unknown]`
@@ -481,7 +481,7 @@ error[call-non-callable]: `NotImplemented` is not callable
 ## `map` with generic callbacks
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 import re
 
 def _(s: Unknown | str):

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1573,7 +1573,7 @@ Or, it can be a type that is assignable to `str`.
 
 ```py
 from typing import Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _(kwargs1: dict[Any, int], kwargs2: dict[Unknown, int]) -> None:
     f(**kwargs1)
@@ -1616,7 +1616,7 @@ def _(kwargs: dict[str, int]) -> None:
 ### `Unknown` type
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def f(**kwargs: int) -> None: ...
 def _(kwargs: Unknown):
@@ -1760,7 +1760,7 @@ variadic expansion should not greedily consume optional positional parameters th
 as explicit keyword arguments.
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def f(a: int = 0, b: int = 0, c: int = 0, fmt: str | None = None) -> None: ...
 def _(args: "Unknown | tuple[int, int, int]"):

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -1483,8 +1483,7 @@ def _(int_str: tuple[int, str], int_any: tuple[int, Any], any_any: tuple[Any, An
 
 ```pyi
 from typing_extensions import Iterable, overload, LiteralString, Protocol
-from ty_extensions import Unknown
-from ty_extensions._internal import is_assignable_to
+from ty_extensions._internal import Unknown, is_assignable_to
 
 class Foo:
     @overload

--- a/crates/ty_python_semantic/resources/mdtest/call/subclass_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/subclass_of.md
@@ -32,7 +32,7 @@ def _(subclass_of_c: type[C]):
 
 ```py
 from typing import Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _(subclass_of_any: type[Any], subclass_of_unknown: type[Unknown]):
     reveal_type(subclass_of_any())  # revealed: Any

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -518,7 +518,7 @@ them:
 
 ```py
 from typing import Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def f(a: type[Any], b: type[Unknown]):
     reveal_type(a.__mro__)  # revealed: tuple[type, ...] & Any

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -132,7 +132,7 @@ Once `value is None` has succeeded, the value can only be the `None` singleton e
 original type is `Unknown`.
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def f(value: Unknown) -> None:
     if value is None:

--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
@@ -8,7 +8,7 @@
 
 ```py
 from typing_extensions import assert_never, Never, Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _(never: Never):
     assert_never(never)  # fine
@@ -20,7 +20,7 @@ If it is not, a `type-assertion-failure` diagnostic is emitted.
 
 ```py
 from typing_extensions import assert_never, Never, Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _():
     assert_never(0)  # snapshot: type-assertion-failure

--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
@@ -163,7 +163,7 @@ def _(f: F):
 from typing import Any
 from typing_extensions import Literal, assert_type
 
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 # Any and Unknown are considered equivalent
 def _(a: Unknown, b: Any):
@@ -188,7 +188,7 @@ Tuple types with the same elements are the same.
 ```py
 from typing_extensions import Any, assert_type
 
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _(a: tuple[int, str, bytes]):
     assert_type(a, tuple[int, str, bytes])  # fine

--- a/crates/ty_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/cast.md
@@ -63,7 +63,7 @@ the gradual guarantee and leads to cascading errors when an object is inferred a
 `Unknown` due to a missing import or similar.
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def f(x: Any, y: Unknown, z: Any | str | int):
     a = cast(dict[str, Any], x)

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
@@ -22,8 +22,8 @@ Types that "produce" data on demand are covariant in their typevar. If you expec
 get from the sequence is a valid `int`.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to, is_equivalent_to, is_subtype_of
 from typing import Any, Generic, TypeVar
 
 class A: ...
@@ -104,8 +104,8 @@ Types that "consume" data are contravariant in their typevar. If you expect a co
 that you pass into the consumer is a valid `int`.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to, is_equivalent_to, is_subtype_of
 from typing import Any, Generic, TypeVar
 
 class A: ...
@@ -217,8 +217,8 @@ In the end, if you expect a mutable list, you must always be given a list of exa
 since we can't know in advance which of the allowed methods you'll want to use.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to, is_equivalent_to, is_subtype_of
 from typing import Any, Generic, TypeVar
 
 class A: ...

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -29,8 +29,8 @@ Types that "produce" data on demand are covariant in their typevar. If you expec
 get from the sequence is a valid `int`.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to, is_equivalent_to, is_subtype_of
 from typing import Any, Never
 
 class A: ...
@@ -108,8 +108,8 @@ Types that "consume" data are contravariant in their typevar. If you expect a co
 that you pass into the consumer is a valid `int`.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to, is_equivalent_to, is_subtype_of
 from typing import Any, Never
 
 class A: ...
@@ -216,8 +216,8 @@ In the end, if you expect a mutable list, you must always be given a list of exa
 since we can't know in advance which of the allowed methods you'll want to use.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to, is_equivalent_to, is_subtype_of
 from typing import Any, Never
 
 class A: ...
@@ -292,8 +292,8 @@ If inference for a PEP 695 type parameter would otherwise conclude bivariance be
 parameter is unused, we fall back to covariance instead.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to, is_equivalent_to, is_subtype_of
 from typing import Any, Never
 
 class A: ...

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -34,7 +34,7 @@ We also support unions in type aliases:
 
 ```py
 from typing_extensions import Any, Never, Literal, LiteralString, Tuple, Annotated, Optional, Union, Callable, TypeVar
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 T = TypeVar("T")
 

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -727,7 +727,8 @@ simplified, due to the fact that a `LiteralString` inhabitant is known to have `
 exactly `str` (and not a subclass of `str`):
 
 ```py
-from ty_extensions import AlwaysTruthy, AlwaysFalsy, Unknown
+from ty_extensions import AlwaysTruthy, AlwaysFalsy
+from ty_extensions._internal import Unknown
 from typing_extensions import LiteralString
 
 def f(
@@ -826,7 +827,8 @@ This slightly strange-looking test is a regression test for a mistake that was n
 <https://github.com/astral-sh/ruff/pull/15475#discussion_r1915041987>.
 
 ```py
-from ty_extensions import AlwaysFalsy, Unknown
+from ty_extensions import AlwaysFalsy
+from ty_extensions._internal import Unknown
 from typing_extensions import Literal
 
 def _(x: str & Unknown & AlwaysFalsy & Literal[""]):
@@ -842,7 +844,7 @@ is still an unknown set of runtime values, so `~Any` is equivalent to `Any`. We 
 simplify `~Any` to `Any` in intersections. The same applies to `Unknown`.
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 from typing_extensions import Any, Never
 
 class P: ...
@@ -872,7 +874,7 @@ The intersection of an unknown set of runtime values with (another) unknown set 
 still an unknown set of runtime values:
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 from typing_extensions import Any
 
 class P: ...
@@ -907,7 +909,7 @@ of another unknown set of values is not necessarily empty, so we keep the positi
 
 ```py
 from typing import Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def any(
     i1: Any & ~Any,
@@ -930,7 +932,7 @@ Gradually-equivalent types can be simplified out of intersections:
 
 ```py
 from typing import Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def mixed(
     i1: Any & Unknown,
@@ -1349,7 +1351,7 @@ For any gradual type `G`, `Invariant[G] & Invariant[Any] = Invariant[G]`.
 
 ```py
 from typing import Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 class P: ...
 class Q: ...

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1486,8 +1486,8 @@ A class literal can be iterated over if it has `Any` or `Unknown` in its MRO, si
 ```py
 from unresolved_module import SomethingUnknown  # error: [unresolved-import]
 from typing import Any, Iterable
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import TypeOf, is_assignable_to, reveal_mro
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, TypeOf, is_assignable_to, reveal_mro
 
 class Foo(SomethingUnknown): ...
 

--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -227,8 +227,8 @@ guarantee:
 
 ```py
 from typing import Any
-from ty_extensions import Unknown, Intersection
-from ty_extensions._internal import reveal_mro
+from ty_extensions import Intersection
+from ty_extensions._internal import Unknown, reveal_mro
 
 def f(x: type[Any], y: Intersection[Unknown, type[Any]]):
     class Foo(x): ...

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -7,7 +7,7 @@ We support type narrowing for attributes and subscripts.
 ### Basic
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 class C:
     x: int | None = None

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1754,7 +1754,7 @@ import sys
 from enum import Enum, IntEnum
 from typing import Any, Literal, TypeAlias, TypeVar
 
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 from typing_extensions import assert_never, assert_type
 
 T = TypeVar("T", bound=object)

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -365,7 +365,7 @@ a fixed-length tuple, we can determine exactly which elements appear in that lis
 
 ```py
 from typing import Any, Literal, TypeVar
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 BoundTupleT = TypeVar("BoundTupleT", bound=tuple[int] | tuple[str])
 
@@ -1444,7 +1444,7 @@ declared by the pattern class.
 
 ```py
 from typing import Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 class GradualPatternBox:
     value: int
@@ -1613,7 +1613,7 @@ keep the same uncertainty as the subject.
 
 ```py
 from typing import Any
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def test_match_gradual_mapping_captures(any_value: Any, unknown_value: Unknown) -> None:
     match any_value:
@@ -1736,7 +1736,7 @@ also keeps the uncertainty of an `Any` or `Unknown` subject.
 ```py
 from typing import Any, Generic, Literal, TypeVar, final
 from typing_extensions import TypedDict
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 TagT = TypeVar("TagT")
 PayloadT = TypeVar("PayloadT")
@@ -1948,7 +1948,8 @@ exercise three separate checks: an optional field, an unknown key, and a non-str
 
 ```py
 from typing import Any, Literal, Protocol, TypeVar, TypedDict
-from ty_extensions import Intersection, Unknown
+from ty_extensions import Intersection
+from ty_extensions._internal import Unknown
 
 class RequiredPayload(TypedDict):
     tag: Literal["int"]
@@ -3116,7 +3117,7 @@ python-version = "3.11"
 ```py
 from enum import Enum, IntEnum, StrEnum, auto
 from typing import Literal, assert_never
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 class Color(StrEnum):
     RED = "r"

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5685,7 +5685,7 @@ python-version = "3.12"
 ```py
 from typing import Protocol, cast
 
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 class UnknownMethod[T](Protocol):
     def method(self) -> Unknown: ...
@@ -5700,7 +5700,7 @@ checked.
 ```py
 from typing import Protocol, cast
 
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 class IntProperty[T](Protocol):
     @property
@@ -5723,7 +5723,7 @@ has been replaced by `int`, so the cast is redundant.
 ```py
 from typing import Protocol, TypeVar, cast
 
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 T = TypeVar("T", bound=Unknown)
 
@@ -5776,7 +5776,7 @@ example, descriptor overload resolution exposes `Unknown` only through the neste
 ```py
 from typing import Protocol, cast, overload
 
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 class Descriptor:
     @overload

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -91,8 +91,8 @@ The `Unknown` type is a special type that we use to represent actually unknown t
 annotation), as opposed to `Any` which represents an explicitly unknown type.
 
 ```py
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_assignable_to, reveal_mro
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to, reveal_mro
 
 static_assert(is_assignable_to(Unknown, int))
 static_assert(is_assignable_to(int, Unknown))
@@ -111,7 +111,7 @@ class C(Unknown): ...
 # revealed: (<class 'C'>, Unknown, <class 'object'>)
 reveal_mro(C)
 
-# error: "Special form `ty_extensions.Unknown` expected no type parameter"
+# error: "Special form `ty_extensions._internal.Unknown` expected no type parameter"
 u: Unknown[str]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -506,8 +506,8 @@ An unspecialized tuple is equivalent to `tuple[Any, ...]` and `tuple[Unknown, ..
 
 ```py
 from typing_extensions import Any, assert_type
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 
 static_assert(is_equivalent_to(tuple[Any, ...], tuple[Unknown, ...]))
 

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -97,7 +97,8 @@ reveal_type(union_bound(Multiply))  # revealed: Multiply
 ## Union
 
 ```py
-from ty_extensions import Intersection, Unknown
+from ty_extensions import Intersection
+from ty_extensions._internal import Unknown
 
 def _[T: int](x: type | type[T]):
     reveal_type(x())  # revealed: Any

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -45,8 +45,8 @@ static_assert(not is_assignable_to(Child1, Child2))
 The dynamic type is assignable to or from any type.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to
 from typing import Any, Literal
 
 static_assert(is_assignable_to(Unknown, Literal[1]))
@@ -208,8 +208,8 @@ Both `TypeOf[str]` and `type[str]` are subtypes of `type` and `type[object]`, wh
 is known to be no larger than the set of possible objects represented by `type`.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import TypeOf, is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, TypeOf, is_assignable_to
 from typing import Any
 
 static_assert(is_assignable_to(type, type))
@@ -687,8 +687,8 @@ static_assert(not is_assignable_to(tuple[int, *tuple[int, ...], int], tuple[int,
 ## Union types
 
 ```py
-from ty_extensions import AlwaysTruthy, AlwaysFalsy, static_assert, Unknown
-from ty_extensions._internal import is_assignable_to
+from ty_extensions import AlwaysTruthy, AlwaysFalsy, static_assert
+from ty_extensions._internal import Unknown, is_assignable_to
 from typing_extensions import Literal, Any, LiteralString
 
 static_assert(is_assignable_to(int, int | str))
@@ -813,8 +813,8 @@ The root cause was that we failed to properly materialize a `Callable[..., Unkno
 `Unknown` return type originated from a missing annotation.
 
 ```pyi
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import RegularCallableTypeOf, is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, RegularCallableTypeOf, is_assignable_to
 from typing import Callable
 
 # `Callable[..., Unknown]` has explicit Unknown return type
@@ -906,8 +906,8 @@ See also: our property tests in `property_tests.rs`.
 `object` is Python's top type; the set of all possible objects at runtime:
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to
 from typing import Literal, Any
 
 static_assert(is_assignable_to(str, object))
@@ -927,8 +927,8 @@ static_assert(is_assignable_to(type[Any], object))
 any type is assignable to them:
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to
 from typing import Literal, Any
 
 static_assert(is_assignable_to(str, Any))
@@ -958,8 +958,8 @@ static_assert(is_assignable_to(type[Any], Unknown))
 assignable to any arbitrary type.
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to
 from typing_extensions import Never, Any, Literal
 
 static_assert(is_assignable_to(Never, str))
@@ -979,8 +979,8 @@ static_assert(is_assignable_to(Never, type[Any]))
 including `Never`.
 
 ```pyi
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to
 from typing_extensions import Never, Any
 
 static_assert(is_assignable_to(Any, Never))
@@ -1001,8 +1001,8 @@ are covered in the [subtyping tests](./is_subtype_of.md#callable).
 ### Return type
 
 ```py
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import RegularCallableTypeOf, is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, RegularCallableTypeOf, is_assignable_to
 from typing import Any, Callable
 
 static_assert(is_assignable_to(Callable[[], Any], Callable[[], int]))
@@ -1158,7 +1158,7 @@ python-version = "3.12"
 
 ```py
 from typing import Any, Callable
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 class C:
     def concrete[T](self: T) -> type[int]:
@@ -1602,8 +1602,8 @@ static_assert(not is_assignable_to(TypeOf[GenericFinalClass[str]], type[GenericF
 `TypeGuard[...]` and `TypeIs[...]` are always assignable to `bool`.
 
 ```py
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to
 from typing_extensions import Any, TypeGuard, TypeIs
 
 static_assert(is_assignable_to(TypeGuard[Unknown], bool))
@@ -1654,8 +1654,8 @@ takes_plugin_predicate(callable)
 ## `ParamSpec`
 
 ```py
-from ty_extensions import static_assert, Unknown
-from ty_extensions._internal import TypeOf, is_assignable_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, TypeOf, is_assignable_to
 from typing import ParamSpec, Mapping, Callable, Any
 
 P = ParamSpec("P")

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -14,8 +14,8 @@ materializations of `B`, and all materializations of `B` are also materializatio
 
 ```py
 from typing_extensions import Literal, LiteralString, Protocol, Never
-from ty_extensions import Unknown, static_assert, AlwaysTruthy, AlwaysFalsy
-from ty_extensions._internal import TypeOf, is_equivalent_to
+from ty_extensions import static_assert, AlwaysTruthy, AlwaysFalsy
+from ty_extensions._internal import Unknown, TypeOf, is_equivalent_to
 from enum import Enum
 
 class Answer(Enum):
@@ -72,8 +72,8 @@ static_assert(is_equivalent_to(type, type[object]))
 ```py
 from typing import Any
 from typing_extensions import Literal, LiteralString, Never
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 
 static_assert(is_equivalent_to(Any, Any))
 static_assert(is_equivalent_to(Unknown, Unknown))
@@ -100,8 +100,8 @@ For a covariant bounded type parameter, this applies to aliases containing eithe
 ```py
 from typing import Any
 
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 
 type AnyTuple = tuple[Any, ...]
 type UnknownTuple = tuple[Unknown, ...]
@@ -178,8 +178,8 @@ static_assert(not is_equivalent_to(BoundedInvariant[tuple[Any, ...]], BoundedInv
 
 ```pyi
 from typing import Any, Literal, TypeAlias
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 from enum import Enum
 
 static_assert(is_equivalent_to(str | int, str | int))
@@ -242,8 +242,8 @@ static_assert(is_equivalent_to(Any, ~None & Unknown | Unknown))
 ## Tuples
 
 ```py
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 from typing import Any
 
 static_assert(is_equivalent_to(tuple[str, Any], tuple[str, Unknown]))
@@ -461,8 +461,8 @@ Two unions containing different `Callable` types are equivalent even if the unio
 ordered:
 
 ```py
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import RegularCallableTypeOf, is_equivalent_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, RegularCallableTypeOf, is_equivalent_to
 
 def f(x): ...
 def g(x: Unknown): ...
@@ -579,8 +579,8 @@ gradual types. The cases with fully static types and using different combination
 are covered above.
 
 ```py
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import CallableTypeOf, RegularCallableTypeOf, TypeOf, is_equivalent_to
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, CallableTypeOf, RegularCallableTypeOf, TypeOf, is_equivalent_to
 from typing import Any, Callable
 
 static_assert(is_equivalent_to(Callable[..., int], Callable[..., int]))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -890,8 +890,8 @@ of the first type represent sets of values that are a subset of every possible s
 represented by a materialization of the second type.
 
 ```pyi
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_subtype_of
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_subtype_of
 from typing_extensions import Any
 
 static_assert(not is_subtype_of(Any, Any))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -29,7 +29,8 @@ The dynamic type at the top-level is replaced with `object`.
 
 ```py
 from typing import Any, Callable
-from ty_extensions import Unknown, Top
+from ty_extensions import Top
+from ty_extensions._internal import Unknown
 
 def _(top_any: Top[Any], top_unknown: Top[Unknown]):
     reveal_type(top_any)  # revealed: object
@@ -56,7 +57,8 @@ The dynamic type at the top-level is replaced with `Never`.
 
 ```py
 from typing import Any, Callable
-from ty_extensions import Unknown, Bottom
+from ty_extensions import Bottom
+from ty_extensions._internal import Unknown
 
 def _(bottom_any: Bottom[Any], bottom_unknown: Bottom[Unknown]):
     reveal_type(bottom_any)  # revealed: Never
@@ -150,8 +152,8 @@ python-version = "3.12"
 
 ```py
 from typing import Any, Callable
-from ty_extensions import Unknown, Bottom, Top
-from ty_extensions._internal import TypeOf
+from ty_extensions import Bottom, Top
+from ty_extensions._internal import Unknown, TypeOf
 
 type C1 = Callable[[Any, Unknown], Any]
 
@@ -288,8 +290,8 @@ python-version = "3.12"
 
 ```py
 from typing import Any, Never
-from ty_extensions import Unknown, Bottom, Top, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 
 static_assert(is_equivalent_to(Top[tuple[Any, int]], tuple[object, int]))
 static_assert(is_equivalent_to(Bottom[tuple[Any, int]], Never))
@@ -351,8 +353,8 @@ python-version = "3.12"
 
 ```py
 from typing import Any
-from ty_extensions import Unknown, Bottom, Top, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 
 static_assert(is_equivalent_to(Top[Any | int], object))
 static_assert(is_equivalent_to(Bottom[Any | int], int))
@@ -404,8 +406,8 @@ All positions in an intersection are covariant.
 ```pyi
 from typing import Any
 from typing_extensions import Never
-from ty_extensions import Unknown, Bottom, Top, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 
 static_assert(is_equivalent_to(Top[Any & int], int))
 static_assert(is_equivalent_to(Bottom[Any & int], Never))
@@ -460,8 +462,8 @@ All positions in a negation are contravariant.
 ```pyi
 from typing import Any
 from typing_extensions import Never
-from ty_extensions import Unknown, Bottom, Top, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 
 # ~Any is still Any, so the top materialization is object
 static_assert(is_equivalent_to(Top[~Any], object))
@@ -483,8 +485,8 @@ python-version = "3.12"
 ```py
 from typing import Any
 from typing_extensions import Never
-from ty_extensions import Unknown, Bottom, Top, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import Unknown, is_equivalent_to
 
 static_assert(is_equivalent_to(Top[type[Any]], type))
 static_assert(is_equivalent_to(Bottom[type[Any]], Never))
@@ -575,8 +577,8 @@ python-version = "3.12"
 
 ```py
 from typing import Any, Never, TypeVar
-from ty_extensions import Unknown, Bottom, Top, static_assert
-from ty_extensions._internal import is_subtype_of
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import Unknown, is_subtype_of
 
 def bounded_by_gradual[T: Any](t: T) -> None:
     # Top materialization of `T: Any` is `T: object`

--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -153,7 +153,7 @@ def _(
 ## Do not erase `Unknown`
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _(u1: Unknown | str, u2: str | Unknown) -> None:
     reveal_type(u1)  # revealed: Unknown | str
@@ -166,7 +166,7 @@ Since `Unknown` is a gradual type, it is not a subtype of anything, but multiple
 union are still redundant:
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _(u1: Unknown | Unknown | str, u2: Unknown | str | Unknown, u3: str | Unknown | Unknown) -> None:
     reveal_type(u1)  # revealed: Unknown | str
@@ -179,7 +179,7 @@ def _(u1: Unknown | Unknown | str, u2: Unknown | str | Unknown, u3: str | Unknow
 Simplifications still apply when `Unknown` is present.
 
 ```py
-from ty_extensions import Unknown
+from ty_extensions._internal import Unknown
 
 def _(u1: int | Unknown | bool) -> None:
     reveal_type(u1)  # revealed: int | Unknown

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -75,7 +75,7 @@ pub enum SpecialFormType {
     NoReturn,
     /// The symbol `typing.Never` available since 3.11 (which can also be found as `typing_extensions.Never`)
     Never,
-    /// The symbol `ty_extensions.Unknown`
+    /// The symbol `ty_extensions._internal.Unknown`
     Unknown,
     /// The symbol `ty_extensions._internal.Divergent`
     Divergent,
@@ -559,15 +559,15 @@ impl SpecialFormType {
                 matches!(module, KnownModule::Typing | KnownModule::TypingExtensions)
             }
 
-            Self::Unknown
-            | Self::AlwaysTruthy
+            Self::AlwaysTruthy
             | Self::AlwaysFalsy
             | Self::Not
             | Self::Top
             | Self::Bottom
             | Self::Intersection => module.is_ty_extensions(),
 
-            Self::Divergent
+            Self::Unknown
+            | Self::Divergent
             | Self::Todo
             | Self::TypeOf
             | Self::CallableTypeOf
@@ -786,15 +786,15 @@ impl SpecialFormType {
 
             SpecialFormType::CollectionsAbcCallable => &[KnownModule::CollectionsAbc],
 
-            SpecialFormType::Unknown
-            | SpecialFormType::AlwaysTruthy
+            SpecialFormType::AlwaysTruthy
             | SpecialFormType::AlwaysFalsy
             | SpecialFormType::Not
             | SpecialFormType::Intersection
             | SpecialFormType::Top
             | SpecialFormType::Bottom => &[KnownModule::TyExtensions],
 
-            SpecialFormType::Divergent
+            SpecialFormType::Unknown
+            | SpecialFormType::Divergent
             | SpecialFormType::Todo
             | SpecialFormType::TypeOf
             | SpecialFormType::CallableTypeOf

--- a/crates/ty_vendored/ty_extensions/__init__.pyi
+++ b/crates/ty_vendored/ty_extensions/__init__.pyi
@@ -1,4 +1,6 @@
 # ruff: noqa: PYI021
+"""Experimental ty APIs intended to be exposed to end users."""
+
 import collections.abc
 import sys
 from typing import Any, ClassVar, Protocol, _SpecialForm
@@ -105,15 +107,6 @@ eagerly.
 # -----
 # Types
 # -----
-
-Unknown: _SpecialForm
-"""
-`Unknown` is a dynamic type inferred due to missing type information or an inference error.
-
-ty infers `Unknown` for unannotated values with insufficient type information. It also uses it as a
-fallback after certain type errors. This contrasts with `Any`, which represents an *explicitly*
-annotated dynamic type. Like `Any`, however, it is a dynamic type, so ty allows any operation on it.
-"""
 
 AlwaysTruthy: _SpecialForm
 """

--- a/crates/ty_vendored/ty_extensions/_internal.pyi
+++ b/crates/ty_vendored/ty_extensions/_internal.pyi
@@ -1,4 +1,11 @@
 # ruff: noqa: PYI021
+"""
+Internal-only symbols for special forms and type-system tests.
+
+Some symbols provide definitions and on-hover documentation for special forms. Others exist only as
+helpers for ty's tests. None of these symbols are intended to be directly imported by end users.
+"""
+
 import types
 from enum import Enum
 from typing import Any, Protocol, _SpecialForm
@@ -48,6 +55,15 @@ ordinary `Callable[...]` types in type-theoretic tests.
 # -----
 # Types
 # -----
+
+Unknown: _SpecialForm
+"""
+`Unknown` is a dynamic type inferred due to missing type information or an inference error.
+
+ty infers `Unknown` for unannotated values with insufficient type information. It also uses it as a
+fallback after certain type errors. This contrasts with `Any`, which represents an *explicitly*
+annotated dynamic type. Like `Any`, however, it is a dynamic type, so ty allows any operation on it.
+"""
 
 Todo: _SpecialForm
 """


### PR DESCRIPTION
`Unknown` is an internal type-system concept and should not be part of the experimental user-facing `ty_extensions` API.

Move its definition into `ty_extensions._internal`, update special-form lookup, fixtures, and IDE snapshots to use the new location, and document the distinction between experimental public APIs and internal special-form definitions and testing helpers.