### PR TITLE
[ty] Diagnose invalid __getattribute__ calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2869,6 +2869,9 @@ reveal_type(InvalidGetAttribute().missing)  # revealed: str
 
 # error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `InvalidGetAttribute`"
 reveal_type(InvalidGetAttribute().defined)  # revealed: bool
+
+# error: [invalid-attribute-access] "Invalid access to attribute `__getattribute__` on type `InvalidGetAttribute`"
+InvalidGetAttribute().__getattribute__
 ```
 
 ```snapshot
@@ -2878,6 +2881,7 @@ error[invalid-attribute-access]: Invalid access to attribute `missing` on type `
 8 | InvalidGetAttribute().missing  # snapshot: invalid-attribute-access
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Too many positional arguments to bound method `InvalidGetAttribute.__getattribute__`: expected 1, got 2
 info: This access implicitly calls `__getattribute__`
+info: Method signature here
  --> src/mdtest_snippet.py:5:9
   |
 5 |     def __getattribute__(self) -> str:
@@ -3056,6 +3060,9 @@ reveal_type(Foo.missing)  # revealed: int
 
 # error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `<class 'Foo'>`"
 reveal_type(Foo.defined)  # revealed: str
+
+# error: [invalid-attribute-access] "Invalid access to attribute `__getattribute__` on type `<class 'Foo'>`"
+Foo.__getattribute__
 ```
 
 ### Class attributes take precedence

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2788,6 +2788,8 @@ def _(ns: argparse.Namespace):
 
 ## Classes with custom `__getattribute__` methods
 
+### Basic
+
 If a type provides a custom `__getattribute__`, we use its return type as the type for unknown
 attributes. Note that this behavior differs from runtime, where `__getattribute__` is called
 unconditionally, even for known attributes. The rationale for doing this is that it allows users to
@@ -2844,6 +2846,71 @@ class ThisFails:
 
 # error: [unresolved-attribute]
 ThisFails().x
+```
+
+### Invalid `__getattribute__` calls
+
+An invalid `__getattribute__` call fails before Python can look up either a defined or missing
+attribute. A defined member retains its declared type, while a missing member uses the method's
+return type for error recovery.
+
+```py
+class InvalidGetAttribute:
+    defined: bool = True
+
+    # error: [invalid-method-override]
+    def __getattribute__(self) -> str:
+        return "fallback"
+
+InvalidGetAttribute().missing  # snapshot: invalid-attribute-access
+
+# error: [invalid-attribute-access] "Invalid access to attribute `missing` on type `InvalidGetAttribute`"
+reveal_type(InvalidGetAttribute().missing)  # revealed: str
+
+# error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `InvalidGetAttribute`"
+reveal_type(InvalidGetAttribute().defined)  # revealed: bool
+```
+
+```snapshot
+error[invalid-attribute-access]: Invalid access to attribute `missing` on type `InvalidGetAttribute`
+ --> src/mdtest_snippet.py:8:1
+  |
+8 | InvalidGetAttribute().missing  # snapshot: invalid-attribute-access
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Too many positional arguments to bound method `InvalidGetAttribute.__getattribute__`: expected 1, got 2
+info: This access implicitly calls `__getattribute__`
+ --> src/mdtest_snippet.py:5:9
+  |
+5 |     def __getattribute__(self) -> str:
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+An incompatible type for the attribute name also makes the implicit call invalid.
+
+```py
+class InvalidNameType:
+    # error: [invalid-method-override]
+    def __getattribute__(self, name: int) -> bytes:
+        return b"fallback"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `missing` on type `InvalidNameType`"
+reveal_type(InvalidNameType().missing)  # revealed: bytes
+```
+
+### Invalid `__getattribute__` takes precedence over `__getattr__`
+
+An invalid `__getattribute__` raises before Python can call an otherwise valid `__getattr__` method.
+
+```py
+class CustomAccess:
+    # error: [invalid-method-override]
+    def __getattribute__(self) -> int:
+        return 1
+
+    def __getattr__(self, name: str) -> str:
+        return "fallback"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `missing` on type `CustomAccess`"
+reveal_type(CustomAccess().missing)  # revealed: int
 ```
 
 ## Metaclasses with custom `__getattr__` methods
@@ -2968,6 +3035,27 @@ class Meta(type):
 class Foo(metaclass=Meta): ...
 
 reveal_type(Foo.whatever)  # revealed: int
+```
+
+### Invalid `__getattribute__` calls
+
+A malformed metaclass `__getattribute__` prevents access to both defined and missing class
+attributes. Their original types remain available for error recovery.
+
+```py
+class Meta(type):
+    # error: [invalid-method-override]
+    def __getattribute__(cls) -> int:
+        return 1
+
+class Foo(metaclass=Meta):
+    defined: str = "hello"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `missing` on type `<class 'Foo'>`"
+reveal_type(Foo.missing)  # revealed: int
+
+# error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `<class 'Foo'>`"
+reveal_type(Foo.defined)  # revealed: str
 ```
 
 ### Class attributes take precedence

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2867,6 +2867,9 @@ reveal_type(InvalidGetAttribute().missing)  # revealed: str
 
 # error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `InvalidGetAttribute`"
 reveal_type(InvalidGetAttribute().defined)  # revealed: bool
+
+# error: [invalid-attribute-access] "Invalid access to attribute `__getattribute__` on type `InvalidGetAttribute`"
+InvalidGetAttribute().__getattribute__
 ```
 
 ```snapshot
@@ -2876,6 +2879,7 @@ error[invalid-attribute-access]: Invalid access to attribute `missing` on type `
 8 | InvalidGetAttribute().missing  # snapshot: invalid-attribute-access
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Too many positional arguments to bound method `InvalidGetAttribute.__getattribute__`: expected 1, got 2
 info: This access implicitly calls `__getattribute__`
+info: Method signature here
  --> src/mdtest_snippet.py:5:9
   |
 5 |     def __getattribute__(self) -> str:
@@ -3054,6 +3058,9 @@ reveal_type(Foo.missing)  # revealed: int
 
 # error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `<class 'Foo'>`"
 reveal_type(Foo.defined)  # revealed: str
