### PR TITLE
[ty] Avoid exponential inference after TypedDict key-membership narrowing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2978,6 +2978,97 @@ def _(p: Person) -> None:
     type(p).name  # error: [unresolved-attribute] "Class `dict[str, object]` has no attribute `name`"
 ```
 
+## Copying a `TypedDict` union after key membership narrowing
+
+A key membership check may add a synthesized, required-key `TypedDict` to each member of an open
+`TypedDict` union. Copying the resulting intersections must remain efficient and preserve the
+ordinary dictionary value type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from _typeshed import SupportsKeysAndGetItem
+from typing import Any, Literal, NotRequired, TypedDict
+
+T0 = TypedDict("T0", {"kind": Literal[0], "field0": NotRequired[int]})
+T1 = TypedDict("T1", {"kind": Literal[1], "field1": NotRequired[int]})
+T2 = TypedDict("T2", {"kind": Literal[2], "field2": NotRequired[int]})
+T3 = TypedDict("T3", {"kind": Literal[3], "field3": NotRequired[int]})
+T4 = TypedDict("T4", {"kind": Literal[4], "field4": NotRequired[int]})
+T5 = TypedDict("T5", {"kind": Literal[5], "field5": NotRequired[int]})
+T6 = TypedDict("T6", {"kind": Literal[6], "field6": NotRequired[int]})
+T7 = TypedDict("T7", {"kind": Literal[7], "field7": NotRequired[int]})
+T8 = TypedDict("T8", {"kind": Literal[8], "field8": NotRequired[int]})
+T9 = TypedDict("T9", {"kind": Literal[9], "field9": NotRequired[int]})
+T10 = TypedDict("T10", {"kind": Literal[10], "field10": NotRequired[int]})
+T11 = TypedDict("T11", {"kind": Literal[11], "field11": NotRequired[int]})
+
+Item = T0 | T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10 | T11
+```
+
+Copying after the membership test preserves the mapping's ordinary key and value types:
+
+```py
+def copy_after_key_membership(item: Item) -> None:
+    if "missing" in item:
+        reveal_type(dict(item))  # revealed: dict[str, object]
+```
+
+An `isinstance` check before the membership test must preserve the same result:
+
+```py
+def copy_after_isinstance_and_key_membership(item: Item | str) -> None:
+    if isinstance(item, dict) and "missing" in item:
+        reveal_type(dict(item))  # revealed: dict[str, object]
+```
+
+A regular string-keyed dictionary can appear alongside the `TypedDict` union:
+
+```py
+def copy_mixed_union_after_key_membership(item: Item | dict[str, Any]) -> None:
+    if "missing" in item:
+        reveal_type(dict(item))  # revealed: dict[str, object]
+```
+
+The same behavior holds when both narrowing operations apply to the mixed union:
+
+```py
+def copy_mixed_union_after_isinstance_and_key_membership(item: Item | dict[str, Any] | str) -> None:
+    if isinstance(item, dict) and "missing" in item:
+        reveal_type(dict(item))  # revealed: dict[str, object]
+```
+
+User-defined functions accepting the same mapping protocol infer precise key and value types:
+
+```py
+def infer_mapping[Key, Value](value: SupportsKeysAndGetItem[Key, Value]) -> tuple[Key, Value]:
+    raise NotImplementedError
+
+def infer_mapping_after_key_membership(item: Item) -> None:
+    if "missing" in item:
+        reveal_type(infer_mapping(item))  # revealed: tuple[str, object]
+```
+
+Explicitly typed extra items must retain their value type even after a key membership check:
+
+```py
+from typing_extensions import TypedDict as ExtensionsTypedDict
+
+class FirstWithAnyExtraItems(ExtensionsTypedDict, extra_items=Any):
+    missing: NotRequired[Any]
+
+class SecondWithAnyExtraItems(ExtensionsTypedDict, extra_items=Any):
+    missing: NotRequired[Any]
+
+def preserve_any_extra_items(value: FirstWithAnyExtraItems | SecondWithAnyExtraItems) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, Any]
+    if "missing" in value:
+        reveal_type(dict(value))  # revealed: dict[str, Any]
+```
+
 ## Special properties
 
 ### Python 3.12

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3051,6 +3051,23 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 })
         }
 
