### PR TITLE
[ty] Infer generic TypedDicts from positional dictionary literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3624,7 +3624,7 @@ class ListBox[T](TypedDict):
 reveal_type(ListBox(value=[1]))  # revealed: ListBox[int]
 ```
 
-An exact positional dictionary literal contributes its individual field values to inference.
+A positional dictionary literal can infer the element type of a mutable container.
 
 ```py
 reveal_type(ListBox({"value": [1]}))  # revealed: ListBox[int]
@@ -3856,7 +3856,7 @@ def unpack(source: IntSource | StrSource):
 
 ### Constructor inference from positional dictionary literals
 
-Different values in a positional dictionary literal can constrain the same type parameter.
+When two fields use the same type parameter, both values determine its inferred type.
 
 ```toml
 [environment]
@@ -3873,13 +3873,13 @@ class Pair[T](TypedDict):
 reveal_type(Pair({"first": 1, "second": "x"}))  # revealed: Pair[int | str]
 ```
 
-An overwritten callback cannot affect the final values or prevent inference.
+An overwritten value is ignored even when it contains a callback.
 
 ```py
 reveal_type(Pair({"first": [lambda value: value.upper()], "first": 1, "second": "x"}))  # revealed: Pair[int | str]
 ```
 
-A missing required field retains its existing constructor diagnostic.
+A missing required key still produces the existing error.
 
 ```py
 Pair({"first": 1})  # error: [missing-typed-dict-key]
@@ -3887,8 +3887,7 @@ Pair({"first": 1})  # error: [missing-typed-dict-key]
 
 ### Generic function inference from TypedDict literals
 
-A dictionary literal passed to a generic `TypedDict` parameter constrains the function's type
-argument.
+A dictionary literal passed to a `TypedDict` parameter determines the function's type argument.
 
 ```toml
 [environment]
@@ -3907,20 +3906,20 @@ def get_value[T](box: Box[T]) -> T:
 reveal_type(get_value({"value": 1}))  # revealed: int
 ```
 
-A partially specialized parameter keeps its existing concrete type argument.
+A type argument already fixed by the function parameter is preserved.
 
 ```py
-class PartiallySpecialized[A, B](TypedDict):
+class Pair[A, B](TypedDict):
     fixed: A
-    inferred: B
+    value: B
 
-def get_inferred[T](value: PartiallySpecialized[object, T]) -> T:
-    return value["inferred"]
+def get_pair_value[T](pair: Pair[object, T]) -> T:
+    return pair["value"]
 
-reveal_type(get_inferred({"fixed": 1, "inferred": "x"}))  # revealed: str
+reveal_type(get_pair_value({"fixed": 1, "value": "x"}))  # revealed: str
 ```
 
-An unrelated `TypedDict` does not provide a specialization for the generic parameter.
+An unrelated `TypedDict` does not determine the function's type argument.
 
 ```py
 class Source(TypedDict):
@@ -3932,7 +3931,7 @@ def unrelated_source(source: Source):
 
 ### Generic function inference with unused TypedDict parameters
 
-A type parameter absent from a `TypedDict` schema does not constrain another function argument.
+A type parameter that does not appear in any field does not constrain another function argument.
 
 ```toml
 [environment]
@@ -3954,9 +3953,9 @@ def use(box: Box[str]):
     result: int = choose(box, 1)
 ```
 
-### Generic function inference with legacy contravariant fields
+### Generic function inference with legacy read-only callbacks
 
-A legacy type parameter inherits the structural variance of a read-only callable field.
+A read-only callback that accepts any `Animal` is valid when another argument requires a `Dog`.
 
 ```toml
 [environment]
@@ -3982,9 +3981,9 @@ def use(consumer: Consumer[Animal]):
     dog: Dog = choose(consumer, Dog())
 ```
 
-### Constructor inference from positional callable signatures
+### Constructor inference from positional callable fields
 
