### PR TITLE
[ty] Consider object members in protocol comparisons

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4855,6 +4855,53 @@ static_assert(not is_assignable_to(MethodPSuper, MethodPUnrelated))
 static_assert(not is_assignable_to(MethodPSuper, MethodPSub))
 ```
 
+## Object members in protocol-to-protocol comparisons
+
+A protocol inherits ordinary `object` members even when they are not part of its declared interface.
+Those inherited members can satisfy compatible requirements on another protocol.
+
+```py
+from collections.abc import Hashable, Iterator
+from typing import Literal, Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+class HasValue(Protocol):
+    value: int
+
+class HasValueAndRepr(Protocol):
+    value: int
+
+    def __repr__(self) -> str: ...
+
+static_assert(is_assignable_to(HasValue, HasValueAndRepr))
+static_assert(is_subtype_of(HasValue, HasValueAndRepr))
+```
+
+An inherited method must still have a compatible signature.
+
+```py
+class HasValueAndPreciseRepr(Protocol):
+    value: int
+
+    def __repr__(self) -> Literal["precise"]: ...
+
+static_assert(not is_assignable_to(HasValue, HasValueAndPreciseRepr))
+```
+
+Unlike other inherited `object` methods, `__hash__` can be disabled by a subclass. Protocols must
+explicitly require a callable `__hash__` before they can satisfy a hashability requirement.
+
+```py
+class HasValueAndHash(Protocol):
+    value: int
+
+    def __hash__(self) -> int: ...
+
+static_assert(not is_assignable_to(HasValue, HasValueAndHash))
+static_assert(not is_assignable_to(Iterator[int], Hashable))
+```
+
 ## Subtyping between protocols with method members and protocols with non-method members
 
 A protocol with a method member can be considered a subtype of a protocol with a read-only

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -423,6 +423,7 @@ impl<'db> ProtocolInterfaceView<'db> {
     ) -> bool {
         self.includes_member(db, name)
             || name != "__hash__"
+                && object_member_names(db, self.interface.program(db)).contains(name)
                 && matches!(
                     Type::object().member(db, env, name).place,
                     Place::Defined(place) if place.is_definitely_defined()
@@ -3241,9 +3242,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         if source.member_count(db) < target.member_count(db)
             && !self.is_context_collection_enabled()
-            && target.members(db).any(|member| {
-                !source.includes_member_or_object_fallback(db, self.env, member.name())
-            })
+            && source.member_count(db) < non_object_protocol_member_count(db, target.interface)
         {
             return self.never();
         }
@@ -3506,6 +3505,35 @@ impl<'db> ProtocolMemberCandidate<'db> {
     }
 }
 
+/// Cache `object` member names so missing protocol members can be rejected without member lookup.
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+fn object_member_names<'db>(db: &'db dyn Db, program: Program<'db>) -> FxHashSet<Name> {
+    let env = ProgramEnvironment::from_program(program);
+    let Some((object, _)) = ClassType::object(db, &env).static_class_literal(db) else {
+        return FxHashSet::default();
+    };
+
+    let mut names = place_table(db, object.body_scope(db))
+        .symbols()
+        .map(|symbol| symbol.name().clone())
+        .collect::<FxHashSet<_>>();
+    names.shrink_to_fit();
+    names
+}
+
+/// Count protocol requirements that cannot be supplied by inherited `object` members.
+#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+fn non_object_protocol_member_count<'db>(
+    db: &'db dyn Db,
+    interface: ProtocolInterface<'db>,
+) -> usize {
+    let inherited_member_count = object_member_names(db, interface.program(db))
+        .iter()
+        .filter(|name| name.as_str() != "__hash__" && interface.includes_member(db, name))
+        .count();
+    interface.member_count(db) - inherited_member_count
+}
+
 /// Inner Salsa query for [`ProtocolClass::interface`].
 #[salsa::tracked(
     returns(copy),
@@ -3665,9 +3693,12 @@ pub(super) fn has_all_protocol_members_defined<'db>(
         Type::ProtocolInstance(source_protocol) => {
             let source_interface = source_protocol.interface(db);
 
-            target_interface.members(db).all(|member| {
-                source_interface.includes_member_or_object_fallback(db, env, member.name())
-            })
+            (source_interface.member_count(db) >= target_interface.member_count(db)
+                || source_interface.member_count(db)
+                    >= non_object_protocol_member_count(db, target_interface.interface))
+                && target_interface.members(db).all(|member| {
+                    source_interface.includes_member_or_object_fallback(db, env, member.name())
+                })
         }
         _ => target_interface.members(db).all(|member| {
             matches!(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -414,6 +414,21 @@ impl<'db> ProtocolInterfaceView<'db> {
         self.interface.includes_member(db, name)
     }
 
+    /// Includes inherited `object` members except `__hash__`, which subclasses can disable.
+    fn includes_member_or_object_fallback(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+    ) -> bool {
+        self.includes_member(db, name)
+            || name != "__hash__"
+                && matches!(
+                    Type::object().member(db, env, name).place,
+                    Place::Defined(place) if place.is_definitely_defined()
+                )
+    }
+
     /// Compare the original and materialized forms of members required by `required`.
     ///
     /// An unrelated materialized member must not prevent a protocol from retaining its
@@ -3226,6 +3241,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         if source.member_count(db) < target.member_count(db)
             && !self.is_context_collection_enabled()
+            && target.members(db).any(|member| {
+                !source.includes_member_or_object_fallback(db, self.env, member.name())
+            })
         {
             return self.never();
         }
@@ -3236,6 +3254,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             .sorted_by_cached_key(|member| member.structural_member_priority(db, env))
             .when_all(db, self.constraints, |target_member| {
                 let source_member = source.member_by_name(db, target_member.name);
+
+                if source_member.is_none()
+                    && source.includes_member_or_object_fallback(db, env, target_member.name)
+                {
+                    return self.type_satisfies_protocol_member(db, source_type, &target_member);
+                }
 
                 if let Some(context) = self.report_context()
                     && source_member.is_none()
@@ -3641,10 +3665,9 @@ pub(super) fn has_all_protocol_members_defined<'db>(
         Type::ProtocolInstance(source_protocol) => {
             let source_interface = source_protocol.interface(db);
 
-            source_interface.member_count(db) >= target_interface.member_count(db)
-                && target_interface
-                    .members(db)
-                    .all(|member| source_interface.includes_member(db, member.name()))
+            target_interface.members(db).all(|member| {
+                source_interface.includes_member_or_object_fallback(db, env, member.name())
+            })
         }
         _ => target_interface.members(db).all(|member| {
             matches!(


### PR DESCRIPTION
## Summary

Consider attributes inherited from `object` when checking assignability between protocol types.

- Reuse the same fallback policy in structural comparison and missing-member fast paths while preserving signature compatibility.
- Preserve fast protocol mismatch rejection by caching `object` member names and each protocol's non-`object` requirement count.
- Keep `__hash__` excluded because subclasses can disable hashing; `Iterator[int]` therefore remains incompatible with `Hashable`.

Related to astral-sh/ty#4196.

## Test plan

- Added mdtests for protocol requirements satisfied by `object.__repr__`.
- Covered incompatible inherited method signatures and both custom and standard-library hashability requirements.
- Verified the existing many-protocol-members mismatch benchmark retains its fast rejection path.
