### PR TITLE
[ty] Add "Go to Definition" support for pytest fixtures

### DIFF
--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -26,6 +26,7 @@ use ty_python_semantic::{Db as SemanticDb, ResolvedDefinition};
 use ty_python_semantic::{
     HasDefinition, HasType, ImportAliasResolution, ProgramEnvironment, SemanticModel,
     TypeQualifiers, definitions_for_imported_symbol, definitions_for_name,
+    fixture_bindings_for_parameter,
 };
 
 #[derive(Clone, Debug)]
@@ -344,8 +345,27 @@ impl<'db> Definitions<'db> {
         model: &SemanticModel<'db>,
         goto_target: &GotoTarget<'_>,
     ) -> Option<Definitions<'db>> {
-        let definitions = self.goto_declaration(model, goto_target)?;
-        Some(definitions.map_stubs(model.db()))
+        let mut definitions = self;
+
+        if let GotoTarget::Parameter(parameter) = goto_target {
+            let fixture_bindings =
+                fixture_bindings_for_parameter(model.db(), parameter.definition(model));
+
+            if !fixture_bindings.is_empty() {
+                definitions = Self::new(
+                    fixture_bindings
+                        .iter()
+                        .map(|binding| ResolvedDefinition::Definition(binding.fixture()))
+                        .collect(),
+                );
+            }
+        }
+
+        Some(
+            definitions
+                .goto_declaration(model, goto_target)?
+                .map_stubs(model.db()),
+        )
     }
 
     /// Map definitions from stub files to corresponding source implementations.

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -26,6 +26,7 @@ use ty_python_semantic::{Db as SemanticDb, ResolvedDefinition};
 use ty_python_semantic::{
     HasDefinition, HasType, ImportAliasResolution, ProgramEnvironment, SemanticModel,
     TypeQualifiers, definitions_for_imported_symbol, definitions_for_name,
+    fixture_bindings_for_parameter,
 };
 
 #[derive(Clone, Debug)]
@@ -344,7 +345,23 @@ impl<'db> Definitions<'db> {
         model: &SemanticModel<'db>,
         goto_target: &GotoTarget<'_>,
     ) -> Option<Definitions<'db>> {
-        let definitions = self.goto_declaration(model, goto_target)?;
+        let definitions = if let GotoTarget::Parameter(parameter) = goto_target {
+            let fixture_bindings =
+                fixture_bindings_for_parameter(model.db(), parameter.definition(model));
+            if fixture_bindings.is_empty() {
+                self
+            } else {
+                Self::new(
+                    fixture_bindings
+                        .iter()
+                        .map(|binding| ResolvedDefinition::Definition(binding.fixture()))
+                        .collect(),
+                )
+            }
+        } else {
+            self
+        };
+        let definitions = definitions.goto_declaration(model, goto_target)?;
         Some(definitions.map_stubs(model.db()))
     }
 

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -134,6 +134,82 @@ def f(items):
     }
 
     #[test]
