### PR TITLE
[ty] Restore bottom callable subtyping for gradual prefixes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1821,6 +1821,120 @@ def f(*args: Any, **kwargs: Any) -> Any: ...
 static_assert(not is_subtype_of(RegularCallableTypeOf[f], Callable[[], object]))
 ```
 
+#### Bottom callables with gradual positional prefixes
+
+A callable accepting every argument list is a subtype of a gradual callable with any positional
+prefix when its return type is compatible.
+
+```py
+from typing import Any, Callable, Concatenate, Never
+from ty_extensions import static_assert
+from ty_extensions._internal import RegularCallableTypeOf, is_subtype_of
+
+def bottom(*args: object, **kwargs: object) -> Never:
+    raise Exception()
+
+type BottomCallable = RegularCallableTypeOf[bottom]
+
+static_assert(is_subtype_of(BottomCallable, Callable[Concatenate[int, ...], None]))
+static_assert(is_subtype_of(BottomCallable, Callable[Concatenate[int, str, ...], None]))
+```
+
+A callable with an optional positional-only parameter and a dynamically typed variadic tail is also
+a supertype of the bottom callable.
+
+```py
+def gradual_prefix(value: int = 0, /, *args: Any, **kwargs: Any) -> None: ...
+
+static_assert(is_subtype_of(BottomCallable, RegularCallableTypeOf[gradual_prefix]))
+```
+
+#### Object-variadic callables with matching gradual prefixes
+
+Object-variadic callables are subtypes of gradual callables when their required positional
+parameters match the gradual callable's prefix.
+
+```py
+from typing import Callable, Concatenate
+from ty_extensions import static_assert
+from ty_extensions._internal import RegularCallableTypeOf, is_subtype_of
+
+def positional_or_keyword(value: int, *args: object, **kwargs: object) -> None: ...
+def positional_only(value: int, /, *args: object, **kwargs: object) -> None: ...
+
+type GradualIntCallable = Callable[Concatenate[int, ...], None]
+
+static_assert(is_subtype_of(RegularCallableTypeOf[positional_or_keyword], GradualIntCallable))
+static_assert(is_subtype_of(RegularCallableTypeOf[positional_only], GradualIntCallable))
+```
+
+An unrestricted variadic parameter can satisfy additional positional parameters in the target.
+
+```py
+static_assert(
+    is_subtype_of(
+        RegularCallableTypeOf[positional_only],
+        Callable[Concatenate[int, str, ...], None],
+    )
+)
+```
+
+Unpacked positional parameters are normalized before comparing an unrestricted variadic tail.
+
+```py
+def unpacked_prefix(*args: *tuple[int, *tuple[object, ...]], **kwargs: object) -> None: ...
+
+static_assert(is_subtype_of(RegularCallableTypeOf[unpacked_prefix], GradualIntCallable))
+```
+
+#### Object-variadic callables with incompatible gradual prefixes
+
+A source callable cannot be a subtype when its prefix has an incompatible parameter or requires more
+positional arguments than the target's prefix.
+
+```py
+from typing import Callable, Concatenate
+from ty_extensions import static_assert
+from ty_extensions._internal import RegularCallableTypeOf, is_subtype_of
+
+type GradualIntCallable = Callable[Concatenate[int, ...], None]
+
+def wrong_prefix(value: str, *args: object, **kwargs: object) -> None: ...
+def extra_required(value: int, another: str, *args: object, **kwargs: object) -> None: ...
+
+static_assert(not is_subtype_of(RegularCallableTypeOf[wrong_prefix], GradualIntCallable))
+static_assert(not is_subtype_of(RegularCallableTypeOf[extra_required], GradualIntCallable))
+```
+
+Both variadic parameters must accept every possible argument from the gradual tail.
+
+```py
+def restricted_args(value: int, *args: int, **kwargs: object) -> None: ...
+def restricted_kwargs(value: int, *args: object, **kwargs: int) -> None: ...
+
+static_assert(not is_subtype_of(RegularCallableTypeOf[restricted_args], GradualIntCallable))
+static_assert(not is_subtype_of(RegularCallableTypeOf[restricted_kwargs], GradualIntCallable))
+```
+
+An additional keyword-only parameter also restricts the otherwise unrestricted variadic tail.
+
+```py
+def required_keyword(value: int, *args: object, flag: int, **kwargs: object) -> None: ...
+def optional_keyword(value: int, *args: object, flag: int = 0, **kwargs: object) -> None: ...
+
+static_assert(not is_subtype_of(RegularCallableTypeOf[required_keyword], GradualIntCallable))
+static_assert(not is_subtype_of(RegularCallableTypeOf[optional_keyword], GradualIntCallable))
+```
+
+The return type must remain compatible even when the parameters accept every possible call.
+
+```py
+def wrong_return(value: int, *args: object, **kwargs: object) -> int:
+    return 1
+
+static_assert(not is_subtype_of(RegularCallableTypeOf[wrong_return], GradualIntCallable))
+```
+
 ### Classes with `__call__`
 
 ```py

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3456,6 +3456,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         }
                         target_index += 1;
                     }
+
+                    // Once every fixed source parameter matches the target prefix, an
+                    // object-variadic tail accepts every materialization of the gradual remainder.
+                    // Reject additional fixed or keyword-only parameters: they would make the
+                    // source more restrictive than at least one possible target signature.
+                    if let [source_prefix @ .., variadic, keyword_variadic] =
+                        source_parameters.as_slice()
+                        && source_prefix.len() <= target_prefix_params.len()
+                        && variadic.is_variadic()
+                        && variadic.annotated_type().is_object()
+                        && keyword_variadic.is_keyword_variadic()
+                        && keyword_variadic.annotated_type().is_object()
+                    {
+                        return result;
+                    }
                 }
 
                 _ => {}


### PR DESCRIPTION
## Summary

- Restore bottom-callable subtyping against gradual `Concatenate` signatures after validating their required positional prefixes.
- Accept compatible object-variadic callables while preserving return-type constraints and rejecting signatures that restrict possible arguments.
- Compare normalized callable parameters so unpacked positional prefixes continue to work on current `main`.

Fixes astral-sh/ty#4186.

## Test plan

- Add mdtests for bottom callables with single and multiple gradual positional prefixes, including the optional-prefix shape generated by the failing property test.
- Cover matching positional-only, positional-or-keyword, and unpacked prefixes, plus additional target parameters consumed by an unrestricted variadic tail.
- Verify incompatible prefixes, extra required parameters, restricted variadic arguments, keyword-only restrictions, and incompatible return types remain rejected.
- Exercise the original bottom-callable property and the broader stable type-relation property suite.
