### PR TITLE
[ty] Normalize unpacked callable signatures for assignability

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1671,11 +1671,10 @@ reveal_type(f7)  # revealed: (*args) -> None
 f8: Callable[[int], None] = lambda *, x=1: None
 reveal_type(f8)  # revealed: (int, /) -> None
 
-# `Callable` annotations only describe positional parameters, so the keyword-only `x` is not
-# compatible with the positional suffix in the annotation.
-# error: [invalid-assignment]
+# An optional keyword-only parameter does not prevent `*args` from accepting the positional
+# suffix in a `Callable` annotation.
 f9: Callable[[*tuple[int, ...], int], None] = lambda *args, x=1: None
-reveal_type(f9)  # revealed: (*tuple[int, ...], int) -> None
+reveal_type(f9)  # revealed: (*args, *, x=1) -> None
 
 f10: Callable[[str, int, str], tuple[str, int, str]] = lambda x, y, z: reveal_type((x, y, z))  # revealed: tuple[str, int, str]
 reveal_type(f10)  # revealed: (x: str, y: int, z: str) -> tuple[str, int, str]

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -614,13 +614,7 @@ def fn0(a: int) -> None: ...
 def fn1(a: int, b: str) -> None: ...
 def fn2(a: int, b: str, c: bytes) -> None: ...
 
-# TODO: Should reveal `tuple[()]` without an error.
-# error: [invalid-argument-type] "Argument to function `test` is incorrect: Expected `(int, /, *args: tuple[Unknown, ...]) -> None`, found `def fn0(a: int) -> None`"
-reveal_type(test(fn0))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[str]` without an error.
-# error: [invalid-argument-type] "Argument to function `test` is incorrect: Expected `(int, /, *args: tuple[Unknown, ...]) -> None`, found `def fn1(a: int, b: str) -> None`"
-reveal_type(test(fn1))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[str, bytes]` without an error.
-# error: [invalid-argument-type] "Argument to function `test` is incorrect: Expected `(int, /, *args: tuple[Unknown, ...]) -> None`, found `def fn2(a: int, b: str, c: bytes) -> None`"
-reveal_type(test(fn2))  # revealed: tuple[Unknown, ...]
+reveal_type(test(fn0))  # revealed: tuple[()]
+reveal_type(test(fn1))  # revealed: tuple[str]
+reveal_type(test(fn2))  # revealed: tuple[str, bytes]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -546,10 +546,25 @@ def expect_nested(
 def pass_flattened(
     callback: Callable[[int, *tuple[str, ...], bytes, str], None],
 ) -> None:
-    # TODO: This should be assignable because the nested unpacking is equivalent to the flattened
-    # form.
-    # error: [invalid-argument-type]
     expect_nested(callback)
+```
+
+### Nested unpacked `TypeVarTuple` callable parameters
+
+A `TypeVarTuple` nested inside an unpacked tuple remains inferable after the surrounding tuple is
+expanded into its fixed prefix and suffix.
+
+```py
+from typing import Callable
+
+def infer_nested[*Ts](callback: Callable[[int, *tuple[*Ts, bytes]], None]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def fixed_middle(prefix: int, middle: str, suffix: bytes, /) -> None: ...
+def empty_middle(prefix: int, suffix: bytes, /) -> None: ...
+
+reveal_type(infer_nested(fixed_middle))  # revealed: tuple[str]
+reveal_type(infer_nested(empty_middle))  # revealed: tuple[()]
 ```
 
 ### Callable inference with additional keyword parameters
@@ -595,18 +610,12 @@ def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None: ...
 def positional_or_keyword(x: int, y: str, flag: bool) -> None: ...
 def keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def explicit_keyword_only(x: int, y: str, *, flag: bool) -> None`"
-reveal_type(infer_keyword_only(explicit_keyword_only))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None`"
-reveal_type(infer_keyword_only(positional_only_with_keyword))  # revealed: tuple[Unknown, ...]
+reveal_type(infer_keyword_only(explicit_keyword_only))  # revealed: tuple[int, str]
+reveal_type(infer_keyword_only(positional_only_with_keyword))  # revealed: tuple[int, str]
 # TODO: Should reveal `tuple[int, str]`.
 # error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_or_keyword(x: int, y: str, flag: bool) -> None`"
 reveal_type(infer_keyword_only(positional_or_keyword))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
-reveal_type(infer_keyword_only(keyword_catch_all))  # revealed: tuple[Unknown, ...]
+reveal_type(infer_keyword_only(keyword_catch_all))  # revealed: tuple[int, str]
 
 class OptionalKeywordCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, flag: bool = False) -> None: ...
@@ -616,9 +625,7 @@ def infer_optional_keyword[*Ts](callback: OptionalKeywordCallback[*Ts]) -> tuple
 
 def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_optional_keyword` is incorrect: Expected `OptionalKeywordCallback[*tuple[Unknown, ...]]`, found `def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None`"
-reveal_type(infer_optional_keyword(optional_keyword_callback))  # revealed: tuple[Unknown, ...]
+reveal_type(infer_optional_keyword(optional_keyword_callback))  # revealed: tuple[int, str]
 
 class PrefixedKeywordCallback[*Ts](Protocol):
     def __call__(self, prefix: bytes, *args: *Ts, flag: bool) -> None: ...
@@ -629,9 +636,7 @@ def infer_prefixed[*Ts](callback: PrefixedKeywordCallback[*Ts]) -> tuple[*Ts]:
 def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None: ...
 def prefixed_variadic(prefix: bytes, *args: str, flag: bool) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_prefixed` is incorrect: Expected `PrefixedKeywordCallback[*tuple[Unknown, ...]]`, found `def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None`"
-reveal_type(infer_prefixed(prefixed))  # revealed: tuple[Unknown, ...]
+reveal_type(infer_prefixed(prefixed))  # revealed: tuple[int, str]
 
 # An open-ended positional parameter can be inferred in an otherwise mixed signature.
 reveal_type(infer_prefixed(prefixed_variadic))  # revealed: tuple[str, ...]
