### PR TITLE
[ty] Avoid double inference of Unpack operands in Union

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -92,8 +92,9 @@ def f(
 
 ## Unsupported union unpacking
 
-Unpacking a type variable tuple into `Union` is currently not supported. Both the rejected union and
-runtime element access recover to `object`.
+Unpacking a type variable tuple into `Union` is currently not supported. The rejected union recovers
+to `object` both on its own and inside another generic specialization. Runtime element access also
+recovers to `object`.
 
 ```py
 from typing import TypeVarTuple, Union, Unpack
@@ -106,6 +107,10 @@ def reject_union(value: Union[Unpack[Ts]]) -> None:
     # TODO: should reveal `Union[*Ts]` representation
     reveal_type(value)  # revealed: object
 
+# error: [invalid-type-form] "Unpacking a `TypeVarTuple` in `Union` is not supported"
+def reject_nested_union(value: list[Union[Unpack[Ts], None]]) -> None:
+    reveal_type(value)  # revealed: list[object]
+
 def element_types(values: tuple[Unpack[Ts]]) -> None:
     # TODO: should reveal `Union[*Ts]` representation
     reveal_type(values[0])  # revealed: object
@@ -113,6 +118,35 @@ def element_types(values: tuple[Unpack[Ts]]) -> None:
     for value in values:
         # TODO: should reveal `Union[*Ts]` representation
         reveal_type(value)  # revealed: object
+```
+
+## Invalid unpack operand nested in a union
+
+Although `Unpack[int]` is valid Python syntax, its non-tuple operand should report an ordinary
+diagnostic when the union appears inside a generic specialization.
+
+```py
+from typing import Union, Unpack
+
+# error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
+def invalid_operand(value: list[Union[Unpack[int], None]]) -> None:
+    reveal_type(value)  # revealed: list[tuple[Unknown, ...] | None]
+```
+
+## Invalid unpack contexts still infer the operand
+
+An invalid unpack context should not suppress runtime errors from its operand. String annotations do
+not execute their contents, so unresolved names inside an invalid string annotation remain silent.
+
+```py
+from typing import Unpack
+
+# error: [invalid-type-form] "`Unpack` is not allowed in parameter annotations"
+# error: [unresolved-reference] "Name `Missing` used when not defined"
+def invalid_context(value: Unpack[Missing]) -> None: ...
+
+# error: [invalid-type-form] "`Unpack` is not allowed in parameter annotations"
+def invalid_stringified_context(value: "Unpack[Missing]") -> None: ...
 ```
 
 ## Concrete and nested tuple unpacking

--- a/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
@@ -143,6 +143,23 @@ def _(u: InvalidEmptyUnion):
     reveal_type(u)  # revealed: Unknown
 ```
 
+### `typing.Unpack`
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+An empty `Unpack` nested inside a union and a generic specialization should report its syntax error
+without panicking.
+
+```py
+from typing import Union, Unpack
+
+# error: [invalid-syntax] "Expected index or slice expression"
+list[Union[Unpack[], None]]
+```
+
 ### `typing.Annotated`
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2069,17 +2069,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 ty,
                                 Type::TypeVar(typevar) if typevar.is_typevartuple(db)
                             ) || if let ast::Expr::Subscript(subscript) = argument {
-                                let previously_in_unpack_type_argument = self
-                                    .context
-                                    .inference_flags
-                                    .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
-                                let inner_ty = self.infer_type_expression(&subscript.slice);
-                                self.context.inference_flags.set(
-                                    InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
-                                    previously_in_unpack_type_argument,
-                                );
                                 matches!(
-                                    inner_ty,
+                                    self.expression_type(&subscript.slice),
                                     Type::TypeVar(typevar) if typevar.is_typevartuple(db)
                                 )
                             } else {
@@ -2470,10 +2461,40 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     TypeExpressionFlags::UNPACK,
                 );
 
-                if self
-                    .inference_flags()
-                    .contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT)
+                let inference_flags = self.inference_flags();
+                let is_nested_unpack =
+                    inference_flags.contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT);
+                let is_nested_kwargs = inference_flags
+                    .contains(InferenceFlags::IN_KWARG_ANNOTATION)
+                    && inference_flags.contains(InferenceFlags::IN_NESTED_TYPE_EXPRESSION);
+                let is_invalid_context = !inference_flags.intersects(
+                    InferenceFlags::IN_VARARG_ANNOTATION
+                        | InferenceFlags::IN_KWARG_ANNOTATION
+                        | InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                );
+
+                let previously_in_unpack_type_argument = self
+                    .context
+                    .inference_flags
+                    .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
+                let inner_ty = if self.in_string_annotation()
+                    && (is_nested_unpack || is_nested_kwargs || is_invalid_context)
                 {
+                    // Invalid string annotations never execute, so their operands must not
+                    // produce runtime errors even though their inferred types are still needed.
+                    let mut speculative = self.speculate_without_diagnostics();
+                    let inner_ty = speculative.infer_type_expression(arguments_slice);
+                    self.extend(speculative);
+                    inner_ty
+                } else {
+                    self.infer_type_expression(arguments_slice)
+                };
+                self.context.inference_flags.set(
+                    InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
+                    previously_in_unpack_type_argument,
+                );
+
+                if is_nested_unpack {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         diagnostic::add_type_expression_reference_link(
                             builder.into_diagnostic("`Unpack` cannot be nested"),
@@ -2482,13 +2503,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return Type::unknown();
                 }
 
-                if self
-                    .inference_flags()
-                    .contains(InferenceFlags::IN_KWARG_ANNOTATION)
-                    && self
-                        .inference_flags()
-                        .contains(InferenceFlags::IN_NESTED_TYPE_EXPRESSION)
-                {
+                if is_nested_kwargs {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         diagnostic::add_type_expression_reference_link(builder.into_diagnostic(
                             "`Unpack` is only valid as the top-level `**kwargs` annotation form",
@@ -2497,11 +2512,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return Type::unknown();
                 }
 
-                if !self.inference_flags().intersects(
-                    InferenceFlags::IN_VARARG_ANNOTATION
-                        | InferenceFlags::IN_KWARG_ANNOTATION
-                        | InferenceFlags::IN_VALID_UNPACK_CONTEXT,
-                ) {
+                if is_invalid_context {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         diagnostic::add_type_expression_reference_link(builder.into_diagnostic(
                             format_args!(
@@ -2512,16 +2523,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     return Type::unknown();
                 }
-
-                let previously_in_unpack_type_argument = self
-                    .context
-                    .inference_flags
-                    .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
-                let inner_ty = self.infer_type_expression(arguments_slice);
-                self.context.inference_flags.set(
-                    InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
-                    previously_in_unpack_type_argument,
-                );
 
                 if self
                     .inference_flags()


### PR DESCRIPTION
Fixes astral-sh/ty#4193.

Ensure `Unpack` always infers its operand, including in invalid contexts, so `Union` can reuse the recorded type instead of inferring the same expression twice. Preserve runtime diagnostics for evaluated operands while suppressing them inside invalid string annotations.

## Test plan

- Cover malformed `Unpack[]` nested inside `Union` and a generic specialization.
- Cover syntactically valid `Unpack[int]` nested inside `Union` and preserve unsupported `Unpack[Ts]` recovery.
- Verify invalid evaluated contexts report operand errors while invalid string annotations suppress them.
