### PR TITLE
[ty] Preserve class type parameters through generic decorators

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -143,6 +143,45 @@ class C2:
 C2().method_decorated(1)
 ```
 
+A generic decorator must preserve a type variable bound by the method's enclosing class, even when
+the decorator uses an ellipsis instead of a `ParamSpec`:
+
+```py
+def preserve_return[R](function: Callable[..., R]) -> Callable[..., R]:
+    return function
+
+class DecoratedBox[T]:
+    @preserve_return
+    def value(self) -> T:
+        raise NotImplementedError
+
+    @preserve_return
+    def values(self) -> list[T]:
+        raise NotImplementedError
+
+reveal_type(DecoratedBox[int]().value())  # revealed: int
+reveal_type(DecoratedBox[int]().values())  # revealed: list[int]
+```
+
+The same behavior applies to decorators and classes using legacy type variables:
+
+```py
+from typing import Generic, TypeVar
+
+LegacyT = TypeVar("LegacyT")
+LegacyR = TypeVar("LegacyR")
+
+def legacy_preserve_return(function: Callable[..., LegacyR]) -> Callable[..., LegacyR]:
+    return function
+
+class LegacyDecoratedBox(Generic[LegacyT]):
+    @legacy_preserve_return
+    def value(self) -> LegacyT:
+        raise NotImplementedError
+
+reveal_type(LegacyDecoratedBox[int]().value())  # revealed: int
+```
+
 And if the callable-typed decorator leaves some generic parameters unconstrained, we should keep
 those parameters unspecialized rather than collapsing them to `Never`:
 

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -179,6 +179,30 @@ class Foo:
 reveal_type(Foo().foo)  # revealed: str
 ```
 
+### `functools.cached_property` on a generic class
+
+A cached property must preserve the type variable bound by its enclosing generic class, including
+when the return type is a union:
+
+```py
+from functools import cached_property
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+    @cached_property
+    def value(self) -> T:
+        raise NotImplementedError
+
+    @cached_property
+    def values(self) -> list[T] | None:
+        raise NotImplementedError
+
+reveal_type(Box[int]().value)  # revealed: int
+reveal_type(Box[int]().values)  # revealed: list[int] | None
+```
+
 ## Lambdas as decorators
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -740,6 +740,35 @@ reveal_type(invoke(head_invariant, Invariant[int]()))
 reveal_type(invoke(lift_invariant, 1))
 ```
 
+## Passing unbound generic methods to generic functions
+
+An unbound method of a generic class can be passed to a generic higher-order function. The class
+type parameter must still be inferred from the concrete receiver expected by that function.
+
+```py
+from __future__ import annotations
+
+from collections.abc import Callable
+
+class Box[T]:
+    def merge(self, other: Box[T]) -> Box[T]:
+        return self
+
+def fold[T](function: Callable[[T, T], T], values: list[T]) -> T:
+    return values[0]
+
+def merge_boxes(values: list[Box[str]]) -> Box[str]:
+    return fold(Box.merge, values)
+```
+
+The same applies to the standard-library `set.union` method passed to `functools.reduce`.
+
+```py
+from functools import reduce
+
+reveal_type(reduce(set.union, [set[str]()]))  # revealed: set[str]
+```
+
 ## Protocols as TypeVar bounds
 
 Protocol types can be used as TypeVar bounds, just like nominal types.

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2756,9 +2756,8 @@ has_name: HasCachedName = WithCachedName()
 
 ### Generic descriptor result types
 
-Applying a generic descriptor decorator to a generic protocol method currently loses the protocol's
-type variable and produces `cached_property[Unknown]`. The protocol must preserve that descriptor
-type instead of reducing it to a bare `Unknown`, which would allow an incompatible implementation.
+Applying a generic descriptor decorator to a generic protocol method must preserve the protocol's
+type variable and expose the specialized descriptor's readable and writable member types.
 
 ```py
 from functools import cached_property
@@ -2779,9 +2778,7 @@ class StrValue:
 
 static_assert(not is_assignable_to(StrValue, HasValue[int]))
 
-# TODO: This should be a property with an `int` read type once decorator calls preserve enclosing
-# type variables.
-# revealed: {"value": AttributeMember(`cached_property[Unknown]`)}
+# revealed: {"value": PropertyMember { read: `int`, write: `int` }}
 reveal_protocol_interface(HasValue[int])
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1400,7 +1400,13 @@ the generic callable.)
 ```py
 from typing import Callable, Self
 from ty_extensions import static_assert
-from ty_extensions._internal import RegularCallableTypeOf, TypeOf, is_assignable_to
+from ty_extensions._internal import (
+    ConstraintSet,
+    RegularCallableTypeOf,
+    TypeOf,
+    is_assignable_to,
+    is_constraint_set_assignable_to,
+)
 
 def identity[T](t: T) -> T:
     return t
@@ -1490,6 +1496,20 @@ static_assert(
         Callable[[SelfCarrier[int], str], tuple[int, str]],
     )
 )
+```
+
+A constraint-producing comparison must keep an enclosing class variable symbolic while solving the
+surrounding callable's return variable:
+
+```py
+class OuterCarrier[A_outer]:
+    def method(self) -> A_outer:
+        raise NotImplementedError
+
+    def check[R](self) -> None:
+        actual = is_constraint_set_assignable_to(RegularCallableTypeOf[OuterCarrier[A_outer].method], Callable[..., R])
+        expected = ConstraintSet.range(A_outer, R, object)
+        static_assert(actual == expected)
 ```
 
 The reverse is not true — if someone expects a generic function that can be called with any

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2292,8 +2292,25 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
 