@@ -653,9 +658,7 @@ def infer_keyword_variadic[*Ts](callback: KeywordVariadicCallback[*Ts]) -> tuple
 
 def keyword_variadic(x: int, y: str, **kwargs: int) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_variadic` is incorrect: Expected `KeywordVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_variadic(x: int, y: str, **kwargs: int) -> None`"
-reveal_type(infer_keyword_variadic(keyword_variadic))  # revealed: tuple[Unknown, ...]
+reveal_type(infer_keyword_variadic(keyword_variadic))  # revealed: tuple[int, str]
 
 class KeywordOnlyAndVariadicCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, flag: bool, **kwargs: int) -> None: ...
@@ -667,9 +670,7 @@ def infer_keyword_only_and_variadic[*Ts](
 
 def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only_and_variadic` is incorrect: Expected `KeywordOnlyAndVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None`"
-reveal_type(infer_keyword_only_and_variadic(keyword_only_and_variadic))  # revealed: tuple[Unknown, ...]
+reveal_type(infer_keyword_only_and_variadic(keyword_only_and_variadic))  # revealed: tuple[int, str]
 
 class MultipleKeywordCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, first: int, second: str) -> None: ...
@@ -679,9 +680,7 @@ def infer_multiple_keywords[*Ts](callback: MultipleKeywordCallback[*Ts]) -> tupl
 
 def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_multiple_keywords` is incorrect: Expected `MultipleKeywordCallback[*tuple[Unknown, ...]]`, found `def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
-reveal_type(infer_multiple_keywords(multiple_keyword_catch_all))  # revealed: tuple[Unknown, ...]
+reveal_type(infer_multiple_keywords(multiple_keyword_catch_all))  # revealed: tuple[int, str]
 ```
 
 ### Length-sensitive inference
@@ -937,15 +936,9 @@ def fn0(a: int) -> None: ...
 def fn1(a: int, b: str) -> None: ...
 def fn2(a: int, b: str, c: bytes) -> None: ...
 
-# TODO: Should reveal `tuple[()]` without an error.
-# error: [invalid-argument-type] "Argument to function `test` is incorrect: Expected `Alias[*tuple[int, *tuple[Unknown, ...]]]`, found `def fn0(a: int) -> None`"
-reveal_type(test(fn0))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[str]` without an error.
-# error: [invalid-argument-type] "Argument to function `test` is incorrect: Expected `Alias[*tuple[int, *tuple[Unknown, ...]]]`, found `def fn1(a: int, b: str) -> None`"
-reveal_type(test(fn1))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[str, bytes]` without an error.
-# error: [invalid-argument-type] "Argument to function `test` is incorrect: Expected `Alias[*tuple[int, *tuple[Unknown, ...]]]`, found `def fn2(a: int, b: str, c: bytes) -> None`"
-reveal_type(test(fn2))  # revealed: tuple[Unknown, ...]
+reveal_type(test(fn0))  # revealed: tuple[()]
+reveal_type(test(fn1))  # revealed: tuple[str]
+reveal_type(test(fn2))  # revealed: tuple[str, bytes]
 ```
 
 ### Indexing and iteration

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1083,7 +1083,7 @@ A variadic positional parameter can accept both the unpacked tuple and a require
 parameter following that tuple.
 
 ```py
-from typing import Callable, Unpack
+from typing import Any, Callable, Never, Unpack, cast
 from ty_extensions import static_assert
 from ty_extensions._internal import RegularCallableTypeOf, is_assignable_to
 
@@ -1143,6 +1143,86 @@ def expects_prefix_and_suffix(
 def accepts_prefixed_objects(first: int, *args: object) -> None: ...
 
 expects_prefix_and_suffix(accepts_prefixed_objects)
+```
+
+A required suffix can align with a longer suffix or an equivalent positional prefix when all the
+unpacked elements have the same type.
+
+```py
+def requires_one_integer(*args: *tuple[*tuple[int, ...], int]) -> None: ...
+
+longer_suffix: Callable[[*tuple[int, ...], int, int], None] = requires_one_integer
+equivalent_prefix: Callable[[int, *tuple[int, ...]], None] = requires_one_integer
+
+type OneOrMoreIntegers = RegularCallableTypeOf[requires_one_integer]
+
+static_assert(is_assignable_to(OneOrMoreIntegers, Callable[[*tuple[int, ...], int, int], None]))
+static_assert(is_assignable_to(OneOrMoreIntegers, Callable[[int, *tuple[int, ...]], None]))
+```
+
+A type alias for the variadic element does not prevent the required suffix from matching.
+
+```py
+type Integer = int
+
+def requires_one_aliased_integer(*args: *tuple[*tuple[Integer, ...], int]) -> None: ...
+
+type AliasedIntegers = RegularCallableTypeOf[requires_one_aliased_integer]
+
+static_assert(is_assignable_to(AliasedIntegers, Callable[[int, *tuple[int, ...]], None]))
+```
+
+A longer suffix is aligned from the end when its other elements fit the source variadic parameter.
+
+```py
+def requires_string_suffix(*args: *tuple[*tuple[object, ...], str]) -> None: ...
+def requires_string_after_integers(*args: *tuple[*tuple[int, ...], str]) -> None: ...
+
+type StringSuffix = RegularCallableTypeOf[requires_string_suffix]
+type IntegerStringSuffix = RegularCallableTypeOf[requires_string_after_integers]
+
+static_assert(is_assignable_to(StringSuffix, Callable[[*tuple[object, ...], int, str], None]))
+static_assert(is_assignable_to(IntegerStringSuffix, Callable[[*tuple[int, ...], int, str], None]))
+```
+
+Gradual variadic elements remain assignable in both directions.
+
+```py
+type GradualSuffix = Callable[[*tuple[Any, ...], int], None]
+
+static_assert(is_assignable_to(OneOrMoreIntegers, GradualSuffix))
+static_assert(is_assignable_to(GradualSuffix, OneOrMoreIntegers))
+```
+
+A positional parameter cannot also be filled by a target keyword argument.
+
+```py
+def occupies_keyword(a: int, *args: int, **kwargs: int) -> None: ...
+def accepts_keyword(*args: *tuple[*tuple[int, ...], int], **kwargs: int) -> None: ...
+
+type OccupiesKeyword = RegularCallableTypeOf[occupies_keyword]
+type AcceptsKeyword = RegularCallableTypeOf[accepts_keyword]
+
+static_assert(not is_assignable_to(OccupiesKeyword, AcceptsKeyword))
+```
+
+An uninhabited keyword parameter cannot collide with an occupied positional parameter.
+
+```py
+type Bottom = Never
+
+def rejects_keywords(*args: *tuple[*tuple[int, ...], int], **kwargs: Bottom) -> None: ...
+def rejects_named_keyword(*args: *tuple[*tuple[int, ...], int], a: Never = cast(Never, 0)) -> None: ...
+
+static_assert(is_assignable_to(OccupiesKeyword, RegularCallableTypeOf[rejects_keywords]))
+static_assert(is_assignable_to(OccupiesKeyword, RegularCallableTypeOf[rejects_named_keyword]))
+```
+
+A suffix cannot be extended with elements that the source variadic parameter rejects.
+
+```py
+# error: [invalid-assignment]
+incompatible_suffix: Callable[[*tuple[int, ...], str, str], None] = requires_string_after_integers
 ```
 
 ### Fixed-length unpacked positional parameters

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1098,14 +1098,22 @@ suffix.
 
 ```py
 def accepts_objects(*args: object) -> None: ...
+def accepts_strings_or_none(*args: str | None) -> None: ...
 def accepts_strings(*args: str) -> None: ...
 
 expects_suffix(accepts_objects)
+expects_suffix(accepts_strings_or_none)
 expects_suffix(accepts_strings)  # error: [invalid-argument-type]
 
 static_assert(
     is_assignable_to(
         RegularCallableTypeOf[accepts_objects],
+        Callable[[Unpack[tuple[str, ...]], None], None],
+    )
+)
+static_assert(
+    is_assignable_to(
+        RegularCallableTypeOf[accepts_strings_or_none],
         Callable[[Unpack[tuple[str, ...]], None], None],
     )
 )
@@ -1139,15 +1147,39 @@ expects_prefix_and_suffix(accepts_prefixed_objects)
 
 ### Fixed-length unpacked positional parameters
 
-An unpacked fixed-length tuple accepts only its declared positional arguments. It cannot satisfy a
-callable that accepts arbitrarily many tuple arguments.
+An unpacked fixed-length tuple accepts exactly its declared positional arguments, including when the
+tuple is empty. Equivalent unpacked source and target tuples are compatible.
 
 ```py
 from typing import Callable, Unpack
 from ty_extensions import static_assert
 from ty_extensions._internal import RegularCallableTypeOf, is_assignable_to
 