+
+# error: [invalid-attribute-access] "Invalid access to attribute `__getattribute__` on type `<class 'Foo'>`"
+Foo.__getattribute__
 ```
 
 ### Class attributes take precedence

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2786,6 +2786,8 @@ def _(ns: argparse.Namespace):
 
 ## Classes with custom `__getattribute__` methods
 
+### Basic
+
 If a type provides a custom `__getattribute__`, we use its return type as the type for unknown
 attributes. Note that this behavior differs from runtime, where `__getattribute__` is called
 unconditionally, even for known attributes. The rationale for doing this is that it allows users to
@@ -2842,6 +2844,71 @@ class ThisFails:
 
 # error: [unresolved-attribute]
 ThisFails().x
+```
+
+### Invalid `__getattribute__` calls
+
+An invalid `__getattribute__` call fails before Python can look up either a defined or missing
+attribute. A defined member retains its declared type, while a missing member uses the method's
+return type for error recovery.
+
+```py
+class InvalidGetAttribute:
+    defined: bool = True
+
+    # error: [invalid-method-override]
+    def __getattribute__(self) -> str:
+        return "fallback"
+
+InvalidGetAttribute().missing  # snapshot: invalid-attribute-access
+
+# error: [invalid-attribute-access] "Invalid access to attribute `missing` on type `InvalidGetAttribute`"
+reveal_type(InvalidGetAttribute().missing)  # revealed: str
+
+# error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `InvalidGetAttribute`"
+reveal_type(InvalidGetAttribute().defined)  # revealed: bool
+```
+
+```snapshot
+error[invalid-attribute-access]: Invalid access to attribute `missing` on type `InvalidGetAttribute`
+ --> src/mdtest_snippet.py:8:1
+  |
+8 | InvalidGetAttribute().missing  # snapshot: invalid-attribute-access
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Too many positional arguments to bound method `InvalidGetAttribute.__getattribute__`: expected 1, got 2
+info: This access implicitly calls `__getattribute__`
+ --> src/mdtest_snippet.py:5:9
+  |
+5 |     def __getattribute__(self) -> str:
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+An incompatible type for the attribute name also makes the implicit call invalid.
+
+```py
+class InvalidNameType:
+    # error: [invalid-method-override]
+    def __getattribute__(self, name: int) -> bytes:
+        return b"fallback"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `missing` on type `InvalidNameType`"
+reveal_type(InvalidNameType().missing)  # revealed: bytes
+```
+
+### Invalid `__getattribute__` takes precedence over `__getattr__`
+
+An invalid `__getattribute__` raises before Python can call an otherwise valid `__getattr__` method.
+
+```py
+class CustomAccess:
+    # error: [invalid-method-override]
+    def __getattribute__(self) -> int:
+        return 1
+
+    def __getattr__(self, name: str) -> str:
+        return "fallback"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `missing` on type `CustomAccess`"
+reveal_type(CustomAccess().missing)  # revealed: int
 ```
 
 ## Metaclasses with custom `__getattr__` methods
@@ -2966,6 +3033,27 @@ class Meta(type):
 class Foo(metaclass=Meta): ...
 
 reveal_type(Foo.whatever)  # revealed: int
+```
+
+### Invalid `__getattribute__` calls
+
+A malformed metaclass `__getattribute__` prevents access to both defined and missing class
+attributes. Their original types remain available for error recovery.
+
+```py
+class Meta(type):
+    # error: [invalid-method-override]
+    def __getattribute__(cls) -> int:
+        return 1
+
+class Foo(metaclass=Meta):
+    defined: str = "hello"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `missing` on type `<class 'Foo'>`"
+reveal_type(Foo.missing)  # revealed: int
+
+# error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `<class 'Foo'>`"
+reveal_type(Foo.defined)  # revealed: str
 ```
 
 ### Class attributes take precedence

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2900,6 +2900,44 @@ class InvalidNameType:
 reveal_type(InvalidNameType().missing)  # revealed: bytes
 ```
 
+### Inherited invalid `__getattribute__` calls
+
+An invalid interceptor inherited from a base class also prevents access to attributes declared on
+the subclass.
+
+```py
+class InvalidBase:
+    # error: [invalid-method-override]
+    def __getattribute__(self) -> int:
+        return 1
+
+class Child(InvalidBase):
+    defined: str = "hello"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `Child`"
+reveal_type(Child().defined)  # revealed: str
+```
+
+### Invalid `__getattribute__` installed by a metaclass
+
+A metaclass can install an invalid interceptor in the namespace of each class it creates.
+
+```py
+def invalid_getattribute(self) -> int:
+    return 1
+
+class Meta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        # error: [invalid-assignment]
+        cls.__getattribute__ = invalid_getattribute
+
+class Example(metaclass=Meta):
+    defined: str = "hello"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `Example`"
+reveal_type(Example().defined)  # revealed: str
+```
+
 ### Invalid `__getattribute__` takes precedence over `__getattr__`
 
 An invalid `__getattribute__` raises before Python can call an otherwise valid `__getattr__` method.
@@ -3063,6 +3101,26 @@ reveal_type(Foo.defined)  # revealed: str
 
 # error: [invalid-attribute-access] "Invalid access to attribute `__getattribute__` on type `<class 'Foo'>`"
 Foo.__getattribute__
+```
+
+### Inherited invalid `__getattribute__` calls
+
+A malformed interceptor inherited by a metaclass still runs before looking up attributes declared on
+the class object.
+
+```py
+class InvalidBaseMeta(type):
+    # error: [invalid-method-override]
+    def __getattribute__(cls) -> int:
+        return 1
+
+class Meta(InvalidBaseMeta): ...
+
+class Foo(metaclass=Meta):
+    defined: str = "hello"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `defined` on type `<class 'Foo'>`"
+reveal_type(Foo.defined)  # revealed: str
 ```
 
 ### Class attributes take precedence

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -1287,6 +1287,24 @@ class C:
 reveal_type(C().value)  # revealed: int
 ```
 
+### An unknown `__getattribute__` can bypass descriptors
+
+A dynamic base may provide an attribute interceptor that avoids a malformed descriptor, so the
+descriptor access cannot be guaranteed to fail.
+
+```py
+from typing import Any
+
+class Descriptor:
+    def __get__(self) -> int:
+        return 1
+
+class C(Any):
+    value = Descriptor()
+
+reveal_type(C().value)  # revealed: int
+```
+
 ### An instance `__getattribute__` may delegate to descriptor lookup
 
 The return annotation of an override does not establish whether it delegates to the default

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -1307,6 +1307,27 @@ class C:
 C().value
 ```
 
+### An invalid `__getattribute__` runs before descriptors
+
+A malformed `__getattribute__` fails before it can invoke a malformed descriptor. The diagnostic
+therefore describes the `__getattribute__` call while preserving the descriptor's return type.
+
+```py
+class Descriptor:
+    def __get__(self) -> int:
+        return 1
+
+class C:
+    value = Descriptor()
+
+    # error: [invalid-method-override]
+    def __getattribute__(self) -> str:
+        return "fallback"
+
+# error: [invalid-attribute-access] "Invalid access to attribute `value` on type `C`"
+reveal_type(C().value)  # revealed: int
+```
+
 ### An assigned instance attribute shadows a non-data descriptor
 
 An instance attribute takes precedence over a non-data descriptor. After the assignment, reading the

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -67,7 +67,7 @@ pub(crate) use crate::types::class_base::ClassBase;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 use crate::types::diagnostic::{
-    INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_dunder_get_call, report_bad_dunder_getattr_call,
+    INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_attribute_access_call, report_bad_dunder_get_call,
 };
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
 pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_metadata};
@@ -622,6 +622,12 @@ enum MemberLookupErrorKind<'db> {
         receiver: Type<'db>,
         name: Type<'db>,
     },
+
+    /// An invalid attribute-interception call, represented by its receiver and attribute name.
+    GetAttribute {
+        receiver: Type<'db>,
+        name: Type<'db>,
+    },
 }
 
 /// A failed member lookup together with the member used to recover from the error.
@@ -665,21 +671,38 @@ impl<'db> MemberLookupError<'db> {
                     target,
                 );
             }
