### PR TITLE
[ty] Select benchmark projects in memory reports

### DIFF
--- a/scripts/memory_report.py
+++ b/scripts/memory_report.py
@@ -280,7 +280,7 @@ def run_ty_memory_check(
 
     print(f"Running {ty_path} on {project_path.name}...", file=sys.stderr)
     result = subprocess.run(
-        [ty_path, "check", str(project_path), "--exit-zero"],
+        [ty_path, "check", "--project", str(project_path), "--exit-zero"],
         capture_output=True,
         text=True,
         env=env,


### PR DESCRIPTION
## Summary

Run memory benchmarks against their own project configuration instead of inheriting the Python version of the Ruff checkout.

This fixes the memory usage report for sphinx, because it used to use Python 3.7 (as defined in Ruff's repository), instead of the project's actual Python version. I noticed this when analyzing the PEP 723 memory report, where sphinx didn't reuse parsed modules between the project and scripts.

## Test Plan

Testing: Verified project-specific configuration discovery and repository hooks.