### PR TITLE
[ty] Infer generic TypedDicts from unpacked dictionary literals

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -3204,6 +3204,28 @@ def ab(a: str):
     }
 
     #[test]
+    fn hover_overload_disambiguated_by_unpacked_dictionary_literal() {
+        let test = hover_test(
+            r#"
+from typing import overload
+
+@overload
+def convert(*, value: int, label: str) -> int: ...
+@overload
+def convert(*, value: str, label: int) -> str: ...
+def convert(*, value: object, label: object) -> object:
+    return value
+
+conv<CURSOR>ert(**{"value": 1, "label": "x"})
+"#,
+        );
+
+        let hover = test.hover();
+        assert!(hover.contains("value: int"), "{hover}");
+        assert!(!hover.contains("value: str"), "{hover}");
+    }
+
+    #[test]
     fn hover_overload_arity_disambiguated1() {
         let test = CursorTest::builder()
             .source(

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1385,10 +1385,9 @@ f(**dict(a=1, b=2))
 f(**Foo(a=1, b=2))
 ```
 
-### Dictionary literals preserve individual value types
+### Generic functions with unpacked dictionary literals
 
-An unpacked dictionary literal keeps the value type associated with each key when inferring a
-generic function call.
+Each value in an unpacked dictionary is matched with the parameter named by its key.
 
 ```toml
 [environment]
@@ -1402,13 +1401,20 @@ def value_and_label[T](*, value: T, label: str) -> T:
 reveal_type(value_and_label(**{"value": 1, "label": "x"}))  # revealed: Literal[1]
 ```
 
-Separate unpacked dictionary literals also retain their own keys and value types.
+Values from separate unpacked dictionaries are matched independently.
 
 ```py
 reveal_type(value_and_label(**{"value": 1}, **{"label": "x"}))  # revealed: Literal[1]
 ```
 
-The same key information is preserved when a method receives its implicit `self` argument.
+### Generic methods with unpacked dictionary literals
+
+An unpacked dictionary preserves its key-value pairs when a method supplies `self`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
 class Reader:
@@ -1418,9 +1424,9 @@ class Reader:
 reveal_type(Reader().value_and_label(**{"value": 1, "label": "x"}))  # revealed: Literal[1]
 ```
 
-### Dictionary literals forwarded through a ParamSpec
+### Forwarded unpacked dictionary literals
 
-Forwarding an unpacked dictionary literal preserves the wrapped callable's distinct parameter types.
+Forwarding an unpacked dictionary through a `ParamSpec` preserves each parameter's type.
 
 ```toml
 [environment]
@@ -1435,6 +1441,11 @@ def forward[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs)
     callback(*args, **kwargs)
 
 forward(target, **{"value": 1, "other": "x"})
+```
+
+An argument with the wrong type still produces an error after forwarding.
+
+```py
 forward(target, **{"value": "invalid", "other": "x"})  # error: [invalid-argument-type]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1385,6 +1385,29 @@ f(**dict(a=1, b=2))
 f(**Foo(a=1, b=2))
 ```
 
+### Dictionary literals preserve individual value types
+
+An unpacked dictionary literal keeps the value type associated with each key when inferring a
+generic function call.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+def value_and_label[T](*, value: T, label: str) -> T:
+    return value
+
+reveal_type(value_and_label(**{"value": 1, "label": "x"}))  # revealed: Literal[1]
+```
+
+Separate unpacked dictionary literals also retain their own keys and value types.
+
+```py
+reveal_type(value_and_label(**{"value": 1}, **{"label": "x"}))  # revealed: Literal[1]
+```
+
 ### Keyword-only parameters
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1408,6 +1408,36 @@ Separate unpacked dictionary literals also retain their own keys and value types
 reveal_type(value_and_label(**{"value": 1}, **{"label": "x"}))  # revealed: Literal[1]
 ```
 
+The same key information is preserved when a method receives its implicit `self` argument.
+
+```py
+class Reader:
+    def value_and_label[T](self, *, value: T, label: str) -> T:
+        return value
+
+reveal_type(Reader().value_and_label(**{"value": 1, "label": "x"}))  # revealed: Literal[1]
+```
+
+### Dictionary literals forwarded through a ParamSpec
+
+Forwarding an unpacked dictionary literal preserves the wrapped callable's distinct parameter types.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable
+
+def target(value: int, *, other: str) -> None: ...
+def forward[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None:
+    callback(*args, **kwargs)
+
+forward(target, **{"value": 1, "other": "x"})
+forward(target, **{"value": "invalid", "other": "x"})  # error: [invalid-argument-type]
+```
+
 ### Keyword-only parameters
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -1272,10 +1272,10 @@ def _(x1: int, x2: int, kwargs: dict[str, int]):
     reveal_type(f(x1=x1))  # revealed: int
     reveal_type(f(x1=x1, x2=x2))  # revealed: tuple[int, int]
 
-    # A dictionary literal has known keys, so the matching fixed-parameter overload is selected.
+    # A dictionary literal has known keys, so it selects the overload with matching parameters.
     reveal_type(f(**{"x1": x1, "x2": x2}))  # revealed: tuple[int, int]
 
-    # An arbitrary mapping may contain other keys, so step 4 selects the variadic overload.
+    # A mapping may contain other keys, so step 4 selects the `**kwargs` overload.
     reveal_type(f(**kwargs))  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -1272,8 +1272,10 @@ def _(x1: int, x2: int, kwargs: dict[str, int]):
     reveal_type(f(x1=x1))  # revealed: int
     reveal_type(f(x1=x1, x2=x2))  # revealed: tuple[int, int]
 
-    # Step 4 should filter out all but the last overload.
-    reveal_type(f(**{"x1": x1, "x2": x2}))  # revealed: int
+    # A dictionary literal has known keys, so the matching fixed-parameter overload is selected.
+    reveal_type(f(**{"x1": x1, "x2": x2}))  # revealed: tuple[int, int]
+
+    # An arbitrary mapping may contain other keys, so step 4 selects the variadic overload.
     reveal_type(f(**kwargs))  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3616,7 +3616,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import TypedDict
+from typing import Callable, Literal, TypedDict
 
 class ListBox[T](TypedDict):
     value: list[T]
@@ -3624,25 +3624,54 @@ class ListBox[T](TypedDict):
 reveal_type(ListBox(value=[1]))  # revealed: ListBox[int]
 ```
 
-Positional and unpacked dictionary literals are validated but do not yet infer type arguments.
+Positional dictionary literals are validated but do not yet infer type arguments.
 
 ```py
 # TODO: Infer `ListBox[int]`.
 reveal_type(ListBox({"value": [1]}))  # revealed: ListBox[Unknown]
-# TODO: Infer `ListBox[int]`.
-reveal_type(ListBox(**{"value": [1]}))  # revealed: ListBox[Unknown]
 ```
 
-A dictionary containing different field types, or multiple unpacked dictionaries, must not cause
-spurious argument errors.
+An unpacked dictionary literal contributes the value type associated with each individual key.
+
+```py
+unpacked_list_box = ListBox(**{"value": [1]})
+reveal_type(unpacked_list_box)  # revealed: ListBox[int]
+```
+
+Different field types remain distinct within one dictionary or across multiple unpacked
+dictionaries.
 
 ```py
 class Pair[T](TypedDict):
     first: T
     second: str
 
-reveal_type(Pair(**{"first": 1, "second": "x"}))  # revealed: Pair[Unknown]
-reveal_type(Pair(**{"first": 1}, **{"second": "x"}))  # revealed: Pair[Unknown]
+reveal_type(Pair(**{"first": 1, "second": "x"}))  # revealed: Pair[int]
+reveal_type(Pair(**{"first": 1}, **{"second": "x"}))  # revealed: Pair[int]
+```
+
+Later entries in the same dictionary literal replace earlier values for the same key.
+
+```py
+reveal_type(Pair(**{"first": "overwritten", "first": 1, "second": "x"}))  # revealed: Pair[int]
+```
+
+The expected specialization still supplies context to mutable container fields.
+
+```py
+literal_box: ListBox[Literal[1]] = ListBox(**{"value": [1]})
+```
+
+A context-sensitive callback remains gradual until unpacked values can receive field-specific
+inference context.
+
+```py
+class CallbackBox[T](TypedDict):
+    value: T
+    callback: Callable[[T], int]
+
+# TODO: Infer `CallbackBox[int]` and report the invalid attribute access.
+reveal_type(CallbackBox(**{"value": 1, "callback": lambda value: value.upper()}))  # revealed: CallbackBox[Unknown]
 ```
 
 ### Constructor inference from unpacked TypedDicts

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3645,6 +3645,55 @@ reveal_type(Pair(**{"first": 1, "second": "x"}))  # revealed: Pair[Unknown]
 reveal_type(Pair(**{"first": 1}, **{"second": "x"}))  # revealed: Pair[Unknown]
 ```
 
+### Constructor inference from unpacked TypedDicts
+
+Unpacking a `TypedDict` with required keys contributes each field's type to constructor inference.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import NotRequired, TypedDict
+
+class Source(TypedDict):
+    value: int
+
+class Box[T](TypedDict):
+    value: T
+
+def unpack(source: Source):
+    reveal_type(Box(**source))  # revealed: Box[int]
+```
+
+Different unpacked `TypedDict` arguments retain their separate field types.
+
+```py
+class First(TypedDict):
+    first: int
+
+class Second(TypedDict):
+    second: str
+
+class Pair[T](TypedDict):
+    first: T
+    second: str
+
+def unpack_multiple(first: First, second: Second):
+    reveal_type(Pair(**first, **second))  # revealed: Pair[int]
+```
+
+An optional source key does not satisfy a required constructor field.
+
+```py
+class MaybeSource(TypedDict):
+    value: NotRequired[int]
+
+def unpack_optional(source: MaybeSource):
+    Box(**source)  # error: [missing-typed-dict-key]
+```
+
 ### Constructor inference from recursive fields
 
 Recursive construction remains valid even though the outer constructor cannot yet infer its type

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3616,7 +3616,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Callable, Literal, TypedDict
+from typing import TypedDict
 
 class ListBox[T](TypedDict):
     value: list[T]
@@ -3631,15 +3631,25 @@ Positional dictionary literals are validated but do not yet infer type arguments
 reveal_type(ListBox({"value": [1]}))  # revealed: ListBox[Unknown]
 ```
 
-An unpacked dictionary literal contributes the value type associated with each individual key.
+### Constructor inference from unpacked dictionary literals
 
-```py
-unpacked_list_box = ListBox(**{"value": [1]})
-reveal_type(unpacked_list_box)  # revealed: ListBox[int]
+An unpacked dictionary literal preserves the type of each value.
+
+```toml
+[environment]
+python-version = "3.12"
 ```
 
-Different field types remain distinct within one dictionary or across multiple unpacked
-dictionaries.
+```py
+from typing import TypedDict
+
+class ListBox[T](TypedDict):
+    value: list[T]
+
+reveal_type(ListBox(**{"value": [1]}))  # revealed: ListBox[int]
+```
+
+The values of other fields do not affect the field that determines the type argument.
 
 ```py
 class Pair[T](TypedDict):
@@ -3647,75 +3657,115 @@ class Pair[T](TypedDict):
     second: str
 
 reveal_type(Pair(**{"first": 1, "second": "x"}))  # revealed: Pair[int]
+```
+
+Separate unpacked dictionaries contribute their values to the same constructor.
+
+```py
 reveal_type(Pair(**{"first": 1}, **{"second": "x"}))  # revealed: Pair[int]
 ```
 
-Later entries in the same dictionary literal replace earlier values for the same key.
+### Constructor inference from overwritten dictionary values
 
-```py
-reveal_type(Pair(**{"first": "overwritten", "first": 1, "second": "x"}))  # revealed: Pair[int]
+The last value for a repeated key determines the inferred type argument.
+
+```toml
+[environment]
+python-version = "3.12"
 ```
 
-An overwritten callback cannot affect the final field value or its inferred type.
-
 ```py
-reveal_type(Pair(**{"first": lambda value: value.upper(), "first": 1, "second": "x"}))  # revealed: Pair[int]
+from typing import TypedDict
+
+class Box[T](TypedDict):
+    value: T
+
+reveal_type(Box(**{"value": "overwritten", "value": 1}))  # revealed: Box[int]
 ```
 
-The expected specialization still supplies context to mutable container fields.
+An overwritten callback is ignored because it is not part of the final dictionary.
 
 ```py
-literal_box: ListBox[Literal[1]] = ListBox(**{"value": [1]})
+reveal_type(Box(**{"value": lambda value: value.upper(), "value": 1}))  # revealed: Box[int]
 ```
 
-An expected specialization wrapped in a union also preserves the field's context.
+### Constructor inference from unpacked dictionaries with an expected type
+
+An expected literal type is preserved when the value is unpacked from a dictionary.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
-optional_literal_box: ListBox[Literal[1]] | None = ListBox(**{"value": [1]})
+from typing import Literal, TypedDict
 
-type OptionalListBox[T] = ListBox[T] | None
+class Box[T](TypedDict):
+    value: list[T]
 
-aliased_literal_box: OptionalListBox[Literal[1]] = ListBox(**{"value": [1]})
+literal: Box[Literal[1]] = Box(**{"value": [1]})
 ```
 
-Multiple possible specializations do not discard the contextual literal type.
+A union containing the expected `TypedDict` provides the same context.
 
 ```py
-literal_choices: ListBox[Literal[1]] | ListBox[Literal[2]] = ListBox(**{"value": [1]})
+optional: Box[Literal[1]] | None = Box(**{"value": [1]})
 ```
 
-A wider expected specialization remains valid when the dictionary value is mutable.
+A type alias to that union also preserves the expected literal type.
+
+```py
+type OptionalBox[T] = Box[T] | None
+
+aliased: OptionalBox[Literal[1]] = Box(**{"value": [1]})
+```
+
+Multiple matching `TypedDict` types do not determine which type argument should be used.
+
+```py
+choices: Box[Literal[1]] | Box[Literal[2]] = Box(**{"value": [1]})
+```
+
+A wider expected type is not replaced by the narrower dictionary value.
 
 ```py
 class Animal: ...
 class Dog(Animal): ...
-class Cat(Animal): ...
 
-optional_animal_box: ListBox[Animal] | None = ListBox(**{"value": [Dog()]})
-animal_choices: ListBox[Animal] | ListBox[Cat] = ListBox(**{"value": [Dog()]})
+animal: Box[Animal] | None = Box(**{"value": [Dog()]})
 ```
 
-A context-sensitive callback remains gradual until unpacked values can receive field-specific
-inference context.
+### Constructor inference from unpacked callbacks
+
+A callback needs its parameter type before its body can be checked. Until an unpacked value receives
+that information, the constructor cannot safely infer its type argument.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
-class CallbackBox[T](TypedDict):
+from typing import Callable, TypedDict
+
+class Box[T](TypedDict):
     value: T
     callback: Callable[[T], int]
 
-# TODO: Infer `CallbackBox[int]` and report the invalid attribute access.
-reveal_type(CallbackBox(**{"value": 1, "callback": lambda value: value.upper()}))  # revealed: CallbackBox[Unknown]
+# TODO: Infer `Box[int]` and report the invalid attribute access.
+reveal_type(Box(**{"value": 1, "callback": lambda value: value.upper()}))  # revealed: Box[Unknown]
 ```
 
-Wrapping a callback in another expression does not make it safe to infer without context.
+The same limitation applies when a callback is inside another expression.
 
 ```py
-def unpack_conditional_callback(flag: bool):
-    callback = CallbackBox(**{
+def conditional_callback(flag: bool):
+    callback = Box(**{
         "value": 1,
         "callback": (lambda value: value.upper()) if flag else (lambda value: 0),
     })
-    reveal_type(callback)  # revealed: CallbackBox[Unknown]
+    reveal_type(callback)  # revealed: Box[Unknown]
 ```
 
 ### Constructor inference from unpacked TypedDicts

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3667,6 +3667,15 @@ def unpack(source: Source):
     reveal_type(Box(**source))  # revealed: Box[int]
 ```
 
+A type alias to a single `TypedDict` contributes the same field information.
+
+```py
+type SourceAlias = Source
+
+def unpack_alias(source: SourceAlias):
+    reveal_type(Box(**source))  # revealed: Box[int]
+```
+
 Different unpacked `TypedDict` arguments retain their separate field types.
 
 ```py
@@ -3692,6 +3701,35 @@ class MaybeSource(TypedDict):
 
 def unpack_optional(source: MaybeSource):
     Box(**source)  # error: [missing-typed-dict-key]
+```
+
+### Constructor inference from unpacked TypedDict unions
+
+A union can associate different value types with different callbacks. Inference remains gradual
+because combining those fields independently would reject a valid constructor call.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, TypedDict
+
+class IntSource(TypedDict):
+    value: int
+    callback: Callable[[int], None]
+
+class StrSource(TypedDict):
+    value: str
+    callback: Callable[[str], None]
+
+class Box[T](TypedDict):
+    value: T
+    callback: Callable[[T], None]
+
+def unpack(source: IntSource | StrSource):
+    reveal_type(Box(**source))  # revealed: Box[Unknown]
 ```
 
 ### Constructor inference from recursive fields

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3656,10 +3656,43 @@ Later entries in the same dictionary literal replace earlier values for the same
 reveal_type(Pair(**{"first": "overwritten", "first": 1, "second": "x"}))  # revealed: Pair[int]
 ```
 
+An overwritten callback cannot affect the final field value or its inferred type.
+
+```py
+reveal_type(Pair(**{"first": lambda value: value.upper(), "first": 1, "second": "x"}))  # revealed: Pair[int]
+```
+
 The expected specialization still supplies context to mutable container fields.
 
 ```py
 literal_box: ListBox[Literal[1]] = ListBox(**{"value": [1]})
+```
+
+An expected specialization wrapped in a union also preserves the field's context.
+
+```py
+optional_literal_box: ListBox[Literal[1]] | None = ListBox(**{"value": [1]})
+
+type OptionalListBox[T] = ListBox[T] | None
+
+aliased_literal_box: OptionalListBox[Literal[1]] = ListBox(**{"value": [1]})
+```
+
+Multiple possible specializations do not discard the contextual literal type.
+
+```py
+literal_choices: ListBox[Literal[1]] | ListBox[Literal[2]] = ListBox(**{"value": [1]})
+```
+
+A wider expected specialization remains valid when the dictionary value is mutable.
+
+```py
+class Animal: ...
+class Dog(Animal): ...
+class Cat(Animal): ...
+
+optional_animal_box: ListBox[Animal] | None = ListBox(**{"value": [Dog()]})
+animal_choices: ListBox[Animal] | ListBox[Cat] = ListBox(**{"value": [Dog()]})
 ```
 
 A context-sensitive callback remains gradual until unpacked values can receive field-specific
@@ -3672,6 +3705,17 @@ class CallbackBox[T](TypedDict):
 
 # TODO: Infer `CallbackBox[int]` and report the invalid attribute access.
 reveal_type(CallbackBox(**{"value": 1, "callback": lambda value: value.upper()}))  # revealed: CallbackBox[Unknown]
+```
+
+Wrapping a callback in another expression does not make it safe to infer without context.
+
+```py
+def unpack_conditional_callback(flag: bool):
+    callback = CallbackBox(**{
+        "value": 1,
+        "callback": (lambda value: value.upper()) if flag else (lambda value: 0),
+    })
+    reveal_type(callback)  # revealed: CallbackBox[Unknown]
 ```
 
 ### Constructor inference from unpacked TypedDicts

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 
 use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
+use ruff_python_ast::name::Name;
 use rustc_hash::FxHashMap;
 
 use crate::ProgramEnvironment;
@@ -44,6 +45,7 @@ pub(crate) struct CallArguments<'a, 'db> {
 struct CallArgument<'a, 'db> {
     argument: Argument<'a>,
     types: CallArgumentTypes<'db>,
+    exact_keyword_items: Option<Box<[(Name, Type<'db>)]>>,
 }
 
 /// Inferred types for a given argument.
@@ -140,6 +142,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
             call_arguments.items.push(CallArgument {
                 argument,
                 types: CallArgumentTypes::new(ty),
+                exact_keyword_items: None,
             });
         }
 
@@ -206,6 +209,22 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         self.items.get(index).map(|item| &item.types)
     }
 
+    /// Records the known keys and individual value types of an unpacked dictionary literal.
+    pub(crate) fn set_exact_keyword_items(
+        &mut self,
+        index: usize,
+        items: Box<[(Name, Type<'db>)]>,
+    ) {
+        if let Some(argument) = self.items.get_mut(index) {
+            argument.exact_keyword_items = Some(items);
+        }
+    }
+
+    /// Returns the exact fields of a `**{...}` argument when every key is a string literal.
+    pub(crate) fn exact_keyword_items(&self, index: usize) -> Option<&[(Name, Type<'db>)]> {
+        self.items.get(index)?.exact_keyword_items.as_deref()
+    }
+
     pub(crate) fn insert_type(
         &mut self,
         index: usize,
@@ -247,6 +266,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
             items.push(CallArgument {
                 argument: Argument::Synthetic,
                 types: CallArgumentTypes::new(bound_self),
+                exact_keyword_items: None,
             });
             items.extend(self.items.iter().cloned());
             Cow::Owned(CallArguments { items })
@@ -570,6 +590,7 @@ impl<'a, 'db> FromIterator<(Argument<'a>, Option<Type<'db>>)> for CallArguments<
             items.push(CallArgument {
                 argument,
                 types: CallArgumentTypes::new(ty),
+                exact_keyword_items: None,
             });
         }
 

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 
 use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
+use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashMap;
 
@@ -35,17 +36,20 @@ pub(crate) enum Argument<'a> {
     Keywords,
 }
 
+/// Known fields from unpacked dictionary literals, indexed by their call argument.
+type ExactKeywordItems<'db> = FxHashMap<usize, Box<[(Name, Type<'db>)]>>;
+
 /// Arguments for a single call, in source order, along with inferred types for each argument.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CallArguments<'a, 'db> {
     items: Vec<CallArgument<'a, 'db>>,
+    exact_keyword_items: Option<Box<ExactKeywordItems<'db>>>,
 }
 
 #[derive(Clone, Debug)]
 struct CallArgument<'a, 'db> {
     argument: Argument<'a>,
     types: CallArgumentTypes<'db>,
-    exact_keyword_items: Option<Box<[(Name, Type<'db>)]>>,
 }
 
 /// Inferred types for a given argument.
@@ -119,6 +123,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     ) -> Self {
         let mut call_arguments = Self {
             items: Vec::with_capacity(arguments.len()),
+            exact_keyword_items: None,
         };
 
         for arg_or_keyword in arguments.iter_source_order() {
@@ -142,7 +147,6 @@ impl<'a, 'db> CallArguments<'a, 'db> {
             call_arguments.items.push(CallArgument {
                 argument,
                 types: CallArgumentTypes::new(ty),
-                exact_keyword_items: None,
             });
         }
 
@@ -157,7 +161,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         arguments: &'a ast::Arguments,
         mut infer_argument_type: impl FnMut(&ast::Expr) -> Type<'db>,
     ) -> Self {
-        arguments
+        let mut call_arguments: Self = arguments
             .iter_source_order()
             .map(|arg_or_keyword| match arg_or_keyword {
                 ast::ArgOrKeyword::Arg(arg) => match arg {
@@ -179,7 +183,9 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                     }
                 }
             })
-            .collect()
+            .collect();
+        call_arguments.infer_exact_keyword_items(arguments, infer_argument_type);
+        call_arguments
     }
 
     /// Create a [`CallArguments`] with no arguments.
@@ -209,20 +215,58 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         self.items.get(index).map(|item| &item.types)
     }
 
-    /// Records the known keys and individual value types of an unpacked dictionary literal.
-    pub(crate) fn set_exact_keyword_items(
+    /// Records known fields from dictionary literals unpacked into this call.
+    ///
+    /// Both type checking and IDE queries use these fields to resolve calls such as
+    /// `function(**{"value": 1, "label": "x"})` without merging the value types.
+    pub(crate) fn infer_exact_keyword_items(
         &mut self,
-        index: usize,
-        items: Box<[(Name, Type<'db>)]>,
+        arguments: &'a ast::Arguments,
+        mut infer_argument_type: impl FnMut(&ast::Expr) -> Type<'db>,
     ) {
-        if let Some(argument) = self.items.get_mut(index) {
-            argument.exact_keyword_items = Some(items);
+        for (index, argument) in arguments.iter_source_order().enumerate() {
+            let Some(keyword) = argument.as_variadic() else {
+                continue;
+            };
+            let Some(dict) = keyword.value.as_dict_expr() else {
+                continue;
+            };
+            let Some(items) = dict
+                .items
+                .iter()
+                .rev()
+                .map(|item| {
+                    let key = item.key.as_ref()?.as_string_literal_expr()?;
+                    Some((Name::new(key.value.to_str()), &item.value))
+                })
+                .collect::<Option<Vec<_>>>()
+            else {
+                continue;
+            };
+            let Some(mut items) = items
+                .into_iter()
+                .unique_by(|(name, _)| name.clone())
+                .map(|(name, value)| {
+                    (!any_over_expr(value, ast::Expr::is_lambda_expr))
+                        .then(|| (name, infer_argument_type(value)))
+                })
+                .collect::<Option<Vec<_>>>()
+            else {
+                continue;
+            };
+            items.reverse();
+            self.exact_keyword_items
+                .get_or_insert_default()
+                .insert(index, items.into_boxed_slice());
         }
     }
 
     /// Returns the exact fields of a `**{...}` argument when every key is a string literal.
     pub(crate) fn exact_keyword_items(&self, index: usize) -> Option<&[(Name, Type<'db>)]> {
-        self.items.get(index)?.exact_keyword_items.as_deref()
+        self.exact_keyword_items
+            .as_ref()?
+            .get(&index)
+            .map(Box::as_ref)
     }
 
     pub(crate) fn insert_type(
@@ -266,10 +310,20 @@ impl<'a, 'db> CallArguments<'a, 'db> {
             items.push(CallArgument {
                 argument: Argument::Synthetic,
                 types: CallArgumentTypes::new(bound_self),
-                exact_keyword_items: None,
             });
             items.extend(self.items.iter().cloned());
-            Cow::Owned(CallArguments { items })
+            let exact_keyword_items = self.exact_keyword_items.as_ref().map(|exact_items| {
+                Box::new(
+                    exact_items
+                        .iter()
+                        .map(|(index, items)| (index + 1, items.clone()))
+                        .collect(),
+                )
+            });
+            Cow::Owned(CallArguments {
+                items,
+                exact_keyword_items,
+            })
         } else {
             Cow::Borrowed(self)
         }
@@ -283,8 +337,20 @@ impl<'a, 'db> CallArguments<'a, 'db> {
 
     /// Create a new [`CallArguments`] starting from the specified index.
     fn start_from(&self, index: usize) -> Self {
+        let exact_keyword_items = self.exact_keyword_items.as_ref().and_then(|exact_items| {
+            let items = exact_items
+                .iter()
+                .filter_map(|(argument_index, items)| {
+                    argument_index
+                        .checked_sub(index)
+                        .map(|argument_index| (argument_index, items.clone()))
+                })
+                .collect::<FxHashMap<_, _>>();
+            (!items.is_empty()).then_some(Box::new(items))
+        });
         Self {
             items: self.items[index..].to_vec(),
+            exact_keyword_items,
         }
     }
 
@@ -299,11 +365,24 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     /// wrapper(TagSet=[...], func=f)  # select `TagSet=[...]`, but not the later `func=f`
     /// ```
     pub(crate) fn select(&self, indices: &[usize]) -> Self {
+        let exact_keyword_items = self.exact_keyword_items.as_ref().and_then(|exact_items| {
+            let items = indices
+                .iter()
+                .enumerate()
+                .filter_map(|(selected_index, argument_index)| {
+                    exact_items
+                        .get(argument_index)
+                        .map(|items| (selected_index, items.clone()))
+                })
+                .collect::<FxHashMap<_, _>>();
+            (!items.is_empty()).then_some(Box::new(items))
+        });
         Self {
             items: indices
                 .iter()
                 .map(|index| self.items[*index].clone())
                 .collect(),
+            exact_keyword_items,
         }
     }
 
@@ -590,11 +669,13 @@ impl<'a, 'db> FromIterator<(Argument<'a>, Option<Type<'db>>)> for CallArguments<
             items.push(CallArgument {
                 argument,
                 types: CallArgumentTypes::new(ty),
-                exact_keyword_items: None,
             });
         }
 
-        Self { items }
+        Self {
+            items,
+            exact_keyword_items: None,
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5049,7 +5049,9 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument_index: usize,
         argument_type: Option<Type<'db>>,
     ) {
-        if let Some(items) = self.arguments.exact_keyword_items(argument_index) {
+        if self.parameters.as_paramspec_with_prefix().is_none()
+            && let Some(items) = self.arguments.exact_keyword_items(argument_index)
+        {
             for (name, value_ty) in items.iter().cloned() {
                 let _ = self.match_keyword(
                     argument_index,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5049,6 +5049,18 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument_index: usize,
         argument_type: Option<Type<'db>>,
     ) {
+        if let Some(items) = self.arguments.exact_keyword_items(argument_index) {
+            for (name, value_ty) in items.iter().cloned() {
+                let _ = self.match_keyword(
+                    argument_index,
+                    Argument::Keywords,
+                    Some(value_ty),
+                    name.as_str(),
+                );
+            }
+            return;
+        }
+
         if let Some(unpacked) =
             argument_type.and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, env, ty))
         {
@@ -6344,7 +6356,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         paramspec_component_start: Option<usize>,
     ) {
         let db = self.db;
-        if extract_unpacked_typed_dict_from_value_type(db, self.env, argument_type).is_some() {
+        if self.arguments.exact_keyword_items(argument_index).is_some()
+            || extract_unpacked_typed_dict_from_value_type(db, self.env, argument_type).is_some()
+        {
             self.check_variadic_argument_type(
                 constraints,
                 argument_index,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8497,39 +8497,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ty
             });
 
-        for (argument_index, argument) in arguments.iter_source_order().enumerate() {
-            let Some(keyword) = argument.as_variadic() else {
-                continue;
-            };
-            let Some(dict) = keyword.value.as_dict_expr() else {
-                continue;
-            };
-            let Some(mut items) = dict
-                .items
-                .iter()
-                .map(|item| {
-                    if matches!(&item.value, ast::Expr::Lambda(_)) {
-                        return None;
-                    }
-                    let key = item.key.as_ref()?.as_string_literal_expr()?;
-                    Some((
-                        Name::new(key.value.to_str()),
-                        self.expression_type(&item.value),
-                    ))
-                })
-                .collect::<Option<Vec<_>>>()
-            else {
-                continue;
-            };
-
-            items.reverse();
-            let mut items = items
-                .into_iter()
-                .unique_by(|(name, _)| name.clone())
-                .collect_vec();
-            items.reverse();
-            call_arguments.set_exact_keyword_items(argument_index, items.into_boxed_slice());
-        }
+        call_arguments.infer_exact_keyword_items(arguments, |value| self.expression_type(value));
 
         for arg in &arguments.args {
             if let ast::Expr::Starred(ast::ExprStarred { value, .. }) = arg {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8483,7 +8483,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> CallArguments<'a, 'db> {
         let db = self.db();
         let env = self.program_environment();
-        let call_arguments =
+        let mut call_arguments =
             CallArguments::from_arguments(arguments, |arg_or_keyword, splatted_value| {
                 let ty = self.get_or_infer_expression(splatted_value, TypeContext::default());
                 if let ast::ArgOrKeyword::Arg(argument) = arg_or_keyword
@@ -8496,6 +8496,40 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 ty
             });
+
+        for (argument_index, argument) in arguments.iter_source_order().enumerate() {
+            let Some(keyword) = argument.as_variadic() else {
+                continue;
+            };
+            let Some(dict) = keyword.value.as_dict_expr() else {
+                continue;
+            };
+            let Some(mut items) = dict
+                .items
+                .iter()
+                .map(|item| {
+                    if matches!(&item.value, ast::Expr::Lambda(_)) {
+                        return None;
+                    }
+                    let key = item.key.as_ref()?.as_string_literal_expr()?;
+                    Some((
+                        Name::new(key.value.to_str()),
+                        self.expression_type(&item.value),
+                    ))
+                })
+                .collect::<Option<Vec<_>>>()
+            else {
+                continue;
+            };
+
+            items.reverse();
+            let mut items = items
+                .into_iter()
+                .unique_by(|(name, _)| name.clone())
+                .collect_vec();
+            items.reverse();
+            call_arguments.set_exact_keyword_items(argument_index, items.into_boxed_slice());
+        }
 
         for arg in &arguments.args {
             if let ast::Expr::Starred(ast::ExprStarred { value, .. }) = arg {

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -15,9 +15,8 @@ use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
     TypedDictOpenness, TypedDictSchema, collect_guaranteed_keyword_keys,
-    extract_unpacked_typed_dict_from_value_type, functional_typed_dict_field,
-    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
-    validate_typed_dict_dict_literal,
+    functional_typed_dict_field, infer_unpacked_keyword_types, typed_dict_with_relaxed_keys,
+    validate_typed_dict_constructor, validate_typed_dict_dict_literal,
 };
 use crate::types::{
     ClassType, IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictModule,
@@ -593,10 +592,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
 
                 self.try_expression_type(&keyword.value)
-                    .and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, env, ty))
+                    .and_then(|ty| ty.resolve_type_alias(db).as_typed_dict())
                     .is_some_and(|unpacked| {
-                        unpacked.keys.iter().all(|(name, field)| {
-                            field.is_required && permits_field_inference(name.as_str())
+                        unpacked.items(db).iter().all(|(name, field)| {
+                            field.is_required() && permits_field_inference(name.as_str())
                         })
                     })
             })

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -1,6 +1,6 @@
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, AnyNodeRef, HasNodeIndex, NodeIndex, PythonVersion};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use strum::IntoEnumIterator;
 
@@ -451,7 +451,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         );
         if is_generic && arguments.args.is_empty() {
             for keyword in &arguments.keywords {
-                if keyword.arg.is_none() && !keyword.value.is_dict_expr() {
+                if keyword.arg.is_none() {
                     self.get_or_infer_expression(&keyword.value, TypeContext::default());
                 }
             }
@@ -571,6 +571,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         })
                 })
             });
+        let concrete_class_context = class_literal
+            .as_static()
+            .zip(call_expression_tcx.annotation)
+            .and_then(|(class_literal, annotation)| {
+                let annotation = annotation.resolve_type_alias(db);
+                let specialization = annotation.specialization_of(db, env, class_literal)?;
+                if specialization
+                    .types(db)
+                    .iter()
+                    .any(|ty| ty.is_unknown() || ty.has_typevar(db, env))
+                {
+                    return None;
+                }
+                annotation.as_typed_dict()
+            });
         let typed_dict = TypedDictType::new(class_literal.identity_specialization(db));
 
         arguments.args.is_empty()
@@ -591,13 +606,46 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return permits_field_inference(name.id.as_str());
                 }
 
-                self.try_expression_type(&keyword.value)
-                    .and_then(|ty| ty.resolve_type_alias(db).as_typed_dict())
-                    .is_some_and(|unpacked| {
-                        unpacked.items(db).iter().all(|(name, field)| {
-                            field.is_required() && permits_field_inference(name.as_str())
-                        })
+                if let Some(dict) = keyword.value.as_dict_expr() {
+                    let mut seen_keys = FxHashSet::default();
+                    dict.items.iter().rev().all(|item| {
+                        if matches!(&item.value, ast::Expr::Lambda(_)) {
+                            return false;
+                        }
+
+                        let Some(key) = item
+                            .key
+                            .as_ref()
+                            .and_then(ast::Expr::as_string_literal_expr)
+                        else {
+                            return false;
+                        };
+                        let key = key.value.to_str();
+
+                        if !seen_keys.insert(key) {
+                            return true;
+                        }
+
+                        permits_field_inference(key)
+                            && concrete_class_context.is_none_or(|context| {
+                                context.item(db, key).is_none_or(|field| {
+                                    self.expression_type(&item.value).is_assignable_to(
+                                        db,
+                                        env,
+                                        field.declared_ty,
+                                    )
+                                })
+                            })
                     })
+                } else {
+                    self.try_expression_type(&keyword.value)
+                        .and_then(|ty| ty.resolve_type_alias(db).as_typed_dict())
+                        .is_some_and(|unpacked| {
+                            unpacked.items(db).iter().all(|(name, field)| {
+                                field.is_required() && permits_field_inference(name.as_str())
+                            })
+                        })
+                }
             })
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -1,3 +1,4 @@
+use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, AnyNodeRef, HasNodeIndex, NodeIndex, PythonVersion};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -571,10 +572,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         })
                 })
             });
