### PR TITLE
Render suggestion applicability note through annotate-snippets

### DIFF
--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -69,6 +69,7 @@ impl<'a> FullRenderer<'a> {
                     Diff::from_diagnostic(diag, &stylesheet, self.resolver, self.config)
             {
                 write!(f, "{diff}")?;
+                write_applicability_note(diff.fix, &stylesheet, f)?;
             }
 
             writeln!(f)?;
@@ -294,8 +295,6 @@ impl<'a> Diff<'a> {
 
             self.write_gutter(f, digit_with)?;
         }
-
-        write_applicability_note(self.fix, self.stylesheet, f)?;
 
         Ok(())
     }

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -356,35 +356,26 @@ fn write_applicability_note(
     stylesheet: &DiagnosticStylesheet,
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
-    match fix.applicability() {
-        Applicability::Safe => {}
-        Applicability::Unsafe => {
-            writeln!(
-                f,
-                "{note}: {msg}",
-                note = fmt_styled("note", stylesheet.warning),
-                msg = fmt_styled(
-                    "This is an unsafe fix and may change runtime behavior",
-                    stylesheet.emphasis
-                )
-            )?;
-        }
-        Applicability::DisplayOnly => {
+    let (style, message) = match fix.applicability() {
+        Applicability::Safe => return Ok(()),
+        Applicability::Unsafe => (
+            stylesheet.warning,
+            "This is an unsafe fix and may change runtime behavior",
+        ),
+        Applicability::DisplayOnly => (
             // Note that this is still only used in tests. There's no `--display-only-fixes`
             // analog to `--unsafe-fixes` for users to activate this or see the styling.
-            writeln!(
-                f,
-                "{note}: {msg}",
-                note = fmt_styled("note", stylesheet.error),
-                msg = fmt_styled(
-                    "This is a display-only fix and is likely to be incorrect",
-                    stylesheet.emphasis
-                )
-            )?;
-        }
-    }
+            stylesheet.error,
+            "This is a display-only fix and is likely to be incorrect",
+        ),
+    };
 
-    Ok(())
+    writeln!(
+        f,
+        "{note}: {message}",
+        note = fmt_styled("note", style),
+        message = fmt_styled(message, stylesheet.emphasis),
+    )
 }
 
 #[cfg(test)]

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -295,7 +295,7 @@ impl<'a> Diff<'a> {
             self.write_gutter(f, digit_with)?;
         }
 
-        Self::write_applicability_note(self.fix, self.stylesheet, f)?;
+        write_applicability_note(self.fix, self.stylesheet, f)?;
 
         Ok(())
     }
@@ -307,42 +307,6 @@ impl<'a> Diff<'a> {
             line = fmt_styled(Line { index: None, width }, self.stylesheet.line_no),
             separator = fmt_styled("|", self.stylesheet.line_no),
         )
-    }
-
-    fn write_applicability_note(
-        fix: &Fix,
-        stylesheet: &DiagnosticStylesheet,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        match fix.applicability() {
-            Applicability::Safe => {}
-            Applicability::Unsafe => {
-                writeln!(
-                    f,
-                    "{note}: {msg}",
-                    note = fmt_styled("note", stylesheet.warning),
-                    msg = fmt_styled(
-                        "This is an unsafe fix and may change runtime behavior",
-                        stylesheet.emphasis
-                    )
-                )?;
-            }
-            Applicability::DisplayOnly => {
-                // Note that this is still only used in tests. There's no `--display-only-fixes`
-                // analog to `--unsafe-fixes` for users to activate this or see the styling.
-                writeln!(
-                    f,
-                    "{note}: {msg}",
-                    note = fmt_styled("note", stylesheet.error),
-                    msg = fmt_styled(
-                        "This is a display-only fix and is likely to be incorrect",
-                        stylesheet.emphasis
-                    )
-                )?;
-            }
-        }
-
-        Ok(())
     }
 }
 
@@ -385,6 +349,42 @@ fn show_nonprinting(s: &str) -> Cow<'_, str> {
     } else {
         Cow::Borrowed(s)
     }
