### PR TITLE
Add pywin32 to Ruff ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -60,6 +60,7 @@ DEFAULT_TARGETS = [
     Project(repo=Repository(owner="langchain-ai", name="langchain", ref="master")),
     Project(repo=Repository(owner="latchbio", name="latch", ref="main")),
     Project(repo=Repository(owner="lnbits", name="lnbits", ref="main")),
+    Project(repo=Repository(owner="mhammond", name="pywin32", ref="main")),
     Project(repo=Repository(owner="milvus-io", name="pymilvus", ref="master")),
     Project(repo=Repository(owner="mlflow", name="mlflow", ref="master")),
     Project(repo=Repository(owner="model-bakers", name="model_bakery", ref="main")),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

As a pywin32 maintainer and Ruff user, I'd like to add pywin32 to the ecosystem checks.

I think that pywin32 would be a good fit given its age, size, popularity, and importance to the Python on Windows ecosystem. As well as my efforts in the past 3 years modernizing its Python codebase.

Most of the Ruff issues / requests I opened have come from using it in setuptools and pywin32.

## Test Plan

N/A ?
