### PR TITLE
[ty] Install primer dependencies for memory reports

### DIFF
--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -61,6 +61,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.1"
+          enable-cache: true
+
       - name: Install Rust toolchain
         run: rustup show
 

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -42,6 +42,8 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
+  # TODO: Update the mypy-primer revision in scripts/setup_primer_project.py
+  # and regenerate its lockfile when updating ecosystem-analyzer.
   ECOSYSTEM_ANALYZER_COMMIT: f6f1b7b8586c8a6c60dc3d37c3f6ae917a9ad9c4
 
 jobs:

--- a/scripts/memory_report.py
+++ b/scripts/memory_report.py
@@ -4,13 +4,13 @@ Compare memory usage reports between two ty versions and generate a PR comment.
 This script can be used in two modes:
 
 1. Report comparison mode: Reads pre-generated JSON memory reports and compares them.
-2. Full run mode: Clones projects, builds ty, runs memory tests, and generates comparison.
+2. Full run mode: Sets up projects, runs memory tests, and generates comparison.
 
 Examples:
     # Compare pre-generated memory reports
     %(prog)s compare --old-dir old_reports/ --new-dir new_reports/
 
-    # Full run: clone projects, build ty, run memory tests
+    # Full run: set up projects and their dependencies, then run memory tests
     %(prog)s run --old-ty ./ty-old --new-ty ./ty-new
 
     # Write output to a file
@@ -25,18 +25,11 @@ import os
 import subprocess
 import sys
 import tempfile
-from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Final, Self
 
-# Known projects with their Git URLs for memory testing.
-KNOWN_PROJECTS: Final[Mapping[str, str]] = {
-    "flake8": "https://github.com/PyCQA/flake8",
-    "sphinx": "https://github.com/sphinx-doc/sphinx",
-    "prefect": "https://github.com/PrefectHQ/prefect",
-    "trio": "https://github.com/python-trio/trio",
-}
+KNOWN_PROJECTS: Final = ("flake8", "sphinx", "prefect", "trio")
 
 
 @dataclass(slots=True, kw_only=True)
@@ -251,18 +244,29 @@ def render_summary(projects: list[ProjectComparison]) -> str:
     return "\n".join(lines)
 
 
-def clone_project(*, name: str, url: str, dest: Path) -> Path:
-    """Clone a project from Git. Returns the path to the cloned project."""
+def setup_project(*, name: str, dest: Path) -> Path:
+    """Clone a project and install its mypy-primer dependencies."""
     project_path = dest / name
     if project_path.exists():
         print(f"Project {name} already exists at {project_path}", file=sys.stderr)
         return project_path
 
-    print(f"Cloning {name} from {url}...", file=sys.stderr)
+    setup_script = Path(__file__).with_name("setup_primer_project.py")
+    print(f"Setting up {name} and its dependencies...", file=sys.stderr)
     subprocess.run(
-        ["git", "clone", "--depth=1", url, str(project_path)],
+        [
+            "uv",
+            "run",
+            "--locked",
+            "--python",
+            sys.executable,
+            "--script",
+            str(setup_script),
+            name,
+            str(project_path),
+        ],
         check=True,
-        capture_output=True,
+        stdout=sys.stderr,
     )
     return project_path
 