-A callable field can infer a `ParamSpec` from a positional dictionary literal.
+A callable field determines the constructor's `ParamSpec`.
 
 ```toml
 [environment]
@@ -4122,8 +4121,7 @@ reveal_type(AliasBox(value=[1]))  # revealed: AliasBox[int]
 
 ### Constructor inference with upper bounds
 
-A literal upper bound preserves its literal, while an ordinary `int` upper bound permits the usual
-promotion.
+A literal upper bound preserves the literal type.
 
 ```toml
 [environment]
@@ -4138,19 +4136,40 @@ class LiteralBound[T: Literal[1]](TypedDict):
 
 reveal_type(LiteralBound(value=1))  # revealed: LiteralBound[Literal[1]]
 reveal_type(LiteralBound({"value": 1}))  # revealed: LiteralBound[Literal[1]]
+```
 
+An ordinary `int` upper bound allows a literal value to widen to `int`.
+
+```py
 class IntBound[T: int](TypedDict):
     value: T
 
 reveal_type(IntBound(value=1))  # revealed: IntBound[int]
 reveal_type(IntBound({"value": 1}))  # revealed: IntBound[int]
+```
 
+A value outside the upper bound produces an error.
+
+```py
 IntBound({"value": "invalid"})  # error: [invalid-argument-type]
+```
 
-class Constrained[T: (int, str)](TypedDict):
+### Constructor inference with constrained type parameters
+
+A positional dictionary value selects one of the declared type constraints.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypedDict
+
+class Box[T: (int, str)](TypedDict):
     value: T
 
-reveal_type(Constrained({"value": True}))  # revealed: Constrained[int]
+reveal_type(Box({"value": True}))  # revealed: Box[int]
 ```
 
 ### Constructor inference with callable parameters
@@ -4191,6 +4210,11 @@ class Box[T](TypedDict):
     value: T
 
 literal: Box[Literal[1]] = Box(value=1)
+```
+
+A positional dictionary receives the same expected literal type.
+
+```py
 positional_literal: Box[Literal[1]] = Box({"value": 1})
 ```
 
@@ -4201,6 +4225,11 @@ class Animal: ...
 class Dog(Animal): ...
 
 animal: Box[Animal] = Box(value=Dog())
+```
+
+The wider expected type also applies to positional dictionary values.
+
+```py
 positional_animal: Box[Animal] = Box({"value": Dog()})
 ```
 
@@ -4234,16 +4263,14 @@ literal_box = Box(value=1)
 literal: Box[Literal[1]] = literal_box
 ```
 
-Read-only positional fields remain gradual until positional inference can preserve covariance.
+A positional read-only field keeps an unknown type until its literal type can be preserved.
 
 ```py
-positional_literal_box = Box({"value": 1})
 # TODO: Infer `Box[Literal[1]]`.
-reveal_type(positional_literal_box)  # revealed: Box[Unknown]
-positional_literal: Box[Literal[1]] = positional_literal_box
+reveal_type(Box({"value": 1}))  # revealed: Box[Unknown]
 ```
 
-A read-only dictionary literal passed to a generic function also remains gradual.
+A generic function also keeps its return type unknown when the dictionary field is read-only.
 
 ```py
 def get_value[T](value: Box[T]) -> T:
@@ -4318,7 +4345,11 @@ class Box[T](TypedDict, extra_items=T): ...
 box = Box(value=1)
 reveal_type(box)  # revealed: Box[int]
 box["value"] = "invalid"  # error: [invalid-assignment]
+```
 
+A positional dictionary also determines the type of mutable extra items.
+
+```py
 positional = Box({"value": 1})
 reveal_type(positional)  # revealed: Box[int]
 positional["value"] = "invalid"  # error: [invalid-assignment]
@@ -4355,13 +4386,18 @@ class Box[T](TypedDict):
     callback: Callable[[T], int]
 
 Box(value=1, callback=lambda x: x.upper())  # error: [unresolved-attribute]
