### PR TITLE
[ty] Fix unused hints for OR-pattern captures

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4935,6 +4935,33 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
     }
 
     fn visit_pattern(&mut self, pattern: &'ast ast::Pattern) {
+        if let ast::Pattern::MatchOr(ast::PatternMatchOr { patterns, .. }) = pattern
+            && let Some((first, alternatives)) = patterns.split_first()
+        {
+            let incoming = self.flow_snapshot();
+            let first_definition = self.current_use_def_map().next_definition_id();
+            self.visit_pattern(first);
+
+            // Valid alternatives bind the same names, so capture-free patterns need no flow merge.
+            if self.current_use_def_map().next_definition_id() == first_definition {
+                for alternative in alternatives {
+                    self.visit_pattern(alternative);
+                }
+                return;
+            }
+
+            // Each alternative starts with the same bindings. Otherwise a repeated capture in a
+            // later alternative shadows the earlier capture even though only one pattern matches.
+            let mut merged_alternatives = self.flow_snapshot();
+            for alternative in alternatives {
+                self.flow_restore(incoming.clone());
+                self.visit_pattern(alternative);
+                self.flow_merge(merged_alternatives);
+                merged_alternatives = self.flow_snapshot();
+            }
+            return;
+        }
+
         if let ast::Pattern::MatchStar(ast::PatternMatchStar {
             name: Some(name),
             range: _,

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -322,6 +322,57 @@ mod tests {
     }
 
     #[test]
+    fn or_pattern_captures_used_in_body_are_not_reported() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def f(subject):
+                match subject:
+                    case [first, second] | {\"first\": first, \"second\": second} | (first, second):
+                        print(first, second)
+            ",
+        );
+
+        assert!(collect_unused_names(&source)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn nested_or_pattern_capture_used_in_guard_is_not_reported() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def f(subject):
+                match subject:
+                    case [[value] | {\"item\": value}] if value:
+                        pass
+            ",
+        );
+
+        assert!(collect_unused_names(&source)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn or_pattern_captures_do_not_hide_other_unused_bindings() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def f(subject):
+                value = 0
+                match subject:
+                    case [value] | {\"used\": value}:
+                        print(value)
+                    case {\"unused\": value} | {\"also_unused\": value}:
+                        pass
+            ",
+        );
+
+        assert_eq!(
+            collect_unused_names(&source)?,
+            vec!["value", "value", "value"]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn skips_module_and_class_scope_bindings() -> anyhow::Result<()> {
         let source = dedent(
             "


### PR DESCRIPTION
## Summary

OR-pattern alternatives can bind the same names but "execute" mutually exclusively. The semantic index previously visited alternatives as consecutive assignments, so later captures shadowed earlier captures and caused the language server to incorrectly report those earlier bindings as unused.

Visit each capture-bearing alternative from the same incoming flow state and merge the resulting bindings. Preserve the existing fast path for OR patterns that do not bind names.

Closes astral-sh/ty#4163.

## Test plan

- Used captures across multiple OR-pattern alternatives and captured names.
- Nested OR-pattern captures referenced only by a match guard.
- Genuinely unused alternative captures, earlier shadowed assignments, and captures in separate match cases.