### PR TITLE
[ty] Suppress `unimported-reveal` diagnostics in stub files and `if TYPE_CHECKING` blocks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/reveal_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/reveal_type.md
@@ -38,6 +38,43 @@ fail at runtime:
 reveal_type(1)  # revealed: Literal[1]
 ```
 
+## In type-checking blocks
+
+An unimported `reveal_type` cannot fail at runtime inside a `TYPE_CHECKING` block because that code
+is never executed at runtime.
+
+Note that this test uses `# error: [revealed-type]` assertions instead of the more common
+`# revealed` assertions that we use elsewhere for `reveal_type` calls. `# revealed` assertions
+swallow `undefined-reveal` errors as well as asserting the revealed type, but
+`# error: [revealed-type]` assertions do not also match `undefined-reveal`. This means that an
+unexpected so an unexpected `undefined-reveal` warning would cause these tests to fail.
+
+```py
+from typing import TYPE_CHECKING
+import typing
+
+if TYPE_CHECKING:
+    reveal_type(1)  # error: [revealed-type] "Literal[1]"
+
+    def nested() -> None:
+        reveal_type("nested")  # error: [revealed-type] "nested"
+
+if typing.TYPE_CHECKING:
+    reveal_type(True)  # error: [revealed-type] "Literal[True]"
+```
+
+## In stub files
+
+An unimported `reveal_type` also cannot fail at runtime in a stub file because stub files are never
+executed.
+
+As in the previous section, this test uses `# error: [revealed-type]` rather than `revealed:`
+assertions to ensure that an unexpected `undefined-reveal` warning is not silently matched.
+
+```pyi
+reveal_type(1)  # error: [revealed-type] "Literal[1]"
+```
+
 ## In unreachable code
 
 Make sure that `reveal_type` works even in unreachable code.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9644,7 +9644,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Still not found? It might be `reveal_type`...
             .or_fall_back_to(db, env, || {
                 if symbol_name == "reveal_type" {
-                    if let Some(builder) = self.context.report_lint(&UNDEFINED_REVEAL, name_node) {
+                    if !self.in_stub()
+                        && !self.is_in_type_checking_block(self.scope(), name_node)
+                        && let Some(builder) =
+                            self.context.report_lint(&UNDEFINED_REVEAL, name_node)
+                    {
                         let mut diag =
                             builder.into_diagnostic("`reveal_type` used without importing it");
                         diag.info(


### PR DESCRIPTION
## Summary

Stub files and `if TYPE_CHECKING` blocks are never executed at runtime, so this diagnostic is irrelevant in those contexts.

## Test Plan

mdtests