+```
+
+A callback in a positional dictionary receives the same inferred parameter type.
+
+```py
 Box({"value": 1, "callback": lambda x: x.upper()})  # error: [unresolved-attribute]
 ```
 
-### Constructor inference from nested callbacks
+### Constructor inference from positional nested callbacks
 
-A callback inside a positional container remains gradual until inference can propagate its field
-context into the nested expression.
+A callback inside a list needs its parameter type before its body can be checked. The constructor
+keeps its type argument unknown until that information can reach the callback.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3873,6 +3873,12 @@ class Pair[T](TypedDict):
 reveal_type(Pair({"first": 1, "second": "x"}))  # revealed: Pair[int | str]
 ```
 
+An overwritten callback cannot affect the final values or prevent inference.
+
+```py
+reveal_type(Pair({"first": [lambda value: value.upper()], "first": 1, "second": "x"}))  # revealed: Pair[int | str]
+```
+
 A missing required field retains its existing constructor diagnostic.
 
 ```py
@@ -3912,6 +3918,68 @@ def get_inferred[T](value: PartiallySpecialized[object, T]) -> T:
     return value["inferred"]
 
 reveal_type(get_inferred({"fixed": 1, "inferred": "x"}))  # revealed: str
+```
+
+An unrelated `TypedDict` does not provide a specialization for the generic parameter.
+
+```py
+class Source(TypedDict):
+    value: int
+
+def unrelated_source(source: Source):
+    reveal_type(get_value(source))  # revealed: Unknown
+```
+
+### Generic function inference with unused TypedDict parameters
+
+A type parameter absent from a `TypedDict` schema does not constrain another function argument.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generic, TypeVar, TypedDict
+
+T = TypeVar("T")
+
+class Box(TypedDict, Generic[T]):
+    value: int
+
+def choose[U](box: Box[U], fallback: U) -> U:
+    return fallback
+
+def use(box: Box[str]):
+    result: int = choose(box, 1)
+```
+
+### Generic function inference with legacy contravariant fields
+
+A legacy type parameter inherits the structural variance of a read-only callable field.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, Generic, TypeVar, TypedDict
+from typing_extensions import ReadOnly
+
+class Animal: ...
+class Dog(Animal): ...
+
+T = TypeVar("T")
+
+class Consumer(TypedDict, Generic[T]):
+    callback: ReadOnly[Callable[[T], None]]
+
+def choose[U](consumer: Consumer[U], fallback: U) -> U:
+    return fallback
+
+def use(consumer: Consumer[Animal]):
+    dog: Dog = choose(consumer, Dog())
 ```
 
 ### Constructor inference from positional callable signatures
@@ -4175,6 +4243,15 @@ reveal_type(positional_literal_box)  # revealed: Box[Unknown]
 positional_literal: Box[Literal[1]] = positional_literal_box
 ```
 
+A read-only dictionary literal passed to a generic function also remains gradual.
+
+```py
+def get_value[T](value: Box[T]) -> T:
+    return value["value"]
+
+reveal_type(get_value({"value": 1}))  # revealed: Unknown
+```
+
 A legacy type variable is invariant by default, so assigning `LegacyBox[Dog]` to `LegacyBox[Animal]`
 should eventually produce an error.
 
@@ -4279,6 +4356,27 @@ class Box[T](TypedDict):
 
 Box(value=1, callback=lambda x: x.upper())  # error: [unresolved-attribute]
 Box({"value": 1, "callback": lambda x: x.upper()})  # error: [unresolved-attribute]
+```
+
+### Constructor inference from nested callbacks
+
+A callback inside a positional container remains gradual until inference can propagate its field
+context into the nested expression.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, TypedDict
+
+class Box[T](TypedDict):
+    value: T
+    callbacks: list[Callable[[T], int]]
+
+# TODO: Infer `Box[int]`.
+reveal_type(Box({"value": 1, "callbacks": [lambda value: value + 1]}))  # revealed: Box[Unknown]
 ```
 
 ### Constructor inference with a contextual callable

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3624,11 +3624,10 @@ class ListBox[T](TypedDict):
 reveal_type(ListBox(value=[1]))  # revealed: ListBox[int]
 ```
 
