### PR TITLE
[ty] Resolve imported pytest fixture exposures

### DIFF
--- a/crates/ty_module_resolver/src/lib.rs
+++ b/crates/ty_module_resolver/src/lib.rs
@@ -13,7 +13,7 @@ pub use path::{SearchPath, SearchPathError};
 pub use resolve::{
     SearchPaths, file_to_module, resolve_module, resolve_module_confident,
     resolve_module_for_import_from, resolve_real_module, resolve_real_module_confident,
-    resolve_real_shadowable_module,
+    resolve_real_shadowable_module, stub_file_to_real_module,
 };
 pub use settings::{SearchPathSettings, SearchPathSettingsError};
 pub use strategy::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -3,6 +3,7 @@ This module principally provides several routines for resolving a particular mod
 name to a `Module`:
 
 * [`file_to_module`][]: resolves the module `.<self>` (often as the first step in resolving `.`)
+* [`stub_file_to_real_module`][]: resolves the runtime module corresponding to a stub file
 * [`resolve_module`][]: resolves an absolute module name
 
 You may notice that we actually provide `resolve_(real)_(shadowable)_module_(confident)`.
@@ -363,6 +364,31 @@ pub fn file_to_module<'db>(
             relative_desperate_search_paths(db, resolver_file).iter(),
         )
     })
+}
+
+/// Resolves the runtime module corresponding to a stub file.
+///
+/// Modules that are only available as stubs, including built-in modules, return `None`.
+pub fn stub_file_to_real_module<'db>(
+    db: &'db dyn Db,
+    resolver_file: ResolverFile<'db>,
+) -> Option<Module<'db>> {
+    debug_assert!(resolver_file.file(db).is_stub(db));
+
+    let module = file_to_module(db, resolver_file)?;
+    // Built-in modules have no source file to find. Checking here also avoids a failed
+    // resolution attempt that would emit misleading logs.
+    if ruff_python_stdlib::sys::is_builtin_module(module.python_version(db).minor, module.name(db))
+    {
+        return None;
+    }
+    // This lookup is equivalent to resolving `.<self>` from the stub, so the stub is the correct
+    // importing file.
+    resolve_real_module(
+        db,
+        ImportingFile::ResolverFile(resolver_file),
+        module.name(db),
+    )
 }
 
 fn file_to_module_impl<'db, 'a>(

--- a/crates/ty_python_semantic/src/lexical_name_path.rs
+++ b/crates/ty_python_semantic/src/lexical_name_path.rs
@@ -1,0 +1,127 @@
+use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+use ruff_python_ast::{self as ast, name::Name};
+use tracing::trace;
+use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::scope::NodeWithScopeKind;
+use ty_python_core::semantic_index;
+
+use crate::Db;
+
+/// Returns the module-relative lexical name path to `definition`.
+///
+/// For example, the path to `method` here is `["Outer", "method"]`:
+/// ```python
+/// class Outer:
+///     def method(): ...
+/// ```
+pub(crate) fn lexical_name_path_for_definition(
+    db: &dyn Db,
+    definition: Definition,
+) -> Option<Box<[Name]>> {
+    let parsed = parsed_module(db, definition.python_file(db));
+    let module = parsed.load(db);
+
+    let mut path = vec![
+        lexical_name_path_component_for_leaf(db, &module, definition)
+            .map_err(|()| {
+                trace!("Found unsupported DefinitionKind for lexical name path");
+            })
+            .ok()?,
+    ];
+
+    let index = semantic_index(db, definition.program_file(db));
+    for (_scope_id, scope) in index.ancestor_scopes(definition.file_scope(db)) {
+        let component = lexical_name_path_component_for_node(&module, scope.node())
+            .map_err(|()| {
+                trace!("Found unsupported NodeScopeKind for lexical name path");
+            })
+            .ok()?;
+        if let Some(component) = component {
+            path.push(component);
+        }
+    }
+
+    path.reverse();
+    Some(path.into_boxed_slice())
+}
+
+/// Computes a lexical name path component for an enclosing scope.
+///
+/// See [`lexical_name_path_for_definition`][] for details.
+pub(crate) fn lexical_name_path_component_for_node(
+    parsed: &ParsedModuleRef,
+    node: &NodeWithScopeKind,
+) -> Result<Option<Name>, ()> {
+    let component = match node {
+        NodeWithScopeKind::Module => {
+            // This is just implicit, so has no component
+            return Ok(None);
+        }
+        NodeWithScopeKind::Class(class) => class.node(parsed).name.id.clone(),
+        NodeWithScopeKind::Function(func) => func.node(parsed).name.id.clone(),
+        NodeWithScopeKind::TypeAlias(_)
+        | NodeWithScopeKind::ClassTypeParameters(_)
+        | NodeWithScopeKind::FunctionTypeParameters(_)
+        | NodeWithScopeKind::TypeAliasTypeParameters(_)
+        | NodeWithScopeKind::Lambda(_)
+        | NodeWithScopeKind::ListComprehension(_)
+        | NodeWithScopeKind::SetComprehension(_)
+        | NodeWithScopeKind::DictComprehension(_)
+        | NodeWithScopeKind::GeneratorExpression(_) => {
+            // Not yet implemented
+            return Err(());
+        }
+    };
+    Ok(Some(component))
+}
+
+/// Computes the final component of a lexical name path.
+///
+/// See [`lexical_name_path_for_definition`][] for details.
+fn lexical_name_path_component_for_leaf(
+    db: &dyn Db,
+    parsed: &ParsedModuleRef,
+    definition: Definition,
+) -> Result<Name, ()> {
+    let component = match definition.kind(db) {
+        DefinitionKind::Function(func) => func.node(parsed).name.id.clone(),
+        DefinitionKind::Class(class) => class.node(parsed).name.id.clone(),
+        DefinitionKind::Assignment(assignment) => {
+            let ast::Expr::Name(name) = assignment.target(parsed) else {
+                return Err(());
+            };
+            name.id.clone()
+        }
+        DefinitionKind::AnnotatedAssignment(assignment) => {
+            let ast::Expr::Name(name) = assignment.target(parsed) else {
+                return Err(());
+            };
+            name.id.clone()
+        }
+        DefinitionKind::TypeAlias(_)
+        | DefinitionKind::Import(_)
+        | DefinitionKind::ImportFrom(_)
+        | DefinitionKind::ImportFromSubmodule(_)
+        | DefinitionKind::StarImport(_)
+        | DefinitionKind::NamedExpression(_)
+        | DefinitionKind::AugmentedAssignment(_)
+        | DefinitionKind::DictKeyAssignment(_)
+        | DefinitionKind::For(_)
+        | DefinitionKind::Comprehension(_)
+        | DefinitionKind::Parameter(_)
+        | DefinitionKind::LambdaParameter { .. }
+        | DefinitionKind::WithItem(_)
+        | DefinitionKind::MatchPattern(_)
+        | DefinitionKind::ExceptHandler(_)
+        | DefinitionKind::TypeVar(_)
+        | DefinitionKind::ParamSpec(_)
+        | DefinitionKind::TypeVarTuple(_)
+        | DefinitionKind::LoopHeader(_)
+        | DefinitionKind::NestedBindings(_) => {
+            // Not yet implemented
+            return Err(());
+        }
+    };
+
+    Ok(component)
+}

--- a/crates/ty_python_semantic/src/lexical_name_path.rs
+++ b/crates/ty_python_semantic/src/lexical_name_path.rs
@@ -17,7 +17,7 @@ use crate::Db;
 pub(crate) fn lexical_name_path_for_definition(
     db: &dyn Db,
     definition: Definition,
-) -> Option<Box<[Name]>> {
+) -> Option<Vec<Name>> {
     let parsed = parsed_module(db, definition.python_file(db));
     let module = parsed.load(db);
 
@@ -42,7 +42,7 @@ pub(crate) fn lexical_name_path_for_definition(
     }
 
     path.reverse();
-    Some(path.into_boxed_slice())
+    Some(path)
 }
 
 /// Computes a lexical name path component for an enclosing scope.

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -56,6 +56,7 @@ pub use types::{
 mod db;
 mod dunder_all;
 mod fixes;
+mod lexical_name_path;
 pub mod lint;
 pub(crate) mod place;
 pub(crate) mod place_load;

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1,3 +1,5 @@
+pub(crate) mod definitions;
+
 use crate::ProgramEnvironment;
 use itertools::Either;
 use ruff_index::IndexSlice;

--- a/crates/ty_python_semantic/src/place/definitions.rs
+++ b/crates/ty_python_semantic/src/place/definitions.rs
@@ -1,0 +1,53 @@
+use smallvec::SmallVec;
+use ty_python_core::BindingWithConstraintsIterator;
+use ty_python_core::definition::{Definition, DefinitionState};
+
+use crate::Db;
+use crate::reachability::ReachabilityConstraintsExtension;
+
+/// A set of definitions found by name resolution.
+#[expect(
+    dead_code,
+    reason = "shared infrastructure is dormant until a definition-resolution consumer is added"
+)]
+pub(crate) struct DefinitionResolution<'db> {
+    definitions: SmallVec<[Definition<'db>; 2]>,
+}
+
+#[expect(
+    dead_code,
+    reason = "shared infrastructure is dormant until a definition-resolution consumer is added"
+)]
+impl<'db> DefinitionResolution<'db> {
+    /// Returns the definitions found by name resolution.
+    pub(crate) fn definitions(&self) -> &[Definition<'db>] {
+        &self.definitions
+    }
+
+    /// Resolves the reachable definitions supplied by the given bindings.
+    pub(crate) fn from_bindings(
+        db: &'db dyn Db,
+        mut bindings: BindingWithConstraintsIterator<'db, 'db>,
+    ) -> Self {
+        let mut definitions = SmallVec::new();
+
+        while let Some(binding) = bindings.next() {
+            let reachability = bindings.reachability_constraints().evaluate(
+                db,
+                bindings.predicates(),
+                binding.reachability_constraint,
+            );
+            if reachability.is_always_false() {
+                continue;
+            }
+
+            if let DefinitionState::Defined(definition) = binding.binding
+                && !definitions.contains(&definition)
+            {
+                definitions.push(definition);
+            }
+        }
+
+        Self { definitions }
+    }
+}

