### PR TITLE
Prepare ruff_annotate_snippets for it to be used for suggestions

### DIFF
--- a/crates/ruff_annotate_snippets/src/renderer/render.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/render.rs
@@ -541,7 +541,10 @@ fn format_origin(origin: &Origin<'_>, anonymized_line_numbers: bool) -> String {
         write!(&mut buffer, "{path}").unwrap();
     }
     if let Some(cell_index) = origin.cell_index {
-        write!(&mut buffer, ":cell {cell_index}").unwrap();
+        if !buffer.is_empty() {
+            write!(&mut buffer, ":").unwrap();
+        }
+        write!(&mut buffer, "cell {cell_index}").unwrap();
     }
     if let Some(line) = origin.line {
         if anonymized_line_numbers {
@@ -1528,8 +1531,8 @@ fn emit_suggestion_default(
     let (complete, parts, highlights, replaced_highlights) = spliced_lines;
     let is_multiline = complete.lines().count() > 1;
 
-    if suggestion.path.as_ref() != primary_path
-        && let Some(path) = suggestion.path.as_ref()
+    let secondary_path = suggestion.path.as_ref() != primary_path;
+    if ((secondary_path && suggestion.path.as_ref().is_some()) || suggestion.cell_index.is_some())
         && !matches_previous_suggestion
     {
         let (loc, _) = sm.span_to_locations(parts[0].span.clone());
@@ -1540,9 +1543,12 @@ fn emit_suggestion_default(
         }
         let arrow = renderer.decor_style.file_start(is_first, false);
         buffer.append(row_num - 1, arrow, ElementStyle::LineNumber);
-        let mut origin = Origin::path(path.as_ref()).cell_index(suggestion.cell_index);
-        origin.line = Some(loc.line);
-        origin.char_column = Some(loc.char + 1);
+        let origin = Origin {
+            path: suggestion.path.as_ref().map(|p| Cow::Borrowed(p.as_ref())),
+            cell_index: suggestion.cell_index,
+            line: Some(loc.line),
+            char_column: Some(loc.char + 1),
+        };
         let message = format_origin(&origin, renderer.anonymized_line_numbers);
         buffer.append(row_num - 1, &message, ElementStyle::LineAndColumn);
 

--- a/crates/ruff_annotate_snippets/src/renderer/render.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/render.rs
@@ -155,8 +155,8 @@ pub(crate) fn render(renderer: &Renderer, groups: Report<'_>) -> String {
                         spliced_lines,
                         display_suggestion,
                     )) => {
-                        let matches_previous_suggestion =
-                            last_suggestion_path == Some(suggestion.path.as_ref());
+                        let matches_previous_suggestion = last_suggestion_path
+                            == Some((Some(suggestion.path.as_ref()), suggestion.cell_index));
                         emit_suggestion_default(
                             renderer,
                             &mut buffer,
@@ -173,7 +173,8 @@ pub(crate) fn render(renderer: &Renderer, groups: Report<'_>) -> String {
                         );
 
                         if matches!(peek, Some(PreProcessedElement::Suggestion(_))) {
-                            last_suggestion_path = Some(suggestion.path.as_ref());
+                            last_suggestion_path =
+                                Some((Some(suggestion.path.as_ref()), suggestion.cell_index));
                         } else {
                             last_suggestion_path = None;
                         }

--- a/crates/ruff_annotate_snippets/src/renderer/render.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/render.rs
@@ -1523,7 +1523,7 @@ fn emit_suggestion_default(
     sm: &SourceMap<'_>,
     primary_path: Option<&Cow<'_, str>>,
     matches_previous_suggestion: bool,
-    is_first: bool,
+    _is_first: bool,
     is_cont: bool,
 ) {
     let buffer_offset = buffer.num_lines();
@@ -1541,7 +1541,7 @@ fn emit_suggestion_default(
         for _ in 0..max_line_num_len {
             buffer.append(row_num - 1, " ", ElementStyle::NoStyle);
         }
-        let arrow = renderer.decor_style.file_start(is_first, false);
+        let arrow = renderer.decor_style.secondary_file_start();
         buffer.append(row_num - 1, arrow, ElementStyle::LineNumber);
         let origin = Origin {
             path: suggestion

--- a/crates/ruff_annotate_snippets/src/renderer/render.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/render.rs
@@ -528,26 +528,28 @@ fn render_origin(
         );
     }
 
-    let str = {
-        use core::fmt::Write as _;
-
-        let mut buffer = origin.path.as_ref().to_owned();
-        if let Some(cell_index) = origin.cell_index {
-            write!(&mut buffer, ":cell {cell_index}").unwrap();
-        }
-        if let Some(line) = origin.line {
-            if renderer.anonymized_line_numbers {
-                write!(&mut buffer, ":{ANONYMIZED_LINE_NUM}").unwrap();
-            } else {
-                write!(&mut buffer, ":{line}").unwrap();
-            }
-            if let Some(col) = origin.char_column {
-                write!(&mut buffer, ":{col}").unwrap();
-            }
-        }
-        buffer
-    };
+    let str = format_origin(origin, renderer.anonymized_line_numbers);
     buffer.append(buffer_msg_line_offset, &str, ElementStyle::LineAndColumn);
+}
+
+fn format_origin(origin: &Origin<'_>, anonymized_line_numbers: bool) -> String {
+    use core::fmt::Write as _;
+
+    let mut buffer = origin.path.as_ref().to_owned();
+    if let Some(cell_index) = origin.cell_index {
+        write!(&mut buffer, ":cell {cell_index}").unwrap();
+    }
+    if let Some(line) = origin.line {
+        if anonymized_line_numbers {
+            write!(&mut buffer, ":{ANONYMIZED_LINE_NUM}").unwrap();
+        } else {
+            write!(&mut buffer, ":{line}").unwrap();
+        }
+        if let Some(col) = origin.char_column {
+            write!(&mut buffer, ":{col}").unwrap();
+        }
+    }
+    buffer
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/ruff_annotate_snippets/src/renderer/render.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/render.rs
@@ -181,7 +181,7 @@ pub(crate) fn render(renderer: &Renderer, groups: Report<'_>) -> String {
 
                     PreProcessedElement::Origin(origin) => {
                         let buffer_msg_line_offset = buffer.num_lines();
-                        let is_primary = primary_path == Some(&origin.path) && !seen_primary;
+                        let is_primary = primary_path == origin.path.as_ref() && !seen_primary;
                         seen_primary |= is_primary;
                         render_origin(
                             renderer,
@@ -535,7 +535,10 @@ fn render_origin(
 fn format_origin(origin: &Origin<'_>, anonymized_line_numbers: bool) -> String {
     use core::fmt::Write as _;
 
-    let mut buffer = origin.path.as_ref().to_owned();
+    let mut buffer = String::new();
+    if let Some(path) = &origin.path {
+        write!(&mut buffer, "{path}").unwrap();
+    }
     if let Some(cell_index) = origin.cell_index {
         write!(&mut buffer, ":cell {cell_index}").unwrap();
     }
@@ -2806,7 +2809,7 @@ fn pre_process<'a>(
                 }
                 Element::Origin(origin) => {
                     if primary_path.is_none() {
-                        primary_path = Some(Some(&origin.path));
+                        primary_path = Some(origin.path.as_ref());
                     }
                     elements.push(PreProcessedElement::Origin(origin));
                 }

--- a/crates/ruff_annotate_snippets/src/renderer/render.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/render.rs
@@ -1544,7 +1544,11 @@ fn emit_suggestion_default(
         let arrow = renderer.decor_style.file_start(is_first, false);
         buffer.append(row_num - 1, arrow, ElementStyle::LineNumber);
         let origin = Origin {
-            path: suggestion.path.as_ref().map(|p| Cow::Borrowed(p.as_ref())),
+            path: suggestion
+                .path
+                .as_ref()
+                .filter(|_| secondary_path)
+                .map(|p| Cow::Borrowed(p.as_ref())),
             cell_index: suggestion.cell_index,
             line: Some(loc.line),
             char_column: Some(loc.char + 1),

--- a/crates/ruff_annotate_snippets/src/renderer/render.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/render.rs
@@ -1535,9 +1535,9 @@ fn emit_suggestion_default(
         let arrow = renderer.decor_style.file_start(is_first, false);
         buffer.append(row_num - 1, arrow, ElementStyle::LineNumber);
         let message = if renderer.anonymized_line_numbers {
-            format!("{}:{}:{}", path, loc.line, loc.char + 1)
-        } else {
             format!("{}:{}:{}", path, ANONYMIZED_LINE_NUM, loc.char + 1)
+        } else {
+            format!("{}:{}:{}", path, loc.line, loc.char + 1)
         };
         buffer.append(row_num - 1, &message, ElementStyle::LineAndColumn);
 

--- a/crates/ruff_annotate_snippets/src/renderer/render.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/render.rs
@@ -1536,11 +1536,10 @@ fn emit_suggestion_default(
         }
         let arrow = renderer.decor_style.file_start(is_first, false);
         buffer.append(row_num - 1, arrow, ElementStyle::LineNumber);
-        let message = if renderer.anonymized_line_numbers {
-            format!("{}:{}:{}", path, ANONYMIZED_LINE_NUM, loc.char + 1)
-        } else {
-            format!("{}:{}:{}", path, loc.line, loc.char + 1)
-        };
+        let mut origin = Origin::path(path.as_ref()).cell_index(suggestion.cell_index);
+        origin.line = Some(loc.line);
+        origin.char_column = Some(loc.char + 1);
+        let message = format_origin(&origin, renderer.anonymized_line_numbers);
         buffer.append(row_num - 1, &message, ElementStyle::LineAndColumn);
 
         draw_col_separator_no_space(renderer, buffer, row_num, max_line_num_len + 1);

--- a/crates/ruff_annotate_snippets/src/renderer/source_map.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/source_map.rs
@@ -457,6 +457,7 @@ impl<'a> SourceMap<'a> {
         };
 
         let lines = self.span_to_lines(lo..hi);
+        let (bounding_lo, bounding_hi) = self.span_to_locations(lo..hi);
 
         let mut highlights = vec![];
         // To build up the result, we do this for each span:
@@ -468,7 +469,7 @@ impl<'a> SourceMap<'a> {
         // - splice in the span substitution
         //
         // Finally push the trailing line segment of the last span
-        let (mut prev_hi, _) = self.span_to_locations(lo..hi);
+        let mut prev_hi = bounding_lo;
         prev_hi.char = 0;
         let mut prev_line = lines.first().map(|line| line.line);
         let mut buf = String::new();
@@ -565,7 +566,6 @@ impl<'a> SourceMap<'a> {
             buf.pop();
         }
 
-        let (bounding_lo, bounding_hi) = self.span_to_locations(lo..hi);
         let line_count = bounding_hi.line.saturating_sub(bounding_lo.line) + 1;
         let mut replaced_highlights: Vec<Vec<SubstitutionHighlight>> = vec![Vec::new(); line_count];
         for part in &trimmed_patches {

--- a/crates/ruff_annotate_snippets/src/renderer/source_map.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/source_map.rs
@@ -449,15 +449,24 @@ impl<'a> SourceMap<'a> {
 
         // Find the bounding span.
         let (lo, hi) = if fold {
-            let lo = patches.iter().map(|p| p.span.start).min()?;
-            let hi = patches.iter().map(|p| p.span.end).max()?;
+            let lo = patches
+                .iter()
+                .map(|p| p.span.clone())
+                .min_by_key(|s| s.start)?;
+            let hi = patches
+                .iter()
+                .map(|p| p.span.clone())
+                .max_by_key(|s| s.end)?;
             (lo, hi)
         } else {
-            (0, source_len)
+            let lo = 0..source_len;
+            let hi = 0..source_len;
+            (lo, hi)
         };
 
-        let lines = self.span_to_lines(lo..hi);
-        let (bounding_lo, bounding_hi) = self.span_to_locations(lo..hi);
+        let lines = self.span_to_lines(lo.start..hi.end);
+        let (bounding_lo, _) = self.span_to_locations(lo);
+        let (_, bounding_hi) = self.span_to_locations(hi);
 
         let mut highlights = vec![];
         // To build up the result, we do this for each span:

--- a/crates/ruff_annotate_snippets/src/snippet.rs
+++ b/crates/ruff_annotate_snippets/src/snippet.rs
@@ -523,7 +523,7 @@ impl<'a> Patch<'a> {
 /// ```
 #[derive(Clone, Debug)]
 pub struct Origin<'a> {
-    pub(crate) path: Cow<'a, str>,
+    pub(crate) path: Option<Cow<'a, str>>,
     /// The optional cell index in a Jupyter notebook, used for reporting source locations along
     /// with the ranges on `annotations`.
     pub(crate) cell_index: Option<usize>,
@@ -541,7 +541,7 @@ impl<'a> Origin<'a> {
     /// </div>
     pub fn path(path: impl Into<Cow<'a, str>>) -> Self {
         Self {
-            path: path.into(),
+            path: Some(path.into()),
             cell_index: None,
             line: None,
             char_column: None,

--- a/crates/ruff_annotate_snippets/tests/color/highlight_first_line_tab_371.ascii.term.svg
+++ b/crates/ruff_annotate_snippets/tests/color/highlight_first_line_tab_371.ascii.term.svg
@@ -22,7 +22,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">: &lt;sample error message&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>&lt;sample path&gt;:6:18</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">::: </tspan><tspan>&lt;sample path&gt;:6:18</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>

--- a/crates/ruff_annotate_snippets/tests/color/highlight_first_line_tab_371.ascii.term.svg
+++ b/crates/ruff_annotate_snippets/tests/color/highlight_first_line_tab_371.ascii.term.svg
@@ -22,7 +22,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">: &lt;sample error message&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>&lt;sample path&gt;:LL:18</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>&lt;sample path&gt;:6:18</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>

--- a/crates/ruff_annotate_snippets/tests/formatter.rs
+++ b/crates/ruff_annotate_snippets/tests/formatter.rs
@@ -5281,7 +5281,7 @@ error[E0624]: method `five_years` is private
   |    ---------- private method defined here
   |
 help: consider making `bar` public
- --> other.rs:1:1
+ ::: other.rs:1:1
   |
 1 | pub fn bar(&self) {
   | +++
@@ -5302,7 +5302,7 @@ error[E0624]: method `five_years` is private
   │    ────────── private method defined here
   ╰╴
 help: consider making `bar` public
-  ╭▸ other.rs:1:1
+  ⸬  other.rs:1:1
   │
 1 │ pub fn bar(&self) {
   ╰╴+++

--- a/crates/ruff_annotate_snippets/tests/formatter.rs
+++ b/crates/ruff_annotate_snippets/tests/formatter.rs
@@ -5281,7 +5281,7 @@ error[E0624]: method `five_years` is private
   |    ---------- private method defined here
   |
 help: consider making `bar` public
- --> other.rs:LL:1
+ --> other.rs:1:1
   |
 1 | pub fn bar(&self) {
   | +++
@@ -5302,7 +5302,7 @@ error[E0624]: method `five_years` is private
   │    ────────── private method defined here
   ╰╴
 help: consider making `bar` public
-  ╭▸ other.rs:LL:1
+  ╭▸ other.rs:1:1
   │
 1 │ pub fn bar(&self) {
   ╰╴+++

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -91,7 +91,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> cell 1:2:8
+ ::: cell 1:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -111,7 +111,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ cell 1:2:8
+  ⸬  cell 1:2:8
   │
 2 - Second oops line
 2 + Second line
@@ -157,7 +157,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> cell 1:2:8
+ ::: cell 1:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -178,7 +178,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ cell 1:2:8
+  ⸬  cell 1:2:8
   │
 2 - Second oops line
 2 + Second line
@@ -224,12 +224,12 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> cell 1:2:8
+ ::: cell 1:2:8
   |
 2 - Second oops line
 2 + Second line
   |
- --> cell 2:2:12
+ ::: cell 2:2:12
   |
 2 - Second oops line
 2 + Second oops
@@ -247,12 +247,12 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ cell 1:2:8
+  ⸬  cell 1:2:8
   │
 2 - Second oops line
 2 + Second line
   │
-  ├▸ cell 2:2:12
+  ⸬  cell 2:2:12
   │
 2 - Second oops line
 2 + Second oops
@@ -291,7 +291,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> cell 2:2:8
+ ::: cell 2:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -311,7 +311,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ cell 2:2:8
+  ⸬  cell 2:2:8
   │
 2 - Second oops line
 2 + Second line
@@ -357,7 +357,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> bar.ipynb:cell 2:2:8
+ ::: bar.ipynb:cell 2:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -378,7 +378,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ bar.ipynb:cell 2:2:8
+  ⸬  bar.ipynb:cell 2:2:8
   │
 2 - Second oops line
 2 + Second line
@@ -424,12 +424,12 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> bar.ipynb:cell 2:2:8
+ ::: bar.ipynb:cell 2:2:8
   |
 2 - Second oops line
 2 + Second line
   |
- --> bar.ipynb:cell 3:2:12
+ ::: bar.ipynb:cell 3:2:12
   |
 2 - Second oops line
 2 + Second oops
@@ -447,12 +447,12 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ bar.ipynb:cell 2:2:8
+  ⸬  bar.ipynb:cell 2:2:8
   │
 2 - Second oops line
 2 + Second line
   │
-  ├▸ bar.ipynb:cell 3:2:12
+  ⸬  bar.ipynb:cell 3:2:12
   │
 2 - Second oops line
 2 + Second oops

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -91,6 +91,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
+ --> cell 1:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -110,7 +111,8 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭╴
+  ╭▸ cell 1:2:8
+  │
 2 - Second oops line
 2 + Second line
   ├╴
@@ -155,6 +157,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
+ --> foo.ipynb:cell 1:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -175,7 +178,8 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭╴
+  ╭▸ foo.ipynb:cell 1:2:8
+  │
 2 - Second oops line
 2 + Second line
   ├╴
@@ -220,10 +224,12 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
+ --> foo.ipynb:cell 1:2:8
   |
 2 - Second oops line
 2 + Second line
   |
+ --> foo.ipynb:cell 2:2:12
   |
 2 - Second oops line
 2 + Second oops
@@ -241,11 +247,13 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭╴
+  ╭▸ foo.ipynb:cell 1:2:8
+  │
 2 - Second oops line
 2 + Second line
   │
-  ╭╴
+  ├▸ foo.ipynb:cell 2:2:12
+  │
 2 - Second oops line
 2 + Second oops
   ╰╴
@@ -283,6 +291,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
+ --> cell 2:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -302,7 +311,8 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭╴
+  ╭▸ cell 2:2:8
+  │
 2 - Second oops line
 2 + Second line
   ├╴

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -345,7 +345,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> bar.ipynb:2:8
+ --> bar.ipynb:cell 2:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -366,7 +366,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ bar.ipynb:2:8
+  ╭▸ bar.ipynb:cell 2:2:8
   │
 2 - Second oops line
 2 + Second line
@@ -412,7 +412,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> bar.ipynb:2:8
+ --> bar.ipynb:cell 2:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -433,7 +433,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ bar.ipynb:2:8
+  ╭▸ bar.ipynb:cell 2:2:8
   │
 2 - Second oops line
 2 + Second line

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -157,7 +157,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> foo.ipynb:cell 1:2:8
+ --> cell 1:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -178,7 +178,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ foo.ipynb:cell 1:2:8
+  ╭▸ cell 1:2:8
   │
 2 - Second oops line
 2 + Second line
@@ -224,12 +224,12 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> foo.ipynb:cell 1:2:8
+ --> cell 1:2:8
   |
 2 - Second oops line
 2 + Second line
   |
- --> foo.ipynb:cell 2:2:12
+ --> cell 2:2:12
   |
 2 - Second oops line
 2 + Second oops
@@ -247,12 +247,12 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ foo.ipynb:cell 1:2:8
+  ╭▸ cell 1:2:8
   │
 2 - Second oops line
 2 + Second line
   │
-  ├▸ foo.ipynb:cell 2:2:12
+  ├▸ cell 2:2:12
   │
 2 - Second oops line
 2 + Second oops

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -224,6 +224,7 @@ help: remove the entry
 2 - Second oops line
 2 + Second line
   |
+  |
 2 - Second oops line
 2 + Second oops
   |
@@ -243,7 +244,8 @@ help: remove the entry
   ╭╴
 2 - Second oops line
 2 + Second line
-  ├╴
+  │
+  ╭╴
 2 - Second oops line
 2 + Second oops
   ╰╴
@@ -417,6 +419,8 @@ help: remove the entry
 2 - Second oops line
 2 + Second line
   |
+ --> bar.ipynb:cell 3:2:12
+  |
 2 - Second oops line
 2 + Second oops
   |
@@ -437,7 +441,9 @@ help: remove the entry
   │
 2 - Second oops line
 2 + Second line
-  ├╴
+  │
+  ├▸ bar.ipynb:cell 3:2:12
+  │
 2 - Second oops line
 2 + Second oops
   ╰╴

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -345,7 +345,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> bar.ipynb:LL:8
+ --> bar.ipynb:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -366,7 +366,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ bar.ipynb:LL:8
+  ╭▸ bar.ipynb:2:8
   │
 2 - Second oops line
 2 + Second line
@@ -412,7 +412,7 @@ error: oops
   |        ^^^^ oops
   |
 help: remove the entry
- --> bar.ipynb:LL:8
+ --> bar.ipynb:2:8
   |
 2 - Second oops line
 2 + Second line
@@ -433,7 +433,7 @@ error: oops
   │        ━━━━ oops
   ╰╴
 help: remove the entry
-  ╭▸ bar.ipynb:LL:8
+  ╭▸ bar.ipynb:2:8
   │
 2 - Second oops line
 2 + Second line

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -1,0 +1,447 @@
+use annotate_snippets::{AnnotationKind, Level, Patch, Renderer, Snippet};
+
+use annotate_snippets::renderer::DecorStyle;
+use snapbox::{assert_data_eq, str};
+
+#[test]
+fn snippet_with_cell() {
+    let source = "First line\r\nSecond oops line";
+    let input = &[Level::ERROR.primary_title("oops").element(
+        Snippet::source(source)
+            .cell_index(Some(1))
+            .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+    )];
+    let expected_ascii = str![[r#"
+error: oops
+  |
+2 | Second oops line
+  |        ^^^^ oops
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: oops
+  ╭▸ 
+2 │ Second oops line
+  ╰╴       ━━━━ oops
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn snippet_with_path_cell() {
+    let source = "First line\r\nSecond oops line";
+    let input = &[Level::ERROR.primary_title("oops").element(
+        Snippet::source(source)
+            .path("foo.ipynb")
+            .cell_index(Some(1))
+            .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+    )];
+    let expected_ascii = str![[r#"
+error: oops
+ --> foo.ipynb:cell 1:2:8
+  |
+2 | Second oops line
+  |        ^^^^ oops
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: oops
+  ╭▸ foo.ipynb:cell 1:2:8
+  │
+2 │ Second oops line
+  ╰╴       ━━━━ oops
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn patch_with_primary_cell() {
+    let source = "First line\r\nSecond oops line";
+    let input = &[
+        Level::ERROR.primary_title("oops").element(
+            Snippet::source(source)
+                .cell_index(Some(1))
+                .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+        ),
+        Level::HELP
+            .secondary_title("remove the entry")
+            .element(
+                Snippet::source(source)
+                    .cell_index(Some(1))
+                    .patch(Patch::new(19..24, "")),
+            )
+            .element(
+                Snippet::source(source)
+                    .cell_index(Some(1))
+                    .patch(Patch::new(23..28, "")),
+            ),
+    ];
+    let expected_ascii = str![[r#"
+error: oops
+  |
+2 | Second oops line
+  |        ^^^^ oops
+  |
+help: remove the entry
+  |
+2 - Second oops line
+2 + Second line
+  |
+2 - Second oops line
+2 + Second oops
+  |
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: oops
+  ╭▸ 
+2 │ Second oops line
+  │        ━━━━ oops
+  ╰╴
+help: remove the entry
+  ╭╴
+2 - Second oops line
+2 + Second line
+  ├╴
+2 - Second oops line
+2 + Second oops
+  ╰╴
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn patch_with_primary_path_cell() {
+    let source = "First line\r\nSecond oops line";
+    let input = &[
+        Level::ERROR.primary_title("oops").element(
+            Snippet::source(source)
+                .path("foo.ipynb")
+                .cell_index(Some(1))
+                .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+        ),
+        Level::HELP
+            .secondary_title("remove the entry")
+            .element(
+                Snippet::source(source)
+                    .path("foo.ipynb")
+                    .cell_index(Some(1))
+                    .patch(Patch::new(19..24, "")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("foo.ipynb")
+                    .cell_index(Some(1))
+                    .patch(Patch::new(23..28, "")),
+            ),
+    ];
+    let expected_ascii = str![[r#"
+error: oops
+ --> foo.ipynb:cell 1:2:8
+  |
+2 | Second oops line
+  |        ^^^^ oops
+  |
+help: remove the entry
+  |
+2 - Second oops line
+2 + Second line
+  |
+2 - Second oops line
+2 + Second oops
+  |
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: oops
+  ╭▸ foo.ipynb:cell 1:2:8
+  │
+2 │ Second oops line
+  │        ━━━━ oops
+  ╰╴
+help: remove the entry
+  ╭╴
+2 - Second oops line
+2 + Second line
+  ├╴
+2 - Second oops line
+2 + Second oops
+  ╰╴
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn patch_with_primary_path_incrementing_cell() {
+    let source = "First line\r\nSecond oops line";
+    let input = &[
+        Level::ERROR.primary_title("oops").element(
+            Snippet::source(source)
+                .path("foo.ipynb")
+                .cell_index(Some(1))
+                .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+        ),
+        Level::HELP
+            .secondary_title("remove the entry")
+            .element(
+                Snippet::source(source)
+                    .path("foo.ipynb")
+                    .cell_index(Some(1))
+                    .patch(Patch::new(19..24, "")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("foo.ipynb")
+                    .cell_index(Some(2))
+                    .patch(Patch::new(23..28, "")),
+            ),
+    ];
+    let expected_ascii = str![[r#"
+error: oops
+ --> foo.ipynb:cell 1:2:8
+  |
+2 | Second oops line
+  |        ^^^^ oops
+  |
+help: remove the entry
+  |
+2 - Second oops line
+2 + Second line
+  |
+2 - Second oops line
+2 + Second oops
+  |
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: oops
+  ╭▸ foo.ipynb:cell 1:2:8
+  │
+2 │ Second oops line
+  │        ━━━━ oops
+  ╰╴
+help: remove the entry
+  ╭╴
+2 - Second oops line
+2 + Second line
+  ├╴
+2 - Second oops line
+2 + Second oops
+  ╰╴
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn patch_with_other_cell() {
+    let source = "First line\r\nSecond oops line";
+    let input = &[
+        Level::ERROR.primary_title("oops").element(
+            Snippet::source(source)
+                .cell_index(Some(1))
+                .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+        ),
+        Level::HELP
+            .secondary_title("remove the entry")
+            .element(
+                Snippet::source(source)
+                    .cell_index(Some(2))
+                    .patch(Patch::new(19..24, "")),
+            )
+            .element(
+                Snippet::source(source)
+                    .cell_index(Some(2))
+                    .patch(Patch::new(23..28, "")),
+            ),
+    ];
+    let expected_ascii = str![[r#"
+error: oops
+  |
+2 | Second oops line
+  |        ^^^^ oops
+  |
+help: remove the entry
+  |
+2 - Second oops line
+2 + Second line
+  |
+2 - Second oops line
+2 + Second oops
+  |
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: oops
+  ╭▸ 
+2 │ Second oops line
+  │        ━━━━ oops
+  ╰╴
+help: remove the entry
+  ╭╴
+2 - Second oops line
+2 + Second line
+  ├╴
+2 - Second oops line
+2 + Second oops
+  ╰╴
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn patch_with_other_path_cell() {
+    let source = "First line\r\nSecond oops line";
+    let input = &[
+        Level::ERROR.primary_title("oops").element(
+            Snippet::source(source)
+                .path("foo.ipynb")
+                .cell_index(Some(1))
+                .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+        ),
+        Level::HELP
+            .secondary_title("remove the entry")
+            .element(
+                Snippet::source(source)
+                    .path("bar.ipynb")
+                    .cell_index(Some(2))
+                    .patch(Patch::new(19..24, "")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("bar.ipynb")
+                    .cell_index(Some(2))
+                    .patch(Patch::new(23..28, "")),
+            ),
+    ];
+    let expected_ascii = str![[r#"
+error: oops
+ --> foo.ipynb:cell 1:2:8
+  |
+2 | Second oops line
+  |        ^^^^ oops
+  |
+help: remove the entry
+ --> bar.ipynb:LL:8
+  |
+2 - Second oops line
+2 + Second line
+  |
+2 - Second oops line
+2 + Second oops
+  |
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: oops
+  ╭▸ foo.ipynb:cell 1:2:8
+  │
+2 │ Second oops line
+  │        ━━━━ oops
+  ╰╴
+help: remove the entry
+  ╭▸ bar.ipynb:LL:8
+  │
+2 - Second oops line
+2 + Second line
+  ├╴
+2 - Second oops line
+2 + Second oops
+  ╰╴
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn patch_with_other_path_incrementing_cell() {
+    let source = "First line\r\nSecond oops line";
+    let input = &[
+        Level::ERROR.primary_title("oops").element(
+            Snippet::source(source)
+                .path("foo.ipynb")
+                .cell_index(Some(1))
+                .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+        ),
+        Level::HELP
+            .secondary_title("remove the entry")
+            .element(
+                Snippet::source(source)
+                    .path("bar.ipynb")
+                    .cell_index(Some(2))
+                    .patch(Patch::new(19..24, "")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("bar.ipynb")
+                    .cell_index(Some(3))
+                    .patch(Patch::new(23..28, "")),
+            ),
+    ];
+    let expected_ascii = str![[r#"
+error: oops
+ --> foo.ipynb:cell 1:2:8
+  |
+2 | Second oops line
+  |        ^^^^ oops
+  |
+help: remove the entry
+ --> bar.ipynb:LL:8
+  |
+2 - Second oops line
+2 + Second line
+  |
+2 - Second oops line
+2 + Second oops
+  |
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: oops
+  ╭▸ foo.ipynb:cell 1:2:8
+  │
+2 │ Second oops line
+  │        ━━━━ oops
+  ╰╴
+help: remove the entry
+  ╭▸ bar.ipynb:LL:8
+  │
+2 - Second oops line
+2 + Second line
+  ├╴
+2 - Second oops line
+2 + Second oops
+  ╰╴
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -461,3 +461,83 @@ help: remove the entry
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
+
+#[test]
+fn insertion_with_trailing_whitespace() {
+    let source = "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\nline 11\nline 12\nline 13\n";
+    let input = &[
+        Level::ERROR
+            .primary_title("main diagnostic message")
+            .id("test-diagnostic")
+            .element(
+                Snippet::source(source)
+                    .path("example.py")
+                    .annotation(AnnotationKind::Primary.span(7..13)),
+            ),
+        Level::HELP
+            .secondary_title("Replace three lines")
+            .element(Snippet::source(source).patch(Patch::new(7..7, "fixed "))),
+    ];
+    let expected_ascii = str![[r#"
+error[test-diagnostic]: main diagnostic message
+ --> example.py:2:1
+  |
+2 | line 2
+  | ^^^^^^
+  |
+help: Replace three lines
+  |
+2 | fixed line 2
+  | +++++
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error[test-diagnostic]: main diagnostic message
+  ╭▸ example.py:2:1
+  │
+2 │ line 2
+  │ ━━━━━━
+  ╰╴
+help: Replace three lines
+  ╭╴
+2 │ fixed line 2
+  ╰╴+++++
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+#[should_panic = "index out of bounds: the len is 11 but the index is 11"]
+fn multiple_insertions() {
+    let source = "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\nline 11\nline 12\nline 13\n";
+    let input = &[
+        Level::ERROR
+            .primary_title("main diagnostic message")
+            .id("test-diagnostic")
+            .element(
+                Snippet::source(source)
+                    .path("example.py")
+                    .annotation(AnnotationKind::Primary.span(7..13)),
+            ),
+        Level::HELP.secondary_title("Replace three lines").element(
+            Snippet::source(source)
+                .patch(Patch::new(7..7, "fixed "))
+                .patch(Patch::new(42..42, "fixed "))
+                .patch(Patch::new(87..87, "fixed ")),
+        ),
+    ];
+    let expected_ascii = str![[r#"
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}

--- a/crates/ruff_annotate_snippets/tests/ruff.rs
+++ b/crates/ruff_annotate_snippets/tests/ruff.rs
@@ -511,7 +511,6 @@ help: Replace three lines
 }
 
 #[test]
-#[should_panic = "index out of bounds: the len is 11 but the index is 11"]
 fn multiple_insertions() {
     let source = "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\nline 11\nline 12\nline 13\n";
     let input = &[
@@ -531,12 +530,48 @@ fn multiple_insertions() {
         ),
     ];
     let expected_ascii = str![[r#"
+error[test-diagnostic]: main diagnostic message
+  --> example.py:2:1
+   |
+ 2 | line 2
+   | ^^^^^^
+   |
+help: Replace three lines
+   |
+ 2 ~ fixed line 2
+ 3 | line 3
+...
+ 6 | line 6
+ 7 ~ fixed line 7
+ 8 | line 8
+...
+12 | line 12
+13 ~ fixed line 13
+   |
 "#]];
 
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input), expected_ascii);
 
     let expected_unicode = str![[r#"
+error[test-diagnostic]: main diagnostic message
+   ╭▸ example.py:2:1
+   │
+ 2 │ line 2
+   │ ━━━━━━
+   ╰╴
+help: Replace three lines
+   ╭╴
+ 2 ± fixed line 2
+ 3 │ line 3
+ …
+ 6 │ line 6
+ 7 ± fixed line 7
+ 8 │ line 8
+ …
+12 │ line 12
+13 ± fixed line 13
+   ╰╴
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);


### PR DESCRIPTION
## Summary

These are all changes in code paths that are unused for now for the sake of making follow up PRs smaller.

Focuses
- bug fixes
- adjust renderer to be more like the existing `ruff_db` suggestion renderer
  - Some may be rolled back in a follow up so we can be more intentional and incremental about changes

## Test Plan