-Positional dictionary literals are validated but do not yet infer type arguments.
+An exact positional dictionary literal contributes its individual field values to inference.
 
 ```py
-# TODO: Infer `ListBox[int]`.
-reveal_type(ListBox({"value": [1]}))  # revealed: ListBox[Unknown]
+reveal_type(ListBox({"value": [1]}))  # revealed: ListBox[int]
 ```
 
 ### Constructor inference from unpacked dictionary literals
@@ -3855,6 +3854,87 @@ def unpack(source: IntSource | StrSource):
     reveal_type(Box(**source))  # revealed: Box[Unknown]
 ```
 
+### Constructor inference from positional dictionary literals
+
+Different values in a positional dictionary literal can constrain the same type parameter.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypedDict
+
+class Pair[T](TypedDict):
+    first: T
+    second: T
+
+reveal_type(Pair({"first": 1, "second": "x"}))  # revealed: Pair[int | str]
+```
+
+A missing required field retains its existing constructor diagnostic.
+
+```py
+Pair({"first": 1})  # error: [missing-typed-dict-key]
+```
+
+### Generic function inference from TypedDict literals
+
+A dictionary literal passed to a generic `TypedDict` parameter constrains the function's type
+argument.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypedDict
+
+class Box[T](TypedDict):
+    value: T
+
+def get_value[T](box: Box[T]) -> T:
+    return box["value"]
+
+reveal_type(get_value({"value": 1}))  # revealed: int
+```
+
+A partially specialized parameter keeps its existing concrete type argument.
+
+```py
+class PartiallySpecialized[A, B](TypedDict):
+    fixed: A
+    inferred: B
+
+def get_inferred[T](value: PartiallySpecialized[object, T]) -> T:
+    return value["inferred"]
+
+reveal_type(get_inferred({"fixed": 1, "inferred": "x"}))  # revealed: str
+```
+
+### Constructor inference from positional callable signatures
+
+A callable field can infer a `ParamSpec` from a positional dictionary literal.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, TypedDict
+
+class CallbackBox[**P](TypedDict):
+    callback: Callable[P, None]
+
+def accepts_int(value: int) -> None: ...
+
+callback_box = CallbackBox({"callback": accepts_int})
+callback_box["callback"]("invalid")  # error: [invalid-argument-type]
+```
+
 ### Constructor inference from recursive fields
 
 Recursive construction remains valid even though the outer constructor cannot yet infer its type
@@ -3989,11 +4069,20 @@ class LiteralBound[T: Literal[1]](TypedDict):
     value: T
 
 reveal_type(LiteralBound(value=1))  # revealed: LiteralBound[Literal[1]]
+reveal_type(LiteralBound({"value": 1}))  # revealed: LiteralBound[Literal[1]]
 
 class IntBound[T: int](TypedDict):
     value: T
 
 reveal_type(IntBound(value=1))  # revealed: IntBound[int]
+reveal_type(IntBound({"value": 1}))  # revealed: IntBound[int]
+
+IntBound({"value": "invalid"})  # error: [invalid-argument-type]
+
+class Constrained[T: (int, str)](TypedDict):
+    value: T
+
+reveal_type(Constrained({"value": True}))  # revealed: Constrained[int]
 ```
 
 ### Constructor inference with callable parameters
@@ -4034,6 +4123,7 @@ class Box[T](TypedDict):
     value: T
 
 literal: Box[Literal[1]] = Box(value=1)
+positional_literal: Box[Literal[1]] = Box({"value": 1})
 ```
 
 A wider expected type is also respected because a mutable `TypedDict` is invariant.
