### PR TITLE
[ty] Validate constructor calls on unbounded type variables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -685,11 +685,12 @@ expects_type_c_default_of_int_str(C[str, int])
 
 ## Upcasting a `type[]` type to a `Callable` type
 
-`type[T]` accepts the same parameters as `object.__init__` if `T` does not have an upper bound. If
-`T` is bound to a nominal-instance type, `type[T]` accepts the same parameters as the constructor of
-the class that the instance-type refers to.
+`type[T]` accepts the same parameters as `object.__init__` if `T` has an implicit or explicit
+`object` upper bound. If `T` has a more specific upper bound, `type[T]` accepts the same parameters
+as that bound's constructor. Bare `type` retains its permissive constructor signature.
 
 ```py
+from collections.abc import Callable
 from ty_extensions._internal import RegularCallableTypeOf
 
 class TakesStrInConstructor:
@@ -728,9 +729,17 @@ def f[
     # error: [too-many-positional-arguments]
     reveal_type(type_t_unbound(""))  # revealed: T@f
 
+    zero_argument_unbound: Callable[[], T] = type_t_unbound
+    # error: [invalid-assignment]
+    one_argument_unbound: Callable[[int], T] = type_t_unbound
+
     reveal_type(type_t_object_bound())  # revealed: T1@f
     # error: [too-many-positional-arguments]
     reveal_type(type_t_object_bound(""))  # revealed: T1@f
+
+    zero_argument_object_bound: Callable[[], T1] = type_t_object_bound
+    # error: [invalid-assignment]
+    one_argument_object_bound: Callable[[int], T1] = type_t_object_bound
 
     reveal_type(type_int())  # revealed: int
     reveal_type(type_int("1"))  # revealed: int
@@ -773,10 +782,8 @@ def f[
         reveal_type(bare_type_upcast)  # revealed: (...) -> Any
         reveal_type(type_object_upcast)  # revealed: (...) -> Any
 
-        # TODO: if we did decide to override typeshed's `type.__call__` annotations (see above),
-        # we should also turn these two into `() -> T@f` / `() -> T1@f`
-        reveal_type(type_t_unbound_upcast)  # revealed: (...) -> T@f
-        reveal_type(type_t_object_bound_upcast)  # revealed: (...) -> T1@f
+        reveal_type(type_t_unbound_upcast)  # revealed: () -> T@f
+        reveal_type(type_t_object_bound_upcast)  # revealed: () -> T1@f
 
         # revealed: Overload[(x: str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = 0, /) -> int, (x: str | bytes | bytearray, /, base: SupportsIndex) -> int]
         reveal_type(type_int_upcast)

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -16,7 +16,8 @@ def _[T](x: T):
     reveal_type(type(x))  # revealed: type[T@_]
 ```
 
-`type[T]` with an unbounded type variable represents any subclass of `object`.
+`type[T]` with an unbounded type variable represents any subclass of `object`. Constructor calls are
+checked against `object.__init__`.
 
 ```py
 def unbounded[T](x: type[T]) -> T:
@@ -25,7 +26,27 @@ def unbounded[T](x: type[T]) -> T:
     reveal_type(x.__init__)  # revealed: def __init__(self) -> None
     reveal_type(x.__qualname__)  # revealed: str
     reveal_type(x())  # revealed: T@unbounded
+    x(1)  # error: [too-many-positional-arguments]
 
+    return x()
+```
+
+An explicit `object` upper bound has the same constructor signature as an implicit `object` bound,
+including for legacy type variables:
+
+```py
+from typing import TypeVar
+
+LegacyObjectT = TypeVar("LegacyObjectT", bound=object)
+
+def explicit_object_bound[T: object](x: type[T]) -> T:
+    reveal_type(x())  # revealed: T@explicit_object_bound
+    x(1)  # error: [too-many-positional-arguments]
+    return x()
+
+def legacy_object_bound(x: type[LegacyObjectT]) -> LegacyObjectT:
+    reveal_type(x())  # revealed: LegacyObjectT@legacy_object_bound
+    x(1)  # error: [too-many-positional-arguments]
     return x()
 ```
 
@@ -160,6 +181,32 @@ class Holder(Generic[T]):
     def narrow(self) -> None:
         if isinstance(self.value, type):
             reveal_type(self.value)  # revealed: type[T@Holder] | ((() -> type[T@Holder]) & type)
