### PR TITLE
[ty] Preserve contextual types when overloaded constructors fail

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -401,6 +401,62 @@ def accepts_dog(value: Dog) -> None: ...
 consumer: Consumer[Animal] = Consumer(accepts_dog)  # error: [invalid-argument-type]
 ```
 
+### Failed overloaded constructor inference
+
+When several constructor overloads accept the same argument shape, an expected specialization does
+not depend on choosing between them. A failed call retains that specialization and reports only its
+overload error.
+
+```py
+from collections.abc import Callable
+from typing import overload
+
+class Animal: ...
+class Dog(Animal): ...
+
+class Consumer[T]:
+    callback: Callable[[T], None]
+
+    @overload
+    def __init__(self, callback: Callable[[T], None]) -> None: ...
+    @overload
+    def __init__(self, callback: Callable[[T], int]) -> None: ...
+    def __init__(self, callback: object) -> None: ...
+
+def accepts_dog(value: Dog) -> None: ...
+
+consumer: Consumer[Animal] = Consumer(accepts_dog)  # error: [no-matching-overload]
+```
+
+Without an expected specialization, an unresolved type parameter falls back to `Unknown`:
+
+```py
+# error: [no-matching-overload]
+reveal_type(Consumer(1))  # revealed: Consumer[Unknown]
+```
+
+### Failed overloaded constructors preserve default type arguments
+
+If an overloaded constructor cannot infer a class type parameter, the result uses its declared
+default instead of exposing the unresolved parameter. Explicit type arguments remain unchanged.
+
+```py
+from typing import overload
+
+class Consumer[T = str]:
+    @overload
+    def __init__(self, value: int) -> None: ...
+    @overload
+    def __init__(self, value: bytes) -> None: ...
+    def __init__(self, value: object) -> None: ...
+
+# error: [no-matching-overload]
+reveal_type(Consumer(None))  # revealed: Consumer[str]
+
+# error: [no-matching-overload]
+reveal_type(Consumer[int](None))  # revealed: Consumer[int]
+```
+
 ### Constructing the class from its own type variable
 
 A constructor call inside a generic class can use a value whose type is one of the class's type

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -33,6 +33,8 @@ pub(super) struct ConstructorBinding<'db> {
     /// The next downstream constructor method, if any, to be (conditionally) checked after this
     /// one.
     pub(super) downstream_constructor: Option<Box<Bindings<'db>>>,
+    /// The expected type of the constructor call, retained independently of overload resolution.
+    call_expression_tcx: TypeContext<'db>,
 }
 
 impl<'db> ConstructorBinding<'db> {
@@ -44,6 +46,7 @@ impl<'db> ConstructorBinding<'db> {
             entry,
             constructor_context,
             downstream_constructor: None,
+            call_expression_tcx: TypeContext::default(),
         }
     }
 
@@ -182,6 +185,7 @@ impl<'db> ConstructorBinding<'db> {
         call_expression_tcx: TypeContext<'db>,
         mode: CheckTypesMode,
     ) {
+        self.call_expression_tcx = call_expression_tcx;
         self.entry
             .check_types(db, env, constraints, argument_types, call_expression_tcx);
 
@@ -304,6 +308,7 @@ impl<'db> ConstructorBinding<'db> {
             entry: f(self.entry),
             constructor_context: self.constructor_context,
             downstream_constructor: None,
+            call_expression_tcx: self.call_expression_tcx,
         }
     }
 
@@ -456,6 +461,39 @@ impl<'db> ConstructorBinding<'db> {
             {
                 combine_binding_specialization(downstream_binding);
             }
+        }
+
+        if self.callable().has_binding_errors() {
+            // The expected specialization does not depend on which constructor overload matched.
+            // For example, `consumer: Consumer[Animal] = Consumer(accepts_dog)` still establishes
+            // `T = Animal` even when every `Consumer.__init__` overload rejects the callback.
+            if let Some(contextual_specialization) =
+                static_class_literal.and_then(|class_literal| {
+                    self.call_expression_tcx
+                        .annotation?
+                        .specialization_of(db, env, class_literal)
+                })
+            {
+                return Some(
+                    contextual_specialization
+                        .apply_optional_specialization(db, Some(class_specialization)),
+                );
+            }
+
+            // Failed inference must not expose the constructed class's own type variables. Keep
+            // inferred or explicit arguments, but replace unresolved variables with their declared
+            // defaults (or `Unknown` when no default exists).
+            let default_specialization = class_context.default_specialization(
+                db,
+                self.constructed_class_literal(db, env)
+                    .and_then(|class_literal| class_literal.known(db)),
+            );
+            return Some(
+                combined
+                    .unwrap_or(default_specialization)
+                    .apply_optional_specialization(db, Some(class_specialization))
+                    .apply_optional_specialization(db, Some(default_specialization)),
+            );
         }
 
         combined.map(|specialization| {


### PR DESCRIPTION
## Summary

Previously, we only recovered a failed generic constructor's specialization when a single overload matched the call's argument shape. That avoids choosing an arbitrary failing overload, but it still allows unresolved class type variables to escape when several overloads accept the same arguments:

```py
from collections.abc import Callable
from typing import overload

class Animal: ...
class Dog(Animal): ...

class Consumer[T]:
    callback: Callable[[T], None]

    @overload
    def __init__(self, callback: Callable[[T], None]) -> None: ...
    @overload
    def __init__(self, callback: Callable[[T], int]) -> None: ...
    def __init__(self, callback: object) -> None: ...

def accepts_dog(value: Dog) -> None: ...

# error: [invalid-assignment] Object of type `Consumer[T@Consumer]` is not assignable to `Consumer[Animal]`
# error: [no-matching-overload] No overload of `Consumer.__init__` matches arguments
consumer: Consumer[Animal] = Consumer(accepts_dog)
```

The overload error is correct, but the assignment error is not: the surrounding annotation establishes `T = Animal` independently of which overload is selected.

We now retain the constructor's expected type separately from overload resolution, preserving its specialization even when all overloads fail. Without a matching expected type, unresolved parameters instead use their declared defaults or `Unknown`, while explicit type arguments remain unchanged.
