### PR TITLE
[ty] Update ecosystem-analyzer workflow pins

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -44,7 +44,7 @@ env:
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   # TODO: Update the mypy-primer revision in scripts/setup_primer_project.py
   # and regenerate its lockfile when updating ecosystem-analyzer.
-  ECOSYSTEM_ANALYZER_COMMIT: 27b644f296d70fccacb7d7c23c91c5d6ccd8713d
+  ECOSYSTEM_ANALYZER_COMMIT: 0d91d750881d0d96a25d137374f13f972a890651
 
 jobs:
   build-ty:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -44,7 +44,7 @@ env:
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   # TODO: Update the mypy-primer revision in scripts/setup_primer_project.py
   # and regenerate its lockfile when updating ecosystem-analyzer.
-  ECOSYSTEM_ANALYZER_COMMIT: f6f1b7b8586c8a6c60dc3d37c3f6ae917a9ad9c4
+  ECOSYSTEM_ANALYZER_COMMIT: 0d91d750881d0d96a25d137374f13f972a890651
 
 jobs:
   build-ty:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -44,7 +44,7 @@ env:
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   # TODO: Update the mypy-primer revision in scripts/setup_primer_project.py
   # and regenerate its lockfile when updating ecosystem-analyzer.
-  ECOSYSTEM_ANALYZER_COMMIT: 0d91d750881d0d96a25d137374f13f972a890651
+  ECOSYSTEM_ANALYZER_COMMIT: 585f99dd3eb90f992d6764684fb1b83506ceb938
 
 jobs:
   build-ty:

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -44,7 +44,7 @@ env:
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   # TODO: Update the mypy-primer revision in scripts/setup_primer_project.py
   # and regenerate its lockfile when updating ecosystem-analyzer.
-  ECOSYSTEM_ANALYZER_COMMIT: 585f99dd3eb90f992d6764684fb1b83506ceb938
+  ECOSYSTEM_ANALYZER_COMMIT: 2b409ad30445f16b863919e0799b438c6b04c645
 
 jobs:
   build-ty:

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -20,7 +20,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
-  ECOSYSTEM_ANALYZER_COMMIT: 585f99dd3eb90f992d6764684fb1b83506ceb938
+  ECOSYSTEM_ANALYZER_COMMIT: 2b409ad30445f16b863919e0799b438c6b04c645
 
 jobs:
   ty-ecosystem-report:

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -20,7 +20,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
-  ECOSYSTEM_ANALYZER_COMMIT: f6f1b7b8586c8a6c60dc3d37c3f6ae917a9ad9c4
+  ECOSYSTEM_ANALYZER_COMMIT: 0d91d750881d0d96a25d137374f13f972a890651
 
 jobs:
   ty-ecosystem-report:

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -20,7 +20,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
-  ECOSYSTEM_ANALYZER_COMMIT: 0d91d750881d0d96a25d137374f13f972a890651
+  ECOSYSTEM_ANALYZER_COMMIT: 585f99dd3eb90f992d6764684fb1b83506ceb938
 
 jobs:
   ty-ecosystem-report:

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -20,7 +20,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
-  ECOSYSTEM_ANALYZER_COMMIT: 27b644f296d70fccacb7d7c23c91c5d6ccd8713d
+  ECOSYSTEM_ANALYZER_COMMIT: 0d91d750881d0d96a25d137374f13f972a890651
 
 jobs:
   ty-ecosystem-report:


### PR DESCRIPTION
Updates the ecosystem-analyzer revisions used by the ty ecosystem-analyzer and ty ecosystem-report workflows to the latest upstream `main` commit, `585f99dd3eb90f992d6764684fb1b83506ceb938`.

This keeps both workflows aligned with the latest ecosystem-analyzer improvements.