+```
+
+## Narrowing constructor calls
+
+Narrowing a class object with `issubclass` uses the narrowed class's constructor without losing its
+original type variable:
+
+```py
+class IntConstructor:
+    def __init__(self, value: int) -> None: ...
+
+def narrowed_subclass[T](cls: type[T]) -> T:
+    if issubclass(cls, IntConstructor):
+        reveal_type(cls(1))  # revealed: T@narrowed_subclass & IntConstructor
+        return cls(1)
+    return cls()
+```
+
+Checking a class object's identity preserves the original type variable in the same way:
+
+```py
+def narrowed_identity[T](cls: type[T]) -> T:
+    if cls is IntConstructor:
+        reveal_type(cls(1))  # revealed: T@narrowed_identity & IntConstructor
+        return cls(1)
+    return cls()
 ```
 
 ## `__class__`
@@ -678,11 +725,11 @@ def f[
     reveal_type(type_object(""))  # revealed: Any
 
     reveal_type(type_t_unbound())  # revealed: T@f
-    # TODO: we could consider emitting an error here as well
+    # error: [too-many-positional-arguments]
     reveal_type(type_t_unbound(""))  # revealed: T@f
 
     reveal_type(type_t_object_bound())  # revealed: T1@f
-    # TODO: we could consider emitting an error here as well
+    # error: [too-many-positional-arguments]
     reveal_type(type_t_object_bound(""))  # revealed: T1@f
 
     reveal_type(type_int())  # revealed: int

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -26,7 +26,10 @@ def unbounded[T](x: type[T]) -> T:
     reveal_type(x.__init__)  # revealed: def __init__(self) -> None
     reveal_type(x.__qualname__)  # revealed: str
     reveal_type(x())  # revealed: T@unbounded
-    x(1)  # error: [too-many-positional-arguments]
+    # error: [too-many-positional-arguments] "Too many positional arguments to `type[T]`: expected 0, got 1"
+    x(1)
+    # error: [unknown-argument] "Argument `value` does not match any known parameter of `type[T]`"
+    x(value=1)
 
     return x()
 ```
@@ -48,6 +51,27 @@ def legacy_object_bound(x: type[LegacyObjectT]) -> LegacyObjectT:
     reveal_type(x())  # revealed: LegacyObjectT@legacy_object_bound
     x(1)  # error: [too-many-positional-arguments]
     return x()
+```
+
+Aliases of `object` have the same constructor and callable signature as a direct `object` bound,
+even when the bound contains more than one alias:
+
+```py
+from collections.abc import Callable
+
+type ObjectAlias = object
+type ChainedObjectAlias = ObjectAlias
+
+def aliased_object_bound[T: ChainedObjectAlias](cls: type[T]) -> T:
+    # error: [too-many-positional-arguments] "Too many positional arguments to `type[T]`: expected 0, got 1"
+    cls(1)
+    # error: [unknown-argument] "Argument `value` does not match any known parameter of `type[T]`"
+    cls(value=1)
+
+    zero_argument: Callable[[], T] = cls
+    # error: [invalid-assignment]
+    one_argument: Callable[[int], T] = cls
+    return cls()
 ```
 
 `type[T]` with an upper bound of `T: A` represents any subclass of `A`.
@@ -197,6 +221,25 @@ def narrowed_subclass[T](cls: type[T]) -> T:
         reveal_type(cls(1))  # revealed: T@narrowed_subclass & IntConstructor
         return cls(1)
     return cls()
+```
+
+An invalid call after narrowing should report only the narrowed constructor's argument error.
+Existing intersection-call issues currently add a redundant error from the original upper bound:
+
+```py
+def narrowed_invalid[T](cls: type[T]) -> None:
+    if issubclass(cls, IntConstructor):
+        # TODO: Only report `invalid-argument-type`; the upper-bound constructor also reports
+        # `too-many-positional-arguments` and describes the attempted intersection as `Never`.
+        # error: [too-many-positional-arguments]
+        # error: [invalid-argument-type]
+        cls("wrong")
+
+        # TODO: Only report `invalid-argument-type`; the upper-bound constructor also reports
+        # `unknown-argument` for the same call.
+        # error: [unknown-argument]
+        # error: [invalid-argument-type]
+        cls(value="wrong")
 ```
 
 Checking a class object's identity preserves the original type variable in the same way:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1805,6 +1805,23 @@ impl<'db> Type<'db> {
         ty
     }
 