+        // A successful key-membership test adds a synthesized protocol to non-`TypedDict`
+        // union members. Its sole `__contains__` requirement does not change the key or value
+        // constraints of a mapping in the same intersection.
+        fn is_key_membership_protocol<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+            let Type::ProtocolInstance(protocol) = ty.resolve_type_alias(db) else {
+                return false;
+            };
+            if protocol.class_origin(db).is_some() {
+                return false;
+            }
+            let mut members = protocol.interface(db).members(db);
+            members
+                .next()
+                .is_some_and(|member| member.name() == "__contains__")
+                && members.next().is_none()
+        }
+
         fn collect_typed_dicts<'db>(
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,
@@ -3116,6 +3133,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         && intersection.iter_positive(db).all(|element| {
                             let element = element.resolve_type_alias(db);
                             is_string_keyed_mapping(db, env, element)
+                                || is_key_membership_protocol(db, element)
                                 || element
                                     == KnownClass::Dict
                                         .to_instance_unknown(db, env)
@@ -3144,6 +3162,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mut typed_dicts = FxHashSet::default();
         let mut other_types = FxOrderSet::default();
         let env = self.env;
+        let is_keys_and_get_item_protocol = matches!(formal, Type::ProtocolInstance(protocol)
+        if protocol.class_origin(db).is_some_and(|class| {
+            class.is_known(db, KnownClass::SupportsKeysAndGetItem)
+        }));
 
         if !actual.elements(db).iter().all(|element| {
             collect_typed_dicts(
@@ -3163,12 +3185,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
         // Other protocols can observe key-specific or gradual evidence that the shared mapping
         // fallback erases; restrict mixed unions to the protocol used by dictionary constructors.
-        if !other_types.is_empty()
-            && !matches!(formal, Type::ProtocolInstance(protocol)
-            if protocol.class_origin(db).is_some_and(|class| {
-                class.is_known(db, KnownClass::SupportsKeysAndGetItem)
-            }))
-        {
+        if !other_types.is_empty() && !is_keys_and_get_item_protocol {
             return None;
         }
 
@@ -3179,22 +3196,54 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mapping = KnownClass::Mapping.to_specialized_instance(db, env, spec);
         let mapping_when = mapping.when_constraint_set_assignable_to_owned(db, env, formal);
         let mapping_when = self.constraints.load(db, env, &mapping_when);
-        // Logically equivalent constraints can still infer different solutions, such as `Any`
-        // instead of `object`; preserve the original constraints when gradual evidence differs.
-        let mapping_solutions = mapping_when.solutions(db, env, self.constraints, self.inferable);
-        if !typed_dicts.into_iter().all(|element| {
-            let element_when = self.constraints.load(
-                db,
-                env,
-                &element.when_constraint_set_assignable_to_owned(db, env, formal),
-            );
-            element_when
-                .iff(db, self.constraints, mapping_when)
-                .is_always_satisfied(db, env)
-                && element_when.solutions(db, env, self.constraints, self.inferable)
-                    == mapping_solutions
-        }) {
-            return None;
+
+        // An implicitly open `TypedDict` can contain arbitrary hidden values, so its mapping value
+        // type is always `object`, even when membership narrowing adds a required-key schema.
+        // `SupportsKeysAndGetItem` only observes those mapping constraints; other protocols and
+        // `TypedDict`s with closed or explicitly typed extra items still need the full comparison.
+        let share_open_typed_dict_constraints = is_keys_and_get_item_protocol
+            && typed_dicts
+                .iter()
+                .all(|element| match element.resolve_type_alias(db) {
+                    Type::TypedDict(typed_dict) => typed_dict.openness(db).is_implicitly_open(),
+                    Type::Intersection(intersection) => {
+                        intersection.iter_positive(db).all(|positive| {
+                            let positive = positive.resolve_type_alias(db);
+                            match positive {
+                                Type::TypedDict(typed_dict) => {
+                                    typed_dict.openness(db).is_implicitly_open()
+                                }
+                                _ => {
+                                    positive
+                                        == KnownClass::Dict
+                                            .to_instance_unknown(db, env)
+                                            .top_materialization(db, env)
+                                }
+                            }
+                        })
+                    }
+                    _ => false,
+                });
+
+        if !share_open_typed_dict_constraints {
+            // Logically equivalent constraints can still infer different solutions, such as `Any`
+            // instead of `object`; preserve the original constraints when gradual evidence differs.
+            let mapping_solutions =
+                mapping_when.solutions(db, env, self.constraints, self.inferable);
+            if !typed_dicts.into_iter().all(|element| {
+                let element_when = self.constraints.load(
+                    db,
+                    env,
+                    &element.when_constraint_set_assignable_to_owned(db, env, formal),
+                );
+                element_when
+                    .iff(db, self.constraints, mapping_when)
+                    .is_always_satisfied(db, env)
+                    && element_when.solutions(db, env, self.constraints, self.inferable)
+                        == mapping_solutions
+            }) {
+                return None;
+            }
         }
 
         // Reuse one constraint for all equivalent TypedDicts, but retain each mapping arm's


### PR DESCRIPTION
## Summary

- Extend the shared `TypedDict` mapping-constraint optimization to positive key-membership narrowing, including mixed dictionary unions and synthesized `__contains__` evidence.
- Reuse `Mapping[str, object]` constraints only for implicitly open `TypedDict` arms; preserve the existing checks for explicitly typed extra items, closed schemas, and other protocols.
- Cover direct and `isinstance`-preceded membership checks, mixed dictionary unions, generic mapping-protocol inference, and `extra_items=Any`.

Fixes https://github.com/astral-sh/ty/issues/4176.

With a 12-arm, dependency-free reproducer, the patched debug build takes approximately 200 ms, versus approximately 187 ms for the control without the problematic call; the unpatched build exceeds 12 seconds. The affected production file improves from more than 15 seconds and 800 MiB to approximately 1.3 seconds and 108 MiB.

## Test plan

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_DEBUG=line-tables-only INSTA_FORCE_PASS=1 INSTA_UPDATE=always MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic` (796 passed, 34 skipped).
- `cargo clippy -p ty_python_semantic --all-targets -- -D warnings`.
- `uvx prek run --files crates/ty_python_semantic/src/types/generics.rs crates/ty_python_semantic/resources/mdtest/typed_dict.md`.
