### PR TITLE
[ty] Infer TypeVarTuple arguments from variadic calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -25,6 +25,6 @@ reveal_type(append_int())  # revealed: tuple[*tuple[Unknown, ...], int]
 def first_arg_int(*args: *tuple[int, *tuple[str, ...]]): ...
 
 first_arg_int(42, "42", "42")  # fine
-first_arg_int("not an int", "42", "42")  # TODO: should error
-first_arg_int(56, "42", 56)  # TODO: should error
+first_arg_int("not an int", "42", "42")  # error: [invalid-argument-type]
+first_arg_int(56, "42", 56)  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -17,10 +17,8 @@ def append_int(*args: *Ts) -> tuple[*Ts, int]:
 
     return (*args, 1)
 
-# TODO should be tuple[Literal[True], Literal["a"], int]
-reveal_type(append_int(True, "a"))  # revealed: tuple[*tuple[Unknown, ...], int]
-# TODO should be tuple[int]
-reveal_type(append_int())  # revealed: tuple[*tuple[Unknown, ...], int]
+reveal_type(append_int(True, "a"))  # revealed: tuple[Literal[True], Literal["a"], int]
+reveal_type(append_int())  # revealed: tuple[int]
 
 def first_arg_int(*args: *tuple[int, *tuple[str, ...]]): ...
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -45,8 +45,8 @@ def ex3(msg: str):
 def first_arg_int(*args: Unpack[tuple[int, Unpack[tuple[str, ...]]]]): ...
 
 first_arg_int(42, "42", "42")  # fine
-first_arg_int("not an int", "42", "42")  # TODO: should error
-first_arg_int(56, "42", 56)  # TODO: should error
+first_arg_int("not an int", "42", "42")  # error: [invalid-argument-type]
+first_arg_int(56, "42", 56)  # error: [invalid-argument-type]
 ```
 
 ## Allowed `Unpack` contexts

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1213,6 +1213,117 @@ def f(*args: int) -> int:
 reveal_type(f())  # revealed: int
 ```
 
+### Unpacked variadic arguments can require positional arguments
+
+An unpacked tuple can require arguments even though an ordinary variadic parameter can be empty.
+Fixed tuples also reject positional arguments beyond their declared length.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+def at_least_one(*args: *tuple[*tuple[int, ...], int]) -> None: ...
+def exactly_two(*args: *tuple[int, str]) -> None: ...
+def exactly_zero(*args: *tuple[()]) -> None: ...
+
+at_least_one()  # error: [missing-argument]
+at_least_one(1)
+at_least_one(1, 2)
+at_least_one("wrong")  # error: [invalid-argument-type]
+at_least_one(1, "wrong")  # error: [invalid-argument-type]
+
+exactly_two()  # error: [missing-argument]
+exactly_two(1)  # error: [missing-argument]
+exactly_two(1, "two")
+exactly_two("one", "two")  # error: [invalid-argument-type]
+exactly_two(1, 2)  # error: [invalid-argument-type]
+exactly_two(1, "two", 3)  # error: [too-many-positional-arguments]
+
+exactly_zero()
+exactly_zero(1)  # error: [too-many-positional-arguments]
+```
+
+### Unpacked variadic arguments preserve element positions
+
+Fixed prefixes, a homogeneous variadic segment, and fixed suffixes each retain their own argument
+types. A required suffix also requires any preceding defaulted positional parameter to be filled.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+def mixed(*args: *tuple[int, *tuple[str, ...], bytes]) -> None: ...
+def with_default(first: int = 0, *args: *tuple[*tuple[int, ...], int]) -> None: ...
+
+mixed(1, b"last")
+mixed(1, "middle", b"last")
+mixed("first", b"last")  # error: [invalid-argument-type]
+mixed(1, 2, b"last")  # error: [invalid-argument-type]
+mixed(1, "middle", "last")  # error: [invalid-argument-type]
+
+with_default()  # error: [missing-argument]
+with_default(first=1)  # error: [missing-argument]
+with_default(1)  # error: [missing-argument]
+with_default(1, 2)
+```
+
+### Unpacked variadic elements preserve generic bounds
+
+Ordinary type variables are inferred from individual unpacked elements, even beside an unresolved
+type-variable tuple. Their upper bounds remain enforced.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+def fixed[T: str](*args: *tuple[T]) -> T:
+    return args[0]
+
+def suffix[T: str, *Ts](*args: *tuple[*Ts, T]) -> T:
+    return args[-1]
+
+reveal_type(fixed("valid"))  # revealed: Literal["valid"]
+fixed(1)  # error: [invalid-argument-type]
+
+reveal_type(suffix("prefix", "valid"))  # revealed: Literal["valid"]
+suffix("prefix", 1)  # error: [invalid-argument-type]
+```
+
+### Callable protocols enforce unpacked variadic requirements
+
+Calling a callable protocol uses the same tuple element types and argument-count bounds as calling
+an ordinary function.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Protocol
+
+class AtLeastOne(Protocol):
+    def __call__(self, *args: *tuple[*tuple[int, ...], int]) -> None: ...
+
+class ExactlyOne(Protocol):
+    def __call__(self, *args: *tuple[int]) -> None: ...
+
+def call(at_least_one: AtLeastOne, exactly_one: ExactlyOne) -> None:
+    at_least_one()  # error: [missing-argument]
+    at_least_one(1)
+    at_least_one("wrong")  # error: [invalid-argument-type]
+
+    exactly_one(1)
+    exactly_one()  # error: [missing-argument]
+    exactly_one(1, 2)  # error: [too-many-positional-arguments]
+```
+
 ### Keywords argument is not required
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -370,13 +370,12 @@ class Variadic(Generic[*Ts]):
 reveal_type(Positional(()))  # revealed: Positional[()]
 reveal_type(Positional((1, "a")))  # revealed: Positional[int, str]
 