+    /// Selects the constructor used for a type variable's upper bound.
+    ///
+    /// The meta-type of `object` simplifies to permissive bare `type`, so retain the exact class
+    /// object instead. Resolve aliases first so an alias of `object` cannot bypass that behavior.
+    fn constructor_for_typevar_bound(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Type<'db> {
+        let bound = self.resolve_type_alias(db);
+        if bound.is_object() {
+            KnownClass::Object.to_class_literal(db, env)
+        } else {
+            bound.to_meta_type(db, env)
+        }
+    }
+
     /// Returns `Some(UnionType)` if this type behaves like a union. Apart from explicit unions,
     /// this returns `Some` for `TypeAlias`es of unions and `NewType`s of `float` and `complex`.
     fn as_union_like(self, db: &'db dyn Db) -> Option<UnionType<'db>> {
@@ -5150,13 +5167,16 @@ impl<'db> Type<'db> {
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
                     let bindings = match tvar.typevar(db).require_bound_or_constraints(db, env) {
-                        TypeVarBoundOrConstraints::UpperBound(bound) if bound.is_object() => {
-                            KnownClass::Object
-                                .to_class_literal(db, env)
-                                .bindings(db, env)
-                        }
                         TypeVarBoundOrConstraints::UpperBound(bound) => {
-                            bound.to_meta_type(db, env).bindings(db, env)
+                            let constructor = bound.constructor_for_typevar_bound(db, env);
+                            if let Type::ClassLiteral(class) = constructor
+                                && let Some(bindings) =
+                                    self.known_class_literal_bindings(db, env, class)
+                            {
+                                bindings
+                            } else {
+                                constructor.bindings(db, env)
+                            }
                         }
                         TypeVarBoundOrConstraints::Constraints(constraints) => {
                             Bindings::from_union(

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5149,12 +5149,16 @@ impl<'db> Type<'db> {
                 ),
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
-                    let bindings = match tvar.typevar(db).bound_or_constraints(db, env) {
-                        None => KnownClass::Type.to_instance(db, env).bindings(db, env),
-                        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    let bindings = match tvar.typevar(db).require_bound_or_constraints(db, env) {
+                        TypeVarBoundOrConstraints::UpperBound(bound) if bound.is_object() => {
+                            KnownClass::Object
+                                .to_class_literal(db, env)
+                                .bindings(db, env)
+                        }
+                        TypeVarBoundOrConstraints::UpperBound(bound) => {
                             bound.to_meta_type(db, env).bindings(db, env)
                         }
-                        Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                        TypeVarBoundOrConstraints::Constraints(constraints) => {
                             Bindings::from_union(
                                 self,
                                 constraints
@@ -5164,17 +5168,11 @@ impl<'db> Type<'db> {
                             )
                         }
                     };
-                    // TODO We would ideally be able to just do `into_constructor_bindings` in the
-                    // no-bounds/constraints case above (where we get back the bindings for
-                    // `Type.__call__`), and just do `with_constructed_instance_type` in the
-                    // bound/constrained cases, where we should get back constructor bindings (or
-                    // if we don't, we probably shouldn't return `T` from the call?). But currently
-                    // we can't because we special-case some built-in types to return regular
-                    // (not constructor) bindings from `constructor_bindings()`.
+                    // Some built-in constructors, including `object`, are special-cased as regular
+                    // callable bindings. Wrap them so that every bound or constrained call has
+                    // constructor context and constructs `T`; existing constructor bindings keep
+                    // their original kind.
                     bindings
-                        // `into_constructor_bindings` is a no-op for already-constructor bindings,
-                        // so we are just setting the `MetaclassCall` type for `Type.__call__`, or
-                        // the special-cased builtin classes that return regular bindings.
                         .into_constructor_bindings(
                             constructor_instance_type,
                             ConstructorCallableKind::MetaclassCall,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -531,11 +531,18 @@ impl<'db> BindingsElement<'db> {
     /// `f: KnownCallable & Top[Callable[..., Awaitable[object]]]`, even though the top-callable
     /// call itself is unsafe. (We know that somewhere in the infinite-union of the top callable,
     /// there is a callable with the right parameters to match the call.)
+    ///
+    /// Likewise, a narrowed class can provide a more specific constructor signature than `type[T]`.
+    /// Even when the `type[T]` constructor rejects the arguments, its return type still constrains
+    /// the successful constructor call.
     fn retain_successful(&mut self, db: &'db dyn Db) {
         if self.is_intersection() && self.as_result(db).is_ok() {
             self.items.retain(|item| {
                 item.as_result(db).is_ok()
                     || item.error_priority(db) == CallErrorPriority::TopCallable
+                    || item.as_constructor().is_some_and(|constructor| {
+                        matches!(constructor.constructed_instance_type(), Type::TypeVar(_))
+                    })
             });
         }
     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7695,6 +7695,12 @@ impl<'db> CallableDescription<'db> {
                 kind: Some("class"),
                 name: Cow::Borrowed(class_type.name(db)),
             }),
+            Type::SubclassOf(subclass) if let Some(typevar) = subclass.into_type_var() => {
+                Some(CallableDescription {
+                    kind: None,
+                    name: Cow::Owned(format!("type[{}]", typevar.name(db))),
+                })
+            }
             Type::BoundMethod(bound_method) => Some({
                 let function = bound_method.function(db);
                 let kind = if function.name(db) == "__init__" {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -174,10 +174,14 @@ impl<'db> Type<'db> {
                     }
                 }),
                 SubclassOfInner::TypeVar(tvar) => {
-                    match tvar.typevar(db).bound_or_constraints(db, env) {
-                        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            let upcast_callables = bound
-                                .to_meta_type(db, env)
+                    match tvar.typevar(db).require_bound_or_constraints(db, env) {
+                        TypeVarBoundOrConstraints::UpperBound(bound) => {
+                            let constructor = if bound.is_object() {
+                                KnownClass::Object.to_class_literal(db, env)
+                            } else {
+                                bound.to_meta_type(db, env)
+                            };
+                            let upcast_callables = constructor
                                 .try_upcast_to_callable_with_policy_and_context(
                                     db, env, policy, context,
                                 )?;
@@ -194,7 +198,7 @@ impl<'db> Type<'db> {
                                 )
                             }))
                         }
-                        Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                        TypeVarBoundOrConstraints::Constraints(constraints) => {
                             let mut callables = SmallVec::new();
                             for constraint in constraints.elements(db) {
                                 let element_upcast = constraint
@@ -217,10 +221,6 @@ impl<'db> Type<'db> {
                             }
                             Some(CallableTypes::new(callables))
                         }
-                        None => Some(CallableTypes::one(CallableType::single(
-                            db,
-                            Signature::new(Parameters::gradual_form(), Type::TypeVar(tvar)),
-                        ))),
                     }
                 }
                 SubclassOfInner::Dynamic(_) => Some(CallableTypes::one(CallableType::single(

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -176,12 +176,8 @@ impl<'db> Type<'db> {
                 SubclassOfInner::TypeVar(tvar) => {
                     match tvar.typevar(db).require_bound_or_constraints(db, env) {
                         TypeVarBoundOrConstraints::UpperBound(bound) => {
-                            let constructor = if bound.is_object() {
-                                KnownClass::Object.to_class_literal(db, env)
-                            } else {
-                                bound.to_meta_type(db, env)
-                            };
-                            let upcast_callables = constructor
+                            let upcast_callables = bound
+                                .constructor_for_typevar_bound(db, env)
                                 .try_upcast_to_callable_with_policy_and_context(
                                     db, env, policy, context,
                                 )?;


### PR DESCRIPTION
## Summary

This PR validates `type[T]` against `T`'s upper-bound, but leaves bare `type` permissive:

```py
from collections.abc import Callable

def permissive(cls: type) -> None:
    cls(1)  # still accepted

def unbounded[T](cls: type[T]) -> T:
    zero_argument: Callable[[], T] = cls
    one_argument: Callable[[int], T] = cls  # error: [invalid-assignment]
    return cls(1)  # error: [too-many-positional-arguments]

def object_bound[T: object](cls: type[T]) -> T:
    return cls(1)  # error: [too-many-positional-arguments]
```

I believe this is both consistent with the [constructor typing specification](https://typing.python.org/en/latest/spec/constructors.html#constructor-calls-for-type-t) and gets us passing the relevant conformance tests.

The background is that in #24357, we brought constructor handling much closer to the typing specification by respecting `__new__` and metaclass `__call__` return types, but `constructors_call_type.py` still had one false negative (calling an unbounded `type[T]` with arguments).

We then put up #23514 which addressed that case by overriding the permissive typeshed signature for `type.__call__`, making bare `type`, `type[object]`, and unbounded `type[T]` all use `object`'s zero-argument constructor. That created substantial ecosystem fallout and added conformance false-positives. @carljm suggested that, if we eventually want stricter `type[object]`, we should instead distinguish it from bare `type` instead of globally replacing `type.__call__`.
