### PR TITLE
Disable local ThinLTO for optimized development workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,28 +18,30 @@ instructions to PR authors or flag unrelated pre-existing issues.
 
 ## Running Tests
 
-Run all tests (using `nextest` for faster execution, setting `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_DEBUG="line-tables-only"` to enable optimizations while retaining some debug info, and setting `INSTA_FORCE_PASS=1 INSTA_UPDATE=always MDTEST_UPDATE_SNAPSHOTS=1` to ensure all snapshots are updated):
+For every Cargo command that compiles Rust, including tests, Clippy, `cargo check`, debug builds, and code generation, use `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off CARGO_PROFILE_DEV_DEBUG="line-tables-only"`. Keeping these settings consistent enables optimizations, avoids local ThinLTO, preserves useful debug information, and avoids unnecessary profile-related cache churn.
+
+Run all tests (using `nextest` for faster execution and setting `INSTA_FORCE_PASS=1 INSTA_UPDATE=always MDTEST_UPDATE_SNAPSHOTS=1` to ensure all snapshots are updated):
 
 ```sh
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run
 ```
 
 Run tests for a specific crate:
 
 ```sh
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic
 ```
 
 Run a single mdtest file. The path to the mdtest file should be relative to the `crates/ty_python_semantic/resources/mdtest` folder. Include `--test mdtest` to avoid building unrelated test binaries:
 
 ```sh
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic --test mdtest -- mdtest::<path/to/mdtest_file.md>
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic --test mdtest -- mdtest::<path/to/mdtest_file.md>
 ```
 
 To run a specific mdtest within a file, use a substring of the Markdown header text as `MDTEST_TEST_FILTER`. Only use this if it's necessary to isolate a single test case:
 
 ```sh
-MDTEST_TEST_FILTER="<filter>" CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic --test mdtest -- mdtest::<path/to/mdtest_file.md>
+MDTEST_TEST_FILTER="<filter>" CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic --test mdtest -- mdtest::<path/to/mdtest_file.md>
 ```
 
 ### Fallback without nextest
@@ -48,16 +50,16 @@ If `cargo nextest` is not available, use `cargo test` with the same environment 
 
 ```sh
 # Run all tests.
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test
 
 # Run tests for a specific crate.
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ty_python_semantic
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ty_python_semantic
 
 # Run a single mdtest file.
-CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ty_python_semantic --test mdtest -- <path/to/mdtest_file.md>
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ty_python_semantic --test mdtest -- <path/to/mdtest_file.md>
 
 # Run a specific mdtest within a file.
-MDTEST_TEST_FILTER="<filter>" CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ty_python_semantic --test mdtest -- <path/to/mdtest_file.md>
+MDTEST_TEST_FILTER="<filter>" CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ty_python_semantic --test mdtest -- <path/to/mdtest_file.md>
 ```
 
 ### Snapshot updates
@@ -80,7 +82,7 @@ Never edit snapshot files or inline snapshot bodies manually. Regenerate them by
 ## Running Clippy
 
 ```sh
-cargo clippy --workspace --all-targets --all-features -- -D warnings
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off CARGO_PROFILE_DEV_DEBUG="line-tables-only" cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
 ## Running Debug Builds
@@ -90,13 +92,13 @@ Use debug builds (not `--release`) when developing, as release builds lack debug
 Run Ruff:
 
 ```sh
-cargo run --bin ruff -- check path/to/file.py
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off CARGO_PROFILE_DEV_DEBUG="line-tables-only" cargo run --bin ruff -- check path/to/file.py
 ```
 
 Run ty:
 
 ```sh
-cargo run --bin ty -- check path/to/file.py
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off CARGO_PROFILE_DEV_DEBUG="line-tables-only" cargo run --bin ty -- check path/to/file.py
 ```
 
 ## Working on ty
@@ -160,9 +162,9 @@ Parts of `.github/workflows/release.yml` are generated by cargo-dist from `dist-
 - Before writing significant amounts of new code, look for existing utilities or mechanisms that could solve the problem. Avoid expanding the task to unrelated issues, but do not confuse keeping the task focused with minimizing the size of the implementation. Prefer addressing the underlying architectural problem over adding a localized workaround, even when doing so requires a substantial refactor or rearchitecture. Ask the user for guidance if in doubt about whether to attempt a larger refactor or not.
 - Try hard to avoid patterns that require `panic!`, `unreachable!`, `.unwrap()` or `.expect()`. Instead, try to encode those constraints in the type system. Don't be afraid to write code that's more verbose or requires largeish refactors if it enables you to avoid these unsafe calls.
 - Prefer let chains (`if let` combined with `&&`) and let guards (`PAT if let ... =>`) over nested `if let` statements to reduce indentation and improve readability. At the end of a task, always check your work to see if you missed opportunities to use `let` chains or `let` guards.
