### PR TITLE
[ty] Infer variance through type[T]

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
@@ -423,4 +423,57 @@ static_assert(not is_assignable_to(GoodInferredInvariant[B], GoodInferredInvaria
 static_assert(not is_assignable_to(GoodInferredInvariant[A], GoodInferredInvariant[B]))
 ```
 
+## Inferred variance for writable subclass-type attributes
+
+A writable public `type[T]` attribute makes a legacy type variable with inferred variance invariant.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+T = TypeVar("T", infer_variance=True)
+
+class ClassContainer(Generic[T]):
+    cls: type[T]
+
+static_assert(not is_subtype_of(ClassContainer[int], ClassContainer[object]))
+static_assert(not is_subtype_of(ClassContainer[object], ClassContainer[int]))
+
+static_assert(not is_assignable_to(ClassContainer[int], ClassContainer[object]))
+static_assert(not is_assignable_to(ClassContainer[object], ClassContainer[int]))
+```
+
+## Inferred variance for subclass-type method parameters
+
+A method parameter annotated as `type[T]` makes a legacy type variable with inferred variance
+contravariant.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+T = TypeVar("T", infer_variance=True)
+
+class ClassContainer(Generic[T]):
+    def put(self, cls: type[T]) -> None: ...
+
+static_assert(is_subtype_of(ClassContainer[object], ClassContainer[int]))
+static_assert(not is_subtype_of(ClassContainer[int], ClassContainer[object]))
+
+static_assert(is_assignable_to(ClassContainer[object], ClassContainer[int]))
+static_assert(not is_assignable_to(ClassContainer[int], ClassContainer[object]))
+```
+
 [spec]: https://typing.python.org/en/latest/spec/generics.html#variance

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -879,37 +879,6 @@ static_assert(not is_subtype_of(ClassContainer[A], ClassContainer[B]))
 static_assert(is_assignable_to(ClassContainer[B], ClassContainer[A]))
 static_assert(not is_assignable_to(ClassContainer[A], ClassContainer[B]))
 
-# A writable public type[T] attribute makes the enclosing class invariant.
-class MutableClassContainer[T]:
-    cls: type[T]
-
-static_assert(not is_subtype_of(MutableClassContainer[B], MutableClassContainer[A]))
-static_assert(not is_subtype_of(MutableClassContainer[A], MutableClassContainer[B]))
-
-static_assert(not is_assignable_to(MutableClassContainer[B], MutableClassContainer[A]))
-static_assert(not is_assignable_to(MutableClassContainer[A], MutableClassContainer[B]))
-
-# A type[T] return retains the wrapped type variable's covariance.
-class ClassSource[T]:
-    def get(self) -> type[T]:
-        raise NotImplementedError
-
-static_assert(is_subtype_of(ClassSource[B], ClassSource[A]))
-static_assert(not is_subtype_of(ClassSource[A], ClassSource[B]))
-
-static_assert(is_assignable_to(ClassSource[B], ClassSource[A]))
-static_assert(not is_assignable_to(ClassSource[A], ClassSource[B]))
-
-# A type[T] parameter makes the enclosing class contravariant.
-class ClassSink[T]:
-    def put(self, cls: type[T]) -> None: ...
-
-static_assert(is_subtype_of(ClassSink[A], ClassSink[B]))
-static_assert(not is_subtype_of(ClassSink[B], ClassSink[A]))
-
-static_assert(is_assignable_to(ClassSink[A], ClassSink[B]))
-static_assert(not is_assignable_to(ClassSink[B], ClassSink[A]))
-
 # Practical example: you can pass a ClassContainer[B] where ClassContainer[A] is expected
 # because type[B] can safely be used where type[A] is expected
 def use_a_class_container(container: ClassContainer[A]) -> A:
@@ -917,6 +886,64 @@ def use_a_class_container(container: ClassContainer[A]) -> A:
 
 b_container = ClassContainer[B](B)
 a_instance: A = use_a_class_container(b_container)  # This should work
+```
+
+## Subclass types in writable attributes
+
+A writable public `type[T]` attribute makes its enclosing class invariant in `T`.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+class ClassContainer[T]:
+    cls: type[T]
+
+static_assert(not is_subtype_of(ClassContainer[int], ClassContainer[object]))
+static_assert(not is_subtype_of(ClassContainer[object], ClassContainer[int]))
+
+static_assert(not is_assignable_to(ClassContainer[int], ClassContainer[object]))
+static_assert(not is_assignable_to(ClassContainer[object], ClassContainer[int]))
+```
+
+## Subclass types in return positions
+
+A `type[T]` return contributes covariance for `T`. Combining it with a method that accepts `T`
+therefore makes the enclosing class invariant.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+class ClassContainer[T]:
+    def get(self) -> type[T]:
+        raise NotImplementedError
+
+    def put(self, value: T) -> None: ...
+
+static_assert(not is_subtype_of(ClassContainer[int], ClassContainer[object]))
+static_assert(not is_subtype_of(ClassContainer[object], ClassContainer[int]))
+
+static_assert(not is_assignable_to(ClassContainer[int], ClassContainer[object]))
+static_assert(not is_assignable_to(ClassContainer[object], ClassContainer[int]))
+```
+
+## Subclass types in parameter positions
+
+A method parameter annotated as `type[T]` makes the enclosing class contravariant in `T`.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+class ClassContainer[T]:
+    def put(self, cls: type[T]) -> None: ...
+
+static_assert(is_subtype_of(ClassContainer[object], ClassContainer[int]))
+static_assert(not is_subtype_of(ClassContainer[int], ClassContainer[object]))
+
+static_assert(is_assignable_to(ClassContainer[object], ClassContainer[int]))
+static_assert(not is_assignable_to(ClassContainer[int], ClassContainer[object]))
 ```
 
 ## TypeIs

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -847,7 +847,8 @@ static_assert(not is_assignable_to(Intersection[C, Not[B]], Intersection[C, Not[
 ## Subclass Types (type[T])
 
 The `type[T]` construct represents the type of classes that are subclasses of `T`. It is covariant
-in `T` because if `A <: B`, then `type[A] <: type[B]` holds.
+in `T` because if `A <: B`, then `type[A] <: type[B]` holds. A public, writable `type[T]` attribute
+still makes its enclosing class invariant, while a private attribute can remain covariant.
 
 ```py
 from ty_extensions import static_assert
@@ -866,10 +867,10 @@ static_assert(not is_assignable_to(type[A], type[B]))
 # With generic classes using type[T]
 class ClassContainer[T]:
     def __init__(self, cls: type[T]) -> None:
-        self.cls = cls
+        self._cls = cls
 
     def create_instance(self) -> T:
-        return self.cls()
+        return self._cls()
 
 # ClassContainer is covariant in T due to type[T]
 static_assert(is_subtype_of(ClassContainer[B], ClassContainer[A]))
@@ -877,6 +878,37 @@ static_assert(not is_subtype_of(ClassContainer[A], ClassContainer[B]))
 
 static_assert(is_assignable_to(ClassContainer[B], ClassContainer[A]))
 static_assert(not is_assignable_to(ClassContainer[A], ClassContainer[B]))
+
+# A writable public type[T] attribute makes the enclosing class invariant.
+class MutableClassContainer[T]:
+    cls: type[T]
+
+static_assert(not is_subtype_of(MutableClassContainer[B], MutableClassContainer[A]))
+static_assert(not is_subtype_of(MutableClassContainer[A], MutableClassContainer[B]))
+
+static_assert(not is_assignable_to(MutableClassContainer[B], MutableClassContainer[A]))
+static_assert(not is_assignable_to(MutableClassContainer[A], MutableClassContainer[B]))
+
+# A type[T] return retains the wrapped type variable's covariance.
+class ClassSource[T]:
+    def get(self) -> type[T]:
+        raise NotImplementedError
+
+static_assert(is_subtype_of(ClassSource[B], ClassSource[A]))
+static_assert(not is_subtype_of(ClassSource[A], ClassSource[B]))
+
+static_assert(is_assignable_to(ClassSource[B], ClassSource[A]))
+static_assert(not is_assignable_to(ClassSource[A], ClassSource[B]))
+
+# A type[T] parameter makes the enclosing class contravariant.
+class ClassSink[T]:
+    def put(self, cls: type[T]) -> None: ...
+
+static_assert(is_subtype_of(ClassSink[A], ClassSink[B]))
+static_assert(not is_subtype_of(ClassSink[B], ClassSink[A]))
+
+static_assert(is_assignable_to(ClassSink[A], ClassSink[B]))
+static_assert(not is_assignable_to(ClassSink[B], ClassSink[A]))
 
 # Practical example: you can pass a ClassContainer[B] where ClassContainer[A] is expected
 # because type[B] can safely be used where type[A] is expected

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -377,7 +377,8 @@ impl<'db> VarianceInferable<'db> for SubclassOfType<'db> {
         match self.subclass_of {
             SubclassOfInner::Class(class) => class.variance_of(db, env, typevar),
             SubclassOfInner::Protocol(protocol) => protocol.variance_of(db, env, typevar),
-            SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => TypeVarVariance::Bivariant,
+            SubclassOfInner::TypeVar(inner) => Type::TypeVar(inner).variance_of(db, env, typevar),
+            SubclassOfInner::Dynamic(_) => TypeVarVariance::Bivariant,
         }
     }
 }


### PR DESCRIPTION
## Summary

Previously, variance inference treated `type[T]` as independent of `T`. As a result, generic classes with writable class-object attributes could incorrectly be treated as covariant:

```python
class Mutable[T]:
    cls: type[T]


def overwrite(value: Mutable[object]) -> None:
    value.cls = str


def unsound(value: Mutable[int]) -> None:
    overwrite(value)  # error: [invalid-argument-type]
```

We now retain the wrapped type variable when inferring variance through `type[T]`. Return positions remain covariant, parameter positions become contravariant, and writable public attributes correctly make their containing class invariant.
