### PR TITLE
[ty] Recognize overlapping NewTypes and their underlying values

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -644,9 +644,11 @@ info: Perhaps you were looking for: `Foo = NewType('Foo', X)`
 info: Definition of class `Foo` will raise `TypeError` at runtime
 ```
 
-## Don't narrow `NewType`-wrapped `Enum`s inside of match arms
+## `NewType`-wrapped enums match their members
 
-`Literal[Foo.X]` is actually disjoint from `N` here:
+A `NewType` constructor returns its argument unchanged, so an enum member can inhabit both its
+literal type and a `NewType` based on the enum. Each arm retains both types, and matching every enum
+member is exhaustive.
 
 ```py
 from enum import Enum
@@ -661,11 +663,12 @@ N = NewType("N", Foo)
 def f(x: N):
     match x:
         case Foo.X:
-            reveal_type(x)  # revealed: N
-        case Foo.Y:
-            reveal_type(x)  # revealed: N
+            reveal_type(x)  # revealed: N & Literal[Foo.X]
+        case Foo.Y as matched:
+            reveal_type(x)  # revealed: N & Literal[Foo.Y]
+            reveal_type(matched)  # revealed: N & Literal[Foo.Y]
         case _:
-            reveal_type(x)  # revealed: N
+            reveal_type(x)  # revealed: Never
 ```
 
 ## The base of a `NewType` can't be a protocol class or a `TypedDict`

--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -13,6 +13,16 @@ def _(user_id: UserId):
     reveal_type(user_id)  # revealed: UserId
 ```
 
+A `NewType` constructor preserves its argument's runtime identity but gives the result its own
+static tag. Applying an unrelated `NewType` constructor replaces the previous tag.
+
+```py
+MediaId = NewType("MediaId", int)
+
+def retag(user_id: UserId) -> None:
+    reveal_type(MediaId(user_id))  # revealed: MediaId
+```
+
 ## Subtyping
 
 The basic purpose of `NewType` is that it acts like a subtype of its base, but not the exact same
@@ -646,9 +656,9 @@ info: Definition of class `Foo` will raise `TypeError` at runtime
 
 ## `NewType`-wrapped enums match their members
 
-A `NewType` constructor returns its argument unchanged, so an enum member can inhabit both its
-literal type and a `NewType` based on the enum. Each arm retains both types, and matching every enum
-member is exhaustive.
+A `NewType` constructor returns its argument unchanged at runtime, and an ordinary literal does not
+restrict `NewType` tags. An enum member can therefore inhabit both its literal type and a `NewType`
+based on the enum. Each arm retains both types, and matching every enum member is exhaustive.
 
 ```py
 from enum import Enum

--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -19,8 +19,7 @@ static tag. Applying an unrelated `NewType` constructor replaces the previous ta
 ```py
 MediaId = NewType("MediaId", int)
 
-def retag(user_id: UserId) -> None:
-    reveal_type(MediaId(user_id))  # revealed: MediaId
+reveal_type(MediaId(UserId(1)))  # revealed: MediaId
 ```
 
 ## Subtyping
@@ -674,9 +673,8 @@ def f(x: N):
     match x:
         case Foo.X:
             reveal_type(x)  # revealed: N & Literal[Foo.X]
-        case Foo.Y as matched:
+        case Foo.Y:
             reveal_type(x)  # revealed: N & Literal[Foo.Y]
-            reveal_type(matched)  # revealed: N & Literal[Foo.Y]
         case _:
             reveal_type(x)  # revealed: Never
 ```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -67,9 +67,8 @@ def f(x: str, y: int):
     reveal_type(x is not y)  # revealed: Literal[True]
 ```
 
-but simple disjointness is not enough -- these two `NewType`s are disjoint, yet `B(True)` shares the
-same memory address as `C(True)`. Disjointness of the nominal-instance types *backing* the `NewType`
-is the necessary precondition:
+Distinct `NewType`s with compatible bases are not disjoint: their constructors return their
+arguments unchanged, so `B(True)` and `C(True)` share the same memory address.
 
 ```py
 from typing import NewType, Literal
@@ -78,8 +77,8 @@ from ty_extensions._internal import is_disjoint_from
 B = NewType("B", bool)
 C = NewType("C", bool)
 
-reveal_type(is_disjoint_from(B, C))  # revealed: ConstraintSet[Literal[True]]
-reveal_type(is_disjoint_from(B, Literal[True]))  # revealed: ConstraintSet[Literal[True]]
+reveal_type(is_disjoint_from(B, C))  # revealed: ConstraintSet[Literal[False]]
+reveal_type(is_disjoint_from(B, Literal[True]))  # revealed: ConstraintSet[Literal[False]]
 
 def f(x: B, y: C):
     reveal_type(x is y)  # revealed: bool

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -80,7 +80,6 @@ C = NewType("C", bool)
 
 reveal_type(is_disjoint_from(B, C))  # revealed: ConstraintSet[Literal[True]]
 reveal_type(is_disjoint_from(B, Literal[True]))  # revealed: ConstraintSet[Literal[False]]
-reveal_type(is_disjoint_from(C, Literal[True]))  # revealed: ConstraintSet[Literal[False]]
 
 def f(x: B, y: C):
     reveal_type(x is y)  # revealed: bool

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -67,8 +67,9 @@ def f(x: str, y: int):
     reveal_type(x is not y)  # revealed: Literal[True]
 ```
 
-Distinct `NewType`s with compatible bases are not disjoint: their constructors return their
-arguments unchanged, so `B(True)` and `C(True)` share the same memory address.
+Distinct `NewType` tags are mutually exclusive, so their types are disjoint. Their constructors
+still return their arguments unchanged: `B(True)` and `C(True)` have different tags but share the
+same memory address, so an identity comparison can succeed.
 
 ```py
 from typing import NewType, Literal
@@ -77,8 +78,9 @@ from ty_extensions._internal import is_disjoint_from
 B = NewType("B", bool)
 C = NewType("C", bool)
 
-reveal_type(is_disjoint_from(B, C))  # revealed: ConstraintSet[Literal[False]]
+reveal_type(is_disjoint_from(B, C))  # revealed: ConstraintSet[Literal[True]]
 reveal_type(is_disjoint_from(B, Literal[True]))  # revealed: ConstraintSet[Literal[False]]
+reveal_type(is_disjoint_from(C, Literal[True]))  # revealed: ConstraintSet[Literal[False]]
 
 def f(x: B, y: C):
     reveal_type(x is y)  # revealed: bool

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -133,29 +133,6 @@ def f(value: Not[UserId]) -> None:
     reveal_type(value is 1)  # revealed: bool
 ```
 
-`LiteralString` describes how a string was constructed rather than which runtime object it is. A
-string excluded from `LiteralString` can therefore still be identical to a particular string
-literal.
-
-```py
-from typing_extensions import LiteralString
-from ty_extensions import Intersection
-
-def f(value: Not[LiteralString], nonliteral_string: Intersection[str, Not[LiteralString]]) -> None:
-    reveal_type(value is "hello")  # revealed: bool
-    reveal_type(nonliteral_string is not "hello")  # revealed: bool
-```
-
-A string literal determines its value, not the identity of its runtime object. Negating that literal
-excludes every other string literal with the same value, so the identity comparison is definite.
-
-```py
-from typing import Literal
-
-def f(value: Not[Literal["hello"]]) -> None:
-    reveal_type(value is "hello")  # revealed: Literal[False]
-```
-
 After `not isinstance(value, B)`, `value` cannot be identical to a `B` instance. This remains true
 when `value` has also been narrowed to `A`, so the inner branch is unreachable.
 

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -131,7 +131,6 @@ UserId = NewType("UserId", int)
 
 def f(value: Not[UserId]) -> None:
     reveal_type(value is 1)  # revealed: bool
-    reveal_type(value is not 1)  # revealed: bool
 ```
 
 `LiteralString` describes how a string was constructed rather than which runtime object it is. A
@@ -155,7 +154,6 @@ from typing import Literal
 
 def f(value: Not[Literal["hello"]]) -> None:
     reveal_type(value is "hello")  # revealed: Literal[False]
-    reveal_type(value is not "hello")  # revealed: Literal[True]
 ```
 
 After `not isinstance(value, B)`, `value` cannot be identical to a `B` instance. This remains true

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -144,8 +144,6 @@ from ty_extensions import Intersection
 
 def f(value: Not[LiteralString], nonliteral_string: Intersection[str, Not[LiteralString]]) -> None:
     reveal_type(value is "hello")  # revealed: bool
-    reveal_type(value is not "hello")  # revealed: bool
-    reveal_type(nonliteral_string is "hello")  # revealed: bool
     reveal_type(nonliteral_string is not "hello")  # revealed: bool
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -121,6 +121,45 @@ def f(value: Not[E]) -> None:
         value.does_not_exist  # no error (unreachable branch)
 ```
 
