### PR TITLE
[ty] Rename the Markdown code-span predicate used in docstring parsing

### DIFF
--- a/crates/ty_ide/src/docstring/document/numpy.rs
+++ b/crates/ty_ide/src/docstring/document/numpy.rs
@@ -28,8 +28,8 @@ use ruff_text_size::{TextRange, TextSize};
 
 use super::preformatted::{PreformattedBlockScanner, starts_preformatted_block};
 use super::syntax::{
-    ParsedLine, container_block_end, is_dotted_identifier, is_markdown_code_span, parsed_lines,
-    split_once_at_top_level_colon, starts_container_block,
+    ParsedLine, container_block_end, is_dotted_identifier, is_wrapped_in_markdown_code_span,
+    parsed_lines, split_once_at_top_level_colon, starts_container_block,
 };
 use super::{DescriptionBuilder, HeaderKind, SectionKind};
 use crate::FxIndexMap;
@@ -652,7 +652,7 @@ impl<'a> ItemLine<'a> {
         }
 
         // A complete code span is an anonymous type even when its contents contain a colon.
-        if is_markdown_code_span(text) {
+        if is_wrapped_in_markdown_code_span(text) {
             return Some(Self::new(ItemBuilder::new(None, Some(text), ""), false));
         }
 
@@ -689,7 +689,7 @@ impl<'a> ItemLine<'a> {
             .map_or((text, ""), |(name, description)| {
                 (name.trim(), description.trim())
             });
-        if !is_item_name(name) && !is_markdown_code_span(name) {
+        if !is_item_name(name) && !is_wrapped_in_markdown_code_span(name) {
             return None;
         }
 

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -58,11 +58,11 @@ pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
         && matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
 }
 
-/// Returns whether `text` consists of a complete Markdown code span.
+/// Returns whether `text` is wrapped in a Markdown code span.
 ///
 /// For example, this returns `true` for ``"`value`"`` and `false` for
 /// ``"`value` trailing"``.
-pub(crate) fn is_markdown_code_span(text: &str) -> bool {
+pub(crate) fn is_wrapped_in_markdown_code_span(text: &str) -> bool {
     let mut tokens = InlineMarkupScanner::new(text);
     let Some(InlineMarkupToken::Code(_)) = tokens.next() else {
         return false;
@@ -530,8 +530,9 @@ pub(super) fn indentation(line: &str) -> TextSize {
 #[cfg(test)]
 mod tests {
     use super::{
-        BacktickScanner, InlineMarkupScanner, InlineMarkupToken, TextSize, is_markdown_code_span,
-        split_once_at_top_level_colon, split_trailing_parenthetical,
+        BacktickScanner, InlineMarkupScanner, InlineMarkupToken, TextSize,
+        is_wrapped_in_markdown_code_span, split_once_at_top_level_colon,
+        split_trailing_parenthetical,
     };
 
     #[test]
@@ -581,7 +582,7 @@ mod tests {
     }
 
     #[test]
-    fn recognizes_complete_markdown_code_spans() {
+    fn recognizes_wrapped_markdown_code_spans() {
         for (text, expected) in [
             ("`value`", true),
             ("``value`with:ticks``", true),
@@ -592,7 +593,7 @@ mod tests {
             ("``", false),
             ("value", false),
         ] {
-            assert_eq!(is_markdown_code_span(text), expected, "{text:?}");
+            assert_eq!(is_wrapped_in_markdown_code_span(text), expected, "{text:?}");
         }
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -6,7 +6,9 @@ use strum::IntoEnumIterator;
 use super::general;
 use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
-use crate::docstring::document::syntax::{is_markdown_code_span, starts_with_markdown_list_item};
+use crate::docstring::document::syntax::{
+    is_wrapped_in_markdown_code_span, starts_with_markdown_list_item,
+};
 
 mod google;
 mod numpy;
@@ -372,7 +374,7 @@ fn description_block_start(description: &str) -> Option<usize> {
 fn render_type_code_span_into(output: &mut String, ty: &str) {
     let normalized = normalize_type_for_code_span(ty);
 
-    if is_markdown_code_span(&normalized) {
+    if is_wrapped_in_markdown_code_span(&normalized) {
         output.push_str(&normalized);
         return;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This renames an internal helper function to be slightly more descriptive of the predicate it encapsulates.

## Test Plan

This is a simple rename that relies on existing test coverage.
<!-- How was it tested? -->
