### PR TITLE
[`numpy`] Make `np.chararray` autofix backwards-compatible (`NPY201`)

### DIFF
--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -683,12 +683,23 @@ pub(crate) fn numpy_2_0_deprecation(checker: &Checker, expr: &Expr) {
             compatibility,
         } => {
             diagnostic.try_set_fix(|| {
+                // `numpy.char` is not an importable module path on NumPy 1.x.
+                let (path, name, attribute) = if (path, name) == ("numpy.char", "chararray") {
+                    ("numpy", "char", Some("chararray"))
+                } else {
+                    (path, name, None)
+                };
                 let (import_edit, binding) = checker.importer().get_or_import_symbol(
                     &ImportRequest::import_from(path, name),
                     expr.start(),
                     checker.semantic(),
                 )?;
-                let replacement_edit = Edit::range_replacement(binding, expr.range());
+                let replacement = if let Some(attribute) = attribute {
+                    format!("{binding}.{attribute}")
+                } else {
+                    binding
+                };
+                let replacement_edit = Edit::range_replacement(replacement, expr.range());
                 Ok(match compatibility {
                     Compatibility::BackwardsCompatible => {
                         Fix::safe_edits(import_edit, [replacement_edit])

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -684,7 +684,7 @@ pub(crate) fn numpy_2_0_deprecation(checker: &Checker, expr: &Expr) {
         } => {
             diagnostic.try_set_fix(|| {
                 // `numpy.char` is not an importable module path on NumPy 1.x.
-                let (path, name, attribute) = if (path, name) == ("numpy.char", "chararray") {
+                let (path, name, attribute) = if matches!((path, name), ("numpy.char", "chararray" | "compare_chararrays")) {
                     ("numpy", "char", Some("chararray"))
                 } else {
                     (path, name, None)

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -684,7 +684,10 @@ pub(crate) fn numpy_2_0_deprecation(checker: &Checker, expr: &Expr) {
         } => {
             diagnostic.try_set_fix(|| {
                 // `numpy.char` is not an importable module path on NumPy 1.x.
-                let (path, name, attribute) = if matches!((path, name), ("numpy.char", "chararray" | "compare_chararrays")) {
+                let (path, name, attribute) = if matches!(
+                    (path, name),
+                    ("numpy.char", "chararray" | "compare_chararrays")
+                ) {
                     ("numpy", "char", Some(name))
                 } else {
                     (path, name, None)

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -685,7 +685,7 @@ pub(crate) fn numpy_2_0_deprecation(checker: &Checker, expr: &Expr) {
             diagnostic.try_set_fix(|| {
                 // `numpy.char` is not an importable module path on NumPy 1.x.
                 let (path, name, attribute) = if matches!((path, name), ("numpy.char", "chararray" | "compare_chararrays")) {
-                    ("numpy", "char", Some("chararray"))
+                    ("numpy", "char", Some(name))
                 } else {
                     (path, name, None)
                 };

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
@@ -434,13 +434,10 @@ NPY201 [*] `np.compare_chararrays` will be removed in NumPy 2.0. Use `numpy.char
    |
 help: Replace with `numpy.char.compare_chararrays`
    |
-1  + from numpy.char import compare_chararrays
-2  | def func():
---------------------------------------------------------------------------------
-58 |
+57 |
    -     np.compare_chararrays
-59 +     compare_chararrays
-60 |
+58 +     np.char.chararray
+59 |
    |
 
 NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `numpy.all` instead.

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
@@ -436,7 +436,7 @@ help: Replace with `numpy.char.compare_chararrays`
    |
 57 |
    -     np.compare_chararrays
-58 +     np.char.chararray
+58 +     np.char.compare_chararrays
 59 |
    |
 

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_3.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_3.py.snap
@@ -119,13 +119,10 @@ NPY201 [*] `np.chararray` will be removed in NumPy 2.0. Use `numpy.char.chararra
    |
 help: Replace with `numpy.char.chararray`
    |
-1  + from numpy.char import chararray
-2  | def func():
---------------------------------------------------------------------------------
-14 |
+13 |
    -     np.chararray
-15 +     chararray
-16 |
+14 +     np.char.chararray
+15 |
    |
 
 NPY201 [*] `np.format_parser` will be removed in NumPy 2.0. Use `numpy.rec.format_parser` instead.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

`NPY201` currently rewrites:

```python
import numpy as np
np.chararray((1,), 4, unicode=True)
```

to:

```python
from numpy.char import chararray
chararray((1,), 4, unicode=True)
```

On NumPy versions 1.x , this fails with:

```text
ModuleNotFoundError: No module named 'numpy.char'
```

Although `numpy.char` is not an importable module, it is available as an attribute. The fix now reuses the existing NumPy binding:

```python
import numpy as np

np.char.chararray((1,), 4, unicode=True)
```

If necessary, Ruff instead imports `char` with `from numpy import char` and uses `char.chararray`.
## Test Plan

This is a relatively minimal change, and I verified that it correctly handles both import cases:

### Reusing an existing NumPy module import

Before:

```python
import numpy as np
array = np.chararray((1,), itemsize=4, unicode=True)
```

After running:

```bash
ruff check --select NPY201 --fix example.py
```

```python
import numpy as np
array = np.char.chararray((1,), itemsize=4, unicode=True)
```

### Importing the `char` namespace

Before:

```python
from numpy import chararray
array = chararray((1,), itemsize=4, unicode=True)
```

After running:

```bash
ruff check --select NPY201 --fix example.py
```

```python
from numpy import chararray, char
array = char.chararray((1,), itemsize=4, unicode=True)
```

The original `chararray` import is now unused and can subsequently be removed by `F401`.