@@ -4043,6 +4133,7 @@ class Animal: ...
 class Dog(Animal): ...
 
 animal: Box[Animal] = Box(value=Dog())
+positional_animal: Box[Animal] = Box({"value": Dog()})
 ```
 
 ### Constructor inference with read-only fields
@@ -4073,6 +4164,15 @@ A read-only field also preserves a literal when the inferred value is used with 
 ```py
 literal_box = Box(value=1)
 literal: Box[Literal[1]] = literal_box
+```
+
+Read-only positional fields remain gradual until positional inference can preserve covariance.
+
+```py
+positional_literal_box = Box({"value": 1})
+# TODO: Infer `Box[Literal[1]]`.
+reveal_type(positional_literal_box)  # revealed: Box[Unknown]
+positional_literal: Box[Literal[1]] = positional_literal_box
 ```
 
 A legacy type variable is invariant by default, so assigning `LegacyBox[Dog]` to `LegacyBox[Animal]`
@@ -4141,6 +4241,10 @@ class Box[T](TypedDict, extra_items=T): ...
 box = Box(value=1)
 reveal_type(box)  # revealed: Box[int]
 box["value"] = "invalid"  # error: [invalid-assignment]
+
+positional = Box({"value": 1})
+reveal_type(positional)  # revealed: Box[int]
+positional["value"] = "invalid"  # error: [invalid-assignment]
 ```
 
 A nested generic extra item should constrain its enclosing `TypedDict` without rejecting the inner
@@ -4174,6 +4278,7 @@ class Box[T](TypedDict):
     callback: Callable[[T], int]
 
 Box(value=1, callback=lambda x: x.upper())  # error: [unresolved-attribute]
