### PR TITLE
[ty] Enable (but downrank) auto-import completion suggestions from stub-only modules

### DIFF
--- a/crates/ty_completion_eval/completion-evaluation-tasks.csv
+++ b/crates/ty_completion_eval/completion-evaluation-tasks.csv
@@ -21,6 +21,8 @@ import-deprioritizes-type_check_only,main.py,1,1
 import-deprioritizes-type_check_only,main.py,2,1
 import-deprioritizes-type_check_only,main.py,3,2
 import-deprioritizes-type_check_only,main.py,4,3
+import-deprioritizes-type_check_only,main.pyi,0,1
+import-deprioritizes-type_check_only,main.pyi,1,1
 import-keyword-completion,main.py,0,1
 internal-typeshed-hidden,main.py,0,1
 local-over-auto-import,main.py,0,1
@@ -46,3 +48,12 @@ typing-gets-priority,main.py,1,1
 typing-gets-priority,main.py,2,1
 typing-gets-priority,main.py,3,1
 typing-gets-priority,main.py,4,1
+typing-only-auto-import-ranking,main.py,0,1
+typing-only-auto-import-ranking,main.py,1,1
+typing-only-auto-import-ranking,main.py,2,1
+typing-only-auto-import-ranking,main.py,3,2
+typing-only-auto-import-ranking,main.py,4,1
+typing-only-auto-import-ranking,main.py,5,1
+typing-only-auto-import-ranking,main.pyi,0,1
+typing-only-auto-import-ranking,main.pyi,1,1
+typing-only-auto-import-ranking,main.pyi,2,1

--- a/crates/ty_completion_eval/src/main.rs
+++ b/crates/ty_completion_eval/src/main.rs
@@ -545,6 +545,7 @@ fn copy_project(src_dir: &SystemPath, dst_dir: &SystemPath) -> anyhow::Result<Ve
 
     let mut cursors = vec![];
     let it = walkdir::WalkDir::new(src_dir.as_std_path())
