### PR TITLE
[ty] Add subdiagnostic hint when an open `TypedDict` is not assignable to a certain `Mapping` type, but it would be if it were closed

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -819,6 +819,33 @@ help: A TypedDict is not usually assignable to any `dict[..]` type; `dict` types
 help: Consider using `Mapping[..]` instead of `dict[..]`.
 ```
 
+Assigning an open `TypedDict` to a specialized `Mapping`:
+
+```py
+from collections.abc import Mapping
+from typing import TypedDict
+
+class D(TypedDict):
+    a: int
+    b: int
+
+def f(d: D) -> Mapping[str, int]:
+    return d  # snapshot
+```
+
+```snapshot
+error[invalid-return-type]: Return type does not match returned value
+  --> src/mdtest_snippet.py:40:12
+   |
+39 | def f(d: D) -> Mapping[str, int]:
+   |                ----------------- Expected `Mapping[str, int]` because of return type
+40 |     return d  # snapshot
+   |            ^ expected `Mapping[str, int]`, found `D`
+info: TypedDict `D` is not assignable to `Mapping[str, int]`
+help: `D` would be assignable to this `Mapping` type if it were declared with `closed=True`, but TypedDicts are open by default.
+help: A subclass of `D` could validly add a new field of an arbitrary type, violating subtyping with the `Mapping` type
+```
+
 ## Generic `TypedDict` field conflicts in overload diagnostics
 
 A generic `TypedDict` relation can be unsatisfiable without being the `never` terminal. The

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2156,13 +2156,45 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         )
                     };
                     let result = self.check_type_pair(db, fallback, target);
+
                     if let Some(context) = self.report_context()
                         && result.is_never_satisfied(db, env)
                         && let Type::NominalInstance(instance) = target
-                        && instance.class(db, env).is_known(db, KnownClass::Dict)
                     {
-                        context.push(ErrorContext::TypedDictNotAssignableToDict(typed_dict));
+                        match instance.class(db, env).known(db) {
+                            Some(KnownClass::Dict) => {
+                                context
+                                    .push(ErrorContext::TypedDictNotAssignableToDict(typed_dict));
+                            }
+                            Some(KnownClass::Mapping)
+                                if typed_dict.openness(db).is_implicitly_open() =>
+                            {
+                                let field_types =
+                                    typed_dict.items(db).values().map(|field| field.declared_ty);
+                                let mapping_fallback_spec = &[
+                                    KnownClass::Str.to_instance(db, env),
+                                    UnionType::from_elements(db, env, field_types),
+                                ];
+
+                                let closed_typeddict_fallback = KnownClass::Mapping
+                                    .to_specialized_instance(db, env, mapping_fallback_spec);
+
+                                if self
+                                    .check_type_pair(db, closed_typeddict_fallback, target)
+                                    .is_always_satisfied(db, env)
+                                {
+                                    let context_element =
+                                        ErrorContext::OpenTypedDictNotAssignableToMapping {
+                                            source: typed_dict,
+                                            target,
+                                        };
+                                    context.push(context_element);
+                                }
+                            }
+                            _ => {}
+                        }
                     }
+
                     result
                 })
             }

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -92,6 +92,10 @@ pub(crate) enum ErrorContext<'db> {
         target_field: Type<'db>,
     },
     TypedDictNotAssignableToDict(TypedDictType<'db>),
+    OpenTypedDictNotAssignableToMapping {
+        source: TypedDictType<'db>,
+        target: Type<'db>,
+    },
     IncompatibleReturnTypes {
         source: Type<'db>,
         target: Type<'db>,
@@ -279,6 +283,21 @@ impl<'db> ErrorContext<'db> {
                     source = typed_dict_name(typed_dict)
                 )
             }
+            Self::OpenTypedDictNotAssignableToMapping { source, target } => {
+                let name = source.defining_class().map(|class| class.name(db));
+                help_messages.insert(HelpMessages::OpenTypedDictNotAssignableToMapping {
+                    typed_dict_name: name.cloned(),
+                });
+                help_messages.insert(HelpMessages::ExplainOpenTypedDictUnsoundness {
+                    typed_dict_name: name.cloned(),
+                });
+
+                format!(
+                    "{source} is not assignable to `{target}`",
+                    source = typed_dict_name(source),
+                    target = target.display(db, env)
+                )
+            }
             Self::IncompatibleReturnTypes { source, target } => format!(
                 "incompatible return types: `{source}` is not assignable to `{target}`",
                 source = source.display(db, env),
@@ -426,6 +445,8 @@ enum HelpMessages {
     ConsiderUsingMappingInsteadOfDict,
     TopCallableExplanation,
     ConsiderAddingADefaultValue { parameter_name: Option<Name> },
+    OpenTypedDictNotAssignableToMapping { typed_dict_name: Option<Name> },
+    ExplainOpenTypedDictUnsoundness { typed_dict_name: Option<Name> },
 }
 
 impl std::fmt::Display for HelpMessages {
@@ -439,6 +460,22 @@ impl std::fmt::Display for HelpMessages {
             }
             HelpMessages::ConsiderUsingMappingInsteadOfDict => {
                 f.write_str("Consider using `Mapping[..]` instead of `dict[..]`.")
+            }
+            HelpMessages::OpenTypedDictNotAssignableToMapping {typed_dict_name} => {
+                let name = typed_dict_name.as_ref().map(|name|format!("`{name}`")).unwrap_or_else(||"this TypedDict".to_string());
+                write!(
+                    f,
+                    "{name} would be assignable to this `Mapping` type \
+                    if it were declared with `closed=True`, but TypedDicts are open by default."
+                )
+            }
+            HelpMessages::ExplainOpenTypedDictUnsoundness {typed_dict_name} => {
+                let name = typed_dict_name.as_ref().map(|name|format!("`{name}`")).unwrap_or_else(||"this TypedDict".to_string());
+                write!(
+                    f,
+                    "A subclass of {name} could validly add a new field of an arbitrary type, \
+                    violating subtyping with the `Mapping` type"
+                )
             }
             HelpMessages::TopCallableExplanation => f.write_str(
                 "This type includes all possible parameter sets, \


### PR DESCRIPTION
Closes https://github.com/astral-sh/ty/issues/4184