+    fn goto_definition_uses_pytest_fixture_binding() {
+        let mut builder = CursorTest::builder().with_site_packages();
+        let test = builder
+            .site_packages(
+                "_pytest/__init__.pyi",
+                r#"
+                "#,
+            )
+            .site_packages(
+                "_pytest/fixtures.pyi",
+                r#"
+                from typing import Any, Callable
+
+                def fixture(
+                    function: Callable[..., Any] | None = ...,
+                    *,
+                    name: str | None = ...,
+                ) -> Any: ...
+                "#,
+            )
+            .site_packages(
+                "pytest/__init__.pyi",
+                r#"
+                from _pytest.fixtures import fixture as fixture
+                "#,
+            )
+            .source(
+                "test_example.py",
+                r#"
+                import pytest
+
+                @pytest.fixture(name="resource")
+                def implementation(): ...
+
+                def test_use(resource<CURSOR>): ...
+                "#,
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> src/test_example.py:7:14
+          |
+        7 | def test_use(resource): ...
+          |              ^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/test_example.py:5:5
+          |
+        5 | def implementation(): ...
+          |     --------------
+        ");
+    }
+
+    #[test]
+    fn goto_definition_parameter_declaration() {
+        let test = cursor_test(
+            r#"
+            def function(parameter<CURSOR>): ...
+            "#,
+        );
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> main.py:2:14
+          |
+        2 | def function(parameter): ...
+          |              ^^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> main.py:2:14
+          |
+        2 | def function(parameter): ...
+          |              ---------
+        ");
+    }
+
+    #[test]
     fn goto_definition_imported_comprehension_walrus() {
         let test = CursorTest::builder()
             .source("lib.py", "[(last := item) for item in [1]]\n")

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -34,7 +34,7 @@ pub fn goto_definition(
 #[cfg(test)]
 pub(super) mod test {
 
-    use crate::tests::{CursorTest, IntoDiagnostic, cursor_test};
+    use crate::tests::{CursorTest, IntoDiagnostic, SitePackagesCursorTestBuilder, cursor_test};
     use crate::{NavigationTargets, RangedValue, goto_definition};
     use insta::assert_snapshot;
     use ruff_db::diagnostic::{
@@ -130,6 +130,256 @@ def f(items):
           |
         3 |     [[(last := item) for item in items] for _ in [1]]
           |        ----
+        ");
+    }
+
+    #[test]
+    fn goto_definition_pytest_fixture_from_test_parameter() {
+        let test = pytest_cursor_test(
+            r#"
+            import pytest
+
+            @pytest.fixture
+            def resource(): ...
+
+            def test_use(resource<CURSOR>): ...
+            "#,
+        );
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> src/test_example.py:7:14
+          |
+        7 | def test_use(resource): ...
+          |              ^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/test_example.py:5:5
+          |
+        5 | def resource(): ...
+          |     --------
+        ");
+    }
+
+    #[test]
+    fn goto_definition_pytest_fixture_dependency() {
+        let test = pytest_cursor_test(
+            r#"
+            import pytest
+
+            @pytest.fixture
+            def parent(): ...
+
+            @pytest.fixture
+            def child(parent<CURSOR>): ...
+            "#,
+        );
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> src/test_example.py:8:11
+          |
+        8 | def child(parent): ...
+          |           ^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/test_example.py:5:5
+          |
+        5 | def parent(): ...
+          |     ------
+        ");
+    }
+
+    #[test]
+    fn goto_definition_prefers_pytest_class_fixture() {
+        let test = pytest_cursor_test(
+            r#"
+            import pytest
+
+            @pytest.fixture
+            def resource(): ...
+
+            class TestExample:
+                @pytest.fixture
+                def resource(self): ...
+
+                def test_use(self, resource<CURSOR>): ...
+            "#,
+        );
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+          --> src/test_example.py:11:24
+           |
+        11 |     def test_use(self, resource): ...
+           |                        ^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/test_example.py:9:9
+          |
+        9 |     def resource(self): ...
+          |         --------
+        ");
+    }
+
+    #[test]
+    fn goto_definition_pytest_fixture_with_explicit_name() {
+        let test = pytest_cursor_test(
+            r#"
+            import pytest
+
+            @pytest.fixture(name="resource")
+            def implementation(): ...
+
+            def test_use(resource<CURSOR>): ...
+            "#,
+        );
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> src/test_example.py:7:14
+          |
+        7 | def test_use(resource): ...
+          |              ^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/test_example.py:5:5
+          |
+        5 | def implementation(): ...
+          |     --------------
+        ");
+    }
+
+    #[test]
+    fn goto_definition_pytest_indirect_parameter() {
+        let test = pytest_cursor_test(
+            r#"
+            import pytest
+
+            @pytest.fixture
+            def resource(): ...
+
+            @pytest.mark.parametrize("resource", [1], indirect=True)
+            def test_use(resource<CURSOR>): ...
+            "#,
+        );
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> src/test_example.py:8:14
+          |
+        8 | def test_use(resource): ...
+          |              ^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/test_example.py:5:5
+          |
+        5 | def resource(): ...
+          |     --------
+        ");
+    }
+
+    #[test]
+    fn goto_definition_pytest_fixture_imported_exposure() {
+        let mut builder = pytest_cursor_test_builder();
+        let test = builder
+            .source(
+                "fixtures.py",
+                r#"
+                import pytest
+
+                @pytest.fixture
+                def resource(): ...
+                "#,
+            )
+            .source(
+                "test_example.py",
+                r#"
+                from fixtures import resource as imported_resource
+
+                def test_use(imported_resource<CURSOR>): ...
+                "#,
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> src/test_example.py:4:14
+          |
+        4 | def test_use(imported_resource): ...
+          |              ^^^^^^^^^^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/fixtures.py:5:5
+          |
+        5 | def resource(): ...
+          |     --------
+        ");
+    }
+
+    #[test]
+    fn goto_definition_pytest_fixture_from_nearest_conftest() {
+        let mut builder = pytest_cursor_test_builder();
+        let test = builder
+            .source(
+                "conftest.py",
+                r#"
+                import pytest
+
+                @pytest.fixture
+                def resource(): ...
+                "#,
+            )
+            .source(
+                "package/conftest.py",
+                r#"
+                import pytest
+
+                @pytest.fixture
+                def resource(): ...
+                "#,
+            )
+            .source(
+                "package/tests/test_example.py",
+                r#"
+                def test_use(resource<CURSOR>): ...
+                "#,
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> src/package/tests/test_example.py:2:14
+          |
+        2 | def test_use(resource): ...
+          |              ^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/package/conftest.py:5:5
+          |
+        5 | def resource(): ...
+          |     --------
+        ");
+    }
+
+    #[test]
+    fn goto_definition_pytest_direct_parameter_falls_back() {
+        let test = pytest_cursor_test(
+            r#"
+            import pytest
+
+            @pytest.fixture
+            def resource(): ...
+
+            @pytest.mark.parametrize("resource", [1])
+            def test_use(resource<CURSOR>): ...
+            "#,
+        );
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> src/test_example.py:8:14
+          |
+        8 | def test_use(resource): ...
+          |              ^^^^^^^^ Clicking here
+        info: Found 1 definition
+         --> src/test_example.py:8:14
+          |
+        8 | def test_use(resource): ...
+          |              --------
         ");
     }
 
@@ -2747,5 +2997,44 @@ class GenericFoo[T](Base):
                 GotoAction::Implementation => "implementation",
             }
         }
+    }
+
+    fn pytest_cursor_test(source: &str) -> CursorTest {
+        pytest_cursor_test_builder()
+            .source("test_example.py", source)
+            .build()
+    }
+
+    fn pytest_cursor_test_builder() -> SitePackagesCursorTestBuilder {
+        let mut builder = CursorTest::builder().with_site_packages();
+        builder
+            .site_packages("_pytest/__init__.pyi", "")
+            .site_packages(
+                "_pytest/fixtures.pyi",
+                r#"
+                from typing import Any, Callable
+
+                def fixture(
+                    function: Callable[..., Any] | None = ...,
+                    *,
+                    name: str | None = ...,
+                ) -> Any: ...
+                "#,
+            )
+            .site_packages(
+                "pytest/__init__.pyi",
+                r#"
+                from _pytest.fixtures import fixture as fixture
+
+                class MarkDecorator:
+                    def __call__(self, *args: object, **kwargs: object) -> object: ...
+
+                class MarkGenerator:
+                    parametrize: MarkDecorator
+
+                mark: MarkGenerator
+                "#,
+            );
+        builder
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This adds "Go to Definition" support for pytest fixture request parameters in tests and fixture functions. It resolves user-authored fixtures exposed through modules, imports and reexports, class hierarchies, and applicable `conftest.py` files, together with fixtures registered by pytest's installed core plugins.

For example, given:

```python
# src/test_example.py
import pytest

@pytest.fixture(name="resource")
def implementation(): ...

def test_use(resource): ...
```

"Go to Definition" on the `resource` parameter selects the underlying `implementation` function, even though the public fixture name differs from the function name:

```text
info[goto-definition]: Go to definition
 --> src/test_example.py:7:14
  |
7 | def test_use(resource): ...
  |              ^^^^^^^^ Clicking here
info: Found 1 definition
 --> src/test_example.py:5:5
  |
5 | def implementation(): ...
  |     --------------
```

This initial delivery has the following limitations:

- Fixtures exposed only through third-party plugin registration—such as `pytest_plugins` or installed `pytest11` entry points—are not discovered. Explicitly imported fixtures are supported.
- Fixture dependencies requested by another fixture are resolved from the declaring fixture's lexical context. pytest instead resolves them according to the test that activates the fixture, so navigation can differ from runtime:

  ```python
  import pytest

  @pytest.fixture
  def dependency(): ...

  @pytest.fixture
  def consumer(dependency): ...  # Go to Definition selects the module fixture.

  class TestOverride:
      @pytest.fixture
      def dependency(self): ...

      def test_consumer(self, consumer): ...
      # At runtime, consumer receives TestOverride.dependency.
  ```

- Fixture discovery and request classification cover common static pytest patterns, but not all custom collection, configuration, or decorator patterns.
- The special `request` fixture has no source declaration, so it has no fixture navigation target.

This PR changes only "Go to Definition". Fixture-aware "Go to Declaration", references, rename, hover, document highlights, type inference, completion, and inlay hints remain unchanged here.

/xref https://github.com/astral-sh/ty/issues/4115

## Test Plan

See included tests. Please note that most behaviours are tested directly within `ty_python_semantic`, so all that's necessary at this layer are simple integration tests.

<!-- How was it tested? -->
