### PR TITLE
[ty] Top-materialize `is_dataclass` type guard

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2471,8 +2471,7 @@ asdict(Foo)
 ## `dataclasses.is_dataclass`
 
 `is_dataclass` recognizes both dataclass instances and dataclass classes. A concrete dataclass
-instance always satisfies the `DataclassInstance` protocol, but we do not currently recognize that
-the negative branch is unreachable:
+instance always satisfies the `DataclassInstance` protocol:
 
 ```py
 from dataclasses import dataclass, is_dataclass
@@ -2483,8 +2482,15 @@ class Event:
 
 def check(event: Event) -> None:
     if not is_dataclass(event):
-        # TODO: This should be `Never`.
-        reveal_type(event)  # revealed: Event & ~DataclassInstance & ~type[DataclassInstance]
+        reveal_type(event)  # revealed: Never
+```
+
+This also works for class objects:
+
+```py
+def check_class(event_type: type[Event]) -> None:
+    if not is_dataclass(event_type):
+        reveal_type(event_type)  # revealed: Never
 ```
 
 ## `dataclasses.KW_ONLY`

--- a/crates/ty_vendored/typeshed_patches/0007-dataclasses-is-dataclass-top.patch
+++ b/crates/ty_vendored/typeshed_patches/0007-dataclasses-is-dataclass-top.patch
@@ -1,0 +1,30 @@
+diff --git a/stdlib/dataclasses.pyi b/stdlib/dataclasses.pyi
+index d46b694a7e..1db97b1893 100644
+--- a/stdlib/dataclasses.pyi
++++ b/stdlib/dataclasses.pyi
+@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterable, Mapping
+ from types import GenericAlias
+ from typing import Any, Final, Generic, Literal, Protocol, TypeVar, overload, type_check_only
+ from typing_extensions import Never, TypeIs
++from ty_extensions import Top
+ 
+ _T = TypeVar("_T")
+ _T_co = TypeVar("_T_co", covariant=True)
+@@ -402,14 +403,14 @@ def fields(class_or_instance: DataclassInstance | type[DataclassInstance]) -> tu
+ 
+ # HACK: `obj: Never` typing matches if object argument is using `Any` type.
+ @overload
+-def is_dataclass(obj: Never) -> TypeIs[DataclassInstance | type[DataclassInstance]]:  # type: ignore[narrowed-type-not-subtype]  # pyright: ignore[reportGeneralTypeIssues]  # ty:ignore[invalid-type-guard-definition]
++def is_dataclass(obj: Never) -> TypeIs[Top[DataclassInstance | type[DataclassInstance]]]:  # type: ignore[narrowed-type-not-subtype]  # pyright: ignore[reportGeneralTypeIssues]  # ty:ignore[invalid-type-guard-definition]
+     """Returns True if obj is a dataclass or an instance of a
+     dataclass.
+     """
+ @overload
+-def is_dataclass(obj: type) -> TypeIs[type[DataclassInstance]]: ...
++def is_dataclass(obj: type) -> TypeIs[Top[type[DataclassInstance]]]: ...
+ @overload
+-def is_dataclass(obj: object) -> TypeIs[DataclassInstance | type[DataclassInstance]]: ...
++def is_dataclass(obj: object) -> TypeIs[Top[DataclassInstance | type[DataclassInstance]]]: ...
+ 
+ class FrozenInstanceError(AttributeError): ...
+ 

--- a/crates/ty_vendored/vendor/typeshed/stdlib/dataclasses.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/dataclasses.pyi
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterable, Mapping
 from types import GenericAlias
 from typing import Any, Final, Generic, Literal, Protocol, TypeVar, overload, type_check_only
 from typing_extensions import Never, TypeIs
+from ty_extensions import Top
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
@@ -402,14 +403,14 @@ def fields(class_or_instance: DataclassInstance | type[DataclassInstance]) -> tu
 
 # HACK: `obj: Never` typing matches if object argument is using `Any` type.
 @overload
-def is_dataclass(obj: Never) -> TypeIs[DataclassInstance | type[DataclassInstance]]:  # type: ignore[narrowed-type-not-subtype]  # pyright: ignore[reportGeneralTypeIssues]  # ty:ignore[invalid-type-guard-definition]
+def is_dataclass(obj: Never) -> TypeIs[Top[DataclassInstance | type[DataclassInstance]]]:  # type: ignore[narrowed-type-not-subtype]  # pyright: ignore[reportGeneralTypeIssues]  # ty:ignore[invalid-type-guard-definition]
     """Returns True if obj is a dataclass or an instance of a
     dataclass.
     """
 @overload
-def is_dataclass(obj: type) -> TypeIs[type[DataclassInstance]]: ...
+def is_dataclass(obj: type) -> TypeIs[Top[type[DataclassInstance]]]: ...
 @overload
-def is_dataclass(obj: object) -> TypeIs[DataclassInstance | type[DataclassInstance]]: ...
+def is_dataclass(obj: object) -> TypeIs[Top[DataclassInstance | type[DataclassInstance]]]: ...
 
 class FrozenInstanceError(AttributeError): ...
 


### PR DESCRIPTION
## Summary

Top-materialize th gradual `DataclassInstance` protocol in the `TypeIs` return type of `is_dataclass`, so that we can recognize dataclass instances as being a subtype of that return type.

Fixes https://github.com/astral-sh/ty/issues/4149.

## Ecosystem impact

Looks good!

## Test plan

Updated and added mdtests.