-# TODO: Infer the `TypeVarTuple` from arguments matched to the variadic parameter.
-reveal_type(Variadic())  # revealed: Variadic[*tuple[Unknown, ...]]
-reveal_type(Variadic(1, "a"))  # revealed: Variadic[*tuple[Unknown, ...]]
+reveal_type(Variadic())  # revealed: Variadic[()]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
 
 def _(i: int, s: str) -> None:
     reveal_type(Positional((i, s)))  # revealed: Positional[int, str]
-    reveal_type(Variadic(i, s))  # revealed: Variadic[*tuple[Unknown, ...]]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
 ### Unspecified type arguments
@@ -443,6 +442,46 @@ class WithBackportedDefault(Generic[Unpack[Ts]]):
     attr: tuple[Unpack[Ts]]
 
 reveal_type(WithBackportedDefault().attr)  # revealed: tuple[int, str]
+```
+
+## Generic Functions
+
+### Starred variadic parameters
+
+A legacy type-variable tuple is inferred from all positional arguments matched to `*args`, including
+an empty argument list.
+
+```py
+from typing import TypeVarTuple, assert_type
+
+Ts = TypeVarTuple("Ts")
+
+def args_to_tuple(*args: *Ts) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def _(i: int, s: str) -> None:
+    assert_type(args_to_tuple(), tuple[()])
+    assert_type(args_to_tuple(i, s), tuple[int, str])
+```
+
+### Starred variadic parameters with fixed suffixes
+
+Required tuple elements following the type-variable tuple are excluded from its inferred
+specialization. The type-variable tuple can still be empty.
+
+```py
+from typing import TypeVarTuple, assert_type
+
+Ts = TypeVarTuple("Ts")
+
+class Env: ...
+
+def exec_le(path: str, *args: *tuple[*Ts, Env], env: Env | None = None) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def _(i: int, s: str) -> None:
+    assert_type(exec_le("", Env()), tuple[()])
+    assert_type(exec_le(s, i, s, Env()), tuple[int, str])
 ```
 
 ## Type Aliases

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -40,9 +40,8 @@ def collect(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     reveal_type(args)  # revealed: tuple[*Ts@collect]
     raise NotImplementedError
 
-# TODO: Infer the `TypeVarTuple` from arguments matched to the variadic parameter.
-reveal_type(collect())  # revealed: tuple[Unknown, ...]
-reveal_type(collect(1, "a"))  # revealed: tuple[Unknown, ...]
+reveal_type(collect())  # revealed: tuple[()]
+reveal_type(collect(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
 ```
 
 ## Callable parameters

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -128,8 +128,7 @@ def accept(
 
 accept(True, "phase", "status", b"ok")
 accept(True, b"ok")
-# TODO: error: [invalid-argument-type] "Argument to function `accept` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
-accept(True, 1, b"bad")
+accept(True, 1, b"bad")  # error: [invalid-argument-type]
 ```
 
 ## Defaults

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -791,8 +791,7 @@ def remove_bytes[*Prefix](*args: *tuple[*Prefix, bytes]) -> tuple[*Prefix]:
 
 accept_str_in_between(True, "phase", "status", b"ok")
 accept_str_in_between(True, b"ok")
-# TODO: error: [invalid-argument-type] "Argument to function `accept_str_in_between` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
-accept_str_in_between(True, 1, b"bad")
+accept_str_in_between(True, 1, b"bad")  # error: [invalid-argument-type]
 
 # TODO: Infer the `TypeVarTuple` from arguments matched to the variadic parameter.
 reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[Unknown, ...]

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -135,13 +135,12 @@ class Variadic[*Ts]:
 reveal_type(Positional(()))  # revealed: Positional[()]
 reveal_type(Positional((1, "a")))  # revealed: Positional[int, str]
 
-# TODO: Infer the `TypeVarTuple` from arguments matched to the variadic parameter.
-reveal_type(Variadic())  # revealed: Variadic[*tuple[Unknown, ...]]
-reveal_type(Variadic(1, "a"))  # revealed: Variadic[*tuple[Unknown, ...]]
+reveal_type(Variadic())  # revealed: Variadic[()]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
 
 def _(i: int, s: str) -> None:
     reveal_type(Positional((i, s)))  # revealed: Positional[int, str]
-    reveal_type(Variadic(i, s))  # revealed: Variadic[*tuple[Unknown, ...]]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
 ### Unspecified type arguments
@@ -301,8 +300,9 @@ def materialized_default[*Ts = *tuple[Any, ...]]() -> None:
 
 ### Starred variadic parameters
 
-An unpacked `TypeVarTuple` can annotate `*args`. Inferring the `TypeVarTuple` from arguments matched
-to the variadic parameter is not yet supported, so these calls use a gradual specialization.
+An unpacked `TypeVarTuple` can annotate `*args`. Arguments matched to the variadic parameter infer
+the complete type-variable tuple, preserving the shape of forwarded tuples and excluding ordinary
+positional and keyword-only parameters.
 
 ```py
 def simple[*Ts](*args: *Ts) -> tuple[*Ts]:
@@ -316,29 +316,61 @@ def with_kw_only[T, *Ts](*args: *Ts, kw: T) -> tuple[*Ts, T]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool, t: tuple[int, str], vt: tuple[int, ...]) -> None:
-    reveal_type(simple())  # revealed: tuple[Unknown, ...]
-    reveal_type(simple(i, s))  # revealed: tuple[Unknown, ...]
-    reveal_type(simple(*(i, s)))  # revealed: tuple[Unknown, ...]
-    reveal_type(simple(t))  # revealed: tuple[Unknown, ...]
-    reveal_type(simple(*t))  # revealed: tuple[Unknown, ...]
-    reveal_type(simple(*vt))  # revealed: tuple[Unknown, ...]
+    reveal_type(simple())  # revealed: tuple[()]
+    reveal_type(simple(i, s))  # revealed: tuple[int, str]
+    reveal_type(simple(*(i, s)))  # revealed: tuple[int, str]
+    reveal_type(simple(t))  # revealed: tuple[tuple[int, str]]
+    reveal_type(simple(*t))  # revealed: tuple[int, str]
+    reveal_type(simple(*vt))  # revealed: tuple[int, ...]
 