--- a/crates/ty_python_semantic/src/place/definitions.rs
+++ b/crates/ty_python_semantic/src/place/definitions.rs
@@ -6,18 +6,10 @@ use crate::Db;
 use crate::reachability::ReachabilityConstraintsExtension;
 
 /// A set of definitions found by name resolution.
-#[expect(
-    dead_code,
-    reason = "shared infrastructure is dormant until a definition-resolution consumer is added"
-)]
 pub(crate) struct DefinitionResolution<'db> {
     definitions: SmallVec<[Definition<'db>; 2]>,
 }
 
-#[expect(
-    dead_code,
-    reason = "shared infrastructure is dormant until a definition-resolution consumer is added"
-)]
 impl<'db> DefinitionResolution<'db> {
     /// Returns the definitions found by name resolution.
     pub(crate) fn definitions(&self) -> &[Definition<'db>] {

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -9,6 +9,7 @@ use ty_python_core::{ProgramFile, global_scope, place_table, semantic_index, use
 use crate::Db;
 use crate::types::Type;
 use crate::types::function::FunctionDecorators;
+use crate::types::ide_support::resolve_definition_targets;
 use crate::types::infer::{function_known_decorator_flags, function_known_decorators};
 
 /// Resolve the same-file pytest fixtures requested by `parameter`.
@@ -167,24 +168,26 @@ fn bindings_in_provider<'db>(
     for (symbol_id, definitions) in use_def.all_end_of_scope_symbol_bindings() {
         let symbol_name = table.symbol(symbol_id).name();
         for definition in definitions.filter_map(|binding| binding.binding.definition()) {
-            let Some(declaration) = fixture_declaration(db, definition) else {
-                continue;
-            };
-            let Some(exposure) = fixture_exposure(symbol_name, declaration) else {
-                continue;
-            };
-            if exposure.name != request.name
-                || exposure.declaration.definition == request.owner
-                || bindings
-                    .iter()
-                    .any(|binding: &FixtureBinding<'db>| binding.fixture == definition)
-            {
-                continue;
+            for definition in resolve_definition_targets(db, definition, symbol_name) {
+                let Some(declaration) = fixture_declaration(db, definition) else {
+                    continue;
+                };
+                let Some(exposure) = fixture_exposure(symbol_name, declaration) else {
+                    continue;
+                };
+                if exposure.name != request.name
+                    || exposure.declaration.definition == request.owner
+                    || bindings
+                        .iter()
+                        .any(|binding: &FixtureBinding<'db>| binding.fixture == definition)
+                {
+                    continue;
+                }
+                bindings.push(FixtureBinding {
+                    request: request.definition,
+                    fixture: definition,
+                });
             }
-            bindings.push(FixtureBinding {
-                request: request.definition,
-                fixture: definition,
-            });
         }
     }
 
@@ -612,6 +615,140 @@ def test_use(value): ...
         Ok(())
     }
 
+    #[test]
+    fn resolves_imported_fixture_exposures() -> Result<()> {
+        let db = pytest_db_with_files(&[
+            (
+                "/src/fixtures.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def resource(): ...
+
+@pytest.fixture(name="public_name")
+def implementation(): ...
+"#,
+            ),
+            (
+                "/src/reexports.py",
+                r#"
+from fixtures import resource as middle
+"#,
+            ),
+            (
+                "/src/star_fixtures.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def star_fixture(): ...
+"#,
+            ),
+            (
+                "/src/test_example.py",
+                r#"
+from fixtures import resource as direct_alias, implementation
+from reexports import middle as chained
+from star_fixtures import *
+
+def test_use(
+    direct_alias,
+    chained,
+    public_name,
+    implementation,
+    resource,
+    star_fixture,
+): ...
+"#,
+            ),
+        ])?;
+
+        assert_eq!(fixture_names(&db, "test_use", "direct_alias"), ["resource"]);
+        assert_eq!(fixture_names(&db, "test_use", "chained"), ["resource"]);
+        assert_eq!(
+            fixture_names(&db, "test_use", "public_name"),
+            ["implementation"]
+        );
+        assert_eq!(
+            fixture_names(&db, "test_use", "star_fixture"),
+            ["star_fixture"]
+        );
+        assert!(fixture_names(&db, "test_use", "implementation").is_empty());
+        assert!(fixture_names(&db, "test_use", "resource").is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_overwritten_imported_fixture_exposures() -> Result<()> {
+        let db = pytest_db_with_files(&[
+            (
+                "/src/fixtures.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def resource(): ...
+"#,
+            ),
+            (
+                "/src/test_example.py",
+                r#"
+from fixtures import resource
+
+resource = object()
+
+def test_use(resource): ...
+"#,
+            ),
+        ])?;
+
+        assert!(fixture_names(&db, "test_use", "resource").is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn preserves_conditional_imported_fixture_definitions() -> Result<()> {
+        let db = pytest_db_with_files(&[
+            (
+                "/src/first.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def first(): ...
+"#,
+            ),
+            (
+                "/src/second.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def second(): ...
+"#,
+            ),
+            (
+                "/src/test_example.py",
+                r#"
+flag: bool
+
+if flag:
+    from first import first as resource
+else:
+    from second import second as resource
+
+def test_use(resource): ...
+"#,
+            ),
+        ])?;
+
+        let mut fixtures = fixture_names(&db, "test_use", "resource");
+        fixtures.sort();
+        assert_eq!(fixtures, ["first", "second"]);
+        Ok(())
+    }
+
     fn fixture_names(db: &TestDb, function: &str, parameter: &str) -> Vec<String> {
         let parameter = parameter_definition(db, function, parameter);
         fixture_bindings_for_parameter(db, parameter)
@@ -679,7 +816,11 @@ def test_use(value): ...
     }
 
     fn pytest_db(path: &'static str, source: &'static str) -> Result<TestDb> {
-        TestDbBuilder::new()
+        pytest_db_with_files(&[(path, source)])
+    }
+
+    fn pytest_db_with_files(files: &[(&'static str, &'static str)]) -> Result<TestDb> {
+        let mut builder = TestDbBuilder::new()
             .with_site_packages()
             .with_file("/site-packages/_pytest/__init__.pyi", "")
             .with_file(
@@ -713,8 +854,10 @@ class MarkGenerator:
 
 mark: MarkGenerator
 "#,
-            )
-            .with_file(path, source)
-            .build()
+            );
+        for (path, source) in files {
+            builder = builder.with_file(*path, source);
+        }
+        builder.build()
     }
 }

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -1,18 +1,19 @@
 //! Models the semantic relationships that pytest creates between fixtures and parameters.
 //!
-//! Pytest injects fixture values by matching parameter names to fixture providers. Ordinary Python
-//! name resolution does not represent that relationship: the parameter is a local definition, and
-//! the fixture function may be defined in another provider scope. This module therefore overlays
-//! the pytest relationship on top of the parameter's normal Python definition (which is preserved).
+//! Pytest injects fixture values by matching parameter names to fixtures available in a particular
+//! search scope. Ordinary Python name resolution does not represent that relationship: the
+//! parameter is a local definition, and the fixture function may be defined in another scope.
+//! This module therefore overlays the pytest relationship on top of the parameter's normal
+//! Python definition (which is preserved).
 //!
 //! The model distinguishes four concepts:
 //!
 //! - A [`FixtureDeclaration`] is a function decorated with pytest's canonical `fixture` or
 //!   `yield_fixture` decorator.
-//! - A [`FixtureExposure`] is the name under which a provider makes that declaration available.
-//!   The decorator's `name` argument can make this differ from the Python binding name.
+//! - A [`FixtureExposure`] is the name under which that declaration is available during fixture
+//!   lookup. The decorator's `name` argument can make this differ from the Python binding name.
 //! - A [`FixtureRequest`] is an eligible parameter in a collected test or another fixture function.
-//! - A [`FixtureBinding`] links a request to the declaration selected by static fixture provider lookup.
+//! - A [`FixtureBinding`] links a request to the declaration selected by static fixture lookup.
 //!
 //! For example:
 //!
@@ -24,16 +25,16 @@
 //!     return object()
 //!
 //! # Request: the parameter asks for the fixture exposed as `database`.
-//! # Binding: provider lookup connects the request to the `make_database` declaration.
+//! # Binding: fixture lookup connects the request to the `make_database` declaration.
 //! def test_query(database):
 //!     assert database is not None
 //! ```
 //!
 //! [`fixture_bindings_for_parameter`] provides the public interface to the model. Given a parameter
-//! definition, it classifies the parameter as a possible request, searches providers in pytest
-//! precedence order, and returns every equally viable declaration in the first matching provider
-//! layer. Language server and type-inference features can consume this data without changing
-//! general definition, reference or rename behavior for the parameter.
+//! definition, it classifies the parameter as a possible request, inspects fixture search scopes in
+//! pytest precedence order, and returns every equally viable declaration in the first matching
+//! scope. Language server and type-inference features can consume this data without changing general
+//! definition, reference or rename behavior for the parameter.
 
 use std::cmp::Ordering;
 
@@ -41,19 +42,24 @@ use itertools::Either;
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::{self as ast, name::Name};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{KnownModule, file_to_module};
+use ty_module_resolver::{
+    ImportingFile, KnownModule, file_to_module, resolve_module_for_import_from,
+    stub_file_to_real_module,
+};
 use ty_python_core::definition::{Definition, DefinitionKind, ParameterDefinitionNodeKind};
 use ty_python_core::scope::{FileScopeId, ScopeId, ScopeKind};
 use ty_python_core::{ProgramFile, global_scope, place_table, semantic_index, use_def_map};
 
-use crate::Db;
+use crate::lexical_name_path::lexical_name_path_for_definition;
+use crate::place::definitions::DefinitionResolution;
 use crate::types::function::{FunctionType, KnownFunction};
 use crate::types::infer::{function_known_decorators, infer_definition_types, original_class_type};
 use crate::types::signatures::Parameter as SignatureParameter;
 use crate::types::{
     ClassBase, ClassLiteral, KnownClass, ProgramEnvironment, Type, definition_expression_type,
-    extract_fixed_length_iterable_element_types,
+    exists_at_runtime, extract_fixed_length_iterable_element_types,
 };
+use crate::{Db, FxIndexSet};
 
 /// Resolves pytest fixtures requested by `parameter`.
 ///
@@ -129,7 +135,7 @@ pub fn fixture_bindings_for_parameter<'db>(
             let Some(class) = original_class_type(db, class_definition) else {
                 return Box::default();
             };
-            let bindings = bindings_in_provider(db, &request, FixtureProvider::Class(class));
+            let bindings = bindings_in_search_scope(db, &request, FixtureSearchScope::Class(class));
             if !bindings.is_empty() {
                 return bindings;
             }
@@ -137,10 +143,10 @@ pub fn fixture_bindings_for_parameter<'db>(
     }
 
     let module_scope = global_scope(db, parameter.program_file(db));
-    bindings_in_provider(db, &request, FixtureProvider::Scope(module_scope))
+    bindings_in_search_scope(db, &request, FixtureSearchScope::Scope(module_scope))
 }
 
-/// A pytest fixture request and the declaration selected by static provider lookup.
+/// A pytest fixture request and the declaration selected by static fixture lookup.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub struct FixtureBinding<'db> {
     request: Definition<'db>,
@@ -328,7 +334,7 @@ fn is_mock_patch_parameter<'db>(
 }
 
 /// A decorated fixture function.
-#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 struct FixtureDeclaration<'db> {
     // The definition for the fixture function.
     definition: Definition<'db>,
@@ -336,37 +342,40 @@ struct FixtureDeclaration<'db> {
     name: FixtureName,
 }
 
-/// A fixture declaration made available under a name in a provider scope.
+/// A fixture declaration made available under a particular name.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 struct FixtureExposure<'db> {
     name: Name,
-    declaration: FixtureDeclaration<'db>,
+    definition: Definition<'db>,
 }
 
 impl<'db> FixtureExposure<'db> {
     /// Exposes a declaration under its explicit fixture name or local Python binding name.
-    fn new(symbol_name: &Name, declaration: FixtureDeclaration<'db>) -> Option<Self> {
+    fn new(symbol_name: &Name, declaration: &FixtureDeclaration<'db>) -> Option<Self> {
         let name = match &declaration.name {
             FixtureName::Default => symbol_name.clone(),
             FixtureName::Explicit(name) => name.clone(),
             FixtureName::Unknown => return None,
         };
-        Some(Self { name, declaration })
+        Some(Self {
+            name,
+            definition: declaration.definition,
+        })
     }
 }
 
-/// A name and any fixture exposures that it contributes to a provider scope.
+/// A possible fixture name and the exposures it contributes to a fixture search scope.
 ///
 /// Bound names in class scopes are retained even without fixture exposures because they can
-/// shadow fixtures inherited from another class in the provider's MRO.
+/// shadow fixtures inherited from another class in the searched class's MRO.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-struct FixtureProviderName<'db> {
+struct FixtureNameCandidate<'db> {
     name: Name,
     exposures: Box<[FixtureExposure<'db>]>,
 }
 
 /// How a fixture decorator determines the fixture's public name.
-#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 enum FixtureName {
     /// Uses the Python binding name at the exposure site.
     Default,
@@ -377,69 +386,99 @@ enum FixtureName {
     Unknown,
 }
 
-/// A fixture provider layer in which to resolve a request.
+/// A class hierarchy or scope searched when resolving a fixture request.
 #[derive(Clone, Copy)]
-enum FixtureProvider<'db> {
-    /// Uses a class and its statically known ancestors.
+enum FixtureSearchScope<'db> {
+    /// Searches a class and its statically known ancestors.
     Class(ClassLiteral<'db>),
-    /// Uses a single provider scope.
+    /// Searches a single scope.
     Scope(ScopeId<'db>),
 }
 
-/// Returns the names that participate in fixture lookup for one provider scope.
+/// Returns the names that may participate in fixture lookup for one fixture search scope.
 ///
 /// Separating this summary from request resolution lets Salsa reuse scope-specific fixture
 /// discovery across parameters.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-fn fixture_provider_names<'db>(
+fn fixture_name_candidates<'db>(
     db: &'db dyn Db,
     scope: ScopeId<'db>,
-) -> Box<[FixtureProviderName<'db>]> {
+) -> Box<[FixtureNameCandidate<'db>]> {
     let is_class_scope = scope.node(db).scope_kind() == ScopeKind::Class;
     let table = place_table(db, scope);
-    let mut provider_names = Vec::new();
+    let mut name_candidates = Vec::new();
 
-    for (symbol_id, definitions) in use_def_map(db, scope).all_end_of_scope_symbol_bindings() {
+    for (symbol_id, bindings) in use_def_map(db, scope).all_end_of_scope_symbol_bindings() {
         let symbol = table.symbol(symbol_id);
-        let name = symbol.name().clone();
-        let is_bound_class_attribute = is_class_scope && symbol.is_bound();
+        let name = symbol.name();
+        let resolution = DefinitionResolution::from_bindings(db, bindings);
         let mut exposures = Vec::new();
 
-        for binding in definitions {
-            let Some(definition) = binding.binding.definition() else {
+        for fixture_definition in
+            fixture_candidates_from_symbol_definitions(db, name, resolution.definitions())
+        {
+            let Some(declaration) = fixture_declaration(db, fixture_definition) else {
                 continue;
             };
-            let Some(declaration) = fixture_declaration(db, definition).clone() else {
-                continue;
-            };
-            let Some(exposure) = FixtureExposure::new(&name, declaration) else {
+            let Some(exposure) = FixtureExposure::new(name, declaration) else {
                 continue;
             };
             exposures.push(exposure);
         }
 
-        // Reject names that neither expose a fixture nor bind a class attribute that can
-        // shadow an inherited fixture.
-        if exposures.is_empty() && !is_bound_class_attribute {
+        // Reject names that neither expose a fixture nor bind a runtime class attribute that
+        // can shadow an inherited fixture.
+        if exposures.is_empty()
+            && !(is_class_scope
+                && symbol.is_bound()
+                && class_attribute_exists_at_runtime(db, resolution.definitions()))
+        {
             continue;
         }
-        provider_names.push(FixtureProviderName {
-            name,
+        name_candidates.push(FixtureNameCandidate {
+            name: name.clone(),
             exposures: exposures.into_boxed_slice(),
         });
     }
 
-    provider_names.into_boxed_slice()
+    name_candidates.into_boxed_slice()
 }
 
-/// Resolves a request against the fixture exposures in `provider`.
-fn bindings_in_provider<'db>(
+/// Returns fixture function candidates reachable from the resolved definitions for one symbol.
+fn fixture_candidates_from_symbol_definitions<'db>(
+    db: &'db dyn Db,
+    name: &Name,
+    definitions: &[Definition<'db>],
+) -> Vec<Definition<'db>> {
+    let mut candidates = FxIndexSet::default();
+
+    for definition in definitions.iter().copied() {
+        for candidate in fixture_candidates_from_definition(db, definition, name) {
+            candidates.insert(candidate);
+        }
+    }
+
+    candidates.into_iter().collect()
+}
+
+/// Returns whether a class attribute has any reachable runtime binding.
+fn class_attribute_exists_at_runtime<'db>(
+    db: &'db dyn Db,
+    definitions: &[Definition<'db>],
+) -> bool {
+    definitions
+        .iter()
+        .any(|definition| exists_at_runtime(db, *definition))
+}
+
+/// Resolves a request against the fixture exposures in `search_scope`.
+fn bindings_in_search_scope<'db>(
     db: &'db dyn Db,
     request: &FixtureRequest<'db>,
-    provider: FixtureProvider<'db>,
+    search_scope: FixtureSearchScope<'db>,
 ) -> Box<[FixtureBinding<'db>]> {
-    let provider_scopes = match provider {
-        FixtureProvider::Class(class) => Either::Left(
+    let search_scopes = match search_scope {
+        FixtureSearchScope::Class(class) => Either::Left(
             class
                 .iter_mro(db)
                 .filter_map(ClassBase::into_class)
@@ -447,56 +486,59 @@ fn bindings_in_provider<'db>(
                 .filter_map(|ancestor| ancestor.static_class_literal(db))
                 .map(|(ancestor, _)| ancestor.body_scope(db)),
         ),
-        FixtureProvider::Scope(scope) => Either::Right(std::iter::once(scope)),
+        FixtureSearchScope::Scope(scope) => Either::Right(std::iter::once(scope)),
     };
 
     let mut seen_names = FxHashSet::default();
-    let mut winning_name: Option<Name> = None;
-    let mut bindings = Vec::new();
+    let mut winning_name: Option<&Name> = None;
+    let mut fixtures = FxIndexSet::default();
 
-    for provider_scope in provider_scopes {
-        for provider_name in fixture_provider_names(db, provider_scope) {
-            let symbol_name = &provider_name.name;
+    for scope in search_scopes {
+        for name_candidate in fixture_name_candidates(db, scope) {
+            let symbol_name = &name_candidate.name;
             // A name supplied by an earlier scope shadows the same name here.
-            if !seen_names.insert(symbol_name.clone()) {
+            if !seen_names.insert(symbol_name) {
                 continue;
             }
 
-            for exposure in &provider_name.exposures {
+            for exposure in &name_candidate.exposures {
                 // Request must match public name of the fixture
                 if request.name != exposure.name
                     // A fixture definition cannot fulfill a request for itself
-                    || request.function_definition == exposure.declaration.definition
+                    || request.function_definition == exposure.definition
                 {
                     continue;
                 }
 
                 // Semantic-index traversal is unordered. Pytest registers fixture attributes in
                 // sorted `dir()` order and selects the last registration, so retain bindings for
-                // the lexicographically last matching attribute. Thus, if `first_provider` and
-                // `second_provider` both expose `resource`, `second_provider` wins.
+                // the lexicographically last matching attribute. Thus, if `first_fixture` and
+                // `second_fixture` both expose `resource`, `second_fixture` wins.
                 //
                 // `dir()` ordering: https://docs.python.org/3/library/functions.html#dir
                 // Fixture discovery: https://github.com/pytest-dev/pytest/blob/9.0.1/src/_pytest/fixtures.py#L1852-L1880
                 // Registration order: https://github.com/pytest-dev/pytest/blob/9.0.1/src/_pytest/fixtures.py#L1788-L1797
                 // Fixture selection: https://github.com/pytest-dev/pytest/blob/9.0.1/src/_pytest/fixtures.py#L583-L599
-                match winning_name.as_ref().map(|winner| winner.cmp(symbol_name)) {
+                match winning_name.map(|winner| winner.cmp(symbol_name)) {
                     Some(Ordering::Greater) => continue,
                     Some(Ordering::Less) | None => {
-                        winning_name = Some(symbol_name.clone());
-                        bindings.clear();
+                        winning_name = Some(symbol_name);
+                        fixtures.clear();
                     }
                     Some(Ordering::Equal) => {}
                 }
-                bindings.push(FixtureBinding {
-                    request: request.parameter_definition,
-                    fixture: exposure.declaration.definition,
-                });
+                fixtures.insert(exposure.definition);
             }
         }
     }
 
-    bindings.into_boxed_slice()
+    fixtures
+        .into_iter()
+        .map(|fixture| FixtureBinding {
+            request: request.parameter_definition,
+            fixture,
+        })
+        .collect()
 }
 
 /// Returns a fixture declaration for a function with a canonical pytest fixture decorator.
@@ -532,6 +574,184 @@ fn fixture_declaration<'db>(
         })
     });
     Some(FixtureDeclaration { definition, name })
+}
+
+/// Returns fixture function candidates reachable from a symbol definition.
+fn fixture_candidates_from_definition<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    symbol_name: &Name,
+) -> Vec<Definition<'db>> {
+    if definition.file(db).is_stub(db) {
+        if let Some(source_file) =
+            stub_file_to_real_module(db, definition.program_file(db).resolver_file(db))
+                .and_then(|module| module.file(db))
+        {
+            let source_file = ProgramFile::new(db, source_file, definition.program(db));
+            if definition.scope(db).node(db).scope_kind() == ScopeKind::Class {
+                return fixture_candidates_from_stub_class_definition(db, definition, source_file);
+            }
+
+            return fixture_candidates_for_name_in_scope(
+                db,
+                global_scope(db, source_file),
+                symbol_name.clone(),
+            )
+            .to_vec();
+        }
+    }
+
+    if !exists_at_runtime(db, definition) {
+        return Vec::new();
+    }
+
+    match definition.kind(db) {
+        DefinitionKind::Function(_) => vec![definition],
+        DefinitionKind::ImportFrom(import) => {
+            let parsed = parsed_module(db, definition.python_file(db)).load(db);
+            fixture_candidates_from_import(
+                db,
+                definition,
+                import.import(&parsed),
+                import.alias(&parsed).name.id(),
+            )
+        }
+        DefinitionKind::StarImport(import) => {
+            let parsed = parsed_module(db, definition.python_file(db)).load(db);
+            fixture_candidates_from_import(db, definition, import.import(&parsed), symbol_name)
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Returns fixture candidates for a stub class member from its runtime source class.
+///
+/// For example, given these corresponding files:
+///
+/// ```python
+/// # plugin.pyi
+/// class Plugin:
+///     def resource(self): ...
+///
+/// # plugin.py
+/// class Plugin:
+///     @pytest.fixture
+///     def resource(self): ...
+/// ```
+///
+/// The stub definition yields the lexical path `["Plugin", "resource"]`. This function finds the
+/// `Plugin` scope in the source file, then resolves the visible `resource` definitions in that scope.
+fn fixture_candidates_from_stub_class_definition<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    source_file: ProgramFile<'db>,
+) -> Vec<Definition<'db>> {
+    let Some(path) = lexical_name_path_for_definition(db, definition) else {
+        return Vec::new();
+    };
+    let mut path = path;
+    let Some(member_name) = path.pop() else {
+        return Vec::new();
+    };
+
+    let mut candidates = FxIndexSet::default();
+    for source_scope in source_scopes_for_lexical_path(db, source_file, path.into_boxed_slice()) {
+        candidates.extend(
+            fixture_candidates_for_name_in_scope(db, *source_scope, member_name.clone())
+                .iter()
+                .copied(),
+        );
+    }
+
+    candidates.into_iter().collect()
+}
+
+/// Returns scopes in `source_file` with the given lexical path.
+#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
+fn source_scopes_for_lexical_path<'db>(
+    db: &'db dyn Db,
+    source_file: ProgramFile<'db>,
+    path: Box<[Name]>,
+) -> Box<[ScopeId<'db>]> {
+    let index = semantic_index(db, source_file);
+    let parsed = parsed_module(db, source_file.python_file(db)).load(db);
+    let mut scopes = vec![global_scope(db, source_file)];
+    let mut next_scopes = FxIndexSet::default();
+
+    for name in path {
+        for scope in scopes {
+            next_scopes.extend(
+                index
+                    .child_scopes(scope.file_scope_id(db))
+                    .filter(|(_, child_scope)| {
+                        matches!(child_scope.kind(), ScopeKind::Class | ScopeKind::Function)
+                    })
+                    .map(|(child_scope_id, _)| child_scope_id.to_scope_id(db, source_file))
+                    .filter(|child_scope| child_scope.name(db, &parsed) == name.as_str()),
+            );
+        }
+        if next_scopes.is_empty() {
+            return Box::default();
+        }
+        scopes = next_scopes.drain(..).collect();
+    }
+
+    scopes.into_boxed_slice()
+}
+
+/// Returns fixture candidates supplied by a name's end-of-scope bindings.
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "Salsa requires owned query keys, and lint expectations cannot observe diagnostics from the generated function"
+)]
+#[salsa::tracked(
+    returns(deref),
+    cycle_initial=|_, _, _, _| Box::default(),
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn fixture_candidates_for_name_in_scope<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    name: Name,
+) -> Box<[Definition<'db>]> {
+    let Some(symbol) = place_table(db, scope).symbol_id(name.as_str()) else {
+        return Box::default();
+    };
+
+    let resolution = DefinitionResolution::from_bindings(
+        db,
+        use_def_map(db, scope).end_of_scope_symbol_bindings(symbol),
+    );
+    fixture_candidates_from_symbol_definitions(db, &name, resolution.definitions())
+        .into_boxed_slice()
+}
+
+/// Follows an import to fixture function candidates exposed by its target.
+fn fixture_candidates_from_import<'db>(
+    db: &'db dyn Db,
+    importing_definition: Definition<'db>,
+    import: &ast::StmtImportFrom,
+    name: &Name,
+) -> Vec<Definition<'db>> {
+    let program_file = importing_definition.program_file(db);
+    let importing_file =
+        ImportingFile::File(program_file.file(db), program_file.resolver_environment(db));
+    let Some(imported_module) = resolve_module_for_import_from(db, importing_file, import) else {
+        return Vec::new();
+    };
+
+    let Some(imported_file) = imported_module.file(db) else {
+        return Vec::new();
+    };
+    fixture_candidates_for_name_in_scope(
+        db,
+        global_scope(
+            db,
+            ProgramFile::new(db, imported_file, program_file.program(db)),
+        ),
+        name.clone(),
+    )
+    .to_vec()
 }
 
 /// Classifies the `name` argument to a fixture decorator.
@@ -1147,11 +1367,11 @@ import pytest
 
 class First:
     @pytest.fixture(name="resource")
-    def first_provider(self): ...
+    def first_fixture(self): ...
 
 class Second:
     @pytest.fixture(name="resource")
-    def second_provider(self): ...
+    def second_fixture(self): ...
 
 class TestExample(First, Second):
     def test_use(self, resource): ...
@@ -1169,8 +1389,8 @@ class TestExample(First, Second):
         info: Found 1 fixture
           --> src/test_example.py:10:9
            |
-        10 |     def second_provider(self): ...
-           |         ---------------
+        10 |     def second_fixture(self): ...
+           |         --------------
         ");
     }
 
@@ -1496,6 +1716,561 @@ def test_use(value): ...
         assert_snapshot!(test_use.fixture_resolution("value"), @"No fixture resolved for parameter `value`");
     }
 
+    #[test]
+    fn resolves_imported_fixture_exposures() {
+        let test = PytestTestCase::with_files(
+            "/src/test_example.py",
+            &[
+                (
+                    "/src/fixtures.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def resource(): ...
+
+@pytest.fixture(name="public_name")
+def implementation(): ...
+"#,
+                ),
+                (
+                    "/src/reexports.py",
+                    r#"
+from fixtures import resource as middle
+"#,
+                ),
+                (
+                    "/src/star_fixtures.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def star_fixture(): ...
+"#,
+                ),
+                // Import the same explicitly named fixture twice to verify that its exposures are
+                // deduplicated.
+                (
+                    "/src/test_example.py",
+                    r#"
+from fixtures import implementation, implementation as second_exposure
+from reexports import middle as chained
+from star_fixtures import *
+
+def test_use(
+    chained,
+    public_name,
+    resource,
+    star_fixture,
+): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_use = test.function("test_use");
+
+        assert_snapshot!(test_use.fixture_resolution("chained"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:7:5
+          |
+        7 |     chained,
+          |     ^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/fixtures.py:5:5
+          |
+        5 | def resource(): ...
+          |     --------
+        ");
+
+        assert_snapshot!(test_use.fixture_resolution("public_name"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:8:5
+          |
+        8 |     public_name,
+          |     ^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/fixtures.py:8:5
+          |
+        8 | def implementation(): ...
+          |     --------------
+        ");
+
+        assert_snapshot!(test_use.fixture_resolution("star_fixture"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+          --> src/test_example.py:10:5
+           |
+        10 |     star_fixture,
+           |     ^^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/star_fixtures.py:5:5
+          |
+        5 | def star_fixture(): ...
+          |     ------------
+        ");
+
+        assert_snapshot!(test_use.fixture_resolution("resource"), @"No fixture resolved for parameter `resource`");
+    }
+
+    #[test]
+    fn resolves_fixture_alongside_cyclic_reexport() {
+        let test = PytestTestCase::with_files(
+            "/src/test_example.py",
+            &[
+                (
+                    "/src/a.py",
+                    r#"
+import pytest
+
+flag: bool
+if flag:
+    from b import resource
+else:
+    @pytest.fixture
+    def resource(): ...
+"#,
+                ),
+                (
+                    "/src/b.py",
+                    r#"
+from a import resource
+"#,
+                ),
+                (
+                    "/src/test_example.py",
+                    r#"
+from a import resource
+
+def test_use(resource): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_use = test.function("test_use");
+
+        assert_snapshot!(test_use.fixture_resolution("resource"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:4:14
+          |
+        4 | def test_use(resource): ...
+          |              ^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/a.py:9:9
+          |
+        9 |     def resource(): ...
+          |         --------
+        ");
+    }
+
+    #[test]
+    fn resolves_imported_fixture_declarations_from_source_when_available() {
+        let test = PytestTestCase::with_files(
+            "/src/test_example.py",
+            &[
+                // Use the same symbol and fixture name at module and class scope so
+                // stub mapping must preserve the class path.
+                (
+                    "/src/fixtures.py",
+                    r#"
+import pytest
+
+@pytest.fixture(name="public_name")
+def implementation(): ...
+
+class Base:
+    @pytest.fixture(name="public_name")
+    def implementation(self): ...
+"#,
+                ),
+                // Expose `implementation` only through a synthetic lazy binding in the stub.
+                // The binding must survive long enough for fixture discovery to inspect the source.
+                (
+                    "/src/fixtures.pyi",
+                    r#"
+def initialize() -> None:
+    global implementation
+    implementation = ...
+
+class Base:
+    def implementation(self): ...
+"#,
+                ),
+                (
+                    "/src/test_example.py",
+                    r#"
+from fixtures import Base, implementation
+
+def test_use(public_name): ...
+
+class TestExample(Base):
+    def test_inherited(self, public_name): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_use = test.function("test_use");
+
+        assert_snapshot!(test_use.fixture_resolution("public_name"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:4:14
+          |
+        4 | def test_use(public_name): ...
+          |              ^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/fixtures.py:5:5
+          |
+        5 | def implementation(): ...
+          |     --------------
+        ");
+
+        let test_inherited = test.function("TestExample.test_inherited");
+
+        assert_snapshot!(test_inherited.fixture_resolution("public_name"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:7:30
+          |
+        7 |     def test_inherited(self, public_name): ...
+          |                              ^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/fixtures.py:9:9
+          |
+        9 |     def implementation(self): ...
+          |         --------------
+        ");
+    }
+
+    #[test]
+    fn resolves_fixture_declarations_from_stub_only_classes() {
+        let test = PytestTestCase::with_files(
+            "/src/test_example.py",
+            &[
+                (
+                    "/src/plugin.pyi",
+                    r#"
+import pytest
+
+class Plugin:
+    @pytest.fixture
+    def resource(self): ...
+"#,
+                ),
+                (
+                    "/src/test_example.py",
+                    r#"
+from plugin import Plugin
+
+class TestExample(Plugin):
+    def test_use(self, resource): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_use = test.function("TestExample.test_use");
+
+        assert_snapshot!(test_use.fixture_resolution("resource"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:5:24
+          |
+        5 |     def test_use(self, resource): ...
+          |                        ^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/plugin.pyi:6:9
+          |
+        6 |     def resource(self): ...
+          |         --------
+        ");
+    }
+
+    #[test]
+    fn resolves_fixture_reexports_through_stub_only_modules() {
+        let test = PytestTestCase::with_files(
+            "/src/test_example.py",
+            &[
+                (
+                    "/src/origin.pyi",
+                    r#"
+import pytest
+
+@pytest.fixture
+def module_fixture(): ...
+
+@pytest.fixture
+def class_fixture(): ...
+
+@pytest.fixture
+def star_fixture(): ...
+"#,
+                ),
+                (
+                    "/src/plugin.pyi",
+                    r#"
+from origin import module_fixture as module_fixture
+from origin import *
+
+class Plugin:
+    from origin import class_fixture as class_fixture
+"#,
+                ),
+                (
+                    "/src/test_example.py",
+                    r#"
+from plugin import Plugin, module_fixture, star_fixture
+
+def test_module(module_fixture, star_fixture): ...
+
+class TestExample(Plugin):
+    def test_use(self, class_fixture): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_module = test.function("test_module");
+        let test_use = test.function("TestExample.test_use");
+
+        assert_snapshot!(test_module.fixture_resolution("module_fixture"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:4:17
+          |
+        4 | def test_module(module_fixture, star_fixture): ...
+          |                 ^^^^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/origin.pyi:5:5
+          |
+        5 | def module_fixture(): ...
+          |     --------------
+        ");
+        assert_snapshot!(test_module.fixture_resolution("star_fixture"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:4:33
+          |
+        4 | def test_module(module_fixture, star_fixture): ...
+          |                                 ^^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+          --> src/origin.pyi:11:5
+           |
+        11 | def star_fixture(): ...
+           |     ------------
+        ");
+        assert_snapshot!(test_use.fixture_resolution("class_fixture"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:7:24
+          |
+        7 |     def test_use(self, class_fixture): ...
+          |                        ^^^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/origin.pyi:8:5
+          |
+        8 | def class_fixture(): ...
+          |     -------------
+        ");
+    }
+
+    #[test]
+    fn ignores_overwritten_imported_fixtures() {
+        let test = PytestTestCase::with_files(
+            "/src/test_example.py",
+            &[
+                (
+                    "/src/origin.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def resource(): ...
+"#,
+                ),
+                (
+                    "/src/provider.py",
+                    r#"
+from origin import resource
+
+resource = object()
+"#,
+                ),
+                (
+                    "/src/test_example.py",
+                    r#"
+from origin import resource as local_resource
+from provider import resource
+
+local_resource = object()
+
+def test_use(local_resource, resource): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_use = test.function("test_use");
+
+        assert_snapshot!(test_use.fixture_resolution("local_resource"), @"No fixture resolved for parameter `local_resource`");
+        assert_snapshot!(test_use.fixture_resolution("resource"), @"No fixture resolved for parameter `resource`");
+    }
+
+    #[test]
+    fn preserves_conditional_imported_fixture_definitions() {
+        let test = PytestTestCase::with_files(
+            "/src/test_example.py",
+            &[
+                (
+                    "/src/first.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def first(): ...
+"#,
+                ),
+                (
+                    "/src/second.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def second(): ...
+"#,
+                ),
+                (
+                    "/src/test_example.py",
+                    r#"
+flag: bool
+
+if flag:
+    from first import first as resource
+else:
+    from second import second as resource
+
+def test_use(resource): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_use = test.function("test_use");
+
+        assert_snapshot!(test_use.fixture_resolution("resource"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/test_example.py:9:14
+          |
+        9 | def test_use(resource): ...
+          |              ^^^^^^^^ fixture requested here
+        info: Found 2 fixtures
+         --> src/first.py:5:5
+          |
+        5 | def first(): ...
+          |     -----
+          |
+         ::: src/second.py:5:5
+          |
+        5 | def second(): ...
+          |     ------
+        ");
+    }
+
+    #[test]
+    fn ignores_local_fixture_declarations_unavailable_at_runtime() {
+        let test = PytestTestCase::new(
+            "/src/test_example.py",
+            r#"
+from typing import TYPE_CHECKING
+import pytest
+
+if TYPE_CHECKING:
+    @pytest.fixture
+    def typing_only(): ...
+
+class Base:
+    @pytest.fixture
+    def resource(self): ...
+
+class TestDerived(Base):
+    if TYPE_CHECKING:
+        @pytest.fixture
+        def resource(self): ...
+
+    def test_inherited(self, resource): ...
+
+def test_use(typing_only): ...
+"#,
+        );
+
+        let test_inherited = test.function("TestDerived.test_inherited");
+        let test_use = test.function("test_use");
+
+        assert_snapshot!(test_inherited.fixture_resolution("resource"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+          --> src/test_example.py:18:30
+           |
+        18 |     def test_inherited(self, resource): ...
+           |                              ^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+          --> src/test_example.py:11:9
+           |
+        11 |     def resource(self): ...
+           |         --------
+        ");
+
+        assert_snapshot!(test_use.fixture_resolution("typing_only"), @"No fixture resolved for parameter `typing_only`");
+    }
+
+    #[test]
+    fn ignores_imported_fixture_exposures_unavailable_at_runtime() {
+        let test = PytestTestCase::with_files(
+            "/src/test_example.py",
+            &[
+                (
+                    "/src/fixtures.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def resource(): ...
+"#,
+                ),
+                (
+                    "/src/provider.py",
+                    r#"
+from typing import TYPE_CHECKING
+import pytest
+
+if TYPE_CHECKING:
+    from fixtures import resource as typing_only_reexport
+
+    @pytest.fixture
+    def typing_only_declaration(): ...
+"#,
+                ),
+                (
+                    "/src/test_example.py",
+                    r#"
+from typing import TYPE_CHECKING
+
+from provider import *
+
+if False:
+    from fixtures import resource as unreachable
+
+if TYPE_CHECKING:
+    from fixtures import resource as typing_only
+
+def test_use(unreachable, typing_only, typing_only_declaration, typing_only_reexport): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_use = test.function("test_use");
+
+        assert_snapshot!(test_use.fixture_resolution("unreachable"), @"No fixture resolved for parameter `unreachable`");
+        assert_snapshot!(test_use.fixture_resolution("typing_only"), @"No fixture resolved for parameter `typing_only`");
+        assert_snapshot!(test_use.fixture_resolution("typing_only_declaration"), @"No fixture resolved for parameter `typing_only_declaration`");
+        assert_snapshot!(test_use.fixture_resolution("typing_only_reexport"), @"No fixture resolved for parameter `typing_only_reexport`");
+    }
+
     struct PytestTestCase {
         db: TestDb,
         path: &'static str,
@@ -1505,6 +2280,13 @@ def test_use(value): ...
         fn new(path: &'static str, source: &'static str) -> Self {
             Self {
                 db: pytest_db(path, source),
+                path,
+            }
+        }
+
+        fn with_files(path: &'static str, files: &[(&'static str, &'static str)]) -> Self {
+            Self {
+                db: pytest_db_with_files(files),
                 path,
             }
         }
@@ -1612,7 +2394,11 @@ def test_use(value): ...
     }
 
     fn pytest_db(path: &'static str, source: &'static str) -> TestDb {
-        TestDbBuilder::new()
+        pytest_db_with_files(&[(path, source)])
+    }
+
+    fn pytest_db_with_files(files: &[(&'static str, &'static str)]) -> TestDb {
+        let mut builder = TestDbBuilder::new()
             .with_third_party_packages()
             .with_file(
                 "/.venv/lib/python3.13/site-packages/_pytest/__init__.pyi",
@@ -1660,9 +2446,10 @@ from _pytest.mark.structures import MarkGenerator
 
 mark: MarkGenerator
 "#,
-            )
-            .with_file(path, source)
-            .build()
-            .expect("valid pytest test database")
+            );
+        for (path, source) in files {
+            builder = builder.with_file(*path, source);
+        }
+        builder.build().expect("valid pytest test database")
     }
 }

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -397,25 +397,39 @@ fn fixture_provider_names<'db>(
 ) -> Box<[FixtureProviderName<'db>]> {
     let is_class_scope = scope.node(db).scope_kind() == ScopeKind::Class;
     let table = place_table(db, scope);
-    use_def_map(db, scope)
-        .all_end_of_scope_symbol_bindings()
-        .filter_map(|(symbol_id, definitions)| {
-            let symbol = table.symbol(symbol_id);
-            let name = symbol.name().clone();
-            let is_bound_class_attribute = is_class_scope && symbol.is_bound();
-            let exposures: Box<[_]> = definitions
-                .filter_map(|binding| binding.binding.definition())
-                .filter_map(|definition| fixture_declaration(db, definition).clone())
-                .filter_map(|declaration| FixtureExposure::new(&name, declaration))
-                .collect();
-            // Reject names that neither expose a fixture nor bind a class attribute that can
-            // shadow an inherited fixture.
-            if exposures.is_empty() && !is_bound_class_attribute {
-                return None;
-            }
-            Some(FixtureProviderName { name, exposures })
-        })
-        .collect()
+    let mut provider_names = Vec::new();
+
+    for (symbol_id, definitions) in use_def_map(db, scope).all_end_of_scope_symbol_bindings() {
+        let symbol = table.symbol(symbol_id);
+        let name = symbol.name().clone();
+        let is_bound_class_attribute = is_class_scope && symbol.is_bound();
+        let mut exposures = Vec::new();
+
+        for binding in definitions {
+            let Some(definition) = binding.binding.definition() else {
+                continue;
+            };
+            let Some(declaration) = fixture_declaration(db, definition).clone() else {
+                continue;
+            };
+            let Some(exposure) = FixtureExposure::new(&name, declaration) else {
+                continue;
+            };
+            exposures.push(exposure);
+        }
+
+        // Reject names that neither expose a fixture nor bind a class attribute that can
+        // shadow an inherited fixture.
+        if exposures.is_empty() && !is_bound_class_attribute {
+            continue;
+        }
+        provider_names.push(FixtureProviderName {
+            name,
+            exposures: exposures.into_boxed_slice(),
+        });
+    }
+
+    provider_names.into_boxed_slice()
 }
 
 /// Resolves a request against the fixture exposures in `provider`.

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1289,6 +1289,25 @@ pub fn definitions_for_imported_symbol<'db>(
     )
 }
 
+/// Resolve a binding to its canonical definitions, following imports recursively.
+pub(crate) fn resolve_definition_targets<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    symbol_name: &str,
+) -> Vec<Definition<'db>> {
+    let env = ProgramEnvironment::from_definition(definition);
+    resolve_definition(
+        db,
+        &env,
+        definition,
+        Some(symbol_name),
+        ImportAliasResolution::ResolveAliases,
+    )
+    .into_iter()
+    .filter_map(|resolved| resolved.definition())
+    .collect()
+}
+
 /// Returns the definition and overload co-definitions for a function declaration.
 ///
 /// For overloaded functions this includes sibling overload declarations and the

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -2072,7 +2072,7 @@ mod resolve_definition {
 
     use indexmap::IndexSet;
     use ruff_db::files::{FileRange, vendored_path_to_file};
-    use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+    use ruff_db::parsed::parsed_module;
     use ruff_db::system::SystemPath;
     use ruff_db::vendored::VendoredPathBuf;
     use ruff_python_ast as ast;
@@ -2087,10 +2087,13 @@ mod resolve_definition {
 
     use crate::Db;
     use crate::ProgramEnvironment;
+    use crate::lexical_name_path::{
+        lexical_name_path_component_for_node, lexical_name_path_for_definition,
+    };
     use crate::module_docstring;
     use crate::types::binding_type;
     use ty_python_core::definition::{Definition, DefinitionCategory, DefinitionKind};
-    use ty_python_core::scope::{NodeWithScopeKind, ScopeId};
+    use ty_python_core::scope::ScopeId;
     use ty_python_core::{ProgramFile, global_scope, place_table, semantic_index, use_def_map};
 
     /// Represents the result of resolving an import to either a specific definition or
@@ -2547,49 +2550,22 @@ mod resolve_definition {
         let real_file = real_parse_file.file(db);
         trace!("Found real file: {}", real_file.path(db));
 
-        // A definition has a "Definition Path" in a file made of nested definitions (~scopes):
+        // A definition's lexical name path describes its nesting within a module:
         //
         // ```
-        // class myclass:  # ./myclass
-        //     def some_func(args: bool):  # ./myclass/some_func
-        //                 # ^~~~ ./myclass/other_func/args/
+        // class Outer:          # [Outer]
+        //     def method(): ... # [Outer, method]
         // ```
         //
-        // So our heuristic goal here is to compute a Definition Path in the stub file
-        // and then resolve the same Definition Path in the real file.
+        // Compute the path in the stub file, then resolve the same path in the real file.
         //
-        // NOTE: currently a path component is just a str, but in the future additional
+        // NOTE: currently a path component is just a name, but in the future additional
         // disambiguators (like "is a class def") could be added if needed.
-        let mut path = Vec::new();
-        let stub_parsed;
-        let stub_ref;
-        match *def {
+        let path = match *def {
             ResolvedDefinition::Definition(definition) => {
-                stub_parsed = parsed_module(db, definition.python_file(db));
-                stub_ref = stub_parsed.load(db);
-
-                // Get the leaf of the path (the definition itself)
-                let leaf = definition_path_component_for_leaf(db, &stub_ref, definition)
-                    .map_err(|()| {
-                        trace!("Found unsupported DefinitionKind while stub mapping, giving up");
-                    })
-                    .ok()?;
-                path.push(leaf);
-
-                // Get the ancestors of the path (all the definitions we're nested under)
-                let index = semantic_index(db, definition.program_file(db));
-                for (_scope_id, scope) in index.ancestor_scopes(definition.file_scope(db)) {
-                    let node = scope.node();
-                    let component = definition_path_component_for_node(&stub_ref, node)
-                        .map_err(|()| {
-                            trace!("Found unsupported NodeScopeKind while stub mapping, giving up");
-                        })
-                        .ok()?;
-                    if let Some(component) = component {
-                        path.push(component);
-                    }
-                }
-                trace!("Built Definition Path: {path:?}");
+                let path = lexical_name_path_for_definition(db, definition)?;
+                trace!("Built lexical name path: {path:?}");
+                path
             }
             ResolvedDefinition::Module(_) => {
                 trace!(
@@ -2601,13 +2577,13 @@ mod resolve_definition {
             }
             ResolvedDefinition::FileWithRange(_) => {
                 // Not yet implemented -- in this case we want to recover something like a Definition
-                // and build a Definition Path, but this input is a bit too abstract for now.
+                // and build a lexical name path, but this input is a bit too abstract for now.
                 trace!("Found arbitrary FileWithRange while stub mapping, giving up");
                 return None;
             }
-        }
+        };
 
-        // Walk down the Definition Path in the real file
+        // Walk down the lexical name path in the real file.
         let mut definitions = Vec::new();
         let index = semantic_index(db, real_parse_file);
         let global_scope = global_scope(db, real_parse_file);
@@ -2615,24 +2591,25 @@ mod resolve_definition {
         let real_ref = real_parsed.load(db);
         // Start our search in the module (global) scope
         let mut scopes = vec![global_scope];
-        while let Some(component) = path.pop() {
-            trace!("Traversing definition path component: {}", component);
+        let mut path = path.iter().peekable();
+        while let Some(component) = path.next() {
+            trace!("Traversing lexical name path component: {}", component);
             // We're doing essentially a breadth-first traversal of the definitions.
             // If ever we find multiple matching scopes for a component, we need to continue
             // walking down each of them to try to resolve the path. Here we loop over
             // all the scopes at the current level of search.
             for scope in std::mem::take(&mut scopes) {
-                if path.is_empty() {
+                if path.peek().is_none() {
                     // We're at the end of the path, everything we find here is the final result
                     definitions.extend(
-                        find_symbol_in_scope(db, scope, component)
+                        find_symbol_in_scope(db, scope, component.as_str())
                             .into_iter()
                             .flat_map(|definition| {
                                 resolve_definition(
                                     db,
                                     &env,
                                     definition,
-                                    Some(component),
+                                    Some(component.as_str()),
                                     ImportAliasResolution::ResolveAliases,
                                 )
                             }),
@@ -2643,11 +2620,10 @@ mod resolve_definition {
                     {
                         let scope_node = child_scope.node();
                         if let Ok(Some(real_component)) =
-                            definition_path_component_for_node(&real_ref, scope_node)
+                            lexical_name_path_component_for_node(&real_ref, scope_node)
+                            && real_component == *component
                         {
-                            if real_component == component {
-                                scopes.push(child_scope_id.to_scope_id(db, real_parse_file));
-                            }
+                            scopes.push(child_scope_id.to_scope_id(db, real_parse_file));
                         }
                         scope.node(db);
                     }
@@ -2666,87 +2642,6 @@ mod resolve_definition {
             trace!("Found {} definitions from stub mapping", definitions.len());
             Some(definitions)
         }
-    }
-
-    /// Computes a "Definition Path" component for an internal node of the definition path.
-    ///
-    /// See [`map_stub_definition`][] for details.
-    fn definition_path_component_for_node<'parse>(
-        parsed: &'parse ParsedModuleRef,
-        node: &NodeWithScopeKind,
-    ) -> Result<Option<&'parse str>, ()> {
-        let component = match node {
-            NodeWithScopeKind::Module => {
-                // This is just implicit, so has no component
-                return Ok(None);
-            }
-            NodeWithScopeKind::Class(class) => class.node(parsed).name.as_str(),
-            NodeWithScopeKind::Function(func) => func.node(parsed).name.as_str(),
-            NodeWithScopeKind::TypeAlias(_)
-            | NodeWithScopeKind::ClassTypeParameters(_)
-            | NodeWithScopeKind::FunctionTypeParameters(_)
-            | NodeWithScopeKind::TypeAliasTypeParameters(_)
-            | NodeWithScopeKind::Lambda(_)
-            | NodeWithScopeKind::ListComprehension(_)
-            | NodeWithScopeKind::SetComprehension(_)
-            | NodeWithScopeKind::DictComprehension(_)
-            | NodeWithScopeKind::GeneratorExpression(_) => {
-                // Not yet implemented
-                return Err(());
-            }
-        };
-        Ok(Some(component))
-    }
-
-    /// Computes a "Definition Path" component for a leaf node of the definition path.
-    ///
-    /// See [`map_stub_definition`][] for details.
-    fn definition_path_component_for_leaf<'parse>(
-        db: &dyn Db,
-        parsed: &'parse ParsedModuleRef,
-        definition: Definition,
-    ) -> Result<&'parse str, ()> {
-        let component = match definition.kind(db) {
-            DefinitionKind::Function(func) => func.node(parsed).name.as_str(),
-            DefinitionKind::Class(class) => class.node(parsed).name.as_str(),
-            DefinitionKind::Assignment(assignment) => {
-                let ast::Expr::Name(name) = assignment.target(parsed) else {
-                    return Err(());
-                };
-                name.id.as_str()
-            }
-            DefinitionKind::AnnotatedAssignment(assignment) => {
-                let ast::Expr::Name(name) = assignment.target(parsed) else {
-                    return Err(());
-                };
-                name.id.as_str()
-            }
-            DefinitionKind::TypeAlias(_)
-            | DefinitionKind::Import(_)
-            | DefinitionKind::ImportFrom(_)
-            | DefinitionKind::ImportFromSubmodule(_)
-            | DefinitionKind::StarImport(_)
-            | DefinitionKind::NamedExpression(_)
-            | DefinitionKind::AugmentedAssignment(_)
-            | DefinitionKind::DictKeyAssignment(_)
-            | DefinitionKind::For(_)
-            | DefinitionKind::Comprehension(_)
-            | DefinitionKind::Parameter(_)
-            | DefinitionKind::LambdaParameter { .. }
-            | DefinitionKind::WithItem(_)
-            | DefinitionKind::MatchPattern(_)
-            | DefinitionKind::ExceptHandler(_)
-            | DefinitionKind::TypeVar(_)
-            | DefinitionKind::ParamSpec(_)
-            | DefinitionKind::TypeVarTuple(_)
-            | DefinitionKind::LoopHeader(_)
-            | DefinitionKind::NestedBindings(_) => {
-                // Not yet implemented
-                return Err(());
-            }
-        };
-
-        Ok(component)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -2076,13 +2076,12 @@ mod resolve_definition {
     use ruff_db::system::SystemPath;
     use ruff_db::vendored::VendoredPathBuf;
     use ruff_python_ast as ast;
-    use ruff_python_stdlib::sys::is_builtin_module;
     use ruff_text_size::TextRange;
     use rustc_hash::FxHashSet;
     use tracing::trace;
     use ty_module_resolver::{
-        ImportingFile, ModuleName, file_to_module, resolve_module, resolve_module_for_import_from,
-        resolve_real_module,
+        ImportingFile, ModuleName, resolve_module, resolve_module_for_import_from,
+        stub_file_to_real_module,
     };
 
     use crate::Db;
@@ -2526,25 +2525,7 @@ mod resolve_definition {
 
         // It's definitely a stub, so now rerun module resolution but with stubs disabled.
         let resolver_file = stub_file_for_module_lookup.resolver_file(db);
-        let stub_module = file_to_module(db, resolver_file)?;
-        trace!("Found stub module: {}", stub_module.name(db));
-        // We need to pass an importing file to `resolve_real_module` which is a bit odd
-        // here because there isn't really an importing file. However this `resolve_real_module`
-        // can be understood as essentially `import .`, which is also what `file_to_module` is,
-        // so this is in fact exactly the file we want to consider the importer.
-        //
-        // ... unless we have a builtin module. i.e., A module embedded
-        // into the interpreter. In which case, all we have are stubs.
-        // `resolve_real_module` will always return `None` for this case, but
-        // it will emit false positive logs. And this saves us some work.
-        if is_builtin_module(stub_module.python_version(db).minor, stub_module.name(db)) {
-            return None;
-        }
-        let real_module = resolve_real_module(
-            db,
-            ImportingFile::ResolverFile(resolver_file),
-            stub_module.name(db),
-        )?;
+        let real_module = stub_file_to_real_module(db, resolver_file)?;
         trace!("Found real module: {}", real_module.name(db));
         let real_parse_file = ProgramFile::new(db, real_module.file(db)?, env.program(db));
         let real_file = real_parse_file.file(db);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Building on https://github.com/astral-sh/ruff/pull/27443, this extends the model for recognizing the pytest fixture bound to a test parameter to support imported fixtures (as opposed to only fixtures defined in that same module). Specifically, we now attempt to traverse recursively through the local name bound by an import to find an underlying pytest fixture.

The entire semantic model in `pytest.rs` remains unused until https://github.com/astral-sh/ruff/pull/27444.

## Approach

The implementation proceeds in three stages:

1. (4fcaf2af93060ff8586e4eff36de69956018a126) Introduces a new interface for resolving the bindings that supply a module global in a way that respects control flow and shadowing. This is general infrastructure, hence its centralization (it will be used again in [#26677](https://github.com/astral-sh/ruff/pull/26677) towards [astral-sh/ty#1560](https://github.com/astral-sh/ty/issues/1560) and [astral-sh/ty#3410](https://github.com/astral-sh/ty/issues/3410)), but it is immediately necessary here for correct import resolution.
2. (3056c8c6e9f5cbb60d5261aa75ae1538dc1ebb44) Implements a small refactor to make a loop clearer.
3. (a1f9f6b1c24a81fae821d5557e63b644c5186c0c) Implements the actual fixture import resolution logic.

## Test Plan

See included tests.
<!-- How was it tested? -->
