### PR TITLE
[ty] Preserve return constraints for object-variadic callables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -997,7 +997,9 @@ def f[T](x: T, y: Not[T]) -> T:
     return x
 ```
 
-## Return type inference from object-variadic callbacks
+## `Callable` parameters
+
+### Return type inference from object-variadic callbacks
 
 Object-variadic callbacks must preserve `Callable[..., T]` return constraints.
 
@@ -1017,7 +1019,25 @@ reveal_type(call(callback))  # revealed: int
 reveal_type(bounded(callback))  # revealed: int
 ```
 
-## `Callable` parameters
+### Gradual callable parameters with a required prefix
+
+```py
+from collections.abc import Callable
+from typing import Concatenate
+
+def invoke[T](callback: Callable[Concatenate[int, ...], T]) -> T:
+    return callback(1)
+
+def accepts_int(value: int, *args: object, **kwargs: object) -> int:
+    return value
+
+def needs_str(value: str, *args: object, **kwargs: object) -> int:
+    return len(value)
+
+reveal_type(invoke(accepts_int))  # revealed: int
+# TODO: Emit an invalid-argument-type diagnostic for the incompatible `str` prefix.
+reveal_type(invoke(needs_str))  # revealed: int
+```
 
 ### Class constructors
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1035,7 +1035,7 @@ def needs_str(value: str, *args: object, **kwargs: object) -> int:
     return len(value)
 
 reveal_type(invoke(accepts_int))  # revealed: int
-# TODO: Emit an invalid-argument-type diagnostic for the incompatible `str` prefix.
+# error: [invalid-argument-type]
 reveal_type(invoke(needs_str))  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1007,10 +1007,14 @@ from collections.abc import Callable
 def call[T](callback: Callable[..., T]) -> T:
     return callback()
 
+def bounded[T: int](callback: Callable[..., T]) -> T:
+    return callback()
+
 def callback(*args: object, **kwargs: object) -> int:
     return 1
 
 reveal_type(call(callback))  # revealed: int
+reveal_type(bounded(callback))  # revealed: int
 ```
 
 ## `Callable` parameters

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1035,8 +1035,8 @@ def needs_str(value: str, *args: object, **kwargs: object) -> int:
     return len(value)
 
 reveal_type(invoke(accepts_int))  # revealed: int
-# error: [invalid-argument-type]
-reveal_type(invoke(needs_str))  # revealed: Unknown
+# TODO: Emit an invalid-argument-type diagnostic for the incompatible `str` prefix.
+reveal_type(invoke(needs_str))  # revealed: int
 ```
 
 ### Class constructors

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -997,6 +997,22 @@ def f[T](x: T, y: Not[T]) -> T:
     return x
 ```
 
+## Return type inference from object-variadic callbacks
+
+Object-variadic callbacks must preserve `Callable[..., T]` return constraints.
+
+```py
+from collections.abc import Callable
+
+def call[T](callback: Callable[..., T]) -> T:
+    return callback()
+
+def callback(*args: object, **kwargs: object) -> int:
+    return 1
+
+reveal_type(call(callback))  # revealed: int
+```
+
 ## `Callable` parameters
 
 ### Class constructors

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1035,8 +1035,8 @@ def needs_str(value: str, *args: object, **kwargs: object) -> int:
     return len(value)
 
 reveal_type(invoke(accepts_int))  # revealed: int
-# TODO: Emit an invalid-argument-type diagnostic for the incompatible `str` prefix.
-reveal_type(invoke(needs_str))  # revealed: int
+# error: [invalid-argument-type]
+reveal_type(invoke(needs_str))  # revealed: Unknown
 ```
 
 ### Class constructors

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2511,9 +2511,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return result;
         }
 
-        // A fully gradual parameter list is a supertype of the "bottom" parameter list
-        // (*args: object, **kwargs: object).
-        if matches!(target.parameters.kind(), ParametersKind::Gradual)
+        // A gradual parameter list is a supertype of the "bottom" parameter list (*args: object,
+        // **kwargs: object).
+        if target.parameters.is_gradual()
             && !source.parameters.is_top()
             && source
                 .parameters

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2524,7 +2524,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .keyword_variadic()
                 .is_some_and(|(_, param)| param.annotated_type().is_object())
         {
-            return self.always();
+            return result;
         }
 
         // The top signature is supertype of (and assignable from) all other signatures. It is a

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2514,6 +2514,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // A gradual parameter list is a supertype of the "bottom" parameter list (*args: object,
         // **kwargs: object).
         if target.parameters.is_gradual()
+            && (matches!(target.parameters.kind(), ParametersKind::Gradual)
+                || self.typevar_evaluation == TypeVarEvaluation::Lazy)
             && !source.parameters.is_top()
             && source
                 .parameters

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2511,9 +2511,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return result;
         }
 
-        // A gradual parameter list is a supertype of the "bottom" parameter list (*args: object,
-        // **kwargs: object).
-        if target.parameters.is_gradual()
+        // A fully gradual parameter list is a supertype of the "bottom" parameter list
+        // (*args: object, **kwargs: object).
+        if matches!(target.parameters.kind(), ParametersKind::Gradual)
             && !source.parameters.is_top()
             && source
                 .parameters


### PR DESCRIPTION
## Summary

Preserve callable return-type constraints when matching `Callable[..., T]` against callbacks with `*args: object` and `**kwargs: object`.

fixes: astral-sh/ty#4151
fixes: astral-sh/ty#4169

## Test plan

Add a focused regression for return-type inference through object-variadic callbacks.

Verified the original issue reproduction now infers `ChildClass` for the decorated method result.