+}
+
+fn write_applicability_note(
+    fix: &Fix,
+    stylesheet: &DiagnosticStylesheet,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    match fix.applicability() {
+        Applicability::Safe => {}
+        Applicability::Unsafe => {
+            writeln!(
+                f,
+                "{note}: {msg}",
+                note = fmt_styled("note", stylesheet.warning),
+                msg = fmt_styled(
+                    "This is an unsafe fix and may change runtime behavior",
+                    stylesheet.emphasis
+                )
+            )?;
+        }
+        Applicability::DisplayOnly => {
+            // Note that this is still only used in tests. There's no `--display-only-fixes`
+            // analog to `--unsafe-fixes` for users to activate this or see the styling.
+            writeln!(
+                f,
+                "{note}: {msg}",
+                note = fmt_styled("note", stylesheet.error),
+                msg = fmt_styled(
+                    "This is a display-only fix and is likely to be incorrect",
+                    stylesheet.emphasis
+                )
+            )?;
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -3,7 +3,9 @@ use std::num::NonZeroUsize;
 
 use similar::{ChangeTag, DiffOp, TextDiff};
 
-use annotate_snippets::Renderer as AnnotateRenderer;
+use annotate_snippets::{
+    Group as AnnotateGroup, Level as AnnotateLevel, Renderer as AnnotateRenderer,
+};
 use ruff_diagnostics::{Applicability, Fix};
 use ruff_notebook::NotebookIndex;
 use ruff_source_file::OneIndexed;
@@ -69,7 +71,9 @@ impl<'a> FullRenderer<'a> {
                     Diff::from_diagnostic(diag, &stylesheet, self.resolver, self.config)
             {
                 write!(f, "{diff}")?;
-                write_applicability_note(diff.fix, &stylesheet, f)?;
+                if let Some(applicability) = to_applicability_annotate(diff.fix) {
+                    writeln!(f, "{}", renderer.render(&[applicability]))?;
+                }
             }
 
             writeln!(f)?;
@@ -350,31 +354,23 @@ fn show_nonprinting(s: &str) -> Cow<'_, str> {
     }
 }
 
-fn write_applicability_note(
-    fix: &Fix,
-    stylesheet: &DiagnosticStylesheet,
-    f: &mut std::fmt::Formatter<'_>,
-) -> std::fmt::Result {
-    let (style, message) = match fix.applicability() {
-        Applicability::Safe => return Ok(()),
+fn to_applicability_annotate(fix: &Fix) -> Option<AnnotateGroup<'static>> {
+    let (level, message) = match fix.applicability() {
+        Applicability::Safe => return None,
         Applicability::Unsafe => (
-            stylesheet.warning,
+            AnnotateLevel::WARNING,
             "This is an unsafe fix and may change runtime behavior",
         ),
         Applicability::DisplayOnly => (
             // Note that this is still only used in tests. There's no `--display-only-fixes`
             // analog to `--unsafe-fixes` for users to activate this or see the styling.
-            stylesheet.error,
+            AnnotateLevel::ERROR,
             "This is a display-only fix and is likely to be incorrect",
         ),
     };
+    let level = level.with_name("note");
 
-    writeln!(
-        f,
-        "{note}: {message}",
-        note = fmt_styled("note", style),
-        message = fmt_styled(message, stylesheet.emphasis),
-    )
+    Some(AnnotateGroup::with_title(level.primary_title(message)))
 }
 
 #[cfg(test)]

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -295,7 +295,7 @@ impl<'a> Diff<'a> {
             self.write_gutter(f, digit_with)?;
         }
 
-        self.write_applicability_note(f)?;
+        Self::write_applicability_note(self.fix, self.stylesheet, f)?;
 
         Ok(())
     }
@@ -309,17 +309,21 @@ impl<'a> Diff<'a> {
         )
     }
 
-    fn write_applicability_note(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.fix.applicability() {
+    fn write_applicability_note(
+        fix: &Fix,
+        stylesheet: &DiagnosticStylesheet,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        match fix.applicability() {
             Applicability::Safe => {}
             Applicability::Unsafe => {
                 writeln!(
                     f,
                     "{note}: {msg}",
-                    note = fmt_styled("note", self.stylesheet.warning),
+                    note = fmt_styled("note", stylesheet.warning),
                     msg = fmt_styled(
                         "This is an unsafe fix and may change runtime behavior",
-                        self.stylesheet.emphasis
+                        stylesheet.emphasis
                     )
                 )?;
             }
@@ -329,10 +333,10 @@ impl<'a> Diff<'a> {
                 writeln!(
                     f,
                     "{note}: {msg}",
-                    note = fmt_styled("note", self.stylesheet.error),
+                    note = fmt_styled("note", stylesheet.error),
                     msg = fmt_styled(
                         "This is a display-only fix and is likely to be incorrect",
-                        self.stylesheet.emphasis
+                        stylesheet.emphasis
                     )
                 )?;
             }

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -295,6 +295,21 @@ impl<'a> Diff<'a> {
             self.write_gutter(f, digit_with)?;
         }
 
+        self.write_applicability_note(f)?;
+
+        Ok(())
+    }
+
+    fn write_gutter(&self, f: &mut std::fmt::Formatter, width: NonZeroUsize) -> std::fmt::Result {
+        writeln!(
+            f,
+            "{line} {separator}",
+            line = fmt_styled(Line { index: None, width }, self.stylesheet.line_no),
+            separator = fmt_styled("|", self.stylesheet.line_no),
+        )
+    }
+
+    fn write_applicability_note(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.fix.applicability() {
             Applicability::Safe => {}
             Applicability::Unsafe => {
@@ -324,15 +339,6 @@ impl<'a> Diff<'a> {
         }
 
         Ok(())
-    }
-
-    fn write_gutter(&self, f: &mut std::fmt::Formatter, width: NonZeroUsize) -> std::fmt::Result {
-        writeln!(
-            f,
-            "{line} {separator}",
-            line = fmt_styled(Line { index: None, width }, self.stylesheet.line_no),
-            separator = fmt_styled("|", self.stylesheet.line_no),
-        )
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -113,21 +113,7 @@ impl<'a> Diff<'a> {
         })
     }
 
-    fn write_gutter(&self, f: &mut std::fmt::Formatter, width: NonZeroUsize) -> std::fmt::Result {
-        writeln!(
-            f,
-            "{line} {separator}",
-            line = fmt_styled(Line { index: None, width }, self.stylesheet.line_no),
-            separator = fmt_styled("|", self.stylesheet.line_no),
-        )
-    }
-}
-
-/// Limit diffs to a narrow range around each fix rather than diffing the whole file.
-const DIFF_CONTEXT_WINDOW: usize = 3;
-
-impl std::fmt::Display for Diff<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn write(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let source_code = self.diagnostic_source.as_source_code();
         let source_text = source_code.text();
 
@@ -338,6 +324,24 @@ impl std::fmt::Display for Diff<'_> {
         }
 
         Ok(())
+    }
+
+    fn write_gutter(&self, f: &mut std::fmt::Formatter, width: NonZeroUsize) -> std::fmt::Result {
+        writeln!(
+            f,
+            "{line} {separator}",
+            line = fmt_styled(Line { index: None, width }, self.stylesheet.line_no),
+            separator = fmt_styled("|", self.stylesheet.line_no),
+        )
+    }
+}
+
+/// Limit diffs to a narrow range around each fix rather than diffing the whole file.
+const DIFF_CONTEXT_WINDOW: usize = 3;
+
+impl std::fmt::Display for Diff<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.write(f)
     }
 }
 


### PR DESCRIPTION
## Summary

This serves two purposes
- Reduce our duplicating of annotate-snippets
- Prepares for suggestions to be rendered by annotate-snippets

The `Diff::fmt` delegation change mostly exists to reduce the noise in the follow up PR.

## Test Plan

