### PR TITLE
[ty] Remove deprecated `src.root` setting in favor of `environment.root`

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1054,43 +1054,6 @@ Enabled by default.
 
 ---
 
-### `root`
-
-!!! warning "Deprecated"
-    This option has been deprecated. Use `environment.root` instead.
-
-The root of the project, used for finding first-party modules.
-
-If left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly.
-The project root (`.`) is always included. Additionally, the following directories are included
-if they exist and are not packages (i.e. they do not contain `__init__.py` or `__init__.pyi` files):
-
-* `./src`
-* `./<project-name>` (if a `./<project-name>/<project-name>` directory exists)
-* `./python`
-
-**Default value**: `null`
-
-**Type**: `str`
-
-**Example usage**:
-
-=== "pyproject.toml"
-
-    ```toml
-    [tool.ty.src]
-    root = "./app"
-    ```
-
-=== "ty.toml"
-
-    ```toml
-    [src]
-    root = "./app"
-    ```
-
----
-
 ## `terminal`
 
 ### `error-on-warning`

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -2206,66 +2206,6 @@ fn ty_system_environment_and_local_venv() -> anyhow::Result<()> {
 }
 
 #[test]
-fn src_root_is_not_supported() -> anyhow::Result<()> {
-    let case = CliTest::with_files([
-        (
-            "pyproject.toml",
-            r#"
-            [tool.ty.src]
-            root = "./src"
-            "#,
-        ),
-        ("src/test.py", ""),
-    ])?;
-
-    assert_cmd_snapshot!(case.command(), @r#"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    ty failed
-      Cause: <temp_dir>/pyproject.toml is not a valid `pyproject.toml`
-      Cause: TOML parse error at line 3, column 1
-      |
-    3 | root = "./src"
-      | ^^^^
-    unknown field `root`, expected one of `respect-ignore-files`, `exclude-scripts`, `include`, `exclude`
-    "#);
-
-    Ok(())
-}
-
-#[test]
-fn environment_root_configures_module_resolution() -> anyhow::Result<()> {
-    let case = CliTest::with_files([
-        (
-            "pyproject.toml",
-            r#"
-            [tool.ty.environment]
-            root = ["./app"]
-            "#,
-        ),
-        ("src/test.py", "import my_module"),
-        (
-            "app/my_module.py",
-            "# This module exists in app/ but not src/",
-        ),
-    ])?;
-
-    assert_cmd_snapshot!(case.command(), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
-
-    ----- stderr -----
-    ");
-
-    Ok(())
-}
-
-#[test]
 fn default_root_src_layout() -> anyhow::Result<()> {
     let case = CliTest::with_files([
         ("src/foo.py", "foo = 10"),

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -2206,7 +2206,7 @@ fn ty_system_environment_and_local_venv() -> anyhow::Result<()> {
 }
 
 #[test]
-fn src_root_deprecation_warning() -> anyhow::Result<()> {
+fn src_root_is_not_supported() -> anyhow::Result<()> {
     let case = CliTest::with_files([
         (
             "pyproject.toml",
@@ -2220,66 +2220,28 @@ fn src_root_deprecation_warning() -> anyhow::Result<()> {
 
     assert_cmd_snapshot!(case.command(), @r#"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
-    warning[deprecated-setting]: The `src.root` setting is deprecated. Use `environment.root` instead.
-     --> pyproject.toml:3:8
-      |
-    3 | root = "./src"
-      |        ^^^^^^^
-
-    Found 1 diagnostic
 
     ----- stderr -----
+    ty failed
+      Cause: <temp_dir>/pyproject.toml is not a valid `pyproject.toml`
+      Cause: TOML parse error at line 3, column 1
+      |
+    3 | root = "./src"
+      | ^^^^
+    unknown field `root`, expected one of `respect-ignore-files`, `exclude-scripts`, `include`, `exclude`
     "#);
 
     Ok(())
 }
 
 #[test]
-fn src_root_deprecation_warning_with_environment_root() -> anyhow::Result<()> {
+fn environment_root_configures_module_resolution() -> anyhow::Result<()> {
     let case = CliTest::with_files([
         (
             "pyproject.toml",
             r#"
-            [tool.ty.src]
-            root = "./src"
-
-            [tool.ty.environment]
-            root = ["./app"]
-            "#,
-        ),
-        ("app/test.py", ""),
-    ])?;
-
-    assert_cmd_snapshot!(case.command(), @r#"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    warning[deprecated-setting]: The `src.root` setting is deprecated. Use `environment.root` instead.
-     --> pyproject.toml:3:8
-      |
-    3 | root = "./src"
-      |        ^^^^^^^
-    info: The `src.root` setting was ignored in favor of the `environment.root` setting
-
-    Found 1 diagnostic
-
-    ----- stderr -----
-    "#);
-
-    Ok(())
-}
-
-#[test]
-fn environment_root_takes_precedence_over_src_root() -> anyhow::Result<()> {
-    let case = CliTest::with_files([
-        (
-            "pyproject.toml",
-            r#"
-            [tool.ty.src]
-            root = "./src"
-
             [tool.ty.environment]
             root = ["./app"]
             "#,
@@ -2291,23 +2253,14 @@ fn environment_root_takes_precedence_over_src_root() -> anyhow::Result<()> {
         ),
     ])?;
 
-    // The test should pass because environment.root points to ./app where my_module.py exists
-    // If src.root took precedence, it would fail because my_module.py doesn't exist in ./src
-    assert_cmd_snapshot!(case.command(), @r#"
-    success: false
-    exit_code: 1
+    assert_cmd_snapshot!(case.command(), @"
+    success: true
+    exit_code: 0
     ----- stdout -----
-    warning[deprecated-setting]: The `src.root` setting is deprecated. Use `environment.root` instead.
-     --> pyproject.toml:3:8
-      |
-    3 | root = "./src"
-      |        ^^^^^^^
-    info: The `src.root` setting was ignored in favor of the `environment.root` setting
-
-    Found 1 diagnostic
+    All checks passed!
 
     ----- stderr -----
-    "#);
+    ");
 
     Ok(())
 }

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -769,8 +769,8 @@ unclosed table, expected `]`
                     [project]
                     name = "project-root"
 
-                    [tool.ty.src]
-                    root = "src"
+                    [tool.ty.environment]
+                    root = ["src"]
                     "#,
                 ),
                 (
@@ -779,8 +779,8 @@ unclosed table, expected `]`
                     [project]
                     name = "nested-project"
 
-                    [tool.ty.src]
-                    root = "src"
+                    [tool.ty.environment]
+                    root = ["src"]
                     "#,
                 ),
             ])
@@ -794,8 +794,10 @@ unclosed table, expected `]`
               name: ProjectName("nested-project"),
               root: "/app/packages/a",
               options: Options(
-                src: Some(SrcOptions(
-                  root: Some("src"),
+                environment: Some(EnvironmentOptions(
+                  root: Some([
+                    "src",
+                  ]),
                 )),
               ),
             )
@@ -819,8 +821,8 @@ unclosed table, expected `]`
                     [project]
                     name = "project-root"
 
-                    [tool.ty.src]
-                    root = "src"
+                    [tool.ty.environment]
+                    root = ["src"]
                     "#,
                 ),
                 (
@@ -829,8 +831,8 @@ unclosed table, expected `]`
                     [project]
                     name = "nested-project"
 
-                    [tool.ty.src]
-                    root = "src"
+                    [tool.ty.environment]
+                    root = ["src"]
                     "#,
                 ),
             ])
@@ -844,8 +846,10 @@ unclosed table, expected `]`
               name: ProjectName("project-root"),
               root: "/app",
               options: Options(
-                src: Some(SrcOptions(
-                  root: Some("src"),
+                environment: Some(EnvironmentOptions(
+                  root: Some([
+                    "src",
+                  ]),
                 )),
               ),
             )
@@ -1221,15 +1225,15 @@ unclosed table, expected `]`
                     name = "super-app"
                     requires-python = ">=3.12"
 
-                    [tool.ty.src]
-                    root = "this_option_is_ignored"
+                    [tool.ty.environment]
+                    root = ["this_option_is_ignored"]
                     "#,
                 ),
                 (
                     root.join("ty.toml"),
                     r#"
-                    [src]
-                    root = "src"
+                    [environment]
+                    root = ["src"]
                     "#,
                 ),
             ])
@@ -1244,10 +1248,10 @@ unclosed table, expected `]`
               root: "/app",
               options: Options(
                 environment: Some(EnvironmentOptions(
+                  root: Some([
+                    "src",
+                  ]),
                   r#python-version: Some(r#3.12),
-                )),
-                src: Some(SrcOptions(
-                  root: Some("src"),
                 )),
               ),
             )

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -308,57 +308,6 @@ impl Options {
     ) -> Result<SearchPaths, Strategy::Error<SearchPathSettingsError>> {
         let environment = self.environment.or_default();
 
-        let src_roots = if let Some(roots) = environment.root.as_deref() {
-            roots
-                .iter()
-                .map(|root| root.absolute(project_root, system))
-                .collect()
-        } else {
-            let mut roots = vec![];
-            let is_package = |dir: &SystemPath| {
-                system.is_file(&dir.join("__init__.py"))
-                    || system.is_file(&dir.join("__init__.pyi"))
-            };
-
-            // Check for `./src` directory (src-layout)
-            let src = project_root.join("src");
-            if system.is_directory(&src) && !is_package(&src) {
-                tracing::debug!(
-                    "Including `./src` in `environment.root` because a `./src` directory exists and is not a package"
-                );
-                roots.push(src);
-            }
-
-            // Check for `./<project-name>/<project-name>` directory (src-layout with project-named folder)
-            // For example, the "src" folder for `psycopg` is called `psycopg` and the python files are in `psycopg/psycopg/_adapters_map.py`
-            let project_name_dir = project_root.join(project_name);
-            if system.is_directory(&project_name_dir.join(project_name))
-                && !is_package(&project_name_dir)
-                && !roots.contains(&project_name_dir)
-            {
-                tracing::debug!(
-                    "Including `./{project_name}` in `environment.root` because a `./{project_name}/{project_name}` directory exists and `./{project_name}` is not a package"
-                );
-                roots.push(project_name_dir);
-            }
-
-            // Check for `./python` directory (maturin-based rust/python projects)
-            // https://github.com/PyO3/maturin/blob/979fe1db42bb9e58bc150fa6fc45360b377288bf/README.md?plain=1#L88-L99
-            let python = project_root.join("python");
-            if system.is_directory(&python) && !is_package(&python) && !roots.contains(&python) {
-                tracing::debug!(
-                    "Including `./python` in `environment.root` because a `./python` directory exists and is not a package"
-                );
-                roots.push(python);
-            }
-
-            // The project root is always included, and should always come last
-            // (after any subdirectories such as `./src`, `./<project-name>`, and/or `./python`).
-            roots.push(project_root.to_path_buf());
-
-            roots
-        };
-
         // collect the existing site packages
         let mut extra_paths: Vec<SystemPathBuf> = environment
             .extra_paths
@@ -404,7 +353,7 @@ impl Options {
 
         let settings = SearchPathSettings {
             extra_paths,
-            src_roots,
+            src_roots: environment.root_paths(project_root, project_name, system),
             custom_typeshed: environment
                 .typeshed
                 .as_ref()
@@ -859,6 +808,65 @@ pub struct EnvironmentOptions {
         "#
     )]
     pub python: Option<RelativePathBuf>,
+}
+
+impl EnvironmentOptions {
+    fn root_paths(
+        &self,
+        project_root: &SystemPath,
+        project_name: &str,
+        system: &dyn System,
+    ) -> Vec<SystemPathBuf> {
+        if let Some(roots) = self.root.as_deref() {
+            return roots
+                .iter()
+                .map(|root| root.absolute(project_root, system))
+                .collect();
+        }
+
+        let mut roots = vec![];
+        let is_package = |dir: &SystemPath| {
+            system.is_file(&dir.join("__init__.py")) || system.is_file(&dir.join("__init__.pyi"))
+        };
+
+        // Check for `./src` directory (src-layout)
+        let src = project_root.join("src");
+        if system.is_directory(&src) && !is_package(&src) {
+            tracing::debug!(
+                "Including `./src` in `environment.root` because a `./src` directory exists and is not a package"
+            );
+            roots.push(src);
+        }
+
+        // Check for `./<project-name>/<project-name>` directory (src-layout with project-named folder)
+        // For example, the "src" folder for `psycopg` is called `psycopg` and the python files are in `psycopg/psycopg/_adapters_map.py`
+        let project_name_dir = project_root.join(project_name);
+        if system.is_directory(&project_name_dir.join(project_name))
+            && !is_package(&project_name_dir)
+            && !roots.contains(&project_name_dir)
+        {
+            tracing::debug!(
+                "Including `./{project_name}` in `environment.root` because a `./{project_name}/{project_name}` directory exists and `./{project_name}` is not a package"
+            );
+            roots.push(project_name_dir);
+        }
+
+        // Check for `./python` directory (maturin-based rust/python projects)
+        // https://github.com/PyO3/maturin/blob/979fe1db42bb9e58bc150fa6fc45360b377288bf/README.md?plain=1#L88-L99
+        let python = project_root.join("python");
+        if system.is_directory(&python) && !is_package(&python) && !roots.contains(&python) {
+            tracing::debug!(
+                "Including `./python` in `environment.root` because a `./python` directory exists and is not a package"
+            );
+            roots.push(python);
+        }
+
+        // The project root is always included, and should always come last
+        // (after any subdirectories such as `./src`, `./<project-name>`, and/or `./python`).
+        roots.push(project_root.to_path_buf());
+
+        roots
+    }
 }
 
 #[derive(

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -308,6 +308,57 @@ impl Options {
     ) -> Result<SearchPaths, Strategy::Error<SearchPathSettingsError>> {
         let environment = self.environment.or_default();
 
+        let environment_roots = if let Some(roots) = environment.root.as_deref() {
+            roots
+                .iter()
+                .map(|root| root.absolute(project_root, system))
+                .collect()
+        } else {
+            let mut roots = vec![];
+            let is_package = |dir: &SystemPath| {
+                system.is_file(&dir.join("__init__.py"))
+                    || system.is_file(&dir.join("__init__.pyi"))
+            };
+
+            // Check for `./src` directory (src-layout)
+            let src = project_root.join("src");
+            if system.is_directory(&src) && !is_package(&src) {
+                tracing::debug!(
+                    "Including `./src` in `environment.root` because a `./src` directory exists and is not a package"
+                );
+                roots.push(src);
+            }
+
+            // Check for `./<project-name>/<project-name>` directory (src-layout with project-named folder)
+            // For example, the "src" folder for `psycopg` is called `psycopg` and the python files are in `psycopg/psycopg/_adapters_map.py`
+            let project_name_dir = project_root.join(project_name);
+            if system.is_directory(&project_name_dir.join(project_name))
+                && !is_package(&project_name_dir)
+                && !roots.contains(&project_name_dir)
+            {
+                tracing::debug!(
+                    "Including `./{project_name}` in `environment.root` because a `./{project_name}/{project_name}` directory exists and `./{project_name}` is not a package"
+                );
+                roots.push(project_name_dir);
+            }
+
+            // Check for `./python` directory (maturin-based rust/python projects)
+            // https://github.com/PyO3/maturin/blob/979fe1db42bb9e58bc150fa6fc45360b377288bf/README.md?plain=1#L88-L99
+            let python = project_root.join("python");
+            if system.is_directory(&python) && !is_package(&python) && !roots.contains(&python) {
+                tracing::debug!(
+                    "Including `./python` in `environment.root` because a `./python` directory exists and is not a package"
+                );
+                roots.push(python);
+            }
+
+            // The project root is always included, and should always come last
+            // (after any subdirectories such as `./src`, `./<project-name>`, and/or `./python`).
+            roots.push(project_root.to_path_buf());
+
+            roots
+        };
+
         // collect the existing site packages
         let mut extra_paths: Vec<SystemPathBuf> = environment
             .extra_paths
@@ -353,7 +404,7 @@ impl Options {
 
         let settings = SearchPathSettings {
             extra_paths,
-            src_roots: environment.root_paths(project_root, project_name, system),
+            src_roots: environment_roots,
             custom_typeshed: environment
                 .typeshed
                 .as_ref()
@@ -808,65 +859,6 @@ pub struct EnvironmentOptions {
         "#
     )]
     pub python: Option<RelativePathBuf>,
-}
-
-impl EnvironmentOptions {
-    fn root_paths(
-        &self,
-        project_root: &SystemPath,
-        project_name: &str,
-        system: &dyn System,
-    ) -> Vec<SystemPathBuf> {
-        if let Some(roots) = self.root.as_deref() {
-            return roots
-                .iter()
-                .map(|root| root.absolute(project_root, system))
-                .collect();
-        }
-
-        let mut roots = vec![];
-        let is_package = |dir: &SystemPath| {
-            system.is_file(&dir.join("__init__.py")) || system.is_file(&dir.join("__init__.pyi"))
-        };
-
-        // Check for `./src` directory (src-layout)
-        let src = project_root.join("src");
-        if system.is_directory(&src) && !is_package(&src) {
-            tracing::debug!(
-                "Including `./src` in `environment.root` because a `./src` directory exists and is not a package"
-            );
-            roots.push(src);
-        }
-
-        // Check for `./<project-name>/<project-name>` directory (src-layout with project-named folder)
-        // For example, the "src" folder for `psycopg` is called `psycopg` and the python files are in `psycopg/psycopg/_adapters_map.py`
-        let project_name_dir = project_root.join(project_name);
-        if system.is_directory(&project_name_dir.join(project_name))
-            && !is_package(&project_name_dir)
-            && !roots.contains(&project_name_dir)
-        {
-            tracing::debug!(
-                "Including `./{project_name}` in `environment.root` because a `./{project_name}/{project_name}` directory exists and `./{project_name}` is not a package"
-            );
-            roots.push(project_name_dir);
-        }
-
-        // Check for `./python` directory (maturin-based rust/python projects)
-        // https://github.com/PyO3/maturin/blob/979fe1db42bb9e58bc150fa6fc45360b377288bf/README.md?plain=1#L88-L99
-        let python = project_root.join("python");
-        if system.is_directory(&python) && !is_package(&python) && !roots.contains(&python) {
-            tracing::debug!(
-                "Including `./python` in `environment.root` because a `./python` directory exists and is not a package"
-            );
-            roots.push(python);
-        }
-
-        // The project root is always included, and should always come last
-        // (after any subdirectories such as `./src`, `./<project-name>`, and/or `./python`).
-        roots.push(project_root.to_path_buf());
-
-        roots
-    }
 }
 
 #[derive(

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -307,14 +307,8 @@ impl Options {
         strategy: &Strategy,
     ) -> Result<SearchPaths, Strategy::Error<SearchPathSettingsError>> {
         let environment = self.environment.or_default();
-        let src = self.src.or_default();
 
-        #[allow(deprecated)]
-        let src_roots = if let Some(roots) = environment
-            .root
-            .as_deref()
-            .or_else(|| Some(std::slice::from_ref(src.root.as_ref()?)))
-        {
+        let src_roots = if let Some(roots) = environment.root.as_deref() {
             roots
                 .iter()
                 .map(|root| root.absolute(project_root, system))
@@ -442,34 +436,6 @@ impl Options {
         };
 
         let src_options = self.src.or_default();
-
-        #[allow(deprecated)]
-        if let Some(src_root) = src_options.root.as_ref() {
-            let mut diagnostic = OptionDiagnostic::new(
-                DiagnosticId::DeprecatedSetting,
-                "The `src.root` setting is deprecated. Use `environment.root` instead.".to_string(),
-                Severity::Warning,
-            );
-
-            if let Some(file) = src_root
-                .source()
-                .file()
-                .and_then(|path| system_path_to_file(db, path).ok())
-            {
-                diagnostic = diagnostic.with_annotation(Some(Annotation::primary(
-                    Span::from(file).with_optional_range(src_root.range()),
-                )));
-            }
-
-            if self.environment.or_default().root.is_some() {
-                diagnostic = diagnostic.sub(SubDiagnostic::new(
-                    SubDiagnosticSeverity::Info,
-                    "The `src.root` setting was ignored in favor of the `environment.root` setting",
-                ));
-            }
-
-            diagnostics.push(diagnostic);
-        }
 
         let src = src_options
             .to_settings(db, project_root, &mut diagnostics)
@@ -910,26 +876,6 @@ pub struct EnvironmentOptions {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SrcOptions {
-    /// The root of the project, used for finding first-party modules.
-    ///
-    /// If left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly.
-    /// The project root (`.`) is always included. Additionally, the following directories are included
-    /// if they exist and are not packages (i.e. they do not contain `__init__.py` or `__init__.pyi` files):
-    ///
-    /// * `./src`
-    /// * `./<project-name>` (if a `./<project-name>/<project-name>` directory exists)
-    /// * `./python`
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[option(
-        default = r#"null"#,
-        value_type = "str",
-        example = r#"
-            root = "./app"
-        "#
-    )]
-    #[deprecated(note = "Use `environment.root` instead.")]
-    pub root: Option<RelativePathBuf>,
-
     /// Whether to automatically exclude files that are ignored by `.ignore`,
     /// `.gitignore`, `.git/info/exclude`, and global `gitignore` files.
     /// Enabled by default.

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -1610,18 +1610,6 @@
             "boolean",
             "null"
           ]
-        },
-        "root": {
-          "description": "The root of the project, used for finding first-party modules.\n\nIf left unspecified, ty will try to detect common project layouts and initialize `src.root` accordingly.\nThe project root (`.`) is always included. Additionally, the following directories are included\nif they exist and are not packages (i.e. they do not contain `__init__.py` or `__init__.pyi` files):\n\n* `./src`\n* `./<project-name>` (if a `./<project-name>/<project-name>` directory exists)\n* `./python`",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RelativePathBuf"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Remove the deprecated `src.root` setting and require `environment.root` for explicit first-party module search paths.

`src.root` was deprecated in [ty 0.0.1-alpha.12](https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12) by #18760 (June 2025). I think it's safe to remove this now and we should do so before stable. 