+        .sort_by_file_name()
         .into_iter()
         .filter_entry(|dent| {
             !dent

--- a/crates/ty_completion_eval/truth/import-deprioritizes-type_check_only/main.pyi
+++ b/crates/ty_completion_eval/truth/import-deprioritizes-type_check_only/main.pyi
@@ -1,0 +1,3 @@
+# Typing-only declarations are not penalized when completing a stub.
+from module import UniquePrefixA<CURSOR: UniquePrefixApple>
+from module import unique_prefix_<CURSOR: unique_prefix_apple>

--- a/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/completion.toml
+++ b/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/completion.toml
@@ -1,0 +1,2 @@
+[settings]
+auto-import = true

--- a/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/main.py
+++ b/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/main.py
@@ -1,0 +1,9 @@
+# Runtime symbols outrank alternatives from typing-only modules in Python files.
+deprecated<CURSOR: warnings.deprecated>
+NoneTy<CURSOR: types.NoneType>
+Not<CURSOR: ast.Not>
+
+# Typing-only symbols are included in auto-import suggestions.
+static_ass<CURSOR: ty_extensions.static_assert>
+is_equiv<CURSOR: ty_extensions._internal.is_equivalent_to>
+TypedDictFall<CURSOR: _typeshed._type_checker_internals.TypedDictFallback>

--- a/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/main.pyi
+++ b/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/main.pyi
@@ -1,0 +1,4 @@
+# Typing-only symbols retain their usual ranking in stub files.
+deprecated<CURSOR: typing_extensions.deprecated>
+NoneTy<CURSOR: _typeshed.NoneType>
+static_ass<CURSOR: ty_extensions.static_assert>

--- a/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/pyproject.toml
+++ b/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "test"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = []

--- a/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/uv.lock
+++ b/crates/ty_completion_eval/truth/typing-only-auto-import-ranking/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "test"
+version = "0.1.0"
+source = { virtual = "." }

--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -1,9 +1,7 @@
 use compact_str::CompactString;
 use rayon::prelude::*;
 use ruff_db::files::File;
-use ty_module_resolver::{
-    ImportingFile, Module, ModuleName, all_modules, resolve_real_shadowable_module,
-};
+use ty_module_resolver::{Module, all_modules};
 use ty_project::{Db, parallel::ParallelIteratorExt};
 use ty_python_core::ProgramFile;
 
@@ -29,12 +27,8 @@ pub fn all_symbols<'db>(
     let all_symbols_span = tracing::debug_span!("all_symbols");
     let _span = all_symbols_span.enter();
 
-    let typing_extensions = ModuleName::new_static("typing_extensions").unwrap();
     let program = importing_from.program(db);
     let resolver_environment = importing_from.resolver_environment(db);
-    let importing_file = ImportingFile::File(importing_from.file(db), resolver_environment);
-    let is_typing_extensions_available = importing_from.file(db).is_stub(db)
-        || resolve_real_shadowable_module(db, importing_file, &typing_extensions).is_some();
 
     let results = all_modules(db, resolver_environment)
         .into_par_iter()
@@ -49,15 +43,11 @@ pub fn all_symbols<'db>(
             // namespace packages in auto-import anyway.)
             let is_non_first_party = module.search_path(db).is_none_or(|sp| !sp.is_first_party());
 
-            // Filter out non-first-party modules that are conventionally
-            // regarded as private or tests.
-            if is_non_first_party && (name.is_private() || name.is_test_module()) {
-                return Vec::new();
-            }
-
-            // TODO: also make it available in `TYPE_CHECKING` blocks
-            // (we'd need https://github.com/astral-sh/ty/issues/1553 to do this well)
-            if !is_typing_extensions_available && name == &typing_extensions {
+            // Filter out non-first-party test and private modules, while retaining private
+            // typeshed packages that are useful when writing type annotations.
+            if is_non_first_party
+                && (name.is_test_module() || name.is_private() && !module.is_type_check_only(db))
+            {
                 return Vec::new();
             }
 

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -664,6 +664,17 @@ mod tests {
         2 |
           |
 
+        info[code-action]: import typing_extensions.reveal_type
+         --> main.py:2:1
+          |
+        2 | reveal_type(1)
+          | ^^^^^^^^^^^
+        help: This is a preferred code action
+          |
+        1 + from typing_extensions import reveal_type
+        2 |
+          |
+
         info[code-action]: Ignore 'undefined-reveal' for this line
          --> main.py:2:1
           |
@@ -695,6 +706,17 @@ mod tests {
         help: This is a preferred code action
           |
         1 + from warnings import deprecated
+        2 |
+          |
+
+        info[code-action]: import typing_extensions.deprecated
+         --> main.py:2:2
+          |
+        2 | @deprecated("do not use")
+          |  ^^^^^^^^^^
+        help: This is a preferred code action
+          |
+        1 + from typing_extensions import deprecated
         2 |
           |
 
@@ -732,6 +754,17 @@ mod tests {
         help: This is a preferred code action
           |
         1 + from warnings import deprecated
+        2 |
+          |
+
+        info[code-action]: import typing_extensions.deprecated
+         --> main.py:4:2
+          |
+        4 | @deprecated("do not use")
+          |  ^^^^^^^^^^
+        help: This is a preferred code action
+          |
+        1 + from typing_extensions import deprecated
         2 |
           |
 

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -10,12 +10,14 @@ use ruff_python_ast::find_node::{CoveringNode, covering_node};
 use ruff_python_ast::name::{Name, UnqualifiedName};
 use ruff_python_ast::str::Quote;
 use ruff_python_ast::token::{Token, TokenKind, Tokens};
-use ruff_python_ast::{self as ast, AnyNodeRef};
+use ruff_python_ast::{self as ast, AnyNodeRef, PySourceType};
 use ruff_python_codegen::Stylist;
 use ruff_python_literal::escape::{Escape, UnicodeEscape};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{ImportingFile, KnownModule, Module, ModuleName};
+use ty_module_resolver::{
+    ImportingFile, KnownModule, Module, ModuleName, resolve_real_shadowable_module,
+};
 use ty_python_core::ProgramFile;
 use ty_python_semantic::HasType;
 use ty_python_semantic::types::{SpecialFormType, UnionType};
@@ -523,7 +525,12 @@ impl<'db> CompletionBuilder<'db> {
         let kind = self
             .kind
             .or_else(|| self.ty.and_then(|ty| completion_kind_from_type(db, ty)));
-        let relevance = Relevance::new(collection_context, query, &self);
+        let relevance = Relevance::new(
+            collection_context,
+            query,
+            &self,
+            program_file.file(db).source_type(db),
+        );
         let (label, insert, insert_text_format, command) =
             if collection_context.should_complete_callable_parentheses(kind) {
                 let label = self.insert.unwrap_or_else(|| self.name.clone());
@@ -1767,7 +1774,7 @@ struct Relevance {
     /// the user's project.
     is_module: Sort,
     /// Sorts based on whether this symbol is only available during
-    /// type checking and not at runtime.
+    /// type checking and not at runtime. This does not lower its rank in a stub file.
     type_check_only: Sort,
     /// Deprecated symbols appear lower in the completion result.
     deprecated: Sort,
@@ -1788,7 +1795,12 @@ impl Relevance {
     ///
     /// A smaller rank means the completion should appear higher in the
     /// results shown to end users.
-    fn new(_ctx: &CollectionContext, query: &UserQuery, c: &CompletionBuilder) -> Relevance {
+    fn new(
+        _ctx: &CollectionContext,
+        query: &UserQuery,
+        c: &CompletionBuilder,
+        source_type: PySourceType,
+    ) -> Relevance {
         Relevance {
             definitively_usable: if c.is_context_specific {
                 Sort::Higher
@@ -1825,7 +1837,7 @@ impl Relevance {
             } else {
                 Sort::Even
             },
-            type_check_only: if c.is_type_check_only {
+            type_check_only: if c.is_type_check_only && !source_type.is_stub() {
                 Sort::Lower
             } else {
                 Sort::Even
@@ -1954,6 +1966,32 @@ impl ModuleDependencyKind {
             ModuleDependencyKind::Project
         }
     }
+}
+
+/// Returns whether importing this module would require a typing-only runtime context.
+fn is_type_check_only_module<'db>(
+    db: &'db dyn Db,
+    importing_from: ProgramFile<'db>,
+    module: Module<'db>,
+) -> bool {
+    if !module.is_type_check_only(db) {
+        return false;
+    }
+
+    if module.name(db).first_component() != "typing_extensions" {
+        return true;
+    }
+
+    // typeshed bundles `typing_extensions` with its standard-library stubs even
+    // though the actual module is a third-party package. Since the bundled stub
+    // takes precedence during module resolution, look past it to check whether a
+    // corresponding runtime module is also available from the project or site-packages.
+    let importing_file = ImportingFile::File(
+        importing_from.file(db),
+        importing_from.resolver_environment(db),
+    );
+    resolve_real_shadowable_module(db, importing_file, &KnownModule::TypingExtensions.name())
+        .is_none()
 }
 
 /// An instruction to indicate an ordering preference.
@@ -2338,6 +2376,7 @@ fn add_unimported_completions<'db>(
                 .module_name(module_name)
                 .import(import_action.import().cloned())
                 .deprecated(symbol.deprecated())
+                .type_check_only(is_type_check_only_module(db, file, symbol.module()))
                 .module_dependency_kind(ModuleDependencyKind::from_module(db, symbol.module())),
         );
     }
@@ -3085,7 +3124,15 @@ fn add_import_completions_impl<'db>(
     let env = ProgramEnvironment::from_file(completions.program_file);
     for semantic in semantic_completions {
         let module_dependency_kind = module_dependency_kind(&semantic);
+        let is_from_type_check_only_module = matches!(
+            semantic.ty,
+            Some(Type::ModuleLiteral(module))
+                if is_type_check_only_module(db, completions.program_file, module.module(db))
+        );
         let mut builder = CompletionBuilder::from_semantic_completion(db, &env, semantic);
+        if is_from_type_check_only_module {
+            builder = builder.type_check_only(true);
+        }
         if let Some(module_dependency_kind) = module_dependency_kind {
             builder = builder.module_dependency_kind(module_dependency_kind);
         }
@@ -9406,7 +9453,10 @@ if foo:
     #[test]
     fn from_import_no_space_not_suggests_import() {
         let builder = completion_test_builder("from typing<CURSOR>");
-        assert_snapshot!(builder.build().snapshot(), @"typing");
+        assert_snapshot!(builder.build().snapshot(), @"
+        typing
+        typing_extensions
+        ");
     }
 
     #[test]
@@ -9617,183 +9667,111 @@ from .imp<CURSOR>
     }
 
     #[test]
-    fn typing_extensions_excluded_from_import() {
+    fn bundled_typing_extensions_module_completion() {
         let builder = completion_test_builder("from typing<CURSOR>").module_names();
-        assert_snapshot!(builder.build().snapshot(), @"typing :: <no import required>");
+        let completions = builder.build();
+        assert!(completions.completions().iter().any(|completion| {
+            completion.name == "typing_extensions" && completion.is_type_check_only
+        }));
+        assert_snapshot!(completions.snapshot(), @"
+        typing :: <no import required>
+        typing_extensions :: <no import required>
+        ");
     }
 
     #[test]
-    fn typing_extensions_excluded_from_auto_import() {
-        let builder = completion_test_builder("deprecated<CURSOR>").module_names();
-        assert_snapshot!(builder.build().snapshot(), @"deprecated :: warnings");
+    fn bundled_ty_extensions_module_completion() {
+        let builder = completion_test_builder("from ty_ex<CURSOR>")
+            .module_names()
+            .filter(|completion| completion.name == "ty_extensions");
+        let completions = builder.build();
+        assert!(
+            completions
+                .completions()
+                .iter()
+                .all(|completion| completion.is_type_check_only)
+        );
+        assert_snapshot!(completions.snapshot(), @"ty_extensions :: <no import required>");
     }
 
     #[test]
-    fn ty_extensions_excluded_from_auto_import_without_existing_import() {
-        completion_test_builder("static_ass<CURSOR>")
-            .build()
-            .not_contains("static_assert");
+    fn bundled_typeshed_module_completion() {
+        let builder = completion_test_builder("from _type<CURSOR>")
+            .module_names()
+            .filter(|completion| completion.name == "_typeshed");
+        let completions = builder.build();
+        assert!(
+            completions
+                .completions()
+                .iter()
+                .all(|completion| completion.is_type_check_only)
+        );
+        assert_snapshot!(completions.snapshot(), @"_typeshed :: <no import required>");
     }
 
     #[test]
-    fn ty_extensions_excluded_from_import_without_existing_import() {
-        completion_test_builder("from ty_ex<CURSOR>")
-            .build()
-            .not_contains("ty_extensions");
-    }
-
-    #[test]
-    fn typeshed_excluded_from_import_without_existing_import() {
-        completion_test_builder("from _type<CURSOR>")
-            .build()
-            .not_contains("_typeshed");
-    }
-
-    #[test]
-    fn ty_extensions_runtime_module_included_from_auto_import_without_existing_import() {
+    fn runtime_ty_extensions_auto_import_is_not_type_check_only() {
         let builder = CursorTest::builder()
             .source("ty_extensions.py", "static_assert = 1")
             .source("main.py", "static_ass<CURSOR>")
             .completion_test_builder()
             .module_names()
             .filter(|completion| completion.name == "static_assert");
-        assert_snapshot!(builder.build().snapshot(), @"static_assert :: ty_extensions");
-    }
-
-    #[test]
-    fn ty_extensions_included_from_auto_import_after_module_import() {
-        let builder = completion_test_builder("import ty_extensions\nstatic_ass<CURSOR>")
-            .module_names()
-            .imports()
-            .filter(|completion| completion.name == "static_assert");
-        assert_snapshot!(
-            builder.build().snapshot(),
-            @"ty_extensions.static_assert :: ty_extensions :: <no import edit>",
+        let completions = builder.build();
+        assert!(
+            completions
+                .completions()
+                .iter()
+                .all(|completion| !completion.is_type_check_only)
         );
+        assert_snapshot!(completions.snapshot(), @"static_assert :: ty_extensions");
     }
 
     #[test]
-    fn ty_extensions_included_from_auto_import_after_aliased_module_import() {
-        let builder = completion_test_builder("import ty_extensions as tx\nstatic_ass<CURSOR>")
-            .module_names()
-            .imports()
-            .filter(|completion| completion.name == "static_assert");
-        assert_snapshot!(
-            builder.build().snapshot(),
-            @"tx.static_assert :: ty_extensions :: <no import edit>",
-        );
-    }
-
-    #[test]
-    fn ty_extensions_included_from_auto_import_after_symbol_import() {
-        let builder =
-            completion_test_builder("from ty_extensions import Intersection\nstatic_ass<CURSOR>")
-                .module_names()
-                .imports()
-                .filter(|completion| completion.name == "static_assert");
-        assert_snapshot!(
-            builder.build().snapshot(),
-            @"static_assert :: ty_extensions :: , static_assert",
-        );
-    }
-
-    #[test]
-    fn ty_extensions_included_from_auto_import_after_conditional_symbol_import() {
-        let builder = completion_test_builder(
-            "\
-if True:
-    from ty_extensions import Intersection
-
-static_ass<CURSOR>",
-        )
-        .module_names()
-        .filter(|completion| completion.name == "static_assert");
-        assert_snapshot!(builder.build().snapshot(), @"static_assert :: ty_extensions");
-    }
-
-    #[test]
-    fn ty_extensions_submodule_included_from_auto_import_after_star_import() {
-        let builder = completion_test_builder(
-            "\
-from ty_extensions import *
-LaxDa<CURSOR>",
-        )
-        .module_names()
-        .filter(|completion| completion.name == "LaxDate");
-        assert_snapshot!(builder.build().snapshot(), @"LaxDate :: ty_extensions.pydantic");
-    }
-
-    #[test]
-    fn typing_extensions_included_from_auto_import_after_symbol_import() {
-        let builder =
-            completion_test_builder("from typing_extensions import Literal\ndeprecat<CURSOR>")
-                .module_names()
-                .imports()
-                .filter(|completion| {
-                    completion.name == "deprecated"
-                        && completion.module_name.map(ModuleName::as_str)
-                            == Some("typing_extensions")
-                });
-        assert_snapshot!(
-            builder.build().snapshot(),
-            @"deprecated :: typing_extensions :: , deprecated",
-        );
-    }
-
-    #[test]
-    fn ty_extensions_internal_included_from_auto_import_after_symbol_import() {
-        let builder =
-            completion_test_builder("from ty_extensions._internal import TypeOf\nis_equiv<CURSOR>")
-                .module_names()
-                .imports()
-                .filter(|completion| completion.name == "is_equivalent_to");
-        assert_snapshot!(
-            builder.build().snapshot(),
-            @"is_equivalent_to :: ty_extensions._internal :: , is_equivalent_to",
-        );
-    }
-
-    #[test]
-    fn ty_extensions_pydantic_included_from_auto_import_after_parent_symbol_import() {
-        let builder =
-            completion_test_builder("from ty_extensions import Intersection\nLaxDa<CURSOR>")
-                .module_names()
-                .imports()
-                .filter(|completion| completion.name == "LaxDate");
-        assert_snapshot!(
-            builder.build().snapshot(),
-            @"LaxDate :: ty_extensions.pydantic :: from ty_extensions.pydantic import LaxDate",
-        );
-    }
-
-    #[test]
-    fn ty_extensions_pydantic_included_from_auto_import_after_submodule_import() {
-        let builder = completion_test_builder("from ty_extensions import pydantic\nLaxDa<CURSOR>")
+    fn ty_extensions_pydantic_auto_import_generates_import_edit() {
+        let builder = completion_test_builder("LaxDa<CURSOR>")
             .module_names()
             .imports()
             .filter(|completion| completion.name == "LaxDate");
-        assert_snapshot!(
-            builder.build().snapshot(),
-            @"LaxDate :: ty_extensions.pydantic :: from ty_extensions.pydantic import LaxDate",
-        );
+        assert_snapshot!(builder.build().snapshot(), @"LaxDate :: ty_extensions.pydantic :: from ty_extensions.pydantic import LaxDate");
     }
 
     #[test]
-    fn typeshed_internal_included_from_auto_import_after_sibling_symbol_import() {
-        let builder = completion_test_builder(
-            "from _typeshed.dbapi import DBAPITypeCode\nTypedDictFall<CURSOR>",
-        )
-        .module_names()
-        .imports()
-        .filter(|completion| completion.name == "TypedDictFallback");
-        assert_snapshot!(
-            builder.build().snapshot(),
-            @"TypedDictFallback :: _typeshed._type_checker_internals :: from _typeshed._type_checker_internals import TypedDictFallback",
+    fn ty_extensions_auto_import_is_type_check_only_in_stub() {
+        let builder = CursorTest::builder()
+            .source("main.pyi", "static_ass<CURSOR>")
+            .completion_test_builder()
+            .module_names()
+            .filter(|completion| completion.name == "static_assert");
+        let completions = builder.build();
+        assert!(
+            completions
+                .completions()
+                .iter()
+                .all(|completion| completion.is_type_check_only)
         );
+        assert_snapshot!(completions.snapshot(), @"static_assert :: ty_extensions");
     }
 
     #[test]
-    fn typing_extensions_included_from_import() {
+    fn typeshed_auto_import_is_type_check_only_in_stub() {
+        let builder = CursorTest::builder()
+            .source("main.pyi", "TypedDictFall<CURSOR>")
+            .completion_test_builder()
+            .module_names()
+            .filter(|completion| completion.name == "TypedDictFallback");
+        let completions = builder.build();
+        assert!(
+            completions
+                .completions()
+                .iter()
+                .all(|completion| completion.is_type_check_only)
+        );
+        assert_snapshot!(completions.snapshot(), @"TypedDictFallback :: _typeshed._type_checker_internals");
+    }
+
+    #[test]
+    fn runtime_typing_extensions_module_completion() {
         let builder = CursorTest::builder()
             .source("typing_extensions.py", "deprecated = 1")
             .source("foo.py", "from typing<CURSOR>")
@@ -9806,37 +9784,54 @@ LaxDa<CURSOR>",
     }
 
     #[test]
-    fn typing_extensions_included_from_auto_import() {
+    fn runtime_typing_extensions_auto_import_is_not_type_check_only() {
         let builder = CursorTest::builder()
             .source("typing_extensions.py", "deprecated = 1")
             .source("foo.py", "deprecated<CURSOR>")
             .completion_test_builder()
             .module_names();
-        assert_snapshot!(builder.build().snapshot(), @"
+        let completions = builder.build();
+        assert!(
+            completions.completions().iter().any(|completion| {
+                completion.module_name.map(ModuleName::as_str) == Some("typing_extensions")
+                    && !completion.is_type_check_only
+            }),
+            "runtime `typing_extensions` should not be downranked",
+        );
+        assert_snapshot!(completions.snapshot(), @"
         deprecated :: typing_extensions
         deprecated :: warnings
         ");
     }
 
     #[test]
-    fn typing_extensions_included_from_import_in_stub() {
+    fn typing_extensions_module_completion_is_type_check_only_in_stub() {
         let builder = CursorTest::builder()
             .source("foo.pyi", "from typing<CURSOR>")
             .completion_test_builder()
             .module_names();
-        assert_snapshot!(builder.build().snapshot(), @"
+        let completions = builder.build();
+        assert!(completions.completions().iter().any(|completion| {
+            completion.name == "typing_extensions" && completion.is_type_check_only
+        }));
+        assert_snapshot!(completions.snapshot(), @"
         typing :: <no import required>
         typing_extensions :: <no import required>
         ");
     }
 
     #[test]
-    fn typing_extensions_included_from_auto_import_in_stub() {
+    fn typing_extensions_auto_import_is_type_check_only_in_stub() {
         let builder = CursorTest::builder()
             .source("foo.pyi", "deprecated<CURSOR>")
             .completion_test_builder()
             .module_names();
-        assert_snapshot!(builder.build().snapshot(), @"
+        let completions = builder.build();
+        assert!(completions.completions().iter().any(|completion| {
+            completion.module_name.map(ModuleName::as_str) == Some("typing_extensions")
+                && completion.is_type_check_only
+        }));
+        assert_snapshot!(completions.snapshot(), @"
         deprecated :: typing_extensions
         deprecated :: warnings
         ");
@@ -10659,15 +10654,17 @@ import typing
 from typing import Callable
 TypedDi<CURSOR>
 ",
-        );
+        )
+        .imports()
+        .filter(|completion| matches!(completion.name.as_str(), "TypedDict" | "is_typeddict"));
         assert_snapshot!(
-            builder.imports().build().snapshot(),
+            builder.build().snapshot(),
             @"
         TypedDict :: , TypedDict
         is_typeddict :: , is_typeddict
-        _FilterConfigurationTypedDict :: from logging.config import _FilterConfigurationTypedDict
+        TypedDict :: from typing_extensions import TypedDict
 
-        _FormatterConfigurationTypedDict :: from logging.config import _FormatterConfigurationTypedDict
+        is_typeddict :: from typing_extensions import is_typeddict
         ",
         );
     }

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -9629,6 +9629,170 @@ from .imp<CURSOR>
     }
 
     #[test]
+    fn ty_extensions_excluded_from_auto_import_without_existing_import() {
+        completion_test_builder("static_ass<CURSOR>")
+            .build()
+            .not_contains("static_assert");
+    }
+
+    #[test]
+    fn ty_extensions_excluded_from_import_without_existing_import() {
+        completion_test_builder("from ty_ex<CURSOR>")
+            .build()
+            .not_contains("ty_extensions");
+    }
+
+    #[test]
+    fn typeshed_excluded_from_import_without_existing_import() {
+        completion_test_builder("from _type<CURSOR>")
+            .build()
+            .not_contains("_typeshed");
+    }
+
+    #[test]
+    fn ty_extensions_runtime_module_included_from_auto_import_without_existing_import() {
+        let builder = CursorTest::builder()
+            .source("ty_extensions.py", "static_assert = 1")
+            .source("main.py", "static_ass<CURSOR>")
+            .completion_test_builder()
+            .module_names()
+            .filter(|completion| completion.name == "static_assert");
+        assert_snapshot!(builder.build().snapshot(), @"static_assert :: ty_extensions");
+    }
+
+    #[test]
+    fn ty_extensions_included_from_auto_import_after_module_import() {
+        let builder = completion_test_builder("import ty_extensions\nstatic_ass<CURSOR>")
+            .module_names()
+            .imports()
+            .filter(|completion| completion.name == "static_assert");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"ty_extensions.static_assert :: ty_extensions :: <no import edit>",
+        );
+    }
+
+    #[test]
+    fn ty_extensions_included_from_auto_import_after_aliased_module_import() {
+        let builder = completion_test_builder("import ty_extensions as tx\nstatic_ass<CURSOR>")
+            .module_names()
+            .imports()
+            .filter(|completion| completion.name == "static_assert");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"tx.static_assert :: ty_extensions :: <no import edit>",
+        );
+    }
+
+    #[test]
+    fn ty_extensions_included_from_auto_import_after_symbol_import() {
+        let builder =
+            completion_test_builder("from ty_extensions import Intersection\nstatic_ass<CURSOR>")
+                .module_names()
+                .imports()
+                .filter(|completion| completion.name == "static_assert");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"static_assert :: ty_extensions :: , static_assert",
+        );
+    }
+
+    #[test]
+    fn ty_extensions_included_from_auto_import_after_conditional_symbol_import() {
+        let builder = completion_test_builder(
+            "\
+if True:
+    from ty_extensions import Intersection
+
+static_ass<CURSOR>",
+        )
+        .module_names()
+        .filter(|completion| completion.name == "static_assert");
+        assert_snapshot!(builder.build().snapshot(), @"static_assert :: ty_extensions");
+    }
+
+    #[test]
+    fn ty_extensions_submodule_included_from_auto_import_after_star_import() {
+        let builder = completion_test_builder(
+            "\
+from ty_extensions import *
+LaxDa<CURSOR>",
+        )
+        .module_names()
+        .filter(|completion| completion.name == "LaxDate");
+        assert_snapshot!(builder.build().snapshot(), @"LaxDate :: ty_extensions.pydantic");
+    }
+
+    #[test]
+    fn typing_extensions_included_from_auto_import_after_symbol_import() {
+        let builder =
+            completion_test_builder("from typing_extensions import Literal\ndeprecat<CURSOR>")
+                .module_names()
+                .imports()
+                .filter(|completion| {
+                    completion.name == "deprecated"
+                        && completion.module_name.map(ModuleName::as_str)
+                            == Some("typing_extensions")
+                });
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"deprecated :: typing_extensions :: , deprecated",
+        );
+    }
+
+    #[test]
+    fn ty_extensions_internal_included_from_auto_import_after_symbol_import() {
+        let builder =
+            completion_test_builder("from ty_extensions._internal import TypeOf\nis_equiv<CURSOR>")
+                .module_names()
+                .imports()
+                .filter(|completion| completion.name == "is_equivalent_to");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"is_equivalent_to :: ty_extensions._internal :: , is_equivalent_to",
+        );
+    }
+
+    #[test]
+    fn ty_extensions_pydantic_included_from_auto_import_after_parent_symbol_import() {
+        let builder =
+            completion_test_builder("from ty_extensions import Intersection\nLaxDa<CURSOR>")
+                .module_names()
+                .imports()
+                .filter(|completion| completion.name == "LaxDate");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"LaxDate :: ty_extensions.pydantic :: from ty_extensions.pydantic import LaxDate",
+        );
+    }
+
+    #[test]
+    fn ty_extensions_pydantic_included_from_auto_import_after_submodule_import() {
+        let builder = completion_test_builder("from ty_extensions import pydantic\nLaxDa<CURSOR>")
+            .module_names()
+            .imports()
+            .filter(|completion| completion.name == "LaxDate");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"LaxDate :: ty_extensions.pydantic :: from ty_extensions.pydantic import LaxDate",
+        );
+    }
+
+    #[test]
+    fn typeshed_internal_included_from_auto_import_after_sibling_symbol_import() {
+        let builder = completion_test_builder(
+            "from _typeshed.dbapi import DBAPITypeCode\nTypedDictFall<CURSOR>",
+        )
+        .module_names()
+        .imports()
+        .filter(|completion| completion.name == "TypedDictFallback");
+        assert_snapshot!(
+            builder.build().snapshot(),
+            @"TypedDictFallback :: _typeshed._type_checker_internals :: from _typeshed._type_checker_internals import TypedDictFallback",
+        );
+    }
+
+    #[test]
     fn typing_extensions_included_from_import() {
         let builder = CursorTest::builder()
             .source("typing_extensions.py", "deprecated = 1")

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -626,6 +626,20 @@ mod tests {
     }
 
     #[test]
+    fn ty_extensions_vendored() {
+        let TestCase { db, .. } = TestCaseBuilder::new().with_vendored_typeshed().build();
+
+        insta::assert_debug_snapshot!(
+            list_snapshot_filter(&db, |module| module.name(&db).as_str() == "ty_extensions"),
+            @r#"
+        [
+            Module::File("ty_extensions", "std-vendored", "stdlib/ty_extensions/__init__.pyi", Package, Some(TyExtensions)),
+        ]
+        "#,
+        );
+    }
+
+    #[test]
     fn builtins_custom() {
         const TYPESHED: MockedTypeshed = MockedTypeshed {
             stdlib_files: &[("builtins.pyi", "def min(a, b): ...")],

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -109,6 +109,19 @@ impl<'db> Module<'db> {
         }
     }
 
+    /// Returns whether this module resolves to a bundled typing-only stub.
+    ///
+    /// A project or installed module with the same name may still exist on a
+    /// lower-priority search path and be available at runtime.
+    pub fn is_type_check_only(self, db: &'db dyn Database) -> bool {
+        self.search_path(db)
+            .is_some_and(SearchPath::is_standard_library)
+            && matches!(
+                self.name(db).first_component(),
+                "_typeshed" | "typing_extensions" | "ty_extensions"
+            )
+    }
+
     /// Determine whether this module is a single-file module or a package
     pub fn kind(self, db: &'db dyn Database) -> ModuleKind {
         match self {

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -159,8 +159,10 @@ impl<'db> SemanticModel<'db> {
         list_modules(self.db, resolver_environment)
             .iter()
             .copied()
-            .filter(|module| {
-                is_typing_extensions_available || module.name(self.db) != &typing_extensions
+            .filter(|module| match module.known(self.db) {
+                Some(KnownModule::Typeshed | KnownModule::TyExtensions) => false,
+                Some(KnownModule::TypingExtensions) => is_typing_extensions_available,
+                _ => true,
             })
             .map(|module| {
                 let builtin = module.is_known(self.db, KnownModule::Builtins);

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -12,7 +12,6 @@ use ruff_text_size::Ranged;
 use rustc_hash::FxHashMap;
 use ty_module_resolver::{
     ImportingFile, KnownModule, Module, ModuleName, list_modules, resolve_module,
-    resolve_real_shadowable_module,
 };
 
 use crate::Db;
@@ -146,24 +145,10 @@ impl<'db> SemanticModel<'db> {
 
     /// Returns completions for symbols available in a `import <CURSOR>` context.
     pub fn import_completions(&self) -> Vec<Completion<'db>> {
-        let typing_extensions = ModuleName::new_static("typing_extensions").unwrap();
-        let file = self.file();
         let resolver_environment = self.program_environment().resolver_environment(self.db);
-        let is_typing_extensions_available = file.is_stub(self.db)
-            || resolve_real_shadowable_module(
-                self.db,
-                ImportingFile::File(file, resolver_environment),
-                &typing_extensions,
-            )
-            .is_some();
         list_modules(self.db, resolver_environment)
             .iter()
             .copied()
-            .filter(|module| match module.known(self.db) {
-                Some(KnownModule::Typeshed | KnownModule::TyExtensions) => false,
-                Some(KnownModule::TypingExtensions) => is_typing_extensions_available,
-                _ => true,
-            })
             .map(|module| {
                 let builtin = module.is_known(self.db, KnownModule::Builtins);
                 let ty = Type::module_literal(self.db, self.program_file(), module);

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -273,6 +273,32 @@ is_typedd
           "title": "Trigger parameter hints",
           "command": "ty.triggerParameterHints"
         }
+      },
+      {
+        "label": "is_typeddict (import typing_extensions)",
+        "kind": 3,
+        "sortText": "1",
+        "insertText": "is_typeddict($0)",
+        "insertTextFormat": 2,
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import is_typeddict\n"
+          }
+        ],
+        "command": {
+          "title": "Trigger parameter hints",
+          "command": "ty.triggerParameterHints"
+        }
       }
     ]
     "#);
@@ -320,9 +346,72 @@ TypedDi<CURSOR>
         "insertText": "typing.is_typeddict"
       },
       {
+        "label": "TypedDict (import typing_extensions)",
+        "kind": 6,
+        "sortText": "2",
+        "insertText": "TypedDict",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import TypedDict\n"
+          }
+        ]
+      },
+      {
+        "label": "TypedDictFallback (import _typeshed._type_checker_internals)",
+        "kind": 7,
+        "sortText": "3",
+        "insertText": "TypedDictFallback",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from _typeshed._type_checker_internals import TypedDictFallback\n"
+          }
+        ]
+      },
+      {
+        "label": "is_typeddict (import typing_extensions)",
+        "kind": 3,
+        "sortText": "4",
+        "insertText": "is_typeddict",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import is_typeddict\n"
+          }
+        ]
+      },
+      {
         "label": "_FilterConfigurationTypedDict (import logging.config)",
         "kind": 7,
-        "sortText": "2",
+        "sortText": "5",
         "insertText": "_FilterConfigurationTypedDict",
         "additionalTextEdits": [
           {
@@ -343,7 +432,7 @@ TypedDi<CURSOR>
       {
         "label": "_FormatterConfigurationTypedDict (import logging.config)",
         "kind": 6,
-        "sortText": "3",
+        "sortText": "6",
         "insertText": "_FormatterConfigurationTypedDict",
         "additionalTextEdits": [
           {
@@ -358,6 +447,27 @@ TypedDi<CURSOR>
               }
             },
             "newText": "from logging.config import _FormatterConfigurationTypedDict\n"
+          }
+        ]
+      },
+      {
+        "label": "_typeshed.dbapi (import _typeshed.dbapi)",
+        "kind": 9,
+        "sortText": "7",
+        "insertText": "_typeshed.dbapi",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "import _typeshed.dbapi\n"
           }
         ]
       }
@@ -434,9 +544,72 @@ TypedDi<CURSOR>
         ]
       },
       {
+        "label": "TypedDict (import typing_extensions)",
+        "kind": 6,
+        "sortText": "2",
+        "insertText": "TypedDict",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import TypedDict\n"
+          }
+        ]
+      },
+      {
+        "label": "TypedDictFallback (import _typeshed._type_checker_internals)",
+        "kind": 7,
+        "sortText": "3",
+        "insertText": "TypedDictFallback",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from _typeshed._type_checker_internals import TypedDictFallback\n"
+          }
+        ]
+      },
+      {
+        "label": "is_typeddict (import typing_extensions)",
+        "kind": 3,
+        "sortText": "4",
+        "insertText": "is_typeddict",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import is_typeddict\n"
+          }
+        ]
+      },
+      {
         "label": "_FilterConfigurationTypedDict (import logging.config)",
         "kind": 7,
-        "sortText": "2",
+        "sortText": "5",
         "insertText": "_FilterConfigurationTypedDict",
         "additionalTextEdits": [
           {
@@ -457,7 +630,7 @@ TypedDi<CURSOR>
       {
         "label": "_FormatterConfigurationTypedDict (import logging.config)",
         "kind": 6,
-        "sortText": "3",
+        "sortText": "6",
         "insertText": "_FormatterConfigurationTypedDict",
         "additionalTextEdits": [
           {
@@ -472,6 +645,27 @@ TypedDi<CURSOR>
               }
             },
             "newText": "from logging.config import _FormatterConfigurationTypedDict\n"
+          }
+        ]
+      },
+      {
+        "label": "_typeshed.dbapi (import _typeshed.dbapi)",
+        "kind": 9,
+        "sortText": "7",
+        "insertText": "_typeshed.dbapi",
+        "additionalTextEdits": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "import _typeshed.dbapi\n"
           }
         ]
       }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_existing_import_undefined_decorator.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_existing_import_undefined_decorator.snap
@@ -49,6 +49,51 @@ expression: code_actions
     }
   },
   {
+    "title": "import typing_extensions.deprecated",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 1
+          },
+          "end": {
+            "line": 3,
+            "character": 11
+          }
+        },
+        "severity": 1,
+        "code": "unresolved-reference",
+        "codeDescription": {
+          "href": "https://ty.dev/rules#unresolved-reference"
+        },
+        "source": "ty",
+        "message": "Name `deprecated` used when not defined"
+      }
+    ],
+    "isPreferred": true,
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/src/foo.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import deprecated\n"
+          }
+        ]
+      }
+    }
+  },
+  {
     "title": "qualify warnings.deprecated",
     "kind": "quickfix",
     "diagnostics": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_decorator.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_decorator.snap
@@ -49,6 +49,51 @@ expression: code_actions
     }
   },
   {
+    "title": "import typing_extensions.deprecated",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 1
+          },
+          "end": {
+            "line": 1,
+            "character": 11
+          }
+        },
+        "severity": 1,
+        "code": "unresolved-reference",
+        "codeDescription": {
+          "href": "https://ty.dev/rules#unresolved-reference"
+        },
+        "source": "ty",
+        "message": "Name `deprecated` used when not defined"
+      }
+    ],
+    "isPreferred": true,
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/src/foo.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import deprecated\n"
+          }
+        ]
+      }
+    }
+  },
+  {
     "title": "Ignore 'unresolved-reference' for this line",
     "kind": "quickfix",
     "diagnostics": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_reference_multi.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_reference_multi.snap
@@ -49,6 +49,51 @@ expression: code_actions
     }
   },
   {
+    "title": "import typing_extensions.Literal",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 3
+          },
+          "end": {
+            "line": 0,
+            "character": 10
+          }
+        },
+        "severity": 1,
+        "code": "unresolved-reference",
+        "codeDescription": {
+          "href": "https://ty.dev/rules#unresolved-reference"
+        },
+        "source": "ty",
+        "message": "Name `Literal` used when not defined"
+      }
+    ],
+    "isPreferred": true,
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/src/foo.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import Literal\n"
+          }
+        ]
+      }
+    }
+  },
+  {
     "title": "Ignore 'unresolved-reference' for this line",
     "kind": "quickfix",
     "diagnostics": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_with_full_diagnostic_output_link.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_with_full_diagnostic_output_link.snap
@@ -49,6 +49,51 @@ expression: code_actions
     }
   },
   {
+    "title": "import typing_extensions.Literal",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 3
+          },
+          "end": {
+            "line": 0,
+            "character": 10
+          }
+        },
+        "severity": 1,
+        "code": "Click for full diagnostic",
+        "codeDescription": {
+          "href": "https://ty.dev/rules#unresolved-reference"
+        },
+        "source": "ty",
+        "message": "Name `Literal` used when not defined"
+      }
+    ],
+    "isPreferred": true,
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/src/foo.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing_extensions import Literal\n"
+          }
+        ]
+      }
+    }
+  },
+  {
     "title": "Ignore 'unresolved-reference' for this line",
     "kind": "quickfix",
     "diagnostics": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import.snap
@@ -44,5 +44,47 @@ expression: completions
         "newText": "from typing import LiteralString\n"
       }
     ]