-- If you *have* to suppress a Clippy lint, prefer to use `#[expect()]` over `[allow()]`, where possible. But if a lint is complaining about unused/dead code, it's usually best to just delete the unused code.
+- If you _have_ to suppress a Clippy lint, prefer to use `#[expect()]` over `[allow()]`, where possible. But if a lint is complaining about unused/dead code, it's usually best to just delete the unused code.
 - Don't use comments to narrate code, but do use them to explain invariants and why something unusual was done a particular way. Make sure that a comment will make sense to somebody who's reading the code for the first time. Prefer plain language, avoid jargon, and don't be afraid to be more verbose if it's necessary to explain something well. Giving examples of the kind of Python code we're trying to model at this particular point in Ruff or ty can often be very helpful for future readers of the code.
-- Run `cargo dev generate-all` after changing configuration options, CLI arguments, lint rules, or environment variable definitions, as these changes require regeneration of schemas, docs, and CLI references.
+- Run `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off CARGO_PROFILE_DEV_DEBUG="line-tables-only" cargo dev generate-all` after changing configuration options, CLI arguments, lint rules, or environment variable definitions, as these changes require regeneration of schemas, docs, and CLI references.
 - Don't prefix tests with `test_`.
 - Don't separate struct definitions from their `impl` blocks unless the `impl` is deliberately placed in a separate file, as for large structs.
 - Avoid running `uv run` for any scripts from the repository root unless you use `--no-project`, `--script` or similar. Using `uv run` from the Ruff repo root without these flags will build Ruff from source, which is very slow and usually unnecessary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,6 @@ instructions to PR authors or flag unrelated pre-existing issues.
 
 ## Running Tests
 
-For every Cargo command that compiles Rust, including tests, Clippy, `cargo check`, debug builds, and code generation, use `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off CARGO_PROFILE_DEV_DEBUG="line-tables-only"`. Keeping these settings consistent enables optimizations, avoids local ThinLTO, preserves useful debug information, and avoids unnecessary profile-related cache churn.
-
 Run all tests (using `nextest` for faster execution and setting `INSTA_FORCE_PASS=1 INSTA_UPDATE=always MDTEST_UPDATE_SNAPSHOTS=1` to ensure all snapshots are updated):
 
 ```sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,6 +300,9 @@ inherits = "release"
 opt-level = "z"
 codegen-units = 1
 
+[profile.dev]
+lto = "off"
+
 [profile.dev.package.insta]
 opt-level = 3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,8 @@ opt-level = "z"
 codegen-units = 1
 
 [profile.dev]
-# Cargo still enables local ThinLTO when optimization is enabled, slowing
+# Cargo enables local ThinLTO when optimization is enabled, which we often do
+# when testing via CARGO_PROFILE_DEV_OPT_LEVEL=1. Disable it to speed up
 # incremental test builds.
 lto = "off"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,6 +301,8 @@ opt-level = "z"
 codegen-units = 1
 
 [profile.dev]
+# Cargo still enables local ThinLTO when optimization is enabled, slowing
+# incremental test builds.
 lto = "off"
 
 [profile.dev.package.insta]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,12 +300,6 @@ inherits = "release"
 opt-level = "z"
 codegen-units = 1
 
-[profile.dev]
-# Cargo enables local ThinLTO when optimization is enabled, which we often do
-# when testing via CARGO_PROFILE_DEV_OPT_LEVEL=1. Disable it to speed up
-# incremental test builds.
-lto = "off"
-
 [profile.dev.package.insta]
 opt-level = 3
 
@@ -349,6 +343,9 @@ lto = false
 [profile.fast-test]
 inherits = "dev"
 opt-level = 1
+debug = "line-tables-only"
+# Avoid the local ThinLTO that Cargo enables at nonzero optimization levels.
+lto = "off"
 
 # The profile that 'cargo dist' will build with.
 [profile.dist]


### PR DESCRIPTION
## Summary

Configure agent-directed Cargo commands and the existing `fast-test` profile to consistently use `opt-level = 1`, `debug = "line-tables-only"`, and `lto = "off"`. Apply the same settings to tests, Clippy, debug runs, and code generation while preserving ordinary development, CI, and release defaults.

Cargo's default `lto = false` still applies local ThinLTO when optimization is enabled, adding substantial work to incremental Rust edits. Across 222 recent agent test commands, 110 ran one mdtest file, 41 ran the full `ty_python_semantic` suite, and 48 ran a two-crate suite. Holding `opt-level = 1` fixed, three alternating paired runs give:

| Workflow                                    | Local ThinLTO | Disabled | Change |
| ------------------------------------------- | ------------: | -------: | -----: |
| Rust edit + one mdtest file                 |        9.84 s |   6.81 s | -30.7% |
| Rust edit + full semantic suite (797 tests) |       24.86 s |  18.11 s | -27.1% |
| Warm semantic suite, no edits (797 tests)   |        5.28 s |   5.64 s |  +6.9% |

Keeping optimization enabled remains worthwhile for broader runs. With ThinLTO disabled, `opt-level = 1` reduced a same-crate edit followed by all 797 semantic tests from 22.73 s to 17.27 s, and an already-built semantic suite from 13.64 s to 5.59 s. The mdtest executable grows from 49.0 MiB to 56.3 MiB (+14.7%).