-    reveal_type(with_prefix(i))  # revealed: tuple[int, *tuple[Unknown, ...]]
-    reveal_type(with_prefix(i, s, b))  # revealed: tuple[int, *tuple[Unknown, ...]]
-    reveal_type(with_prefix(*t))  # revealed: tuple[int, *tuple[Unknown, ...]]
-    reveal_type(with_prefix(i, *t))  # revealed: tuple[int, *tuple[Unknown, ...]]
-    reveal_type(with_prefix(*vt))  # revealed: tuple[int, *tuple[Unknown, ...]]
-    reveal_type(with_prefix(i, *vt))  # revealed: tuple[int, *tuple[Unknown, ...]]
+    reveal_type(with_prefix(i))  # revealed: tuple[int]
+    reveal_type(with_prefix(i, s, b))  # revealed: tuple[int, str, bool]
+    reveal_type(with_prefix(*t))  # revealed: tuple[int, str]
+    reveal_type(with_prefix(i, *t))  # revealed: tuple[int, int, str]
+    reveal_type(with_prefix(*vt))  # revealed: tuple[int, *tuple[int, ...]]
+    reveal_type(with_prefix(i, *vt))  # revealed: tuple[int, *tuple[int, ...]]
 
-    reveal_type(with_kw_only(kw=b))  # revealed: tuple[*tuple[Unknown, ...], bool]
-    reveal_type(with_kw_only(i, s, kw=b))  # revealed: tuple[*tuple[Unknown, ...], bool]
-    reveal_type(with_kw_only(t, kw=b))  # revealed: tuple[*tuple[Unknown, ...], bool]
-    reveal_type(with_kw_only(*t, kw=b))  # revealed: tuple[*tuple[Unknown, ...], bool]
-    reveal_type(with_kw_only(vt, kw=b))  # revealed: tuple[*tuple[Unknown, ...], bool]
-    reveal_type(with_kw_only(*vt, kw=b))  # revealed: tuple[*tuple[Unknown, ...], bool]
+    reveal_type(with_kw_only(kw=b))  # revealed: tuple[bool]
+    reveal_type(with_kw_only(i, s, kw=b))  # revealed: tuple[int, str, bool]
+    reveal_type(with_kw_only(t, kw=b))  # revealed: tuple[tuple[int, str], bool]
+    reveal_type(with_kw_only(*t, kw=b))  # revealed: tuple[int, str, bool]
+    reveal_type(with_kw_only(vt, kw=b))  # revealed: tuple[tuple[int, ...], bool]
+    reveal_type(with_kw_only(*vt, kw=b))  # revealed: tuple[*tuple[int, ...], bool]
 
     # error: [missing-argument] "No argument provided for required parameter `kw` of function `with_kw_only`"
