### PR TITLE
[ty] Compress cached source text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,6 +2041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,6 +3200,7 @@ dependencies = [
  "get-size2",
  "ignore",
  "insta",
+ "lz4_flex",
  "matchit",
  "path-slash",
  "pathdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ arrayvec = { version = "0.7.6" }
 anstream = { version = "1.0.0" }
 anstyle = { version = "1.0.10" }
 anyhow = { version = "1.0.80" }
-arc-swap = { version = "1.7.1" }
+arc-swap = { version = "1.7.1", features = ["weak"] }
 argfile = { version = "1.0.0" }
 assert_fs = { version = "1.1.0" }
 rkyv = { version = "0.8.16" }
@@ -132,6 +132,7 @@ libcst = { version = "1.8.4", default-features = false }
 log = { version = "0.4.17" }
 lsp-server = { version = "0.10.0" }
 lsp-types = { package = "gen-lsp-types", version = "0.11.0", features = ["url"] }
+lz4_flex = { version = "0.12.2", default-features = false }
 matchit = { version = "0.9.0" }
 memchr = { version = "2.7.1" }
 mimalloc = { version = "0.1.49", features = ["v2"] }

--- a/crates/mdtest/src/matcher.rs
+++ b/crates/mdtest/src/matcher.rs
@@ -13,7 +13,7 @@ use ruff_db::PythonFile;
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId};
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
-use ruff_db::source::{SourceText, line_index, source_text};
+use ruff_db::source::{SourceTextRef, line_index, source_text};
 use ruff_python_ast::PythonVersion;
 use ruff_source_file::{LineIndex, OneIndexed};
 use smallvec::SmallVec;