+Box({"value": 1, "callback": lambda x: x.upper()})  # error: [unresolved-attribute]
 ```
 
 ### Constructor inference with a contextual callable

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3947,7 +3947,33 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            (formal @ Type::TypedDict(_), actual @ Type::TypedDict(_)) => {
+            (
+                formal @ Type::TypedDict(formal_typed_dict),
+                actual @ Type::TypedDict(actual_typed_dict),
+            ) => {
+                let (
+                    Some(ClassType::Generic(formal_alias)),
+                    Some(ClassType::Generic(actual_alias)),
+                ) = (
+                    formal_typed_dict.defining_class(),
+                    actual_typed_dict.defining_class(),
+                )
+                else {
+                    return Ok(());
+                };
+                if formal_alias.origin(db) != actual_alias.origin(db) {
+                    return Ok(());
+                }
+
+                let actual_specialization = actual_alias.specialization(db);
+                if actual_specialization
+                    .types(db)
+                    .iter()
+                    .any(|ty| ty.has_unspecialized_type_var(db, self.env))
+                {
+                    return Ok(());
+                }
+
                 let when = actual.when_constraint_set_assignable_to(
                     db,
                     self.env,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3947,6 +3947,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
+            (formal @ Type::TypedDict(_), actual @ Type::TypedDict(_)) => {
+                let when = actual.when_constraint_set_assignable_to(
+                    db,
+                    self.env,
+                    formal,
+                    self.constraints,
+                );
+                self.infer_from_constraint_set(when)?;
+                return Ok(());
+            }
+
             // TODO: in principle this could be a generalized Union-actual arm that maps over the
             // union, but the old solver isn't well-equipped to handle that (due to side effects
             // from even failed matches), so for now we handle this particular case.

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -481,6 +481,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             if !seen_keys.insert(name) {
                 continue;
             }
+            if !item.value.is_lambda_expr() && any_over_expr(&item.value, ast::Expr::is_lambda_expr)
+            {
+                return None;
+            }
             let field_ty = if let Some(field) = identity.item(db, name) {
                 if field.is_read_only() {
                     return None;
@@ -799,27 +803,38 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             && let [ast::Expr::Dict(dict)] = &arguments.args[..]
         {
             let mut provided_keys = FxHashSet::default();
-            dict.items.iter().all(|item| {
-                item.key
+            dict.items.iter().rev().all(|item| {
+                let Some(key) = item
+                    .key
                     .as_ref()
                     .and_then(ast::Expr::as_string_literal_expr)
-                    .and_then(|key| {
-                        let key = key.value.to_str();
-                        provided_keys.insert(key);
-                        if let Some(field) = typed_dict.item(db, key) {
-                            (!field.is_read_only()).then_some(field.declared_ty)
-                        } else {
-                            typed_dict.arbitrary_key_initialization_type(db, env)
-                        }
-                    })
-                    .is_some_and(|field_ty| {
-                        !contains_generic_typed_dict(
-                            db,
-                            env,
-                            field_ty,
-                            &ActiveRecursionDetector::default(),
-                        )
-                    })
+                else {
+                    return false;
+                };
+                let key = key.value.to_str();
+                if !provided_keys.insert(key) {
+                    return true;
+                }
+
+                if !item.value.is_lambda_expr()
+                    && any_over_expr(&item.value, ast::Expr::is_lambda_expr)
+                {
+                    return false;
+                }
+
+                let field_ty = if let Some(field) = typed_dict.item(db, key) {
+                    if field.is_read_only() {
+                        return false;
+                    }
+                    field.declared_ty
+                } else if let Some(field_ty) = typed_dict.arbitrary_key_initialization_type(db, env)
+                {
+                    field_ty
+                } else {
+                    return false;
+                };
+
+                !contains_generic_typed_dict(db, env, field_ty, &ActiveRecursionDetector::default())
             }) && typed_dict
                 .items(db)
                 .iter()

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -6,6 +6,7 @@ use smallvec::SmallVec;
 use strum::IntoEnumIterator;
 
 use super::{ArgumentsIter, TypeInferenceBuilder};
+use crate::types::call::{Argument, CallArguments};
 use crate::types::class::{ClassLiteral, DynamicTypedDictAnchor, DynamicTypedDictLiteral};
 use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::diagnostic::{
@@ -367,6 +368,30 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     ) -> Option<Type<'db>> {
         let db = self.db();
         let env = self.program_environment();
+        let has_unspecialized_arguments = typed_dict
+            .defining_class()
+            .and_then(ClassType::into_generic_alias)
+            .is_some_and(|alias| {
+                alias
+                    .specialization(db)
+                    .types(db)
+                    .iter()
+                    .any(|ty| ty.has_unspecialized_type_var(db, env))
+            });
+        if has_unspecialized_arguments {
+            let mut speculative_builder = self.speculate();
+            let mut speculative_item_types = FxHashMap::default();
+            if let Some(inferred) = speculative_builder.infer_generic_typed_dict_literal(
+                dict,
+                typed_dict,
+                &mut speculative_item_types,
+            ) {
+                self.extend(speculative_builder);
+                item_types.extend(speculative_item_types);
+                return Some(inferred);
+            }
+        }
+
         let ast::ExprDict {
             range: _,
             node_index: _,
@@ -421,14 +446,120 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         .map(|_| Type::TypedDict(typed_dict))
     }
 
+    /// Infers unresolved `TypedDict` arguments by binding literal fields as ordinary keywords.
+    ///
+    /// Without field-level inference, `get_value({"value": 1})` and `Box({"value": 1})` are
+    /// checked against `Box[Unknown]` before their values reach generic call inference. Binding the
+    /// fields to the existing synthesized constructor reuses the normal solver, including contextual
+    /// specializations, bounds, literal promotion, and callback inference.
+    fn infer_generic_typed_dict_literal(
+        &mut self,
+        dict: &ast::ExprDict,
+        typed_dict: TypedDictType<'db>,
+        item_types: &mut FxHashMap<NodeIndex, Type<'db>>,
+    ) -> Option<Type<'db>> {
+        let db = self.db();
+        let env = self.program_environment();
+        let ClassType::Generic(alias) = typed_dict.defining_class()? else {
+            return None;
+        };
+        if !alias
+            .specialization(db)
+            .types(db)
+            .iter()
+            .any(|ty| ty.has_unspecialized_type_var(db, env))
+        {
+            return None;
+        }
+
+        let identity = TypedDictType::new(alias.origin(db).identity_specialization(db));
+        let mut seen_keys = FxHashSet::default();
+        let mut fields = Vec::with_capacity(dict.items.len());
+        for item in dict.items.iter().rev() {
+            let key = item.key.as_ref()?.as_string_literal_expr()?;
+            let name = key.value.to_str();
+            if !seen_keys.insert(name) {
+                continue;
+            }
+            let field_ty = if let Some(field) = identity.item(db, name) {
+                if field.is_read_only() {
+                    return None;
+                }
+                field.declared_ty
+            } else {
+                identity.arbitrary_key_initialization_type(db, env)?
+            };
+            if contains_generic_typed_dict(db, env, field_ty, &ActiveRecursionDetector::default()) {
+                return None;
+            }
+            fields.push((name, &item.value));
+        }
+        fields.reverse();
+
+        let source_arguments: Vec<_> = fields
+            .iter()
+            .map(|(_, value)| ast::ArgOrKeyword::Arg(value))
+            .collect();
+        let mut call_arguments: CallArguments<'_, 'db> = fields
+            .iter()
+            .map(|(name, _)| (Argument::Keyword(name), None))
+            .collect();
+        let mut bindings = self
+            .bindings_for_call(Type::ClassLiteral(ClassLiteral::Static(alias.origin(db))))
+            .match_parameters(db, env, &call_arguments);
+        if !bindings.satisfies(|_| true) {
+            return None;
+        }
+
+        let inference = self.infer_and_check_argument_types(
+            ArgumentsIter::synthesized(&source_arguments),
+            &mut call_arguments,
+            &mut |builder, (_, expression, tcx)| builder.infer_expression(expression, tcx),
+            &mut bindings,
+            TypeContext::new(Some(Type::TypedDict(typed_dict))),
+        );
+        if inference.is_err() {
+            bindings.report_diagnostics(&self.context, dict.into());
+            return Some(Type::unknown());
+        }
+
+        let inferred = bindings.return_type(db, env);
+        let inferred_typed_dict = inferred.as_typed_dict()?;
+        let key_tcx = TypeContext::new(self.typed_dict_key_expected_type(inferred));
+        for item in &dict.items {
+            if let Some(key) = &item.key {
+                item_types.insert(key.node_index().load(), self.infer_expression(key, key_tcx));
+            }
+            let value_ty = self.get_or_infer_expression(&item.value, TypeContext::default());
+            item_types.insert(item.value.node_index().load(), value_ty);
+        }
+
+        validate_typed_dict_dict_literal(
+            &self.context,
+            inferred_typed_dict,
+            dict,
+            dict.into(),
+            |expression, _| {
+                item_types
+                    .get(&expression.node_index().load())
+                    .copied()
+                    .unwrap_or_else(Type::unknown)
+            },
+        )
+        .ok()
+        .map(|_| inferred)
+    }
+
     /// Infers and validates a `TypedDict` constructor through one call-binding pipeline.
     ///
-    /// Bare generic constructors infer from direct keyword arguments. Other forms use the existing
-    /// field-directed validation and bind against the class's default specialization:
+    /// Bare generic constructors infer from direct keywords, unpacked `TypedDict`s, and exact
+    /// positional or unpacked dictionary literals. Other forms use the existing field-directed
+    /// validation and bind against the class's default specialization:
     ///
     /// ```python