-    reveal_type(with_kw_only(i, s, b))  # revealed: tuple[*tuple[Unknown, ...], Unknown]
+    reveal_type(with_kw_only(i, s, b))  # revealed: tuple[int, str, bool, Unknown]
+```
+
+Variadic inference must preserve contextual argument types, including contexts that contain an outer
+type variable.
+
+```py
+from typing import TypedDict
+
+class Payload(TypedDict):
+    value: int
+
+def contextual[T](value: T) -> None:
+    concrete: tuple[Payload, list[int]] = simple({"value": 1}, [])
+    generic: tuple[Payload, T] = simple({"value": 1}, value)
+```
+
+Fixed elements beside the type-variable tuple retain their individual bound diagnostics without
+reporting the same error twice.
+
+```py
+def bounded_suffix[T: str, *Ts](*args: *tuple[*Ts, T]) -> tuple[*Ts, T]:
+    raise NotImplementedError
+
+def bounded_arguments[U: bytes, T: str, *Ts](first: U, *args: *tuple[*Ts, T]) -> tuple[*Ts, T]:
+    raise NotImplementedError
+
+bounded_suffix("ok", 1)  # error: [invalid-argument-type] "upper bound `str`"
+bounded_arguments(
+    1,  # error: [invalid-argument-type] "upper bound `bytes`"
+    "ok",
+    2,  # error: [invalid-argument-type] "upper bound `str`"
+)
 ```
 
 ### Callable inference
@@ -793,8 +825,7 @@ accept_str_in_between(True, "phase", "status", b"ok")
 accept_str_in_between(True, b"ok")
 accept_str_in_between(True, 1, b"bad")  # error: [invalid-argument-type]
 
-# TODO: Infer the `TypeVarTuple` from arguments matched to the variadic parameter.
-reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[Unknown, ...]
+reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[Literal[1], Literal["record"]]
 ```
 
 ## `@staticmethod` and `@classmethod`

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -58,7 +58,7 @@ use crate::types::signatures::{
     CallableSignature, Parameter, ParameterDisplayName, ParameterKind, Parameters, ParametersKind,
     PartialApplication, PartialSignatureApplication,
 };
-use crate::types::tuple::{TupleLength, TupleSpec, TupleType, VariableSegment};
+use crate::types::tuple::{TupleLength, TupleSpec, TupleSpecBuilder, TupleType, VariableSegment};
 use crate::types::typed_dict::{TypedDictOpenness, extract_unpacked_typed_dict_from_value_type};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator, TypeVarSet};
 use crate::types::visitor::{
@@ -5920,6 +5920,175 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         self.inference = Some(inference);
     }
 
