### PR TITLE
[ty] Fix panic from mismatched OR-pattern bindings

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2168,6 +2168,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     PredicateNode::SubjectElementPattern(_)
                     | PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::IsNonEmptyIterable(_)
+                    | PredicateNode::OrPatternAlternative(_)
                     | PredicateNode::StarImportPlaceholder(_) => {
                         // These predicates don't narrow any places
                         PossiblyNarrowedPlaces::default()
@@ -2277,6 +2278,40 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     fn current_statement_mut(&mut self) -> Option<&mut CurrentStatement<'ast, 'db>> {
         self.current_statements.last_mut()
+    }
+
+    /// Return whether a pattern contains any capture that changes the current flow state.
+    fn pattern_has_bindings(pattern: &ast::Pattern) -> bool {
+        match pattern {
+            ast::Pattern::MatchValue(_) | ast::Pattern::MatchSingleton(_) => false,
+            ast::Pattern::MatchSequence(ast::PatternMatchSequence { patterns, .. })
+            | ast::Pattern::MatchOr(ast::PatternMatchOr { patterns, .. }) => {
+                patterns.iter().any(Self::pattern_has_bindings)
+            }
+            ast::Pattern::MatchMapping(pattern) => {
+                pattern.rest.is_some() || pattern.patterns.iter().any(Self::pattern_has_bindings)
+            }
+            ast::Pattern::MatchClass(pattern) => pattern
+                .arguments
+                .patterns
+                .iter()
+                .chain(
+                    pattern
+                        .arguments
+                        .keywords
+                        .iter()
+                        .map(|keyword| &keyword.pattern),
+                )
+                .any(Self::pattern_has_bindings),
+            ast::Pattern::MatchStar(pattern) => pattern.name.is_some(),
+            ast::Pattern::MatchAs(pattern) => {
+                pattern.name.is_some()
+                    || pattern
+                        .pattern
+                        .as_deref()
+                        .is_some_and(Self::pattern_has_bindings)
+            }
+        }
     }
 
     fn predicate_kind(&mut self, pattern: &ast::Pattern) -> PatternPredicateKind<'db> {
@@ -4950,28 +4985,33 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
 
     fn visit_pattern(&mut self, pattern: &'ast ast::Pattern) {
         if let ast::Pattern::MatchOr(ast::PatternMatchOr { patterns, .. }) = pattern
-            && let Some((first, alternatives)) = patterns.split_first()
+            && let Some((last, alternatives)) = patterns.split_last()
+            // Capture-free alternatives do not affect bindings and need no flow merge.
+            && patterns.iter().any(Self::pattern_has_bindings)
         {
-            let incoming = self.flow_snapshot();
-            let first_definition = self.current_use_def_map().next_definition_id();
-            self.visit_pattern(first);
-
-            // Valid alternatives bind the same names, so capture-free patterns need no flow merge.
-            if self.current_use_def_map().next_definition_id() == first_definition {
-                for alternative in alternatives {
-                    self.visit_pattern(alternative);
+            // Start each alternative without earlier captures so repeated names do not shadow one
+            // another. Complementary predicates preserve possible missing captures while all
+            // alternatives together recover the incoming reachability.
+            let mut successful_alternatives = None;
+            for alternative in alternatives {
+                let remaining_alternatives = self.flow_snapshot();
+                let selected_alternative =
+                    self.record_reachability_constraint(PredicateOrLiteral::Predicate(Predicate {
+                        node: PredicateNode::OrPatternAlternative(self.current_scope_id()),
+                        is_positive: true,
+                    }));
+                self.visit_pattern(alternative);
+                if let Some(previous_alternatives) = successful_alternatives.take() {
+                    self.flow_merge(previous_alternatives);
                 }
-                return;
+                successful_alternatives = Some(self.flow_snapshot());
+                self.flow_restore(remaining_alternatives);
+                self.record_negated_reachability_constraint(selected_alternative);
             }
 
-            // Each alternative starts with the same bindings. Otherwise a repeated capture in a
-            // later alternative shadows the earlier capture even though only one pattern matches.
-            let mut merged_alternatives = self.flow_snapshot();
-            for alternative in alternatives {
-                self.flow_restore(incoming.clone());
-                self.visit_pattern(alternative);
-                self.flow_merge(merged_alternatives);
-                merged_alternatives = self.flow_snapshot();
+            self.visit_pattern(last);
+            if let Some(successful_alternative) = successful_alternatives {
+                self.flow_merge(successful_alternative);
             }
             return;
         }

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -138,6 +138,10 @@ pub enum PredicateNode<'db> {
     /// semantically during type checking, so calls to a shadowed `range` remain ambiguous.
     IsNonEmptyIterable(Expression<'db>),
     Pattern(PatternPredicate<'db>),
+    /// Whether control flow takes one branch of an OR pattern instead of its remaining
+    /// alternatives. The selected branch is unknown, but recording a predicate and its negation
+    /// preserves the fact that exactly one branch is taken.
+    OrPatternAlternative(ScopeId<'db>),
     SubjectElementPattern(SubjectElementPatternPredicate<'db>),
     StarImportPlaceholder(StarImportPlaceholderPredicate<'db>),
 }

--- a/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
@@ -106,6 +106,111 @@ out = (obj.attr := obj).attr
 out = (obj[0] := obj).attr
 ```
 
+## Match-pattern alternatives binding different names
+
+A capture present in only one invalid `or` alternative is possibly undefined.
+
+```py
+match 0:
+    case first | second:  # error: [invalid-syntax] "alternative patterns bind different names"
+        first  # error: [possibly-unresolved-reference]
+        second  # error: [possibly-unresolved-reference]
+```
+
+## Match-pattern alternative without a binding
+
+A capture missing from one alternative is possibly undefined, regardless of alternative order.
+
+```py
+match (0,):
+    # error: [invalid-syntax] "alternative patterns bind different names"
+    case [first_value] | []:
+        first_value  # error: [possibly-unresolved-reference]
+```
+
+An alternative without a capture can also occur first.
+
+```py
+match (0,):
+    # error: [invalid-syntax] "alternative patterns bind different names"
+    case [] | [last_value]:
+        last_value  # error: [possibly-unresolved-reference]
+```
+
+A capture limited to the middle of three alternatives also remains possibly undefined.
+
+```py
+match (0,):
+    # error: [invalid-syntax] "alternative patterns bind different names"
+    case [] | [middle_value] | []:
+        middle_value  # error: [possibly-unresolved-reference]
+```
+
+## Previously bound match-pattern captures
+
+A prior binding remains visible on alternatives that do not capture the name.
+
+```py
+value = "previous"
+
+match (0,):
+    case [value] | []:  # error: [invalid-syntax] "alternative patterns bind different names"
+        value
+
+value
+```
+
+## Partially overlapping match-pattern bindings
+
+Shared captures remain definitely bound; branch-specific captures are possibly undefined.
+
+```py
+match (0, 1):
+    # error: [invalid-syntax] "alternative patterns bind different names"
+    case [first, shared] | [second, shared]:
+        first  # error: [possibly-unresolved-reference]
+        second  # error: [possibly-unresolved-reference]
+        shared
+```
+
+## Nested mismatched match-pattern bindings
+
+Syntax checking stops after an outer mismatch, but unchecked nested alternatives must still be
+modeled safely.
+
+```py
+match (0,):
+    # error: [invalid-syntax] "alternative patterns bind different names"
+    case [first] | [second] | [third | fourth]:
+        third  # error: [possibly-unresolved-reference]
+        fourth  # error: [possibly-unresolved-reference]
+```
+
+## Partially bound match-pattern capture in a guard
+
+A guard can observe a name that is bound by only one invalid alternative.
+
+```py
+match (0,):
+    # error: [invalid-syntax] "alternative patterns bind different names"
+    # error: [possibly-unresolved-reference]
+    case [value] | [] if value:
+        pass
+```
+
+## Malformed match-case recovery
+
+Parser recovery treats the trailing name as an annotation-only statement, whose binding lookup must
+not panic.
+
+```py
+match 0:
+    # error: [invalid-syntax] "alternative patterns bind different names"
+    # error: [invalid-syntax] "Expected `:`, found name"
+    # error: [invalid-syntax] "Expected an expression"
+    case first | second first:
+```
+
 ## Invalid annotation
 
 ### `typing.Callable`

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -547,6 +547,7 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
             callable.scope(db)
         }
         PredicateNode::Pattern(pattern) => pattern.scope(db),
+        PredicateNode::OrPatternAlternative(scope) => scope,
         PredicateNode::SubjectElementPattern(subject_element) => subject_element.pattern.scope(db),
         PredicateNode::IsNonEmptyIterable(expression) => expression.scope(db),
         PredicateNode::StarImportPlaceholder(star_import) => star_import.scope(db),
@@ -1529,6 +1530,7 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
         }) => analyze_non_terminal_call(db, callable, call_expr, is_await)
             .negate_if(!predicate.is_positive),
         PredicateNode::Pattern(inner) => analyze_pattern_predicate(db, inner),
+        PredicateNode::OrPatternAlternative(_) => Truthiness::Ambiguous,
         PredicateNode::SubjectElementPattern(subject_element) => {
             analyze_pattern_predicate(db, subject_element.pattern)
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -104,6 +104,7 @@ pub(crate) fn infer_narrowing_constraints<'db>(
         }
         PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::IsNonEmptyIterable(_)
+        | PredicateNode::OrPatternAlternative(_)
         | PredicateNode::StarImportPlaceholder(_) => (None, None),
     };
 
@@ -1143,6 +1144,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             }
             PredicateNode::IsNonTerminalCall(_) => return None,
             PredicateNode::IsNonEmptyIterable(_) => return None,
+            PredicateNode::OrPatternAlternative(_) => return None,
             PredicateNode::StarImportPlaceholder(_) => return None,
         };
 
@@ -2788,6 +2790,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         match self.predicate {
             PredicateNode::Expression(expression) => expression.scope(db),
             PredicateNode::Pattern(pattern) => pattern.scope(db),
+            PredicateNode::OrPatternAlternative(scope) => scope,
             PredicateNode::SubjectElementPattern(subject_element) => {
                 subject_element.pattern.scope(db)
             }


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ruff/pull/27438 modeled OR-pattern alternatives as distinct control-flow paths rather than linear control flow. This is correct, but the implementation was inadequate; it effectively treated all of these branches simultaneously as "definitely taken", which becomes a problem in the (invalid syntax) case where not all branches bind the same name(s). That caused a panic.

Fix this by introducing reachability predicates to explicitly model that only one of these "branches" can be taken.

Closes astral-sh/ty#4194.

## Test plan

Added mdtests covering distinct and overlapping captures, alternatives without bindings in either order, three-way alternatives, previously bound names, nested mismatches, guard references, and the original malformed-case panic.