-    /// Box(value=1)        # Box[int]
-    /// Box({"value": 1})   # Box[Unknown]
+    /// Box(value=1)          # Box[int]
+    /// Box({"value": 1})     # Box[int]
+    /// Box(**{"value": 1})   # Box[int]
     /// ```
     pub(super) fn infer_typed_dict_constructor<'expr>(
         &mut self,
@@ -536,8 +667,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
     /// Returns whether constructor arguments can safely constrain a generic `TypedDict`.
     ///
-    /// Mapping arguments, unresolved nested `TypedDict` fields, and gradual expected types remain
-    /// on the field-directed path so sibling arguments cannot force an unsound specialization:
+    /// Opaque mapping arguments, unresolved nested `TypedDict` fields, and gradual expected types
+    /// remain on the field-directed path so sibling arguments cannot force an unsound
+    /// specialization:
     ///
     /// ```python
     /// Outer(inner=Inner(value=1), marker="x")  # Outer[Unknown]
@@ -602,8 +734,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         });
         let typed_dict = TypedDictType::new(class_literal.identity_specialization(db));
 
-        arguments.args.is_empty()
-            && !has_gradual_class_context
+        let supports_keywords = arguments.args.is_empty()
             && arguments.keywords.iter().all(|keyword| {
                 let permits_field_inference = |name: &str| {
                     typed_dict.item(db, name).is_none_or(|field| {
@@ -615,7 +746,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         )
                     })
                 };
-
                 if let Some(name) = keyword.arg.as_ref() {
                     return permits_field_inference(name.id.as_str());
                 }
@@ -664,7 +794,41 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             })
                         })
                 }
