### PR TITLE
[ty] Fix specialization cycle with deferred TypeVar defaults

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -1021,37 +1021,6 @@ reveal_type(D().x)  # revealed: Unknown
 
 ## Regression
 
-### Specializing a type variable defined after branching calls
-
-In Python 3.14, annotations are evaluated lazily, so a function can reference a type variable that
-is defined after calls to the function. Resolving that type variable's default must not panic when
-it depends on the reachability of those calls.
-
-```toml
-[environment]
-python-version = "3.14"
-```
-
-```py
-class C:
-    pass
-
-def f(a: T):
-    pass
-
-if f():  # error: [missing-argument]
-    pass
-
-if f():  # error: [missing-argument]
-    sum()  # error: [no-matching-overload]
-else:
-    sum()  # error: [no-matching-overload]
-
-from typing import TypeVar
-
-T = TypeVar("T", default=C)
-```
-
 ### Specialization cycle recovery preserves concrete defaults
 
 When a generic call uses a type variable's default, cycle recovery must allow the initial `Unknown`

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -1052,6 +1052,71 @@ from typing import TypeVar
 T = TypeVar("T", default=C)
 ```
 
+### Specialization cycle recovery preserves concrete defaults
+
+When a generic call uses a type variable's default, cycle recovery must allow the initial `Unknown`
+specialization to resolve to the concrete default.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+class C:
+    pass
+
+def f(a: T | None = None) -> T:
+    raise NotImplementedError
+
+if f():
+    pass
+
+if f():
+    sum()  # error: [no-matching-overload]
+else:
+    sum()  # error: [no-matching-overload]
+
+from typing import TypeVar
+
+T = TypeVar("T", default=C)
+
+reveal_type(f())  # revealed: C
+```
+
+### Specialization cycle recovery prevents oscillating defaults
+
+A type variable's default can depend on an overloaded call that itself uses the same type variable.
+Specialization must converge even when overload selection changes between cycle iterations.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import TypeVar, overload
+
+@overload
+def choose(value: int) -> type[int]: ...
+@overload
+def choose(value: object) -> type[str]: ...
+def choose(value: object) -> type[int] | type[str]:
+    return str
+
+def f() -> T:
+    raise NotImplementedError
+
+if f():
+    Default = str
+else:
+    Default = choose(f())
+
+T = TypeVar("T", default=Default)
+
+reveal_type(f())  # revealed: Unknown
+```
+
 ### Use of typevar with default inside a function body that binds it
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -1021,6 +1021,37 @@ reveal_type(D().x)  # revealed: Unknown
 
 ## Regression
 
+### Specializing a type variable defined after branching calls
+
+In Python 3.14, annotations are evaluated lazily, so a function can reference a type variable that
+is defined after calls to the function. Resolving that type variable's default must not panic when
+it depends on the reachability of those calls.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+class C:
+    pass
+
+def f(a: T):
+    pass
+
+if f():  # error: [missing-argument]
+    pass
+
+if f():  # error: [missing-argument]
+    sum()  # error: [no-matching-overload]
+else:
+    sum()  # error: [no-matching-overload]
+
+from typing import TypeVar
+
+T = TypeVar("T", default=C)
+```
+
 ### Use of typevar with default inside a function body that binds it
 
 ```toml

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2380,7 +2380,12 @@ impl get_size2::GetSize for TypeVarInference<'_> {}
 impl<'db> TypeVarInference<'db> {
     /// Project this inference result into a closed specialization.
     pub(crate) fn specialization(self, db: &'db dyn Db) -> Specialization<'db> {
-        #[salsa::tracked(returns(copy))]
+        #[salsa::tracked(
+            returns(copy),
+            cycle_initial=|db, _, inference: TypeVarInference<'db>| {
+                inference.generic_context(db).unknown_specialization(db, None)
+            }
+        )]
         fn specialization_inner<'db>(
             db: &'db dyn Db,
             inference: TypeVarInference<'db>,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2384,6 +2384,15 @@ impl<'db> TypeVarInference<'db> {
             returns(copy),
             cycle_initial=|db, _, inference: TypeVarInference<'db>| {
                 inference.generic_context(db).unknown_specialization(db, None)
+            },
+            cycle_fn=|db, cycle: &salsa::Cycle, previous: &Specialization<'db>, current: Specialization<'db>, inference: TypeVarInference<'db>| {
+                if cycle.iteration() <= crate::TAINTED_CYCLES {
+                    current
+                } else {
+                    current
+                        .merge_cycle_recovery(db, *previous)
+                        .unwrap_or_else(|| inference.generic_context(db).unknown_specialization(db, None))
+                }
             }
         )]
         fn specialization_inner<'db>(


### PR DESCRIPTION
## Summary

On Python 3.14, deferred annotations allow a function to reference a `TypeVar` declared after calls to that function:

```python
class C: ...

def f(a: T): ...

if f():
    pass

if f():
    sum()
else:
    sum()

from typing import TypeVar

T = TypeVar("T", default=C)
```

Previously, resolving `T`'s default during generic specialization re-entered the same Salsa query through reachability analysis, causing a dependency-cycle panic.

We now initialize specialization cycle recovery with unknown type arguments, allowing Salsa to complete the surrounding inference without evaluating the default recursively. Once inference stabilizes, the actual default remains `C` and we report the expected argument and overload diagnostics.

Closes https://github.com/astral-sh/ty/issues/4174.