+    /// Infer a variadic type-variable tuple from all positional arguments bound to `*args`.
+    ///
+    /// A type-variable tuple represents the complete argument sequence, not an independent type
+    /// variable for each argument. The ordinary tuple inference machinery also accounts for any
+    /// fixed elements surrounding the pack:
+    ///
+    /// ```python
+    /// def collect[*Ts](*args: *Ts) -> tuple[*Ts]: ...
+    /// def discard_suffix[*Ts](*args: *tuple[*Ts, bytes]) -> tuple[*Ts]: ...
+    ///
+    /// collect(1, "two")
+    /// discard_suffix(1, "two", b"last")
+    /// ```
+    fn infer_typevartuple_argument_constraints<'c>(
+        &self,
+        builder: &mut SpecializationBuilder<'db, 'c>,
+    ) -> Result<(), SpecializationError<'db>> {
+        let db = self.db;
+        let Some((parameter_index, parameter)) = self.signature.parameters().variadic() else {
+            return Ok(());
+        };
+        if !parameter.has_starred_annotation() {
+            return Ok(());
+        }
+
+        let (formal, typevartuple) = match parameter.annotated_type() {
+            Type::TypeVar(typevar) if typevar.is_typevartuple(db) => (
+                Type::tuple(Some(TupleType::unpacked_typevartuple(
+                    db, self.env, typevar,
+                ))),
+                typevar,
+            ),
+            annotation => {
+                let Some(typevartuple) =
+                    annotation.exact_tuple_instance_spec(db).and_then(|tuple| {
+                        match tuple.as_ref() {
+                            TupleSpec::Variable(variable) => variable.variable().typevartuple(),
+                            TupleSpec::Fixed(_) => None,
+                        }
+                    })
+                else {
+                    return Ok(());
+                };
+                (annotation, typevartuple)
+            }
+        };
+
+        let contains_typevartuple = |ty| {
+            any_over_type(db, self.env, ty, true, |nested| {
+                matches!(
+                    nested,
+                    Type::TypeVar(typevar)
+                        if typevar.identity(db) == typevartuple.identity(db)
+                )
+            })
+        };
+
+        // Other occurrences of the same pack require joint inference. Preserve the existing
+        // behavior until those constraints can be solved together instead of independently
+        // widening an already established specialization.
+        if !contains_typevartuple(self.return_ty)
+            || self
+                .enumerate_argument_types()
+                .any(|(argument_index, _, argument, _)| {
+                    !matches!(argument, Argument::Synthetic)
+                        && self.argument_matches[argument_index].iter().any(|matched| {
+                            matched.index != parameter_index
+                                && contains_typevartuple(
+                                    self.signature.parameters()[matched.index].annotated_type(),
+                                )
+                        })
+                })
+        {
+            return Ok(());
+        }
+
+        let mut actual = TupleSpecBuilder::with_capacity(self.arguments.len());
+        for (argument_index, _, argument, argument_types) in self.enumerate_argument_types() {
+            let matches = &self.argument_matches[argument_index];
+            if !matches
+                .iter()
+                .any(|matched| matched.index == parameter_index)
+            {
+                continue;
+            }
+
+            if matches!(argument, Argument::Variadic) {
+                let Some(argument_type) = argument_types.get_default() else {
+                    return Ok(());
+                };
+                // Iteration would merge union branches, losing correlations between their
+                // argument counts and element types.
+                if matches!(argument_type.resolve_type_alias(db), Type::Union(_)) {
+                    return Ok(());
+                }
+                let mut argument_tuple = argument_type.iterate(db, self.env).into_owned();
+                let consumed_prefix = matches
+                    .parameters
+                    .iter()
+                    .take_while(|matched| matched.index != parameter_index)
+                    .count();
+                if consumed_prefix != 0 {
+                    let Ok(consumed_prefix) = i32::try_from(consumed_prefix) else {
+                        return Ok(());
+                    };
+                    let Ok(sliced) = argument_tuple.py_slice_type(
+                        db,
+                        self.env,
+                        Some(consumed_prefix),
+                        None,
+                        None,
+                    ) else {
+                        return Ok(());
+                    };
+                    let Some(sliced) = sliced.exact_tuple_instance_spec(db) else {
+                        return Ok(());
+                    };
+                    argument_tuple = sliced.into_owned();
+                }
+                actual = actual.concat(db, self.env, &argument_tuple);
+                continue;
+            }
+
+            for matched in matches
+                .iter()
+                .filter(|matched| matched.index == parameter_index)
+            {
+                let declared_type = matched
+                    .expected_type
+                    .unwrap_or_else(|| parameter.annotated_type());
+                actual.push(
+                    matched
+                        .argument_type
+                        .unwrap_or_else(|| argument_types.get_for_declared_type(declared_type)),
+                );
+            }
+        }
+
+        let actual = Type::tuple(TupleType::new(db, self.env, &actual.build()));
+
+        // An inference fixpoint can supply its previous result as context. Only defer to that
+        // context when independently inferring the argument pack would actually contradict it.
+        if let Some(expected) = self.call_expression_tcx.annotation
+            && !expected.is_dynamic()
+            && let Some(generic_context) = self.signature.generic_context
+        {
+            let constraints = ConstraintSetBuilder::new();
+            let mut projected =
+                SpecializationBuilder::new(db, self.env, &constraints, self.inferable_typevars);
+            projected.infer(formal, actual)?;
+
+            if let Ok(inference) = projected.build_inference_with(generic_context, |_, _| None) {
+                let candidate = self
+                    .return_ty
+                    .apply_specialization(db, inference.specialization(db));
+
+                if !candidate.is_assignable_to(db, self.env, expected)
+                    && !candidate
+                        .promote(db, self.env)
+                        .is_assignable_to(db, self.env, expected)
+                {
+                    return Ok(());
+                }
+            }
+        }
+
+        builder.infer(formal, actual)
+    }
+
     fn infer_argument_constraints<'c>(
         &mut self,
         builder: &mut SpecializationBuilder<'db, 'c>,