@@ -301,8 +305,8 @@ def run_memory_tests(
     old_reports_dir.mkdir(parents=True, exist_ok=True)
     new_reports_dir.mkdir(parents=True, exist_ok=True)
 
-    for project_name, url in KNOWN_PROJECTS.items():
-        project_path = clone_project(name=project_name, url=url, dest=projects_dir)
+    for project_name in KNOWN_PROJECTS:
+        project_path = setup_project(name=project_name, dest=projects_dir)
 
         # Run old ty
         old_report_path = old_reports_dir / f"{project_name}.json"
@@ -455,7 +459,7 @@ def parse_args() -> argparse.Namespace:
     # Run subcommand
     run_parser = subparsers.add_parser(
         "run",
-        help="Clone projects, run ty, and compare memory usage",
+        help="Set up projects, run ty, and compare memory usage",
     )
     run_parser.add_argument(
         "--old-ty",

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -12,7 +12,9 @@
 # exclude-newer = "7 days"
 #
 # [tool.uv.sources]
-# mypy-primer = { git = "https://github.com/hauntsaninja/mypy_primer" }
+# # Keep this revision and the script's lockfile in sync with ecosystem-analyzer's
+# # mypy-primer pin so memory reports and ecosystem jobs use the same project definitions.
+# mypy-primer = { git = "https://github.com/hauntsaninja/mypy_primer", rev = "6d6eebd8d37c9b8931381e79aa99808d9378c988" }
 # ///
 
 """Clone a mypy-primer project and set up a virtualenv with its dependencies installed.

--- a/scripts/setup_primer_project.py.lock
+++ b/scripts/setup_primer_project.py.lock
@@ -7,9 +7,9 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [manifest]
-requirements = [{ name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer" }]
+requirements = [{ name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=6d6eebd8d37c9b8931381e79aa99808d9378c988" }]
 
 [[package]]
 name = "mypy-primer"
 version = "0.1.0"
-source = { git = "https://github.com/hauntsaninja/mypy_primer#05f73ec3d85bb4f55676f3c57f2c3e5136228977" }
+source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=6d6eebd8d37c9b8931381e79aa99808d9378c988#6d6eebd8d37c9b8931381e79aa99808d9378c988" }


### PR DESCRIPTION
## Summary

Codex made me aware that our memory report only clones the projects but does not install their dependencies. This is concerning, because we use the memory report to guide our memory usage improvements, and third party dependencies can contribute a significant chunk to memory usage.


## Test Plan

Diff between main and this PR


## Memory usage report

### Summary

| Project | Old | New | Diff | Outcome |
|---------|-----|-----|------|---------|
| prefect | 547.17MB | 664.98MB | +21.53% (117.81MB) | ⏫ |
| sphinx | 177.87MB | 203.28MB | +14.29% (25.41MB) | ⏫ |
| trio | 77.58MB | 94.46MB | +21.76% (16.88MB) | ⏫ |
| flake8 | 29.99MB | 35.70MB | +19.03% (5.71MB) | ⏫ |

### Significant changes

<details>
<summary>Click to expand detailed breakdown</summary>

### prefect

| Name | Old | New | Diff | Outcome |
|------|-----|-----|------|---------|
| `parsed_module` | 48.52MB | 93.67MB | +93.05% (45.15MB) |⏫ |
| `semantic_index` | 111.68MB | 136.62MB | +22.33% (24.94MB) |⏫ |
| `source_text` | 25.71MB | 31.99MB | +24.45% (6.28MB) |⏫ |
| `Definition` | 20.81MB | 25.83MB | +24.10% (5.02MB) |⏫ |
| `infer_definition_types` | 56.67MB | 60.38MB | +6.55% (3.71MB) |⏫ |
| `Type<'db>::class_member_with_policy_inner_` | 9.79MB | 12.50MB | +27.75% (2.72MB) |⏫ |
| `member_lookup_with_policy_inner` | 12.80MB | 14.53MB | +13.52% (1.73MB) |⏫ |
| `StaticClassLiteral<'db>::try_mro_` | 5.15MB | 6.87MB | +33.57% (1.73MB) |⏫ |
| `Expression` | 9.17MB | 10.87MB | +18.56% (1.70MB) |⏫ |
| `infer_expression_types_impl` | 45.34MB | 47.04MB | +3.75% (1.70MB) |⏫ |
| `CallableType` | 9.95MB | 11.23MB | +12.82% (1.28MB) |⏫ |
| `StaticClassLiteral<'db>::fields_inner_` | 108.68kB | 1.33MB | +1155.14% (1.23MB) |⏫ |
| `TypePair` | 8.24MB | 9.45MB | +14.67% (1.21MB) |⏫ |
| `has_before_or_plain_field_validator` | 0.00B | 1.20MB | +1.20MB (new) |⏫ |
| `when_constraint_set_assignable_to_owned_impl` | 5.78MB | 6.95MB | +20.23% (1.17MB) |⏫ |
| ... | | | *178 more* |

### sphinx

| Name | Old | New | Diff | Outcome |
|------|-----|-----|------|---------|
| `parsed_module` | 30.53MB | 40.13MB | +31.45% (9.60MB) |⏫ |
| `semantic_index` | 34.51MB | 40.85MB | +18.38% (6.34MB) |⏫ |
| `Definition` | 7.11MB | 8.44MB | +18.70% (1.33MB) |⏫ |
| `source_text` | 6.96MB | 8.07MB | +15.82% (1.10MB) |⏫ |
| `infer_definition_types` | 13.52MB | 14.04MB | +3.83% (530.77kB) |⏫ |
| `infer_expression_types_impl` | 16.31MB | 16.82MB | +3.12% (521.05kB) |⏫ |
| `member_lookup_with_policy_inner` | 4.88MB | 5.35MB | +9.54% (476.82kB) |⏫ |
| `Expression` | 2.89MB | 3.33MB | +15.33% (453.06kB) |⏫ |
| `TypePair` | 2.28MB | 2.71MB | +19.03% (444.09kB) |⏫ |
| `check_file_impl` | 1.05MB | 652.42kB | -39.45% (425.03kB) |⬇️ |
| `Type<'db>::class_member_with_policy_inner_` | 2.98MB | 3.33MB | +11.64% (355.15kB) |⏫ |
| `CallableType` | 1.68MB | 1.96MB | +16.81% (288.70kB) |⏫ |
| `MemberLookupKey` | 3.16MB | 3.42MB | +8.03% (260.21kB) |⏫ |
| `infer_deferred_types` | 2.56MB | 2.81MB | +9.70% (254.49kB) |⏫ |
| `FunctionType` | 1.92MB | 2.15MB | +12.12% (238.59kB) |⏫ |
| ... | | | *146 more* |

### trio

| Name | Old | New | Diff | Outcome |
|------|-----|-----|------|---------|
| `parsed_module` | 17.84MB | 23.74MB | +33.05% (5.90MB) |⏫ |
| `semantic_index` | 17.15MB | 20.44MB | +19.18% (3.29MB) |⏫ |
| `source_text` | 3.79MB | 4.47MB | +17.86% (693.41kB) |⏫ |
| `Definition` | 3.68MB | 4.33MB | +17.65% (665.31kB) |⏫ |
| `Type<'db>::apply_specialization_inner_::interned_arguments` | 800.70kB | 1.19MB | +52.78% (422.58kB) |⏫ |
| `infer_scope_types_impl` | 2.60MB | 2.99MB | +14.79% (394.47kB) |⏫ |
| `when_constraint_set_assignable_to_owned_impl` | 586.36kB | 972.47kB | +65.85% (386.11kB) |⏫ |
| `Specialization` | 710.92kB | 1.03MB | +47.65% (338.75kB) |⏫ |
| `TypePair` | 630.47kB | 964.12kB | +52.92% (333.66kB) |⏫ |
| `infer_expression_types_impl` | 4.99MB | 5.31MB | +6.52% (333.09kB) |⏫ |
| `infer_definition_types` | 4.21MB | 4.50MB | +6.99% (301.19kB) |⏫ |
| `Expression` | 1.28MB | 1.56MB | +21.54% (282.44kB) |⏫ |
| `Type<'db>::apply_specialization_inner_` | 519.33kB | 801.25kB | +54.29% (281.92kB) |⏫ |
| `CallableType` | 1.15MB | 1.41MB | +23.04% (270.41kB) |⏫ |
| `StaticClassLiteral<'db>::try_mro_` | 664.49kB | 928.78kB | +39.77% (264.29kB) |⏫ |
| ... | | | *160 more* |

### flake8

| Name | Old | New | Diff | Outcome |
|------|-----|-----|------|---------|
| `parsed_module` | 10.32MB | 13.09MB | +26.92% (2.78MB) |⏫ |
| `semantic_index` | 7.67MB | 9.23MB | +20.31% (1.56MB) |⏫ |
| `source_text` | 1.63MB | 1.98MB | +21.51% (359.80kB) |⏫ |
| `Definition` | 1.86MB | 2.16MB | +15.79% (301.25kB) |⏫ |
| `Expression` | 331.19kB | 475.81kB | +43.67% (144.62kB) |⏫ |
| `StaticClassLiteral<'db>::try_mro_` | 245.48kB | 306.33kB | +24.79% (60.84kB) |⏫ |
| `FunctionType` | 248.12kB | 305.87kB | +23.28% (57.75kB) |⏫ |
| `TypePair` | 164.34kB | 221.25kB | +34.63% (56.91kB) |⏫ |
| `Specialization` | 204.56kB | 245.47kB | +20.00% (40.91kB) |⏫ |
| `infer_definition_types` | 1.01MB | 1.04MB | +3.04% (31.42kB) |⏫ |
| `FunctionType<'db>::signature_` | 315.22kB | 345.39kB | +9.57% (30.16kB) |⏫ |
| `check_file_impl` | 115.70kB | 86.01kB | -25.66% (29.69kB) |⬇️ |
| `ScopeId` | 241.60kB | 265.90kB | +10.06% (24.30kB) |⏫ |
| `is_redundant_with_impl` | 55.11kB | 77.98kB | +41.51% (22.88kB) |⏫ |
| `CallableType` | 264.39kB | 287.00kB | +8.55% (22.61kB) |⏫ |
| ... | | | *109 more* |

</details>