-            MemberLookupErrorKind::GetAttr { receiver, name }
-                if assigned_type.is_none()
-                    && let Err(CallDunderError::CallError(kind, bindings, _)) = receiver
-                        .try_call_dunder(
-                            db,
-                            env,
-                            "__getattr__",
-                            CallArguments::positional([name]),
-                            TypeContext::default(),
-                        ) =>
-            {
-                let failure = CallError(kind, bindings);
-                report_bad_dunder_getattr_call(context, &failure, object_type, target);
+            kind @ (MemberLookupErrorKind::GetAttr { receiver, name }
+            | MemberLookupErrorKind::GetAttribute { receiver, name }) => {
+                let is_fallback = matches!(kind, MemberLookupErrorKind::GetAttr { .. });
+                if is_fallback && assigned_type.is_some() {
+                    return;
+                }
+
+                let method = if is_fallback {
+                    "__getattr__"
+                } else {
+                    "__getattribute__"
+                };
+                if let Err(CallDunderError::CallError(kind, bindings, _)) = receiver
+                    .try_call_dunder(
+                        db,
+                        env,
+                        method,
+                        CallArguments::positional([name]),
+                        TypeContext::default(),
+                    )
+                {
+                    let failure = CallError(kind, bindings);
+                    report_bad_attribute_access_call(
+                        context,
+                        &failure,
+                        object_type,
+                        target,
+                        method,
+                    );
+                }
             }
-            MemberLookupErrorKind::DescriptorGet(_) | MemberLookupErrorKind::GetAttr { .. } => {}
+            MemberLookupErrorKind::DescriptorGet(_) => {}
         }
     }
 }
@@ -6616,46 +6639,62 @@ impl<'db> Type<'db> {
             }
         };
 
-        let custom_getattribute = OnceCell::new();
-        let custom_getattribute = || {
-            *custom_getattribute.get_or_init(|| {
-                if "__getattribute__" == name.as_str() {
-                    return (MemberLookupResult::from(Place::Undefined), false);
+        let custom_getattribute = if "__getattribute__" == name.as_str() {
+            (MemberLookupResult::from(Place::Undefined), false)
+        } else {
+            // Skip `object.__getattribute__`, which is the default mechanism we
+            // already model via the normal attribute-lookup path.
+            let name_type = Type::string_literal(db, name);
+            match self.try_call_dunder_with_policy(
+                db,
+                env,
+                "__getattribute__",
+                &mut CallArguments::positional([name_type]),
+                TypeContext::default(),
+                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            ) {
+                Ok(bindings) => (Place::bound(bindings.return_type(db, env)).into(), true),
+                Err(CallDunderError::CallError(_, bindings, _)) => (
+                    member_lookup_result(
+                        db,
+                        Place::bound(bindings.return_type(db, env)).into(),
+                        Some(MemberLookupErrorKind::GetAttribute {
+                            receiver: self,
+                            name: name_type,
+                        }),
+                    ),
+                    true,
+                ),
+                Err(CallDunderError::PossiblyUnbound { .. }) => {
+                    (MemberLookupResult::from(Place::Undefined), true)
                 }
-
-                // Skip `object.__getattribute__`, which is the default mechanism we
-                // already model via the normal attribute-lookup path.
-                match self.try_call_dunder_with_policy(
-                    db,
-                    env,
-                    "__getattribute__",
-                    &mut CallArguments::positional([Type::string_literal(db, name)]),
-                    TypeContext::default(),
-                    MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-                ) {
-                    Ok(bindings) => (Place::bound(bindings.return_type(db, env)).into(), true),
-                    Err(
-                        CallDunderError::PossiblyUnbound { .. } | CallDunderError::CallError(..),
-                    ) => (MemberLookupResult::from(Place::Undefined), true),
-                    Err(CallDunderError::MethodNotAvailable) => {
-                        (MemberLookupResult::from(Place::Undefined), false)
-                    }
+                Err(CallDunderError::MethodNotAvailable) => {
+                    (MemberLookupResult::from(Place::Undefined), false)
                 }
-            })
+            }
         };
+
+        if let Err(error) = custom_getattribute.0 {
+            let member = result.unwrap_or_else(|error| error.fallback_member(db));
+            return Err(MemberLookupError::new(
+                db,
+                member.or_fall_back_to(db, env, || error.fallback_member(db)),
+                error.kind(db),
+            ));
+        }
 
         // A custom override runs before the descriptor and might return without invoking it.
         let result = if matches!(
             result.err().map(|error| error.kind(db)),
             Some(MemberLookupErrorKind::DescriptorGet(_))
-        ) && custom_getattribute().1
+        ) && custom_getattribute.1
         {
             Ok(result.unwrap_or_else(|error| error.fallback_member(db)))
         } else {
             result
         };
 
-        let result = member_lookup_or_fall_back_to(db, env, result, || custom_getattribute().0);
+        let result = member_lookup_or_fall_back_to(db, env, result, || custom_getattribute.0);
         member_lookup_or_fall_back_to(db, env, result, custom_getattr_result)
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -23,6 +23,7 @@ use smallvec::smallvec_inline;
 use ty_module_resolver::{ImportingFile, KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
+use self::class::ClassInstanceFlags;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
 pub(crate) use self::diagnostic::TypeCheckDiagnostics;
@@ -6620,11 +6621,16 @@ impl<'db> Type<'db> {
         };
 
         let class = class.class_literal(db);
-        if class.has_custom_getattribute(db) {
+        if class.as_static().is_none() {
             return true;
         }
 
-        if !class.has_dynamic_getattribute(db) {
+        let flags = class.instance_flags(db);
+        if flags.contains(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE) {
+            return true;
+        }
+
+        if !flags.contains(ClassInstanceFlags::HAS_DYNAMIC_GETATTRIBUTE) {
             return false;
         }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -67,7 +67,7 @@ pub(crate) use crate::types::class_base::ClassBase;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 use crate::types::diagnostic::{
-    INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_dunder_get_call, report_bad_dunder_getattr_call,
+    INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_attribute_access_call, report_bad_dunder_get_call,
 };
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
 pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_metadata};
@@ -619,6 +619,12 @@ enum MemberLookupErrorKind<'db> {
         receiver: Type<'db>,
         name: Type<'db>,
     },
+
+    /// An invalid attribute-interception call, represented by its receiver and attribute name.
+    GetAttribute {
+        receiver: Type<'db>,
+        name: Type<'db>,
+    },
 }
 
 /// A failed member lookup together with the member used to recover from the error.
@@ -662,21 +668,38 @@ impl<'db> MemberLookupError<'db> {
                     target,
                 );
             }
-            MemberLookupErrorKind::GetAttr { receiver, name }
-                if assigned_type.is_none()
-                    && let Err(CallDunderError::CallError(kind, bindings, _)) = receiver
-                        .try_call_dunder(
-                            db,
-                            env,
-                            "__getattr__",
-                            CallArguments::positional([name]),
-                            TypeContext::default(),
-                        ) =>
-            {
-                let failure = CallError(kind, bindings);
-                report_bad_dunder_getattr_call(context, &failure, object_type, target);
+            kind @ (MemberLookupErrorKind::GetAttr { receiver, name }
+            | MemberLookupErrorKind::GetAttribute { receiver, name }) => {
+                let is_fallback = matches!(kind, MemberLookupErrorKind::GetAttr { .. });
+                if is_fallback && assigned_type.is_some() {
+                    return;
+                }
+
+                let method = if is_fallback {
+                    "__getattr__"
+                } else {
+                    "__getattribute__"
+                };
+                if let Err(CallDunderError::CallError(kind, bindings, _)) = receiver
+                    .try_call_dunder(
+                        db,
+                        env,
+                        method,
+                        CallArguments::positional([name]),
+                        TypeContext::default(),
+                    )
+                {
+                    let failure = CallError(kind, bindings);
+                    report_bad_attribute_access_call(
+                        context,
+                        &failure,
+                        object_type,
+                        target,
+                        method,
+                    );
+                }
             }
-            MemberLookupErrorKind::DescriptorGet(_) | MemberLookupErrorKind::GetAttr { .. } => {}
+            MemberLookupErrorKind::DescriptorGet(_) => {}
         }
     }
 }
