### PR TITLE
[ty] Recover generic constructor types from failing overloads

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -495,3 +495,61 @@ def _(xs: Unknown | list[str]):
     tokens: list[Unknown | str] = []
     tokens.extend(escaped)
 ```
+
+## Failed `map` calls retain their result type
+
+When the argument count identifies a single `map` overload, an incompatible callback still produces
+its usual error. The mapped values retain the callback's return type and do not produce an
+additional error when called.
+
+```py
+class Function:
+    def __init__(self, value: str) -> None: ...
+    def __call__(self) -> None: ...
+
+# error: [invalid-argument-type]
+for function in map(Function, [object()]):
+    function()
+```
+
+## Failed `dict` calls do not expose internal type variables
+
+Several `dict` overloads accept one positional argument. When none matches, an arbitrarily selected
+overload must not make an otherwise compatible return type fail.
+
+```py
+from collections.abc import Mapping
+
+def copy(value: object) -> dict[str, str]:
+    if isinstance(value, Mapping):
+        return dict(value)  # error: [no-matching-overload]
+    return {}
+```
+
+## Failed `dict` calls preserve narrowed mapping types
+
+An invalid `dict` call must not invalidate an assignment inside a branch where the original value
+has already been narrowed to a mapping.
+
+```py
+from collections.abc import Mapping
+
+def clean(value: dict[str, int] | str | None) -> None:
+    if isinstance(value, Mapping):
+        value = dict(value)  # error: [no-matching-overload]
+        for key, item in value.items():
+            value[key] = item
+```
+
+## Failed inner `OrderedDict` calls do not invalidate outer constructors
+
+Constructing an `OrderedDict` from a list containing both strings and floats is already rejected.
+That failure must not cause a second error when the resulting value is passed to another
+`OrderedDict` constructor.
+
+```py
+from collections import OrderedDict
+
+items = [OrderedDict([["key", 1.0]])]  # error: [no-matching-overload]
+OrderedDict(zip(["name"], items))
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -381,6 +381,26 @@ reveal_type(C(1))  # revealed: C[Literal[1]]
 wrong_innards: C[int] = C("five")
 ```
 
+### Failed constructor inference
+
+A failed constructor call reports its argument error without exposing an unsolved class type
+parameter or producing an additional assignment error.
+
+```py
+from collections.abc import Callable
+
+class Animal: ...
+class Dog(Animal): ...
+
+class Consumer[T]:
+    def __init__(self, callback: Callable[[T], None]) -> None:
+        self.callback = callback
+
+def accepts_dog(value: Dog) -> None: ...
+
+consumer: Consumer[Animal] = Consumer(accepts_dog)  # error: [invalid-argument-type]
+```
+
 ### Constructing the class from its own type variable
 
 A constructor call inside a generic class can use a value whose type is one of the class's type

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4324,6 +4324,20 @@ impl<'db> CallableBinding<'db> {
             .and_then(|index| self.overloads.get(index))
     }
 
+    /// Returns a failing overload only when the call's argument shape selected it uniquely.
+    ///
+    /// The overload chosen for diagnostics can be arbitrary when multiple signatures accept the
+    /// same argument shape. Its specialization must not determine a constructor's return type:
+    /// for example, `dict(value)` may match the shapes of both mapping and iterable overloads.
+    pub(crate) fn unambiguous_failing_overload(&self) -> Option<&Binding<'db>> {
+        match self.overloads.as_slice() {
+            [overload] => Some(overload),
+            _ => self
+                .matching_overload_before_type_checking
+                .and_then(|index| self.overloads.get(index)),
+        }
+    }
+
     /// Returns an iterator over all the mutable overloads that matched for this call binding.
     pub(crate) fn matching_overloads_mut(
         &mut self,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4329,7 +4329,7 @@ impl<'db> CallableBinding<'db> {
     /// The overload chosen for diagnostics can be arbitrary when multiple signatures accept the
     /// same argument shape. Its specialization must not determine a constructor's return type:
     /// for example, `dict(value)` may match the shapes of both mapping and iterable overloads.
-    pub(crate) fn unambiguous_failing_overload(&self) -> Option<&Binding<'db>> {
+    fn unambiguous_failing_overload(&self) -> Option<&Binding<'db>> {
         match self.overloads.as_slice() {
             [overload] => Some(overload),
             _ => self

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -372,7 +372,7 @@ impl<'db> ConstructorBinding<'db> {
         let mut combine_binding_specialization = |binding: &ConstructorBinding<'db>| {
             let Some(overload) = binding
                 .first_matching_overload()
-                .or_else(|| binding.callable().best_failing_overload())
+                .or_else(|| binding.callable().unambiguous_failing_overload())
             else {
                 return;
             };

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -370,7 +370,10 @@ impl<'db> ConstructorBinding<'db> {
 
         let mut combined: Option<Specialization<'db>> = None;
         let mut combine_binding_specialization = |binding: &ConstructorBinding<'db>| {
-            let Some(overload) = binding.first_matching_overload() else {
+            let Some(overload) = binding
+                .first_matching_overload()
+                .or_else(|| binding.callable().best_failing_overload())
+            else {
                 return;
             };
             let return_specialization = static_class_literal

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -512,15 +512,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
 
             bindings.report_diagnostics(&self.context, call_expression.into());
-            if can_infer {
-                // TODO: Remove this fallback once failed generic binding no longer exposes
-                // unresolved type variables. For example, if `Consumer[T]` has a callback
-                // field and `accepts_dog` only accepts `Dog`, then
-                // `value: Consumer[Animal] = Consumer(callback=accepts_dog)` fails while
-                // inferring `T`. Returning `Consumer[T]` would leak the unresolved type
-                // variable and produce an additional assignment error.
-                return fallback_ty;
-            }
         }
 
         bindings.return_type(db, env)


### PR DESCRIPTION
## Summary

Previously, we only recovered a generic constructor's specialization from an overload that passed argument validation. If validation failed, we discarded any type arguments the binding had already inferred, allowing the class's internal type variables to escape into the constructed value.

See here, where we emit two diagnostics on `consumer: Consumer[Animal] = Consumer(accepts_dog)`:

```py
from collections.abc import Callable

class Animal: ...
class Dog(Animal): ...

class Consumer[T]:
    def __init__(self, callback: Callable[[T], None]) -> None:
        self.callback = callback

def accepts_dog(value: Dog) -> None: ...

# error: [invalid-assignment] Object of type `Consumer[T@Consumer]` is not assignable to `Consumer[Animal]`
# error: [invalid-argument-type] Argument to `Consumer.__init__` is incorrect: Expected `(Animal, /) -> None`, found `def accepts_dog(value: Dog) -> None`
consumer: Consumer[Animal] = Consumer(accepts_dog)
```

The callback error is correct: `accepts_dog` cannot handle every `Animal`. But the constructor binding had already established `T = Animal` from its surrounding context. Discarding that specialization returned `Consumer[T@Consumer]` and produced a second, misleading assignment error.

We now preserve the specialization already established by constructor binding, even when argument validation fails, so only the callback error remains. The net effect is that we show fewer redundant errors and fewer cascading errors.