+  },
+  {
+    "label": "Literal (import typing_extensions)",
+    "kind": 6,
+    "sortText": "[RANKING]",
+    "insertText": "Literal",
+    "additionalTextEdits": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 0
+          },
+          "end": {
+            "line": 1,
+            "character": 0
+          }
+        },
+        "newText": "from typing_extensions import Literal\n"
+      }
+    ]
+  },
+  {
+    "label": "LiteralString (import typing_extensions)",
+    "kind": 6,
+    "sortText": "[RANKING]",
+    "insertText": "LiteralString",
+    "additionalTextEdits": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 0
+          },
+          "end": {
+            "line": 1,
+            "character": 0
+          }
+        },
+        "newText": "from typing_extensions import LiteralString\n"
+      }
+    ]
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_docstring.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_docstring.snap
@@ -44,5 +44,47 @@ expression: completions
         "newText": "from typing import LiteralString\n"
       }
     ]
+  },
+  {
+    "label": "Literal (import typing_extensions)",
+    "kind": 6,
+    "sortText": "[RANKING]",
+    "insertText": "Literal",
+    "additionalTextEdits": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 0
+          },
+          "end": {
+            "line": 1,
+            "character": 0
+          }
+        },
+        "newText": "from typing_extensions import Literal\n"
+      }
+    ]
+  },
+  {
+    "label": "LiteralString (import typing_extensions)",
+    "kind": 6,
+    "sortText": "[RANKING]",
+    "insertText": "LiteralString",
+    "additionalTextEdits": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 0
+          },
+          "end": {
+            "line": 1,
+            "character": 0
+          }
+        },
+        "newText": "from typing_extensions import LiteralString\n"
+      }
+    ]
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_from_future.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_from_future.snap
@@ -44,5 +44,47 @@ expression: completions
         "newText": "from typing import LiteralString\n"
       }
     ]