@@ -5936,8 +6105,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 let parameter_index = matched_parameter.index;
                 let parameter = &parameters[parameter_index];
                 let parameter_type = parameter.annotated_type();
-                // TODO: Infer a `TypeVarTuple` from all matched positional arguments as a single
-                // tuple. Fixed elements beside that pack can still infer ordinary type variables.
+                // A `TypeVarTuple` is inferred once from its complete argument tuple below. Fixed
+                // elements beside that pack can still infer ordinary type variables individually.
                 if parameter.has_starred_annotation()
                     && matched_parameter.expected_type.is_none()
                     && (matches!(
@@ -5973,6 +6142,23 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     });
                 }
             }
+        }
+
+        if let Err(error) = self.infer_typevartuple_argument_constraints(builder)
+            && !specialization_errors.iter().any(|existing| {
+                matches!(
+                    existing,
+                    BindingError::SpecializationError {
+                        error: existing,
+                        ..
+                    } if existing == &error
+                )
+            })
+        {
+            specialization_errors.push(BindingError::SpecializationError {
+                error,
+                argument_index: None,
+            });
         }
 
         preferred_type_mappings

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4650,6 +4650,8 @@ struct ArgumentMatcher<'a, 'db> {
     next_positional: usize,
     first_excess_positional: Option<usize>,
     num_synthetic_args: usize,
+    /// Forwarded argument indices and the lengths of their fixed tuple prefixes and suffixes.
+    variable_length_positional_arguments: SmallVec<[(usize, usize, usize); 1]>,
     variadic_argument_matched_to_variadic_parameter: bool,
 
     /// Parameter indices that have explicit keyword arguments (e.g., `foo=value`).
@@ -4685,6 +4687,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             next_positional: 0,
             first_excess_positional: None,
             num_synthetic_args: 0,
+            variable_length_positional_arguments: SmallVec::new(),
             variadic_argument_matched_to_variadic_parameter: false,
             explicit_keyword_parameters,
         }
@@ -4747,6 +4750,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         matched_argument.parameters.push(MatchedParameter {
             index: parameter_index,
             argument_type,
+            expected_type: None,
             provenance,
         });
         matched_argument.matched = true;
@@ -4978,6 +4982,10 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         // `variable_element.is_some()`) or if we have a union of different fixed-length tuples (in
         // which case `variable_element.is_none()`).
         let is_variable = length.is_variable();
+        if let TupleLength::Variable(prefix, suffix) = length {
+            self.variable_length_positional_arguments
+                .push((argument_index, prefix, suffix));
+        }
         let has_fixed_union_tail = is_variable && variable_element.is_none();
 
         // We must be able to match up the fixed-length portion of the argument with positional
@@ -5158,6 +5166,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 matched_argument.parameters.push(MatchedParameter {
                     index: parameter_index,
                     argument_type: Some(extra_items_ty),
+                    expected_type: None,
                     provenance: InvalidArgumentTypeProvenance::Argument,
                 });
             }
@@ -5186,7 +5195,121 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         }
     }
 
