### PR TITLE
[ty] [playground] Make run panel scrollable and wrapping

### DIFF
--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -171,7 +171,7 @@ export default function Chrome({
           <PanelGroup
             id="main-group"
             orientation="horizontal"
-            className="h-full"
+            className="grow min-h-0"
           >
             <Panel id="main" minSize={100}>
               <PanelGroup

--- a/playground/ty/src/Editor/SecondaryPanel.tsx
+++ b/playground/ty/src/Editor/SecondaryPanel.tsx
@@ -150,7 +150,8 @@ function RunOutput({
       className={classNames(
         "m-2",
         "text-sm",
-        "whitespace-pre",
+        "whitespace-pre-wrap",
+        "break-all",
         theme === "dark" ? "text-white" : null,
       )}
     >

--- a/playground/ty/src/Editor/SecondaryPanel.tsx
+++ b/playground/ty/src/Editor/SecondaryPanel.tsx
@@ -152,6 +152,7 @@ function RunOutput({
         "text-sm",
         "whitespace-pre-wrap",
         "break-all",
+        "overflow-auto",
         theme === "dark" ? "text-white" : null,
       )}
     >


### PR DESCRIPTION
## Summary

Currently, if you run code in the playground that produces a long horizontal / vertical output:
- Horizontal text is cut off
- Vertical text is cut off and makes the page gain a vertical scrollbar

This PR adds classes to the relevant code to stop the page from gaining a vertical scrollbar, make the run output scroll vertically, and wrap horizontally

Example playground where this is a problem when running the code:
https://play.ty.dev/211d6e9e-8cef-4fd6-bcf0-6a27519e3e84

Some notes:

I chose `break-all` instead of `break-words` as code can make very long unbreakable lines, but it may also hurt readability in pure text cases, so unsure which is better. Another option would be to not break at all and scroll both horizontally and vertically, but I felt that the horizontal scrolling was awkward to use.

## Test Plan

> [!Warning]
> This was not tested besides editing the HTML by hand, as I cannot build ruff locally. Testing by someone who can would be appreciated.
>
> I'm not 100% sure the `whitespace-pre-wrap` and `break-all` change will work, as in the browser it did not, and I had to add the styles manually.