+A `NewType` exclusion cannot exclude the runtime objects of its base: an unbranded integer can still
+be identical to the integer passed into the `NewType` constructor.
+
+```py
+from typing import NewType
+
+UserId = NewType("UserId", int)
+
+def f(value: Not[UserId]) -> None:
+    reveal_type(value is 1)  # revealed: bool
+    reveal_type(value is not 1)  # revealed: bool
+```
+
+`LiteralString` describes how a string was constructed rather than which runtime object it is. A
+string excluded from `LiteralString` can therefore still be identical to a particular string
+literal.
+
+```py
+from typing_extensions import LiteralString
+from ty_extensions import Intersection
+
+def f(value: Not[LiteralString], nonliteral_string: Intersection[str, Not[LiteralString]]) -> None:
+    reveal_type(value is "hello")  # revealed: bool
+    reveal_type(value is not "hello")  # revealed: bool
+    reveal_type(nonliteral_string is "hello")  # revealed: bool
+    reveal_type(nonliteral_string is not "hello")  # revealed: bool
+```
+
+A specific string literal does identify a runtime value, so excluding it still makes the identity
+comparison definite.
+
+```py
+from typing import Literal
+
+def f(value: Not[Literal["hello"]]) -> None:
+    reveal_type(value is "hello")  # revealed: Literal[False]
+    reveal_type(value is not "hello")  # revealed: Literal[True]
+```
+
 After `not isinstance(value, B)`, `value` cannot be identical to a `B` instance. This remains true
 when `value` has also been narrowed to `A`, so the inner branch is unreachable.
 

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -147,7 +147,7 @@ def f(value: Not[LiteralString], nonliteral_string: Intersection[str, Not[Litera
 ```
 
 A string literal determines its value, not the identity of its runtime object. Negating that literal
-excludes every object with the same value, so the identity comparison is definite.
+excludes every other string literal with the same value, so the identity comparison is definite.
 
 ```py
 from typing import Literal

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -121,8 +121,8 @@ def f(value: Not[E]) -> None:
         value.does_not_exist  # no error (unreachable branch)
 ```
 
-A `NewType` exclusion removes its static tag, not the runtime objects of its base: an integer
-without that tag can still be identical to the integer passed into the `NewType` constructor.
+A `NewType` negation removes its static tag, not the runtime objects of its base: an integer without
+that tag can still be identical to the integer passed into the `NewType` constructor.
 
 ```py
 from typing import NewType
@@ -147,8 +147,8 @@ def f(value: Not[LiteralString], nonliteral_string: Intersection[str, Not[Litera
     reveal_type(nonliteral_string is not "hello")  # revealed: bool
 ```
 
-A specific string literal does identify a runtime value, so excluding it still makes the identity
-comparison definite.
+A string literal determines its value, not the identity of its runtime object. Negating that literal
+excludes every object with the same value, so the identity comparison is definite.
 
 ```py
 from typing import Literal

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -121,8 +121,8 @@ def f(value: Not[E]) -> None:
         value.does_not_exist  # no error (unreachable branch)
 ```
 
-A `NewType` exclusion cannot exclude the runtime objects of its base: an unbranded integer can still
-be identical to the integer passed into the `NewType` constructor.
+A `NewType` exclusion removes its static tag, not the runtime objects of its base: an integer
+without that tag can still be identical to the integer passed into the `NewType` constructor.
 
 ```py
 from typing import NewType

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -449,6 +449,21 @@ def example_type_bool_type_str(
     reveal_type(i)  # revealed: Never
 ```
 
+An integer-based `NewType` is disjoint from `bool`, regardless of the intersection element order.
+
+```py
+from typing import NewType
+
+UserId = NewType("UserId", int)
+
+def newtype_intersections(
+    user_bool: UserId & bool,
+    bool_user: bool & UserId,
+) -> None:
+    reveal_type(user_bool)  # revealed: Never
+    reveal_type(bool_user)  # revealed: Never
+```
+
 #### Positive and negative contributions
 
 If we intersect a type `X` with the negation `~Y` of a disjoint type `Y`, we can remove the negative

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -463,20 +463,15 @@ OtherUserId = NewType("OtherUserId", int)
 NestedUserId = NewType("NestedUserId", UserId)
 
 static_assert(is_equivalent_to(Intersection[UserId, OtherUserId], Never))
-static_assert(is_equivalent_to(Intersection[OtherUserId, UserId], Never))
 static_assert(is_equivalent_to(Intersection[NestedUserId, OtherUserId], Never))
 
 def newtype_intersections(
     user_bool: UserId & bool,
-    bool_user: bool & UserId,
     user_nested: UserId & NestedUserId,
-    nested_user: NestedUserId & UserId,
     user_other: UserId & OtherUserId,
 ) -> None:
     reveal_type(user_bool)  # revealed: UserId & bool
-    reveal_type(bool_user)  # revealed: bool & UserId
     reveal_type(user_nested)  # revealed: NestedUserId
-    reveal_type(nested_user)  # revealed: NestedUserId
     reveal_type(user_other)  # revealed: Never
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -449,28 +449,39 @@ def example_type_bool_type_str(
     reveal_type(i)  # revealed: Never
 ```
 
-An integer-based `NewType` can contain a boolean value or the same object as another integer-based
-`NewType`. Intersections retain overlapping brands and simplify brands with disjoint bases.
+Ordinary types accept values with any `NewType` tag, so an integer-based `NewType` can overlap
+`bool`. Distinct `NewType` tags are mutually exclusive even when their runtime values overlap;
+nested `NewType`s retain their relationship with their parent.
 
 ```py
-from typing import NewType
+from typing import Never, NewType
+from ty_extensions import Intersection, static_assert
+from ty_extensions._internal import is_disjoint_from, is_equivalent_to, is_subtype_of
 
 UserId = NewType("UserId", int)
 OtherUserId = NewType("OtherUserId", int)
+NestedUserId = NewType("NestedUserId", UserId)
 StringId = NewType("StringId", str)
+
+static_assert(is_subtype_of(NestedUserId, UserId))
+static_assert(not is_disjoint_from(UserId, NestedUserId))
+static_assert(is_equivalent_to(Intersection[UserId, OtherUserId], Never))
+static_assert(is_equivalent_to(Intersection[OtherUserId, UserId], Never))
+static_assert(is_equivalent_to(Intersection[NestedUserId, OtherUserId], Never))
+static_assert(is_equivalent_to(Intersection[UserId, StringId], Never))
 
 def newtype_intersections(
     user_bool: UserId & bool,
     bool_user: bool & UserId,
     user_other: UserId & OtherUserId,
-    other_user: OtherUserId & UserId,
-    user_string: UserId & StringId,
+    user_nested: UserId & NestedUserId,
+    nested_user: NestedUserId & UserId,
 ) -> None:
     reveal_type(user_bool)  # revealed: UserId & bool
     reveal_type(bool_user)  # revealed: bool & UserId
-    reveal_type(user_other)  # revealed: UserId & OtherUserId
-    reveal_type(other_user)  # revealed: OtherUserId & UserId
-    reveal_type(user_string)  # revealed: Never
+    reveal_type(user_nested)  # revealed: NestedUserId
+    reveal_type(nested_user)  # revealed: NestedUserId
+    reveal_type(user_other)  # revealed: Never
 ```
 
 #### Positive and negative contributions

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -456,19 +456,15 @@ nested `NewType`s retain their relationship with their parent.
 ```py
 from typing import Never, NewType
 from ty_extensions import Intersection, static_assert
-from ty_extensions._internal import is_disjoint_from, is_equivalent_to, is_subtype_of
+from ty_extensions._internal import is_equivalent_to
 
 UserId = NewType("UserId", int)
 OtherUserId = NewType("OtherUserId", int)
 NestedUserId = NewType("NestedUserId", UserId)
-StringId = NewType("StringId", str)
 
-static_assert(is_subtype_of(NestedUserId, UserId))
-static_assert(not is_disjoint_from(UserId, NestedUserId))
 static_assert(is_equivalent_to(Intersection[UserId, OtherUserId], Never))
 static_assert(is_equivalent_to(Intersection[OtherUserId, UserId], Never))
 static_assert(is_equivalent_to(Intersection[NestedUserId, OtherUserId], Never))
-static_assert(is_equivalent_to(Intersection[UserId, StringId], Never))
 
 def newtype_intersections(
     user_bool: UserId & bool,

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -845,6 +845,52 @@ def _(e: (Single | int) & ~Single) -> None:
     reveal_type(e)  # revealed: int
 ```
 
+A `NewType` is preserved when all but one member of its underlying enum are excluded. The resulting
+intersection is also assignable to the remaining member.
+
+```pyi
+from typing import NewType
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_equivalent_to
+
+ColorId = NewType("ColorId", Color)
+NestedColorId = NewType("NestedColorId", ColorId)
+type NestedAlias = NestedColorId
+
+def enum_newtype(value: ColorId & ~(Red | Green), nested: NestedAlias & ~Red & ~Green) -> None:
+    reveal_type(value)  # revealed: ColorId & Literal[Color.BLUE]
+    reveal_type(nested)  # revealed: NestedColorId & Literal[Color.BLUE]
+
+static_assert(is_assignable_to(ColorId & ~(Red | Green), ColorId))
+static_assert(is_assignable_to(ColorId & ~(Red | Green), Blue))
+static_assert(is_equivalent_to(ColorId & ~(Red | Green), ColorId & Blue))
+```
+
+Aliases name the same enum member, while `Flag` members are not exhaustive.
+
+```pyi
+from enum import Flag
+
+class Aliased(Enum):
+    FIRST = 1
+    FIRST_ALIAS = 1
+    LAST = 2
+
+AliasedId = NewType("AliasedId", Aliased)
+
+def aliased_member(value: AliasedId & ~Literal[Aliased.FIRST_ALIAS]) -> None:
+    reveal_type(value)  # revealed: AliasedId & Literal[Aliased.LAST]
+
+class Permission(Flag):
+    READ = 1
+    WRITE = 2
+
+PermissionId = NewType("PermissionId", Permission)
+
+def non_exhaustive(value: PermissionId & ~Literal[Permission.READ]) -> None:
+    reveal_type(value)  # revealed: PermissionId & ~Literal[Permission.READ]
+```
+
 ## Addition of a type to an intersection with many non-disjoint types
 
 This slightly strange-looking test is a regression test for a mistake that was nearly made in a PR:

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -469,9 +469,9 @@ static_assert(is_equivalent_to(Intersection[NestedUserId, OtherUserId], Never))
 def newtype_intersections(
     user_bool: UserId & bool,
     bool_user: bool & UserId,
-    user_other: UserId & OtherUserId,
     user_nested: UserId & NestedUserId,
     nested_user: NestedUserId & UserId,
+    user_other: UserId & OtherUserId,
 ) -> None:
     reveal_type(user_bool)  # revealed: UserId & bool
     reveal_type(bool_user)  # revealed: bool & UserId

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -449,19 +449,28 @@ def example_type_bool_type_str(
     reveal_type(i)  # revealed: Never
 ```
 
-An integer-based `NewType` is disjoint from `bool`, regardless of the intersection element order.
+An integer-based `NewType` can contain a boolean value or the same object as another integer-based
+`NewType`. Intersections retain overlapping brands and simplify brands with disjoint bases.
 
 ```py
 from typing import NewType
 
 UserId = NewType("UserId", int)
+OtherUserId = NewType("OtherUserId", int)
+StringId = NewType("StringId", str)
 
 def newtype_intersections(
     user_bool: UserId & bool,
     bool_user: bool & UserId,
+    user_other: UserId & OtherUserId,
+    other_user: OtherUserId & UserId,
+    user_string: UserId & StringId,
 ) -> None:
-    reveal_type(user_bool)  # revealed: Never
-    reveal_type(bool_user)  # revealed: Never
+    reveal_type(user_bool)  # revealed: UserId & bool
+    reveal_type(bool_user)  # revealed: bool & UserId
+    reveal_type(user_other)  # revealed: UserId & OtherUserId
+    reveal_type(other_user)  # revealed: OtherUserId & UserId
+    reveal_type(user_string)  # revealed: Never
 ```
 
 #### Positive and negative contributions

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -454,16 +454,11 @@ Ordinary types accept values with any `NewType` tag, so an integer-based `NewTyp
 nested `NewType`s retain their relationship with their parent.
 
 ```py
-from typing import Never, NewType
-from ty_extensions import Intersection, static_assert
-from ty_extensions._internal import is_equivalent_to
+from typing import NewType
 
 UserId = NewType("UserId", int)
 OtherUserId = NewType("OtherUserId", int)
 NestedUserId = NewType("NestedUserId", UserId)
-
-static_assert(is_equivalent_to(Intersection[UserId, OtherUserId], Never))
-static_assert(is_equivalent_to(Intersection[NestedUserId, OtherUserId], Never))
 
 def newtype_intersections(
     user_bool: UserId & bool,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1144,6 +1144,7 @@ type RecursiveBrand = BrandedEnumValue | RecursiveBrand
 
 def compare_recursive_brand_to_member(left: RecursiveBrand) -> None:
     if left == EnumValue.VALUE:
+        # TODO: Ideally, this would narrow to `BrandedEnumValue & Literal[EnumValue.VALUE]`.
         reveal_type(left)  # revealed: BrandedEnumValue
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -2215,8 +2215,9 @@ def compare_branded_exclusion(
     other: Literal[IdentityEnum.A, IdentityEnum.B],
 ) -> None:
     if branded == other:
-        reveal_type(branded)  # revealed: WrappedIdentityEnum & ~Literal[IdentityEnum.A]
+        reveal_type(branded)  # revealed: WrappedIdentityEnum & Literal[IdentityEnum.B]
         reveal_type(other)  # revealed: Literal[IdentityEnum.B]
+        accepts_b(branded)
         accepts_b(other)
     else:
         reveal_type(other)  # revealed: Literal[IdentityEnum.A]
@@ -2228,7 +2229,7 @@ def compare_nested_brand(value: NestedAlias, other: Literal[IdentityEnum.A]) -> 
     if value == other:
         reveal_type(value)  # revealed: NestedIdentityEnum & Literal[IdentityEnum.A]
     else:
-        reveal_type(value)  # revealed: NestedIdentityEnum & ~Literal[IdentityEnum.A]
+        reveal_type(value)  # revealed: NestedIdentityEnum & Literal[IdentityEnum.B]
 ```
 
 Distinct branded `IntEnum` classes still compare by their integer values, and custom equality

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1118,8 +1118,8 @@ def _(answer: CoupledInequality):
 
 ## Recursive aliases containing enum domains
 
-Enum domains nested in a recursive alias fall back to general comparison inference. Comparisons
-against specific enum members preserve the `NewType`:
+Comparisons involving recursive enum aliases remain valid. Comparing against a specific enum member
+narrows both branches to their remaining members while preserving any `NewType` tag.
 
 ```toml
 [environment]
@@ -1144,8 +1144,53 @@ type RecursiveBrand = BrandedEnumValue | RecursiveBrand
 
 def compare_recursive_brand_to_member(left: RecursiveBrand) -> None:
     if left == EnumValue.VALUE:
-        # TODO: Ideally, this would narrow to `BrandedEnumValue & Literal[EnumValue.VALUE]`.
-        reveal_type(left)  # revealed: BrandedEnumValue
+        reveal_type(left)  # revealed: BrandedEnumValue & Literal[EnumValue.VALUE]
+    else:
+        reveal_type(left)  # revealed: BrandedEnumValue & Literal[EnumValue.OTHER]
+
+    if left != EnumValue.VALUE:
+        reveal_type(left)  # revealed: BrandedEnumValue & Literal[EnumValue.OTHER]
+    else:
+        reveal_type(left)  # revealed: BrandedEnumValue & Literal[EnumValue.VALUE]
+```
+
+A recursive alias with changing type arguments may introduce values outside its original enum
+domain. Here, `True` compares equal to the integer-valued enum member, so the `bool` alternative
+must remain reachable.
+
+```py
+from enum import IntEnum
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+BrandedNumber = NewType("BrandedNumber", Number)
+type Changing[T] = T | Changing[bool]
+
+def compare_changing_specialization(value: Changing[BrandedNumber]) -> None:
+    if value == Number.ONE:
+        reveal_type(value)  # revealed: (BrandedNumber & Literal[Number.ONE]) | bool
+    else:
+        reveal_type(value)  # revealed: (BrandedNumber & Literal[Number.TWO]) | bool
+```
+
+Mutually recursive aliases can likewise admit values outside their enum domain. Intersecting the
+aliases does not remove their shared `bool` alternative.
+
+```py
+from ty_extensions import Intersection
+
+type RecursiveWithBool = RecursiveWithBrand | bool
+type RecursiveWithBrand = RecursiveWithBool | BrandedNumber
+
+def compare_mutually_recursive_intersection(
+    value: Intersection[RecursiveWithBool, RecursiveWithBrand],
+) -> None:
+    if value == Number.ONE:
+        reveal_type(value)  # revealed: bool | BrandedNumber
+    else:
+        reveal_type(value)  # revealed: bool | BrandedNumber
 ```
 
 ## Known built-in equality behavior

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1119,7 +1119,7 @@ def _(answer: CoupledInequality):
 ## Recursive aliases containing enum domains
 
 Enum domains nested in a recursive alias fall back to general comparison inference. Comparisons
-against specific enum members must also terminate and preserve the `NewType`:
+against specific enum members preserve the `NewType`:
 
 ```toml
 [environment]
@@ -2199,19 +2199,18 @@ def literal_with_erased_identity(value: WrappedIdentityEnum) -> None:
     reveal_type(IdentityEnum.A != value)  # revealed: bool
 ```
 
-When a `WrappedIdentityEnum` value cannot be `IdentityEnum.A`, equality with
-`Literal[IdentityEnum.A, IdentityEnum.B]` leaves only `IdentityEnum.B`. The narrowed value keeps its
-`WrappedIdentityEnum` type, and both operands can be passed to a function accepting
-`Literal[IdentityEnum.B]`.
+When a `WrappedIdentityEnum` value is `IdentityEnum.B`, equality narrows another `IdentityEnum`
+value to the same member. The first value keeps its `WrappedIdentityEnum` type, and both operands
+can be passed to a function accepting `Literal[IdentityEnum.B]`.
 
 ```py
 from typing import Literal, TypeAlias
-from ty_extensions import Intersection, Not
+from ty_extensions import Intersection
 
 def accepts_b(value: Literal[IdentityEnum.B]) -> None: ...
-def compare_branded_exclusion(
-    branded: Intersection[WrappedIdentityEnum, Not[Literal[IdentityEnum.A]]],
-    other: Literal[IdentityEnum.A, IdentityEnum.B],
+def compare_branded_member(
+    branded: Intersection[WrappedIdentityEnum, Literal[IdentityEnum.B]],
+    other: IdentityEnum,
 ) -> None:
     if branded == other:
         reveal_type(branded)  # revealed: WrappedIdentityEnum & Literal[IdentityEnum.B]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1119,7 +1119,7 @@ def _(answer: CoupledInequality):
 ## Recursive aliases containing enum domains
 
 Enum domains nested in a recursive alias fall back to general comparison inference. Comparisons
-against specific enum members must also terminate and preserve any `NewType` brand:
+against specific enum members must also terminate and preserve the `NewType`:
 
 ```toml
 [environment]
@@ -1141,9 +1141,6 @@ def _(left: Recursive, right: EnumValue):
 
 BrandedEnumValue = NewType("BrandedEnumValue", EnumValue)
 type RecursiveBrand = BrandedEnumValue | RecursiveBrand
-
-def compare_recursive_brand(left: RecursiveBrand, right: EnumValue) -> None:
-    reveal_type(left == right)  # revealed: bool
 
 def compare_recursive_brand_to_member(left: RecursiveBrand) -> None:
     if left == EnumValue.VALUE:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -2183,8 +2183,9 @@ def tuple_with_erased_element_identity(value: NeverEqualTupleElement) -> None:
 
 ## Narrowing with NewTypes
 
-`NewType` wrappers erase their distinction at runtime, so comparisons with an identity-based enum
-literal remain ambiguous:
+A `NewType` constructor returns its argument unchanged at runtime. A `WrappedIdentityEnum` value can
+therefore be either `IdentityEnum.A` or `IdentityEnum.B`, so comparing it with `IdentityEnum.A` has
+an unknown result:
 
 ```py
 from enum import Enum
@@ -2201,9 +2202,10 @@ def literal_with_erased_identity(value: WrappedIdentityEnum) -> None:
     reveal_type(IdentityEnum.A != value)  # revealed: bool
 ```
 
-Branded enum values retain their brand after narrowing, while equality transfers only enum-member
-restrictions to the other operand. Excluding a member from the branded operand therefore narrows a
-union of possible members without producing a spurious argument-type error.
+When a `WrappedIdentityEnum` value cannot be `IdentityEnum.A`, equality with
+`Literal[IdentityEnum.A, IdentityEnum.B]` leaves only `IdentityEnum.B`. The narrowed value keeps its
+`WrappedIdentityEnum` type, and both operands can be passed to a function accepting
+`Literal[IdentityEnum.B]`.
 
 ```py
 from typing import Literal, TypeAlias
@@ -2232,8 +2234,9 @@ def compare_nested_brand(value: NestedAlias, other: Literal[IdentityEnum.A]) -> 
         reveal_type(value)  # revealed: NestedIdentityEnum & Literal[IdentityEnum.B]
 ```
 
-Distinct branded `IntEnum` classes still compare by their integer values, and custom equality
-methods continue to determine comparisons after branding.
+`NewType` does not change how an `IntEnum` compares: values from different `IntEnum` classes still
+compare by their integer values. A custom enum `__eq__` method likewise still determines the result
+after its value is passed through a `NewType` constructor.
 
 ```py
 from enum import IntEnum

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1118,7 +1118,8 @@ def _(answer: CoupledInequality):
 
 ## Recursive aliases containing enum domains
 
-Enum domains nested in a recursive alias fall back to general comparison inference:
+Enum domains nested in a recursive alias fall back to general comparison inference. Comparisons
+against specific enum members must also terminate and preserve any `NewType` brand:
 
 ```toml
 [environment]
@@ -1127,6 +1128,7 @@ python-version = "3.12"
 
 ```py
 from enum import Enum
+from typing import NewType
 
 class EnumValue(Enum):
     VALUE = 1
@@ -1136,6 +1138,16 @@ type Recursive = EnumValue | Recursive
 
 def _(left: Recursive, right: EnumValue):
     reveal_type(left == right)  # revealed: bool
+
+BrandedEnumValue = NewType("BrandedEnumValue", EnumValue)
+type RecursiveBrand = BrandedEnumValue | RecursiveBrand
+
+def compare_recursive_brand(left: RecursiveBrand, right: EnumValue) -> None:
+    reveal_type(left == right)  # revealed: bool
+
+def compare_recursive_brand_to_member(left: RecursiveBrand) -> None:
+    if left == EnumValue.VALUE:
+        reveal_type(left)  # revealed: BrandedEnumValue
 ```
 
 ## Known built-in equality behavior
@@ -2187,6 +2199,72 @@ WrappedIdentityEnum = NewType("WrappedIdentityEnum", IdentityEnum)
 def literal_with_erased_identity(value: WrappedIdentityEnum) -> None:
     reveal_type(IdentityEnum.A == value)  # revealed: bool
     reveal_type(IdentityEnum.A != value)  # revealed: bool
+```
+
+Branded enum values retain their brand after narrowing, while equality transfers only enum-member
+restrictions to the other operand. Excluding a member from the branded operand therefore narrows a
+union of possible members without producing a spurious argument-type error.
+
+```py
+from typing import Literal, TypeAlias
+from ty_extensions import Intersection, Not
+
+def accepts_b(value: Literal[IdentityEnum.B]) -> None: ...
+def compare_branded_exclusion(
+    branded: Intersection[WrappedIdentityEnum, Not[Literal[IdentityEnum.A]]],
+    other: Literal[IdentityEnum.A, IdentityEnum.B],
+) -> None:
+    if branded == other:
+        reveal_type(branded)  # revealed: WrappedIdentityEnum & ~Literal[IdentityEnum.A]
+        reveal_type(other)  # revealed: Literal[IdentityEnum.B]
+        accepts_b(other)
+    else:
+        reveal_type(other)  # revealed: Literal[IdentityEnum.A]
+
+NestedIdentityEnum = NewType("NestedIdentityEnum", WrappedIdentityEnum)
+NestedAlias: TypeAlias = NestedIdentityEnum
+
+def compare_nested_brand(value: NestedAlias, other: Literal[IdentityEnum.A]) -> None:
+    if value == other:
+        reveal_type(value)  # revealed: NestedIdentityEnum & Literal[IdentityEnum.A]
+    else:
+        reveal_type(value)  # revealed: NestedIdentityEnum & ~Literal[IdentityEnum.A]
+```
+
+Distinct branded `IntEnum` classes still compare by their integer values, and custom equality
+methods continue to determine comparisons after branding.
+
+```py
+from enum import IntEnum
+
+class FirstNumber(IntEnum):
+    ONE = 1
+    TWO = 2
+
+class SecondNumber(IntEnum):
+    ONE = 1
+    THREE = 3
+
+BrandedFirstNumber = NewType("BrandedFirstNumber", FirstNumber)
+BrandedSecondNumber = NewType("BrandedSecondNumber", SecondNumber)
+
+def compare_branded_int_enums(left: BrandedFirstNumber, right: BrandedSecondNumber) -> None:
+    if left == right:
+        reveal_type(left)  # revealed: BrandedFirstNumber & Literal[FirstNumber.ONE]
+        reveal_type(right)  # revealed: BrandedSecondNumber & Literal[SecondNumber.ONE]
+
+class NeverEqualEnum(Enum):
+    A = 1
+    B = 2
+
+    def __eq__(self, other: object) -> Literal[False]:
+        return False
+
+BrandedNeverEqual = NewType("BrandedNeverEqual", NeverEqualEnum)
+
+def branded_custom_equality(value: BrandedNeverEqual, other: NeverEqualEnum) -> None:
+    reveal_type(value == other)  # revealed: Literal[False]
+    reveal_type(value != other)  # revealed: bool
 ```
 
 ## Narrowing with enums that have custom `__eq__` methods

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -524,121 +524,23 @@ def excluded_runtime_class(not_int: Not[int], other: UserId) -> None:
         reveal_type(other)  # revealed: Never
 ```
 
-## `is` does not transfer `LiteralString`
+## `is` with string types
 
-`LiteralString` records string provenance, not a guarantee shared by every view of the same string
-object. An identity comparison can establish that another value is a string, but cannot transfer
-that provenance. A concrete string literal still identifies its runtime value.
+Identity comparisons preserve existing `LiteralString` narrowing and do not make negated string
+literal comparisons unreachable.
 
 ```py
-from typing import Any, Literal, TypeVar
-from typing_extensions import LiteralString, TypeIs
-from ty_extensions import Intersection, Not
+from typing import Literal
+from typing_extensions import LiteralString
+from ty_extensions import Not
 
 def literal_string(value: object, text: LiteralString) -> None:
     if value is text:
-        reveal_type(value)  # revealed: str
-        reveal_type(text)  # revealed: LiteralString
+        reveal_type(value)  # revealed: LiteralString
 
-def concrete_literal(value: object, text: Literal["hello"]) -> None:
-    if value is text:
-        reveal_type(value)  # revealed: Literal["hello"]
-```
-
-Negating `LiteralString` likewise does not rule out identity with a concrete string.
-
-```py
-def excluded_literal_string(
-    value: Not[LiteralString],
-    text: Intersection[str, Not[LiteralString]],
-    other: Literal["hello"],
-) -> None:
+def negated_string_literal(value: Not[Literal["hello"]]) -> None:
     if value is "hello":
-        reveal_type(value)  # revealed: str & ~LiteralString
-
-    if text is "hello":
-        reveal_type(text)  # revealed: str & ~LiteralString
-
-    if value is other:
-        reveal_type(value)  # revealed: str & ~LiteralString
-        reveal_type(other)  # revealed: Literal["hello"]
-```
-
-A gradual string literal can arise naturally by narrowing an `Any` value. Comparing it with a string
-whose `LiteralString` provenance was negated must not make the reachable branch disappear.
-
-```py
-def is_literal_string(value: str) -> TypeIs[LiteralString]:
-    return False
-
-def gradual_literal_from_narrowing(value: str, untyped: Any) -> None:
-    if not is_literal_string(value):
-        if untyped is "hello":
-            reveal_type(untyped)  # revealed: Any & Literal["hello"]
-            if value is untyped:
-                reveal_type(value)  # revealed: str & ~LiteralString
-```
-
-The same overlap remains possible for an explicitly gradual string literal, including when both
-operands are gradual.
-
-```py
-def annotated_gradual_literal(
-    value: Intersection[str, Not[LiteralString]],
-    other: Intersection[Literal["hello"], Any],
-) -> None:
-    if value is other:
-        reveal_type(value)  # revealed: str & ~LiteralString
-        reveal_type(other)  # revealed: Literal["hello"] & Any
-
-def both_operands_gradual(
-    value: Intersection[str, Any, Not[LiteralString]],
-    other: Intersection[Literal["hello"], Any],
-) -> None:
-    if value is other:
-        reveal_type(value)  # revealed: str & Any & ~LiteralString
-        reveal_type(other)  # revealed: Literal["hello"] & Any
-```
-
-A `LiteralString` negation can also appear in a type variable's bound. Identity preserves the type
-variable without making the concrete-string comparison unreachable.
-
-```py
-NonLiteralStringT = TypeVar("NonLiteralStringT", bound=Intersection[str, Not[LiteralString]])
-
-def excluded_literal_string_in_bound(value: NonLiteralStringT, other: Literal["hello"]) -> None:
-    if value is other:
-        reveal_type(value)  # revealed: NonLiteralStringT@excluded_literal_string_in_bound
-```
-
-The same negation remains compatible with a concrete string when both operands contain additional
-alternatives. Unrelated alternatives are still removed, while compatible alternatives are retained.
-
-```py
-def excluded_literal_string_in_union(
-    value: Intersection[str, Not[LiteralString]] | int,
-    other: Literal["hello"] | bytes,
-) -> None:
-    if value is other:
-        reveal_type(value)  # revealed: str & ~LiteralString
-        reveal_type(other)  # revealed: Literal["hello"]
-
-def excluded_literal_string_with_shared_alternative(
-    value: Intersection[str, Not[LiteralString]] | bytes,
-    other: Literal["hello"] | bytes,
-) -> None:
-    if value is other:
-        reveal_type(value)  # revealed: bytes | (str & ~LiteralString)
-        reveal_type(other)  # revealed: Literal["hello"] | bytes
-```
-
-In contrast, excluding a concrete literal genuinely rules out identity with string literals that
-have that value.
-
-```py
-def excluded_literal(value: Not[Literal["hello"]]) -> None:
-    if value is "hello":
-        reveal_type(value)  # revealed: Never
+        reveal_type(value)  # revealed: ~Literal["hello"]
 ```
 
 ## `is` with `NewType`s

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -462,7 +462,7 @@ def f(value: int | None | EllipsisType, other: T) -> None:
 ## `is` with a negated `NewType`
 
 Excluding a `NewType` removes its invisible tag, not the runtime objects accepted by its
-constructor. An identity comparison must preserve that negation without making a reachable branch
+constructor. An identity comparison preserves that negation without making a reachable branch
 disappear.
 
 ```py
@@ -627,7 +627,8 @@ def excluded_literal_string_with_shared_alternative(
         reveal_type(other)  # revealed: Literal["hello"] | bytes
 ```
 
-In contrast, excluding a concrete literal genuinely rules out identity with that value.
+In contrast, excluding a concrete literal genuinely rules out identity with string literals that
+have that value.
 
 ```py
 def excluded_literal(value: Not[Literal["hello"]]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -28,6 +28,127 @@ def _(x: A, y: A | None):
     reveal_type(y)  # revealed: A | None
 ```
 
+Identity also transfers facts about the shared object, such as whether a string is truthy.
+
+```py
+def truthy_string(value: object, text: str) -> None:
+    if text:
+        if value is text:
+            reveal_type(value)  # revealed: str & ~AlwaysFalsy
+```
+
+## `is` with invariant generic types
+
+A `list[int]` guarantees that values read from the list are integers. That guarantee must hold for
+every reference to the same mutable list: if another reference could treat it as `list[str]`, it
+could append a string that the first reference would then incorrectly read as an integer. An
+identity comparison can therefore transfer the invariant type argument.
+
+```py
+def generic_type(value: object, items: list[int]) -> None:
+    if value is items:
+        reveal_type(value)  # revealed: list[int]
+        reveal_type(items)  # revealed: list[int]
+```
+
+Incompatible invariant specializations cannot describe the same object in soundly typed code.
+
+```py
+def incompatible_generic_types(integers: list[int], strings: list[str]) -> None:
+    reveal_type(integers is strings)  # revealed: Literal[False]
+```
+
+## `is` with covariant generic types
+
+Covariant specializations can describe the same object: an empty tuple belongs to both
+`tuple[int, ...]` and `tuple[str, ...]`. Identity therefore remains possible and preserves both sets
+of type arguments.
+
+```py
+def covariant_generic_type(value: object, items: tuple[int, ...]) -> None:
+    if value is items:
+        reveal_type(value)  # revealed: tuple[int, ...]
+
+def overlapping_generic_types(integers: tuple[int, ...], strings: tuple[str, ...]) -> None:
+    reveal_type(integers is strings)  # revealed: bool
+    if integers is strings:
+        # TODO: Ideally, this intersection would simplify to tuple[()].
+        reveal_type(integers)  # revealed: tuple[int, ...] & tuple[str, ...]
+```
+
+## `is` with a `NewType`
+
+A `NewType` constructor returns its argument unchanged, so its tag belongs to one static view rather
+than the shared object. Identity can establish the underlying type without transferring that tag.
+
+```py
+from typing import NewType
+
+UserId = NewType("UserId", int)
+
+def discard_newtype_tag(value: object, user_id: UserId) -> None:
+    if value is user_id:
+        reveal_type(value)  # revealed: int
+        reveal_type(user_id)  # revealed: UserId
+```
+
+## `is` with unconstrained type variables
+
+An unconstrained type variable can hold a `NewType`. Identity therefore cannot transfer the type
+variable, since doing so would also transfer the `NewType` tag.
+
+```py
+from typing import NewType, TypeVar
+
+T = TypeVar("T")
+UserId = NewType("UserId", int)
+
+def type_variable(value: object, other: T) -> T:
+    if value is other:
+        reveal_type(value)  # revealed: object
+        reveal_type(other)  # revealed: T@type_variable
+    return other
+
+reveal_type(type_variable(1, UserId(1)))  # revealed: UserId
+```
+
+## `is` with bounded type variables
+
+A type variable bounded by `int` can still hold an integer `NewType`. Identity transfers its `int`
+bound without transferring the type variable or its possible `NewType` tag.
+
+```py
+from typing import NewType, TypeVar
+
+BoundedT = TypeVar("BoundedT", bound=int)
+UserId = NewType("UserId", int)
+
+def bounded_type_variable(value: object, other: BoundedT) -> BoundedT:
+    if value is other:
+        reveal_type(value)  # revealed: int
+        reveal_type(other)  # revealed: BoundedT@bounded_type_variable
+    return other
+
+reveal_type(bounded_type_variable(1, UserId(1)))  # revealed: UserId
+```
+
+## `is` with constrained type variables
+
+Identity transfers a constrained type variable's possible runtime types without transferring any
+`NewType` tags in its constraints.
+
+```py
+from typing import NewType, TypeVar
+
+UserId = NewType("UserId", int)
+TaggedChoice = TypeVar("TaggedChoice", UserId, str)
+
+def constrained_type_variable(value: object, other: TaggedChoice) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: int | str
+        reveal_type(other)  # revealed: TaggedChoice@constrained_type_variable
+```
+
 ## Narrowing tagged unions of nominal classes by attribute identity
 
 ```py
@@ -339,15 +460,14 @@ def f(value: int | None | EllipsisType, other: T) -> None:
         reveal_type(value)  # revealed: int | (None & ~T@f) | (EllipsisType & ~T@f)
 ```
 
-## Static exclusions and runtime identity
+## `is` with a negated `NewType`
 
 Excluding a `NewType` removes its invisible tag, not the runtime objects accepted by its
-constructor. An identity comparison must preserve that exclusion without making a reachable branch
+constructor. An identity comparison must preserve that negation without making a reachable branch
 disappear.
 
 ```py
 from typing import Literal, NewType, TypeVar
-from typing_extensions import LiteralString
 from ty_extensions import Intersection, Not
 
 UserId = NewType("UserId", int)
@@ -356,13 +476,12 @@ def excluded_newtype(value: Not[UserId], other: UserId) -> None:
     if value is other:
         reveal_type(value)  # revealed: int & ~UserId
         reveal_type(other)  # revealed: UserId
-        value.does_not_exist  # error: [unresolved-attribute]
 
     if other is value:
         reveal_type(value)  # revealed: int & ~UserId
 ```
 
-A type variable can hide the same static exclusion in its upper bound. The reachable branch must
+A type variable can hide the same static negation in its upper bound. The reachable branch must
 preserve that type variable.
 
 ```py
@@ -375,7 +494,6 @@ def excluded_newtype_in_bound(
 ) -> None:
     if value is other:
         reveal_type(value)  # revealed: ExcludedBound@excluded_newtype_in_bound
-        other.does_not_exist  # error: [unresolved-attribute]
 
     if without_one is other:
         reveal_type(without_one)  # revealed: ExcludedBound@excluded_newtype_in_bound & ~Literal[1]
@@ -394,8 +512,36 @@ def excluded_newtype_in_unions(
         reveal_type(other)  # revealed: UserId
 ```
 
-`LiteralString` describes string provenance, not runtime identity, so excluding it cannot make an
-identity comparison with a concrete string unreachable.
+Unlike a negated `NewType`, a negated runtime class genuinely rules out identity with its instances.
+
+```py
+def excluded_runtime_class(not_int: Not[int], other: UserId) -> None:
+    if not_int is other:
+        reveal_type(not_int)  # revealed: Never
+```
+
+## `is` does not transfer `LiteralString`
+
+`LiteralString` records string provenance, not a guarantee shared by every view of the same string
+object. An identity comparison can establish that another value is a string, but cannot transfer
+that provenance. A concrete string literal still identifies its runtime value.
+
+```py
+from typing import Literal, TypeVar
+from typing_extensions import LiteralString
+from ty_extensions import Intersection, Not
+
+def literal_string(value: object, text: LiteralString) -> None:
+    if value is text:
+        reveal_type(value)  # revealed: str
+        reveal_type(text)  # revealed: LiteralString
+
+def concrete_literal(value: object, text: Literal["hello"]) -> None:
+    if value is text:
+        reveal_type(value)  # revealed: Literal["hello"]
+```
+
+Negating `LiteralString` likewise does not rule out identity with a concrete string.
 
 ```py
 def excluded_literal_string(
@@ -414,16 +560,45 @@ def excluded_literal_string(
         reveal_type(other)  # revealed: Literal["hello"]
 ```
 
-In contrast, excluding a concrete literal or its runtime class genuinely rules out identity.
+A `LiteralString` negation can also appear in a type variable's bound. Identity preserves the type
+variable without making the concrete-string comparison unreachable.
+
+```py
+NonLiteralStringT = TypeVar("NonLiteralStringT", bound=Intersection[str, Not[LiteralString]])
+
+def excluded_literal_string_in_bound(value: NonLiteralStringT, other: Literal["hello"]) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: NonLiteralStringT@excluded_literal_string_in_bound
+        reveal_type(other)  # revealed: Literal["hello"]
+```
+
+The same negation remains compatible with a concrete string when both operands contain additional
+alternatives. Unrelated alternatives are still removed, while compatible alternatives are retained.
+
+```py
+def excluded_literal_string_in_union(
+    value: Intersection[str, Not[LiteralString]] | int,
+    other: Literal["hello"] | bytes,
+) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: str & ~LiteralString
+        reveal_type(other)  # revealed: Literal["hello"]
+
+def excluded_literal_string_with_shared_alternative(
+    value: Intersection[str, Not[LiteralString]] | bytes,
+    other: Literal["hello"] | bytes,
+) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: bytes | (str & ~LiteralString)
+        reveal_type(other)  # revealed: Literal["hello"] | bytes
+```
+
+In contrast, excluding a concrete literal genuinely rules out identity with that value.
 
 ```py
 def excluded_literal(value: Not[Literal["hello"]]) -> None:
     if value is "hello":
         reveal_type(value)  # revealed: Never
-
-def excluded_runtime_class(not_int: Not[int], other: UserId) -> None:
-    if not_int is other:
-        reveal_type(not_int)  # revealed: Never
 ```
 
 ## `is` with `NewType`s
@@ -503,9 +678,19 @@ def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> tuple[Const
     return (left, right)
 ```
 
+A type variable bounded by a `NewType` also carries that `NewType` tag. Identity cannot transfer the
+type variable to an untagged value, but can establish the underlying runtime class.
+
+```py
+def object_with_bounded_newtype(value: object, tagged: BoundedT) -> None:
+    if value is tagged:
+        reveal_type(value)  # revealed: Foo
+        reveal_type(tagged)  # revealed: BoundedT@object_with_bounded_newtype
+```
+
 Every constraint below is a `NewType` based on `EllipsisType`. Although their tags are mutually
-exclusive, all of these values refer to the same `...` object. After an `is not` check, repeating
-the opposite check must be unreachable.
+exclusive, all of these values refer to the same `...` object. An `is not` check therefore removes
+the singleton alternative, making a subsequent `is` check unreachable.
 
 ```py
 from types import EllipsisType
@@ -524,31 +709,34 @@ def same_singleton(first: SingletonA, second: SingletonB) -> None:
         reveal_type(first)  # revealed: SingletonA
         reveal_type(second)  # revealed: SingletonB
 
-def direct(value: SingletonC | int, other: SingletonT) -> None:
+def contradictory_singleton_comparisons(value: SingletonC | int, other: SingletonT) -> None:
     if value is not other:
+        reveal_type(value)  # revealed: int
         if value is other:
             assert_never(value)
 ```
 
-### Narrowing an object to a `NewType` in the true branch
+### Narrowing an object to the generic base of a `NewType`
 
-If an object is identical to a value with a `NewType`, the true branch narrows the object to that
-`NewType` rather than its underlying type.
+Identity does not transfer a `NewType` tag, but it preserves the invariant type arguments of the
+underlying generic type.
 
 ```py
 from typing import NewType
 
-UserId = NewType("UserId", int)
+UserIds = NewType("UserIds", list[int])
 
-def preserve_newtype(x: object, user_id: UserId) -> None:
-    if x is user_id:
-        reveal_type(x)  # revealed: UserId
+def preserve_generic_base(value: object, user_ids: UserIds) -> None:
+    if value is user_ids:
+        reveal_type(value)  # revealed: list[int]
+        reveal_type(user_ids)  # revealed: UserIds
 ```
 
 ### Comparing `NewType`s with literals
 
 Calls to `NewType` return their arguments unchanged. Comparisons with `bool` and `int` literals can
-therefore succeed, so the true branches below remain reachable.
+therefore succeed. Identity transfers the literal value to the tagged operand, but does not transfer
+its `NewType` tag back to the literal.
 
 ```py
 from typing import Literal, NewType
@@ -558,10 +746,10 @@ IntNewType = NewType("IntNewType", int)
 
 def literals(true: Literal[True], b: BoolNewType, forty_two: Literal[42], i: IntNewType) -> None:
     if b is true:
-        reveal_type(true)  # revealed: Literal[True] & BoolNewType
+        reveal_type(true)  # revealed: Literal[True]
         reveal_type(b)  # revealed: BoolNewType & Literal[True]
     if i is forty_two:
-        reveal_type(forty_two)  # revealed: Literal[42] & IntNewType
+        reveal_type(forty_two)  # revealed: Literal[42]
         reveal_type(i)  # revealed: IntNewType & Literal[42]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -48,7 +48,6 @@ identity comparison can therefore transfer the invariant type argument.
 def generic_type(value: object, items: list[int]) -> None:
     if value is items:
         reveal_type(value)  # revealed: list[int]
-        reveal_type(items)  # revealed: list[int]
 ```
 
 Incompatible invariant specializations cannot describe the same object in soundly typed code.
@@ -569,7 +568,6 @@ NonLiteralStringT = TypeVar("NonLiteralStringT", bound=Intersection[str, Not[Lit
 def excluded_literal_string_in_bound(value: NonLiteralStringT, other: Literal["hello"]) -> None:
     if value is other:
         reveal_type(value)  # revealed: NonLiteralStringT@excluded_literal_string_in_bound
-        reveal_type(other)  # revealed: Literal["hello"]
 ```
 
 The same negation remains compatible with a concrete string when both operands contain additional
@@ -625,13 +623,6 @@ def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
         reveal_type(foo1)  # revealed: FooNewType1
         reveal_type(foo2)  # revealed: FooNewType2
 
-def same_object(value: Foo) -> None:
-    first = FooNewType1(value)
-    second = FooNewType2(value)
-    if first is second:
-        reveal_type(first)  # revealed: FooNewType1
-        reveal_type(second)  # revealed: FooNewType2
-
 def union(value: FooNewType1 | None, other: FooNewType2) -> None:
     if value is other:
         reveal_type(value)  # revealed: FooNewType1
@@ -660,22 +651,20 @@ FooNewType4 = NewType("FooNewType4", Foo)
 BoundedT = TypeVar("BoundedT", bound=FooNewType1)
 BoundedU = TypeVar("BoundedU", bound=FooNewType2)
 
-def bounded_typevars(left: BoundedT, right: BoundedU) -> tuple[BoundedT, BoundedU]:
+def bounded_typevars(left: BoundedT, right: BoundedU) -> None:
     reveal_type(left is right)  # revealed: bool
     if left is right:
         reveal_type(left)  # revealed: BoundedT@bounded_typevars
         reveal_type(right)  # revealed: BoundedU@bounded_typevars
-    return (left, right)
 
 ConstrainedT = TypeVar("ConstrainedT", FooNewType1, FooNewType2)
 ConstrainedU = TypeVar("ConstrainedU", FooNewType3, FooNewType4)
 
-def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> tuple[ConstrainedT, ConstrainedU]:
+def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> None:
     reveal_type(left is right)  # revealed: bool
     if left is right:
         reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
         reveal_type(right)  # revealed: ConstrainedU@constrained_typevars
-    return (left, right)
 ```
 
 A type variable bounded by a `NewType` also carries that `NewType` tag. Identity cannot transfer the

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -339,6 +339,92 @@ def f(value: int | None | EllipsisType, other: T) -> None:
         reveal_type(value)  # revealed: int | (None & ~T@f) | (EllipsisType & ~T@f)
 ```
 
+## Static exclusions and runtime identity
+
+Excluding a `NewType` does not exclude the objects accepted by its constructor. An identity
+comparison must preserve that exclusion without making a reachable branch disappear.
+
+```py
+from typing import Literal, NewType, TypeVar
+from typing_extensions import LiteralString
+from ty_extensions import Intersection, Not
+
+UserId = NewType("UserId", int)
+
+def excluded_newtype(value: Not[UserId], other: UserId) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: int & ~UserId
+        reveal_type(other)  # revealed: UserId
+        value.does_not_exist  # error: [unresolved-attribute]
+
+    if other is value:
+        reveal_type(value)  # revealed: int & ~UserId
+        reveal_type(other)  # revealed: UserId
+```
+
+A type variable can hide the same static exclusion in its upper bound. The reachable branch must
+preserve that type variable.
+
+```py
+ExcludedBound = TypeVar("ExcludedBound", bound=Intersection[int, Not[UserId]])
+
+def excluded_newtype_in_bound(
+    value: ExcludedBound,
+    other: UserId,
+    without_one: Intersection[ExcludedBound, Not[Literal[1]]],
+) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: ExcludedBound@excluded_newtype_in_bound
+        other.does_not_exist  # error: [unresolved-attribute]
+
+    if without_one is other:
+        reveal_type(without_one)  # revealed: ExcludedBound@excluded_newtype_in_bound & ~Literal[1]
+```
+
+The same runtime overlap remains reachable when both operands are unions, while genuinely
+incompatible alternatives are removed.
+
+```py
+def excluded_newtype_in_unions(
+    value: Intersection[int, Not[UserId]] | None,
+    other: UserId | bytes,
+) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: int & ~UserId
+        reveal_type(other)  # revealed: UserId
+```
+
+`LiteralString` describes string provenance, not runtime identity, so excluding it cannot make an
+identity comparison with a concrete string unreachable.
+
+```py
+def excluded_literal_string(
+    value: Not[LiteralString],
+    text: Intersection[str, Not[LiteralString]],
+    other: Literal["hello"],
+) -> None:
+    if value is "hello":
+        reveal_type(value)  # revealed: str & ~LiteralString
+
+    if text is "hello":
+        reveal_type(text)  # revealed: str & ~LiteralString
+
+    if value is other:
+        reveal_type(value)  # revealed: str & ~LiteralString
+        reveal_type(other)  # revealed: Literal["hello"]
+```
+
+In contrast, excluding a concrete literal or its runtime class genuinely rules out identity.
+
+```py
+def excluded_runtime_values(value: Not[Literal["hello"]], not_int: Not[int], other: UserId) -> None:
+    if value is "hello":
+        reveal_type(value)  # revealed: Never
+
+    if not_int is other:
+        reveal_type(not_int)  # revealed: Never
+```
+
 ## `is` with `NewType`s
 
 ### Distinct `NewType`s with the same base

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -341,8 +341,9 @@ def f(value: int | None | EllipsisType, other: T) -> None:
 
 ## Static exclusions and runtime identity
 
-Excluding a `NewType` does not exclude the objects accepted by its constructor. An identity
-comparison must preserve that exclusion without making a reachable branch disappear.
+Excluding a `NewType` removes its invisible tag, not the runtime objects accepted by its
+constructor. An identity comparison must preserve that exclusion without making a reachable branch
+disappear.
 
 ```py
 from typing import Literal, NewType, TypeVar
@@ -429,9 +430,9 @@ def excluded_runtime_values(value: Not[Literal["hello"]], not_int: Not[int], oth
 
 ### Distinct `NewType`s with the same base
 
-Calling a `NewType` returns its argument unchanged. Values with distinct `NewType`s over `Foo` can
-therefore be the same object, and their types are not disjoint. The examples below cover direct
-comparisons and narrowing through unions and intersections.
+Distinct `NewType` tags are mutually exclusive, so their types are disjoint even when they have the
+same concrete base. Their constructors still return their arguments unchanged: an identity
+comparison can succeed, but each operand retains only its own tag.
 
 ```py
 from typing import NewType
@@ -446,23 +447,32 @@ FooNewType2 = NewType("FooNewType2", Foo)
 def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
     reveal_type(foo1 is foo2)  # revealed: bool
     if foo1 is foo2:
-        reveal_type(foo1)  # revealed: FooNewType1 & FooNewType2
-        reveal_type(foo2)  # revealed: FooNewType2 & FooNewType1
+        reveal_type(foo1)  # revealed: FooNewType1
+        reveal_type(foo2)  # revealed: FooNewType2
+
+def same_object(value: Foo) -> None:
+    first = FooNewType1(value)
+    second = FooNewType2(value)
+    if first is second:
+        reveal_type(first)  # revealed: FooNewType1
+        reveal_type(second)  # revealed: FooNewType2
 
 def union(value: FooNewType1 | None, other: FooNewType2) -> None:
     if value is other:
-        reveal_type(value)  # revealed: FooNewType1 & FooNewType2
+        reveal_type(value)  # revealed: FooNewType1
+        reveal_type(other)  # revealed: FooNewType2
 
 def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
     if left is right:
-        reveal_type(right)  # revealed: FooNewType2 & FooNewType1 & FooSub
+        reveal_type(left)  # revealed: FooNewType1 & FooSub
+        reveal_type(right)  # revealed: FooNewType2 & FooSub
 ```
 
 ### `NewType`s in `TypeVar` bounds and constraints
 
 `NewType`s inside `TypeVar` bounds and constraints can likewise refer to the same runtime object.
-Comparing the distinct `TypeVar`s below is not always false, and a true branch narrows to their
-intersection.
+Comparing distinct type variables is not always false, but a successful comparison preserves each
+operand's own type variable and tag.
 
 ```py
 from typing import NewType, TypeVar
@@ -477,27 +487,27 @@ FooNewType4 = NewType("FooNewType4", Foo)
 BoundedT = TypeVar("BoundedT", bound=FooNewType1)
 BoundedU = TypeVar("BoundedU", bound=FooNewType2)
 
-def bounded_typevars(left: BoundedT, right: BoundedU) -> tuple[BoundedU, BoundedU]:
+def bounded_typevars(left: BoundedT, right: BoundedU) -> tuple[BoundedT, BoundedU]:
     reveal_type(left is right)  # revealed: bool
     if left is right:
-        reveal_type(left)  # revealed: BoundedT@bounded_typevars & BoundedU@bounded_typevars
-        return (left, left)
-    return (right, right)
+        reveal_type(left)  # revealed: BoundedT@bounded_typevars
+        reveal_type(right)  # revealed: BoundedU@bounded_typevars
+    return (left, right)
 
 ConstrainedT = TypeVar("ConstrainedT", FooNewType1, FooNewType2)
 ConstrainedU = TypeVar("ConstrainedU", FooNewType3, FooNewType4)
 
-def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> tuple[ConstrainedU, ConstrainedU]:
+def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> tuple[ConstrainedT, ConstrainedU]:
     reveal_type(left is right)  # revealed: bool
     if left is right:
-        reveal_type(left)  # revealed: ConstrainedT@constrained_typevars & ConstrainedU@constrained_typevars
-        return (left, left)
-    return (right, right)
+        reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
+        reveal_type(right)  # revealed: ConstrainedU@constrained_typevars
+    return (left, right)
 ```
 
-Every constraint below is a `NewType` based on `EllipsisType`, so `other` always refers to the same
-`...` object as a `SingletonC` value. After an `is not` check, repeating the opposite check must be
-unreachable.
+Every constraint below is a `NewType` based on `EllipsisType`. Although their tags are mutually
+exclusive, all of these values refer to the same `...` object. After an `is not` check, repeating
+the opposite check must be unreachable.
 
 ```py
 from types import EllipsisType
@@ -509,6 +519,12 @@ SingletonB = NewType("SingletonB", EllipsisType)
 SingletonC = NewType("SingletonC", EllipsisType)
 
 SingletonT = TypeVar("SingletonT", SingletonA, SingletonB)
+
+def same_singleton(first: SingletonA, second: SingletonB) -> None:
+    reveal_type(first is second)  # revealed: Literal[True]
+    if first is second:
+        reveal_type(first)  # revealed: SingletonA
+        reveal_type(second)  # revealed: SingletonB
 
 def direct(value: SingletonC | int, other: SingletonT) -> None:
     if value is not other:
@@ -566,6 +582,10 @@ SingletonB = NewType("SingletonB", EllipsisType)
 def singleton_is_not(value: SingletonA | int, other: SingletonB) -> None:
     if value is not other:
         reveal_type(value)  # revealed: int
+
+    if value is other:
+        reveal_type(value)  # revealed: SingletonA
+        reveal_type(other)  # revealed: SingletonB
 ```
 
 ### Comparisons that are always false

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -598,6 +598,9 @@ BoundedU = TypeVar("BoundedU", bound=FooNewType2)
 def bounded_typevars(left: BoundedT, right: BoundedU) -> None:
     reveal_type(left is right)  # revealed: bool
     if left is right:
+        # These are the same object, so substituting `left` for `right` in a return would be
+        # sound. But `BoundedT & BoundedU` is still empty because their `NewType` tags differ;
+        # inferring that intersection could incorrectly make reachable code disappear.
         reveal_type(left)  # revealed: BoundedT@bounded_typevars
         reveal_type(right)  # revealed: BoundedU@bounded_typevars
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -526,8 +526,8 @@ object. An identity comparison can establish that another value is a string, but
 that provenance. A concrete string literal still identifies its runtime value.
 
 ```py
-from typing import Literal, TypeVar
-from typing_extensions import LiteralString
+from typing import Any, Literal, TypeVar
+from typing_extensions import LiteralString, TypeIs
 from ty_extensions import Intersection, Not
 
 def literal_string(value: object, text: LiteralString) -> None:
@@ -557,6 +557,42 @@ def excluded_literal_string(
     if value is other:
         reveal_type(value)  # revealed: str & ~LiteralString
         reveal_type(other)  # revealed: Literal["hello"]
+```
+
+A gradual string literal can arise naturally by narrowing an `Any` value. Comparing it with a string
+whose `LiteralString` provenance was negated must not make the reachable branch disappear.
+
+```py
+def is_literal_string(value: str) -> TypeIs[LiteralString]:
+    return False
+
+def gradual_literal_from_narrowing(value: str, untyped: Any) -> None:
+    if not is_literal_string(value):
+        if untyped is "hello":
+            reveal_type(untyped)  # revealed: Any & Literal["hello"]
+            if value is untyped:
+                reveal_type(value)  # revealed: str & ~LiteralString
+```
+
+The same overlap remains possible for an explicitly gradual string literal, including when both
+operands are gradual.
+
+```py
+def annotated_gradual_literal(
+    value: Intersection[str, Not[LiteralString]],
+    other: Intersection[Literal["hello"], Any],
+) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: str & ~LiteralString
+        reveal_type(other)  # revealed: Literal["hello"] & Any
+
+def both_operands_gradual(
+    value: Intersection[str, Any, Not[LiteralString]],
+    other: Intersection[Literal["hello"], Any],
+) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: str & Any & ~LiteralString
+        reveal_type(other)  # revealed: Literal["hello"] & Any
 ```
 
 A `LiteralString` negation can also appear in a type variable's bound. Identity preserves the type

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -360,7 +360,6 @@ def excluded_newtype(value: Not[UserId], other: UserId) -> None:
 
     if other is value:
         reveal_type(value)  # revealed: int & ~UserId
-        reveal_type(other)  # revealed: UserId
 ```
 
 A type variable can hide the same static exclusion in its upper bound. The reachable branch must
@@ -418,10 +417,11 @@ def excluded_literal_string(
 In contrast, excluding a concrete literal or its runtime class genuinely rules out identity.
 
 ```py
-def excluded_runtime_values(value: Not[Literal["hello"]], not_int: Not[int], other: UserId) -> None:
+def excluded_literal(value: Not[Literal["hello"]]) -> None:
     if value is "hello":
         reveal_type(value)  # revealed: Never
 
+def excluded_runtime_class(not_int: Not[int], other: UserId) -> None:
     if not_int is other:
         reveal_type(not_int)  # revealed: Never
 ```
@@ -460,11 +460,9 @@ def same_object(value: Foo) -> None:
 def union(value: FooNewType1 | None, other: FooNewType2) -> None:
     if value is other:
         reveal_type(value)  # revealed: FooNewType1
-        reveal_type(other)  # revealed: FooNewType2
 
 def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
     if left is right:
-        reveal_type(left)  # revealed: FooNewType1 & FooSub
         reveal_type(right)  # revealed: FooNewType2 & FooSub
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -55,6 +55,9 @@ Incompatible invariant specializations cannot describe the same object in soundl
 ```py
 def incompatible_generic_types(integers: list[int], strings: list[str]) -> None:
     reveal_type(integers is strings)  # revealed: Literal[False]
+    if integers is strings:
+        reveal_type(integers)  # revealed: Never
+        reveal_type(strings)  # revealed: Never
 ```
 
 ## `is` with covariant generic types
@@ -71,8 +74,9 @@ def covariant_generic_type(value: object, items: tuple[int, ...]) -> None:
 def overlapping_generic_types(integers: tuple[int, ...], strings: tuple[str, ...]) -> None:
     reveal_type(integers is strings)  # revealed: bool
     if integers is strings:
-        # TODO: Ideally, this intersection would simplify to tuple[()].
+        # TODO: Ideally, these intersections would simplify to tuple[()].
         reveal_type(integers)  # revealed: tuple[int, ...] & tuple[str, ...]
+        reveal_type(strings)  # revealed: tuple[str, ...] & tuple[int, ...]
 ```
 
 ## `is` with a `NewType`
@@ -517,6 +521,7 @@ Unlike a negated `NewType`, a negated runtime class genuinely rules out identity
 def excluded_runtime_class(not_int: Not[int], other: UserId) -> None:
     if not_int is other:
         reveal_type(not_int)  # revealed: Never
+        reveal_type(other)  # revealed: Never
 ```
 
 ## `is` does not transfer `LiteralString`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -345,7 +345,7 @@ def f(value: int | None | EllipsisType, other: T) -> None:
 
 Calling a `NewType` returns its argument unchanged. Values with distinct `NewType`s over `Foo` can
 therefore be the same object even though their types are disjoint. The examples below cover direct
-comparisons and narrowing through unions and intersections.
+comparisons and narrowing through unions.
 
 ```py
 from typing import NewType
@@ -366,10 +366,15 @@ def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
 def union(value: FooNewType1 | None, other: FooNewType2) -> None:
     if value is other:
         reveal_type(value)  # revealed: FooNewType1
+```
 
+An intersection between a `NewType` and a proper subclass of its base is statically empty, so
+narrowing through that intersection produces `Never`.
+
+```py
 def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
     if left is right:
-        reveal_type(right)  # revealed: FooNewType2 & FooSub
+        reveal_type(right)  # revealed: Never
 ```
 
 ### `NewType`s in `TypeVar` bounds and constraints

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -344,8 +344,8 @@ def f(value: int | None | EllipsisType, other: T) -> None:
 ### Distinct `NewType`s with the same base
 
 Calling a `NewType` returns its argument unchanged. Values with distinct `NewType`s over `Foo` can
-therefore be the same object even though their types are disjoint. The examples below cover direct
-comparisons and narrowing through unions.
+therefore be the same object, and their types are not disjoint. The examples below cover direct
+comparisons and narrowing through unions and intersections.
 
 ```py
 from typing import NewType
@@ -360,28 +360,23 @@ FooNewType2 = NewType("FooNewType2", Foo)
 def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
     reveal_type(foo1 is foo2)  # revealed: bool
     if foo1 is foo2:
-        reveal_type(foo1)  # revealed: FooNewType1
-        reveal_type(foo2)  # revealed: FooNewType2
+        reveal_type(foo1)  # revealed: FooNewType1 & FooNewType2
+        reveal_type(foo2)  # revealed: FooNewType2 & FooNewType1
 
 def union(value: FooNewType1 | None, other: FooNewType2) -> None:
     if value is other:
-        reveal_type(value)  # revealed: FooNewType1
-```
+        reveal_type(value)  # revealed: FooNewType1 & FooNewType2
 
-An intersection between a `NewType` and a proper subclass of its base is statically empty, so
-narrowing through that intersection produces `Never`.
-
-```py
 def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
     if left is right:
-        reveal_type(right)  # revealed: Never
+        reveal_type(right)  # revealed: FooNewType2 & FooNewType1 & FooSub
 ```
 
 ### `NewType`s in `TypeVar` bounds and constraints
 
 `NewType`s inside `TypeVar` bounds and constraints can likewise refer to the same runtime object.
-Comparing the distinct `TypeVar`s below is not always false, and a true branch keeps the original
-`TypeVar`.
+Comparing the distinct `TypeVar`s below is not always false, and a true branch narrows to their
+intersection.
 
 ```py
 from typing import NewType, TypeVar
@@ -399,9 +394,8 @@ BoundedU = TypeVar("BoundedU", bound=FooNewType2)
 def bounded_typevars(left: BoundedT, right: BoundedU) -> tuple[BoundedU, BoundedU]:
     reveal_type(left is right)  # revealed: bool
     if left is right:
-        # TODO: This should narrow to `BoundedT & BoundedU` and avoid the false positive below.
-        reveal_type(left)  # revealed: BoundedT@bounded_typevars
-        return (left, left)  # error: [invalid-return-type]
+        reveal_type(left)  # revealed: BoundedT@bounded_typevars & BoundedU@bounded_typevars
+        return (left, left)
     return (right, right)
 
 ConstrainedT = TypeVar("ConstrainedT", FooNewType1, FooNewType2)
@@ -410,9 +404,8 @@ ConstrainedU = TypeVar("ConstrainedU", FooNewType3, FooNewType4)
 def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> tuple[ConstrainedU, ConstrainedU]:
     reveal_type(left is right)  # revealed: bool
     if left is right:
-        # TODO: This should narrow to `ConstrainedT & ConstrainedU` and avoid the false positive.
-        reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
-        return (left, left)  # error: [invalid-return-type]
+        reveal_type(left)  # revealed: ConstrainedT@constrained_typevars & ConstrainedU@constrained_typevars
+        return (left, left)
     return (right, right)
 ```
 
@@ -465,11 +458,11 @@ IntNewType = NewType("IntNewType", int)
 
 def literals(true: Literal[True], b: BoolNewType, forty_two: Literal[42], i: IntNewType) -> None:
     if b is true:
-        reveal_type(true)  # revealed: Literal[True]
-        reveal_type(b)  # revealed: BoolNewType
+        reveal_type(true)  # revealed: Literal[True] & BoolNewType
+        reveal_type(b)  # revealed: BoolNewType & Literal[True]
     if i is forty_two:
-        reveal_type(forty_two)  # revealed: Literal[42]
-        reveal_type(i)  # revealed: IntNewType
+        reveal_type(forty_two)  # revealed: Literal[42] & IntNewType
+        reveal_type(i)  # revealed: IntNewType & Literal[42]
 ```
 
 ### `is not` with singleton `NewType`s
@@ -487,38 +480,6 @@ SingletonB = NewType("SingletonB", EllipsisType)
 def singleton_is_not(value: SingletonA | int, other: SingletonB) -> None:
     if value is not other:
         reveal_type(value)  # revealed: int
-```
-
-### Static exclusions
-
-The type `~Literal[True]` excludes the literal type but accepts the distinct `BoolNewType`. However,
-`BoolNewType(True)` returns `True` unchanged, so `value is True` can be either true or false.
-
-```py
-from __future__ import annotations
-
-from typing import Literal, NewType
-
-BoolNewType = NewType("BoolNewType", bool)
-
-def excludes_true(value: ~Literal[True]) -> None:
-    reveal_type(value is True)  # revealed: bool
-
-excludes_true(BoolNewType(True))
-```
-
-Similarly, `int & ~Literal[1]` accepts `IntNewType(1)`, which returns the `1` object unchanged, so
-the comparison remains possible.
-
-```py
-from typing import Literal, NewType
-
-IntNewType = NewType("IntNewType", int)
-
-def excludes_one(value: int & ~Literal[1]) -> None:
-    reveal_type(value is 1)  # revealed: bool
-
-excludes_one(IntNewType(1))
 ```
 
 ### Comparisons that are always false

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -334,9 +334,10 @@ else:
 
 ## `NewType` instances and concrete-base subclasses
 
-A `NewType` constructor returns its argument unchanged at runtime, so the resulting value can still
-be an instance of a subclass of its concrete base. For example, `UserId(True)` is valid because
-`bool` is a subtype of `int`, and the returned value remains a `bool`.
+A `NewType` constructor returns its argument unchanged at runtime, and runtime class checks ignore
+its static tag. The resulting value can therefore still be an instance of a subclass of its concrete
+base. For example, `UserId(True)` is valid because `bool` is a subtype of `int`, and the returned
+value remains a `bool`.
 
 ```py
 from typing import NewType

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -334,10 +334,9 @@ else:
 
 ## `NewType` instances and concrete-base subclasses
 
-A `NewType` constructor returns its argument unchanged, so a branded value can still be an instance
-of any subclass accepted by the concrete base. Type checkers accept `UserId(True)` because `bool` is
-a subtype of `int`, so they cannot reliably prevent an integer-based brand from containing a
-boolean.
+A `NewType` constructor returns its argument unchanged at runtime, so the resulting value can still
+be an instance of a subclass of its concrete base. For example, `UserId(True)` is valid because
+`bool` is a subtype of `int`, and the returned value remains a `bool`.
 
 ```py
 from typing import NewType

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -332,6 +332,37 @@ else:
     reveal_type(x)  # revealed: ~A & ~B & ~C
 ```
 
+## `NewType` instances and concrete-base subclasses
+
+A `NewType` constructor returns its argument unchanged, so a branded value can still be an instance
+of any subclass accepted by the concrete base. Type checkers accept `UserId(True)` because `bool` is
+a subtype of `int`, so they cannot reliably prevent an integer-based brand from containing a
+boolean.
+
+```py
+from typing import NewType
+
+class Base: ...
+class Child(Base): ...
+
+BrandedBase = NewType("BrandedBase", Base)
+UserId = NewType("UserId", int)
+
+UserId(True)
+
+def narrow_branded_subclass(value: BrandedBase) -> None:
+    if isinstance(value, Child):
+        reveal_type(value)  # revealed: BrandedBase & Child
+    else:
+        reveal_type(value)  # revealed: BrandedBase & ~Child
+
+def narrow_branded_boolean(value: UserId) -> None:
+    if isinstance(value, bool):
+        reveal_type(value)  # revealed: UserId & bool
+    else:
+        reveal_type(value)  # revealed: UserId & ~bool
+```
+
 ## No narrowing for instances of `builtins.type`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -46,26 +46,15 @@ reveal_type(x)  # revealed: object
 
 ## Class patterns on `NewType` instances
 
-A `NewType` does not change its argument's runtime class. Its values can therefore match class
-patterns for subclasses of the concrete base, including `bool` for a `NewType` based on `int`.
+A `NewType` does not change its argument's runtime class, so an integer-based `NewType` can match a
+`bool` class pattern.
 
 ```py
 from typing import NewType
 
-class Base: ...
-class Child(Base): ...
-
-BrandedBase = NewType("BrandedBase", Base)
 UserId = NewType("UserId", int)
 
-def match_branded_subclass(value: BrandedBase) -> None:
-    match value:
-        case Child():
-            reveal_type(value)  # revealed: BrandedBase & Child
-        case _:
-            reveal_type(value)  # revealed: BrandedBase & ~Child
-
-def match_branded_boolean(value: UserId) -> None:
+def match_newtype_boolean(value: UserId) -> None:
     match value:
         case bool():
             reveal_type(value)  # revealed: UserId & bool
@@ -3431,10 +3420,8 @@ def branded_int_enum_integer_patterns_are_exhaustive(value: BrandedFirst) -> int
 def branded_int_enum_member_patterns_are_exhaustive(value: BrandedFirst) -> int:
     match value:
         case First.ONE:
-            reveal_type(value)  # revealed: BrandedFirst & Literal[First.ONE]
             return 1
         case First.TWO:
-            reveal_type(value)  # revealed: BrandedFirst & Literal[First.TWO]
             return 2
 
 def branded_cross_int_enum_member_patterns(value: BrandedFirst | BrandedSecond) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -3356,6 +3356,7 @@ python-version = "3.11"
 ```py
 from enum import Enum, IntEnum, StrEnum, auto
 from typing import Literal, NewType, assert_never
+from ty_extensions import Intersection
 from ty_extensions._internal import Unknown
 
 class Color(StrEnum):
@@ -3413,6 +3414,11 @@ class Second(IntEnum):
 BrandedFirst = NewType("BrandedFirst", First)
 BrandedSecond = NewType("BrandedSecond", Second)
 
+def branded_int_enum_literal_pattern_is_exhaustive(value: Intersection[BrandedFirst, Literal[First.ONE]]) -> int:
+    match value:
+        case 1:
+            return 1
+
 def branded_int_enum_integer_patterns_are_exhaustive(value: BrandedFirst) -> int:
     match value:
         case 1:
@@ -3436,7 +3442,7 @@ def branded_cross_int_enum_member_patterns(value: BrandedFirst | BrandedSecond) 
         case First.ONE:
             reveal_type(value)  # revealed: (BrandedFirst & Literal[First.ONE]) | (BrandedSecond & Literal[Second.ONE])
         case _:
-            reveal_type(value)  # revealed: (BrandedFirst & ~Literal[First.ONE]) | (BrandedSecond & ~Literal[Second.ONE])
+            reveal_type(value)  # revealed: (BrandedFirst & Literal[First.TWO]) | (BrandedSecond & Literal[Second.TWO])
 
 def cross_int_enum_members(value: First | Second) -> None:
     match value:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -44,6 +44,35 @@ match x:
 reveal_type(x)  # revealed: object
 ```
 
+## Class patterns on `NewType` instances
+
+A `NewType` does not change its argument's runtime class. Its values can therefore match class
+patterns for subclasses of the concrete base, including `bool` for a `NewType` based on `int`.
+
+```py
+from typing import NewType
+
+class Base: ...
+class Child(Base): ...
+
+BrandedBase = NewType("BrandedBase", Base)
+UserId = NewType("UserId", int)
+
+def match_branded_subclass(value: BrandedBase) -> None:
+    match value:
+        case Child():
+            reveal_type(value)  # revealed: BrandedBase & Child
+        case _:
+            reveal_type(value)  # revealed: BrandedBase & ~Child
+
+def match_branded_boolean(value: UserId) -> None:
+    match value:
+        case bool():
+            reveal_type(value)  # revealed: UserId & bool
+        case _:
+            reveal_type(value)  # revealed: UserId & ~bool
+```
+
 ## Class pattern with guard
 
 ```py
@@ -3326,7 +3355,7 @@ python-version = "3.11"
 
 ```py
 from enum import Enum, IntEnum, StrEnum, auto
-from typing import Literal, assert_never
+from typing import Literal, NewType, assert_never
 from ty_extensions._internal import Unknown
 
 class Color(StrEnum):
@@ -3380,6 +3409,34 @@ class First(IntEnum):
 class Second(IntEnum):
     ONE = 1
     TWO = 2
+
+BrandedFirst = NewType("BrandedFirst", First)
+BrandedSecond = NewType("BrandedSecond", Second)
+
+def branded_int_enum_integer_patterns_are_exhaustive(value: BrandedFirst) -> int:
+    match value:
+        case 1:
+            reveal_type(value)  # revealed: BrandedFirst & Literal[First.ONE]
+            return 1
+        case 2:
+            reveal_type(value)  # revealed: BrandedFirst & Literal[First.TWO]
+            return 2
+
+def branded_int_enum_member_patterns_are_exhaustive(value: BrandedFirst) -> int:
+    match value:
+        case First.ONE:
+            reveal_type(value)  # revealed: BrandedFirst & Literal[First.ONE]
+            return 1
+        case First.TWO:
+            reveal_type(value)  # revealed: BrandedFirst & Literal[First.TWO]
+            return 2
+
+def branded_cross_int_enum_member_patterns(value: BrandedFirst | BrandedSecond) -> None:
+    match value:
+        case First.ONE:
+            reveal_type(value)  # revealed: (BrandedFirst & Literal[First.ONE]) | (BrandedSecond & Literal[Second.ONE])
+        case _:
+            reveal_type(value)  # revealed: (BrandedFirst & ~Literal[First.ONE]) | (BrandedSecond & ~Literal[Second.ONE])
 
 def cross_int_enum_members(value: First | Second) -> None:
     match value:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -3666,6 +3666,49 @@ def test_match_alias_ignores_custom_ne(flag: bool) -> str:
             return item
 ```
 
+## Recursive enum aliases in value patterns
+
+An enum value pattern narrows a recursive alias to the matching member while preserving its
+`NewType` tag.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from enum import IntEnum
+from typing import NewType
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+BrandedNumber = NewType("BrandedNumber", Number)
+type RecursiveNumber = BrandedNumber | RecursiveNumber
+
+def match_recursive_branded_enum(value: RecursiveNumber) -> None:
+    match value:
+        case Number.ONE:
+            reveal_type(value)  # revealed: BrandedNumber & Literal[Number.ONE]
+        case Number.TWO:
+            reveal_type(value)  # revealed: BrandedNumber & Literal[Number.TWO]
+```
+
+A recursive alias that changes its specialization can also contain values outside the enum. Since
+`True` compares equal to `Number.ONE`, both branches preserve the possible boolean values.
+
+```py
+type Changing[T] = T | Changing[bool]
+
+def match_changing_specialization(value: Changing[BrandedNumber]) -> None:
+    match value:
+        case Number.ONE:
+            reveal_type(value)  # revealed: (BrandedNumber & Literal[Number.ONE]) | bool
+        case _:
+            reveal_type(value)  # revealed: (BrandedNumber & Literal[Number.TWO]) | bool
+```
+
 ## Value patterns with guard
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -519,32 +519,21 @@ def _(x: Unrelated | Invariant[int]):
 
 ## `TypeIs` narrowing of `NewType` instances
 
-`NewType` constructors return compatible subclass instances unchanged, and runtime subclass checks
-ignore their static tags. A `TypeIs` guard for such a subclass must therefore preserve the
-possibility of a `NewType` value matching it.
+`NewType` constructors return their arguments unchanged, so an integer-based `NewType` can contain a
+`bool`. A `TypeIs[bool]` guard preserves both the `NewType` and its runtime class.
 
 ```py
 from typing import NewType
 from typing_extensions import TypeIs
 
-class Base: ...
-class Child(Base): ...
-
-BaseId = NewType("BaseId", Base)
 UserId = NewType("UserId", int)
-
-def is_child(value: object) -> TypeIs[Child]:
-    return isinstance(value, Child)
 
 def is_bool(value: object) -> TypeIs[bool]:
     return isinstance(value, bool)
 
-def _(branded: BaseId, user_id: UserId):
-    if is_child(branded):
-        reveal_type(branded)  # revealed: BaseId & Child
-
-    if is_bool(user_id):
-        reveal_type(user_id)  # revealed: UserId & bool
+def _(value: UserId):
+    if is_bool(value):
+        reveal_type(value)  # revealed: UserId & bool
 ```
 
 ## `TypeGuard` special cases

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -517,6 +517,35 @@ def _(x: Unrelated | Invariant[int]):
         reveal_type(x)  # revealed: Unrelated
 ```
 
+## `TypeIs` narrowing of `NewType` instances
+
+`NewType` constructors return compatible subclass instances unchanged. A `TypeIs` guard for such a
+subclass must therefore preserve the possibility of a branded value matching it.
+
+```py
+from typing import NewType
+from typing_extensions import TypeIs
+
+class Base: ...
+class Child(Base): ...
+
+BaseId = NewType("BaseId", Base)
+UserId = NewType("UserId", int)
+
+def is_child(value: object) -> TypeIs[Child]:
+    return isinstance(value, Child)
+
+def is_bool(value: object) -> TypeIs[bool]:
+    return isinstance(value, bool)
+
+def _(branded: BaseId, user_id: UserId):
+    if is_child(branded):
+        reveal_type(branded)  # revealed: BaseId & Child
+
+    if is_bool(user_id):
+        reveal_type(user_id)  # revealed: UserId & bool
+```
+
 ## `TypeGuard` special cases
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -519,8 +519,9 @@ def _(x: Unrelated | Invariant[int]):
 
 ## `TypeIs` narrowing of `NewType` instances
 
-`NewType` constructors return compatible subclass instances unchanged. A `TypeIs` guard for such a
-subclass must therefore preserve the possibility of a branded value matching it.
+`NewType` constructors return compatible subclass instances unchanged, and runtime subclass checks
+ignore their static tags. A `TypeIs` guard for such a subclass must therefore preserve the
+possibility of a `NewType` value matching it.
 
 ```py
 from typing import NewType

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -31,7 +31,7 @@ o: Not[()]
 p: Not[(int,)]
 
 def static_truthiness(not_one: Not[Literal[1]]) -> None:
-    # Negating a literal rules out every object with that value.
+    # Negating a literal rules out every literal with that value.
     reveal_type(not_one is not 1)  # revealed: Literal[True]
     reveal_type(not_one is 1)  # revealed: Literal[False]
 

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -31,7 +31,7 @@ o: Not[()]
 p: Not[(int,)]
 
 def static_truthiness(not_one: Not[Literal[1]]) -> None:
-    # Excluding a literal excludes that exact runtime object.
+    # Negating a literal rules out every object with that value.
     reveal_type(not_one is not 1)  # revealed: Literal[True]
     reveal_type(not_one is 1)  # revealed: Literal[False]
 

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -31,10 +31,9 @@ o: Not[()]
 p: Not[(int,)]
 
 def static_truthiness(not_one: Not[Literal[1]]) -> None:
-    # A `NewType` over `int` is distinct from `Literal[1]` but can refer to the same runtime object,
-    # so neither identity comparison has a definite result.
-    reveal_type(not_one is not 1)  # revealed: bool
-    reveal_type(not_one is 1)  # revealed: bool
+    # Excluding a literal excludes that exact runtime object.
+    reveal_type(not_one is not 1)  # revealed: Literal[True]
+    reveal_type(not_one is 1)  # revealed: Literal[False]
 
     # But these are both `bool`, rather than `Literal[True]` or `Literal[False]`
     # as there are many runtime objects that inhabit the type `~Literal[1]`

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -1140,7 +1140,7 @@ static_assert(not is_disjoint_from(Foo[A], Foo[B]))
 static_assert(not is_disjoint_from(Foo[A], Foo[Any]))
 static_assert(not is_disjoint_from(Foo[Any], Foo[B]))
 
-# `Foo[Never]` is a subtype of both `Foo[int]` and `Foo[str]`.
+# `Foo[Never]` is inhabited (`get` can raise) and is a subtype of both `Foo[int]` and `Foo[str]`.
 static_assert(not is_disjoint_from(Foo[int], Foo[str]))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -85,16 +85,6 @@ static_assert(not is_disjoint_from(FinalIntId, FinalInt))
 static_assert(not is_disjoint_from(FinalIntId, int))
 ```
 
-The same rule applies when the base is `str`, which is not final.
-
-```py
-class OrdinaryStr(str): ...
-
-StringId = NewType("StringId", str)
-
-static_assert(is_disjoint_from(StringId, OrdinaryStr))
-```
-
 An `IntEnum` with members is another subclass disjoint from an integer-based NewType.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -23,9 +23,11 @@ static_assert(not is_disjoint_from(LiteralString, LiteralString))
 static_assert(not is_disjoint_from(str, LiteralString))
 ```
 
-## NewTypes and boolean types
+## NewTypes and literal types
 
-An integer-based `NewType` is disjoint from both boolean literals, their union, and `bool` itself.
+A `NewType` overlaps with any literal compatible with its concrete base. Type checkers accept
+`UserId(True)` and cannot reliably prevent such calls because `bool` is a subtype of `int`, so an
+integer-based `NewType` also overlaps boolean literals.
 
 ```py
 from typing import Literal, NewType
@@ -33,37 +35,82 @@ from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from
 
 UserId = NewType("UserId", int)
+StringId = NewType("StringId", str)
+BytesId = NewType("BytesId", bytes)
 
-static_assert(is_disjoint_from(UserId, Literal[True]))
-static_assert(is_disjoint_from(UserId, Literal[False]))
-static_assert(is_disjoint_from(UserId, Literal[True, False]))
-static_assert(is_disjoint_from(UserId, bool))
-static_assert(is_disjoint_from(bool, UserId))
+UserId(True)
+
+static_assert(not is_disjoint_from(UserId, Literal[True]))
+static_assert(not is_disjoint_from(Literal[True], UserId))
+static_assert(not is_disjoint_from(UserId, Literal[False]))
+static_assert(not is_disjoint_from(Literal[False], UserId))
+static_assert(not is_disjoint_from(UserId, Literal[True, False]))
+static_assert(not is_disjoint_from(UserId, Literal[1]))
+static_assert(not is_disjoint_from(Literal[1], UserId))
+static_assert(not is_disjoint_from(UserId, bool))
+static_assert(not is_disjoint_from(bool, UserId))
 static_assert(not is_disjoint_from(UserId, int))
+static_assert(is_disjoint_from(UserId, Literal["user"]))
+static_assert(is_disjoint_from(Literal["user"], UserId))
+
+static_assert(not is_disjoint_from(StringId, Literal["user"]))
+static_assert(not is_disjoint_from(BytesId, Literal[b"user"]))
 ```
 
-Nested and float-based NewTypes retain the distinction, while a NewType based directly on `bool`
-still overlaps with its base.
+Nested NewTypes retain the overlap, and a float-based NewType also accepts `int` and `bool` through
+the numeric tower.
 
 ```py
 NestedUserId = NewType("NestedUserId", UserId)
 FloatId = NewType("FloatId", float)
 BoolId = NewType("BoolId", bool)
 
-static_assert(is_disjoint_from(NestedUserId, bool))
-static_assert(is_disjoint_from(FloatId, bool))
+static_assert(not is_disjoint_from(NestedUserId, bool))
+static_assert(not is_disjoint_from(NestedUserId, Literal[True]))
+static_assert(not is_disjoint_from(FloatId, bool))
+static_assert(not is_disjoint_from(FloatId, Literal[True]))
+static_assert(not is_disjoint_from(FloatId, Literal[1]))
 static_assert(not is_disjoint_from(FloatId, int))
 static_assert(not is_disjoint_from(FloatId, float))
 static_assert(not is_disjoint_from(BoolId, bool))
 ```
 
-## NewTypes and nominal subclasses
+## Distinct NewTypes
 
-A NewType is disjoint from proper subclasses of its base, whether or not those subclasses are final.
-It still overlaps with its own base and with any supertypes of that base.
+Distinct `NewType`s are not assignable to each other, but they overlap whenever their concrete bases
+overlap. They are disjoint only when their concrete bases are disjoint.
 
 ```py
-from typing import NewType, final
+from typing import NewType
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_disjoint_from, is_subtype_of
+
+First = NewType("First", int)
+Second = NewType("Second", int)
+NestedFirst = NewType("NestedFirst", First)
+Numeric = NewType("Numeric", float)
+Text = NewType("Text", str)
+
+static_assert(not is_disjoint_from(First, Second))
+static_assert(not is_disjoint_from(Second, First))
+static_assert(not is_disjoint_from(NestedFirst, Second))
+static_assert(not is_disjoint_from(First, Numeric))
+static_assert(is_disjoint_from(First, Text))
+static_assert(is_disjoint_from(Text, First))
+
+static_assert(not is_subtype_of(First, Second))
+static_assert(not is_subtype_of(Second, First))
+static_assert(not is_assignable_to(First, Second))
+static_assert(not is_assignable_to(Second, First))
+```
+
+## NewTypes and nominal subclasses
+
+A `NewType` overlaps with subclasses of its base, whether or not those subclasses are final. It also
+overlaps with its own base and with any supertypes of that base.
+
+```py
+from typing import Literal, NewType, final
 from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from
 
@@ -76,16 +123,18 @@ class OrdinaryInt(int): ...
 
 FinalIntId = NewType("FinalIntId", FinalInt)
 
-static_assert(is_disjoint_from(UserId, FinalInt))
-static_assert(is_disjoint_from(UserId, OrdinaryInt))
-static_assert(is_disjoint_from(OrdinaryInt, UserId))
+static_assert(not is_disjoint_from(UserId, FinalInt))
+static_assert(not is_disjoint_from(FinalInt, UserId))
+static_assert(not is_disjoint_from(UserId, OrdinaryInt))
+static_assert(not is_disjoint_from(OrdinaryInt, UserId))
 static_assert(not is_disjoint_from(UserId, int))
 static_assert(not is_disjoint_from(UserId, object))
+static_assert(is_disjoint_from(UserId, str))
 static_assert(not is_disjoint_from(FinalIntId, FinalInt))
 static_assert(not is_disjoint_from(FinalIntId, int))
 ```
 
-An `IntEnum` with members is another subclass disjoint from an integer-based NewType.
+An `IntEnum` and its members also overlap with an integer-based `NewType`.
 
 ```py
 from enum import IntEnum
@@ -94,7 +143,9 @@ class Choice(IntEnum):
     FIRST = 1
     SECOND = 2
 
-static_assert(is_disjoint_from(UserId, Choice))
+static_assert(not is_disjoint_from(UserId, Choice))
+static_assert(not is_disjoint_from(UserId, Literal[Choice.FIRST]))
+static_assert(not is_disjoint_from(Literal[Choice.FIRST], UserId))
 ```
 
 ## NewTypes and generic classes
@@ -104,8 +155,9 @@ static_assert(is_disjoint_from(UserId, Choice))
 python-version = "3.12"
 ```
 
-A NewType based on a covariant generic specialization overlaps with its generic supertypes, but is
-disjoint from incompatible specializations and subclasses of its base.
+A `NewType` based on a covariant generic specialization overlaps with its generic supertypes and
+subclasses. Two differently specialized covariant types can also overlap through a common, more
+specific specialization.
 
 ```py
 from typing import Any, NewType, final
@@ -125,9 +177,9 @@ BaseId = NewType("BaseId", Base[int])
 
 static_assert(not is_disjoint_from(BaseId, Base[int]))
 static_assert(not is_disjoint_from(BaseId, Base[object]))
-static_assert(is_disjoint_from(BaseId, Base[str]))
-static_assert(is_disjoint_from(BaseId, FinalChild[object]))
-static_assert(is_disjoint_from(BaseId, OrdinaryChild[object]))
+static_assert(not is_disjoint_from(BaseId, Base[str]))
+static_assert(not is_disjoint_from(BaseId, FinalChild[object]))
+static_assert(not is_disjoint_from(BaseId, OrdinaryChild[object]))
 ```
 
 Gradual type arguments can overlap even when strict subtyping does not hold.
@@ -135,11 +187,30 @@ Gradual type arguments can overlap even when strict subtyping does not hold.
 ```py
 AnyListId = NewType("AnyListId", list[Any])
 IntListId = NewType("IntListId", list[int])
+StrListId = NewType("StrListId", list[str])
 
 static_assert(not is_subtype_of(AnyListId, list[int]))
 static_assert(not is_disjoint_from(AnyListId, list[int]))
 static_assert(not is_disjoint_from(IntListId, list[Any]))
 static_assert(is_disjoint_from(IntListId, list[str]))
+static_assert(not is_disjoint_from(IntListId, AnyListId))
+static_assert(is_disjoint_from(IntListId, StrListId))
+```
+
+A generic type variable must not make a potentially compatible specialization appear disjoint.
+Compatible constraints and bounds also preserve the overlap.
+
+```py
+def unconstrained[T]() -> None:
+    static_assert(not is_disjoint_from(IntListId, list[T]))
+    static_assert(not is_disjoint_from(list[T], IntListId))
+
+def compatible_constraints[T: (int, str)]() -> None:
+    static_assert(not is_disjoint_from(IntListId, list[T]))
+    static_assert(not is_disjoint_from(list[T], IntListId))
+
+def compatible_bound[T: int]() -> None:
+    static_assert(not is_disjoint_from(IntListId, list[T]))
 ```
 
 ## Statically empty and non-empty ranges
@@ -961,6 +1032,39 @@ static_assert(not is_disjoint_from(bool, TypeIs[str]))
 
 static_assert(is_disjoint_from(str, TypeGuard[str]))
 static_assert(is_disjoint_from(str, TypeIs[str]))
+```
+
+`TypeGuard` and `TypeIs` represent boolean return values, so they overlap with `NewType`s whose
+concrete bases accept booleans, including `int` and `float`. A `NewType` with an incompatible base
+remains disjoint.
+
+```py
+from typing import NewType
+
+Boolean = NewType("Boolean", bool)
+Integer = NewType("Integer", int)
+Numeric = NewType("Numeric", float)
+Text = NewType("Text", str)
+
+static_assert(not is_disjoint_from(Boolean, TypeGuard[str]))
+static_assert(not is_disjoint_from(TypeGuard[str], Boolean))
+static_assert(not is_disjoint_from(Boolean, TypeIs[str]))
+static_assert(not is_disjoint_from(TypeIs[str], Boolean))
+
+static_assert(not is_disjoint_from(Integer, TypeGuard[str]))
+static_assert(not is_disjoint_from(TypeGuard[str], Integer))
+static_assert(not is_disjoint_from(Integer, TypeIs[str]))
+static_assert(not is_disjoint_from(TypeIs[str], Integer))
+
+static_assert(not is_disjoint_from(Numeric, TypeGuard[str]))
+static_assert(not is_disjoint_from(TypeGuard[str], Numeric))
+static_assert(not is_disjoint_from(Numeric, TypeIs[str]))
+static_assert(not is_disjoint_from(TypeIs[str], Numeric))
+
+static_assert(is_disjoint_from(Text, TypeGuard[str]))
+static_assert(is_disjoint_from(TypeGuard[str], Text))
+static_assert(is_disjoint_from(Text, TypeIs[str]))
+static_assert(is_disjoint_from(TypeIs[str], Text))
 ```
 
 ### `Protocol`

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -26,8 +26,7 @@ static_assert(not is_disjoint_from(str, LiteralString))
 
 ## Class hierarchies
 
-Two classes overlap when a subclass could inherit from both. Final classes and incompatible
-metaclasses can rule out that shared subclass.
+Classes overlap through a common subclass unless finality or incompatible metaclasses prevent it.
 
 ```pyi
 from ty_extensions import static_assert
@@ -197,8 +196,7 @@ static_assert(not is_disjoint_from(D, A))
 
 ## Dataclasses
 
-Dataclasses with incompatible non-empty slots are disjoint; dataclasses with empty slots can still
-share a subclass.
+Dataclasses with incompatible non-empty slots are disjoint; those with empty slots can overlap.
 
 ```py
 from dataclasses import dataclass
@@ -277,8 +275,7 @@ static_assert(not is_disjoint_from(Literal[1, 2], Literal[2, 3]))
 
 ## Intersections
 
-Positive requirements and negated types can prevent an intersection from sharing any inhabitants
-with another type.
+Positive requirements and negations can make an intersection disjoint from another type.
 
 ```pyi
 from typing_extensions import Literal, final, Any, LiteralString
@@ -453,8 +450,7 @@ static_assert(is_disjoint_from(LiteralString & ~AlwaysFalsy, ~LiteralString | Al
 
 ### Class, module and function literals
 
-Class, module, and function literals identify specific runtime objects, so distinct objects have
-disjoint literal types.
+Class, module, and function literal types for distinct runtime objects are disjoint.
 
 ```toml
 [environment]
@@ -589,8 +585,7 @@ static_assert(not is_disjoint_from(TypeOf[F().foo], TypeOf[G().foo]))
 
 ### `AlwaysTruthy` and `AlwaysFalsy`
 
-`AlwaysTruthy` and `AlwaysFalsy` are disjoint from types whose possible values cannot have the
-corresponding truthiness.
+`AlwaysTruthy` and `AlwaysFalsy` are disjoint from types with incompatible truthiness.
 
 ```py
 from ty_extensions import AlwaysFalsy, AlwaysTruthy, static_assert
@@ -797,8 +792,7 @@ static_assert(is_disjoint_from(type[Foo], BarNone))
 
 ### `NamedTuple`
 
-A `NamedTuple` overlaps compatible tuple shapes but is disjoint from incompatible tuple lengths and
-distinct final named-tuple classes.
+`NamedTuple`s overlap matching tuple shapes, but not different lengths or distinct final classes.
 
 ```py
 from __future__ import annotations
@@ -978,8 +972,7 @@ static_assert(not is_disjoint_from(TypeOf[OrderedDict], Callable[..., Any]))
 
 ## Statically empty and non-empty ranges
 
-An empty range is disjoint from a range known to be non-empty, but both overlap the general `range`
-type.
+Empty and non-empty ranges are disjoint, but both overlap the general `range` type.
 
 ```py
 from ty_extensions import static_assert
@@ -1122,8 +1115,7 @@ static_assert(not is_disjoint_from(Sequence[int], Sequence[str]))
 
 ### Specialized `@final` types
 
-Final generic classes can have overlapping specializations when a common specialization, such as one
-with a `Never` type argument, inhabits both.
+Final generic specializations can overlap through a shared subtype such as `Foo[Never]`.
 
 ```toml
 [environment]
@@ -1246,11 +1238,9 @@ UserId(True)
 static_assert(not is_disjoint_from(UserId, Literal[True]))
 static_assert(not is_disjoint_from(Literal[True], UserId))
 static_assert(not is_disjoint_from(UserId, Literal[False]))
-static_assert(not is_disjoint_from(UserId, Literal[True, False]))
 static_assert(not is_disjoint_from(UserId, Literal[1]))
 static_assert(not is_disjoint_from(UserId, bool))
 static_assert(not is_disjoint_from(bool, UserId))
-static_assert(not is_disjoint_from(UserId, int))
 static_assert(is_disjoint_from(UserId, Literal["user"]))
 
 static_assert(not is_disjoint_from(StringId, Literal["user"]))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -25,9 +25,9 @@ static_assert(not is_disjoint_from(str, LiteralString))
 
 ## NewTypes and literal types
 
-A `NewType` overlaps with any literal compatible with its concrete base. Type checkers accept
-`UserId(True)` and cannot reliably prevent such calls because `bool` is a subtype of `int`, so an
-integer-based `NewType` also overlaps boolean literals.
+A `NewType` overlaps with any literal compatible with its concrete base. Because `bool` is a subtype
+of `int`, type checkers correctly accept `UserId(True)`, and an integer-based `NewType` also
+overlaps boolean literals.
 
 ```py
 from typing import Literal, NewType
@@ -58,7 +58,7 @@ static_assert(not is_disjoint_from(BytesId, Literal[b"user"]))
 ```
 
 Nested NewTypes retain the overlap, and a float-based NewType also accepts `int` and `bool` through
-the numeric tower.
+the `int`/`float` special case.
 
 ```py
 NestedUserId = NewType("NestedUserId", UserId)
@@ -106,8 +106,8 @@ static_assert(not is_assignable_to(Second, First))
 
 ## NewTypes and nominal subclasses
 
-A `NewType` overlaps with subclasses of its base, whether or not those subclasses are final. It also
-overlaps with its own base and with any supertypes of that base.
+A `NewType` overlaps with subclasses of its base. It also overlaps with its own base and with any
+supertypes of that base.
 
 ```py
 from typing import Literal, NewType, final
@@ -160,7 +160,7 @@ subclasses. Two differently specialized covariant types can also overlap through
 specific specialization.
 
 ```py
-from typing import Any, NewType, final
+from typing import Any, NewType
 from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from, is_subtype_of
 
@@ -168,18 +168,15 @@ class Base[T]:
     def get(self) -> T:
         raise NotImplementedError
 
-@final
-class FinalChild[T](Base[T]): ...
-
-class OrdinaryChild[T](Base[T]): ...
+class Child[T](Base[T]): ...
 
 BaseId = NewType("BaseId", Base[int])
 
 static_assert(not is_disjoint_from(BaseId, Base[int]))
 static_assert(not is_disjoint_from(BaseId, Base[object]))
+# `Base[Never]` is inhabited (`get` can raise) and is a subtype of both `Base[int]` and `Base[str]`.
 static_assert(not is_disjoint_from(BaseId, Base[str]))
-static_assert(not is_disjoint_from(BaseId, FinalChild[object]))
-static_assert(not is_disjoint_from(BaseId, OrdinaryChild[object]))
+static_assert(not is_disjoint_from(BaseId, Child[object]))
 ```
 
 Gradual type arguments can overlap even when strict subtyping does not hold.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -52,13 +52,15 @@ BoolId = NewType("BoolId", bool)
 
 static_assert(is_disjoint_from(NestedUserId, bool))
 static_assert(is_disjoint_from(FloatId, bool))
+static_assert(not is_disjoint_from(FloatId, int))
+static_assert(not is_disjoint_from(FloatId, float))
 static_assert(not is_disjoint_from(BoolId, bool))
 ```
 
-## NewTypes and final classes
+## NewTypes and nominal subclasses
 
-A NewType and a final subclass of its base cannot overlap unless the NewType itself is based on that
-final class. Non-final subclasses may still overlap with the NewType.
+A NewType is disjoint from proper subclasses of its base, whether or not those subclasses are final.
+It still overlaps with its own base and with any supertypes of that base.
 
 ```py
 from typing import NewType, final
@@ -75,11 +77,25 @@ class OrdinaryInt(int): ...
 FinalIntId = NewType("FinalIntId", FinalInt)
 
 static_assert(is_disjoint_from(UserId, FinalInt))
-static_assert(not is_disjoint_from(UserId, OrdinaryInt))
+static_assert(is_disjoint_from(UserId, OrdinaryInt))
+static_assert(is_disjoint_from(OrdinaryInt, UserId))
+static_assert(not is_disjoint_from(UserId, int))
+static_assert(not is_disjoint_from(UserId, object))
 static_assert(not is_disjoint_from(FinalIntId, FinalInt))
+static_assert(not is_disjoint_from(FinalIntId, int))
 ```
 
-An `IntEnum` with members is also final and disjoint from an integer-based NewType.
+The same rule applies when the base is `str`, which is not final.
+
+```py
+class OrdinaryStr(str): ...
+
+StringId = NewType("StringId", str)
+
+static_assert(is_disjoint_from(StringId, OrdinaryStr))
+```
+
+An `IntEnum` with members is another subclass disjoint from an integer-based NewType.
 
 ```py
 from enum import IntEnum
@@ -89,6 +105,51 @@ class Choice(IntEnum):
     SECOND = 2
 
 static_assert(is_disjoint_from(UserId, Choice))
+```
+
+## NewTypes and generic classes
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+A NewType based on a covariant generic specialization overlaps with its generic supertypes, but is
+disjoint from incompatible specializations and subclasses of its base.
+
+```py
+from typing import Any, NewType, final
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
+
+class Base[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+@final
+class FinalChild[T](Base[T]): ...
+
+class OrdinaryChild[T](Base[T]): ...
+
+BaseId = NewType("BaseId", Base[int])
+
+static_assert(not is_disjoint_from(BaseId, Base[int]))
+static_assert(not is_disjoint_from(BaseId, Base[object]))
+static_assert(is_disjoint_from(BaseId, Base[str]))
+static_assert(is_disjoint_from(BaseId, FinalChild[object]))
+static_assert(is_disjoint_from(BaseId, OrdinaryChild[object]))
+```
+
+Gradual type arguments can overlap even when strict subtyping does not hold.
+
+```py
+AnyListId = NewType("AnyListId", list[Any])
+IntListId = NewType("IntListId", list[int])
+
+static_assert(not is_subtype_of(AnyListId, list[int]))
+static_assert(not is_disjoint_from(AnyListId, list[int]))
+static_assert(not is_disjoint_from(IntListId, list[Any]))
+static_assert(is_disjoint_from(IntListId, list[str]))
 ```
 
 ## Statically empty and non-empty ranges
@@ -224,27 +285,6 @@ static_assert(not is_disjoint_from(Foo[Any], Foo[B]))
 
 # `Foo[Never]` is a subtype of both `Foo[int]` and `Foo[str]`.
 static_assert(not is_disjoint_from(Foo[int], Foo[str]))
-```
-
-A covariant final generic specialization can overlap with a NewType without being its supertype:
-`FinalChild[int]` is a subtype of both the NewType's base, `Base[int]`, and `FinalChild[object]`.
-
-```py
-from typing import NewType
-from ty_extensions._internal import is_subtype_of
-
-class Base[T]:
-    def get(self) -> T:
-        raise NotImplementedError
-
-@final
-class FinalChild[T](Base[T]): ...
-
-BaseId = NewType("BaseId", Base[int])
-
-static_assert(is_subtype_of(FinalChild[int], FinalChild[object]))
-static_assert(not is_subtype_of(BaseId, FinalChild[object]))
-static_assert(not is_disjoint_from(BaseId, FinalChild[object]))
 ```
 
 ## Invariant generic specializations and bases

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -1,7 +1,10 @@
 # Disjointness relation
 
-Two types `S` and `T` are disjoint if their intersection `S & T` is empty (equivalent to `Never`).
-This means that it is known that no possible runtime object inhabits both types simultaneously.
+Two types `S` and `T` are disjoint if their intersection `S & T` is empty (equivalent to `Never`). A
+type's inhabitants include both runtime objects and any invisible `NewType` tags. Two types can
+therefore be disjoint even when they describe the same runtime object with different tags.
+Similarly, `list[int]` and `list[str]` are disjoint even though the same empty list can be viewed
+through either specialization.
 
 ## Basic builtin types
 
@@ -25,9 +28,10 @@ static_assert(not is_disjoint_from(str, LiteralString))
 
 ## NewTypes and literal types
 
-A `NewType` overlaps with any literal compatible with its concrete base. Because `bool` is a subtype
-of `int`, type checkers correctly accept `UserId(True)`, and an integer-based `NewType` also
-overlaps boolean literals.
+A `NewType` overlaps with any literal compatible with its concrete base: ordinary types and literal
+types admit runtime values with any `NewType` tag. Because `bool` is a subtype of `int`, type
+checkers correctly accept `UserId(True)`, and an integer-based `NewType` also overlaps boolean
+literals.
 
 ```py
 from typing import Literal, NewType
@@ -77,31 +81,49 @@ static_assert(not is_disjoint_from(BoolId, bool))
 
 ## Distinct NewTypes
 
-Distinct `NewType`s are not assignable to each other, but they overlap whenever their concrete bases
-overlap. They are disjoint only when their concrete bases are disjoint.
+Unrelated `NewType` tags are mutually exclusive, even when their constructors return the same
+runtime object. A nested `NewType` remains a subtype of its parent. Overlap is not transitive: two
+unrelated `NewType`s can each overlap `int`, `bool`, and `Literal[True]` while remaining disjoint
+from each other.
 
 ```py
-from typing import NewType
+from typing import Literal, NewType
 from ty_extensions import static_assert
 from ty_extensions._internal import is_assignable_to, is_disjoint_from, is_subtype_of
 
 First = NewType("First", int)
 Second = NewType("Second", int)
 NestedFirst = NewType("NestedFirst", First)
+OtherNestedFirst = NewType("OtherNestedFirst", First)
 Numeric = NewType("Numeric", float)
 Text = NewType("Text", str)
 
-static_assert(not is_disjoint_from(First, Second))
-static_assert(not is_disjoint_from(Second, First))
-static_assert(not is_disjoint_from(NestedFirst, Second))
-static_assert(not is_disjoint_from(First, Numeric))
+static_assert(is_disjoint_from(First, Second))
+static_assert(is_disjoint_from(Second, First))
+static_assert(is_disjoint_from(NestedFirst, Second))
+static_assert(is_disjoint_from(NestedFirst, OtherNestedFirst))
+static_assert(is_disjoint_from(First, Numeric))
 static_assert(is_disjoint_from(First, Text))
 static_assert(is_disjoint_from(Text, First))
+
+static_assert(not is_disjoint_from(NestedFirst, First))
+static_assert(not is_disjoint_from(First, NestedFirst))
+static_assert(not is_disjoint_from(OtherNestedFirst, First))
+static_assert(not is_disjoint_from(First, int))
+static_assert(not is_disjoint_from(Second, int))
+static_assert(not is_disjoint_from(First, bool))
+static_assert(not is_disjoint_from(Second, bool))
+static_assert(not is_disjoint_from(First, Literal[True]))
+static_assert(not is_disjoint_from(Second, Literal[True]))
+static_assert(is_disjoint_from(list[int], list[str]))
 
 static_assert(not is_subtype_of(First, Second))
 static_assert(not is_subtype_of(Second, First))
 static_assert(not is_assignable_to(First, Second))
 static_assert(not is_assignable_to(Second, First))
+static_assert(is_subtype_of(NestedFirst, First))
+static_assert(is_assignable_to(NestedFirst, First))
+static_assert(not is_assignable_to(First, NestedFirst))
 ```
 
 ## NewTypes and nominal subclasses
@@ -179,7 +201,8 @@ static_assert(not is_disjoint_from(BaseId, Base[str]))
 static_assert(not is_disjoint_from(BaseId, Child[object]))
 ```
 
-Gradual type arguments can overlap even when strict subtyping does not hold.
+An ordinary gradual specialization can overlap a `NewType` even when strict subtyping does not hold.
+Independently defined `NewType`s remain disjoint.
 
 ```py
 AnyListId = NewType("AnyListId", list[Any])
@@ -190,7 +213,7 @@ static_assert(not is_subtype_of(AnyListId, list[int]))
 static_assert(not is_disjoint_from(AnyListId, list[int]))
 static_assert(not is_disjoint_from(IntListId, list[Any]))
 static_assert(is_disjoint_from(IntListId, list[str]))
-static_assert(not is_disjoint_from(IntListId, AnyListId))
+static_assert(is_disjoint_from(IntListId, AnyListId))
 static_assert(is_disjoint_from(IntListId, StrListId))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -1,264 +1,33 @@
 # Disjointness relation
 
-Two types `S` and `T` are disjoint if their intersection `S & T` is empty (equivalent to `Never`). A
-type's inhabitants include both runtime objects and any invisible `NewType` tags. Two types can
-therefore be disjoint even when they describe the same runtime object with different tags.
-Similarly, `list[int]` and `list[str]` are disjoint even though the same empty list can be viewed
-through either specialization.
+Two types `S` and `T` are disjoint if they have no overlap; that is, their intersection `S & T` is
+empty (equivalent to `Never`).
 
 ## Basic builtin types
 
-```pyi
-from typing_extensions import Literal, LiteralString, Any
-from ty_extensions import static_assert
-from ty_extensions._internal import TypeOf, is_disjoint_from
+For basic builtin types, disjointness simply means that no runtime object can inhabit both types.
 
+```pyi
+from typing_extensions import LiteralString
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+# No object can be both a `bool` and a `str`.
 static_assert(is_disjoint_from(bool, str))
+
+# But the same object can be a `bool`, an `int`, and an `object`.
 static_assert(not is_disjoint_from(bool, bool))
 static_assert(not is_disjoint_from(bool, int))
 static_assert(not is_disjoint_from(bool, object))
-
-static_assert(not is_disjoint_from(Any, bool))
-static_assert(not is_disjoint_from(Any, Any))
-static_assert(not is_disjoint_from(Any, ~Any))
 
 static_assert(not is_disjoint_from(LiteralString, LiteralString))
 static_assert(not is_disjoint_from(str, LiteralString))
 ```
 
-## NewTypes and literal types
-
-A `NewType` overlaps with any literal compatible with its concrete base: ordinary types and literal
-types admit runtime values with any `NewType` tag. Because `bool` is a subtype of `int`, type
-checkers correctly accept `UserId(True)`, and an integer-based `NewType` also overlaps boolean
-literals.
-
-```py
-from typing import Literal, NewType
-from ty_extensions import static_assert
-from ty_extensions._internal import is_disjoint_from
-
-UserId = NewType("UserId", int)
-StringId = NewType("StringId", str)
-BytesId = NewType("BytesId", bytes)
-
-UserId(True)
-
-static_assert(not is_disjoint_from(UserId, Literal[True]))
-static_assert(not is_disjoint_from(Literal[True], UserId))
-static_assert(not is_disjoint_from(UserId, Literal[False]))
-static_assert(not is_disjoint_from(UserId, Literal[True, False]))
-static_assert(not is_disjoint_from(UserId, Literal[1]))
-static_assert(not is_disjoint_from(UserId, bool))
-static_assert(not is_disjoint_from(bool, UserId))
-static_assert(not is_disjoint_from(UserId, int))
-static_assert(is_disjoint_from(UserId, Literal["user"]))
-
-static_assert(not is_disjoint_from(StringId, Literal["user"]))
-static_assert(not is_disjoint_from(BytesId, Literal[b"user"]))
-```
-
-Nested NewTypes retain the overlap, and a float-based NewType also accepts `int` and `bool` through
-the `int`/`float` special case.
-
-```py
-NestedUserId = NewType("NestedUserId", UserId)
-FloatId = NewType("FloatId", float)
-BoolId = NewType("BoolId", bool)
-
-static_assert(not is_disjoint_from(NestedUserId, bool))
-static_assert(not is_disjoint_from(NestedUserId, Literal[True]))
-static_assert(not is_disjoint_from(FloatId, bool))
-static_assert(not is_disjoint_from(FloatId, Literal[True]))
-static_assert(not is_disjoint_from(FloatId, Literal[1]))
-static_assert(not is_disjoint_from(FloatId, int))
-static_assert(not is_disjoint_from(BoolId, bool))
-```
-
-## Distinct NewTypes
-
-Unrelated `NewType` tags are mutually exclusive, even when their constructors return the same
-runtime object. A nested `NewType` remains a subtype of its parent. Overlap is not transitive: two
-unrelated `NewType`s can each overlap `int`, `bool`, and `Literal[True]` while remaining disjoint
-from each other.
-
-```py
-from typing import Literal, NewType
-from ty_extensions import static_assert
-from ty_extensions._internal import is_assignable_to, is_disjoint_from, is_subtype_of
-
-First = NewType("First", int)
-Second = NewType("Second", int)
-NestedFirst = NewType("NestedFirst", First)
-OtherNestedFirst = NewType("OtherNestedFirst", First)
-Numeric = NewType("Numeric", float)
-Text = NewType("Text", str)
-
-static_assert(is_disjoint_from(First, Second))
-static_assert(is_disjoint_from(Second, First))
-static_assert(is_disjoint_from(NestedFirst, Second))
-static_assert(is_disjoint_from(NestedFirst, OtherNestedFirst))
-static_assert(is_disjoint_from(First, Numeric))
-static_assert(is_disjoint_from(First, Text))
-
-static_assert(not is_disjoint_from(NestedFirst, First))
-static_assert(not is_disjoint_from(First, NestedFirst))
-static_assert(not is_disjoint_from(First, int))
-static_assert(not is_disjoint_from(Second, int))
-static_assert(not is_disjoint_from(First, bool))
-static_assert(not is_disjoint_from(Second, bool))
-static_assert(not is_disjoint_from(First, Literal[True]))
-static_assert(not is_disjoint_from(Second, Literal[True]))
-static_assert(is_disjoint_from(list[int], list[str]))
-
-static_assert(not is_subtype_of(First, Second))
-static_assert(not is_assignable_to(First, Second))
-static_assert(is_subtype_of(NestedFirst, First))
-static_assert(is_assignable_to(NestedFirst, First))
-static_assert(not is_assignable_to(First, NestedFirst))
-```
-
-## NewTypes and nominal subclasses
-
-A `NewType` overlaps with subclasses of its base. It also overlaps with its own base and with any
-supertypes of that base.
-
-```py
-from typing import Literal, NewType, final
-from ty_extensions import static_assert
-from ty_extensions._internal import is_disjoint_from
-
-UserId = NewType("UserId", int)
-
-@final
-class FinalInt(int): ...
-
-class OrdinaryInt(int): ...
-
-FinalIntId = NewType("FinalIntId", FinalInt)
-
-static_assert(not is_disjoint_from(UserId, FinalInt))
-static_assert(not is_disjoint_from(UserId, OrdinaryInt))
-static_assert(not is_disjoint_from(UserId, int))
-static_assert(not is_disjoint_from(UserId, object))
-static_assert(is_disjoint_from(UserId, str))
-static_assert(not is_disjoint_from(FinalIntId, FinalInt))
-static_assert(not is_disjoint_from(FinalIntId, int))
-```
-
-An `IntEnum` and its members also overlap with an integer-based `NewType`.
-
-```py
-from enum import IntEnum
-
-class Choice(IntEnum):
-    FIRST = 1
-    SECOND = 2
-
-static_assert(not is_disjoint_from(UserId, Choice))
-static_assert(not is_disjoint_from(UserId, Literal[Choice.FIRST]))
-```
-
-## NewTypes and generic classes
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-A `NewType` based on a covariant generic specialization overlaps with its generic supertypes and
-subclasses. Two differently specialized covariant types can also overlap through a common, more
-specific specialization.
-
-```py
-from typing import Any, NewType
-from ty_extensions import static_assert
-from ty_extensions._internal import is_disjoint_from, is_subtype_of
-
-class Base[T]:
-    def get(self) -> T:
-        raise NotImplementedError
-
-class Child[T](Base[T]): ...
-
-BaseId = NewType("BaseId", Base[int])
-
-static_assert(not is_disjoint_from(BaseId, Base[int]))
-static_assert(not is_disjoint_from(BaseId, Base[object]))
-# `Base[Never]` is inhabited (`get` can raise) and is a subtype of both `Base[int]` and `Base[str]`.
-static_assert(not is_disjoint_from(BaseId, Base[str]))
-static_assert(not is_disjoint_from(BaseId, Child[object]))
-```
-
-An ordinary gradual specialization can overlap a `NewType` even when strict subtyping does not hold.
-Independently defined `NewType`s remain disjoint.
-
-```py
-AnyListId = NewType("AnyListId", list[Any])
-IntListId = NewType("IntListId", list[int])
-
-static_assert(not is_subtype_of(AnyListId, list[int]))
-static_assert(not is_disjoint_from(AnyListId, list[int]))
-static_assert(not is_disjoint_from(IntListId, list[Any]))
-static_assert(is_disjoint_from(IntListId, list[str]))
-static_assert(is_disjoint_from(IntListId, AnyListId))
-```
-
-A generic type variable must not make a potentially compatible specialization appear disjoint.
-Compatible constraints and bounds also preserve the overlap.
-
-```py
-def unconstrained[T]() -> None:
-    static_assert(not is_disjoint_from(IntListId, list[T]))
-    static_assert(not is_disjoint_from(list[T], IntListId))
-
-def compatible_constraints[T: (int, str)]() -> None:
-    static_assert(not is_disjoint_from(IntListId, list[T]))
-
-def compatible_bound[T: int]() -> None:
-    static_assert(not is_disjoint_from(IntListId, list[T]))
-```
-
-## Statically empty and non-empty ranges
-
-```py
-from ty_extensions import static_assert
-from ty_extensions._internal import TypeOf, is_disjoint_from
-
-static_assert(is_disjoint_from(TypeOf[range(0)], TypeOf[range(1)]))
-static_assert(is_disjoint_from(TypeOf[range(1)], TypeOf[range(0)]))
-static_assert(not is_disjoint_from(TypeOf[range(0)], range))
-static_assert(not is_disjoint_from(TypeOf[range(1)], range))
-```
-
-## Enum complements
-
-```pyi
-from enum import Enum
-from typing import Literal
-from ty_extensions import static_assert
-from ty_extensions._internal import is_disjoint_from
-
-class Color(Enum):
-    RED = 1
-    GREEN = 2
-    BLUE = 3
-
-static_assert(
-    is_disjoint_from(
-        Color & ~Literal[Color.RED],
-        Color & ~Literal[Color.GREEN, Color.BLUE],
-    )
-)
-static_assert(
-    is_disjoint_from(
-        Color & ~Literal[Color.GREEN, Color.BLUE],
-        Color & ~Literal[Color.RED],
-    )
-)
-```
-
 ## Class hierarchies
+
+Two classes overlap when a subclass could inherit from both. Final classes and incompatible
+metaclasses can rule out that shared subclass.
 
 ```pyi
 from ty_extensions import static_assert
@@ -308,7 +77,7 @@ static_assert(is_disjoint_from(UsesMeta1, UsesMeta2))
 
 ## `@final` builtin types
 
-Some builtins types are declared as `@final`:
+Some builtin types are declared as `@final`:
 
 ```py
 from ty_extensions import static_assert
@@ -325,123 +94,18 @@ static_assert(is_disjoint_from(memoryview, Foo))
 static_assert(is_disjoint_from(type[memoryview], type[Foo]))
 ```
 
-## Specialized `@final` types
+## Gradual types
 
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from typing import Any, final
-from ty_extensions import static_assert
-from ty_extensions._internal import is_disjoint_from
-
-@final
-class Foo[T]:
-    def get(self) -> T:
-        raise NotImplementedError
-
-class A: ...
-class B: ...
-
-static_assert(not is_disjoint_from(A, B))
-static_assert(not is_disjoint_from(Foo[A], Foo[B]))
-static_assert(not is_disjoint_from(Foo[A], Foo[Any]))
-static_assert(not is_disjoint_from(Foo[Any], Foo[B]))
-
-# `Foo[Never]` is a subtype of both `Foo[int]` and `Foo[str]`.
-static_assert(not is_disjoint_from(Foo[int], Foo[str]))
-```
-
-## Invariant generic specializations and bases
-
-Only incompatible invariant generic arguments imply disjointness. Covariant generic arguments do
-not: a covariant container can be inhabited by an empty value.
+Gradual types are not disjoint if any possible materialization is not disjoint.
 
 ```pyi
-from collections.abc import Sequence
-from typing import Any, Generic, TypeVar
+from typing import Any
 from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from
 
-T = TypeVar("T")
-U = TypeVar("U")
-T_co = TypeVar("T_co", covariant=True)
-
-class A: ...
-class B: ...
-
-class Invariant(Generic[T]):
-    x: T
-
-class InvariantPair(Generic[T, U]):
-    x: T
-    y: U
-
-class Covariant(Generic[T_co]):
-    def get(self) -> T_co:
-        raise NotImplementedError()
-
-class InvSubA(Invariant[A]):
-    pass
-
-class CoSubB(Covariant[B]):
-    pass
-
-static_assert(is_disjoint_from(Invariant[A], Invariant[B]))
-static_assert(is_disjoint_from(InvSubA, Invariant[B]))
-static_assert(not is_disjoint_from(Invariant[A], Invariant[A]))
-static_assert(not is_disjoint_from(Invariant[Any], Invariant[B]))
-static_assert(not is_disjoint_from(Invariant[B], Invariant[Any]))
-# `A | Any` cannot materialize to be equivalent to `B`.
-static_assert(is_disjoint_from(Invariant[A | Any], Invariant[B]))
-static_assert(is_disjoint_from(Invariant[B], Invariant[A | Any]))
-static_assert(is_disjoint_from(Invariant[A & Any], Invariant[B]))
-static_assert(is_disjoint_from(Invariant[B], Invariant[A & Any]))
-static_assert(is_disjoint_from(InvariantPair[A, A], InvariantPair[A, B]))
-static_assert(not is_disjoint_from(Covariant[A], Covariant[B]))
-static_assert(not is_disjoint_from(Covariant[A], CoSubB))
-static_assert(not is_disjoint_from(Sequence[int], Sequence[str]))
-```
-
-## Type-variable aliases and empty invariant arguments
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from typing import Generic, Never, TypeVar
-from ty_extensions import static_assert
-from ty_extensions._internal import is_disjoint_from
-
-T = TypeVar("T")
-
-class Invariant(Generic[T]):
-    x: T
-
-type Id[V] = V
-
-def _[U]():
-    static_assert(not is_disjoint_from(Invariant[U], Invariant[int]))
-    static_assert(not is_disjoint_from(Invariant[Id[U]], Invariant[int]))
-
-static_assert(not is_disjoint_from(Invariant[Id[int]], Invariant[int]))
-static_assert(is_disjoint_from(Invariant[Id[int]], Invariant[str]))
-
-class Mixed[T, U]:
-    x: T
-
-# `Mixed` is bivariant in `U`, so the differing second argument cannot make these disjoint.
-static_assert(not is_disjoint_from(Mixed[Never, int], Mixed[Never, str]))
-
-class Left(Invariant[Never]): ...
-class Right(Invariant[Never]): ...
-class Both(Left, Right): ...
-
-static_assert(not is_disjoint_from(Left, Right))
+static_assert(not is_disjoint_from(Any, bool))
+static_assert(not is_disjoint_from(Any, Any))
+static_assert(not is_disjoint_from(Any, ~Any))
 ```
 
 ## "Disjoint base" builtin types
@@ -533,6 +197,9 @@ static_assert(not is_disjoint_from(D, A))
 
 ## Dataclasses
 
+Dataclasses with incompatible non-empty slots are disjoint; dataclasses with empty slots can still
+share a subclass.
+
 ```py
 from dataclasses import dataclass
 from ty_extensions import static_assert
@@ -565,6 +232,8 @@ static_assert(is_disjoint_from(I, J))
 
 ## Tuple types
 
+Tuple types are disjoint when their lengths or corresponding element types cannot overlap.
+
 ```py
 from typing_extensions import Literal, Never
 from ty_extensions import static_assert
@@ -592,6 +261,8 @@ static_assert(is_disjoint_from(tuple[int, int], tuple[None, ...]))  # error: [st
 
 ## Unions
 
+A union is disjoint from another type when none of its alternatives overlap that type.
+
 ```py
 from typing_extensions import Literal
 from ty_extensions import static_assert
@@ -605,6 +276,9 @@ static_assert(not is_disjoint_from(Literal[1, 2], Literal[2, 3]))
 ```
 
 ## Intersections
+
+Positive requirements and negated types can prevent an intersection from sharing any inhabitants
+with another type.
 
 ```pyi
 from typing_extensions import Literal, final, Any, LiteralString
@@ -671,6 +345,8 @@ static_assert(is_disjoint_from(AlwaysFalsy, LiteralString & ~Literal[""]))  # er
 
 ## Special types
 
+Some typing constructs and precisely described runtime values have their own disjointness rules.
+
 ### `Never`
 
 `Never` is disjoint from every type, including itself.
@@ -687,6 +363,8 @@ static_assert(is_disjoint_from(Never, object))
 ```
 
 ### `None`
+
+`None` overlaps only with types that can contain the `None` object.
 
 ```pyi
 from typing_extensions import Literal, LiteralString
@@ -710,6 +388,8 @@ static_assert(is_disjoint_from(None, int & ~str))
 ```
 
 ### Literals
+
+Literal types are disjoint when their values or runtime types cannot overlap.
 
 ```pyi
 from typing_extensions import Literal, LiteralString
@@ -773,6 +453,9 @@ static_assert(is_disjoint_from(LiteralString & ~AlwaysFalsy, ~LiteralString | Al
 
 ### Class, module and function literals
 
+Class, module, and function literals identify specific runtime objects, so distinct objects have
+disjoint literal types.
+
 ```toml
 [environment]
 python-version = "3.12"
@@ -819,6 +502,8 @@ static_assert(not is_disjoint_from(TypeOf[f], object))
 ```
 
 ### Bound methods
+
+Bound methods are disjoint when their names or possible receiver types cannot overlap.
 
 ```py
 from typing import final
@@ -904,6 +589,9 @@ static_assert(not is_disjoint_from(TypeOf[F().foo], TypeOf[G().foo]))
 
 ### `AlwaysTruthy` and `AlwaysFalsy`
 
+`AlwaysTruthy` and `AlwaysFalsy` are disjoint from types whose possible values cannot have the
+corresponding truthiness.
+
 ```py
 from ty_extensions import AlwaysFalsy, AlwaysTruthy, static_assert
 from ty_extensions._internal import is_disjoint_from
@@ -979,6 +667,9 @@ static_assert(is_disjoint_from(type[UsesMeta1], type[UsesMeta2]))
 
 ### `property`
 
+Property descriptors and property-bearing classes are disjoint from incompatible final classes or
+protocol requirements.
+
 ```py
 from ty_extensions import static_assert
 from ty_extensions._internal import TypeOf, is_disjoint_from
@@ -1028,6 +719,8 @@ static_assert(is_disjoint_from(HasReadWriteIntProp, E))
 
 ### `TypeGuard` and `TypeIs`
 
+`TypeGuard` and `TypeIs` represent boolean return values, so they overlap `bool` but not `str`.
+
 ```py
 from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from
@@ -1038,29 +731,6 @@ static_assert(not is_disjoint_from(bool, TypeIs[str]))
 
 static_assert(is_disjoint_from(str, TypeGuard[str]))
 static_assert(is_disjoint_from(str, TypeIs[str]))
-```
-
-`TypeGuard` and `TypeIs` represent boolean return values, so they overlap with `NewType`s whose
-concrete bases accept booleans, including `int` and `float`. A `NewType` with an incompatible base
-remains disjoint.
-
-```py
-from typing import NewType
-
-Boolean = NewType("Boolean", bool)
-Integer = NewType("Integer", int)
-Numeric = NewType("Numeric", float)
-Text = NewType("Text", str)
-
-static_assert(not is_disjoint_from(Boolean, TypeGuard[str]))
-static_assert(not is_disjoint_from(TypeIs[str], Boolean))
-
-static_assert(not is_disjoint_from(Integer, TypeGuard[str]))
-
-static_assert(not is_disjoint_from(Numeric, TypeIs[str]))
-
-static_assert(is_disjoint_from(Text, TypeGuard[str]))
-static_assert(is_disjoint_from(TypeIs[str], Text))
 ```
 
 ### `Protocol`
@@ -1127,6 +797,9 @@ static_assert(is_disjoint_from(type[Foo], BarNone))
 
 ### `NamedTuple`
 
+A `NamedTuple` overlaps compatible tuple shapes but is disjoint from incompatible tuple lengths and
+distinct final named-tuple classes.
+
 ```py
 from __future__ import annotations
 
@@ -1149,49 +822,6 @@ static_assert(not is_disjoint_from(Path, tuple[Path | None, str]))
 static_assert(is_disjoint_from(Path, tuple[Path | None]))
 static_assert(is_disjoint_from(Path, tuple[Path | None, str, int]))
 static_assert(is_disjoint_from(Path, Path2))
-```
-
-## Generic aliases
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from typing import final
-from ty_extensions import static_assert
-from ty_extensions._internal import TypeOf, is_disjoint_from
-
-class GenericClass[T]:
-    x: T  # invariant
-
-static_assert(not is_disjoint_from(TypeOf[GenericClass], type[GenericClass]))  # error: [missing-type-argument]
-static_assert(not is_disjoint_from(TypeOf[GenericClass[int]], type[GenericClass]))  # error: [missing-type-argument]
-static_assert(not is_disjoint_from(TypeOf[GenericClass], type[GenericClass[int]]))
-static_assert(not is_disjoint_from(TypeOf[GenericClass[int]], type[GenericClass[int]]))
-static_assert(is_disjoint_from(TypeOf[GenericClass[str]], type[GenericClass[int]]))
-
-class GenericClassIntBound[T: int]:
-    x: T  # invariant
-
-static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound], type[GenericClassIntBound]))  # error: [missing-type-argument]
-static_assert(
-    # error: [missing-type-argument]
-    not is_disjoint_from(TypeOf[GenericClassIntBound[int]], type[GenericClassIntBound])
-)
-static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound], type[GenericClassIntBound[int]]))
-static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound[int]], type[GenericClassIntBound[int]]))
-
-@final
-class GenericFinalClass[T]:
-    x: T  # invariant
-
-static_assert(not is_disjoint_from(TypeOf[GenericFinalClass], type[GenericFinalClass]))  # error: [missing-type-argument]
-static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericFinalClass]))  # error: [missing-type-argument]
-static_assert(not is_disjoint_from(TypeOf[GenericFinalClass], type[GenericFinalClass[int]]))
-static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericFinalClass[int]]))
-static_assert(is_disjoint_from(TypeOf[GenericFinalClass[str]], type[GenericFinalClass[int]]))
 ```
 
 ## Callables
@@ -1346,7 +976,24 @@ static_assert(not is_disjoint_from(Callable[..., Any], TypeOf[OrderedDict]))
 static_assert(not is_disjoint_from(TypeOf[OrderedDict], Callable[..., Any]))
 ```
 
+## Statically empty and non-empty ranges
+
+An empty range is disjoint from a range known to be non-empty, but both overlap the general `range`
+type.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_disjoint_from
+
+static_assert(is_disjoint_from(TypeOf[range(0)], TypeOf[range(1)]))
+static_assert(is_disjoint_from(TypeOf[range(1)], TypeOf[range(0)]))
+static_assert(not is_disjoint_from(TypeOf[range(0)], range))
+static_assert(not is_disjoint_from(TypeOf[range(1)], range))
+```
+
 ## Custom enum classes
+
+Enum members overlap their enum class and its ancestors, but not other members or unrelated classes.
 
 ```py
 from enum import Enum
@@ -1370,4 +1017,464 @@ static_assert(is_disjoint_from(Literal[MyAnswer.NO], UnrelatedClass))
 
 static_assert(not is_disjoint_from(Literal[MyAnswer.NO], MyAnswer))
 static_assert(not is_disjoint_from(Literal[MyAnswer.NO], MyEnum))
+```
+
+## Enum complements
+
+Enum types with complementary negations are disjoint when no enum member satisfies both.
+
+```pyi
+from enum import Enum
+from typing import Literal
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+static_assert(
+    is_disjoint_from(
+        Color & ~Literal[Color.RED],
+        Color & ~Literal[Color.GREEN, Color.BLUE],
+    )
+)
+static_assert(
+    is_disjoint_from(
+        Color & ~Literal[Color.GREEN, Color.BLUE],
+        Color & ~Literal[Color.RED],
+    )
+)
+```
+
+## Static tags and typed inhabitants
+
+An inhabitant of a type can be more than a bare runtime object: it can also include static type
+information, not present at runtime, which can be understood as an invisible "tag". For example, a
+generic tag records the type arguments of a specialization such as `list[int]`, while a `NewType`
+tag identifies the `NewType` applied to a value. Neither kind of tag is visible on the runtime
+object itself, but both affect which types an inhabitant belongs to.
+
+Generic tags carry guarantees about how an object can be used. The invariant types `list[int]` and
+`list[str]` are disjoint because one reference could append a string that the other would then
+incorrectly read as an integer. These incompatible generic tags cannot describe the same object
+simultaneously in soundly typed code.
+
+Unlike incompatible invariant generic tags, distinct `NewType` tags can describe different typed
+inhabitants of the same runtime object. If `UserId` and `OrderId` are distinct integer `NewType`s,
+both `UserId(value)` and `OrderId(value)` return the same integer unchanged at runtime, but their
+tags are incompatible. The two `NewType`s are disjoint even though their values can identify the
+same runtime object. Both types still overlap `int`, which does not require either specific tag.
+
+### Invariant and covariant generic specializations
+
+Incompatible invariant arguments make generic specializations disjoint. Covariant specializations
+can still overlap when a common empty or bottom specialization satisfies both.
+
+```pyi
+from collections.abc import Sequence
+from typing import Any, Generic, TypeVar
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+static_assert(is_disjoint_from(list[int], list[str]))
+
+T = TypeVar("T")
+U = TypeVar("U")
+T_co = TypeVar("T_co", covariant=True)
+
+class A: ...
+class B: ...
+
+class Invariant(Generic[T]):
+    x: T
+
+class InvariantPair(Generic[T, U]):
+    x: T
+    y: U
+
+class Covariant(Generic[T_co]):
+    def get(self) -> T_co:
+        raise NotImplementedError()
+
+class InvSubA(Invariant[A]):
+    pass
+
+class CoSubB(Covariant[B]):
+    pass
+
+static_assert(is_disjoint_from(Invariant[A], Invariant[B]))
+static_assert(is_disjoint_from(InvSubA, Invariant[B]))
+static_assert(not is_disjoint_from(Invariant[A], Invariant[A]))
+static_assert(not is_disjoint_from(Invariant[Any], Invariant[B]))
+static_assert(not is_disjoint_from(Invariant[B], Invariant[Any]))
+# `A | Any` cannot materialize to be equivalent to `B`.
+static_assert(is_disjoint_from(Invariant[A | Any], Invariant[B]))
+static_assert(is_disjoint_from(Invariant[B], Invariant[A | Any]))
+static_assert(is_disjoint_from(Invariant[A & Any], Invariant[B]))
+static_assert(is_disjoint_from(Invariant[B], Invariant[A & Any]))
+static_assert(is_disjoint_from(InvariantPair[A, A], InvariantPair[A, B]))
+static_assert(not is_disjoint_from(Covariant[A], Covariant[B]))
+static_assert(not is_disjoint_from(Covariant[A], CoSubB))
+static_assert(not is_disjoint_from(Sequence[int], Sequence[str]))
+```
+
+### Specialized `@final` types
+
+Final generic classes can have overlapping specializations when a common specialization, such as one
+with a `Never` type argument, inhabits both.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, final
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+@final
+class Foo[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class A: ...
+class B: ...
+
+static_assert(not is_disjoint_from(A, B))
+static_assert(not is_disjoint_from(Foo[A], Foo[B]))
+static_assert(not is_disjoint_from(Foo[A], Foo[Any]))
+static_assert(not is_disjoint_from(Foo[Any], Foo[B]))
+
+# `Foo[Never]` is a subtype of both `Foo[int]` and `Foo[str]`.
+static_assert(not is_disjoint_from(Foo[int], Foo[str]))
+```
+
+### Type-variable aliases and empty invariant arguments
+
+Type-variable aliases preserve potentially compatible generic arguments. Empty or irrelevant type
+arguments do not make otherwise compatible subclasses disjoint.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generic, Never, TypeVar
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+T = TypeVar("T")
+
+class Invariant(Generic[T]):
+    x: T
+
+type Id[V] = V
+
+def _[U]():
+    static_assert(not is_disjoint_from(Invariant[U], Invariant[int]))
+    static_assert(not is_disjoint_from(Invariant[Id[U]], Invariant[int]))
+
+static_assert(not is_disjoint_from(Invariant[Id[int]], Invariant[int]))
+static_assert(is_disjoint_from(Invariant[Id[int]], Invariant[str]))
+
+class Mixed[T, U]:
+    x: T
+
+# `Mixed` is bivariant in `U`, so the differing second argument cannot make these disjoint.
+static_assert(not is_disjoint_from(Mixed[Never, int], Mixed[Never, str]))
+
+class Left(Invariant[Never]): ...
+class Right(Invariant[Never]): ...
+class Both(Left, Right): ...
+
+static_assert(not is_disjoint_from(Left, Right))
+```
+
+### NewTypes and overlapping types
+
+A `NewType` overlaps with any nominal or structural type that overlaps its concrete base. This
+includes the base itself, its supertypes and subclasses, and protocols satisfied by the base.
+
+```py
+from typing import NewType, Protocol, final
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+UserId = NewType("UserId", int)
+
+@final
+class FinalInt(int): ...
+
+class OrdinaryInt(int): ...
+
+class SupportsInt(Protocol):
+    def __int__(self) -> int: ...
+
+FinalIntId = NewType("FinalIntId", FinalInt)
+
+static_assert(not is_disjoint_from(UserId, int))
+static_assert(not is_disjoint_from(UserId, object))
+static_assert(not is_disjoint_from(UserId, FinalInt))
+static_assert(not is_disjoint_from(UserId, OrdinaryInt))
+static_assert(not is_disjoint_from(UserId, SupportsInt))
+static_assert(is_disjoint_from(UserId, str))
+static_assert(not is_disjoint_from(FinalIntId, FinalInt))
+static_assert(not is_disjoint_from(FinalIntId, int))
+```
+
+### NewTypes and literal types
+
+The same overlap rule applies to literal types: a `NewType` overlaps with any literal type that
+overlaps with its concrete base. Because `bool` is a subtype of `int`, type checkers correctly
+accept `UserId(True)`, and an integer-based `NewType` also overlaps boolean literals.
+
+```py
+from typing import Literal, NewType
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+UserId = NewType("UserId", int)
+StringId = NewType("StringId", str)
+BytesId = NewType("BytesId", bytes)
+
+UserId(True)
+
+static_assert(not is_disjoint_from(UserId, Literal[True]))
+static_assert(not is_disjoint_from(Literal[True], UserId))
+static_assert(not is_disjoint_from(UserId, Literal[False]))
+static_assert(not is_disjoint_from(UserId, Literal[True, False]))
+static_assert(not is_disjoint_from(UserId, Literal[1]))
+static_assert(not is_disjoint_from(UserId, bool))
+static_assert(not is_disjoint_from(bool, UserId))
+static_assert(not is_disjoint_from(UserId, int))
+static_assert(is_disjoint_from(UserId, Literal["user"]))
+
+static_assert(not is_disjoint_from(StringId, Literal["user"]))
+static_assert(not is_disjoint_from(BytesId, Literal[b"user"]))
+```
+
+An `IntEnum` and its members also overlap with an integer-based `NewType`.
+
+```py
+from enum import IntEnum
+
+class Choice(IntEnum):
+    FIRST = 1
+    SECOND = 2
+
+static_assert(not is_disjoint_from(UserId, Choice))
+static_assert(not is_disjoint_from(UserId, Literal[Choice.FIRST]))
+```
+
+Nested NewTypes retain the overlap, and a float-based NewType also accepts `int` and `bool` through
+the `int`/`float` special case.
+
+```py
+NestedUserId = NewType("NestedUserId", UserId)
+FloatId = NewType("FloatId", float)
+BoolId = NewType("BoolId", bool)
+
+static_assert(not is_disjoint_from(NestedUserId, bool))
+static_assert(not is_disjoint_from(NestedUserId, Literal[True]))
+static_assert(not is_disjoint_from(FloatId, bool))
+static_assert(not is_disjoint_from(FloatId, Literal[True]))
+static_assert(not is_disjoint_from(FloatId, Literal[1]))
+static_assert(not is_disjoint_from(FloatId, int))
+static_assert(not is_disjoint_from(BoolId, bool))
+```
+
+### NewTypes and type guards
+
+`TypeGuard` and `TypeIs` represent boolean return values, so they overlap with `NewType`s whose
+concrete bases accept booleans, including `int` and `float`. A `NewType` with an incompatible base
+remains disjoint.
+
+```py
+from typing import NewType
+from typing_extensions import TypeGuard, TypeIs
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+Boolean = NewType("Boolean", bool)
+Integer = NewType("Integer", int)
+Numeric = NewType("Numeric", float)
+Text = NewType("Text", str)
+
+static_assert(not is_disjoint_from(Boolean, TypeGuard[str]))
+static_assert(not is_disjoint_from(TypeIs[str], Boolean))
+
+static_assert(not is_disjoint_from(Integer, TypeGuard[str]))
+
+static_assert(not is_disjoint_from(Numeric, TypeIs[str]))
+
+static_assert(is_disjoint_from(Text, TypeGuard[str]))
+static_assert(is_disjoint_from(TypeIs[str], Text))
+```
+
+### Distinct NewTypes
+
+Unrelated `NewType` tags are mutually exclusive, even when their constructors return the same
+runtime object. For the runtime object `True`, `(bool, First)` and `(bool, Second)` are different
+(runtime type, tag) pairs. Both inhabit `int`, `bool`, and `Literal[True]`, but only the first
+inhabits `First` and only the second inhabits `Second`. No pair inhabits both `NewType`s, so those
+types are disjoint even though each overlaps the same ordinary types.
+
+```py
+from typing import Literal, NewType
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_disjoint_from, is_subtype_of
+
+First = NewType("First", int)
+Second = NewType("Second", int)
+Numeric = NewType("Numeric", float)
+Text = NewType("Text", str)
+
+static_assert(is_disjoint_from(First, Second))
+static_assert(is_disjoint_from(Second, First))
+static_assert(is_disjoint_from(First, Numeric))
+static_assert(is_disjoint_from(First, Text))
+
+static_assert(not is_disjoint_from(First, int))
+static_assert(not is_disjoint_from(Second, int))
+static_assert(not is_disjoint_from(First, bool))
+static_assert(not is_disjoint_from(Second, bool))
+static_assert(not is_disjoint_from(First, Literal[True]))
+static_assert(not is_disjoint_from(Second, Literal[True]))
+
+static_assert(not is_subtype_of(First, Second))
+static_assert(not is_assignable_to(First, Second))
+```
+
+### Nested NewTypes
+
+A nested `NewType` remains a subtype of its parent, so their types overlap. Independently nested
+`NewType`s remain disjoint, as do a nested `NewType` and an unrelated tag.
+
+```py
+from typing import NewType
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_disjoint_from, is_subtype_of
+
+First = NewType("First", int)
+Second = NewType("Second", int)
+NestedFirst = NewType("NestedFirst", First)
+OtherNestedFirst = NewType("OtherNestedFirst", First)
+
+static_assert(is_disjoint_from(NestedFirst, Second))
+static_assert(is_disjoint_from(NestedFirst, OtherNestedFirst))
+static_assert(not is_disjoint_from(NestedFirst, First))
+static_assert(not is_disjoint_from(First, NestedFirst))
+static_assert(is_subtype_of(NestedFirst, First))
+static_assert(is_assignable_to(NestedFirst, First))
+static_assert(not is_assignable_to(First, NestedFirst))
+```
+
+### NewTypes and generic classes
+
+A `NewType` based on a covariant generic specialization overlaps with its generic supertypes and
+subclasses. Two differently specialized covariant types can also overlap through a common, more
+specific specialization.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, NewType
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
+
+class Base[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Child[T](Base[T]): ...
+
+BaseId = NewType("BaseId", Base[int])
+
+static_assert(not is_disjoint_from(BaseId, Base[int]))
+static_assert(not is_disjoint_from(BaseId, Base[object]))
+# `Base[Never]` is inhabited (`get` can raise) and is a subtype of both `Base[int]` and `Base[str]`.
+static_assert(not is_disjoint_from(BaseId, Base[str]))
+static_assert(not is_disjoint_from(BaseId, Child[object]))
+```
+
+An ordinary gradual specialization can overlap a `NewType` even when strict subtyping does not hold.
+Independently defined `NewType`s remain disjoint.
+
+```py
+AnyListId = NewType("AnyListId", list[Any])
+IntListId = NewType("IntListId", list[int])
+
+static_assert(not is_subtype_of(AnyListId, list[int]))
+static_assert(not is_disjoint_from(AnyListId, list[int]))
+static_assert(not is_disjoint_from(IntListId, list[Any]))
+static_assert(is_disjoint_from(IntListId, list[str]))
+static_assert(is_disjoint_from(IntListId, AnyListId))
+```
+
+A generic type variable must not make a potentially compatible specialization appear disjoint.
+Compatible constraints and bounds also preserve the overlap.
+
+```py
+def unconstrained[T]() -> None:
+    static_assert(not is_disjoint_from(IntListId, list[T]))
+    static_assert(not is_disjoint_from(list[T], IntListId))
+
+def compatible_constraints[T: (int, str)]() -> None:
+    static_assert(not is_disjoint_from(IntListId, list[T]))
+
+def compatible_bound[T: int]() -> None:
+    static_assert(not is_disjoint_from(IntListId, list[T]))
+```
+
+## Generic aliases
+
+Generic class objects and aliases overlap compatible `type[...]` types; incompatible invariant
+specializations make them disjoint.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import final
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_disjoint_from
+
+class GenericClass[T]:
+    x: T  # invariant
+
+static_assert(not is_disjoint_from(TypeOf[GenericClass], type[GenericClass]))  # error: [missing-type-argument]
+static_assert(not is_disjoint_from(TypeOf[GenericClass[int]], type[GenericClass]))  # error: [missing-type-argument]
+static_assert(not is_disjoint_from(TypeOf[GenericClass], type[GenericClass[int]]))
+static_assert(not is_disjoint_from(TypeOf[GenericClass[int]], type[GenericClass[int]]))
+static_assert(is_disjoint_from(TypeOf[GenericClass[str]], type[GenericClass[int]]))
+
+class GenericClassIntBound[T: int]:
+    x: T  # invariant
+
+static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound], type[GenericClassIntBound]))  # error: [missing-type-argument]
+static_assert(
+    # error: [missing-type-argument]
+    not is_disjoint_from(TypeOf[GenericClassIntBound[int]], type[GenericClassIntBound])
+)
+static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound], type[GenericClassIntBound[int]]))
+static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound[int]], type[GenericClassIntBound[int]]))
+
+@final
+class GenericFinalClass[T]:
+    x: T  # invariant
+
+static_assert(not is_disjoint_from(TypeOf[GenericFinalClass], type[GenericFinalClass]))  # error: [missing-type-argument]
+static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericFinalClass]))  # error: [missing-type-argument]
+static_assert(not is_disjoint_from(TypeOf[GenericFinalClass], type[GenericFinalClass[int]]))
+static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericFinalClass[int]]))
+static_assert(is_disjoint_from(TypeOf[GenericFinalClass[str]], type[GenericFinalClass[int]]))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -47,15 +47,12 @@ UserId(True)
 static_assert(not is_disjoint_from(UserId, Literal[True]))
 static_assert(not is_disjoint_from(Literal[True], UserId))
 static_assert(not is_disjoint_from(UserId, Literal[False]))
-static_assert(not is_disjoint_from(Literal[False], UserId))
 static_assert(not is_disjoint_from(UserId, Literal[True, False]))
 static_assert(not is_disjoint_from(UserId, Literal[1]))
-static_assert(not is_disjoint_from(Literal[1], UserId))
 static_assert(not is_disjoint_from(UserId, bool))
 static_assert(not is_disjoint_from(bool, UserId))
 static_assert(not is_disjoint_from(UserId, int))
 static_assert(is_disjoint_from(UserId, Literal["user"]))
-static_assert(is_disjoint_from(Literal["user"], UserId))
 
 static_assert(not is_disjoint_from(StringId, Literal["user"]))
 static_assert(not is_disjoint_from(BytesId, Literal[b"user"]))
@@ -75,7 +72,6 @@ static_assert(not is_disjoint_from(FloatId, bool))
 static_assert(not is_disjoint_from(FloatId, Literal[True]))
 static_assert(not is_disjoint_from(FloatId, Literal[1]))
 static_assert(not is_disjoint_from(FloatId, int))
-static_assert(not is_disjoint_from(FloatId, float))
 static_assert(not is_disjoint_from(BoolId, bool))
 ```
 
@@ -104,11 +100,9 @@ static_assert(is_disjoint_from(NestedFirst, Second))
 static_assert(is_disjoint_from(NestedFirst, OtherNestedFirst))
 static_assert(is_disjoint_from(First, Numeric))
 static_assert(is_disjoint_from(First, Text))
-static_assert(is_disjoint_from(Text, First))
 
 static_assert(not is_disjoint_from(NestedFirst, First))
 static_assert(not is_disjoint_from(First, NestedFirst))
-static_assert(not is_disjoint_from(OtherNestedFirst, First))
 static_assert(not is_disjoint_from(First, int))
 static_assert(not is_disjoint_from(Second, int))
 static_assert(not is_disjoint_from(First, bool))
@@ -118,9 +112,7 @@ static_assert(not is_disjoint_from(Second, Literal[True]))
 static_assert(is_disjoint_from(list[int], list[str]))
 
 static_assert(not is_subtype_of(First, Second))
-static_assert(not is_subtype_of(Second, First))
 static_assert(not is_assignable_to(First, Second))
-static_assert(not is_assignable_to(Second, First))
 static_assert(is_subtype_of(NestedFirst, First))
 static_assert(is_assignable_to(NestedFirst, First))
 static_assert(not is_assignable_to(First, NestedFirst))
@@ -146,9 +138,7 @@ class OrdinaryInt(int): ...
 FinalIntId = NewType("FinalIntId", FinalInt)
 
 static_assert(not is_disjoint_from(UserId, FinalInt))
-static_assert(not is_disjoint_from(FinalInt, UserId))
 static_assert(not is_disjoint_from(UserId, OrdinaryInt))
-static_assert(not is_disjoint_from(OrdinaryInt, UserId))
 static_assert(not is_disjoint_from(UserId, int))
 static_assert(not is_disjoint_from(UserId, object))
 static_assert(is_disjoint_from(UserId, str))
@@ -167,7 +157,6 @@ class Choice(IntEnum):
 
 static_assert(not is_disjoint_from(UserId, Choice))
 static_assert(not is_disjoint_from(UserId, Literal[Choice.FIRST]))
-static_assert(not is_disjoint_from(Literal[Choice.FIRST], UserId))
 ```
 
 ## NewTypes and generic classes
@@ -207,14 +196,12 @@ Independently defined `NewType`s remain disjoint.
 ```py
 AnyListId = NewType("AnyListId", list[Any])
 IntListId = NewType("IntListId", list[int])
-StrListId = NewType("StrListId", list[str])
 
 static_assert(not is_subtype_of(AnyListId, list[int]))
 static_assert(not is_disjoint_from(AnyListId, list[int]))
 static_assert(not is_disjoint_from(IntListId, list[Any]))
 static_assert(is_disjoint_from(IntListId, list[str]))
 static_assert(is_disjoint_from(IntListId, AnyListId))
-static_assert(is_disjoint_from(IntListId, StrListId))
 ```
 
 A generic type variable must not make a potentially compatible specialization appear disjoint.
@@ -227,7 +214,6 @@ def unconstrained[T]() -> None:
 
 def compatible_constraints[T: (int, str)]() -> None:
     static_assert(not is_disjoint_from(IntListId, list[T]))
-    static_assert(not is_disjoint_from(list[T], IntListId))
 
 def compatible_bound[T: int]() -> None:
     static_assert(not is_disjoint_from(IntListId, list[T]))
@@ -1067,23 +1053,13 @@ Numeric = NewType("Numeric", float)
 Text = NewType("Text", str)
 
 static_assert(not is_disjoint_from(Boolean, TypeGuard[str]))
-static_assert(not is_disjoint_from(TypeGuard[str], Boolean))
-static_assert(not is_disjoint_from(Boolean, TypeIs[str]))
 static_assert(not is_disjoint_from(TypeIs[str], Boolean))
 
 static_assert(not is_disjoint_from(Integer, TypeGuard[str]))
-static_assert(not is_disjoint_from(TypeGuard[str], Integer))
-static_assert(not is_disjoint_from(Integer, TypeIs[str]))
-static_assert(not is_disjoint_from(TypeIs[str], Integer))
 
-static_assert(not is_disjoint_from(Numeric, TypeGuard[str]))
-static_assert(not is_disjoint_from(TypeGuard[str], Numeric))
 static_assert(not is_disjoint_from(Numeric, TypeIs[str]))
-static_assert(not is_disjoint_from(TypeIs[str], Numeric))
 
 static_assert(is_disjoint_from(Text, TypeGuard[str]))
-static_assert(is_disjoint_from(TypeGuard[str], Text))
-static_assert(is_disjoint_from(Text, TypeIs[str]))
 static_assert(is_disjoint_from(TypeIs[str], Text))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -23,6 +23,74 @@ static_assert(not is_disjoint_from(LiteralString, LiteralString))
 static_assert(not is_disjoint_from(str, LiteralString))
 ```
 
+## NewTypes and boolean types
+
+An integer-based `NewType` is disjoint from both boolean literals, their union, and `bool` itself.
+
+```py
+from typing import Literal, NewType
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+UserId = NewType("UserId", int)
+
+static_assert(is_disjoint_from(UserId, Literal[True]))
+static_assert(is_disjoint_from(UserId, Literal[False]))
+static_assert(is_disjoint_from(UserId, Literal[True, False]))
+static_assert(is_disjoint_from(UserId, bool))
+static_assert(is_disjoint_from(bool, UserId))
+static_assert(not is_disjoint_from(UserId, int))
+```
+
+Nested and float-based NewTypes retain the distinction, while a NewType based directly on `bool`
+still overlaps with its base.
+
+```py
+NestedUserId = NewType("NestedUserId", UserId)
+FloatId = NewType("FloatId", float)
+BoolId = NewType("BoolId", bool)
+
+static_assert(is_disjoint_from(NestedUserId, bool))
+static_assert(is_disjoint_from(FloatId, bool))
+static_assert(not is_disjoint_from(BoolId, bool))
+```
+
+## NewTypes and final classes
+
+A NewType and a final subclass of its base cannot overlap unless the NewType itself is based on that
+final class. Non-final subclasses may still overlap with the NewType.
+
+```py
+from typing import NewType, final
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+UserId = NewType("UserId", int)
+
+@final
+class FinalInt(int): ...
+
+class OrdinaryInt(int): ...
+
+FinalIntId = NewType("FinalIntId", FinalInt)
+
+static_assert(is_disjoint_from(UserId, FinalInt))
+static_assert(not is_disjoint_from(UserId, OrdinaryInt))
+static_assert(not is_disjoint_from(FinalIntId, FinalInt))
+```
+
+An `IntEnum` with members is also final and disjoint from an integer-based NewType.
+
+```py
+from enum import IntEnum
+
+class Choice(IntEnum):
+    FIRST = 1
+    SECOND = 2
+
+static_assert(is_disjoint_from(UserId, Choice))
+```
+
 ## Statically empty and non-empty ranges
 
 ```py
@@ -156,6 +224,27 @@ static_assert(not is_disjoint_from(Foo[Any], Foo[B]))
 
 # `Foo[Never]` is a subtype of both `Foo[int]` and `Foo[str]`.
 static_assert(not is_disjoint_from(Foo[int], Foo[str]))
+```
+
+A covariant final generic specialization can overlap with a NewType without being its supertype:
+`FinalChild[int]` is a subtype of both the NewType's base, `Base[int]`, and `FinalChild[object]`.
+
+```py
+from typing import NewType
+from ty_extensions._internal import is_subtype_of
+
+class Base[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+@final
+class FinalChild[T](Base[T]): ...
+
+BaseId = NewType("BaseId", Base[int])
+
+static_assert(is_subtype_of(FinalChild[int], FinalChild[object]))
+static_assert(not is_subtype_of(BaseId, FinalChild[object]))
+static_assert(not is_disjoint_from(BaseId, FinalChild[object]))
 ```
 
 ## Invariant generic specializations and bases

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -1434,15 +1434,15 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import final
+from typing import Any, final
 from ty_extensions import static_assert
 from ty_extensions._internal import TypeOf, is_disjoint_from
 
 class GenericClass[T]:
     x: T  # invariant
 
-static_assert(not is_disjoint_from(TypeOf[GenericClass], type[GenericClass]))  # error: [missing-type-argument]
-static_assert(not is_disjoint_from(TypeOf[GenericClass[int]], type[GenericClass]))  # error: [missing-type-argument]
+static_assert(not is_disjoint_from(TypeOf[GenericClass], type[GenericClass[Any]]))
+static_assert(not is_disjoint_from(TypeOf[GenericClass[int]], type[GenericClass[Any]]))
 static_assert(not is_disjoint_from(TypeOf[GenericClass], type[GenericClass[int]]))
 static_assert(not is_disjoint_from(TypeOf[GenericClass[int]], type[GenericClass[int]]))
 static_assert(is_disjoint_from(TypeOf[GenericClass[str]], type[GenericClass[int]]))
@@ -1450,11 +1450,8 @@ static_assert(is_disjoint_from(TypeOf[GenericClass[str]], type[GenericClass[int]
 class GenericClassIntBound[T: int]:
     x: T  # invariant
 
-static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound], type[GenericClassIntBound]))  # error: [missing-type-argument]
-static_assert(
-    # error: [missing-type-argument]
-    not is_disjoint_from(TypeOf[GenericClassIntBound[int]], type[GenericClassIntBound])
-)
+static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound], type[GenericClassIntBound[Any]]))
+static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound[int]], type[GenericClassIntBound[Any]]))
 static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound], type[GenericClassIntBound[int]]))
 static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound[int]], type[GenericClassIntBound[int]]))
 
@@ -1462,8 +1459,8 @@ static_assert(not is_disjoint_from(TypeOf[GenericClassIntBound[int]], type[Gener
 class GenericFinalClass[T]:
     x: T  # invariant
 
-static_assert(not is_disjoint_from(TypeOf[GenericFinalClass], type[GenericFinalClass]))  # error: [missing-type-argument]
-static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericFinalClass]))  # error: [missing-type-argument]
+static_assert(not is_disjoint_from(TypeOf[GenericFinalClass], type[GenericFinalClass[Any]]))
+static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericFinalClass[Any]]))
 static_assert(not is_disjoint_from(TypeOf[GenericFinalClass], type[GenericFinalClass[int]]))
 static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericFinalClass[int]]))
 static_assert(is_disjoint_from(TypeOf[GenericFinalClass[str]], type[GenericFinalClass[int]]))

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1333,6 +1333,13 @@ fn finite_alternatives<'db>(
 
                 let expanded = intersection.with_expanded_typevars_and_newtypes(db, env);
                 let complement = match expanded {
+                    Type::LiteralValue(literal)
+                        if matches!(literal.kind(), LiteralValueTypeKind::Enum(_))
+                            && KnownComparisonSemantics::of_type(db, env, expanded, operator)
+                                .is_some() =>
+                    {
+                        return Some(vec![expanded]);
+                    }
                     Type::EnumComplement(complement) => complement,
                     Type::Intersection(intersection) => intersection.enum_complement(db, env)?,
                     _ => return None,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1320,13 +1320,26 @@ fn finite_alternatives<'db>(
                 .then(|| complement.remaining_literal_types(db, env))
         }
         Type::Intersection(intersection) => {
-            let expanded = intersection.with_expanded_typevars_and_newtypes(db, env);
-            let complement = match expanded {
-                Type::EnumComplement(complement) => complement,
-                Type::Intersection(intersection) => intersection.enum_complement(db, env)?,
-                _ => return None,
+            let (comparison_type, complement) = if let Some(complement) =
+                intersection.enum_complement(db, env)
+            {
+                (ty, complement)
+            } else {
+                if !intersection.positive(db).iter().any(|positive| {
+                    matches!(positive.resolve_type_alias(db), Type::NewTypeInstance(_))
+                }) {
+                    return None;
+                }
+
+                let expanded = intersection.with_expanded_typevars_and_newtypes(db, env);
+                let complement = match expanded {
+                    Type::EnumComplement(complement) => complement,
+                    Type::Intersection(intersection) => intersection.enum_complement(db, env)?,
+                    _ => return None,
+                };
+                (expanded, complement)
             };
-            KnownComparisonSemantics::of_type(db, env, expanded, operator)
+            KnownComparisonSemantics::of_type(db, env, comparison_type, operator)
                 .is_some()
                 .then(|| complement.remaining_literal_types(db, env))
         }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1333,12 +1333,10 @@ fn finite_alternatives<'db>(
 
                 let expanded = intersection.with_expanded_typevars_and_newtypes(db, env);
                 let complement = match expanded {
-                    Type::LiteralValue(literal)
-                        if matches!(literal.kind(), LiteralValueTypeKind::Enum(_))
-                            && KnownComparisonSemantics::of_type(db, env, expanded, operator)
-                                .is_some() =>
-                    {
-                        return Some(vec![expanded]);
+                    Type::LiteralValue(literal) if literal.is_enum() => {
+                        return KnownComparisonSemantics::of_type(db, env, expanded, operator)
+                            .is_some()
+                            .then(|| vec![expanded]);
                     }
                     Type::EnumComplement(complement) => complement,
                     Type::Intersection(intersection) => intersection.enum_complement(db, env)?,
@@ -1606,7 +1604,7 @@ fn evaluate_tuple_element_equality<'db>(
     ) {
         ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
         // Known comparison semantics are reflexive, so a false result rules out shared runtime
-        // identity. Nominal distinctness alone is insufficient because `NewType` and similar
+        // identity. Static disjointness alone is insufficient because `NewType` and similar
         // wrappers can erase their distinction at runtime.
         ComparisonResult::AlwaysFalse
             if [left, right]

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -5,14 +5,16 @@
 //! methods.
 
 use rustc_hash::FxHashSet;
+use ty_python_core::definition::Definition;
 
 use crate::{AnalysisSettings, Db, ProgramEnvironment, place::PlaceAndQualifiers};
 
 use super::{
-    CallArguments, CycleDetector, EnumLiteralType, IntersectionBuilder, KnownBoundMethodType,
-    KnownClass, LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type,
-    TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
+    CallArguments, EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass,
+    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type, TypeContext,
+    TypeVarBoundOrConstraints, UnionBuilder,
     bool::BoolError,
+    cyclic::ActiveRecursionDetector,
     enums::{enum_member_literals, enum_metadata},
 };
 
@@ -999,8 +1001,13 @@ pub(super) fn is_same_enum_domain<'db>(
     ty: Type<'db>,
     right: EnumLiteralType<'db>,
 ) -> bool {
-    struct EnumDomain;
-    type EnumDomainVisitor<'db> = CycleDetector<'db, EnumDomain, Type<'db>, bool, 3>;
+    // A proof made while another alias is active can still be disproved by a later union arm, so
+    // completed visits must not be cached.
+    #[derive(Default)]
+    struct EnumDomainVisitor<'db> {
+        active_specializations: ActiveRecursionDetector<Type<'db>>,
+        active_definitions: ActiveRecursionDetector<Definition<'db>>,
+    }
 
     fn visit<'db>(
         db: &'db dyn Db,
@@ -1010,9 +1017,19 @@ pub(super) fn is_same_enum_domain<'db>(
         visitor: &EnumDomainVisitor<'db>,
     ) -> bool {
         match ty {
-            Type::TypeAlias(alias) => visitor.visit(db, ty, || {
-                visit(db, env, alias.value_type(db), right, visitor)
-            }),
+            // The same specialization preserves the domain; different arguments can introduce
+            // values outside it even when the alias definition is the same.
+            Type::TypeAlias(alias) => visitor.active_specializations.visit(
+                &ty,
+                || true,
+                || {
+                    visitor.active_definitions.visit(
+                        &alias.definition(db),
+                        || false,
+                        || visit(db, env, alias.value_type(db), right, visitor),
+                    )
+                },
+            ),
             Type::LiteralValue(literal) => matches!(
                 literal.kind(),
                 LiteralValueTypeKind::Enum(left)
@@ -1037,7 +1054,7 @@ pub(super) fn is_same_enum_domain<'db>(
         }
     }
 
-    visit(db, env, ty, right, &EnumDomainVisitor::new(false))
+    visit(db, env, ty, right, &EnumDomainVisitor::default())
 }
 
 /// Evaluate each alternative of the union being constrained and combine their branch results.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -9,9 +9,9 @@ use rustc_hash::FxHashSet;
 use crate::{AnalysisSettings, Db, ProgramEnvironment, place::PlaceAndQualifiers};
 
 use super::{
-    CallArguments, EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass,
-    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type, TypeContext,
-    TypeVarBoundOrConstraints, UnionBuilder,
+    CallArguments, CycleDetector, EnumLiteralType, IntersectionBuilder, KnownBoundMethodType,
+    KnownClass, LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type,
+    TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
     bool::BoolError,
     enums::{enum_member_literals, enum_metadata},
 };
@@ -999,23 +999,45 @@ pub(super) fn is_same_enum_domain<'db>(
     ty: Type<'db>,
     right: EnumLiteralType<'db>,
 ) -> bool {
-    match ty.resolve_type_alias(db) {
-        Type::LiteralValue(literal) => matches!(
-            literal.kind(),
-            LiteralValueTypeKind::Enum(left)
-                if left.enum_class(db) == right.enum_class(db)
-        ),
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|element| is_same_enum_domain(db, env, *element, right)),
-        Type::NominalInstance(instance) => instance.class_literal(db, env) == right.enum_class(db),
-        Type::EnumComplement(complement) => complement.enum_class(db) == right.enum_class(db),
-        Type::Intersection(intersection) => intersection
-            .enum_complement(db, env)
-            .is_some_and(|complement| complement.enum_class(db) == right.enum_class(db)),
-        _ => false,
+    struct EnumDomain;
+    type EnumDomainVisitor<'db> = CycleDetector<'db, EnumDomain, Type<'db>, bool, 3>;
+
+    fn visit<'db>(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        ty: Type<'db>,
+        right: EnumLiteralType<'db>,
+        visitor: &EnumDomainVisitor<'db>,
+    ) -> bool {
+        match ty {
+            Type::TypeAlias(alias) => visitor.visit(db, ty, || {
+                visit(db, env, alias.value_type(db), right, visitor)
+            }),
+            Type::LiteralValue(literal) => matches!(
+                literal.kind(),
+                LiteralValueTypeKind::Enum(left)
+                    if left.enum_class(db) == right.enum_class(db)
+            ),
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .all(|&element| visit(db, env, element, right, visitor)),
+            Type::NewTypeInstance(newtype) => {
+                visit(db, env, newtype.concrete_base_type(db), right, visitor)
+            }
+            Type::NominalInstance(instance) => {
+                instance.class_literal(db, env) == right.enum_class(db)
+            }
+            Type::EnumComplement(complement) => complement.enum_class(db) == right.enum_class(db),
+            Type::Intersection(intersection) => intersection
+                .positive(db)
+                .iter()
+                .any(|&element| visit(db, env, element, right, visitor)),
+            _ => false,
+        }
     }
