### PR TITLE
[ty] Inline common statement inference data

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1783,6 +1783,12 @@ pub(crate) struct StatementInferenceInner<'db> {
     /// The types and type qualifiers of every declaration in this region.
     declarations: Box<[(Definition<'db>, TypeAndQualifiers<'db>)]>,
 
+    /// The returned types and their corresponding ranges, if this statement is in a function body.
+    return_types_and_ranges: Box<[TypeAndRange<'db>]>,
+
+    /// The constraints on any collection initializers that are accessed in this region.
+    collection_use_constraints: CollectionUseConstraints<'db>,
+
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<StatementInferenceInnerExtra<'db>>>,
 }
@@ -1798,14 +1804,8 @@ struct StatementInferenceInnerExtra<'db> {
     /// Functions called while inferring this statement.
     called_functions: Box<[FunctionType<'db>]>,
 
-    /// The returned types and their corresponding ranges, if this statement is in a function body.
-    return_types_and_ranges: Box<[TypeAndRange<'db>]>,
-
     /// Metadata for type expressions in this region.
     type_expression_flags: FrozenMap<ExpressionNodeKey, TypeExpressionFlags>,
-
-    /// The constraints on any collection initializers that are accessed in this region.
-    collection_use_constraints: CollectionUseConstraints<'db>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
@@ -1829,6 +1829,8 @@ impl<'db> StatementInferenceInner<'db> {
             expressions: FrozenMap::default(),
             bindings: Box::default(),
             declarations: Box::default(),
+            return_types_and_ranges: Box::default(),
+            collection_use_constraints: CollectionUseConstraints::default(),
             #[cfg(debug_assertions)]
             scope,
             extra: Some(Box::new(StatementInferenceInnerExtra {
@@ -1876,13 +1878,11 @@ impl<'db> StatementInferenceInner<'db> {
         }
 
         if cycle.iteration() > crate::TAINTED_CYCLES
-            && let Some(previous_extra) = previous_inference.extra.as_deref()
-            && !previous_extra.collection_use_constraints.is_empty()
+            && !previous_inference.collection_use_constraints.is_empty()
         {
-            let extra = self.extra.get_or_insert_default();
             extend_collection_use_constraints(
-                &mut extra.collection_use_constraints,
-                &previous_extra.collection_use_constraints,
+                &mut self.collection_use_constraints,
+                &previous_inference.collection_use_constraints,
             );
         }
 
@@ -1905,10 +1905,7 @@ impl<'db> StatementInferenceInner<'db> {
         &self,
         collection_def: Definition<'db>,
     ) -> Option<&FxIndexSet<Type<'db>>> {
-        self.extra
-            .as_ref()?
-            .collection_use_constraints
-            .get(&collection_def)
+        self.collection_use_constraints.get(&collection_def)
     }
 
     fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -644,11 +644,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.bindings.extend(inference.bindings());
         }
 
+        self.return_types_and_ranges
+            .extend(inference.return_types_and_ranges.iter().copied());
+
         if let Some(extra) = &inference.extra {
             self.called_functions
                 .extend(extra.called_functions.iter().copied());
-            self.return_types_and_ranges
-                .extend(extra.return_types_and_ranges.iter().copied());
             self.extend_cycle_recovery(extra.cycle_recovery);
             self.context.extend(&extra.diagnostics);
             self.deferred.extend(extra.deferred.iter().copied());
@@ -11188,19 +11189,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let _ = scope;
         let diagnostics = context.finish();
 
+        collection_use_constraints.shrink_to_fit();
+        return_types_and_ranges.shrink_to_fit();
+
         let extra = (!diagnostics.is_empty()
             || !string_annotations.is_empty()
             || cycle_recovery.is_some()
             || !expected_types.is_empty()
             || !deferred.is_empty()
             || !called_functions.is_empty()
-            || !return_types_and_ranges.is_empty()
             || !qualifiers.is_empty()
-            || !type_expression_flags.is_empty()
-            || !collection_use_constraints.is_empty())
+            || !type_expression_flags.is_empty())
         .then(|| {
-            collection_use_constraints.shrink_to_fit();
-            return_types_and_ranges.shrink_to_fit();
             Box::new(StatementInferenceInnerExtra {
                 string_annotations: FrozenSet::from(string_annotations),
                 expected_types: FrozenMap::from(expected_types),
@@ -11208,9 +11208,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .into_iter()
                     .collect::<Vec<_>>()
                     .into_boxed_slice(),
-                return_types_and_ranges: return_types_and_ranges.into_boxed_slice(),
                 type_expression_flags: FrozenMap::from(type_expression_flags),
-                collection_use_constraints,
                 cycle_recovery,
                 deferred: deferred.into_boxed_slice(),
                 diagnostics,
@@ -11240,6 +11238,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             scope,
             bindings: bindings.into_boxed_slice(),
             declarations: declarations.into_boxed_slice(),
+            return_types_and_ranges: return_types_and_ranges.into_boxed_slice(),
+            collection_use_constraints,
             extra,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -274,6 +274,49 @@ fn expected_types_are_collected_only_for_open_files() -> anyhow::Result<()> {
 }
 
 #[test]
+fn common_statement_inference_data_stays_inline() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "src/statement.py",
+        r#"
+        def collect() -> list[int]:
+            values = []
+            return values
+        "#,
+    )?;
+
+    let file = system_path_to_file(&db, "src/statement.py").expect("file to exist");
+    let file = program_file(&db, file);
+    let module = parsed_module(&db, file.python_file(&db)).load(&db);
+    let function = module.syntax().body[0]
+        .as_function_def_stmt()
+        .expect("function definition");
+    let assignment = function.body[0]
+        .as_assign_stmt()
+        .expect("collection assignment");
+    let index = semantic_index(&db, file);
+    let collection = index.expect_single_definition(
+        assignment.targets[0]
+            .as_name_expr()
+            .expect("collection assignment target"),
+    );
+    let statement = index
+        .try_statement(&function.body[1])
+        .and_then(|statement| match statement {
+            Statement::Other(statement) => Some(statement),
+            Statement::Expression(_) | Statement::Definition(_) => None,
+        })
+        .expect("return statement to have its own inference region");
+    let inference = infer_statement_types_impl(&db, statement);
+
+    assert_eq!(inference.return_types_and_ranges.len(), 1);
+    assert!(inference.collection_use_constraints(collection).is_some());
+    assert!(inference.extra.is_none());
+
+    Ok(())
+}
+
+#[test]
 fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
     assert!(
         std::mem::size_of::<DefinitionTypes>()


### PR DESCRIPTION
## Summary

Move commonly populated return types and collection-use constraints directly into statement inference results to avoid allocating rarely needed extra data.

## Test Plan

Testing: Added focused regression coverage, ran the semantic test suite and repository hooks, and verified lower memory usage on real projects.