-            })
+            });
+        let supports_positional_literal = if arguments.keywords.is_empty()
+            && let [ast::Expr::Dict(dict)] = &arguments.args[..]
+        {
+            let mut provided_keys = FxHashSet::default();
+            dict.items.iter().all(|item| {
+                item.key
+                    .as_ref()
+                    .and_then(ast::Expr::as_string_literal_expr)
+                    .and_then(|key| {
+                        let key = key.value.to_str();
+                        provided_keys.insert(key);
+                        if let Some(field) = typed_dict.item(db, key) {
+                            (!field.is_read_only()).then_some(field.declared_ty)
+                        } else {
+                            typed_dict.arbitrary_key_initialization_type(db, env)
+                        }
+                    })
+                    .is_some_and(|field_ty| {
+                        !contains_generic_typed_dict(
+                            db,
+                            env,
+                            field_ty,
+                            &ActiveRecursionDetector::default(),
+                        )
+                    })
+            }) && typed_dict
+                .items(db)
+                .iter()
+                .all(|(name, field)| !field.is_required() || provided_keys.contains(name.as_str()))
+        } else {
+            false
+        };
+
+        !has_gradual_class_context && (supports_keywords || supports_positional_literal)
     }
 
     /// Prepare a `TypedDict` constructor call before general argument inference.


### PR DESCRIPTION
## Summary

Follow-up to #27452.

Allow positional dictionary literals to contribute their individual field types when constructing a generic `TypedDict`:

```py
from typing import TypedDict

class Box[T](TypedDict):
    value: T

reveal_type(Box({"value": 1}))  # Box[int]
```

The same field-level inference also applies when a dictionary literal is passed to a generic function expecting a `TypedDict`:

```py
def get_value[T](box: Box[T]) -> T:
    return box["value"]

reveal_type(get_value({"value": 1}))  # int
```

We bind literal fields through the existing synthesized constructor and reuse ordinary generic constraint solving, including contextual specializations, bounds, defaults, callable parameters, and mutable extra items. Structural `TypedDict` constraints preserve read-only variance and avoid treating unused type parameters as meaningful field evidence.

Only exact dictionary literals with known string keys participate. Opaque mappings, mixed positional and keyword calls, nested generic `TypedDict` fields, read-only fields, and nested callbacks retain their existing conservative behavior.