@@ -101,7 +101,7 @@ pub fn match_file(
 ) -> Result<Vec<Diagnostic>, FailuresByLine> {
     // Parse assertions from comments in the file, and get diagnostics from the file; both
     // ordered by line number.
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
     let line_index = line_index(db, file);
     let (assertions, diagnostics) = if file.path(db).extension() == Some("toml") {
         let assertions =
@@ -314,7 +314,7 @@ fn normalize_paths(ty: &str) -> Cow<'_, str> {
 
 struct Matcher {
     line_index: LineIndex,
-    source: SourceText,
+    source: SourceTextRef,
     options: RunOptions,
 }
 
@@ -322,7 +322,7 @@ impl Matcher {
     fn from_file(db: &dyn Db, file: File, options: RunOptions) -> Self {
         Self {
             line_index: line_index(db, file),
-            source: source_text(db, file),
+            source: source_text(db, file).load(),
             options,
         }
     }

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -135,7 +135,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
                 &case.file_path,
                 format!(
                     "{}\n# A comment\n",
-                    source_text(&case.db, case.file).as_str()
+                    source_text(&case.db, case.file).load().as_str()
                 ),
             )
             .unwrap();

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -32,6 +32,7 @@ dunce = { workspace = true }
 filetime = { workspace = true }
 get-size2 = { workspace = true }
 ignore = { workspace = true, optional = true }
+lz4_flex = { workspace = true }
 matchit = { workspace = true }
 path-slash = { workspace = true }
 pathdiff = { workspace = true }

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -14,7 +14,7 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 use crate::{
     Db,
     files::File,
-    source::{SourceText, line_index, source_text},
+    source::{SourceTextRef, line_index, source_text},
 };
 
 use super::{
@@ -825,7 +825,7 @@ where
 
     fn input(&self, file: File) -> Input {
         Input {
-            text: source_text(self, file),
+            text: source_text(self, file).load(),
             line_index: line_index(self, file),
         }
     }
@@ -861,7 +861,7 @@ impl FileResolver for &dyn Db {
 
     fn input(&self, file: File) -> Input {
         Input {
-            text: source_text(*self, file),
+            text: source_text(*self, file).load(),
             line_index: line_index(*self, file),
         }
     }
@@ -897,7 +897,7 @@ impl FileResolver for &dyn Db {
 /// line index for efficiently querying its contents.
 #[derive(Clone, Debug)]
 pub struct Input {
-    pub(crate) text: SourceText,
+    pub(crate) text: SourceTextRef,
     pub(crate) line_index: LineIndex,
 }
 
@@ -2637,7 +2637,7 @@ watermelon
             let span = self.path(path);
 
             let file = span.expect_ty_file();
-            let text = source_text(&self.db, file);
+            let text = source_text(&self.db, file).load();
             let line_index = line_index(&self.db, file);
             let source = SourceCode::new(text.as_str(), &line_index);
 

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -1,5 +1,5 @@
 use std::fmt::Formatter;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use arc_swap::ArcSwapOption;
 use get_size2::GetSize;
@@ -13,7 +13,7 @@ use ruff_python_parser::{
 };
 
 use crate::files::File;
-use crate::source::source_text;
+use crate::source::{SourceTextRef, source_text};
 use crate::{Db, PythonFile};
 
 /// Returns the parsed AST of `file`, including its token stream.
@@ -47,7 +47,7 @@ pub(super) fn disable_lru(db: &mut dyn Db) {
 }
 
 fn parsed_module_impl(db: &dyn Db, file: File, target_version: PythonVersion) -> Parsed<ModModule> {
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
     let ty = file.source_type(db);
 
     let options = ParseOptions::from(ty).with_target_version(target_version);
@@ -153,6 +153,7 @@ impl ParsedModule {
         ParsedModuleRef {
             module: self.clone(),
             indexed: parsed,
+            source: OnceLock::new(),
         }
     }
 
@@ -191,12 +192,19 @@ impl Eq for ParsedModule {}
 pub struct ParsedModuleRef {
     module: ParsedModule,
     indexed: Arc<indexed::IndexedModule>,
+    source: OnceLock<SourceTextRef>,
 }
 
 impl ParsedModuleRef {
     /// Returns a reference to the [`ParsedModule`] that this instance was loaded from.
     pub fn module(&self) -> &ParsedModule {
         &self.module
+    }
+
+    /// Loads this module's source and retains it for the lifetime of the parsed handle.
+    pub fn source_text(&self, db: &dyn Db) -> &SourceTextRef {
+        self.source
+            .get_or_init(|| source_text(db, self.module.file).load())
     }
 
     /// Returns a reference to the AST node at the given index.
@@ -900,6 +908,24 @@ mod tests {
         let parsed = parsed_module(&db, file).load(&db);
 
         assert!(parsed.has_valid_syntax());
+
+        Ok(())
+    }
+
+    #[test]
+    fn source_text_is_cached_for_loaded_module() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("test.py", "x = 10")?;
+
+        let file = system_path_to_file(&db, "test.py").unwrap();
+        let file = PythonFile::new(&db, file, PythonVersion::latest_ty());
+        let parsed = parsed_module(&db, file).load(&db);
+
+        let first = parsed.source_text(&db);
+        let second = parsed.source_text(&db);
+
+        assert_eq!(first.as_str(), "x = 10");
+        assert!(std::ptr::eq(first, second));
 
         Ok(())
     }

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 use std::ops::Deref;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
+use arc_swap::ArcSwapWeak;
 use ruff_diagnostics::SourceMap;
 use ruff_notebook::Notebook;
 use ruff_python_ast::PySourceType;
@@ -65,17 +66,27 @@ fn is_notebook(system: &dyn System, path: &FilePath) -> bool {
 /// The file containing the source text can either be a text file or a notebook.
 ///
 /// Cheap cloneable in `O(1)`.
-#[derive(Clone, Eq, PartialEq, get_size2::GetSize)]
+#[derive(Clone, get_size2::GetSize)]
 pub struct SourceText {
     inner: Arc<SourceTextInner>,
 }
 
 impl SourceText {
-    /// Returns the python code as a `str`.
-    pub fn as_str(&self) -> &str {
-        match &self.inner.kind {
-            SourceTextKind::Text(source) => source,
-            SourceTextKind::Notebook { notebook } => notebook.source_code(),
+    /// Loads the source text, keeping it decompressed until the returned handle is dropped.
+    ///
+    /// Concurrent handles share the same decompressed text. The cache only retains a weak
+    /// reference, so its backing allocation is released with the final handle.
+    pub fn load(&self) -> SourceTextRef {
+        let kind = match &self.inner.kind {
+            SourceTextKind::Text(source) => LoadedSourceTextKind::Text(source.load()),
+            SourceTextKind::Notebook { notebook } => {
+                LoadedSourceTextKind::Notebook(Arc::clone(notebook))
+            }
+        };
+
+        SourceTextRef {
+            source: self.clone(),
+            kind,
         }
     }
 
@@ -103,7 +114,7 @@ impl SourceText {
     #[must_use]
     pub fn with_text(&self, new_text: String, source_map: &SourceMap) -> Self {
         let new_kind = match &self.inner.kind {
-            SourceTextKind::Text(_) => SourceTextKind::Text(new_text),
+            SourceTextKind::Text(_) => new_text.into(),
 
             SourceTextKind::Notebook { notebook } => {
                 let mut new_notebook = notebook.as_ref().clone();
@@ -124,7 +135,7 @@ impl SourceText {
 
     pub fn to_bytes(&self) -> Cow<'_, [u8]> {
         match &self.inner.kind {
-            SourceTextKind::Text(source) => Cow::Borrowed(source.as_bytes()),
+            SourceTextKind::Text(_) => Cow::Owned(self.load().as_str().as_bytes().to_vec()),
             SourceTextKind::Notebook { notebook } => {
                 let mut output: Vec<u8> = Vec::new();
                 notebook
@@ -137,11 +148,63 @@ impl SourceText {
     }
 }
 
-impl Deref for SourceText {
+impl PartialEq for SourceText {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.kind == other.inner.kind && self.inner.read_error == other.inner.read_error
+    }
+}
+
+impl Eq for SourceText {}
+
+/// A loaded source-text handle that keeps its decompressed contents alive.
+#[derive(Clone)]
+pub struct SourceTextRef {
+    source: SourceText,
+    kind: LoadedSourceTextKind,
+}
+
+#[derive(Clone)]
+enum LoadedSourceTextKind {
+    Text(Arc<String>),
+    Notebook(Arc<Notebook>),
+}
+
+impl SourceTextRef {
+    /// Returns the Python source code.
+    pub fn as_str(&self) -> &str {
+        match &self.kind {
+            LoadedSourceTextKind::Text(text) => text,
+            LoadedSourceTextKind::Notebook(notebook) => notebook.source_code(),
+        }
+    }
+
+    /// Returns the notebook when this handle represents a notebook file.
+    pub fn as_notebook(&self) -> Option<&Notebook> {
+        self.source.as_notebook()
+    }
+
+    /// Returns `true` when this handle represents a notebook file.
+    pub fn is_notebook(&self) -> bool {
+        self.source.is_notebook()
+    }
+
+    /// Returns the error encountered while reading this source file, if any.
+    pub fn read_error(&self) -> Option<&SourceTextError> {
+        self.source.read_error()
+    }
+}
+
+impl Deref for SourceTextRef {
     type Target = str;
 
     fn deref(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl std::fmt::Debug for SourceTextRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(f)
     }
 }
 
@@ -150,8 +213,8 @@ impl std::fmt::Debug for SourceText {
         let mut dbg = f.debug_tuple("SourceText");
 
         match &self.inner.kind {
-            SourceTextKind::Text(text) => {
-                dbg.field(text);
+            SourceTextKind::Text(_) => {
+                dbg.field(&self.load().as_str());
             }
             SourceTextKind::Notebook { notebook } => {
                 dbg.field(notebook);
@@ -162,33 +225,91 @@ impl std::fmt::Debug for SourceText {
     }
 }
 
-#[derive(Eq, PartialEq, get_size2::GetSize, Clone)]
+#[derive(get_size2::GetSize)]
 struct SourceTextInner {
     kind: SourceTextKind,
     read_error: Option<SourceTextError>,
 }
 
-#[derive(Eq, PartialEq, get_size2::GetSize, Clone)]
+#[derive(PartialEq, get_size2::GetSize)]
 enum SourceTextKind {
-    Text(String),
+    Text(CompressedSourceText),
     Notebook {
         // Jupyter notebooks are not very relevant for memory profiling, and contain
         // arbitrary JSON values that do not implement the `GetSize` trait.
         #[get_size(ignore)]
-        notebook: Box<Notebook>,
+        notebook: Arc<Notebook>,
     },
+}
+
+#[derive(get_size2::GetSize)]
+struct CompressedSourceText {
+    compressed: Box<[u8]>,
+    uncompressed_len: usize,
+    #[get_size(ignore)]
+    decoded: ArcSwapWeak<String>,
+}
+
+impl CompressedSourceText {
+    fn new(source: String) -> Self {
+        Self {
+            compressed: lz4_flex::block::compress(source.as_bytes()).into_boxed_slice(),
+            uncompressed_len: source.len(),
+            decoded: ArcSwapWeak::new(Weak::new()),
+        }
+    }
+
+    fn load(&self) -> Arc<String> {
+        if let Some(decoded) = self.decoded.load().upgrade() {
+            return decoded;
+        }
+
+        let bytes = lz4_flex::block::decompress(&self.compressed, self.uncompressed_len)
+            .expect("source text was compressed by the same LZ4 implementation");
+        let text = String::from_utf8(bytes)
+            .expect("compressed source text was constructed from a valid UTF-8 string");
+        let decoded = Arc::new(text);
+
+        loop {
+            let cached = self.decoded.load();
+
+            if let Some(existing) = cached.upgrade() {
+                return existing;
+            }
+
+            // Concurrent cache misses may decompress the same source, but publishing only one
+            // allocation ensures all overlapping handles share the same decoded text.
+            let previous = self
+                .decoded
+                .compare_and_swap(&cached, Arc::downgrade(&decoded));
+
+            if Weak::ptr_eq(&previous, &cached) {
+                return decoded;
+            }
+
+            if let Some(existing) = previous.upgrade() {
+                return existing;
+            }
+        }
+    }
+}
+
+impl PartialEq for CompressedSourceText {
+    fn eq(&self, other: &Self) -> bool {
+        self.uncompressed_len == other.uncompressed_len && self.compressed == other.compressed
+    }
 }
 
 impl From<String> for SourceTextKind {
     fn from(value: String) -> Self {
-        SourceTextKind::Text(value)
+        SourceTextKind::Text(CompressedSourceText::new(value))
     }
 }
 
 impl From<Notebook> for SourceTextKind {
     fn from(notebook: Notebook) -> Self {
         SourceTextKind::Notebook {
-            notebook: Box::new(notebook),
+            notebook: Arc::new(notebook),
         }
     }
 }
@@ -206,13 +327,15 @@ pub enum SourceTextError {
 pub fn line_index(db: &dyn Db, file: File) -> LineIndex {
     let _span = tracing::trace_span!("line_index", ?file).entered();
 
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
 
     LineIndex::from_source_text(&source)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Barrier};
+
     use salsa::EventKind;
     use salsa::Setter as _;
 
@@ -220,7 +343,7 @@ mod tests {
     use ruff_text_size::TextSize;
 
     use crate::files::system_path_to_file;
-    use crate::source::{line_index, source_text};
+    use crate::source::{CompressedSourceText, SourceTextKind, line_index, source_text};
     use crate::system::{DbWithWritableSystem as _, SystemPath};
     use crate::tests::TestDb;
 
@@ -233,11 +356,11 @@ mod tests {
 
         let file = system_path_to_file(&db, path).unwrap();
 
-        assert_eq!(source_text(&db, file).as_str(), "x = 10");
+        assert_eq!(source_text(&db, file).load().as_str(), "x = 10");
 
         db.write_file(path, "x = 20").unwrap();
 
-        assert_eq!(source_text(&db, file).as_str(), "x = 20");
+        assert_eq!(source_text(&db, file).load().as_str(), "x = 20");
 
         Ok(())
     }
@@ -251,13 +374,13 @@ mod tests {
 
         let file = system_path_to_file(&db, path).unwrap();
 
-        assert_eq!(source_text(&db, file).as_str(), "x = 10");
+        assert_eq!(source_text(&db, file).load().as_str(), "x = 10");
 
         // Change the file permission only
         file.set_permissions(&mut db).to(Some(0o777));
 
         db.clear_salsa_events();
-        assert_eq!(source_text(&db, file).as_str(), "x = 10");
+        assert_eq!(source_text(&db, file).load().as_str(), "x = 10");
 
         let events = db.take_salsa_events();
 
@@ -271,6 +394,71 @@ mod tests {
     }
 
     #[test]
+    fn loaded_source_is_shared_and_automatically_evicted() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        let path = SystemPath::new("test.py");
+        db.write_file(path, "x = 10\n")?;
+
+        let file = system_path_to_file(&db, path).unwrap();
+        let source = source_text(&db, file);
+        let SourceTextKind::Text(compressed) = &source.inner.kind else {
+            panic!("a Python source file should not be loaded as a notebook");
+        };
+
+        assert!(compressed.decoded.load().upgrade().is_none());
+
+        let first = source.load();
+        let second = source.load();
+        assert_eq!(first.as_str(), "x = 10\n");
+        assert!(compressed.decoded.load().upgrade().is_some());
+
+        drop(first);
+        assert!(compressed.decoded.load().upgrade().is_some());
+
+        drop(second);
+        assert!(compressed.decoded.load().upgrade().is_none());
+
+        let reloaded = source.load();
+        assert_eq!(reloaded.as_str(), "x = 10\n");
+
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_handles_share_decompressed_source() {
+        let source = Arc::new(CompressedSourceText::new("x = 10\n".repeat(256)));
+        let barrier = Arc::new(Barrier::new(8));
+
+        let loaded = std::thread::scope(|scope| {
+            let mut threads = Vec::new();
+
+            for _ in 0..8 {
+                let source = Arc::clone(&source);
+                let barrier = Arc::clone(&barrier);
+
+                threads.push(scope.spawn(move || {
+                    barrier.wait();
+                    source.load()
+                }));
+            }
+
+            threads
+                .into_iter()
+                .map(|thread| thread.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+
+        assert!(
+            loaded
+                .windows(2)
+                .all(|pair| Arc::ptr_eq(&pair[0], &pair[1]))
+        );
+
+        drop(loaded);
+        assert!(source.decoded.load().upgrade().is_none());
+    }
+
+    #[test]
     fn line_index_for_source() -> crate::system::Result<()> {
         let mut db = TestDb::new();
         let path = SystemPath::new("test.py");
@@ -279,7 +467,7 @@ mod tests {
 
         let file = system_path_to_file(&db, path).unwrap();
         let index = line_index(&db, file);
-        let source = source_text(&db, file);
+        let source = source_text(&db, file).load();
 
         assert_eq!(index.line_count(), 2);
         assert_eq!(
@@ -321,7 +509,7 @@ mod tests {
         )?;
 
         let file = system_path_to_file(&db, path).unwrap();
-        let source = source_text(&db, file);
+        let source = source_text(&db, file).load();
 
         assert!(source.is_notebook());
         assert_eq!(source.as_str(), "x = 10\n");

--- a/crates/ruff_mdtest/src/lib.rs
+++ b/crates/ruff_mdtest/src/lib.rs
@@ -108,7 +108,7 @@ fn run_test(
         .filter_map(|test_file| {
             let mdtest_result = attempt_test(
                 |file| {
-                    let source = source_text(db, file);
+                    let source = source_text(db, file).load();
                     let path = file
                         .path(db)
                         .as_system_path()

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -188,7 +188,7 @@ pub fn formatted_file(db: &dyn Db, file: File) -> Result<Option<String>, FormatM
     }
 
     let trivia = TriviaRanges::from(parsed.tokens());
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
 
     let formatted = format_node(&parsed, &trivia, &source, options)?;
     let printed = formatted.print()?;

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -729,7 +729,7 @@ def bar() -> str:  # error: [empty-body]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22escape-character-in-forward-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L40" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L39" target="_blank">View source</a>
 </small>
 
 
@@ -903,7 +903,7 @@ a = 20 / 0  # ty: ignore[division-by-zero]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22implicit-concatenated-string-type-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L22" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L21" target="_blank">View source</a>
 </small>
 
 
@@ -2731,7 +2731,7 @@ super(B, A)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-syntax-in-forward-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L31" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L30" target="_blank">View source</a>
 </small>
 
 
@@ -4198,7 +4198,7 @@ or explicitly configure the model with `extra="allow"`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22raw-string-type-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L13" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fstring_annotation.rs#L12" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -941,7 +941,7 @@ fn changed_file() -> anyhow::Result<()> {
     let foo_path = case.project_path("foo.py");
 
     let foo = case.system_file(&foo_path)?;
-    assert_eq!(source_text(case.db(), foo).as_str(), foo_source);
+    assert_eq!(source_text(case.db(), foo).load().as_str(), foo_source);
     case.assert_indexed_project_files([foo]);
 
     update_file(&foo_path, "print('Version 2')")?;
@@ -952,7 +952,10 @@ fn changed_file() -> anyhow::Result<()> {
 
     case.apply_changes(&changes);
 
-    assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 2')");
+    assert_eq!(
+        source_text(case.db(), foo).load().as_str(),
+        "print('Version 2')"
+    );
     case.assert_indexed_project_files([foo]);
 
     Ok(())
@@ -1582,8 +1585,14 @@ fn hard_links_in_project() -> anyhow::Result<()> {
     let bar_path = case.project_path("bar.py");
     let bar = case.system_file(&bar_path).unwrap();
 
-    assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 1')");
-    assert_eq!(source_text(case.db(), bar).as_str(), "print('Version 1')");
+    assert_eq!(
+        source_text(case.db(), foo).load().as_str(),
+        "print('Version 1')"
+    );
+    assert_eq!(
+        source_text(case.db(), bar).load().as_str(),
+        "print('Version 1')"
+    );
     case.assert_indexed_project_files([bar, foo]);
 
     // Write to the hard link target.
@@ -1593,11 +1602,17 @@ fn hard_links_in_project() -> anyhow::Result<()> {
 
     case.apply_changes(&changes);
 
-    assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 2')");
+    assert_eq!(
+        source_text(case.db(), foo).load().as_str(),
+        "print('Version 2')"
+    );
 
     // macOS is the only platform that emits events for every hardlink.
     if cfg!(target_os = "macos") {
-        assert_eq!(source_text(case.db(), bar).as_str(), "print('Version 2')");
+        assert_eq!(
+            source_text(case.db(), bar).load().as_str(),
+            "print('Version 2')"
+        );
     }
 
     Ok(())
@@ -1654,8 +1669,14 @@ fn hard_links_to_target_outside_project() -> anyhow::Result<()> {
     let bar_path = case.project_path("bar.py");
     let bar = case.system_file(&bar_path).unwrap();
 
-    assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 1')");
-    assert_eq!(source_text(case.db(), bar).as_str(), "print('Version 1')");
+    assert_eq!(
+        source_text(case.db(), foo).load().as_str(),
+        "print('Version 1')"
+    );
+    assert_eq!(
+        source_text(case.db(), bar).load().as_str(),
+        "print('Version 1')"
+    );
 
     // Write to the hard link target.
     update_file(foo_path, "print('Version 2')").context("Failed to update foo.py")?;
@@ -1664,7 +1685,10 @@ fn hard_links_to_target_outside_project() -> anyhow::Result<()> {
 
     case.apply_changes(&changes);
 
-    assert_eq!(source_text(case.db(), bar).as_str(), "print('Version 2')");
+    assert_eq!(
+        source_text(case.db(), bar).load().as_str(),
+        "print('Version 2')"
+    );
 
     Ok(())
 }
@@ -1767,7 +1791,10 @@ mod unix {
         let baz_project = case.project_path("bar/baz.py");
         let baz_file = baz.file(case.db()).unwrap();
 
-        assert_eq!(source_text(case.db(), baz_file).as_str(), "def baz(): ...");
+        assert_eq!(
+            source_text(case.db(), baz_file).load().as_str(),
+            "def baz(): ..."
+        );
         assert_eq!(
             baz_file.path(case.db()).as_system_path(),
             Some(&*baz_project)
@@ -1784,7 +1811,7 @@ mod unix {
         case.apply_changes(&changes);
 
         assert_eq!(
-            source_text(case.db(), baz_file).as_str(),
+            source_text(case.db(), baz_file).load().as_str(),
             "def baz(): print('Version 2')"
         );
 
@@ -1797,7 +1824,7 @@ mod unix {
         case.apply_changes(&changes);
 
         assert_eq!(
-            source_text(case.db(), baz_file).as_str(),
+            source_text(case.db(), baz_file).load().as_str(),
             "def baz(): print('Version 3')"
         );
 
@@ -1847,11 +1874,14 @@ mod unix {
         let patched_bar_baz_file = case.system_file(&patched_bar_baz).unwrap();
 
         assert_eq!(
-            source_text(case.db(), patched_bar_baz_file).as_str(),
+            source_text(case.db(), patched_bar_baz_file).load().as_str(),
             "def baz(): ..."
         );
 
-        assert_eq!(source_text(case.db(), baz_file).as_str(), "def baz(): ...");
+        assert_eq!(
+            source_text(case.db(), baz_file).load().as_str(),
+            "def baz(): ..."
+        );
         assert_eq!(baz_file.path(case.db()).as_system_path(), Some(&*bar_baz));
 
         case.assert_indexed_project_files([patched_bar_baz_file]);
@@ -1878,10 +1908,10 @@ mod unix {
         //
         // That's why I think it's fine to not support this case for now.
 
-        let patched_baz_text = source_text(case.db(), patched_bar_baz_file);
+        let patched_baz_text = source_text(case.db(), patched_bar_baz_file).load();
         let did_update_patched_baz = patched_baz_text.as_str() == "def baz(): print('Version 2')";
 
-        let bar_baz_text = source_text(case.db(), baz_file);
+        let bar_baz_text = source_text(case.db(), baz_file).load();
         let did_update_bar_baz = bar_baz_text.as_str() == "def baz(): print('Version 2')";
 
         assert!(
@@ -1952,12 +1982,12 @@ mod unix {
         let baz_original_file = case.system_file(&baz_original).unwrap();
 
         assert_eq!(
-            source_text(case.db(), baz_original_file).as_str(),
+            source_text(case.db(), baz_original_file).load().as_str(),
             "def baz(): ..."
         );
 
         assert_eq!(
-            source_text(case.db(), baz_site_packages).as_str(),
+            source_text(case.db(), baz_site_packages).load().as_str(),
             "def baz(): ..."
         );
         assert_eq!(
@@ -1979,7 +2009,7 @@ mod unix {
         case.apply_changes(&changes);
 
         assert_eq!(
-            source_text(case.db(), baz_original_file).as_str(),
+            source_text(case.db(), baz_original_file).load().as_str(),
             "def baz(): print('Version 2')"
         );
 
@@ -1991,7 +2021,7 @@ mod unix {
         // it doesn't seem worth doing considering that as prominent tools like PyCharm don't support it.
         // Pyright does support it, thanks to chokidar.
         assert_ne!(
-            source_text(case.db(), baz_site_packages).as_str(),
+            source_text(case.db(), baz_site_packages).load().as_str(),
             "def baz(): print('Version 2')"
         );
 

--- a/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
@@ -95,7 +95,7 @@ pub fn incoming_calls(db: &dyn Db, file: ProgramFile<'_>, offset: TextSize) -> V
             .into_par_iter()
             .with_min_len(minimum_job_len)
             .map_with_db(db, |db, other_file| {
-                let source = ruff_db::source::source_text(db, other_file);
+                let source = ruff_db::source::source_text(db, other_file).load();
                 if let Some(name) = needle
                     && !contains_identifier(&source, name)
                 {

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -4,7 +4,7 @@ use ty_python_semantic::ProgramEnvironment;
 
 use compact_str::{CompactString, CompactStringExt};
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
-use ruff_db::source::{SourceText, source_text};
+use ruff_db::source::{SourceTextRef, source_text};
 use ruff_diagnostics::Edit;
 use ruff_python_ast::find_node::{CoveringNode, covering_node};
 use ruff_python_ast::name::{Name, UnqualifiedName};
@@ -40,7 +40,7 @@ pub fn completion<'db>(
     let program_file = file;
     let parsed = parsed_module(db, file.python_file(db)).load(db);
     let file = file.file(db);
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
 
     let Some(context) = Context::new(db, program_file, &parsed, &source, offset) else {
         return vec![];
@@ -796,7 +796,7 @@ impl<'m> Context<'m> {
         db: &'_ dyn Db,
         file: ProgramFile<'_>,
         parsed: &'m ParsedModuleRef,
-        source: &'m SourceText,
+        source: &'m SourceTextRef,
         offset: TextSize,
     ) -> Option<Context<'m>> {
         let cursor = ContextCursor::new(parsed, source, offset);
@@ -877,7 +877,7 @@ struct ContextCursor<'m> {
     /// The parsed module containing the cursor.
     parsed: &'m ParsedModuleRef,
     /// The source code of the module containing the cursor.
-    source: &'m SourceText,
+    source: &'m SourceTextRef,
     /// The typed text up to the cursor offset.
     ///
     /// When `Some`, the text is guaranteed to be non-empty.
@@ -928,7 +928,7 @@ impl<'m> ContextCursor<'m> {
     /// Returns information about the context of the cursor.
     fn new(
         parsed: &'m ParsedModuleRef,
-        source: &'m SourceText,
+        source: &'m SourceTextRef,
         offset: TextSize,
     ) -> ContextCursor<'m> {
         let tokens_before = tokens_start_before(parsed.tokens(), offset);
@@ -2301,7 +2301,7 @@ fn add_unimported_completions<'db>(
     }
 
     let source_file = file.file(db);
-    let source = source_text(db, source_file);
+    let source = source_text(db, source_file).load();
     let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
     let importer = Importer::new(db, &stylist, file, source.as_str(), parsed);
     let members = importer.members_in_scope_at(scoped.node, scoped.node.start());

--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -61,7 +61,7 @@ pub fn folding_ranges(
 ) -> Vec<FoldingRange> {
     let parsed = parsed_module(db, file).load(db);
     let file = file.file(db);
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
 
     let mut visitor = FoldingRangeVisitor {
         source: source.as_str(),

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -299,7 +299,7 @@ pub fn inlay_hints(
     let ast = parsed_module(db, file.python_file(db)).load(db);
     let source_file = file.file(db);
 
-    let source = source_text(db, source_file);
+    let source = source_text(db, source_file).load();
     let stylist = Stylist::from_tokens(ast.tokens(), source.as_str());
     let importer = Importer::new(db, &stylist, file, source.as_str(), &ast);
 
@@ -890,7 +890,7 @@ mod tests {
                 settings,
             );
 
-            let mut inlay_hint_buf = source_text(&self.db, self.file).as_str().to_string();
+            let mut inlay_hint_buf = source_text(&self.db, self.file).load().as_str().to_string();
             let mut text_edit_buf = inlay_hint_buf.clone();
             let source_has_errors =
                 parse_unchecked_source(&text_edit_buf, PySourceType::Python).has_invalid_syntax();

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -408,7 +408,7 @@ mod tests {
     };
     use ruff_db::files::{File, FileRootKind, system_path_to_file};
     use ruff_db::parsed::{ParsedModuleRef, parsed_module};
-    use ruff_db::source::{SourceText, source_text};
+    use ruff_db::source::{SourceTextRef, source_text};
     use ruff_db::system::{DbWithWritableSystem, SystemPath, SystemPathBuf};
     use ruff_python_ast::PythonVersion;
     use ruff_python_codegen::Stylist;
@@ -506,7 +506,7 @@ mod tests {
         pub(super) file: File,
         pub(super) offset: TextSize,
         pub(super) parsed: ParsedModuleRef,
-        pub(super) source: SourceText,
+        pub(super) source: SourceTextRef,
         pub(super) stylist: Stylist<'static>,
     }
 
@@ -566,7 +566,7 @@ mod tests {
                     // string-literal completions are only collected for open files.
                     db.project().open_file(&mut db, file);
 
-                    let source = source_text(&db, file);
+                    let source = source_text(&db, file).load();
                     let parsed =
                         parsed_module(&db, db.program_file(file).python_file(&db)).load(&db);
                     let stylist =
@@ -714,7 +714,7 @@ mod tests {
                     // string-literal completions are only collected for open files.
                     db.project().open_file(&mut db, file);
 
-                    let source = source_text(&db, file);
+                    let source = source_text(&db, file).load();
                     let parsed =
                         parsed_module(&db, db.program_file(file).python_file(&db)).load(&db);
                     let stylist =

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -130,7 +130,7 @@ pub(crate) fn references(
             .into_par_iter()
             .with_min_len(minimum_job_len)
             .map_with_db(db, |db, other_file| {
-                let source = ruff_db::source::source_text(db, other_file);
+                let source = ruff_db::source::source_text(db, other_file).load();
                 if !contains_identifier(&source, &target_text) {
                     return Vec::new();
                 }

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -2845,7 +2845,7 @@ LegacyStyle: TypeAlias = IO[str]
         );
 
         let tokens = test.highlight_file();
-        let source = ruff_db::source::source_text(&test.db, test.file);
+        let source = ruff_db::source::source_text(&test.db, test.file).load();
         let io_ranges: Vec<_> = source
             .match_indices("IO")
             .skip(1)
@@ -4746,7 +4746,7 @@ from pathlib import Missing as Alias
         /// Helper function to convert semantic tokens to a snapshot-friendly text format
         fn to_snapshot(&self, tokens: &SemanticTokens) -> String {
             use std::fmt::Write;
-            let source = ruff_db::source::source_text(&self.db, self.file);
+            let source = ruff_db::source::source_text(&self.db, self.file).load();
             let mut result = String::new();
 
             for token in tokens.iter() {

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -977,7 +977,7 @@ pub(crate) fn dynamic_resolution_paths<'db>(
             }) else {
                 continue;
             };
-            let contents = source_text(db, file);
+            let contents = source_text(db, file).load();
             if let Some(error) = contents.read_error() {
                 tracing::warn!("Failed to read .pth file `{path}`: {error}");
                 continue;

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -904,7 +904,7 @@ mod tests {
         db.memory_file_system().remove_file(path)?;
         file.sync(&mut db);
 
-        assert_eq!(source_text(&db, file).as_str(), "");
+        assert_eq!(source_text(&db, file).load().as_str(), "");
         assert_eq!(
             check_file_impl(&db, db.program_file(file))
                 .as_ref()
@@ -921,7 +921,7 @@ mod tests {
         // content returned by `source_text` remains unchanged, but the diagnostics should get updated.
         db.write_file(path, "").unwrap();
 
-        assert_eq!(source_text(&db, file).as_str(), "");
+        assert_eq!(source_text(&db, file).load().as_str(), "");
         assert_eq!(
             check_file_impl(&db, db.program_file(file))
                 .as_ref()

--- a/crates/ty_project/src/metadata/script.rs
+++ b/crates/ty_project/src/metadata/script.rs
@@ -17,7 +17,7 @@ pub(crate) fn script_metadata(db: &dyn Db, file: File) -> Option<Box<PyProject>>
         return None;
     }
 
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
     if source.is_notebook() {
         return None;
     }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1,4 +1,4 @@
-use std::cell::{OnceCell, RefCell};
+use std::cell::RefCell;
 use std::sync::Arc;
 
 use except_handlers::TryNodeContextStackManager;
@@ -8,7 +8,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use ruff_db::parsed::ParsedModuleRef;
 
-use ruff_db::source::{SourceText, source_text};
+use ruff_db::source::{SourceTextRef, source_text};
 use ruff_index::IndexVec;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_keyword, walk_pattern, walk_stmt};
@@ -255,7 +255,6 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     // Used for checking semantic syntax errors
     resolver_environment: ResolverEnvironment<'db>,
     python_version: PythonVersion,
-    source_text: OnceCell<SourceText>,
     semantic_checker: SemanticSyntaxChecker,
     in_try: bool,
 
@@ -347,7 +346,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             resolver_environment: file.resolver_environment(db),
             python_version: file.python_version(db),
-            source_text: OnceCell::new(),
             semantic_checker: SemanticSyntaxChecker::default(),
             in_try: false,
             semantic_syntax_errors: RefCell::default(),
@@ -2941,9 +2939,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.semantic_checker = checker;
     }
 
-    fn source_text(&self) -> &SourceText {
-        self.source_text
-            .get_or_init(|| source_text(self.db, self.file.file(self.db)))
+    fn source_text(&self) -> &SourceTextRef {
+        self.module.source_text(self.db)
     }
 
     fn visit_stmt_impl(&mut self, stmt: &'ast ast::Stmt) {
@@ -5166,7 +5163,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
     }
 
     fn in_notebook(&self) -> bool {
-        self.source_text().is_notebook()
+        source_text(self.db, self.file.file(self.db)).is_notebook()
     }
 
     fn report_semantic_error(&self, error: SemanticSyntaxError) {

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -166,7 +166,7 @@ where
                 source,
                 source_map,
                 applied_fixes,
-            } = apply_fixes(&staged_source, fixes);
+            } = apply_fixes(&staged_source.load(), fixes);
 
             let fixed_source = staged_source.with_text(source, &source_map);
             source_texts.set_unstaged(db, file.file, fixed_source.clone());
@@ -1689,7 +1689,7 @@ class B(A):
         // For this test, we intentionally keep renaming a variable form `a` -> `b` and
         // from `b` -> `a`. This ensures that the fix never converges.
         let check_file = |db: &dyn Db, file: File| {
-            let text = source_text(db, file);
+            let text = source_text(db, file).load();
 
             let message = if text.contains('a') {
                 "Variable `a` should be named `b`."
@@ -1746,7 +1746,7 @@ class B(A):
         assert_snapshot!(convergence_diagnostic.headline_message(), @"Fixes failed to converge after 10 iterations.");
 
         // It should keep the source text from the last allowed fix iteration.
-        assert_eq!(&*source_text(&db, file), "a = 10");
+        assert_eq!(&*source_text(&db, file).load(), "a = 10");
     }
 
     /// Tests that `fix_all` reverts fixes that introduce a syntax error.
@@ -1764,7 +1764,7 @@ class B(A):
         // For this test, we intentionally keep renaming a variable form `a` -> `b` and
         // from `b` -> `a`. This ensures that the fix never converges.
         let check_file = |db: &dyn Db, file: File| {
-            let text = source_text(db, file);
+            let text = source_text(db, file).load();
 
             let message = if text.contains('a') {
                 "Variable `a` should be named `b`."
@@ -1823,7 +1823,7 @@ class B(A):
         assert_snapshot!(syntax_error.headline_message(), @"Applying fixes introduced a syntax error. Reverting changes.");
 
         // It should revert the source to the last known error free version.
-        assert_eq!(&*source_text(&db, file), "b = 10");
+        assert_eq!(&*source_text(&db, file).load(), "b = 10");
     }
 
     #[test]
@@ -1879,7 +1879,7 @@ class B(A):
         assert!(matches!(result, Err(ruff_db::cancellation::Canceled)));
 
         // Cancellation should revert any staged or unstaged source text overrides.
-        assert_eq!(&*source_text(&db, file), "a = 10");
+        assert_eq!(&*source_text(&db, file).load(), "a = 10");
     }
 
     #[test]
@@ -1902,7 +1902,7 @@ class B(A):
         // removes the now-unused `List` import. Because `List[int]` is nested inside
         // `Optional[List[int]]`, only the outer rewrite can apply in the first iteration.
         let check_file = |db: &dyn Db, file: File| {
-            let text = source_text(db, file);
+            let text = source_text(db, file).load();
 
             let range_of = |needle: &str| {
                 let start = TextSize::try_from(text.find(needle).unwrap_or_else(|| {
@@ -1982,7 +1982,7 @@ class B(A):
         assert!(fixes.diagnostics.is_empty());
         assert_eq!(fixes.count, 2);
         assert_eq!(
-            &*source_text(&db, file),
+            &*source_text(&db, file).load(),
             "from typing import Optional\n\
              value: list[int] | None = None\n\
             "
@@ -2052,7 +2052,7 @@ class B(A):
 
         File::sync_path(&mut db, SystemPath::new("test.py"));
 
-        let fixed = source_text(&db, file);
+        let fixed = source_text(&db, file).load();
 
         let parsed = parsed_module(&db, db.program_file(file).python_file(&db));
         let parsed = parsed.load(&db);

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -182,7 +182,7 @@ pub fn check_file(db: &dyn Db, file: ProgramFile<'_>) -> Result<Box<[Diagnostic]
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
     // Abort checking if there are IO errors.
-    let source = source_text(db, source_file);
+    let source = source_text(db, source_file).load();
 
     if let Some(read_error) = source.read_error() {
         return Err(IOErrorDiagnostic {

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -530,7 +530,7 @@ impl<'db> SemanticModel<'db> {
         // The string_annotation will be used as the expr/node for any query that needs
         // to look up a node in the AST to prevent panics, because these sub-AST nodes
         // are not in the File's AST!
-        let source = source_text(self.db, self.file());
+        let source = source_text(self.db, self.file()).load();
         let string_literal = string_expr.as_single_part_string()?;
         let ast = parsed_string_annotation(source.as_str(), string_literal).ok()?;
         let model = Self {

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -79,7 +79,7 @@ pub(crate) fn is_unused_ignore_comment_lint(name: LintName) -> bool {
 pub(crate) fn suppressions(db: &dyn Db, file: PythonFile<'_>) -> Suppressions {
     let source_file = file.file(db);
     let parsed = parsed_module(db, file).load(db);
-    let source = source_text(db, source_file);
+    let source = source_text(db, source_file).load();
 
     let respect_type_ignore = db
         .analysis_settings(source_file)

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -37,7 +37,7 @@ pub(crate) fn suppress_all(
     ids_with_range: &[(LintName, TextRange)],
 ) -> Vec<SuppressFix> {
     let suppressions = suppressions(db, file);
-    let source = source_text(db, file.file(db));
+    let source = source_text(db, file.file(db)).load();
     let parsed = parsed_module(db, file).load(db);
     let tokens = parsed.tokens();
 
@@ -170,7 +170,7 @@ pub fn suppress_single(db: &dyn Db, file: PythonFile<'_>, id: LintId, range: Tex
     let suppression_range = suppression_range(db, file, range);
 
     let suppressions = suppressions(db, file);
-    let source = source_text(db, file.file(db));
+    let source = source_text(db, file.file(db)).load();
     let codes = &[id.name()];
 
     if let Some(existing) = find_existing_suppression(suppressions, &source, range) {

--- a/crates/ty_python_semantic/src/suppression/unused.rs
+++ b/crates/ty_python_semantic/src/suppression/unused.rs
@@ -69,7 +69,7 @@ pub(super) fn check_unused_suppressions(context: &mut CheckSuppressionsContext) 
         })
         .peekable();
 
-    let source = source_text(context.db, context.file);
+    let source = source_text(context.db, context.file).load();
 
     while let Some(suppression) = unused_iter.next() {
         let unused_lint = match suppression.kind {

--- a/crates/ty_python_semantic/src/types/definition.rs
+++ b/crates/ty_python_semantic/src/types/definition.rs
@@ -43,7 +43,7 @@ impl TypeDefinition<'_> {
         match self {
             Self::Module(module) => {
                 let file = module.file(db)?;
-                let source = source_text(db, file);
+                let source = source_text(db, file).load();
                 Some(FileRange::new(file, TextRange::up_to(source.text_len())))
             }
             Self::StaticClass(definition)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2846,7 +2846,7 @@ pub(super) fn abstract_method_span<'db>(
     let file = function.file(db);
     let module = parsed_module(db, function.python_file(db)).load(db);
     let node = implementation.node(db, file, &module);
-    let source_text = source_text(db, file);
+    let source_text = source_text(db, file).load();
 
     if policy == AbstractMethodAnnotationPolicy::ExcludeVerboseBody
         && source_text.line_start(node.name.end()) != source_text.line_start(node.end())

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -727,7 +727,7 @@ fn fmt_file_location<'db>(
         FilePath::Vendored(_) | FilePath::SystemVirtual(_) => Cow::Borrowed(path),
     };
     let line_index = line_index(db, file);
-    let LineColumn { line, column } = line_index.line_column(offset, &source_text(db, file));
+    let LineColumn { line, column } = line_index.line_column(offset, &source_text(db, file).load());
     f.set_invalid_type_annotation();
     write!(f, " @ {path}:{line}:{column}")
 }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2683,7 +2683,7 @@ impl KnownFunction {
                                     let value_precedence = OperatorPrecedence::from_expr(value);
                                     OperatorPrecedence::from_expr_ref(parent) >= value_precedence
                                 });
-                            let value_text = &source_text(db, context.file())[value.range()];
+                            let value_text = &source_text(db, context.file()).load()[value.range()];
                             let replacement = if needs_parens {
                                 format!("({value_text})")
                             } else {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -645,7 +645,7 @@ fn class_implementations_for_file<'db>(
     file: ProgramFile<'db>,
     roots: &FxHashSet<ClassLiteral<'db>>,
 ) -> Vec<ResolvedDefinition<'db>> {
-    if !contains_identifier(&source_text(db, file.file(db)), "class") {
+    if !contains_identifier(&source_text(db, file.file(db)).load(), "class") {
         return Vec::new();
     }
 
@@ -762,7 +762,7 @@ fn member_implementations_for_file<'db>(
 
     // A file can only contribute an override if it contains a class and spells the member name,
     // whether as a method name, a class-body target, or a `self.member` assignment.
-    let source = source_text(db, file.file(db));
+    let source = source_text(db, file.file(db)).load();
     if !contains_identifier(&source, "class") || !contains_identifier(&source, member_name) {
         return definitions;
     }
@@ -2871,7 +2871,7 @@ fn direct_subtypes<'db>(
             continue;
         }
 
-        let source = source_text(db, file);
+        let source = source_text(db, file).load();
         if !contains_identifier(&source, "class") {
             continue;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10416,7 +10416,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 ));
                                 if is_dotted_name(value) {
                                     let source =
-                                        &source_text(self.db(), self.file())[value.range()];
+                                        &source_text(self.db(), self.file()).load()[value.range()];
                                     diag.help(format_args!(
                                         "This error may indicate that `{source}` was defined as \
                                         `{source} = {special_form}` when \

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -318,7 +318,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                             and use PEP 695 type variables",
                     );
                     if let ast::Expr::Subscript(node) = node {
-                        let source = source_text(db, context.file());
+                        let source = source_text(db, context.file()).load();
                         let type_params_range = TextRange::new(
                             type_params.start().saturating_add(TextSize::new(1)),
                             type_params.end().saturating_sub(TextSize::new(1)),
@@ -506,7 +506,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                         && let Some(index) = *generic_index
                         && let [first_base, .., last_base] = class_node.bases()
                     {
-                        let source = source_text(db, context.file());
+                        let source = source_text(db, context.file()).load();
                         let generic_base = &source[class_node.bases()[index].range()];
                         diagnostic.help(format_args!(
                             "Move `{generic_base}` to the end of the bases list"

--- a/crates/ty_python_semantic/src/types/string_annotation.rs
+++ b/crates/ty_python_semantic/src/types/string_annotation.rs
@@ -1,5 +1,4 @@
 use ruff_db::parsed::parsed_string_annotation;
-use ruff_db::source::source_text;
 use ruff_python_ast::{self as ast, ModExpression, StringFlags};
 use ruff_python_parser::{ParseError, ParseErrorType, Parsed};
 use ruff_text_size::Ranged;
@@ -58,7 +57,7 @@ pub(crate) fn parse_string_annotation(
     let _span = tracing::trace_span!("parse_string_annotation", string=?string_expr.range(), ?file)
         .entered();
 
-    let source = source_text(db, file);
+    let source = context.module().source_text(db);
 
     if let Some(string_literal) = string_expr.as_single_part_string() {
         let prefix = string_literal.flags.prefix();

--- a/crates/ty_server/src/document/range.rs
+++ b/crates/ty_server/src/document/range.rs
@@ -137,7 +137,7 @@ impl PositionExt for lsp_types::Position {
         uri: &lsp_types::Uri,
         encoding: PositionEncoding,
     ) -> Option<TextSize> {
-        let source = source_text(db, file);
+        let source = source_text(db, file).load();
         let index = line_index(db, file);
 
         if let Some(notebook) = source.as_notebook() {
@@ -190,7 +190,7 @@ impl TextSizeExt for TextSize {
         file: File,
         encoding: PositionEncoding,
     ) -> Option<LspPosition> {
-        let source = source_text(db, file);
+        let source = source_text(db, file).load();
         let index = line_index(db, file);
 
         if let Some(notebook) = source.as_notebook() {
@@ -291,7 +291,7 @@ impl ToRangeExt for TextRange {
         file: File,
         encoding: PositionEncoding,
     ) -> Option<LspRange> {
-        let source = source_text(db, file);
+        let source = source_text(db, file).load();
         let index = line_index(db, file);
 
         if let Some(notebook) = source.as_notebook() {

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -76,7 +76,7 @@ impl Diagnostics {
                 for annotation in annotations {
                     let file = annotation.get_span().expect_ty_file();
                     if hashed_files.insert(file) {
-                        source_text(db, file).as_str().hash(&mut hasher);
+                        source_text(db, file).load().as_str().hash(&mut hasher);
                     }
                 }
             }

--- a/crates/ty_server/src/server/api/semantic_tokens.rs
+++ b/crates/ty_server/src/server/api/semantic_tokens.rs
@@ -16,7 +16,7 @@ pub(crate) fn generate_semantic_tokens(
     encoding: PositionEncoding,
     multiline_token_support: bool,
 ) -> Vec<SemanticToken> {
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
     let line_index = line_index(db, file);
     let semantic_token_data = semantic_tokens(db, db.program_file(file), range);
 

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -195,7 +195,7 @@ impl DbWithWritableSystem for Db {
 
 #[salsa::tracked(returns(ref))]
 fn file_settings(db: &dyn SemanticDb, file: File) -> FileSettings {
-    let source = source_text(db, file);
+    let source = source_text(db, file).load();
     if source.is_notebook() {
         return FileSettings::Global;
     }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -4,7 +4,7 @@ use js_sys::{Error, JsString};
 use ruff_db::Db as _;
 use ruff_db::diagnostic::{self, DisplayDiagnosticConfig};
 use ruff_db::files::{File, FilePath, FileRange, system_path_to_file, vendored_path_to_file};
-use ruff_db::source::{SourceText, line_index, source_text};
+use ruff_db::source::{SourceTextRef, line_index, source_text};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
     DirectoryEntry, MemoryFileSystem, Metadata, System, SystemPath, SystemPathBuf,
@@ -320,7 +320,7 @@ impl Workspace {
 
     #[wasm_bindgen(js_name = "sourceText")]
     pub fn source_text(&self, file_id: &FileHandle) -> Result<String, Error> {
-        let source_text = ruff_db::source::source_text(&self.db, file_id.file);
+        let source_text = ruff_db::source::source_text(&self.db, file_id.file).load();
 
         Ok(source_text.to_string())
     }
@@ -331,7 +331,7 @@ impl Workspace {
         file_id: &FileHandle,
         position: Position,
     ) -> Result<Vec<LocationLink>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -357,7 +357,7 @@ impl Workspace {
         file_id: &FileHandle,
         position: Position,
     ) -> Result<Vec<LocationLink>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -382,7 +382,7 @@ impl Workspace {
         file_id: &FileHandle,
         position: Position,
     ) -> Result<Vec<LocationLink>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -407,7 +407,7 @@ impl Workspace {
         file_id: &FileHandle,
         position: Position,
     ) -> Result<Vec<LocationLink>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -448,7 +448,7 @@ impl Workspace {
         file_id: &FileHandle,
         position: Position,
     ) -> Result<Option<Range>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -472,7 +472,7 @@ impl Workspace {
         position: Position,
         new_name: &str,
     ) -> Result<Vec<RenameEdit>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -502,7 +502,7 @@ impl Workspace {
 
     #[wasm_bindgen]
     pub fn hover(&self, file_id: &FileHandle, position: Position) -> Result<Option<Hover>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -532,7 +532,7 @@ impl Workspace {
         file_id: &FileHandle,
         position: Position,
     ) -> Result<Vec<Completion>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -584,7 +584,7 @@ impl Workspace {
     #[wasm_bindgen(js_name = "inlayHints")]
     pub fn inlay_hints(&self, file_id: &FileHandle, range: Range) -> Result<Vec<InlayHint>, Error> {
         let index = line_index(&self.db, file_id.file);
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
 
         let result = inlay_hints(
             &self.db,
@@ -643,7 +643,7 @@ impl Workspace {
     #[wasm_bindgen(js_name = "semanticTokens")]
     pub fn semantic_tokens(&self, file_id: &FileHandle) -> Result<Vec<SemanticToken>, Error> {
         let index = line_index(&self.db, file_id.file);
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
 
         let semantic_token =
             ty_ide::semantic_tokens(&self.db, self.db.program_file(file_id.file), None);
@@ -667,7 +667,7 @@ impl Workspace {
         range: Range,
     ) -> Result<Vec<SemanticToken>, Error> {
         let index = line_index(&self.db, file_id.file);
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
 
         let semantic_token = ty_ide::semantic_tokens(
             &self.db,
@@ -738,7 +738,7 @@ impl Workspace {
         file_id: &FileHandle,
         position: Position,
     ) -> Result<Option<SignatureHelp>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -787,7 +787,7 @@ impl Workspace {
         file_id: &FileHandle,
         position: Position,
     ) -> Result<Vec<DocumentHighlight>, Error> {
-        let source = source_text(&self.db, file_id.file);
+        let source = source_text(&self.db, file_id.file).load();
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
@@ -835,7 +835,7 @@ pub(crate) fn into_error<E: std::fmt::Display>(err: E) -> Error {
 fn map_targets_to_links(
     db: &dyn Db,
     targets: RangedValue<NavigationTargets>,
-    source: &SourceText,
+    source: &SourceTextRef,
     index: &LineIndex,
     position_encoding: PositionEncoding,
 ) -> Vec<LocationLink> {
@@ -898,7 +898,7 @@ impl Hint {
             range: Range::from_text_range(
                 hint.range,
                 &line_index(db, file),
-                &source_text(db, file),
+                &source_text(db, file).load(),
                 position_encoding,
             ),
         }
@@ -1074,7 +1074,7 @@ pub struct Location {
 }
 
 fn edit_to_text_edit(workspace: &Workspace, file: File, edit: &Edit) -> TextEdit {
-    let source = source_text(&workspace.db, file);
+    let source = source_text(&workspace.db, file).load();
     let index = line_index(&workspace.db, file);
 
     TextEdit {
@@ -1116,7 +1116,7 @@ impl Range {
         position_encoding: PositionEncoding,
     ) -> Self {
         let index = line_index(db, file_range.file());
-        let source = source_text(db, file_range.file());
+        let source = source_text(db, file_range.file()).load();
 
         Self::from_text_range(file_range.range(), &index, &source, position_encoding)
     }


### PR DESCRIPTION
## Summary

Compress cached Python source with LZ4 and lazily share decoded text through automatically evicted, lock-free handles.
Source storage drops 61–67% and peak RSS drops by up to 22 MiB, with runtime changes between −1.6% and +1.0%.

## Test Plan

Testing: Added eviction and concurrency coverage; all affected tests, workspace checks, Clippy, and repository hooks pass.