-        let source_inferable = source.inferable_typevars(db);
-        let target_inferable = target.inferable_typevars(db);
+        // An implicit `Self` can reach type variables bound by an enclosing class. A standalone,
+        // eager comparison must infer those variables from a concrete receiver, but an outer or
+        // lazy solve must keep them symbolic. Otherwise, quantifying `T@C` out of `T@C <= R`
+        // leaves a decorator's return variable `R` unconstrained.
+        let include_bound_dependencies = self.typevar_evaluation == TypeVarEvaluation::Eager
+            && matches!(self.inferable, TypeVarSet::None);
+        let signature_typevars = |signature: &Signature<'db>| {
+            signature
+                .generic_context
+                .map_or(TypeVarSet::None, |context| {
+                    if include_bound_dependencies {
+                        context.inferable_typevars(db)
+                    } else {
+                        TypeVarSet::from_typevars(db, context.variables(db))
+                    }
+                })
+        };
+        let source_inferable = signature_typevars(source);
+        let target_inferable = signature_typevars(target);
         let signature_inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, signature_inferable);
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2292,12 +2292,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
 
-        // An implicit `Self` can reach type variables bound by an enclosing class. A standalone,
-        // eager comparison must infer those variables from a concrete receiver, but an outer or
-        // lazy solve must keep them symbolic. Otherwise, quantifying `T@C` out of `T@C <= R`
-        // leaves a decorator's return variable `R` unconstrained.
-        let include_bound_dependencies = self.typevar_evaluation == TypeVarEvaluation::Eager
-            && matches!(self.inferable, TypeVarSet::None);
+        // An implicit `Self` can reach type variables bound by an enclosing class. An eager
+        // comparison must infer those variables from a concrete receiver, even when an outer
+        // callable has its own inferable type variables. A lazy solve must keep them symbolic:
+        // quantifying `T@C` out of `T@C <= R` leaves a decorator's return variable `R`
+        // unconstrained.
+        let include_bound_dependencies = self.typevar_evaluation == TypeVarEvaluation::Eager;
         let signature_typevars = |signature: &Signature<'db>| {
             signature
                 .generic_context

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2292,11 +2292,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
 
-        // An implicit `Self` can reach type variables bound by an enclosing class. An eager
-        // comparison must infer those variables from a concrete receiver, even when an outer
-        // callable has its own inferable type variables. A lazy solve must keep them symbolic:
-        // quantifying `T@C` out of `T@C <= R` leaves a decorator's return variable `R`
-        // unconstrained.
+        // `inferable` has different roles in the two type-variable evaluation modes:
+        //
+        // * Eager comparisons decide whether the relation holds immediately. An unbound generic
+        //   method's `Self` can have an upper bound such as `C[T]`, so `T` must also be
+        //   inferable; otherwise, a concrete receiver such as `C[int]` is compared against a
+        //   fixed, symbolic `T` and valid higher-order calls are rejected.
+        // * Lazy comparisons record constraints for every type variable, regardless of whether
+        //   it is inferable. Here, `signature_inferable` also determines which type variables
+        //   `reduce_inferable` existentially removes below, so it must contain only variables
+        //   actually bound by these signatures. Including an enclosing class's `T` would turn a
+        //   decorator's return constraint `T <= R` into `exists T. T <= R`, losing the
+        //   relationship needed to infer `R = T`.
         let include_bound_dependencies = self.typevar_evaluation == TypeVarEvaluation::Eager;
         let signature_typevars = |signature: &Signature<'db>| {
             signature


### PR DESCRIPTION
## Summary

Generic method decorators and descriptor constructors could erase enclosing class type parameters when callable-signature comparison expanded implicit `Self` bounds and existentially quantified the entire inferable set. This caused decorated methods to return `Unknown` and produced false-positive diagnostics for generic `cached_property` methods.

Preserve enclosing class variables during lazy comparisons while retaining expanded inference for eager unbound-method comparisons, including inside generic higher-order calls. Generic cached-property protocol members now expose their correctly specialized readable and writable types.

Fixes astral-sh/ty#4153.
Fixes astral-sh/ty#3256.

## Test plan

- Added mdtests for PEP 695 and legacy generic method decorators, including nested `list[T]` return types.
- Added mdtests for generic `cached_property` methods with direct and union return types, and updated generic protocol descriptor specialization coverage.
- Added mdtests for generic higher-order functions receiving unbound generic methods, including `functools.reduce(set.union, ...)`.
- Added a constraint-level regression while preserving existing unbound-method assignability coverage.