-    fn finish(self) -> Box<[MatchedArgument<'db>]> {
+    /// Checks the positional requirements encoded inside an unpacked variadic annotation.
+    ///
+    /// Unlike ordinary `*args`, an unpacked tuple can require arguments and prescribe a different
+    /// type for each position:
+    ///
+    /// ```python
+    /// def callback(*args: *tuple[int, *tuple[str, ...], bytes]) -> None: ...
+    ///
+    /// callback(1, b"last")
+    /// callback(1, "middle", b"last")
+    /// ```
+    ///
+    /// Store each matched tuple element separately so ordinary argument checking and inference can
+    /// use its type instead of the complete tuple annotation.
+    fn match_unpacked_variadic(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        missing: &mut Vec<ParameterContext>,
+    ) {
+        let Some((parameter_index, parameter)) = self.parameters.variadic() else {
+            return;
+        };
+        if !parameter.has_starred_annotation() {
+            return;
+        }
+        let Some(tuple) = parameter.annotated_type().exact_tuple_instance_spec(db) else {
+            return;
+        };
+
+        let matched_arguments = || {
+            self.argument_matches
+                .iter()
+                .enumerate()
+                .flat_map(|(argument_index, argument)| {
+                    let match_count = argument.parameters.len();
+                    argument
+                        .parameters
+                        .iter()
+                        .enumerate()
+                        .filter(move |(_, matched)| matched.index == parameter_index)
+                        .map(move |(position, _)| (argument_index, position, match_count))
+                })
+        };
+        let is_variable_match = |argument_index, position, match_count: usize| {
+            self.variable_length_positional_arguments
+                .iter()
+                .find(|(index, _, _)| *index == argument_index)
+                .is_some_and(|(_, prefix, suffix)| {
+                    position >= *prefix && position < match_count.saturating_sub(*suffix)
+                })
+        };
+        let argument_count = matched_arguments().count();
+        let first_variable = matched_arguments().position(|(argument_index, position, count)| {
+            is_variable_match(argument_index, position, count)
+        });
+        let last_variable = matched_arguments()
+            .enumerate()
+            .filter_map(|(index, (argument_index, position, count))| {
+                is_variable_match(argument_index, position, count).then_some(index)
+            })
+            .last();
+        let argument_length = first_variable
+            .zip(last_variable)
+            .map_or(TupleLength::Fixed(argument_count), |(first, last)| {
+                TupleLength::Variable(first, argument_count.saturating_sub(last + 1))
+            });
+
+        if !argument_length.is_variable() && argument_count < tuple.len().minimum() {
+            missing.push(ParameterContext::new(parameter, parameter_index, false));
+            return;
+        }
+
+        if let Some(maximum) = tuple.len().maximum()
+            && argument_length.minimum() > maximum
+        {
+            let first_excess_argument_index = matched_arguments()
+                .nth(maximum)
+                .and_then(|(argument_index, _, _)| self.get_argument_index(argument_index));
+            self.errors.push(BindingError::TooManyPositionalArguments {
+                first_excess_argument_index,
+                expected_positional_count: self.parameters.positional().count() + maximum,
+                provided_positional_count: self.next_positional,
+            });
+            return;
+        }
+
+        let Ok(expected) = tuple.resize(db, env, argument_length) else {
+            return;
+        };
+        let variable_type = expected.variable_element_type(db);
+        let mut expected_types = expected.iter_element_types(db);
+        for (position, matched) in self
+            .argument_matches
+            .iter_mut()
+            .flat_map(|argument| argument.parameters.iter_mut())
+            .filter(|matched| matched.index == parameter_index)
+            .enumerate()
+        {
+            matched.expected_type = if first_variable
+                .zip(last_variable)
+                .is_some_and(|(first, last)| position > first && position <= last)
+            {
+                variable_type
+            } else {
+                expected_types.next()
+            };
+        }
+    }
+
+    fn finish(
+        mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Box<[MatchedArgument<'db>]> {
         if let Some(first_excess_argument_index) = self.first_excess_positional {
             self.errors.push(BindingError::TooManyPositionalArguments {
                 first_excess_argument_index: self.get_argument_index(first_excess_argument_index),
@@ -5224,6 +5347,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 missing.push(ParameterContext::new(param, index, false));
             }
         }
+        self.match_unpacked_variadic(db, env, &mut missing);
         if !missing.is_empty() {
             self.errors.push(BindingError::MissingArguments {
                 parameters: ParameterContexts(missing),
@@ -5777,7 +5901,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             continue;
                         }
 
-                        let formal = parameters[parameter_index].annotated_type();
+                        let formal = matched_parameter
+                            .expected_type
+                            .unwrap_or_else(|| parameters[parameter_index].annotated_type());
                         let actual = matched_parameter
                             .argument_type
                             .unwrap_or_else(|| argument_types.get_for_declared_type(formal));
@@ -5809,15 +5935,16 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             for matched_parameter in self.argument_matches[argument_index].iter() {
                 let parameter_index = matched_parameter.index;
                 let parameter = &parameters[parameter_index];
-                let declared_type = parameter.annotated_type();
+                let parameter_type = parameter.annotated_type();
                 // TODO: Infer a `TypeVarTuple` from all matched positional arguments as a single
-                // tuple. Until then, skip per-argument inference.
+                // tuple. Fixed elements beside that pack can still infer ordinary type variables.
                 if parameter.has_starred_annotation()
+                    && matched_parameter.expected_type.is_none()
                     && (matches!(
-                        declared_type,
+                        parameter_type,
                         Type::TypeVar(typevar) if typevar.is_typevartuple(db)
                     ) || matches!(
-                        declared_type.exact_tuple_instance_spec(db).as_deref(),
+                        parameter_type.exact_tuple_instance_spec(db).as_deref(),
                         Some(TupleSpec::Variable(variable))
                             if matches!(
                                 variable.variable(),
@@ -5831,6 +5958,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     continue;
                 }
 
+                let declared_type = matched_parameter.expected_type.unwrap_or(parameter_type);
                 let argument_type = argument_types.get_for_declared_type(declared_type);
                 let specialization_result = builder.infer(
                     declared_type,
@@ -5912,7 +6040,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 Type::SubclassOf(subclass_of) if subclass_of.into_type_var().is_some()
             );
 
-        let mut expected_ty = parameter.annotated_type();
+        let mut expected_ty = matched_parameter
+            .expected_type
+            .unwrap_or_else(|| parameter.annotated_type());
         if let Some(specialization) = self.specialization() {
             if !constructor_receiver {
                 argument_type = argument_type.apply_specialization(db, specialization);
@@ -5949,10 +6079,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // constraint set that we get from this assignability check, instead of inferring and
         // building them in an earlier separate step.
         //
-        // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
+        // An unresolved `*Ts` still has no per-element expected type.
         if !self.constraint_set_errors[argument_index]
             && !constructor_receiver
-            && !parameter.has_starred_annotation()
+            && (!parameter.has_starred_annotation() || matched_parameter.expected_type.is_some())
             && !is_valid_isinstance_target()
             && argument_type
                 .when_assignable_to(
@@ -6474,6 +6604,9 @@ pub struct MatchedParameter<'db> {
     /// matching runs.
     argument_type: Option<Type<'db>>,
 
+    /// The tuple element expected at this position in an unpacked variadic parameter.
+    expected_type: Option<Type<'db>>,
+
     /// Why this parameter match exists.
     provenance: InvalidArgumentTypeProvenance,
 }
@@ -6955,13 +7088,15 @@ impl<'db> Binding<'db> {
         specialization: Option<Specialization<'db>>,
     ) -> Option<ArgumentTypeContext<'db>> {
         let argument_matches = self.matched_argument_for_call_argument(binding, argument_index)?;
-        let [parameter] = argument_matches.parameters.as_slice() else {
+        let [matched_parameter] = argument_matches.parameters.as_slice() else {
             return None;
         };
 
-        let parameter = &self.signature.parameters()[parameter.index];
-        let mut parameter_type = parameter.annotated_type();
-        let original_parameter_type = parameter_type;
+        let parameter = &self.signature.parameters()[matched_parameter.index];
+        let original_parameter_type = parameter.annotated_type();
+        let mut parameter_type = matched_parameter
+            .expected_type
+            .unwrap_or(original_parameter_type);
         let paramspec_callable = |paramspec| {
             let Type::Callable(callable) = self
                 .specialization(db)
@@ -7189,7 +7324,7 @@ impl<'db> Binding<'db> {
         self.parameter_tys = vec![None; parameters.len()].into_boxed_slice();
         self.variadic_argument_matched_to_variadic_parameter =
             matcher.variadic_argument_matched_to_variadic_parameter;
-        self.argument_matches = matcher.finish();
+        self.argument_matches = matcher.finish(db, env);
     }
 
     fn check_types(


### PR DESCRIPTION
## Summary

Follow-up to #27516.

Previously, we inferred `Unknown` for a `TypeVarTuple` appearing directly in a variadic parameter, even when its argument types and tuple shape were known:

```python
def collect[*Ts](*args: *Ts) -> tuple[*Ts]: ...

def caller(i: int, s: str) -> None:
    reveal_type(collect())      # tuple[()]
    reveal_type(collect(i, s))  # tuple[int, str]
```

We now infer the complete argument sequence as a single tuple, preserving fixed prefixes and suffixes, starred tuple shapes, generic constructors, and both PEP 695 and legacy declarations.

Calls requiring joint inference through callbacks or other parameters, forwarded tuple unions, and conflicting contextual return types retain their existing behavior.

The number of passing typing-conformance files increases from 104 to 106.
