### PR TITLE
[ty] Avoid exponential slowdown copying narrowed TypedDict unions

### DIFF
--- a/crates/ruff_benchmark/benches/ty_constraint_set.rs
+++ b/crates/ruff_benchmark/benches/ty_constraint_set.rs
@@ -294,6 +294,52 @@ def copy_narrowed_mapping(value: Item | Mapping[str, Any]) -> dict[str, object] 
     });
 }
 
+fn benchmark_missing_key_typed_dict_union_copy(criterion: &mut Criterion) {
+    const NUM_VARIANTS: usize = 12;
+
+    setup_rayon();
+
+    // Regression benchmark for https://github.com/astral-sh/ty/issues/4176.
+    let mut code = "from typing import Literal, NotRequired, TypedDict\n\n".to_string();
+    for i in 0..NUM_VARIANTS {
+        writeln!(
+            &mut code,
+            "class Item{i}(TypedDict):\n    kind: Literal[{i}]\n    field_{i}: NotRequired[int]\n"
+        )
+        .ok();
+    }
+
+    code.push_str("type Item = ");
+    for i in 0..NUM_VARIANTS {
+        if i > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Item{i}").ok();
+    }
+
+    code.push_str(
+        r#"
+
+def copy(value: Item) -> dict[str, object] | None:
+    if "missing" in value:
+        return dict(value)
+    return None
+"#,
+    );
+
+    criterion.bench_function("ty_micro[missing_key_typed_dict_union_copy]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_recursive_typed_dict_union_contextual_inference(criterion: &mut Criterion) {
     const NUM_BRANCHES: usize = 11;
 
@@ -568,6 +614,7 @@ criterion_group!(
     benchmark_many_upper_bound_callbacks,
     benchmark_pandas_tdd,
     benchmark_mixed_typed_dict_union_copy,
+    benchmark_missing_key_typed_dict_union_copy,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_invariant_generic_return_union,
     benchmark_sequence_literal_union_access,

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2652,6 +2652,50 @@ def _(item: Item | str) -> None:
         reveal_type(dict(item))  # revealed: dict[str, object]
 ```
 
+A successful membership test for an undeclared key narrows each union member to an intersection with
+a synthesized `TypedDict`. Its mapping methods should retain their precise types, and copying the
+narrowed union should remain efficient even when each member has a distinct optional field:
+
+```py
+from typing import NotRequired
+
+MembershipA = TypedDict("MembershipA", {"kind": Literal["a"], "field_a": NotRequired[int]})
+MembershipB = TypedDict("MembershipB", {"kind": Literal["b"], "field_b": NotRequired[int]})
+MembershipC = TypedDict("MembershipC", {"kind": Literal["c"], "field_c": NotRequired[int]})
+MembershipD = TypedDict("MembershipD", {"kind": Literal["d"], "field_d": NotRequired[int]})
+MembershipE = TypedDict("MembershipE", {"kind": Literal["e"], "field_e": NotRequired[int]})
+MembershipF = TypedDict("MembershipF", {"kind": Literal["f"], "field_f": NotRequired[int]})
+MembershipG = TypedDict("MembershipG", {"kind": Literal["g"], "field_g": NotRequired[int]})
+MembershipH = TypedDict("MembershipH", {"kind": Literal["h"], "field_h": NotRequired[int]})
+MembershipI = TypedDict("MembershipI", {"kind": Literal["i"], "field_i": NotRequired[int]})
+MembershipJ = TypedDict("MembershipJ", {"kind": Literal["j"], "field_j": NotRequired[int]})
+
+type MembershipItem = (
+    MembershipA
+    | MembershipB
+    | MembershipC
+    | MembershipD
+    | MembershipE
+    | MembershipF
+    | MembershipG
+    | MembershipH
+    | MembershipI
+    | MembershipJ
+)
+
+def _(item: MembershipItem) -> None:
+    if "missing" in item:
+        reveal_type(item.keys())  # revealed: dict_keys[str, object]
+        reveal_type(item.items())  # revealed: dict_items[str, object]
+        reveal_type(item.values())  # revealed: dict_values[str, object]
+        reveal_type(item["missing"])  # revealed: object
+        reveal_type(dict(item))  # revealed: dict[str, object]
+
+def _(item: MembershipA) -> None:
+    if "missing" in item:
+        reveal_type(item.copy())  # revealed: MembershipA & <TypedDict with items 'missing'>
+```
+
 Adding a regular dictionary to the union should not make copying it slow:
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2961,6 +2961,9 @@ impl<'db> Type<'db> {
             Type::Intersection(inter) => inter.map_with_boundness_and_qualifiers(db, env, |elem| {
                 elem.class_member_with_policy(db, env, name, policy)
             }),
+            Type::TypedDict(TypedDictType::Synthesized(synthesized)) => {
+                class::synthesized_typed_dict_class_member(db, env, synthesized, policy, name)
+            }
             // TODO: Remove this once synthesized protocols have a precise meta-type.
             Type::ProtocolInstance(protocol) if protocol.class_origin(db).is_none() => {
                 ty.instance_member(db, env, name)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -14,7 +14,9 @@ pub(crate) use self::static_literal::{
     ExpandedClassBaseEntry, FrozenDataclassDispatch, StaticClassLiteral,
     expanded_class_base_entries,
 };
-pub(super) use self::typed_dict::{DynamicTypedDictAnchor, DynamicTypedDictLiteral};
+pub(super) use self::typed_dict::{
+    DynamicTypedDictAnchor, DynamicTypedDictLiteral, synthesized_typed_dict_class_member,
+};
 use super::dedicated::pydantic;
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, MemberLookupPolicy, MroIterator, SpecialFormType,

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -17,8 +17,8 @@ use crate::types::member::Member;
 use crate::types::mro::Mro;
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::typed_dict::{
-    TypedDictField, TypedDictOpenness, TypedDictSchema, deferred_functional_typed_dict_openness,
-    deferred_functional_typed_dict_schema,
+    SynthesizedTypedDictType, TypedDictField, TypedDictOpenness, TypedDictSchema,
+    deferred_functional_typed_dict_openness, deferred_functional_typed_dict_schema,
 };
 use crate::types::{
     BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral, ClassType, KnownClass,
@@ -1040,6 +1040,33 @@ impl<'db> DynamicTypedDictLiteral<'db> {
     }
 }
 
+/// Resolves members of a schema that has no defining `TypedDict` class.
+pub(in crate::types) fn synthesized_typed_dict_class_member<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    synthesized: SynthesizedTypedDictType<'db>,
+    lookup_policy: MemberLookupPolicy,
+    name: &str,
+) -> PlaceAndQualifiers<'db> {
+    let typed_dict = TypedDictType::Synthesized(synthesized);
+
+    if let Some(member) = synthesize_typed_dict_method(db, env, typed_dict, name, || {
+        TypedDictFields::Dynamic(synthesized.items(db))
+    }) {
+        return Member::definitely_declared(member).inner;
+    }
+
+    typed_dict_inherited_class_member(
+        db,
+        env,
+        typed_dict,
+        TypedDictModule::Typing,
+        lookup_policy,
+        name,
+        || Type::TypedDict(typed_dict),
+    )
+}
+
 pub(super) fn typed_dict_fallback_class_member<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -1067,18 +1094,39 @@ pub(super) fn typed_dict_class_member<'db>(
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
     let self_class = class.class_literal(db);
+
+    typed_dict_inherited_class_member(
+        db,
+        env,
+        TypedDictType::new(class),
+        module,
+        lookup_policy,
+        name,
+        || determine_upper_bound(db, env, self_class, ClassBase::is_typed_dict),
+    )
+}
+
+fn typed_dict_inherited_class_member<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    typed_dict: TypedDictType<'db>,
+    module: TypedDictModule,
+    lookup_policy: MemberLookupPolicy,
+    name: &str,
+    new_upper_bound: impl FnOnce() -> Type<'db>,
+) -> PlaceAndQualifiers<'db> {
     let fallback_member = typed_dict_fallback_class_member(db, env, module, lookup_policy, name)
         .map_type(|ty| {
-            let new_upper_bound =
-                determine_upper_bound(db, env, self_class, ClassBase::is_typed_dict);
-            let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
+            let mapping = TypeMapping::ReplaceSelf {
+                new_upper_bound: new_upper_bound(),
+            };
             ty.apply_type_mapping(db, env, &mapping, TypeContext::default())
         });
     if !fallback_member.is_undefined() {
         return fallback_member;
     }
 
-    if let Some(value_ty) = TypedDictType::new(class).dict_value_type(db, env)
+    if let Some(value_ty) = typed_dict.dict_value_type(db, env)
         && let Some(dict_class) = KnownClass::Dict.to_specialized_class_type(
             db,
             env,


### PR DESCRIPTION
## Summary

We didn't synthesize various methods/attributes of synthesized TypedDicts like we did for class-backed TypedDicts, instead falling back to a `@Todo` type. This meant that we built up large non-simplifiable unions of intersections (since `@Todo` types are dynamic and do not simplify) in cases where all class-backed TypedDicts would have returned the same type (e.g. a `dict_keys[str, object]`) and immediately collapsed the complex union/intersection into a simple type. Synthesizing these members and avoiding the `@Todo` type thus actually fixes a combinatorial-explosion performance issue.

- Resolve synthesized `TypedDict` members directly from their schemas and reuse the existing class-backed fallback logic, including `Self` handling and explicit extra-item behavior.
- Prevent undeclared-key membership narrowing from injecting dynamic placeholder constraints into discriminated `TypedDict` unions passed to `dict()`.
- Reduces the 12-variant reproduction in astral-sh/ty#4176 from 12.97 seconds to 0.03 seconds; 48 variants complete in 0.04 seconds.

Synthesized `TypedDict` schemas still lack a general-purpose meta-type representation; removing the remaining meta-type TODOs belongs in a separate follow-up.

Closes astral-sh/ty#4176.

## Test plan

- Add an mdtest covering a ten-variant discriminated `TypedDict` union after undeclared-key membership narrowing, including precise `keys()`, `items()`, `values()`, hidden-key indexing, `dict()`, and the narrowed `copy()` result.
- Add a dedicated 12-variant Criterion regression benchmark for copying a narrowed `TypedDict` union.