+def accepts_no_arguments(*args: Unpack[tuple[()]]) -> None: ...
 def accepts_one_integer(*args: Unpack[tuple[int]]) -> None: ...
+def accepts_strings(*args: str) -> None: ...
+
+empty_callback: Callable[[Unpack[tuple[()]]], None] = accepts_no_arguments
+fixed_callback: Callable[[Unpack[tuple[int]]], None] = accepts_one_integer
+fixed_strings: Callable[[Unpack[tuple[str, str]]], None] = accepts_strings
+empty_strings: Callable[[Unpack[tuple[()]]], None] = accepts_strings
+
+static_assert(is_assignable_to(RegularCallableTypeOf[accepts_no_arguments], Callable[[Unpack[tuple[()]]], None]))
+static_assert(is_assignable_to(RegularCallableTypeOf[accepts_one_integer], Callable[[Unpack[tuple[int]]], None]))
+```
+
+Empty and exhausted fixed-length source tuples cannot satisfy a target with additional positional
+arguments or an open-ended variadic parameter.
+
+```py
+# error: [invalid-assignment]
+empty_with_prefix: Callable[[int, Unpack[tuple[str, ...]], None], None] = accepts_no_arguments
+
+# error: [invalid-assignment]
+empty_with_suffix: Callable[[Unpack[tuple[str, ...]], None], None] = accepts_no_arguments
+
+# error: [invalid-assignment]
+exhausted_with_suffix: Callable[[int, Unpack[tuple[str, ...]], None], None] = accepts_one_integer
 
 # error: [invalid-assignment]
 callback: Callable[[Unpack[tuple[tuple[int], ...]], tuple[int]], None] = accepts_one_integer

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1077,6 +1077,51 @@ static_assert(is_assignable_to(RegularCallableTypeOf[keyword_variadic], Callable
 static_assert(is_assignable_to(RegularCallableTypeOf[mixed], Callable[..., None]))
 ```
 
+### Unpacked positional parameters with a required suffix
+
+A variadic positional parameter can accept both the unpacked tuple and a required positional
+parameter following that tuple.
+
+```py
+from typing import Callable, Unpack
+
+def expects_suffix(callback: Callable[[Unpack[tuple[str, ...]], None], None]) -> None: ...
+def accepts_unknown(*args): ...
+
+expects_suffix(accepts_unknown)
+```
+
+The variadic parameter's annotation must be compatible with the unpacked elements and the required
+suffix.
+
+```py
+def accepts_objects(*args: object) -> None: ...
+def accepts_strings(*args: str) -> None: ...
+
+expects_suffix(accepts_objects)
+expects_suffix(accepts_strings)  # error: [invalid-argument-type]
+```
+
+A required keyword-only parameter cannot be supplied by the positional callback signature.
+
+```py
+def requires_keyword(*args: object, value: int) -> None: ...
+
+expects_suffix(requires_keyword)  # error: [invalid-argument-type]
+```
+
+A required positional prefix does not prevent the source variadic parameter from also accepting the
+target's required suffix.
+
+```py
+def expects_prefix_and_suffix(
+    callback: Callable[[int, Unpack[tuple[str, ...]], None], None],
+) -> None: ...
+def accepts_prefixed_objects(first: int, *args: object) -> None: ...
+
+expects_prefix_and_suffix(accepts_prefixed_objects)
+```
+
 ### Function types
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1084,6 +1084,8 @@ parameter following that tuple.
 
 ```py
 from typing import Callable, Unpack
+from ty_extensions import static_assert
+from ty_extensions._internal import RegularCallableTypeOf, is_assignable_to
 
 def expects_suffix(callback: Callable[[Unpack[tuple[str, ...]], None], None]) -> None: ...
 def accepts_unknown(*args): ...
@@ -1100,6 +1102,19 @@ def accepts_strings(*args: str) -> None: ...
 
 expects_suffix(accepts_objects)
 expects_suffix(accepts_strings)  # error: [invalid-argument-type]
+
+static_assert(
+    is_assignable_to(
+        RegularCallableTypeOf[accepts_objects],
+        Callable[[Unpack[tuple[str, ...]], None], None],
+    )
+)
+static_assert(
+    not is_assignable_to(
+        RegularCallableTypeOf[accepts_strings],
+        Callable[[Unpack[tuple[str, ...]], None], None],
+    )
+)
 ```
 
 A required keyword-only parameter cannot be supplied by the positional callback signature.
@@ -1120,6 +1135,29 @@ def expects_prefix_and_suffix(
 def accepts_prefixed_objects(first: int, *args: object) -> None: ...
 
 expects_prefix_and_suffix(accepts_prefixed_objects)
+```
+
+### Fixed-length unpacked positional parameters
+
+An unpacked fixed-length tuple accepts only its declared positional arguments. It cannot satisfy a
+callable that accepts arbitrarily many tuple arguments.
+
+```py
+from typing import Callable, Unpack
+from ty_extensions import static_assert
+from ty_extensions._internal import RegularCallableTypeOf, is_assignable_to
+
+def accepts_one_integer(*args: Unpack[tuple[int]]) -> None: ...
+
+# error: [invalid-assignment]
+callback: Callable[[Unpack[tuple[tuple[int], ...]], tuple[int]], None] = accepts_one_integer
+
+static_assert(
+    not is_assignable_to(
+        RegularCallableTypeOf[accepts_one_integer],
+        Callable[[Unpack[tuple[tuple[int], ...]], tuple[int]], None],
+    )
+)
 ```
 
 ### Function types

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1356,11 +1356,18 @@ from ty_extensions import static_assert
 from ty_extensions._internal import RegularCallableTypeOf, is_subtype_of
 
 def accepts_objects(*args: object) -> None: ...
+def accepts_strings_or_none(*args: str | None) -> None: ...
 def accepts_strings(*args: str) -> None: ...
 
 static_assert(
     is_subtype_of(
         RegularCallableTypeOf[accepts_objects],
+        Callable[[Unpack[tuple[str, ...]], None], None],
+    )
+)
+static_assert(
+    is_subtype_of(
+        RegularCallableTypeOf[accepts_strings_or_none],
         Callable[[Unpack[tuple[str, ...]], None], None],
     )
 )
@@ -1372,11 +1379,33 @@ static_assert(
 )
 ```
 
-An unpacked fixed-length parameter cannot be reused for additional positional arguments.
+Equivalent empty or fixed-length unpacked parameters are compatible, but cannot be reused for
+additional positional arguments.
 
 ```py
+def accepts_no_arguments(*args: Unpack[tuple[()]]) -> None: ...
 def accepts_one_integer(*args: Unpack[tuple[int]]) -> None: ...
 
+static_assert(is_subtype_of(RegularCallableTypeOf[accepts_no_arguments], Callable[[Unpack[tuple[()]]], None]))
+static_assert(is_subtype_of(RegularCallableTypeOf[accepts_one_integer], Callable[[Unpack[tuple[int]]], None]))
+static_assert(
+    not is_subtype_of(
+        RegularCallableTypeOf[accepts_no_arguments],
+        Callable[[int, Unpack[tuple[str, ...]], None], None],
+    )
+)
+static_assert(
+    not is_subtype_of(
+        RegularCallableTypeOf[accepts_no_arguments],
+        Callable[[Unpack[tuple[str, ...]], None], None],
+    )
+)
+static_assert(
+    not is_subtype_of(
+        RegularCallableTypeOf[accepts_one_integer],
+        Callable[[int, Unpack[tuple[str, ...]], None], None],
+    )
+)
 static_assert(
     not is_subtype_of(
         RegularCallableTypeOf[accepts_one_integer],

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1345,6 +1345,46 @@ static_assert(is_subtype_of(RegularCallableTypeOf[variadic], RegularCallableType
 static_assert(is_subtype_of(RegularCallableTypeOf[variadic], RegularCallableTypeOf[positional_variadic]))
 ```
 
+#### Variadic with an unpacked positional suffix
+
+A variadic positional parameter must accept both the unpacked elements and any fixed positional
+suffix in the supertype.
+
+```py
+from typing import Callable, Unpack
+from ty_extensions import static_assert
+from ty_extensions._internal import RegularCallableTypeOf, is_subtype_of
+
+def accepts_objects(*args: object) -> None: ...
+def accepts_strings(*args: str) -> None: ...
+
+static_assert(
+    is_subtype_of(
+        RegularCallableTypeOf[accepts_objects],
+        Callable[[Unpack[tuple[str, ...]], None], None],
+    )
+)
+static_assert(
+    not is_subtype_of(
+        RegularCallableTypeOf[accepts_strings],
+        Callable[[Unpack[tuple[str, ...]], None], None],
+    )
+)
+```
+
+An unpacked fixed-length parameter cannot be reused for additional positional arguments.
+
+```py
+def accepts_one_integer(*args: Unpack[tuple[int]]) -> None: ...
+
+static_assert(
+    not is_subtype_of(
+        RegularCallableTypeOf[accepts_one_integer],
+        Callable[[Unpack[tuple[tuple[int], ...]], tuple[int]], None],
+    )
+)
+```
+
 #### Variadic with other kinds
 
 Variadic parameter in a subtype can only be used to match against an unmatched positional-only

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1351,7 +1351,7 @@ A variadic positional parameter must accept both the unpacked elements and any f
 suffix in the supertype.
 
 ```py
-from typing import Callable, Unpack
+from typing import Callable, Never, Unpack, cast
 from ty_extensions import static_assert
 from ty_extensions._internal import RegularCallableTypeOf, is_subtype_of
 
@@ -1377,6 +1377,67 @@ static_assert(
         Callable[[Unpack[tuple[str, ...]], None], None],
     )
 )
+```
+
+A required suffix can align with a longer suffix or an equivalent positional prefix when all the
+unpacked elements have the same type.
+
+```py
+def requires_one_integer(*args: *tuple[*tuple[int, ...], int]) -> None: ...
+
+type OneOrMoreIntegers = RegularCallableTypeOf[requires_one_integer]
+
+static_assert(is_subtype_of(OneOrMoreIntegers, Callable[[*tuple[int, ...], int, int], None]))
+static_assert(is_subtype_of(OneOrMoreIntegers, Callable[[int, *tuple[int, ...]], None]))
+```
+
+A type alias for the variadic element does not prevent the required suffix from matching.
+
+```py
+type Integer = int
+
+def requires_one_aliased_integer(*args: *tuple[*tuple[Integer, ...], int]) -> None: ...
+
+type AliasedIntegers = RegularCallableTypeOf[requires_one_aliased_integer]
+
+static_assert(is_subtype_of(AliasedIntegers, Callable[[int, *tuple[int, ...]], None]))
+```
+
+A longer suffix is aligned from the end when its other elements fit the source variadic parameter.
+
+```py
+def requires_string_suffix(*args: *tuple[*tuple[object, ...], str]) -> None: ...
+def requires_string_after_integers(*args: *tuple[*tuple[int, ...], str]) -> None: ...
+
+type StringSuffix = RegularCallableTypeOf[requires_string_suffix]
+type IntegerStringSuffix = RegularCallableTypeOf[requires_string_after_integers]
+
+static_assert(is_subtype_of(StringSuffix, Callable[[*tuple[object, ...], int, str], None]))
+static_assert(is_subtype_of(IntegerStringSuffix, Callable[[*tuple[int, ...], int, str], None]))
+```
+
+A positional parameter cannot also be filled by a target keyword argument.
+
+```py
+def occupies_keyword(a: int, *args: int, **kwargs: int) -> None: ...
+def accepts_keyword(*args: *tuple[*tuple[int, ...], int], **kwargs: int) -> None: ...
+
+type OccupiesKeyword = RegularCallableTypeOf[occupies_keyword]
+type AcceptsKeyword = RegularCallableTypeOf[accepts_keyword]
+
+static_assert(not is_subtype_of(OccupiesKeyword, AcceptsKeyword))
+```
+
+An uninhabited keyword parameter cannot collide with an occupied positional parameter.
+
+```py
+type Bottom = Never
+
+def rejects_keywords(*args: *tuple[*tuple[int, ...], int], **kwargs: Bottom) -> None: ...
+def rejects_named_keyword(*args: *tuple[*tuple[int, ...], int], a: Never = cast(Never, 0)) -> None: ...
+
+static_assert(is_subtype_of(OccupiesKeyword, RegularCallableTypeOf[rejects_keywords]))
+static_assert(is_subtype_of(OccupiesKeyword, RegularCallableTypeOf[rejects_named_keyword]))
 ```
 
 Equivalent empty or fixed-length unpacked parameters are compatible, but cannot be reused for

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3841,6 +3841,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             ) {
                                 return result;
                             }
+
+                            // An unpacked target tuple can have a fixed positional suffix. Reuse
+                            // the source variadic parameter unless the source has its own fixed
+                            // suffix to match against it.
+                            reuse_current_source = parameters
+                                .peek_target()
+                                .is_some_and(Parameter::is_positional)
+                                && !parameters
+                                    .source_iter
+                                    .as_slice()
+                                    .first()
+                                    .is_some_and(Parameter::is_positional);
                         }
 
                         (

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2430,8 +2430,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
+        let source_parameters = source.parameters.expand_starred_variadic_annotations(db);
+        let target_parameters = target.parameters.expand_starred_variadic_annotations(db);
+
         let target_typevartuple = if self.typevar_evaluation == TypeVarEvaluation::Lazy {
-            target.parameters.variadic().and_then(|(index, parameter)| {
+            target_parameters.variadic().and_then(|(index, parameter)| {
                 if parameter.has_starred_annotation()
                     && let Type::TypeVar(typevartuple) = parameter.annotated_type()
                     && typevartuple.is_typevartuple(db)
@@ -2450,14 +2453,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // comparison below reaches the same result, but only after doing work that is expensive for
         // large overload sets. An unpacked target TypeVarTuple bypasses this fast path so it can be
         // constrained from the source parameters.
-        if source.parameters.is_standard()
-            && target.parameters.is_standard()
-            && source.parameters.variadic().is_none()
+        if source_parameters.is_standard()
+            && target_parameters.is_standard()
+            && source_parameters.variadic().is_none()
             && target_typevartuple.is_none()
         {
-            let source_positional = source.parameters.positional().count();
-            let target_positional = target.parameters.positional().count();
-            let target_variadic = target.parameters.variadic();
+            let source_positional = source_parameters.positional().count();
+            let target_positional = target_parameters.positional().count();
+            let target_variadic = target_parameters.variadic();
 
             // A subdiagnostic telling the user that `source` is missing a `*args` parameter
             // is only guaranteed to be correct when `target` has a plain, open-ended variadic tail.
@@ -2470,8 +2473,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let target_has_open_ended_variadic = || {
                 target_variadic.is_some_and(|(index, parameter)| {
                     !parameter.has_starred_annotation()
-                        && !target
-                            .parameters
+                        && !target_parameters
                             .iter()
                             .skip(index)
                             .any(Parameter::is_positional)
@@ -2486,8 +2488,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     && (target_positional > source_positional || target_has_open_ended_variadic())
                 {
                     let error_context = if target_positional > source_positional {
-                        let source_parameter_kind = source
-                            .parameters
+                        let source_parameter_kind = source_parameters
                             .get(source_positional)
                             .map(Parameter::kind);
 
@@ -2498,8 +2499,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 }
                             }
                             Some(ParameterKind::KeywordVariadic { .. }) | None => {
-                                let parameter = target
-                                    .parameters
+                                let parameter = target_parameters
                                     .get_positional(source_positional)
                                     .and_then(Parameter::name);
                                 ErrorContext::MissingParameter {
@@ -2598,8 +2598,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         };
 
         if self.typevar_evaluation == TypeVarEvaluation::Lazy {
-            let source_paramspec = source.parameters.as_paramspec_with_prefix();
-            let target_paramspec = target.parameters.as_paramspec_with_prefix();
+            let source_paramspec = source_parameters.as_paramspec_with_prefix();
+            let target_paramspec = target_parameters.as_paramspec_with_prefix();
 
             // If either signature is a ParamSpec, the constraint set should bind the ParamSpec to
             // the other signature before the return-type and gradual/top fast paths can return
@@ -2863,7 +2863,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         CallableSignature::single(
                             Signature::new_generic(
                                 source.generic_context,
-                                source.parameters.clone(),
+                                source_parameters.clone(),
                                 Type::unknown(),
                             )
                             .with_source_overload_index(source.source_overload_index()),
@@ -2885,8 +2885,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // self: callable without ParamSpec
                 // other: `Concatenate[<prefix_params>, P]`
                 (None, Some((target_prefix_params, target_bound_typevar))) => {
-                    let source_parameters =
-                        source.parameters.expand_starred_variadic_annotations(db);
                     // Loop over self parameters and target_prefix_params in a similar manner to the
                     // above loop
                     let mut parameters = ParametersZip {
@@ -3005,9 +3003,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     }
 
                     let (source_params, _) = parameters.into_remaining();
-                    let source_params = source
-                        .parameters
-                        .with_transformed_parameters(source_params.cloned());
+                    let source_params =
+                        source_parameters.with_transformed_parameters(source_params.cloned());
                     let lower = Type::Callable(CallableType::new(
                         db,
                         CallableSignature::single(
@@ -3041,7 +3038,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         CallableSignature::single(
                             Signature::new_generic(
                                 target.generic_context,
-                                target.parameters.clone(),
+                                target_parameters.clone(),
                                 Type::unknown(),
                             )
                             .with_source_overload_index(target.source_overload_index()),
@@ -3067,10 +3064,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         current_source: None,
                         current_target: None,
                         source_iter: source_prefix_params.iter(),
-                        target_iter: target.parameters.iter(),
+                        target_iter: target_parameters.iter(),
                     };
 
-                    if target.parameters.kind() != ParametersKind::Gradual {
+                    if target_parameters.kind() != ParametersKind::Gradual {
                         let mut target_index = 0usize;
                         while let Some(next_parameter) = parameters.next() {
                             match next_parameter {
@@ -3151,9 +3148,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     }
 
                     let (_, target_params) = parameters.into_remaining();
-                    let target_params = target
-                        .parameters
-                        .with_transformed_parameters(target_params.cloned());
+                    let target_params =
+                        target_parameters.with_transformed_parameters(target_params.cloned());
                     let upper = Type::Callable(CallableType::new(
                         db,
                         CallableSignature::single(
@@ -3190,16 +3186,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // A gradual parameter list is a supertype of the "bottom" parameter list (*args: object,
         // **kwargs: object).
-        if target.parameters.is_gradual()
-            && (matches!(target.parameters.kind(), ParametersKind::Gradual)
+        if target_parameters.is_gradual()
+            && (matches!(target_parameters.kind(), ParametersKind::Gradual)
                 || self.typevar_evaluation == TypeVarEvaluation::Lazy)
-            && !source.parameters.is_top()
-            && source
-                .parameters
+            && !source_parameters.is_top()
+            && source_parameters
                 .variadic()
                 .is_some_and(|(_, param)| param.annotated_type().is_object())
-            && source
-                .parameters
+            && source_parameters
                 .keyword_variadic()
                 .is_some_and(|(_, param)| param.annotated_type().is_object())
         {
@@ -3208,9 +3202,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // The top signature is supertype of (and assignable from) all other signatures. It is a
         // subtype of no signature except itself, and assignable only to the gradual signature.
-        if target.parameters.is_top() {
+        if target_parameters.is_top() {
             return result;
-        } else if source.parameters.is_top() && !target.parameters.is_gradual() {
+        } else if source_parameters.is_top() && !target_parameters.is_gradual() {
             if let Some(context) = self.report_context() {
                 context.push(ErrorContext::TopCallableAssignedToNonTop {
                     return_type: source.return_ty,
@@ -3224,9 +3218,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // unpacked target TypeVarTuple instead continues to the ordinary parameter comparison so it
         // can be constrained from the source parameters.
         if target_typevartuple.is_none()
-            && (source.parameters.is_gradual() || target.parameters.is_gradual())
+            && (source_parameters.is_gradual() || target_parameters.is_gradual())
         {
-            match (source.parameters.kind(), target.parameters.kind()) {
+            match (source_parameters.kind(), target_parameters.kind()) {
                 // Both parameter lists are `Concatenate` with gradual forms. All prefix parameters
                 // are going to be positional-only.
                 (
@@ -3234,9 +3228,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ParametersKind::Concatenate(ConcatenateTail::Gradual),
                 ) => {
                     let source_prefix_params =
-                        &source.parameters.as_slice()[..source.parameters.len().saturating_sub(2)];
+                        &source_parameters.as_slice()[..source_parameters.len().saturating_sub(2)];
                     let target_prefix_params =
-                        &target.parameters.as_slice()[..target.parameters.len().saturating_sub(2)];
+                        &target_parameters.as_slice()[..target_parameters.len().saturating_sub(2)];
 
                     for (target_index, (source_param, target_param)) in source_prefix_params
                         .iter()
@@ -3262,11 +3256,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ParametersKind::Standard,
                 ) => {
                     let source_prefix_params =
-                        &source.parameters.as_slice()[..source.parameters.len().saturating_sub(2)];
+                        &source_parameters.as_slice()[..source_parameters.len().saturating_sub(2)];
 
                     for (target_index, param) in source_prefix_params
                         .iter()
-                        .zip_longest(target.parameters.iter())
+                        .zip_longest(target_parameters.iter())
                         .enumerate()
                     {
                         match param {
@@ -3319,12 +3313,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ParametersKind::Concatenate(ConcatenateTail::Gradual),
                 ) => {
                     let target_prefix_params =
-                        &target.parameters.as_slice()[..target.parameters.len().saturating_sub(2)];
+                        &target_parameters.as_slice()[..target_parameters.len().saturating_sub(2)];
 
                     let mut parameters = ParametersZip {
                         current_source: None,
                         current_target: None,
-                        source_iter: source.parameters.iter(),
+                        source_iter: source_parameters.iter(),
                         target_iter: target_prefix_params.iter(),
                     };
 
@@ -3414,29 +3408,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     self.constraints,
                     ConstraintSet::from_bool(
                         self.constraints,
-                        source.parameters.is_gradual() && target.parameters.is_gradual(),
+                        source_parameters.is_gradual() && target_parameters.is_gradual(),
                     ),
                 ),
                 TypeRelation::Assignability => result,
             };
         }
 
-        // TODO: Normalize starred variadic annotations in both signatures for all comparisons.
-        // Expanding only the source unconditionally rejects equivalent fixed-length overloads
-        // whose target parameters have not been expanded.
-        let source_parameters = if target_typevartuple.is_some()
-            || target
-                .parameters
-                .variadic()
-                .is_some_and(|(variadic_index, _)| {
-                    target.parameters.as_slice()[variadic_index + 1..]
-                        .iter()
-                        .any(Parameter::is_positional)
-                }) {
-            source.parameters.expand_starred_variadic_annotations(db)
-        } else {
-            source.parameters.clone()
-        };
         // Align the fixed target prefix and suffix before entering the parameter loop so that the
         // target TypeVarTuple captures only the source parameter entries between them.
         let typevartuple_source_parameter_count = if let Some((typevartuple_index, _)) =
@@ -3446,7 +3424,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .iter()
                 .take_while(|parameter| parameter.is_positional() || parameter.is_variadic())
                 .count();
-            let target_suffix_len = target.parameters.as_slice()[typevartuple_index + 1..]
+            let target_suffix_len = target_parameters.as_slice()[typevartuple_index + 1..]
                 .iter()
                 .take_while(|parameter| parameter.is_positional())
                 .count();
@@ -3495,7 +3473,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             current_source: None,
             current_target: None,
             source_iter: source_parameters.iter(),
-            target_iter: target.parameters.iter(),
+            target_iter: target_parameters.iter(),
         };
 
         // Collect all the standard parameters that have only been matched against a variadic
@@ -3589,7 +3567,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     // If there are more parameters in `target` than in `source`, then `source` is
                     // not a subtype of `target`.
                     if let Some(context) = self.report_context()
-                        && target.parameters.as_paramspec_with_prefix().is_none()
+                        && target_parameters.as_paramspec_with_prefix().is_none()
                     {
                         let error_context = match target_parameter.kind() {
                             ParameterKind::PositionalOnly { .. }
@@ -3816,7 +3794,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 }
                                 target_index += 1;
 
-                                if source.parameters.is_gradual() {
+                                if source_parameters.is_gradual() {
                                     return match self.relation {
                                         TypeRelation::Assignability => result,
                                         TypeRelation::Subtyping
@@ -3829,7 +3807,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
                             if !source_param.is_variadic() {
                                 if let Some(context) = self.report_context()
-                                    && target.parameters.as_paramspec_with_prefix().is_none()
+                                    && target_parameters.as_paramspec_with_prefix().is_none()
                                 {
                                     let parameter = ParameterDescription::new(
                                         target_index,
@@ -3941,8 +3919,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     if default_type.is_none() {
                         if let Some(context) = self.report_context() {
                             if let Some(source_name) = source_param.name()
-                                && target
-                                    .parameters
+                                && target_parameters
                                     .iter()
                                     .any(|target_param| target_param.name() == Some(source_name))
                             {
@@ -4030,7 +4007,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         // For a `source <: target` relationship, if `target` has a keyword variadic
                         // parameter, `source` must also have a keyword variadic parameter.
                         if let Some(context) = self.report_context()
-                            && target.parameters.as_paramspec_with_prefix().is_none()
+                            && target_parameters.as_paramspec_with_prefix().is_none()
                         {
                             context.push(ErrorContext::MissingVariadicKeywordParameter);
                         }
@@ -4905,14 +4882,17 @@ impl<'db> Parameters<'db> {
                             .name()
                             .cloned()
                             .unwrap_or_else(|| Name::new_static("args"));
+                        let variadic = Parameter::variadic(name);
+                        let variadic = match variable.variable() {
+                            VariableSegment::Homogeneous(element) => {
+                                variadic.with_annotated_type(element)
+                            }
+                            VariableSegment::TypeVarTuple(typevartuple) => variadic
+                                .with_annotated_type(Type::TypeVar(typevartuple))
+                                .with_starred_annotation(),
+                        };
                         parameters.push(
-                            Parameter::variadic(name)
-                                .with_annotated_type(match variable.variable() {
-                                    VariableSegment::Homogeneous(element) => element,
-                                    VariableSegment::TypeVarTuple(typevartuple) => {
-                                        Type::TypeVar(typevartuple)
-                                    }
-                                })
+                            variadic
                                 .with_definition(parameter.definition())
                                 .with_source_parameter_index(parameter.source_parameter_index()),
                         );
@@ -4926,7 +4906,7 @@ impl<'db> Parameters<'db> {
         }
 
         if expanded {
-            Self::from_annotation(db, parameters)
+            self.with_transformed_parameters(parameters)
         } else {
             self.clone()
         }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2430,8 +2430,44 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
-        let source_parameters = source.parameters.expand_starred_variadic_annotations(db);
-        let target_parameters = target.parameters.expand_starred_variadic_annotations(db);
+        let mut source_parameters = source.parameters.expand_starred_variadic_annotations(db);
+        let mut target_parameters = target.parameters.expand_starred_variadic_annotations(db);
+
+        // Gradual variadics and TypeVarTuples need their original suffix boundaries for
+        // materialization and inference. Named source prefixes must also remain visible when a
+        // target keyword could fill the same parameter.
+        if let (Some((_, source_variadic)), Some((_, target_variadic))) =
+            (source_parameters.variadic(), target_parameters.variadic())
+            && !source_variadic.has_starred_annotation()
+            && !target_variadic.has_starred_annotation()
+            && source_variadic.annotated_type().resolve_type_alias(db)
+                == target_variadic.annotated_type().resolve_type_alias(db)
+            && !source_variadic
+                .annotated_type()
+                .resolve_type_alias(db)
+                .is_dynamic()
+            && source_parameters.positional().all(|source_parameter| {
+                source_parameter.is_positional_only()
+                    || source_parameter.name().is_none_or(|name| {
+                        match target_parameters.keyword_by_name(name) {
+                            Some((_, parameter)) => {
+                                !parameter.is_keyword_only()
+                                    || parameter.annotated_type().resolve_type_alias(db).is_never()
+                            }
+                            None => {
+                                target_parameters
+                                    .keyword_variadic()
+                                    .is_none_or(|(_, parameter)| {
+                                        parameter.annotated_type().resolve_type_alias(db).is_never()
+                                    })
+                            }
+                        }
+                    })
+            })
+        {
+            source_parameters = source_parameters.with_homogeneous_variadic_suffix_in_prefix(db);
+            target_parameters = target_parameters.with_homogeneous_variadic_suffix_in_prefix(db);
+        }
 
         let target_typevartuple = if self.typevar_evaluation == TypeVarEvaluation::Lazy {
             target_parameters.variadic().and_then(|(index, parameter)| {
@@ -3571,23 +3607,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     {
                         let error_context = match target_parameter.kind() {
                             ParameterKind::PositionalOnly { .. }
-                            | ParameterKind::PositionalOrKeyword { .. } => unreachable!(
-                                "unmatched target positional parameters \
-                                are rejected by the positional fast path"
-                            ),
-                            ParameterKind::Variadic { .. } => {
-                                unreachable!(
-                                    "an unmatched target `*args` is impossible: \
-                                    a source without `*args` is rejected by the positional fast path, \
-                                    while a source with `*args` consumes the target during matching"
-                                )
-                            }
-                            ParameterKind::KeywordOnly { .. } => ErrorContext::MissingParameter {
+                            | ParameterKind::PositionalOrKeyword { .. }
+                            | ParameterKind::KeywordOnly { .. } => ErrorContext::MissingParameter {
                                 parameter: ParameterDescription::new(
                                     target_index,
                                     target_parameter.name(),
                                 ),
                             },
+                            ParameterKind::Variadic { .. } => {
+                                ErrorContext::MissingVariadicPositionalParameter
+                            }
                             ParameterKind::KeywordVariadic { .. } => {
                                 ErrorContext::MissingVariadicKeywordParameter
                             }
@@ -3828,17 +3857,36 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 return result;
                             }
 
-                            // An unpacked target tuple can have a fixed positional suffix. Reuse
-                            // the source variadic parameter unless the source has its own fixed
-                            // suffix to match against it.
-                            reuse_current_source = parameters
-                                .peek_target()
-                                .is_some_and(Parameter::is_positional)
-                                && !parameters
-                                    .source_iter
-                                    .as_slice()
-                                    .first()
-                                    .is_some_and(Parameter::is_positional);
+                            // Align fixed suffixes from the end, reusing the source variadic for
+                            // any additional target suffix elements.
+                            let source_suffix_len = parameters
+                                .source_iter
+                                .as_slice()
+                                .iter()
+                                .take_while(|parameter| parameter.is_positional())
+                                .count();
+                            let target_suffix_len = parameters
+                                .target_iter
+                                .as_slice()
+                                .iter()
+                                .take_while(|parameter| parameter.is_positional())
+                                .count();
+                            for _ in source_suffix_len..target_suffix_len {
+                                let Some(target_parameter) = parameters.peek_target() else {
+                                    break;
+                                };
+                                target_index += 1;
+                                if !check_types(
+                                    &mut result,
+                                    target_parameter.annotated_type(),
+                                    source_param.annotated_type(),
+                                    target_parameter.name(),
+                                    target_index,
+                                ) {
+                                    return result;
+                                }
+                                parameters.next_target();
+                            }
                         }
 
                         (
@@ -4835,6 +4883,35 @@ impl<'db> Parameters<'db> {
         self.iter()
             .enumerate()
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
+    }
+
+    /// Moves required suffix elements that match a homogeneous variadic into its prefix.
+    fn with_homogeneous_variadic_suffix_in_prefix(self, db: &'db dyn Db) -> Self {
+        let Some((variadic_index, variadic)) = self.variadic() else {
+            return self;
+        };
+
+        let matching_suffix_len = self.as_slice()[variadic_index + 1..]
+            .iter()
+            .take_while(|parameter| {
+                parameter.is_positional_only()
+                    && parameter.annotated_type().resolve_type_alias(db)
+                        == variadic.annotated_type().resolve_type_alias(db)
+            })
+            .count();
+
+        if matching_suffix_len == 0
+            || self
+                .as_slice()
+                .get(variadic_index + matching_suffix_len + 1)
+                .is_some_and(Parameter::is_positional)
+        {
+            return self;
+        }
+
+        let mut parameters = self.as_slice().to_vec();
+        parameters[variadic_index..=variadic_index + matching_suffix_len].rotate_left(1);
+        self.with_transformed_parameters(parameters)
     }
 
     /// Expands an unpacked `*args` annotation into its logical callable parameters.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3421,10 +3421,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             };
         }
 
-        // TODO: Normalize starred variadic annotations for all signature comparisons. Restricting
-        // expansion to target TypeVarTuple inference means equivalent nested unpackings such as
-        // `*tuple[*tuple[str, ...], bytes]` and `*tuple[str, ...], bytes` are not related correctly.
-        let source_parameters = if target_typevartuple.is_some() {
+        // TODO: Normalize starred variadic annotations in both signatures for all comparisons.
+        // Expanding only the source unconditionally rejects equivalent fixed-length overloads
+        // whose target parameters have not been expanded.
+        let source_parameters = if target_typevartuple.is_some()
+            || target
+                .parameters
+                .variadic()
+                .is_some_and(|(variadic_index, _)| {
+                    target.parameters.as_slice()[variadic_index + 1..]
+                        .iter()
+                        .any(Parameter::is_positional)
+                }) {
             source.parameters.expand_starred_variadic_annotations(db)
         } else {
             source.parameters.clone()


### PR DESCRIPTION
## Summary

Previously, we compared unpacked callable parameters in inconsistent forms: the positional fast path inspected the original signatures, while later matching sometimes expanded only the source. This could panic on valid code or reject compatible assignments such as:

```python
from typing import Callable, Unpack

def callback(*args: str | None) -> None: ...

target: Callable[[Unpack[tuple[str, ...]], None], None] = callback
```

We now normalize both callable signatures before comparing them. Empty and fixed-length unpacked tuples become positional parameters, homogeneous tuples become variadic parameters with the correct element type, and required target suffixes can be matched against source variadics. The positional fast path, `ParamSpec` handling, gradual-callable checks, and `TypeVarTuple` inference all use the same normalized representation.

This also fixes previously unsupported `TypeVarTuple` inference for nested unpacked parameters, callable protocols, and both legacy and PEP 695 callable aliases.

Closes https://github.com/astral-sh/ty/issues/4172.
