### PR TITLE
[ty] Reject unsupported `dataclass_transform` parameters

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -847,6 +847,30 @@ class NotOrderedWithOverrides:
         return False
 ```
 
+### Unrecognized parameters
+
+`dataclass_transform` rejects unrecognized parameters:
+
+```py
+from typing import dataclass_transform
+
+# error: [unknown-argument] "Argument `unsupported` does not match any known parameter"
+@dataclass_transform(unsupported=True)
+def my_model[T](cls: type[T]) -> type[T]:
+    return cls
+```
+
+This also works for the variant from `typing_extensions`:
+
+```py
+from typing_extensions import dataclass_transform
+
+# error: [unknown-argument] "Argument `unsupported` does not match any known parameter"
+@dataclass_transform(unsupported=True)
+def my_model[T](cls: type[T]) -> type[T]:
+    return cls
+```
+
 ## Other `dataclass` parameters
 
 Other parameters from normal dataclasses can also be set on models created using

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Syntax_(142fa2948c3c6cf1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Syntax_(142fa2948c3c6cf1).snap
@@ -83,9 +83,9 @@ error[missing-argument]: No argument provided for required parameter `arg` of bo
 6 | invalid_deco()  # error: [missing-argument]
   | ^^^^^^^^^^^^^^
 info: Parameter declared here
-    --> stdlib/typing_extensions.pyi:1220:28
+    --> stdlib/typing_extensions.pyi:1219:28
      |
-1220 |         def __call__(self, arg: _T, /) -> _T: ...
+1219 |         def __call__(self, arg: _T, /) -> _T: ...
      |                            ^^^^^^^
 
 ```

--- a/crates/ty_vendored/typeshed_patches/0007-dataclass-transform-unknown-arguments.patch
+++ b/crates/ty_vendored/typeshed_patches/0007-dataclass-transform-unknown-arguments.patch
@@ -1,0 +1,22 @@
+--- a/stdlib/typing.pyi
++++ b/stdlib/typing.pyi
+@@ -2280,7 +2280,6 @@ if sys.version_info >= (3, 11):
+         order_default: bool = False,
+         kw_only_default: bool = False,
+         frozen_default: bool = False,  # on 3.11, runtime accepts it as part of kwargs
+         field_specifiers: tuple[type[Any] | Callable[..., Any], ...] = (),
+-        **kwargs: Any,
+     ) -> IdentityFunction:
+         """Decorator to mark an object as providing dataclass-like behavior.
+
+--- a/stdlib/typing_extensions.pyi
++++ b/stdlib/typing_extensions.pyi
+@@ -804,8 +804,7 @@ else:
+         order_default: bool = False,
+         kw_only_default: bool = False,
+         frozen_default: bool = False,
+         field_specifiers: tuple[type[Any] | Callable[..., Any], ...] = (),
+-        **kwargs: object,
+     ) -> IdentityFunction:
+         """Decorator that marks a function, class, or metaclass as providing
+         dataclass-like behavior.

--- a/crates/ty_vendored/vendor/typeshed/stdlib/typing.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/typing.pyi
@@ -2281,7 +2281,6 @@ if sys.version_info >= (3, 11):
         kw_only_default: bool = False,
         frozen_default: bool = False,  # on 3.11, runtime accepts it as part of kwargs
         field_specifiers: tuple[type[Any] | Callable[..., Any], ...] = (),
-        **kwargs: Any,
     ) -> IdentityFunction:
         """Decorator to mark an object as providing dataclass-like behavior.
 

--- a/crates/ty_vendored/vendor/typeshed/stdlib/typing_extensions.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/typing_extensions.pyi
@@ -805,7 +805,6 @@ else:
         kw_only_default: bool = False,
         frozen_default: bool = False,
         field_specifiers: tuple[type[Any] | Callable[..., Any], ...] = (),
-        **kwargs: object,
     ) -> IdentityFunction:
         """Decorator that marks a function, class, or metaclass as providing
         dataclass-like behavior.


### PR DESCRIPTION
## Summary

Reject unrecognized `dataclass_transform` parameters based on this paragraph in the [spec](https://typing.python.org/en/latest/spec/dataclasses.html#dataclass-transform-parameters) (emphasis mine):

> kwargs allows arbitrary additional keyword args to be passed to dataclass_transform. This gives type checkers the freedom to support experimental parameters without needing to wait for changes in typing.py. **Type checkers should report errors for any unrecognized parameters.**

Since we currently don't do any experiments with unofficial parameters to `dataclass_transform`, we can just remove `**kwargs`.

Fixes https://github.com/astral-sh/ty/issues/4170.

## Test plan

New Markdown tests.