-        let concrete_class_context = class_literal
-            .as_static()
-            .zip(call_expression_tcx.annotation)
-            .and_then(|(class_literal, annotation)| {
+        let mut has_ambiguous_class_context = false;
+        let concrete_class_context = class_literal.as_static().and_then(|class_literal| {
+            let concrete_context = |annotation: Type<'db>| {
                 let annotation = annotation.resolve_type_alias(db);
                 let specialization = annotation.specialization_of(db, env, class_literal)?;
                 if specialization
@@ -585,7 +585,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return None;
                 }
                 annotation.as_typed_dict()
-            });
+            };
+
+            if let Some(targets) = call_expression_tcx.narrow_targets(db, env) {
+                let mut contexts = targets.iter().copied().filter_map(concrete_context);
+                let context = contexts.next()?;
+                if contexts.next().is_some() {
+                    has_ambiguous_class_context = true;
+                    None
+                } else {
+                    Some(context)
+                }
+            } else {
+                call_expression_tcx.annotation.and_then(concrete_context)
+            }
+        });
         let typed_dict = TypedDictType::new(class_literal.identity_specialization(db));
 
         arguments.args.is_empty()
@@ -607,12 +621,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
 
                 if let Some(dict) = keyword.value.as_dict_expr() {
+                    if has_ambiguous_class_context {
+                        return false;
+                    }
+
                     let mut seen_keys = FxHashSet::default();
                     dict.items.iter().rev().all(|item| {
-                        if matches!(&item.value, ast::Expr::Lambda(_)) {
-                            return false;
-                        }
-
                         let Some(key) = item
                             .key
                             .as_ref()
@@ -624,6 +638,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                         if !seen_keys.insert(key) {
                             return true;
+                        }
+
+                        if any_over_expr(&item.value, ast::Expr::is_lambda_expr) {
+                            return false;
                         }
 
                         permits_field_inference(key)

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -15,8 +15,9 @@ use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
     TypedDictOpenness, TypedDictSchema, collect_guaranteed_keyword_keys,
-    functional_typed_dict_field, infer_unpacked_keyword_types, typed_dict_with_relaxed_keys,
-    validate_typed_dict_constructor, validate_typed_dict_dict_literal,
+    extract_unpacked_typed_dict_from_value_type, functional_typed_dict_field,
+    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
+    validate_typed_dict_dict_literal,
 };
 use crate::types::{
     ClassType, IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictModule,
@@ -449,6 +450,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             callable_type,
             Type::ClassLiteral(class_literal) if class_literal.generic_context(db).is_some()
         );
+        if is_generic && arguments.args.is_empty() {
+            for keyword in &arguments.keywords {
+                if keyword.arg.is_none() && !keyword.value.is_dict_expr() {
+                    self.get_or_infer_expression(&keyword.value, TypeContext::default());
+                }
+            }
+        }
         let can_infer = is_generic
             && self.can_infer_generic_typed_dict_constructor(class, arguments, call_expression_tcx);
 
@@ -569,17 +577,28 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         arguments.args.is_empty()
             && !has_gradual_class_context
             && arguments.keywords.iter().all(|keyword| {
-                let Some(name) = keyword.arg.as_ref() else {
-                    return false;
+                let permits_field_inference = |name: &str| {
+                    typed_dict.item(db, name).is_none_or(|field| {
+                        !contains_generic_typed_dict(
+                            db,
+                            env,
+                            field.declared_ty,
+                            &ActiveRecursionDetector::default(),
+                        )
+                    })
                 };
-                typed_dict.item(db, name.id.as_str()).is_none_or(|field| {
-                    !contains_generic_typed_dict(
-                        db,
-                        env,
-                        field.declared_ty,
-                        &ActiveRecursionDetector::default(),
-                    )
-                })
+
+                if let Some(name) = keyword.arg.as_ref() {
+                    return permits_field_inference(name.id.as_str());
+                }
+
+                self.try_expression_type(&keyword.value)
+                    .and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, env, ty))
+                    .is_some_and(|unpacked| {
+                        unpacked.keys.iter().all(|(name, field)| {
+                            field.is_required && permits_field_inference(name.as_str())
+                        })
+                    })
             })
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #27439.

Allow unpacked dictionary literals to contribute their individual field types when constructing a generic `TypedDict`:

```py
from typing import TypedDict

class Box[T](TypedDict):
    value: T

reveal_type(Box(**{"value": 1}))  # Box[int]
```

Unlike a plain `dict[str, int | str]`, a dictionary literal retains the association between each key and its value. We preserve those associations through ordinary call binding, which also improves generic functions, overload resolution, `ParamSpec` forwarding, and editor hover:

```py
class Pair[T](TypedDict):
    first: T
    second: str

reveal_type(Pair(**{"first": 1, "second": "x"}))  # Pair[int]
reveal_type(Pair(**{"first": 1}, **{"second": "x"}))  # Pair[int]
```

Repeated keys within the same dictionary literal use their final value. Opaque mappings, positional mappings, nested generic `TypedDict` fields, and context-sensitive callbacks remain on the existing conservative path.