+
+    visit(db, env, ty, right, &EnumDomainVisitor::new(false))
 }
 
 /// Evaluate each alternative of the union being constrained and combine their branch results.
@@ -1298,10 +1320,23 @@ fn finite_alternatives<'db>(
                 .then(|| complement.remaining_literal_types(db, env))
         }
         Type::Intersection(intersection) => {
-            let complement = intersection.enum_complement(db, env)?;
-            KnownComparisonSemantics::of_type(db, env, ty, operator)
+            let expanded = intersection.with_expanded_typevars_and_newtypes(db, env);
+            let complement = match expanded {
+                Type::EnumComplement(complement) => complement,
+                Type::Intersection(intersection) => intersection.enum_complement(db, env)?,
+                _ => return None,
+            };
+            KnownComparisonSemantics::of_type(db, env, expanded, operator)
                 .is_some()
                 .then(|| complement.remaining_literal_types(db, env))
+        }
+        Type::NewTypeInstance(newtype) => {
+            let base = newtype.concrete_base_type(db);
+            if base.is_enum(db, env) {
+                finite_alternatives(db, env, base, operator)
+            } else {
+                None
+            }
         }
         Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Bool) => {
             Some(vec![Type::bool_literal(true), Type::bool_literal(false)])
@@ -1551,7 +1586,7 @@ fn evaluate_tuple_element_equality<'db>(
     ) {
         ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
         // Known comparison semantics are reflexive, so a false result rules out shared runtime
-        // identity. Static disjointness alone is insufficient because `NewType` and similar
+        // identity. Nominal distinctness alone is insufficient because `NewType` and similar
         // wrappers can erase their distinction at runtime.
         ComparisonResult::AlwaysFalse
             if [left, right]

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -529,11 +529,10 @@ impl<'db> EnumValueSet<'db> {
             .positive(db)
             .iter()
             .any(|positive| matches!(positive.resolve_type_alias(db), Type::NewTypeInstance(_)))
+            && let expanded = intersection.with_expanded_typevars_and_newtypes(db, env)
+            && let Some(value_set) = Self::from_type(db, env, expanded, active_types)
         {
-            let expanded = intersection.with_expanded_typevars_and_newtypes(db, env);
-            if let Some(value_set) = Self::from_type(db, env, expanded, active_types) {
-                return Some(value_set);
-            }
+            return Some(value_set);
         }
 
         // Other intersection components can only reduce the represented enum values. Ignoring

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -384,8 +384,8 @@ enum EnumValueSetMembers<'db> {
 impl<'db> EnumValueSet<'db> {
     /// Extract only structural enum membership facts from `ty`.
     ///
-    /// This deliberately does not use subtyping: a `NewType` over an enum is a subtype of the
-    /// enum but remains disjoint from the enum's literal members.
+    /// This deliberately does not use subtyping: extra nominal restrictions must not be
+    /// transferred to the other comparison operand.
     fn from_type(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -417,6 +417,9 @@ impl<'db> EnumValueSet<'db> {
                     enum_class: instance.class_literal(db, env).into_enum_class(db)?,
                     members: EnumValueSetMembers::All,
                 },
+                Type::NewTypeInstance(newtype) => {
+                    EnumValueSet::from_type(db, env, newtype.concrete_base_type(db), active_types)?
+                }
                 Type::EnumComplement(complement) => EnumValueSet {
                     enum_class: complement.enum_class_literal(db),
                     members: EnumValueSetMembers::AllExcept(complement),
@@ -520,6 +523,17 @@ impl<'db> EnumValueSet<'db> {
     ) -> Option<Self> {
         if let Some(complement) = intersection.enum_complement(db, env) {
             return Self::from_type(db, env, Type::EnumComplement(complement), active_types);
+        }
+
+        if intersection
+            .positive(db)
+            .iter()
+            .any(|positive| matches!(positive.resolve_type_alias(db), Type::NewTypeInstance(_)))
+        {
+            let expanded = intersection.with_expanded_typevars_and_newtypes(db, env);
+            if let Some(value_set) = Self::from_type(db, env, expanded, active_types) {
+                return Some(value_set);
+            }
         }
 
         // Other intersection components can only reduce the represented enum values. Ignoring

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -23,16 +23,15 @@ impl<'db> Type<'db> {
     /// Upcast `self` to a type that conservatively describes its possible runtime objects in an
     /// identity comparison.
     ///
-    /// A `NewType` constructor returns its argument unchanged, and `LiteralString` describes how a
-    /// string was produced rather than which object it is. Those distinctions can therefore differ
-    /// between two views of the same object: upcast a `NewType` to its concrete base and
-    /// `LiteralString` to `str`. In contrast, preserve invariant generic arguments because the same
-    /// mutable object cannot satisfy incompatible commitments such as `list[int]` and `list[str]`
-    /// without some other code already being unsound.
+    /// A `NewType` constructor returns its argument unchanged, so its tag can differ between two
+    /// views of the same object: upcast a `NewType` to its concrete base. In contrast, preserve
+    /// invariant generic arguments because the same mutable object cannot satisfy incompatible
+    /// commitments such as `list[int]` and `list[str]` without some other code already being
+    /// unsound.
     ///
     /// Preserve negations that constrain the object itself, such as `~None`, `~SomeClass`, and
-    /// `~Literal[1]`. Negations of a `NewType`, `LiteralString`, a type variable, or a type-guard
-    /// proof can differ between views of the same object and must instead be discarded.
+    /// `~Literal[1]`. A `NewType` tag, type-variable selection, or type-guard proof can differ
+    /// between views. Retain the existing conservative handling of negated string types.
     ///
     /// A type variable can also hide a `NewType` tag: even a variable bounded by `int` can be
     /// instantiated as an integer `NewType`. Expand variables to their upcast bounds or constraints
@@ -62,9 +61,6 @@ impl<'db> Type<'db> {
                 Type::NewTypeInstance(newtype) => {
                     upcast(db, env, newtype.concrete_base_type(db), visitor)
                 }
-                Type::LiteralValue(literal) if literal.is_literal_string() => {
-                    literal.fallback_instance(db, env)
-                }
                 Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
                     match typevar.typevar(db).bound_or_constraints(db, env) {
                         Some(bound_or_constraints) => {
@@ -82,15 +78,18 @@ impl<'db> Type<'db> {
                         builder = builder.add_positive(upcast(db, env, *element, visitor));
                     }
                     for element in intersection.negative(db) {
-                        // Tags, type-variable selections, `LiteralString` provenance, and predicate
-                        // proofs belong to one static view rather than the shared object. Keep every
-                        // negation that describes the object itself instead.
+                        // Static tags and predicate proofs can differ between views. Retain the
+                        // existing conservative handling of negated string types.
                         match element.resolve_type_alias(db) {
                             Type::NewTypeInstance(_)
                             | Type::TypeVar(_)
                             | Type::TypeIs(_)
                             | Type::TypeGuard(_) => continue,
-                            Type::LiteralValue(literal) if literal.is_literal_string() => continue,
+                            Type::LiteralValue(literal)
+                                if literal.is_literal_string() || literal.is_string() =>
+                            {
+                                continue;
+                            }
                             _ => builder.add_negative_in_place(*element),
                         }
                     }

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -23,12 +23,25 @@ impl<'db> Type<'db> {
     /// Upcast `self` to a type that conservatively describes its possible runtime objects in an
     /// identity comparison.
     ///
-    /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
-    /// type here while remaining distinct for ordinary type relations and intersections.
+    /// A `NewType` constructor returns its argument unchanged, and `LiteralString` describes how a
+    /// string was produced rather than which object it is. Those distinctions can therefore differ
+    /// between two views of the same object: upcast a `NewType` to its concrete base and
+    /// `LiteralString` to `str`. In contrast, preserve invariant generic arguments because the same
+    /// mutable object cannot satisfy incompatible commitments such as `list[int]` and `list[str]`
+    /// without some other code already being unsound.
     ///
-    /// Negative `NewType`, type-variable, and `LiteralString` constraints are omitted because
-    /// their static exclusions need not rule out particular runtime objects. Nominal and concrete
-    /// literal exclusions directly describe runtime objects, so they remain valid.
+    /// Preserve negations that constrain the object itself, such as `~None`, `~SomeClass`, and
+    /// `~Literal[1]`. Negations of a `NewType`, `LiteralString`, a type variable, or a type-guard
+    /// proof can differ between views of the same object and must instead be discarded.
+    ///
+    /// A type variable can also hide a `NewType` tag: even a variable bounded by `int` can be
+    /// instantiated as an integer `NewType`. Expand variables to their upcast bounds or constraints
+    /// instead of transferring that potentially tagged relationship; an unbounded variable becomes
+    /// `object`.
+    ///
+    /// Use this upcast both to decide whether identity is possible and to narrow the other
+    /// operand when it succeeds. Each operand retains its own existing tags and type-variable
+    /// relationships when the resulting constraint is applied.
     pub(crate) fn identity_comparison_type(
         self,
         db: &'db dyn Db,
@@ -46,13 +59,18 @@ impl<'db> Type<'db> {
                 Type::TypeAlias(alias) => {
                     visitor.visit_type(db, ty, || upcast(db, env, alias.value_type(db), visitor))
                 }
-                Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
+                Type::NewTypeInstance(newtype) => {
+                    upcast(db, env, newtype.concrete_base_type(db), visitor)
+                }
+                Type::LiteralValue(literal) if literal.is_literal_string() => {
+                    literal.fallback_instance(db, env)
+                }
                 Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
                     match typevar.typevar(db).bound_or_constraints(db, env) {
                         Some(bound_or_constraints) => {
                             upcast(db, env, bound_or_constraints.as_type(db, env), visitor)
                         }
-                        None => ty,
+                        None => KnownClass::Object.to_instance(db, env),
                     }
                 }),
                 Type::Union(union) => {
@@ -64,12 +82,18 @@ impl<'db> Type<'db> {
                         builder = builder.add_positive(upcast(db, env, *element, visitor));
                     }
                     for element in intersection.negative(db) {
-                        let preserve_exclusion = match element.resolve_type_alias(db) {
-                            Type::NominalInstance(_) => true,
+                        // Tags, type-variable selections, string provenance, and predicate proofs
+                        // belong to one static view rather than the shared object. Keep every
+                        // negation that describes the object itself instead.
+                        let preserve_negation = match element.resolve_type_alias(db) {
+                            Type::NewTypeInstance(_)
+                            | Type::TypeVar(_)
+                            | Type::TypeIs(_)
+                            | Type::TypeGuard(_) => false,
                             Type::LiteralValue(literal) => !literal.is_literal_string(),
-                            _ => false,
+                            _ => true,
                         };
-                        if preserve_exclusion {
+                        if preserve_negation {
                             builder = builder.add_negative(*element);
                         }
                     }

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -26,11 +26,9 @@ impl<'db> Type<'db> {
     /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
     /// type here while remaining distinct for ordinary type relations and intersections.
     ///
-    /// Negative intersection elements are generally omitted. A static exclusion does not imply a
-    /// runtime exclusion: `NewType("N", bool)(True)` can inhabit `~Literal[True]`, but evaluates
-    /// to the `True` singleton at runtime. However, excluding an entire nominal instance type is
-    /// stable under `NewType` erasure, so constraints such as `~None` and `~SomeClass` are
-    /// preserved.
+    /// Negative `NewType`, type-variable, and `LiteralString` constraints are omitted because
+    /// their static exclusions need not rule out particular runtime objects. Nominal and concrete
+    /// literal exclusions directly describe runtime objects, so they remain valid.
     pub(crate) fn identity_comparison_type(
         self,
         db: &'db dyn Db,
@@ -66,7 +64,12 @@ impl<'db> Type<'db> {
                         builder = builder.add_positive(upcast(db, env, *element, visitor));
                     }
                     for element in intersection.negative(db) {
-                        if element.resolve_type_alias(db).is_nominal_instance() {
+                        let preserve_exclusion = match element.resolve_type_alias(db) {
+                            Type::NominalInstance(_) => true,
+                            Type::LiteralValue(literal) => !literal.is_literal_string(),
+                            _ => false,
+                        };
+                        if preserve_exclusion {
                             builder = builder.add_negative(*element);
                         }
                     }

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -82,19 +82,16 @@ impl<'db> Type<'db> {
                         builder = builder.add_positive(upcast(db, env, *element, visitor));
                     }
                     for element in intersection.negative(db) {
-                        // Tags, type-variable selections, string provenance, and predicate proofs
-                        // belong to one static view rather than the shared object. Keep every
+                        // Tags, type-variable selections, `LiteralString` provenance, and predicate
+                        // proofs belong to one static view rather than the shared object. Keep every
                         // negation that describes the object itself instead.
-                        let preserve_negation = match element.resolve_type_alias(db) {
+                        match element.resolve_type_alias(db) {
                             Type::NewTypeInstance(_)
                             | Type::TypeVar(_)
                             | Type::TypeIs(_)
-                            | Type::TypeGuard(_) => false,
-                            Type::LiteralValue(literal) => !literal.is_literal_string(),
-                            _ => true,
-                        };
-                        if preserve_negation {
-                            builder = builder.add_negative(*element);
+                            | Type::TypeGuard(_) => continue,
+                            Type::LiteralValue(literal) if literal.is_literal_string() => continue,
+                            _ => builder.add_negative_in_place(*element),
                         }
                     }
                     builder.build()

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3528,9 +3528,21 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             Type::Union(union) => union.elements(db),
             _ => std::slice::from_ref(&transferable_ty),
         };
-        if !rhs_alternatives.iter().any(|ty| {
-            matches!(ty.resolve_type_alias(db), Type::LiteralValue(literal) if literal.is_string())
-        }) {
+        let concrete_string_literal = |ty: Type<'db>| match ty.resolve_type_alias(db) {
+            Type::Intersection(intersection) => {
+                intersection.iter_positive(db).find_map(|positive| {
+                    positive
+                        .resolve_type_alias(db)
+                        .as_literal_value()
+                        .filter(|literal| literal.is_string())
+                })
+            }
+            ty => ty.as_literal_value().filter(|literal| literal.is_string()),
+        };
+        if !rhs_alternatives
+            .iter()
+            .any(|ty| concrete_string_literal(*ty).is_some())
+        {
             return transferable_ty;
         }
 
@@ -3562,8 +3574,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let mut builder = UnionBuilder::new(db, env).add(transferable_ty);
         for &lhs_alternative in lhs_alternatives {
             for &rhs_alternative in rhs_alternatives {
-                if let Type::LiteralValue(literal) = rhs_alternative.resolve_type_alias(db)
-                    && literal.is_string()
+                if let Some(literal) = concrete_string_literal(rhs_alternative)
                     && lhs_alternative.is_disjoint_from(db, env, rhs_alternative)
                     && lhs_alternative
                         .identity_comparison_truthiness(db, env, rhs_alternative)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3544,7 +3544,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 intersection
                     .positive(db)
                     .iter()
-                    .any(|positive| matches!(positive.resolve_type_alias(db), Type::TypeVar(_)))
+                    .any(|positive| positive.resolve_type_alias(db).is_type_var())
                     || intersection.iter_negative(db).any(|negative| {
                         match negative.resolve_type_alias(db) {
                             Type::TypeVar(_) => true,
@@ -3579,7 +3579,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         literal.fallback_instance(db, env),
                     );
                     if !overlap.is_never() {
-                        builder = builder.add(overlap);
+                        builder.add_in_place(overlap);
                     }
                 }
             }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3487,117 +3487,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
-    /// Return the constraint on `value` when `value is other` succeeds.
-    ///
-    /// A typed inhabitant includes its runtime object and any static tags (such as a generic
-    /// specialization or `NewType`). Identity establishes that both operands identify the same
-    /// object, but cannot transfer tags specific to the other operand. For example, a `NewType`
-    /// constructor returns its argument unchanged, so `value is user_id` establishes that `value`
-    /// is an `int`, not that it carries `user_id`'s `UserId` tag. Similarly, identity with a
-    /// `LiteralString` establishes that the value is a `str`, not that it has the same
-    /// `LiteralString` provenance. Each operand retains its own existing tags and provenance when
-    /// this constraint is applied.
-    ///
-    /// ```python
-    /// def narrow(value: object, user_id: UserId, items: list[int]) -> None:
-    ///     if value is user_id:
-    ///         reveal_type(value)  # int, not UserId
-    ///     if value is items:
-    ///         reveal_type(value)  # list[int], not list[Unknown]
-    ///
-    /// def bounded[T: int](value: object, other: T) -> None:
-    ///     if value is other:
-    ///         reveal_type(value)  # int, not T: T might be UserId
-    /// ```
-    ///
-    /// In contrast, `value is items` for `items: list[int]` establishes that `value` is also a
-    /// `list[int]`: unlike a `NewType` tag, its element type cannot differ between soundly typed
-    /// views of the same mutable list. A type variable can hide an operand-specific tag even when
-    /// its bound is `int`, so only its upcast bound or constraints are transferable. The operand
-    /// being narrowed still retains any type variables already present in its own type.
-    ///
-    /// A concrete string literal is more subtle because its type also implies `LiteralString`
-    /// provenance. Consequently, `~LiteralString & Literal["hello"]` incorrectly simplifies to
-    /// `Never`, even though both values can identify the same string. In this case, retain the
-    /// operand's own `~LiteralString` constraint and widen only the literal to `str`.
-    fn evaluate_expr_is(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Type<'db> {
-        let db = self.db;
-        let env = &self.env;
-        let transferable_ty = rhs_ty.identity_comparison_type(db, env);
-        let rhs_alternatives = match transferable_ty.resolve_type_alias(db) {
-            Type::Union(union) => union.elements(db),
-            _ => std::slice::from_ref(&transferable_ty),
-        };
-        let concrete_string_literal = |ty: Type<'db>| match ty.resolve_type_alias(db) {
-            Type::Intersection(intersection) => {
-                intersection.iter_positive(db).find_map(|positive| {
-                    positive
-                        .resolve_type_alias(db)
-                        .as_literal_value()
-                        .filter(|literal| literal.is_string())
-                })
-            }
-            ty => ty.as_literal_value().filter(|literal| literal.is_string()),
-        };
-        if !rhs_alternatives
-            .iter()
-            .any(|ty| concrete_string_literal(*ty).is_some())
-        {
-            return transferable_ty;
-        }
-
-        let lhs_alternatives = match lhs_ty.resolve_type_alias(db) {
-            Type::Union(union) => union.elements(db),
-            _ => std::slice::from_ref(&lhs_ty),
-        };
-        let may_exclude_literal_string = |ty: &Type<'db>| match ty.resolve_type_alias(db) {
-            Type::TypeVar(_) => true,
-            Type::Intersection(intersection) => {
-                intersection
-                    .positive(db)
-                    .iter()
-                    .any(|positive| positive.resolve_type_alias(db).is_type_var())
-                    || intersection.iter_negative(db).any(|negative| {
-                        match negative.resolve_type_alias(db) {
-                            Type::TypeVar(_) => true,
-                            Type::LiteralValue(literal) => literal.is_literal_string(),
-                            _ => false,
-                        }
-                    })
-            }
-            _ => false,
-        };
-        if !lhs_alternatives.iter().any(may_exclude_literal_string) {
-            return transferable_ty;
-        }
-
-        let mut builder = UnionBuilder::new(db, env).add(transferable_ty);
-        for &lhs_alternative in lhs_alternatives {
-            for &rhs_alternative in rhs_alternatives {
-                if let Some(literal) = concrete_string_literal(rhs_alternative)
-                    && lhs_alternative.is_disjoint_from(db, env, rhs_alternative)
-                    && lhs_alternative
-                        .identity_comparison_truthiness(db, env, rhs_alternative)
-                        .may_be_true()
-                {
-                    // `fallback_instance` also widens annotated, non-promotable literals. Preserve
-                    // the original operand's negations: widening the entire union to `str` would
-                    // also retain other string alternatives that cannot identify the same object.
-                    let overlap = IntersectionType::from_two_elements(
-                        db,
-                        env,
-                        lhs_alternative,
-                        literal.fallback_instance(db, env),
-                    );
-                    if !overlap.is_never() {
-                        builder.add_in_place(overlap);
-                    }
-                }
-            }
-        }
-        builder.build()
-    }
-
     fn evaluate_expr_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         let db = self.db;
         let rhs_ty = rhs_ty.resolve_type_alias(db);
@@ -3742,7 +3631,70 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 };
                 Some(rhs_constraint.negate(db, &self.env))
             }
-            ast::CmpOp::Is => Some(self.evaluate_expr_is(lhs_ty, rhs_ty)),
+            ast::CmpOp::Is => {
+                let rhs_identity_ty = rhs_ty.identity_comparison_type(db, &self.env);
+                // Identity transfers the runtime type, not a `NewType` tag or type-variable
+                // selection belonging to the other operand.
+                let mut builder = UnionBuilder::new(db, &self.env).add(rhs_identity_ty);
+                let rhs_resolved = rhs_ty.resolve_type_alias(db);
+                let add_runtime_overlap = |builder: UnionBuilder<'db>, element: Type<'db>| {
+                    let overlaps_only_at_runtime = |rhs_element| {
+                        element.is_disjoint_from(db, &self.env, rhs_element)
+                            && element
+                                .identity_comparison_truthiness(db, &self.env, rhs_element)
+                                .may_be_true()
+                    };
+                    let has_runtime_only_overlap = match rhs_resolved {
+                        Type::Union(union) => union
+                            .elements(db)
+                            .iter()
+                            .copied()
+                            .any(overlaps_only_at_runtime),
+                        Type::TypeVar(typevar) => {
+                            match typevar.typevar(db).bound_or_constraints(db, &self.env) {
+                                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                                    overlaps_only_at_runtime(bound)
+                                }
+                                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                                    constraints
+                                        .elements(db)
+                                        .iter()
+                                        .copied()
+                                        .any(overlaps_only_at_runtime)
+                                }
+                                None => overlaps_only_at_runtime(rhs_ty),
+                            }
+                        }
+                        rhs_ty => overlaps_only_at_runtime(rhs_ty),
+                    };
+                    if !has_runtime_only_overlap {
+                        return builder;
+                    }
+
+                    let runtime_overlap = IntersectionType::from_two_elements(
+                        db,
+                        &self.env,
+                        element,
+                        rhs_identity_ty,
+                    );
+                    builder.add(if runtime_overlap.is_never() {
+                        element
+                    } else {
+                        runtime_overlap
+                    })
+                };
+
+                if let Type::Union(union) = lhs_ty.resolve_type_alias(db) {
+                    builder = union
+                        .elements(db)
+                        .iter()
+                        .copied()
+                        .fold(builder, add_runtime_overlap);
+                } else {
+                    builder = add_runtime_overlap(builder, lhs_ty);
+                }
+                Some(builder.build())
+            }
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
             _ => None,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3487,92 +3487,100 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
-    /// Return the constraint on the left-hand operand of a successful identity comparison.
+    /// Return the constraint on `value` when `value is other` succeeds.
     ///
-    /// Usually, `value is other` means that `value` can be narrowed to the static type of `other`.
-    /// However, excluding a `NewType` only excludes its static type; it does not exclude the runtime
-    /// objects accepted by its constructor. For example:
+    /// A typed inhabitant includes its runtime object and any static tags (such as a generic
+    /// specialization or `NewType`). Identity establishes that both operands identify the same
+    /// object, but cannot transfer tags specific to the other operand. For example, a `NewType`
+    /// constructor returns its argument unchanged, so `value is user_id` establishes that `value`
+    /// is an `int`, not that it carries `user_id`'s `UserId` tag. Similarly, identity with a
+    /// `LiteralString` establishes that the value is a `str`, not that it has the same
+    /// `LiteralString` provenance. Each operand retains its own existing tags and provenance when
+    /// this constraint is applied.
     ///
     /// ```python
-    /// UserId = NewType("UserId", int)
+    /// def narrow(value: object, user_id: UserId, items: list[int]) -> None:
+    ///     if value is user_id:
+    ///         reveal_type(value)  # int, not UserId
+    ///     if value is items:
+    ///         reveal_type(value)  # list[int], not list[Unknown]
     ///
-    /// def f(value: Not[UserId], other: UserId) -> None:
+    /// def bounded[T: int](value: object, other: T) -> None:
     ///     if value is other:
-    ///         reveal_type(value)  # int & ~UserId
+    ///         reveal_type(value)  # int, not T: T might be UserId
     /// ```
     ///
-    /// A `NewType` constructor returns its argument unchanged, so `value` and `other` can identify
-    /// the same integer even though their static types are disjoint. Intersecting `~UserId` with
-    /// `UserId` directly would incorrectly make this reachable branch `Never`. Instead, retain the
-    /// static exclusion and narrow `value` to the underlying runtime type, yielding `int & ~UserId`.
+    /// In contrast, `value is items` for `items: list[int]` establishes that `value` is also a
+    /// `list[int]`: unlike a `NewType` tag, its element type cannot differ between soundly typed
+    /// views of the same mutable list. A type variable can hide an operand-specific tag even when
+    /// its bound is `int`, so only its upcast bound or constraints are transferable. The operand
+    /// being narrowed still retains any type variables already present in its own type.
     ///
-    /// Distinct `NewType`s can also describe the same runtime object even though their static
-    /// types are disjoint. In that case, preserve each operand's own `NewType` instead of combining
-    /// the incompatible static types.
-    ///
-    /// The same distinction applies to excluded type variables and `LiteralString` provenance.
-    /// Handle each union alternative independently so that genuinely incompatible alternatives
-    /// remain excluded without dropping values that can still identify the same runtime object.
+    /// A concrete string literal is more subtle because its type also implies `LiteralString`
+    /// provenance. Consequently, `~LiteralString & Literal["hello"]` incorrectly simplifies to
+    /// `Never`, even though both values can identify the same string. In this case, retain the
+    /// operand's own `~LiteralString` constraint and widen only the literal to `str`.
     fn evaluate_expr_is(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Type<'db> {
         let db = self.db;
         let env = &self.env;
-        let left = match lhs_ty.resolve_type_alias(db) {
+        let transferable_ty = rhs_ty.identity_comparison_type(db, env);
+        let rhs_alternatives = match transferable_ty.resolve_type_alias(db) {
+            Type::Union(union) => union.elements(db),
+            _ => std::slice::from_ref(&transferable_ty),
+        };
+        if !rhs_alternatives.iter().any(|ty| {
+            matches!(ty.resolve_type_alias(db), Type::LiteralValue(literal) if literal.is_string())
+        }) {
+            return transferable_ty;
+        }
+
+        let lhs_alternatives = match lhs_ty.resolve_type_alias(db) {
             Type::Union(union) => union.elements(db),
             _ => std::slice::from_ref(&lhs_ty),
         };
-        let right = match rhs_ty.resolve_type_alias(db) {
-            Type::Union(union) => union.elements(db),
-            _ => std::slice::from_ref(&rhs_ty),
-        };
-
-        let may_have_static_only_distinction = |ty: &Type<'db>| match ty.resolve_type_alias(db) {
-            Type::NewTypeInstance(_) | Type::TypeVar(_) => true,
+        let may_exclude_literal_string = |ty: &Type<'db>| match ty.resolve_type_alias(db) {
+            Type::TypeVar(_) => true,
             Type::Intersection(intersection) => {
-                intersection.positive(db).iter().any(|positive| {
-                    matches!(
-                        positive.resolve_type_alias(db),
-                        Type::NewTypeInstance(_) | Type::TypeVar(_)
-                    )
-                }) || intersection.iter_negative(db).any(|negative| {
-                    match negative.resolve_type_alias(db) {
-                        Type::NewTypeInstance(_) | Type::TypeVar(_) => true,
-                        Type::LiteralValue(literal) => literal.is_literal_string(),
-                        _ => false,
-                    }
-                })
+                intersection
+                    .positive(db)
+                    .iter()
+                    .any(|positive| matches!(positive.resolve_type_alias(db), Type::TypeVar(_)))
+                    || intersection.iter_negative(db).any(|negative| {
+                        match negative.resolve_type_alias(db) {
+                            Type::TypeVar(_) => true,
+                            Type::LiteralValue(literal) => literal.is_literal_string(),
+                            _ => false,
+                        }
+                    })
             }
             _ => false,
         };
-        if !left
-            .iter()
-            .chain(right)
-            .any(may_have_static_only_distinction)
-        {
-            return rhs_ty;
+        if !lhs_alternatives.iter().any(may_exclude_literal_string) {
+            return transferable_ty;
         }
 
-        // Distinct NewTypes and excluded NewTypes, type variables, or LiteralString can still
-        // describe the same runtime object. Restore those alternatives without weakening others.
-        let mut builder = UnionBuilder::new(db, env).add(rhs_ty);
-        for &left in left {
-            for &right in right {
-                if left.is_disjoint_from(db, env, right)
-                    && left
-                        .identity_comparison_truthiness(db, env, right)
+        let mut builder = UnionBuilder::new(db, env).add(transferable_ty);
+        for &lhs_alternative in lhs_alternatives {
+            for &rhs_alternative in rhs_alternatives {
+                if let Type::LiteralValue(literal) = rhs_alternative.resolve_type_alias(db)
+                    && literal.is_string()
+                    && lhs_alternative.is_disjoint_from(db, env, rhs_alternative)
+                    && lhs_alternative
+                        .identity_comparison_truthiness(db, env, rhs_alternative)
                         .may_be_true()
                 {
-                    let identity = right.identity_comparison_type(db, env);
-                    let overlap = IntersectionType::from_two_elements(db, env, left, identity);
-                    let overlap = if overlap.is_never() {
-                        let fallback = match identity {
-                            Type::LiteralValue(literal) => literal.fallback_instance(db, env),
-                            _ => identity.promote(db, env),
-                        };
-                        IntersectionType::from_two_elements(db, env, left, fallback)
-                    } else {
-                        overlap
-                    };
-                    builder = builder.add(if overlap.is_never() { left } else { overlap });
+                    // `fallback_instance` also widens annotated, non-promotable literals. Preserve
+                    // the original operand's negations: widening the entire union to `str` would
+                    // also retain other string alternatives that cannot identify the same object.
+                    let overlap = IntersectionType::from_two_elements(
+                        db,
+                        env,
+                        lhs_alternative,
+                        literal.fallback_instance(db, env),
+                    );
+                    if !overlap.is_never() {
+                        builder = builder.add(overlap);
+                    }
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3515,6 +3515,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     /// remain excluded without dropping values that can still identify the same runtime object.
     fn evaluate_expr_is(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Type<'db> {
         let db = self.db;
+        let env = &self.env;
         let left = match lhs_ty.resolve_type_alias(db) {
             Type::Union(union) => union.elements(db),
             _ => std::slice::from_ref(&lhs_ty),
@@ -3552,23 +3553,22 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         // Distinct NewTypes and excluded NewTypes, type variables, or LiteralString can still
         // describe the same runtime object. Restore those alternatives without weakening others.
-        let mut builder = UnionBuilder::new(db, &self.env).add(rhs_ty);
+        let mut builder = UnionBuilder::new(db, env).add(rhs_ty);
         for &left in left {
             for &right in right {
-                if left.is_disjoint_from(db, &self.env, right)
+                if left.is_disjoint_from(db, env, right)
                     && left
-                        .identity_comparison_truthiness(db, &self.env, right)
+                        .identity_comparison_truthiness(db, env, right)
                         .may_be_true()
                 {
-                    let identity = right.identity_comparison_type(db, &self.env);
-                    let overlap =
-                        IntersectionType::from_two_elements(db, &self.env, left, identity);
+                    let identity = right.identity_comparison_type(db, env);
+                    let overlap = IntersectionType::from_two_elements(db, env, left, identity);
                     let overlap = if overlap.is_never() {
                         let fallback = match identity {
-                            Type::LiteralValue(literal) => literal.fallback_instance(db, &self.env),
-                            _ => identity.promote(db, &self.env),
+                            Type::LiteralValue(literal) => literal.fallback_instance(db, env),
+                            _ => identity.promote(db, env),
                         };
-                        IntersectionType::from_two_elements(db, &self.env, left, fallback)
+                        IntersectionType::from_two_elements(db, env, left, fallback)
                     } else {
                         overlap
                     };

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3487,6 +3487,89 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
+    /// Return the constraint on the left-hand operand of a successful identity comparison.
+    ///
+    /// Usually, `value is other` means that `value` can be narrowed to the static type of `other`.
+    /// However, excluding a `NewType` only excludes its static type; it does not exclude the runtime
+    /// objects accepted by its constructor. For example:
+    ///
+    /// ```python
+    /// UserId = NewType("UserId", int)
+    ///
+    /// def f(value: Not[UserId], other: UserId) -> None:
+    ///     if value is other:
+    ///         reveal_type(value)  # int & ~UserId
+    /// ```
+    ///
+    /// A `NewType` constructor returns its argument unchanged, so `value` and `other` can identify
+    /// the same integer even though their static types are disjoint. Intersecting `~UserId` with
+    /// `UserId` directly would incorrectly make this reachable branch `Never`. Instead, retain the
+    /// static exclusion and narrow `value` to the underlying runtime type, yielding `int & ~UserId`.
+    ///
+    /// The same distinction applies to excluded type variables and `LiteralString` provenance.
+    /// Handle each union alternative independently so that genuinely incompatible alternatives
+    /// remain excluded without dropping values that can still identify the same runtime object.
+    fn evaluate_expr_is(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Type<'db> {
+        let db = self.db;
+        let left = match lhs_ty.resolve_type_alias(db) {
+            Type::Union(union) => union.elements(db),
+            _ => std::slice::from_ref(&lhs_ty),
+        };
+        let right = match rhs_ty.resolve_type_alias(db) {
+            Type::Union(union) => union.elements(db),
+            _ => std::slice::from_ref(&rhs_ty),
+        };
+
+        let may_have_static_only_exclusion = |ty: &Type<'db>| match ty.resolve_type_alias(db) {
+            Type::TypeVar(_) => true,
+            Type::Intersection(intersection) => {
+                intersection
+                    .positive(db)
+                    .iter()
+                    .any(|positive| matches!(positive.resolve_type_alias(db), Type::TypeVar(_)))
+                    || intersection.iter_negative(db).any(|negative| {
+                        match negative.resolve_type_alias(db) {
+                            Type::NewTypeInstance(_) | Type::TypeVar(_) => true,
+                            Type::LiteralValue(literal) => literal.is_literal_string(),
+                            _ => false,
+                        }
+                    })
+            }
+            _ => false,
+        };
+        if !left.iter().chain(right).any(may_have_static_only_exclusion) {
+            return rhs_ty;
+        }
+
+        // Excluding a NewType, type variable, or LiteralString does not exclude the
+        // same runtime object. Restore those alternatives without weakening other cases.
+        let mut builder = UnionBuilder::new(db, &self.env).add(rhs_ty);
+        for &left in left {
+            for &right in right {
+                if left.is_disjoint_from(db, &self.env, right)
+                    && left
+                        .identity_comparison_truthiness(db, &self.env, right)
+                        .may_be_true()
+                {
+                    let identity = right.identity_comparison_type(db, &self.env);
+                    let overlap =
+                        IntersectionType::from_two_elements(db, &self.env, left, identity);
+                    let overlap = if overlap.is_never() {
+                        let fallback = match identity {
+                            Type::LiteralValue(literal) => literal.fallback_instance(db, &self.env),
+                            _ => identity.promote(db, &self.env),
+                        };
+                        IntersectionType::from_two_elements(db, &self.env, left, fallback)
+                    } else {
+                        overlap
+                    };
+                    builder = builder.add(if overlap.is_never() { left } else { overlap });
+                }
+            }
+        }
+        builder.build()
+    }
+
     fn evaluate_expr_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         let db = self.db;
         let rhs_ty = rhs_ty.resolve_type_alias(db);
@@ -3631,7 +3714,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 };
                 Some(rhs_constraint.negate(db, &self.env))
             }
-            ast::CmpOp::Is => Some(rhs_ty),
+            ast::CmpOp::Is => Some(self.evaluate_expr_is(lhs_ty, rhs_ty)),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
             _ => None,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3631,68 +3631,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 };
                 Some(rhs_constraint.negate(db, &self.env))
             }
-            ast::CmpOp::Is => {
-                let mut builder = UnionBuilder::new(db, &self.env).add(rhs_ty);
-                let rhs_resolved = rhs_ty.resolve_type_alias(db);
-                let rhs_identity_ty = rhs_ty.identity_comparison_type(db, &self.env);
-                let add_runtime_overlap = |builder: UnionBuilder<'db>, element: Type<'db>| {
-                    let overlaps_only_at_runtime = |rhs_element| {
-                        element.is_disjoint_from(db, &self.env, rhs_element)
-                            && element
-                                .identity_comparison_truthiness(db, &self.env, rhs_element)
-                                .may_be_true()
-                    };
-                    let has_runtime_only_overlap = match rhs_resolved {
-                        Type::Union(union) => union
-                            .elements(db)
-                            .iter()
-                            .copied()
-                            .any(overlaps_only_at_runtime),
-                        Type::TypeVar(typevar) => {
-                            match typevar.typevar(db).bound_or_constraints(db, &self.env) {
-                                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                                    overlaps_only_at_runtime(bound)
-                                }
-                                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                                    constraints
-                                        .elements(db)
-                                        .iter()
-                                        .copied()
-                                        .any(overlaps_only_at_runtime)
-                                }
-                                None => overlaps_only_at_runtime(rhs_ty),
-                            }
-                        }
-                        rhs_ty => overlaps_only_at_runtime(rhs_ty),
-                    };
-                    if !has_runtime_only_overlap {
-                        return builder;
-                    }
-
-                    let runtime_overlap = IntersectionType::from_two_elements(
-                        db,
-                        &self.env,
-                        element,
-                        rhs_identity_ty,
-                    );
-                    builder.add(if runtime_overlap.is_never() {
-                        element
-                    } else {
-                        runtime_overlap
-                    })
-                };
-
-                if let Type::Union(union) = lhs_ty.resolve_type_alias(db) {
-                    builder = union
-                        .elements(db)
-                        .iter()
-                        .copied()
-                        .fold(builder, add_runtime_overlap);
-                } else {
-                    builder = add_runtime_overlap(builder, lhs_ty);
-                }
-                Some(builder.build())
-            }
+            ast::CmpOp::Is => Some(rhs_ty),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
             _ => None,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3506,6 +3506,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     /// `UserId` directly would incorrectly make this reachable branch `Never`. Instead, retain the
     /// static exclusion and narrow `value` to the underlying runtime type, yielding `int & ~UserId`.
     ///
+    /// Distinct `NewType`s can also describe the same runtime object even though their static
+    /// types are disjoint. In that case, preserve each operand's own `NewType` instead of combining
+    /// the incompatible static types.
+    ///
     /// The same distinction applies to excluded type variables and `LiteralString` provenance.
     /// Handle each union alternative independently so that genuinely incompatible alternatives
     /// remain excluded without dropping values that can still identify the same runtime object.
@@ -3520,29 +3524,34 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             _ => std::slice::from_ref(&rhs_ty),
         };
 
-        let may_have_static_only_exclusion = |ty: &Type<'db>| match ty.resolve_type_alias(db) {
-            Type::TypeVar(_) => true,
+        let may_have_static_only_distinction = |ty: &Type<'db>| match ty.resolve_type_alias(db) {
+            Type::NewTypeInstance(_) | Type::TypeVar(_) => true,
             Type::Intersection(intersection) => {
-                intersection
-                    .positive(db)
-                    .iter()
-                    .any(|positive| matches!(positive.resolve_type_alias(db), Type::TypeVar(_)))
-                    || intersection.iter_negative(db).any(|negative| {
-                        match negative.resolve_type_alias(db) {
-                            Type::NewTypeInstance(_) | Type::TypeVar(_) => true,
-                            Type::LiteralValue(literal) => literal.is_literal_string(),
-                            _ => false,
-                        }
-                    })
+                intersection.positive(db).iter().any(|positive| {
+                    matches!(
+                        positive.resolve_type_alias(db),
+                        Type::NewTypeInstance(_) | Type::TypeVar(_)
+                    )
+                }) || intersection.iter_negative(db).any(|negative| {
+                    match negative.resolve_type_alias(db) {
+                        Type::NewTypeInstance(_) | Type::TypeVar(_) => true,
+                        Type::LiteralValue(literal) => literal.is_literal_string(),
+                        _ => false,
+                    }
+                })
             }
             _ => false,
         };
-        if !left.iter().chain(right).any(may_have_static_only_exclusion) {
+        if !left
+            .iter()
+            .chain(right)
+            .any(may_have_static_only_distinction)
+        {
             return rhs_ty;
         }
 
-        // Excluding a NewType, type variable, or LiteralString does not exclude the
-        // same runtime object. Restore those alternatives without weakening other cases.
+        // Distinct NewTypes and excluded NewTypes, type variables, or LiteralString can still
+        // describe the same runtime object. Restore those alternatives without weakening others.
         let mut builder = UnionBuilder::new(db, &self.env).add(rhs_ty);
         for &left in left {
             for &right in right {

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -241,7 +241,10 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: NewType<'db>,
         right: NewType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // Different NewTypes are disjoint unless one is derived from the other.
+        // Two NewTypes are disjoint if they're not equal and neither inherits from the other.
+        // NewTypes have single inheritance, and a regular class can't inherit from a NewType, so
+        // it's not possible for some third type to multiply-inherit from both.
+
         let relation_checker = self.as_relation_checker(TypeRelation::Subtyping);
         relation_checker
             .check_newtype_pair(db, left, right)

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -1,7 +1,7 @@
 use crate::Db;
 use crate::ProgramEnvironment;
 use crate::types::constraints::ConstraintSet;
-use crate::types::relation::TypeRelationChecker;
+use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
 use crate::types::{ClassType, KnownUnion, Type, definition_expression_type, visitor};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::{self as ast};
@@ -231,6 +231,24 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
         self.never()
+    }
+}
+
+impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
+    pub(super) fn check_newtype_pair(
+        &self,
+        db: &'db dyn Db,
+        left: NewType<'db>,
+        right: NewType<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        // Different NewTypes are disjoint unless one is derived from the other.
+        let relation_checker = self.as_relation_checker(TypeRelation::Subtyping);
+        relation_checker
+            .check_newtype_pair(db, left, right)
+            .or(db, self.constraints, || {
+                relation_checker.check_newtype_pair(db, right, left)
+            })
+            .negate(db, self.constraints)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -1,7 +1,7 @@
 use crate::Db;
 use crate::ProgramEnvironment;
 use crate::types::constraints::ConstraintSet;
-use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
+use crate::types::relation::TypeRelationChecker;
 use crate::types::{ClassType, KnownUnion, Type, definition_expression_type, visitor};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::{self as ast};
@@ -231,27 +231,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
         self.never()
-    }
-}
-
-impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
-    pub(super) fn check_newtype_pair(
-        &self,
-        db: &'db dyn Db,
-        left: NewType<'db>,
-        right: NewType<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        // Two NewTypes are disjoint if they're not equal and neither inherits from the other.
-        // NewTypes have single inheritance, and a regular class can't inherit from a NewType, so
-        // it's not possible for some third type to multiply-inherit from both.
-
-        let relation_checker = self.as_relation_checker(TypeRelation::Subtyping);
-        relation_checker
-            .check_newtype_pair(db, left, right)
-            .or(db, self.constraints, || {
-                relation_checker.check_newtype_pair(db, right, left)
-            })
-            .negate(db, self.constraints)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3671,16 +3671,16 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                         // compatible concrete base. Assignability preserves overlap both with
                         // supertypes of the base and with gradual specializations such as
                         // `list[Any]`.
-                        //
-                        // Numeric NewTypes have union bases such as `int | float`. Assigning a
-                        // union requires every alternative to match, but proving disjointness
-                        // requires every alternative not to match.
                         let checker = self.as_relation_checker(TypeRelation::Assignability);
                         let check_base = |base| {
                             checker
                                 .check_type_pair(db, base, other)
                                 .negate(db, self.constraints)
                         };
+
+                        // Numeric NewTypes have union bases such as `int | float`. Assigning a
+                        // union requires every alternative to match, but proving disjointness
+                        // requires every alternative not to match.
                         if let Type::Union(union) = base {
                             union
                                 .elements(db)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3674,7 +3674,6 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::NewTypeInstance(left), Type::NewTypeInstance(right)) => {
                 nontrivial_check(self, || self.check_newtype_pair(db, left, right))
             }
-
             (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
                 nontrivial_check(self, || {
                     self.check_type_pair(db, newtype.concrete_base_type(db), other)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3666,14 +3666,25 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
                 nontrivial_check(self, || {
                     let base = newtype.concrete_base_type(db);
-                    if let Type::NominalInstance(instance) = other
-                        && let ClassType::NonGeneric(class) = instance.class(db, env)
-                        && class.is_final(db)
-                        && base != other
-                    {
-                        // Unlike a final generic class, a non-generic final class cannot share a
-                        // narrower subtype with a NewType based on a different class.
-                        self.always()
+                    if matches!(other, Type::NominalInstance(_)) {
+                        // Ordinary classes cannot inherit from a NewType, so overlap must come
+                        // from an assignable concrete base. Assignability preserves overlap for
+                        // gradual specializations such as `list[Any]`, while numeric union bases
+                        // such as `int | float` must be checked one alternative at a time.
+                        let checker = self.as_relation_checker(TypeRelation::Assignability);
+                        let check_base = |base| {
+                            checker
+                                .check_type_pair(db, base, other)
+                                .negate(db, self.constraints)
+                        };
+                        if let Type::Union(union) = base {
+                            union
+                                .elements(db)
+                                .iter()
+                                .when_all(db, self.constraints, |&element| check_base(element))
+                        } else {
+                            check_base(base)
+                        }
                     } else {
                         self.check_type_pair(db, base, other)
                     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3671,6 +3671,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             }
 
+            (Type::NewTypeInstance(left), Type::NewTypeInstance(right)) => {
+                nontrivial_check(self, || self.check_newtype_pair(db, left, right))
+            }
+
             (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
                 nontrivial_check(self, || {
                     self.check_type_pair(db, newtype.concrete_base_type(db), other)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3667,10 +3667,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 nontrivial_check(self, || {
                     let base = newtype.concrete_base_type(db);
                     if matches!(other, Type::NominalInstance(_)) {
-                        // Ordinary classes cannot inherit from a NewType, so overlap must come
-                        // from an assignable concrete base. Assignability preserves overlap for
-                        // gradual specializations such as `list[Any]`, while numeric union bases
-                        // such as `int | float` must be checked one alternative at a time.
+                        // Ordinary classes cannot inherit from a NewType, so overlap requires a
+                        // compatible concrete base. Assignability preserves overlap both with
+                        // supertypes of the base and with gradual specializations such as
+                        // `list[Any]`.
+                        //
+                        // Numeric NewTypes have union bases such as `int | float`. Assigning a
+                        // union requires every alternative to match, but proving disjointness
+                        // requires every alternative not to match.
                         let checker = self.as_relation_checker(TypeRelation::Assignability);
                         let check_base = |base| {
                             checker

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3455,6 +3455,17 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             }
 
+            (
+                Type::NewTypeInstance(newtype),
+                other @ (Type::LiteralValue(_) | Type::TypeIs(_) | Type::TypeGuard(_)),
+            )
+            | (
+                other @ (Type::LiteralValue(_) | Type::TypeIs(_) | Type::TypeGuard(_)),
+                Type::NewTypeInstance(newtype),
+            ) => nontrivial_check(self, || {
+                self.check_type_pair(db, newtype.concrete_base_type(db), other)
+            }),
+
             (Type::TypeIs(_) | Type::TypeGuard(_), _)
             | (_, Type::TypeIs(_) | Type::TypeGuard(_)) => self.always(),
 
@@ -3660,38 +3671,9 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             }
 
-            (Type::NewTypeInstance(left), Type::NewTypeInstance(right)) => {
-                nontrivial_check(self, || self.check_newtype_pair(db, left, right))
-            }
             (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
                 nontrivial_check(self, || {
-                    let base = newtype.concrete_base_type(db);
-                    if matches!(other, Type::NominalInstance(_)) {
-                        // Ordinary classes cannot inherit from a NewType, so overlap requires a
-                        // compatible concrete base. Assignability preserves overlap both with
-                        // supertypes of the base and with gradual specializations such as
-                        // `list[Any]`.
-                        let checker = self.as_relation_checker(TypeRelation::Assignability);
-                        let check_base = |base| {
-                            checker
-                                .check_type_pair(db, base, other)
-                                .negate(db, self.constraints)
-                        };
-
-                        // Numeric NewTypes have union bases such as `int | float`. Assigning a
-                        // union requires every alternative to match, but proving disjointness
-                        // requires every alternative not to match.
-                        if let Type::Union(union) = base {
-                            union
-                                .elements(db)
-                                .iter()
-                                .when_all(db, self.constraints, |&element| check_base(element))
-                        } else {
-                            check_base(base)
-                        }
-                    } else {
-                        self.check_type_pair(db, base, other)
-                    }
+                    self.check_type_pair(db, newtype.concrete_base_type(db), other)
                 })
             }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3665,7 +3665,18 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
             (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
                 nontrivial_check(self, || {
-                    self.check_type_pair(db, newtype.concrete_base_type(db), other)
+                    let base = newtype.concrete_base_type(db);
+                    if let Type::NominalInstance(instance) = other
+                        && let ClassType::NonGeneric(class) = instance.class(db, env)
+                        && class.is_final(db)
+                        && base != other
+                    {
+                        // Unlike a final generic class, a non-generic final class cannot share a
+                        // narrower subtype with a NewType based on a different class.
+                        self.always()
+                    } else {
+                        self.check_type_pair(db, base, other)
+                    }
                 })
             }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1972,6 +1972,18 @@ impl<'db> InnerIntersectionBuilder<'db> {
             if speculative.is_never() {
                 return Type::Never;
             }
+
+            if let Type::EnumComplement(complement) = speculative
+                && complement.is_singleton(db)
+                && self
+                    .positive
+                    .iter()
+                    .any(|positive| matches!(positive, Type::NewTypeInstance(_)))
+            {
+                // Preserve the original NewType while making its sole remaining enum member
+                // explicit.
+                self.add_positive(db, env, complement.remaining_literal_union(db, env));
+            }
         }
 
         if let Some(complement) =

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1980,8 +1980,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     .iter()
                     .any(|positive| matches!(positive, Type::NewTypeInstance(_)))
             {
-                // Preserve the original NewType while making its sole remaining enum member
-                // explicit.
+                // Preserve the NewType while making its remaining enum member explicit.
                 self.add_positive(db, env, complement.remaining_literal_union(db, env));
             }
         }


### PR DESCRIPTION
## Summary

Fix `NewType` disjointness and `is` narrowing by distinguishing runtime objects from typed inhabitants. A typed inhabitant consists of a runtime object plus any invisible static tags, such as a generic specialization or a `NewType`. Two types overlap when they admit the same typed inhabitant, not merely the same runtime object.

`NewType` constructors return the original object unchanged, so distinct tags can represent different typed inhabitants of the same runtime object:

```py
from typing import NewType

UserId = NewType("UserId", int)
OrderId = NewType("OrderId", int)
NestedUserId = NewType("NestedUserId", UserId)

UserId(True) is OrderId(True)  # True at runtime.
```

The inhabitants `(True, UserId)` and `(True, OrderId)` are distinct, so `UserId` and `OrderId` remain disjoint. Ordinary types do not require either tag, so `UserId` still overlaps `int`, `bool`, `Literal[True]`, and other nominal, structural, or literal types that overlap its concrete base. `NestedUserId` overlaps `UserId` because a nested tag remains a subtype of its parent.

Apply these distinctions consistently to identity and narrowing: transfer object-wide generic guarantees and runtime-value constraints, but never transfer another operand's `NewType` tag or potentially tagged type variable. Preserve each operand's own tags and negations. Narrowing through `isinstance`, class patterns, type guards, enum equality, and exhaustive enum matches retains the original `NewType` tag.

Fixes astral-sh/ty#4187.

## Test plan

- Disjointness and intersection mdtests cover nominal and structural base overlaps, literals, boolean/numeric types, enum members, type guards, distinct and nested `NewType`s, and invariant, covariant, and gradual generic specializations.
- Identity mdtests cover operand-specific `NewType` tags, static versus runtime negations, invariant and covariant generics, unconstrained/bounded/constrained type variables, singleton values, and compatibility with existing string-literal narrowing.
- Narrowing mdtests cover `isinstance`, `TypeIs`, class patterns, branded enum members and complements, nested brands, cross-enum and custom equality, exhaustive enum/`IntEnum` matching, and recursive aliases.
