### PR TITLE
[ty] Infer generic TypedDicts from unpacked TypedDicts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3645,6 +3645,55 @@ reveal_type(Pair(**{"first": 1, "second": "x"}))  # revealed: Pair[Unknown]
 reveal_type(Pair(**{"first": 1}, **{"second": "x"}))  # revealed: Pair[Unknown]
 ```
 
+### Constructor inference from unpacked TypedDicts
+
+Unpacking a `TypedDict` with required keys contributes each field's type to constructor inference.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import NotRequired, TypedDict
+
+class Source(TypedDict):
+    value: int
+
+class Box[T](TypedDict):
+    value: T
+
+def unpack(source: Source):
+    reveal_type(Box(**source))  # revealed: Box[int]
+```
+
+Different unpacked `TypedDict` arguments retain their separate field types.
+
+```py
+class First(TypedDict):
+    first: int
+
+class Second(TypedDict):
+    second: str
+
+class Pair[T](TypedDict):
+    first: T
+    second: str
+
+def unpack_multiple(first: First, second: Second):
+    reveal_type(Pair(**first, **second))  # revealed: Pair[int]
+```
+
+An optional source key does not satisfy a required constructor field.
+
+```py
+class MaybeSource(TypedDict):
+    value: NotRequired[int]
+
+def unpack_optional(source: MaybeSource):
+    Box(**source)  # error: [missing-typed-dict-key]
+```
+
 ### Constructor inference from recursive fields
 
 Recursive construction remains valid even though the outer constructor cannot yet infer its type

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3667,6 +3667,15 @@ def unpack(source: Source):
     reveal_type(Box(**source))  # revealed: Box[int]
 ```
 
+A type alias to a single `TypedDict` contributes the same field information.
+
+```py
+type SourceAlias = Source
+
+def unpack_alias(source: SourceAlias):
+    reveal_type(Box(**source))  # revealed: Box[int]
+```
+
 Different unpacked `TypedDict` arguments retain their separate field types.
 
 ```py
@@ -3692,6 +3701,35 @@ class MaybeSource(TypedDict):
 
 def unpack_optional(source: MaybeSource):
     Box(**source)  # error: [missing-typed-dict-key]
+```
+
+### Constructor inference from unpacked TypedDict unions
+
+A union can associate different value types with different callbacks. Inference remains gradual
+because combining those fields independently would reject a valid constructor call.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, TypedDict
+
+class IntSource(TypedDict):
+    value: int
+    callback: Callable[[int], None]
+
+class StrSource(TypedDict):
+    value: str
+    callback: Callable[[str], None]
+
+class Box[T](TypedDict):
+    value: T
+    callback: Callable[[T], None]
+
+def unpack(source: IntSource | StrSource):
+    reveal_type(Box(**source))  # revealed: Box[Unknown]
 ```
 
 ### Constructor inference from recursive fields

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -15,9 +15,8 @@ use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
     TypedDictOpenness, TypedDictSchema, collect_guaranteed_keyword_keys,
-    extract_unpacked_typed_dict_from_value_type, functional_typed_dict_field,
-    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
-    validate_typed_dict_dict_literal,
+    functional_typed_dict_field, infer_unpacked_keyword_types, typed_dict_with_relaxed_keys,
+    validate_typed_dict_constructor, validate_typed_dict_dict_literal,
 };
 use crate::types::{
     ClassType, IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictModule,
@@ -593,10 +592,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
 
                 self.try_expression_type(&keyword.value)
-                    .and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, env, ty))
+                    .and_then(|ty| ty.resolve_type_alias(db).as_typed_dict())
                     .is_some_and(|unpacked| {
-                        unpacked.keys.iter().all(|(name, field)| {
-                            field.is_required && permits_field_inference(name.as_str())
+                        unpacked.items(db).iter().all(|(name, field)| {
+                            field.is_required() && permits_field_inference(name.as_str())
                         })
                     })
             })

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -15,8 +15,9 @@ use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
     TypedDictOpenness, TypedDictSchema, collect_guaranteed_keyword_keys,
-    functional_typed_dict_field, infer_unpacked_keyword_types, typed_dict_with_relaxed_keys,
-    validate_typed_dict_constructor, validate_typed_dict_dict_literal,
+    extract_unpacked_typed_dict_from_value_type, functional_typed_dict_field,
+    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
+    validate_typed_dict_dict_literal,
 };
 use crate::types::{
     ClassType, IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictModule,
@@ -449,6 +450,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             callable_type,
             Type::ClassLiteral(class_literal) if class_literal.generic_context(db).is_some()
         );
+        if is_generic && arguments.args.is_empty() {
+            for keyword in &arguments.keywords {
+                if keyword.arg.is_none() && !keyword.value.is_dict_expr() {
+                    self.get_or_infer_expression(&keyword.value, TypeContext::default());
+                }
+            }
+        }
         let can_infer = is_generic
             && self.can_infer_generic_typed_dict_constructor(class, arguments, call_expression_tcx);
 
@@ -569,17 +577,28 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         arguments.args.is_empty()
             && !has_gradual_class_context
             && arguments.keywords.iter().all(|keyword| {
-                let Some(name) = keyword.arg.as_ref() else {
-                    return false;
+                let permits_field_inference = |name: &str| {
+                    typed_dict.item(db, name).is_none_or(|field| {
+                        !contains_generic_typed_dict(
+                            db,
+                            env,
+                            field.declared_ty,
+                            &ActiveRecursionDetector::default(),
+                        )
+                    })
                 };
-                typed_dict.item(db, name.id.as_str()).is_none_or(|field| {
-                    !contains_generic_typed_dict(
-                        db,
-                        env,
-                        field.declared_ty,
-                        &ActiveRecursionDetector::default(),
-                    )
-                })
+
+                if let Some(name) = keyword.arg.as_ref() {
+                    return permits_field_inference(name.id.as_str());
+                }
+
+                self.try_expression_type(&keyword.value)
+                    .and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, env, ty))
+                    .is_some_and(|unpacked| {
+                        unpacked.keys.iter().all(|(name, field)| {
+                            field.is_required && permits_field_inference(name.as_str())
+                        })
+                    })
             })
     }
 


### PR DESCRIPTION
## Summary

We now allow unpacked `TypedDict` values to contribute their field types when constructing a generic `TypedDict`:

```py
from typing import TypedDict

class Source(TypedDict):
    value: int

class Box[T](TypedDict):
    value: T

def f(source: Source) -> None:
    reveal_type(Box(**source))  # Box[int]
```

This reuses the generic constructor introduced in #27436 and preserves the individual field types of each unpacked `TypedDict`, including calls with multiple unpacked sources.