@@ -6603,46 +6626,62 @@ impl<'db> Type<'db> {
             }
         };
 
-        let custom_getattribute = OnceCell::new();
-        let custom_getattribute = || {
-            *custom_getattribute.get_or_init(|| {
-                if "__getattribute__" == name.as_str() {
-                    return (MemberLookupResult::from(Place::Undefined), false);
+        let custom_getattribute = if "__getattribute__" == name.as_str() {
+            (MemberLookupResult::from(Place::Undefined), false)
+        } else {
+            // Skip `object.__getattribute__`, which is the default mechanism we
+            // already model via the normal attribute-lookup path.
+            let name_type = Type::string_literal(db, name);
+            match self.try_call_dunder_with_policy(
+                db,
+                env,
+                "__getattribute__",
+                &mut CallArguments::positional([name_type]),
+                TypeContext::default(),
+                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            ) {
+                Ok(bindings) => (Place::bound(bindings.return_type(db, env)).into(), true),
+                Err(CallDunderError::CallError(_, bindings, _)) => (
+                    member_lookup_result(
+                        db,
+                        Place::bound(bindings.return_type(db, env)).into(),
+                        Some(MemberLookupErrorKind::GetAttribute {
+                            receiver: self,
+                            name: name_type,
+                        }),
+                    ),
+                    true,
+                ),
+                Err(CallDunderError::PossiblyUnbound { .. }) => {
+                    (MemberLookupResult::from(Place::Undefined), true)
                 }
-
-                // Skip `object.__getattribute__`, which is the default mechanism we
-                // already model via the normal attribute-lookup path.
-                match self.try_call_dunder_with_policy(
-                    db,
-                    env,
-                    "__getattribute__",
-                    &mut CallArguments::positional([Type::string_literal(db, name)]),
-                    TypeContext::default(),
-                    MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-                ) {
-                    Ok(bindings) => (Place::bound(bindings.return_type(db, env)).into(), true),
-                    Err(
-                        CallDunderError::PossiblyUnbound { .. } | CallDunderError::CallError(..),
-                    ) => (MemberLookupResult::from(Place::Undefined), true),
-                    Err(CallDunderError::MethodNotAvailable) => {
-                        (MemberLookupResult::from(Place::Undefined), false)
-                    }
+                Err(CallDunderError::MethodNotAvailable) => {
+                    (MemberLookupResult::from(Place::Undefined), false)
                 }
-            })
+            }
         };
+
+        if let Err(error) = custom_getattribute.0 {
+            let member = result.unwrap_or_else(|error| error.fallback_member(db));
+            return Err(MemberLookupError::new(
+                db,
+                member.or_fall_back_to(db, env, || error.fallback_member(db)),
+                error.kind(db),
+            ));
+        }
 
         // A custom override runs before the descriptor and might return without invoking it.
         let result = if matches!(
             result.err().map(|error| error.kind(db)),
             Some(MemberLookupErrorKind::DescriptorGet(_))
-        ) && custom_getattribute().1
+        ) && custom_getattribute.1
         {
             Ok(result.unwrap_or_else(|error| error.fallback_member(db)))
         } else {
             result
         };
 
-        let result = member_lookup_or_fall_back_to(db, env, result, || custom_getattribute().0);
+        let result = member_lookup_or_fall_back_to(db, env, result, || custom_getattribute.0);
         member_lookup_or_fall_back_to(db, env, result, custom_getattr_result)
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6639,42 +6639,43 @@ impl<'db> Type<'db> {
             }
         };
 
-        let custom_getattribute = if "__getattribute__" == name.as_str() {
-            (MemberLookupResult::from(Place::Undefined), false)
-        } else {
-            // Skip `object.__getattribute__`, which is the default mechanism we
-            // already model via the normal attribute-lookup path.
-            let name_type = Type::string_literal(db, name);
-            match self.try_call_dunder_with_policy(
+        // This lookup is shared by every attribute on the receiver. Only create the requested
+        // name's literal type and check the call when an override actually exists.
+        let getattribute_policy = MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+            | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK;
+        if self
+            .class_member_with_policy(db, env, "__getattribute__", getattribute_policy)
+            .place
+            .is_undefined()
+        {
+            return member_lookup_or_fall_back_to(db, env, result, custom_getattr_result);
+        }
+
+        let name_type = Type::string_literal(db, name);
+        let custom_getattribute = match self.try_call_dunder_with_policy(
+            db,
+            env,
+            "__getattribute__",
+            &mut CallArguments::positional([name_type]),
+            TypeContext::default(),
+            getattribute_policy,
+        ) {
+            Ok(bindings) => Place::bound(bindings.return_type(db, env)).into(),
+            Err(CallDunderError::CallError(_, bindings, _)) => member_lookup_result(
                 db,
-                env,
-                "__getattribute__",
-                &mut CallArguments::positional([name_type]),
-                TypeContext::default(),
-                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-            ) {
-                Ok(bindings) => (Place::bound(bindings.return_type(db, env)).into(), true),
-                Err(CallDunderError::CallError(_, bindings, _)) => (
-                    member_lookup_result(
-                        db,
-                        Place::bound(bindings.return_type(db, env)).into(),
-                        Some(MemberLookupErrorKind::GetAttribute {
-                            receiver: self,
-                            name: name_type,
-                        }),
-                    ),
-                    true,
-                ),
-                Err(CallDunderError::PossiblyUnbound { .. }) => {
-                    (MemberLookupResult::from(Place::Undefined), true)
-                }
-                Err(CallDunderError::MethodNotAvailable) => {
-                    (MemberLookupResult::from(Place::Undefined), false)
-                }
+                Place::bound(bindings.return_type(db, env)).into(),
+                Some(MemberLookupErrorKind::GetAttribute {
+                    receiver: self,
+                    name: name_type,
+                }),
+            ),
+            Err(CallDunderError::PossiblyUnbound { .. }) => Place::Undefined.into(),
+            Err(CallDunderError::MethodNotAvailable) => {
+                return member_lookup_or_fall_back_to(db, env, result, custom_getattr_result);
             }
         };
 
-        if let Err(error) = custom_getattribute.0 {
+        if let Err(error) = custom_getattribute {
             let member = result.unwrap_or_else(|error| error.fallback_member(db));
             return Err(MemberLookupError::new(
                 db,
@@ -6687,14 +6688,13 @@ impl<'db> Type<'db> {
         let result = if matches!(
             result.err().map(|error| error.kind(db)),
             Some(MemberLookupErrorKind::DescriptorGet(_))
-        ) && custom_getattribute.1
-        {
+        ) {
             Ok(result.unwrap_or_else(|error| error.fallback_member(db)))
         } else {
             result
         };
 
-        let result = member_lookup_or_fall_back_to(db, env, result, || custom_getattribute.0);
+        let result = member_lookup_or_fall_back_to(db, env, result, || custom_getattribute);
         member_lookup_or_fall_back_to(db, env, result, custom_getattr_result)
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6600,9 +6600,10 @@ impl<'db> Type<'db> {
 
     /// Return whether a custom `__getattribute__` could affect this lookup.
     ///
-    /// Reusing the class's existing MRO classification avoids interning a member-lookup key just
-    /// to determine whether an override exists. An unknown base can still intercept a missing
-    /// attribute or bypass a failing descriptor, but cannot invalidate a definitely defined member.
+    /// Reusing the receiver class's existing MRO classification avoids interning a member-lookup
+    /// key just to determine whether an override exists. Class objects use their metaclass instead.
+    /// An unknown base can intercept a missing attribute or bypass a failing descriptor, but cannot
+    /// invalidate a definitely defined member.
     fn custom_getattribute_may_affect_lookup(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6598,6 +6598,43 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Return whether a custom `__getattribute__` could affect this lookup.
+    ///
+    /// Reusing the class's existing MRO classification avoids interning a member-lookup key just
+    /// to determine whether an override exists. An unknown base can still intercept a missing
+    /// attribute or bypass a failing descriptor, but cannot invalidate a definitely defined member.
+    fn custom_getattribute_may_affect_lookup(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        result: MemberLookupResult<'db>,
+    ) -> bool {
+        let Some(class) = self.nominal_class(db, env).or_else(|| {
+            self.to_meta_type(db, env)
+                .to_instance_approximation(db, env)
+                .and_then(|instance| instance.nominal_class(db, env))
+        }) else {
+            return true;
+        };
+
+        let class = class.class_literal(db);
+        if class.has_custom_getattribute(db) {
+            return true;
+        }
+
+        if !class.has_dynamic_getattribute(db) {
+            return false;
+        }
+
+        !matches!(
+            result,
+            Ok(PlaceAndQualifiers {
+                place: Place::Defined(place),
+                ..
+            }) if place.is_definitely_defined()
+        )
+    }
+
     /// Apply `__getattr__` / `__getattribute__` fallback to an attribute-lookup result.
     ///
     /// A custom `__getattribute__` can intercept even an always-defined normal lookup result.
@@ -6639,14 +6676,13 @@ impl<'db> Type<'db> {
             }
         };
 
-        // This lookup is shared by every attribute on the receiver. Only create the requested
-        // name's literal type and check the call when an override actually exists.
         let getattribute_policy = MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
             | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK;
-        if self
-            .class_member_with_policy(db, env, "__getattribute__", getattribute_policy)
-            .place
-            .is_undefined()
+        if !self.custom_getattribute_may_affect_lookup(db, env, result)
+            || self
+                .class_member_with_policy(db, env, "__getattribute__", getattribute_policy)
+                .place
+                .is_undefined()
         {
             return member_lookup_or_fall_back_to(db, env, result, custom_getattr_result);
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -67,7 +67,8 @@ pub(crate) use crate::types::class_base::ClassBase;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 use crate::types::diagnostic::{
-    INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_attribute_access_call, report_bad_dunder_get_call,
+    AttributeAccessMethod, INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_attribute_access_call,
+    report_bad_dunder_get_call,
 };
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
 pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_metadata};
@@ -673,21 +674,21 @@ impl<'db> MemberLookupError<'db> {
             }
             kind @ (MemberLookupErrorKind::GetAttr { receiver, name }
             | MemberLookupErrorKind::GetAttribute { receiver, name }) => {
-                let is_fallback = matches!(kind, MemberLookupErrorKind::GetAttr { .. });
-                if is_fallback && assigned_type.is_some() {
+                let method = if matches!(kind, MemberLookupErrorKind::GetAttr { .. }) {
+                    AttributeAccessMethod::GetAttr
+                } else {
+                    AttributeAccessMethod::GetAttribute
+                };
+
+                if method == AttributeAccessMethod::GetAttr && assigned_type.is_some() {
                     return;
                 }
 
-                let method = if is_fallback {
-                    "__getattr__"
-                } else {
-                    "__getattribute__"
-                };
                 if let Err(CallDunderError::CallError(kind, bindings, _)) = receiver
                     .try_call_dunder(
                         db,
                         env,
-                        method,
+                        method.as_str(),
                         CallArguments::positional([name]),
                         TypeContext::default(),
                     )

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6626,42 +6626,43 @@ impl<'db> Type<'db> {
             }
         };
 
-        let custom_getattribute = if "__getattribute__" == name.as_str() {
-            (MemberLookupResult::from(Place::Undefined), false)
-        } else {
-            // Skip `object.__getattribute__`, which is the default mechanism we
-            // already model via the normal attribute-lookup path.
-            let name_type = Type::string_literal(db, name);
-            match self.try_call_dunder_with_policy(
+        // This lookup is shared by every attribute on the receiver. Only create the requested
+        // name's literal type and check the call when an override actually exists.
+        let getattribute_policy = MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+            | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK;
+        if self
+            .class_member_with_policy(db, env, "__getattribute__", getattribute_policy)
+            .place
+            .is_undefined()
+        {
+            return member_lookup_or_fall_back_to(db, env, result, custom_getattr_result);
+        }
+
+        let name_type = Type::string_literal(db, name);
+        let custom_getattribute = match self.try_call_dunder_with_policy(
+            db,
+            env,
+            "__getattribute__",
+            &mut CallArguments::positional([name_type]),
+            TypeContext::default(),
+            getattribute_policy,
+        ) {
+            Ok(bindings) => Place::bound(bindings.return_type(db, env)).into(),
+            Err(CallDunderError::CallError(_, bindings, _)) => member_lookup_result(
                 db,
-                env,
-                "__getattribute__",
-                &mut CallArguments::positional([name_type]),
-                TypeContext::default(),
-                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-            ) {
-                Ok(bindings) => (Place::bound(bindings.return_type(db, env)).into(), true),
-                Err(CallDunderError::CallError(_, bindings, _)) => (
-                    member_lookup_result(
-                        db,
-                        Place::bound(bindings.return_type(db, env)).into(),
-                        Some(MemberLookupErrorKind::GetAttribute {
-                            receiver: self,
-                            name: name_type,
-                        }),
-                    ),
-                    true,
-                ),
-                Err(CallDunderError::PossiblyUnbound { .. }) => {
-                    (MemberLookupResult::from(Place::Undefined), true)
-                }
-                Err(CallDunderError::MethodNotAvailable) => {
-                    (MemberLookupResult::from(Place::Undefined), false)
-                }
+                Place::bound(bindings.return_type(db, env)).into(),
+                Some(MemberLookupErrorKind::GetAttribute {
+                    receiver: self,
+                    name: name_type,
+                }),
+            ),
+            Err(CallDunderError::PossiblyUnbound { .. }) => Place::Undefined.into(),
+            Err(CallDunderError::MethodNotAvailable) => {
+                return member_lookup_or_fall_back_to(db, env, result, custom_getattr_result);
             }
         };
 
-        if let Err(error) = custom_getattribute.0 {
+        if let Err(error) = custom_getattribute {
             let member = result.unwrap_or_else(|error| error.fallback_member(db));
             return Err(MemberLookupError::new(
                 db,
@@ -6674,14 +6675,13 @@ impl<'db> Type<'db> {
         let result = if matches!(
             result.err().map(|error| error.kind(db)),
             Some(MemberLookupErrorKind::DescriptorGet(_))
-        ) && custom_getattribute.1
-        {
+        ) {
             Ok(result.unwrap_or_else(|error| error.fallback_member(db)))
         } else {
             result
         };
 
-        let result = member_lookup_or_fall_back_to(db, env, result, || custom_getattribute.0);
+        let result = member_lookup_or_fall_back_to(db, env, result, || custom_getattribute);
         member_lookup_or_fall_back_to(db, env, result, custom_getattr_result)
     }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -638,6 +638,12 @@ impl<'db> ClassLiteral<'db> {
 
     /// Return whether this class directly or indirectly inherits from an explicit `Any` base.
     pub(super) fn inherits_from_explicit_any(self, db: &'db dyn Db) -> bool {
+        if let Some(class) = self.as_static()
+            && (class.known(db).is_some() || !class.has_explicit_bases(db))
+        {
+            return false;
+        }
+
         self.instance_flags(db)
             .contains(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY)
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -111,7 +111,7 @@ fn dynamic_class_header_range<'db>(
 }
 
 bitflags::bitflags! {
-    /// Properties that affect the representation of instances of a class.
+    /// Properties shared by all instances of a class.
     ///
     /// This combines properties derived from the MRO into the existing class-classification
     /// query, avoiding a separate cached query for each property.
@@ -121,6 +121,10 @@ bitflags::bitflags! {
         const TYPED_DICT = 1 << 0;
         /// The class directly or indirectly inherits from an explicit `Any` base.
         const INHERITS_FROM_EXPLICIT_ANY = 1 << 1;
+        /// The class may define or inherit a custom `__getattribute__` method.
+        const HAS_CUSTOM_GETATTRIBUTE = 1 << 2;
+        /// An unknown base may provide an attribute-interception method.
+        const HAS_DYNAMIC_GETATTRIBUTE = 1 << 3;
     }
 }
 
@@ -610,7 +614,7 @@ impl<'db> ClassLiteral<'db> {
         MroIterator::new(db, self, None)
     }
 
-    /// Return the properties that affect how instances of this class are represented.
+    /// Return the properties shared by all instances of this class.
     fn instance_flags(self, db: &'db dyn Db) -> ClassInstanceFlags {
         match self {
             Self::Static(literal) => literal.instance_flags(db),
@@ -636,6 +640,28 @@ impl<'db> ClassLiteral<'db> {
     pub(super) fn inherits_from_explicit_any(self, db: &'db dyn Db) -> bool {
         self.instance_flags(db)
             .contains(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY)
+    }
+
+    /// Return whether this class may override Python's default attribute lookup.
+    ///
+    /// Dynamically constructed classes are checked conservatively because their namespaces are
+    /// not represented by a static class-body scope.
+    pub(super) fn has_custom_getattribute(self, db: &'db dyn Db) -> bool {
+        match self {
+            Self::Static(class) => class
+                .instance_flags(db)
+                .contains(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE),
+            Self::Dynamic(_)
+            | Self::DynamicNamedTuple(_)
+            | Self::DynamicTypedDict(_)
+            | Self::DynamicEnum(_) => true,
+        }
+    }
+
+    /// Return whether an unknown base might provide an attribute-interception method.
+    pub(super) fn has_dynamic_getattribute(self, db: &'db dyn Db) -> bool {
+        self.instance_flags(db)
+            .contains(ClassInstanceFlags::HAS_DYNAMIC_GETATTRIBUTE)
     }
 
     /// Returns the metaclass of this class.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -615,7 +615,7 @@ impl<'db> ClassLiteral<'db> {
     }
 
     /// Return the properties shared by all instances of this class.
-    fn instance_flags(self, db: &'db dyn Db) -> ClassInstanceFlags {
+    pub(super) fn instance_flags(self, db: &'db dyn Db) -> ClassInstanceFlags {
         match self {
             Self::Static(literal) => literal.instance_flags(db),
             Self::DynamicTypedDict(_) => ClassInstanceFlags::TYPED_DICT,
@@ -640,32 +640,6 @@ impl<'db> ClassLiteral<'db> {
     pub(super) fn inherits_from_explicit_any(self, db: &'db dyn Db) -> bool {
         self.instance_flags(db)
             .contains(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY)
-    }
-
-    /// Return whether this class or a known base overrides Python's default attribute lookup.
-    ///
-    /// Dynamically constructed classes are checked conservatively because their namespaces are
-    /// not represented by a static class-body scope. Unknown bases are considered separately by
-    /// [`Self::has_dynamic_getattribute`].
-    pub(super) fn has_custom_getattribute(self, db: &'db dyn Db) -> bool {
-        match self {
-            Self::Static(class) => class
-                .instance_flags(db)
-                .contains(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE),
-            Self::Dynamic(_)
-            | Self::DynamicNamedTuple(_)
-            | Self::DynamicTypedDict(_)
-            | Self::DynamicEnum(_) => true,
-        }
-    }
-
-    /// Return whether an unknown base might provide `__getattribute__`.
-    ///
-    /// Such an interceptor cannot invalidate a definitely defined member, but it may supply a
-    /// missing attribute or bypass a malformed descriptor.
-    pub(super) fn has_dynamic_getattribute(self, db: &'db dyn Db) -> bool {
-        self.instance_flags(db)
-            .contains(ClassInstanceFlags::HAS_DYNAMIC_GETATTRIBUTE)
     }
 
     /// Returns the metaclass of this class.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -642,10 +642,11 @@ impl<'db> ClassLiteral<'db> {
             .contains(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY)
     }
 
-    /// Return whether this class may override Python's default attribute lookup.
+    /// Return whether this class or a known base overrides Python's default attribute lookup.
     ///
     /// Dynamically constructed classes are checked conservatively because their namespaces are
-    /// not represented by a static class-body scope.
+    /// not represented by a static class-body scope. Unknown bases are considered separately by
+    /// [`Self::has_dynamic_getattribute`].
     pub(super) fn has_custom_getattribute(self, db: &'db dyn Db) -> bool {
         match self {
             Self::Static(class) => class
@@ -658,7 +659,10 @@ impl<'db> ClassLiteral<'db> {
         }
     }
 
-    /// Return whether an unknown base might provide an attribute-interception method.
+    /// Return whether an unknown base might provide `__getattribute__`.
+    ///
+    /// Such an interceptor cannot invalidate a definitely defined member, but it may supply a
+    /// missing attribute or bypass a malformed descriptor.
     pub(super) fn has_dynamic_getattribute(self, db: &'db dyn Db) -> bool {
         self.instance_flags(db)
             .contains(ClassInstanceFlags::HAS_DYNAMIC_GETATTRIBUTE)

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -867,42 +867,52 @@ impl<'db> StaticClassLiteral<'db> {
             .contains(&ClassBase::Class(other))
     }
 
-    /// Return the properties shared by all instances of this class.
-    pub(super) fn instance_flags(self, db: &'db dyn Db) -> ClassInstanceFlags {
-        fn has_own_custom_getattribute<'db>(
-            db: &'db dyn Db,
-            class: StaticClassLiteral<'db>,
-        ) -> bool {
-            if matches!(class.known(db), Some(KnownClass::Object | KnownClass::Type)) {
-                return false;
-            }
-
-            if place_table(db, class.body_scope(db))
-                .symbol_id("__getattribute__")
-                .is_some()
-            {
-                return true;
-            }
-
-            if !class.has_explicit_metaclass(db) {
-                return false;
-            }
-
-            let Some(metaclass) = class.metaclass(db).to_class_type(db) else {
-                return true;
-            };
-
-            metaclass.iter_mro(db).any(|base| match base {
-                ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => true,
-                ClassBase::Class(base) => base.static_class_literal(db).is_none_or(|(base, _)| {
-                    implicit_attribute_names(db, base.body_scope(db))
-                        .binary_search_by(|name| name.as_str().cmp("__getattribute__"))
-                        .is_ok()
-                }),
-                ClassBase::Generic | ClassBase::Protocol | ClassBase::TypedDict(_) => false,
-            })
+    /// Return whether this class defines its own non-default `__getattribute__`.
+    ///
+    /// An explicit metaclass can install the method even when the class body does not define it:
+    ///
+    /// ```python
+    /// def interceptor(self, name): ...
+    ///
+    /// class Meta(type):
+    ///     def __init__(cls, *args):
+    ///         cls.__getattribute__ = interceptor
+    ///
+    /// class Example(metaclass=Meta): ...
+    /// ```
+    fn has_own_custom_getattribute(self, db: &'db dyn Db) -> bool {
+        if matches!(self.known(db), Some(KnownClass::Object | KnownClass::Type)) {
+            return false;
         }
 
+        if place_table(db, self.body_scope(db))
+            .symbol_id("__getattribute__")
+            .is_some()
+        {
+            return true;
+        }
+
+        if !self.has_explicit_metaclass(db) {
+            return false;
+        }
+
+        let Some(metaclass) = self.metaclass(db).to_class_type(db) else {
+            return true;
+        };
+
+        metaclass.iter_mro(db).any(|base| match base {
+            ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => true,
+            ClassBase::Class(base) => base.static_class_literal(db).is_none_or(|(base, _)| {
+                implicit_attribute_names(db, base.body_scope(db))
+                    .binary_search(&Name::new_static("__getattribute__"))
+                    .is_ok()
+            }),
+            ClassBase::Generic | ClassBase::Protocol | ClassBase::TypedDict(_) => false,
+        })
+    }
+
+    /// Return the properties shared by all instances of this class.
+    pub(super) fn instance_flags(self, db: &'db dyn Db) -> ClassInstanceFlags {
         #[salsa::tracked(
             returns(copy),
             cycle_initial=|_, _, _| ClassInstanceFlags::empty(),
@@ -914,48 +924,45 @@ impl<'db> StaticClassLiteral<'db> {
         ) -> ClassInstanceFlags {
             let mut flags = ClassInstanceFlags::empty();
             for base in class.iter_mro(db, None) {
-                if base.is_typed_dict() {
-                    flags.insert(ClassInstanceFlags::TYPED_DICT);
-                }
-                if base.is_explicit_any_base() {
-                    flags.insert(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY);
-                }
-                if match base {
-                    ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => {
+                match base {
+                    ClassBase::Any => flags.insert(
+                        ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY
+                            | ClassInstanceFlags::HAS_DYNAMIC_GETATTRIBUTE,
+                    ),
+                    ClassBase::Dynamic(_) | ClassBase::Divergent(_) => {
                         flags.insert(ClassInstanceFlags::HAS_DYNAMIC_GETATTRIBUTE);
-                        false
                     }
-                    ClassBase::Class(class) => class
-                        .static_class_literal(db)
-                        .is_none_or(|(class, _)| has_own_custom_getattribute(db, class)),
-                    ClassBase::Generic | ClassBase::Protocol | ClassBase::TypedDict(_) => false,
-                } {
-                    flags.insert(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE);
+                    ClassBase::TypedDict(_) => flags.insert(ClassInstanceFlags::TYPED_DICT),
+                    ClassBase::Class(class)
+                        if class
+                            .static_class_literal(db)
+                            .is_none_or(|(class, _)| class.has_own_custom_getattribute(db)) =>
+                    {
+                        flags.insert(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE);
+                    }
+                    ClassBase::Class(_) | ClassBase::Generic | ClassBase::Protocol => {}
                 }
             }
             flags
         }
 
-        if let Some(known) = self.known(db) {
-            let mut flags = if known.is_typed_dict_subclass() {
+        let mut flags = if let Some(known) = self.known(db) {
+            if known.is_typed_dict_subclass() {
                 ClassInstanceFlags::TYPED_DICT
             } else {
                 ClassInstanceFlags::empty()
-            };
-            if has_own_custom_getattribute(db, self) {
-                flags.insert(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE);
             }
-            return flags;
-        }
+        } else if self.has_explicit_bases(db) {
+            return instance_flags_inner(db, self);
+        } else {
+            ClassInstanceFlags::empty()
+        };
 
-        if !self.has_explicit_bases(db) {
-            return if has_own_custom_getattribute(db, self) {
-                ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE
-            } else {
-                ClassInstanceFlags::empty()
-            };
-        }
-        instance_flags_inner(db, self)
+        flags.set(
+            ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE,
+            self.has_own_custom_getattribute(db),
+        );
+        flags
     }
 
     /// Return the module defining the `TypedDict` base of this class.

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -867,8 +867,42 @@ impl<'db> StaticClassLiteral<'db> {
             .contains(&ClassBase::Class(other))
     }
 
-    /// Return the properties that affect how instances of this class are represented.
+    /// Return the properties shared by all instances of this class.
     pub(super) fn instance_flags(self, db: &'db dyn Db) -> ClassInstanceFlags {
+        fn has_own_custom_getattribute<'db>(
+            db: &'db dyn Db,
+            class: StaticClassLiteral<'db>,
+        ) -> bool {
+            if matches!(class.known(db), Some(KnownClass::Object | KnownClass::Type)) {
+                return false;
+            }
+
+            if place_table(db, class.body_scope(db))
+                .symbol_id("__getattribute__")
+                .is_some()
+            {
+                return true;
+            }
+
+            if !class.has_explicit_metaclass(db) {
+                return false;
+            }
+
+            let Some(metaclass) = class.metaclass(db).to_class_type(db) else {
+                return true;
+            };
+
+            metaclass.iter_mro(db).any(|base| match base {
+                ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => true,
+                ClassBase::Class(base) => base.static_class_literal(db).is_none_or(|(base, _)| {
+                    implicit_attribute_names(db, base.body_scope(db))
+                        .binary_search_by(|name| name.as_str().cmp("__getattribute__"))
+                        .is_ok()
+                }),
+                ClassBase::Generic | ClassBase::Protocol | ClassBase::TypedDict(_) => false,
+            })
+        }
+
         #[salsa::tracked(
             returns(copy),
             cycle_initial=|_, _, _| ClassInstanceFlags::empty(),
@@ -886,20 +920,40 @@ impl<'db> StaticClassLiteral<'db> {
                 if base.is_explicit_any_base() {
                     flags.insert(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY);
                 }
+                if match base {
+                    ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => {
+                        flags.insert(ClassInstanceFlags::HAS_DYNAMIC_GETATTRIBUTE);
+                        false
+                    }
+                    ClassBase::Class(class) => class
+                        .static_class_literal(db)
+                        .is_none_or(|(class, _)| has_own_custom_getattribute(db, class)),
+                    ClassBase::Generic | ClassBase::Protocol | ClassBase::TypedDict(_) => false,
+                } {
+                    flags.insert(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE);
+                }
             }
             flags
         }
 
         if let Some(known) = self.known(db) {
-            return if known.is_typed_dict_subclass() {
+            let mut flags = if known.is_typed_dict_subclass() {
                 ClassInstanceFlags::TYPED_DICT
             } else {
                 ClassInstanceFlags::empty()
             };
+            if has_own_custom_getattribute(db, self) {
+                flags.insert(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE);
+            }
+            return flags;
         }
 
         if !self.has_explicit_bases(db) {
-            return ClassInstanceFlags::empty();
+            return if has_own_custom_getattribute(db, self) {
+                ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE
+            } else {
+                ClassInstanceFlags::empty()
+            };
         }
         instance_flags_inner(db, self)
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -975,8 +975,14 @@ impl<'db> StaticClassLiteral<'db> {
     /// Return `true` if this class constitutes a typed dict specification (inherits from
     /// `typing.TypedDict` or `typing_extensions.TypedDict`, either directly or indirectly).
     pub fn is_typed_dict(self, db: &'db dyn Db) -> bool {
-        self.instance_flags(db)
-            .contains(ClassInstanceFlags::TYPED_DICT)
+        if let Some(known) = self.known(db) {
+            return known.is_typed_dict_subclass();
+        }
+
+        self.has_explicit_bases(db)
+            && self
+                .instance_flags(db)
+                .contains(ClassInstanceFlags::TYPED_DICT)
     }
 
     /// Return `true` if this class is, or inherits from, a `NamedTuple` (inherits from

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1806,7 +1806,7 @@ pub(super) fn report_bad_dunder_get_call<'db>(
     }
 }
 
-/// Reports an invalid implicit `__getattr__` call at the original attribute access.
+/// Reports an invalid implicit `__getattr__` or `__getattribute__` call.
 ///
 /// ```python
 /// class C:
@@ -1816,11 +1816,12 @@ pub(super) fn report_bad_dunder_get_call<'db>(
 /// ```
 ///
 /// Preserves the underlying call diagnostic and explains why attribute access invoked the method.
-pub(super) fn report_bad_dunder_getattr_call<'db>(
+pub(super) fn report_bad_attribute_access_call<'db>(
     context: &InferContext<'db, '_>,
     failure: &CallError<'db>,
     object_type: Type<'db>,
     target: &ast::ExprAttribute,
+    method: &str,
 ) {
     let db = context.db();
     let env = &context.program_environment();
@@ -1835,7 +1836,7 @@ pub(super) fn report_bad_dunder_getattr_call<'db>(
                 "Invalid access to attribute `{attribute}` on type `{}`",
                 object_type.display(db, env),
             ),
-            info: "This access implicitly calls `__getattr__`",
+            info: &format!("This access implicitly calls `{method}`"),
             argument_ranges: &[target.range()],
         },
     );

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1821,7 +1821,7 @@ pub(super) fn report_bad_dunder_get_call<'db>(
     }
 }
 
-/// Reports an invalid implicit `__getattr__` call at the original attribute access.
+/// Reports an invalid implicit `__getattr__` or `__getattribute__` call.
 ///
 /// ```python
 /// class C:
@@ -1831,11 +1831,12 @@ pub(super) fn report_bad_dunder_get_call<'db>(
 /// ```
 ///
 /// Preserves the underlying call diagnostic and explains why attribute access invoked the method.
-pub(super) fn report_bad_dunder_getattr_call<'db>(
+pub(super) fn report_bad_attribute_access_call<'db>(
     context: &InferContext<'db, '_>,
     failure: &CallError<'db>,
     object_type: Type<'db>,
     target: &ast::ExprAttribute,
+    method: &str,
 ) {
     let db = context.db();
     let env = &context.program_environment();
@@ -1850,7 +1851,7 @@ pub(super) fn report_bad_dunder_getattr_call<'db>(
                 "Invalid access to attribute `{attribute}` on type `{}`",
                 object_type.display(db, env),
             ),
-            info: "This access implicitly calls `__getattr__`",
+            info: &format!("This access implicitly calls `{method}`"),
             argument_ranges: &[target.range()],
         },
     );

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1821,6 +1821,22 @@ pub(super) fn report_bad_dunder_get_call<'db>(
     }
 }
 
+/// A special method invoked implicitly while accessing an attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AttributeAccessMethod {
+    GetAttr,
+    GetAttribute,
+}
+
+impl AttributeAccessMethod {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::GetAttr => "__getattr__",
+            Self::GetAttribute => "__getattribute__",
+        }
+    }
+}
+
 /// Reports an invalid implicit `__getattr__` or `__getattribute__` call.
 ///
 /// ```python
@@ -1836,7 +1852,7 @@ pub(super) fn report_bad_attribute_access_call<'db>(
     failure: &CallError<'db>,
     object_type: Type<'db>,
     target: &ast::ExprAttribute,
-    method: &str,
+    method: AttributeAccessMethod,
 ) {
     let db = context.db();
     let env = &context.program_environment();
@@ -1851,7 +1867,7 @@ pub(super) fn report_bad_attribute_access_call<'db>(
                 "Invalid access to attribute `{attribute}` on type `{}`",
                 object_type.display(db, env),
             ),
-            info: &format!("This access implicitly calls `{method}`"),
+            info: &format!("This access implicitly calls `{}`", method.as_str()),
             argument_ranges: &[target.range()],
         },
     );


### PR DESCRIPTION
## Summary

Previously, an invalid `__getattribute__` method caused us to discard the implicit call failure even though Python invokes the method before accessing any attribute:

```python
class Example:
    defined: bool = True

    def __getattribute__(self) -> str:
        return "fallback"

Example().defined  # error: [invalid-attribute-access]
Example().missing  # error: [invalid-attribute-access]
```

We now propagate failed implicit `__getattribute__` calls through member lookup, preserve the declared member or method return type for error recovery, and report the invalid call before descriptor or `__getattr__` fallback. This applies to both instance and metaclass attribute access.
