### PR TITLE
[ty] Preserve return constraints for top callables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1060,6 +1060,51 @@ reveal_type(call(callback))  # revealed: int
 reveal_type(bounded(callback))  # revealed: int
 ```
 
+### Return type inference from top callables
+
+Top callable parameters accept any parameter list but must preserve return-type constraints.
+
+```py
+from collections.abc import Callable
+from ty_extensions import Top
+
+def accept_top[T](callback: Top[Callable[..., T]]) -> T:
+    raise NotImplementedError
+
+def accept_bounded[T: int](callback: Top[Callable[..., T]]) -> T:
+    raise NotImplementedError
+
+def accept_int(callback: Top[Callable[..., int]]) -> None: ...
+def ordinary() -> int:
+    return 1
+
+def positional(value: str) -> str:
+    return value
+
+def keyword_only(*, value: bool) -> bool:
+    return value
+
+def object_variadic(*args: object, **kwargs: object) -> tuple[int, str]:
+    return 1, "example"
+
+class Example:
+    def method(self) -> bytes:
+        return b"example"
+
+class Constructed: ...
+
+reveal_type(accept_top(ordinary))  # revealed: int
+reveal_type(accept_top(positional))  # revealed: str
+reveal_type(accept_top(keyword_only))  # revealed: bool
+reveal_type(accept_top(object_variadic))  # revealed: tuple[int, str]
+reveal_type(accept_top(Example().method))  # revealed: bytes
+reveal_type(accept_top(Constructed))  # revealed: Constructed
+reveal_type(accept_bounded(ordinary))  # revealed: int
+
+accept_int(ordinary)
+accept_int(positional)  # error: [invalid-argument-type]
+```
+
 ### Gradual callable parameters with a required prefix
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1062,7 +1062,7 @@ reveal_type(bounded(callback))  # revealed: int
 
 ### Return type inference from top callables
 
-Top callable parameters accept any parameter list but must preserve return-type constraints.
+Top callable parameters must preserve return-type constraints.
 
 ```py
 from collections.abc import Callable
@@ -1071,38 +1071,10 @@ from ty_extensions import Top
 def accept_top[T](callback: Top[Callable[..., T]]) -> T:
     raise NotImplementedError
 
-def accept_bounded[T: int](callback: Top[Callable[..., T]]) -> T:
-    raise NotImplementedError
-
-def accept_int(callback: Top[Callable[..., int]]) -> None: ...
 def ordinary() -> int:
     return 1
 
-def positional(value: str) -> str:
-    return value
-
-def keyword_only(*, value: bool) -> bool:
-    return value
-
-def object_variadic(*args: object, **kwargs: object) -> tuple[int, str]:
-    return 1, "example"
-
-class Example:
-    def method(self) -> bytes:
-        return b"example"
-
-class Constructed: ...
-
 reveal_type(accept_top(ordinary))  # revealed: int
-reveal_type(accept_top(positional))  # revealed: str
-reveal_type(accept_top(keyword_only))  # revealed: bool
-reveal_type(accept_top(object_variadic))  # revealed: tuple[int, str]
-reveal_type(accept_top(Example().method))  # revealed: bytes
-reveal_type(accept_top(Constructed))  # revealed: Constructed
-reveal_type(accept_bounded(ordinary))  # revealed: int
-
-accept_int(ordinary)
-accept_int(positional)  # error: [invalid-argument-type]
 ```
 
 ### Gradual callable parameters with a required prefix

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3209,7 +3209,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // The top signature is supertype of (and assignable from) all other signatures. It is a
         // subtype of no signature except itself, and assignable only to the gradual signature.
         if target.parameters.is_top() {
-            return self.always();
+            return result;
         } else if source.parameters.is_top() && !target.parameters.is_gradual() {
             if let Some(context) = self.report_context() {
                 context.push(ErrorContext::TopCallableAssignedToNonTop {


### PR DESCRIPTION
## Summary

Preserve return-type inference for `Top[Callable[..., T]]`.

Follow-up to https://github.com/astral-sh/ruff/pull/27431#discussion_r3708772027.

## Test plan

Cover return-type inference for an ordinary callback accepted as a top callable.