+  },
+  {
+    "label": "Literal (import typing_extensions)",
+    "kind": 6,
+    "sortText": "[RANKING]",
+    "insertText": "Literal",
+    "additionalTextEdits": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 0
+          },
+          "end": {
+            "line": 1,
+            "character": 0
+          }
+        },
+        "newText": "from typing_extensions import Literal\n"
+      }
+    ]
+  },
+  {
+    "label": "LiteralString (import typing_extensions)",
+    "kind": 6,
+    "sortText": "[RANKING]",
+    "insertText": "LiteralString",
+    "additionalTextEdits": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 0
+          },
+          "end": {
+            "line": 1,
+            "character": 0
+          }
+        },
+        "newText": "from typing_extensions import LiteralString\n"
+      }
+    ]
   }
 ]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_same_cell.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__notebook__auto_import_same_cell.snap
@@ -44,5 +44,47 @@ expression: completions
         "newText": ", LiteralString"
       }
     ]
+  },
+  {
+    "label": "Literal (import typing_extensions)",
+    "kind": 6,
+    "sortText": "[RANKING]",
+    "insertText": "Literal",
+    "additionalTextEdits": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "from typing_extensions import Literal\n"
+      }
+    ]
+  },
+  {
+    "label": "LiteralString (import typing_extensions)",
+    "kind": 6,
+    "sortText": "[RANKING]",
+    "insertText": "LiteralString",
+    "additionalTextEdits": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "from typing_extensions import LiteralString\n"
+      }
+    ]
   }
 ]

--- a/crates/ty_vendored/build.rs
+++ b/crates/ty_vendored/build.rs
@@ -84,6 +84,7 @@ fn write_zipped_typeshed_to(writer: File) -> ZipResult<File> {
     }
 
     // Patch typeshed and add the stubs for the `ty_extensions` package.
+    zip.add_directory("stdlib/ty_extensions/", options)?;
     for (source, destination) in TY_EXTENSIONS_STUBS {
         println!("adding file {source} as {destination} ...");
         zip.start_file(destination, options)?;


### PR DESCRIPTION
## Summary

We generally exclude `ty_extensions`, `_typeshed` and `typing_extensions` from auto-import completion suggestions in `.py` files, on the grounds that these modules aren't available at runtime. But this can be quite annoying in situations where you're playing around with ty in the playground or a scratch file locally in order to test how inference works.

This PR changes things so that we always include auto-import suggestions from these stub-only modules, but we downrank these suggestions relative to symbols that are available at runtime. In `.pyi` files, we do not apply this ranking penalty. In the future, we'll update this to also take account of whether the user's cursor is in an `if TYPE_CHECKING` region

## Test plan

Added completion-evaluation coverage for both source and stub files, as well as some unit tests