### PR TITLE
[ty] Resolve pytest fixtures through conftest

### DIFF
--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -907,6 +907,14 @@ impl SearchPaths {
         }
     }
 
+    /// Returns the configured roots for first-party modules.
+    pub fn first_party_roots(&self) -> impl Iterator<Item = &SystemPath> {
+        self.static_paths
+            .iter()
+            .filter(|path| path.is_first_party())
+            .filter_map(SearchPath::as_system_path)
+    }
+
     /// Registers file roots for all non-dynamically discovered search paths.
     pub fn try_register_static_roots(&self, db: &dyn Db) {
         let files = db.files();
@@ -3443,6 +3451,31 @@ not_a_directory
             !search_paths.contains(
                 &&SearchPath::editable(db.system(), SystemPathBuf::from("/src")).unwrap()
             )
+        );
+    }
+
+    #[test]
+    fn first_party_roots_exclude_dynamic_search_paths() {
+        let TestCase { db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("foo.py", "")])
+            .with_site_packages_files(&[("_foo.pth", "/editable")])
+            .build();
+        db.memory_file_system()
+            .create_directory_all("/editable")
+            .expect("valid editable directory");
+
+        let all_paths: Vec<_> =
+            search_paths(&db, db.resolver_environment(), ModuleResolveMode::Typing).collect();
+        assert!(
+            all_paths.contains(
+                &&SearchPath::editable(db.system(), SystemPathBuf::from("/editable"))
+                    .expect("valid editable search path")
+            )
+        );
+
+        assert_eq!(
+            db.search_paths().first_party_roots().collect::<Vec<_>>(),
+            [&*src]
         );
     }
 

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -220,6 +220,8 @@ pub(crate) mod tests {
         python_version: PythonVersion,
         /// Target Python platform
         python_platform: PythonPlatform,
+        /// Roots containing first-party modules.
+        src_roots: Vec<SystemPathBuf>,
         /// Path and content pairs for files that should be present
         files: Vec<(&'a str, &'a str)>,
         /// Whether module resolution should include packages from the synthetic virtual environment.
@@ -231,6 +233,7 @@ pub(crate) mod tests {
             Self {
                 python_version: PythonVersion::default(),
                 python_platform: PythonPlatform::default(),
+                src_roots: vec![SystemPathBuf::from("/src")],
                 files: vec![],
                 third_party_packages: false,
             }
@@ -243,6 +246,11 @@ pub(crate) mod tests {
 
         pub(crate) fn with_python_platform(mut self, platform: PythonPlatform) -> Self {
             self.python_platform = platform;
+            self
+        }
+
+        pub(crate) fn with_src_roots(mut self, src_roots: Vec<SystemPathBuf>) -> Self {
+            self.src_roots = src_roots;
             self
         }
 
@@ -267,8 +275,9 @@ pub(crate) mod tests {
         pub(crate) fn build(self) -> anyhow::Result<TestDb> {
             let mut db = TestDb::new();
 
-            let src_root = SystemPathBuf::from("/src");
-            db.memory_file_system().create_directory_all(&src_root)?;
+            for src_root in &self.src_roots {
+                db.memory_file_system().create_directory_all(src_root)?;
+            }
 
             let site_packages = SystemPathBuf::from("/.venv/lib/python3.13/site-packages");
             if self.third_party_packages {
@@ -281,12 +290,12 @@ pub(crate) mod tests {
 
             let search_path_settings = if self.third_party_packages {
                 SearchPathSettings {
-                    src_roots: vec![src_root],
+                    src_roots: self.src_roots,
                     site_packages_paths: vec![site_packages],
                     ..SearchPathSettings::empty()
                 }
             } else {
-                SearchPathSettings::new(vec![src_root])
+                SearchPathSettings::new(self.src_roots)
             };
 
             let program_settings = ProgramSettings {

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -1,9 +1,10 @@
+use ruff_db::files::system_path_to_file;
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::{self as ast, name::Name};
 use ruff_text_size::Ranged;
 use ty_module_resolver::{KnownModule, file_to_module};
 use ty_python_core::definition::{Definition, DefinitionKind};
-use ty_python_core::scope::{FileScopeId, ScopeKind};
+use ty_python_core::scope::{FileScopeId, ScopeId, ScopeKind};
 use ty_python_core::{ProgramFile, global_scope, place_table, semantic_index, use_def_map};
 
 use crate::Db;
@@ -12,10 +13,10 @@ use crate::types::function::FunctionDecorators;
 use crate::types::ide_support::resolve_definition_targets;
 use crate::types::infer::{function_known_decorator_flags, function_known_decorators};
 
-/// Resolve the same-file pytest fixtures requested by `parameter`.
+/// Resolve the pytest fixtures requested by `parameter`.
 ///
-/// This query models only fixtures declared directly in the parameter's class or module. Imported,
-/// conftest, built-in, and plugin fixtures are added by later provider layers.
+/// This query searches the parameter's class, module, and enclosing conftest hierarchy. Built-in
+/// and plugin fixtures are added by later provider layers.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
 pub fn fixture_bindings_for_parameter<'db>(
     db: &'db dyn Db,
@@ -26,14 +27,30 @@ pub fn fixture_bindings_for_parameter<'db>(
     };
 
     if let Some(class_scope) = request.class_scope {
-        let bindings = bindings_in_provider(db, &request, class_scope);
+        let bindings = bindings_in_provider(
+            db,
+            &request,
+            class_scope.to_scope_id(db, parameter.program_file(db)),
+        );
         if !bindings.is_empty() {
             return bindings;
         }
     }
 
-    let module_scope = global_scope(db, parameter.program_file(db)).file_scope_id(db);
-    bindings_in_provider(db, &request, module_scope)
+    let request_file = parameter.program_file(db);
+    let bindings = bindings_in_provider(db, &request, global_scope(db, request_file));
+    if !bindings.is_empty() {
+        return bindings;
+    }
+
+    for conftest in conftest_files(db, request_file) {
+        let bindings = bindings_in_provider(db, &request, global_scope(db, *conftest));
+        if !bindings.is_empty() {
+            return bindings;
+        }
+    }
+
+    Box::default()
 }
 
 /// A pytest fixture request and the fixture declaration that satisfies it.
@@ -158,11 +175,10 @@ enum FixtureName {
 fn bindings_in_provider<'db>(
     db: &'db dyn Db,
     request: &FixtureRequest<'db>,
-    provider: FileScopeId,
+    provider: ScopeId<'db>,
 ) -> Box<[FixtureBinding<'db>]> {
-    let scope = provider.to_scope_id(db, request.definition.program_file(db));
-    let table = place_table(db, scope);
-    let use_def = use_def_map(db, scope);
+    let table = place_table(db, provider);
+    let use_def = use_def_map(db, provider);
     let mut bindings = Vec::new();
 
     for (symbol_id, definitions) in use_def.all_end_of_scope_symbol_bindings() {
@@ -192,6 +208,39 @@ fn bindings_in_provider<'db>(
     }
 
     bindings.into_boxed_slice()
+}
+
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+fn conftest_files<'db>(db: &'db dyn Db, request_file: ProgramFile<'db>) -> Box<[ProgramFile<'db>]> {
+    let file = request_file.file(db);
+    let Some(path) = file.path(db).as_system_path() else {
+        return Box::default();
+    };
+    let Some(file_root) = db.files().root(db, path) else {
+        return Box::default();
+    };
+    let root = file_root.path(db);
+    let Some(request_directory) = path.parent() else {
+        return Box::default();
+    };
+
+    // The current conftest's module scope was already searched above. Starting at its parent avoids
+    // processing the same provider twice and lets same-name overrides continue outward.
+    let start_directory = if path.file_name() == Some("conftest.py") {
+        request_directory.parent()
+    } else {
+        Some(request_directory)
+    };
+    let Some(start_directory) = start_directory else {
+        return Box::default();
+    };
+
+    start_directory
+        .ancestors()
+        .take_while(|directory| directory.starts_with(root))
+        .filter_map(|directory| system_path_to_file(db, directory.join("conftest.py")).ok())
+        .map(|file| ProgramFile::new(db, file, request_file.program(db)))
+        .collect()
 }
 
 fn fixture_exposure<'db>(
@@ -408,6 +457,7 @@ mod tests {
     use anyhow::Result;
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
+    use ruff_db::system::DbWithWritableSystem;
     use ruff_python_ast as ast;
     use ty_python_core::definition::Definition;
     use ty_python_core::scope::ScopeKind;
@@ -749,8 +799,218 @@ def test_use(resource): ...
         Ok(())
     }
 
+    #[test]
+    fn resolves_nearest_to_outermost_conftest_providers() -> Result<()> {
+        let db = pytest_db_with_files(&[
+            (
+                "/conftest.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def outside_root(): ...
+"#,
+            ),
+            (
+                "/src/conftest.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def root_fixture(): ...
+
+@pytest.fixture
+def shadowed(): ...
+
+@pytest.fixture
+def module_shadowed(): ...
+"#,
+            ),
+            (
+                "/src/shared_fixtures.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def imported_fixture(): ...
+"#,
+            ),
+            (
+                "/src/project/conftest.py",
+                r#"
+import pytest
+from shared_fixtures import imported_fixture as conftest_alias
+
+@pytest.fixture
+def middle_fixture(): ...
+
+@pytest.fixture
+def shadowed(): ...
+"#,
+            ),
+            (
+                "/src/project/tests/conftest.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def nearest_fixture(): ...
+
+@pytest.fixture
+def shadowed(): ...
+"#,
+            ),
+            (
+                "/src/project/sibling/conftest.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def sibling_fixture(): ...
+"#,
+            ),
+            (
+                "/src/project/tests/test_example.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def module_shadowed(): ...
+
+def test_use(
+    nearest_fixture,
+    middle_fixture,
+    root_fixture,
+    shadowed,
+    module_shadowed,
+    conftest_alias,
+    sibling_fixture,
+    outside_root,
+): ...
+"#,
+            ),
+        ])?;
+
+        let test_file = "/src/project/tests/test_example.py";
+        assert_eq!(
+            fixture_names_in_file(&db, test_file, "test_use", "nearest_fixture"),
+            ["nearest_fixture"]
+        );
+        assert_eq!(
+            fixture_names_in_file(&db, test_file, "test_use", "middle_fixture"),
+            ["middle_fixture"]
+        );
+        assert_eq!(
+            fixture_names_in_file(&db, test_file, "test_use", "root_fixture"),
+            ["root_fixture"]
+        );
+        assert_eq!(
+            fixture_provider_files(&db, test_file, "test_use", "shadowed"),
+            ["/src/project/tests/conftest.py"]
+        );
+        assert_eq!(
+            fixture_provider_files(&db, test_file, "test_use", "module_shadowed"),
+            ["/src/project/tests/test_example.py"]
+        );
+        assert_eq!(
+            fixture_names_in_file(&db, test_file, "test_use", "conftest_alias"),
+            ["imported_fixture"]
+        );
+        assert!(fixture_names_in_file(&db, test_file, "test_use", "sibling_fixture").is_empty());
+        assert!(fixture_names_in_file(&db, test_file, "test_use", "outside_root").is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn same_name_conftest_override_requests_outer_fixture() -> Result<()> {
+        let db = pytest_db_with_files(&[
+            (
+                "/src/conftest.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def value(): ...
+"#,
+            ),
+            (
+                "/src/project/conftest.py",
+                r#"
+import pytest
+
+@pytest.fixture
+def value(value): ...
+"#,
+            ),
+        ])?;
+
+        assert_eq!(
+            fixture_provider_files(&db, "/src/project/conftest.py", "value", "value"),
+            ["/src/conftest.py"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn conftest_discovery_tracks_file_updates() -> Result<()> {
+        let mut db = pytest_db(
+            "/src/project/test_example.py",
+            r#"
+def test_use(resource): ...
+"#,
+        )?;
+
+        assert!(
+            fixture_names_in_file(&db, "/src/project/test_example.py", "test_use", "resource")
+                .is_empty()
+        );
+
+        db.write_file(
+            "/src/project/conftest.py",
+            r#"
+import pytest
+
+@pytest.fixture
+def resource(): ...
+"#,
+        )?;
+        assert_eq!(
+            fixture_names_in_file(&db, "/src/project/test_example.py", "test_use", "resource"),
+            ["resource"]
+        );
+
+        db.write_file(
+            "/src/project/conftest.py",
+            r#"
+import pytest
+
+@pytest.fixture
+def replacement(): ...
+"#,
+        )?;
+        assert!(
+            fixture_names_in_file(&db, "/src/project/test_example.py", "test_use", "resource")
+                .is_empty()
+        );
+        Ok(())
+    }
+
     fn fixture_names(db: &TestDb, function: &str, parameter: &str) -> Vec<String> {
-        let parameter = parameter_definition(db, function, parameter);
+        let path = if system_path_to_file(db, "/src/test_example.py").is_ok() {
+            "/src/test_example.py"
+        } else {
+            "/src/example.py"
+        };
+        fixture_names_in_file(db, path, function, parameter)
+    }
+
+    fn fixture_names_in_file(
+        db: &TestDb,
+        path: &str,
+        function: &str,
+        parameter: &str,
+    ) -> Vec<String> {
+        let parameter = parameter_definition(db, path, function, parameter);
         fixture_bindings_for_parameter(db, parameter)
             .iter()
             .map(|binding| {
@@ -763,21 +1023,33 @@ def test_use(resource): ...
     }
 
     fn fixture_provider_scopes(db: &TestDb, function: &str, parameter: &str) -> Vec<ScopeKind> {
-        let parameter = parameter_definition(db, function, parameter);
+        let parameter = parameter_definition(db, "/src/test_example.py", function, parameter);
         fixture_bindings_for_parameter(db, parameter)
             .iter()
             .map(|binding| binding.fixture().scope(db).scope(db).kind())
             .collect()
     }
 
+    fn fixture_provider_files(
+        db: &TestDb,
+        path: &str,
+        function: &str,
+        parameter: &str,
+    ) -> Vec<String> {
+        let parameter = parameter_definition(db, path, function, parameter);
+        fixture_bindings_for_parameter(db, parameter)
+            .iter()
+            .map(|binding| binding.fixture().file(db).path(db).to_string())
+            .collect()
+    }
+
     fn parameter_definition<'db>(
         db: &'db TestDb,
+        path: &str,
         function: &str,
         parameter: &str,
     ) -> Definition<'db> {
-        let file = system_path_to_file(db, "/src/test_example.py")
-            .or_else(|_| system_path_to_file(db, "/src/example.py"))
-            .expect("test file exists");
+        let file = system_path_to_file(db, path).expect("test file exists");
         let file = db.program_file(file);
         let module = parsed_module(db, file.python_file(db)).load(db);
         let function = find_function(module.suite(), function).expect("function exists");

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -39,6 +39,7 @@
 use std::cmp::Ordering;
 
 use itertools::Either;
+use ruff_db::files::system_path_to_file;
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::{self as ast, name::Name};
 use rustc_hash::FxHashSet;
@@ -79,6 +80,9 @@ use crate::{Db, FxIndexSet};
 /// def consumer(dependency): ...  # B
 /// ```
 ///
+/// At present, we search the parameter's class hierarchy, module, and enclosing
+/// conftest hierarchy. Built-in and plugin fixtures are not yet supported.
+///
 /// The resolution implemented here matches what pytest will actually resolve at
 /// runtime for context A, but not necessarily for context B. To see why,
 /// consider this example:
@@ -118,6 +122,7 @@ pub fn fixture_bindings_for_parameter<'db>(
         return Box::default();
     };
 
+    // First, resolve bindings from the containing class scope, if any.
     let containing_scope = request.function_definition.scope(db);
     let class_scope = containing_scope
         .node(db)
@@ -142,8 +147,30 @@ pub fn fixture_bindings_for_parameter<'db>(
         }
     }
 
-    let module_scope = global_scope(db, parameter.program_file(db));
-    bindings_in_search_scope(db, &request, FixtureSearchScope::Scope(module_scope))
+    // Second, resolve bindings from the module scope.
+    let request_file = parameter.program_file(db);
+    let bindings = bindings_in_search_scope(
+        db,
+        &request,
+        FixtureSearchScope::Scope(global_scope(db, request_file)),
+    );
+    if !bindings.is_empty() {
+        return bindings;
+    }
+
+    // Third, resolve bindings from the conftest hierarchy.
+    for conftest in conftest_files(db, request_file) {
+        let bindings = bindings_in_search_scope(
+            db,
+            &request,
+            FixtureSearchScope::Scope(global_scope(db, conftest)),
+        );
+        if !bindings.is_empty() {
+            return bindings;
+        }
+    }
+
+    Box::default()
 }
 
 /// A pytest fixture request and the declaration selected by static fixture lookup.
@@ -538,6 +565,45 @@ fn bindings_in_search_scope<'db>(
             request: request.parameter_definition,
             fixture,
         })
+        .collect()
+}
+
+/// Returns applicable `conftest.py` files from nearest to outermost.
+fn conftest_files<'db>(db: &'db dyn Db, request_file: ProgramFile<'db>) -> Vec<ProgramFile<'db>> {
+    let Some(path) = request_file.file(db).path(db).as_system_path() else {
+        return Vec::new();
+    };
+
+    let program = request_file.program(db);
+    let Some(root) = program
+        .search_paths(db)
+        .first_party_roots()
+        .filter(|root| path.starts_with(*root))
+        .min_by_key(|root| root.components().count())
+    else {
+        return Vec::new();
+    };
+    let Some(request_directory) = path.parent() else {
+        return Vec::new();
+    };
+
+    let start_directory = if path.file_name() == Some("conftest.py") {
+        // The caller already searched the request file as a module search scope.
+        // Start in its parent when it is itself a conftest to avoid searching
+        // the same search scope twice.
+        request_directory.parent()
+    } else {
+        Some(request_directory)
+    };
+    let Some(start_directory) = start_directory else {
+        return Vec::new();
+    };
+
+    start_directory
+        .ancestors()
+        .take_while(|directory| directory.starts_with(root))
+        .filter_map(|directory| system_path_to_file(db, directory.join("conftest.py")).ok())
+        .map(|file| ProgramFile::new(db, file, program))
         .collect()
 }
 
@@ -1041,6 +1107,7 @@ mod tests {
     };
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
+    use ruff_db::system::{DbWithWritableSystem, SystemPathBuf};
     use ruff_python_ast as ast;
     use ty_python_core::definition::Definition;
     use ty_python_core::semantic_index;
@@ -2271,6 +2338,212 @@ def test_use(unreachable, typing_only, typing_only_declaration, typing_only_reex
         assert_snapshot!(test_use.fixture_resolution("typing_only_reexport"), @"No fixture resolved for parameter `typing_only_reexport`");
     }
 
+    #[test]
+    fn resolves_conftest_fixtures_from_request_directory_to_first_party_root() {
+        let test = PytestTestCase::with_files(
+            "/src/tests/test_example.py",
+            &[
+                (
+                    "/conftest.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def outside_root(): ...
+"#,
+                ),
+                (
+                    "/src/conftest.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def root_fixture(): ...
+
+@pytest.fixture
+def shadowed(): ...
+"#,
+                ),
+                (
+                    "/src/tests/conftest.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def shadowed(): ...
+"#,
+                ),
+                (
+                    "/src/sibling/conftest.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def sibling_fixture(): ...
+"#,
+                ),
+                (
+                    "/src/tests/test_example.py",
+                    r#"
+def test_use(
+    root_fixture,
+    shadowed,
+    outside_root,
+    sibling_fixture,
+): ...
+"#,
+                ),
+            ],
+        );
+
+        let test_use = test.function("test_use");
+
+        assert_snapshot!(test_use.fixture_resolution("root_fixture"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/tests/test_example.py:3:5
+          |
+        3 |     root_fixture,
+          |     ^^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/conftest.py:5:5
+          |
+        5 | def root_fixture(): ...
+          |     ------------
+        ");
+
+        assert_snapshot!(test_use.fixture_resolution("shadowed"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/tests/test_example.py:4:5
+          |
+        4 |     shadowed,
+          |     ^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/tests/conftest.py:5:5
+          |
+        5 | def shadowed(): ...
+          |     --------
+        ");
+
+        assert_snapshot!(test_use.fixture_resolution("outside_root"), @"No fixture resolved for parameter `outside_root`");
+
+        assert_snapshot!(test_use.fixture_resolution("sibling_fixture"), @"No fixture resolved for parameter `sibling_fixture`");
+    }
+
+    #[test]
+    fn resolves_conftest_providers_from_outermost_matching_first_party_root() {
+        let test = PytestTestCase::with_files_and_src_roots(
+            "/src/tests/test_example.py",
+            &[
+                (
+                    "/conftest.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def outer_fixture(): ...
+"#,
+                ),
+                (
+                    "/src/tests/test_example.py",
+                    r#"
+def test_use(outer_fixture): ...
+"#,
+                ),
+            ],
+            // The relative environment roots `["src", "."]` resolve to these absolute paths.
+            vec![SystemPathBuf::from("/src"), SystemPathBuf::from("/")],
+        );
+
+        assert_snapshot!(test.function("test_use").fixture_resolution("outer_fixture"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/tests/test_example.py:2:14
+          |
+        2 | def test_use(outer_fixture): ...
+          |              ^^^^^^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> conftest.py:5:5
+          |
+        5 | def outer_fixture(): ...
+          |     -------------
+        ");
+    }
+
+    #[test]
+    fn resolves_conftest_fixture_dependency_from_parent_conftest() {
+        let test = PytestTestCase::with_files(
+            "/src/project/conftest.py",
+            &[
+                (
+                    "/src/conftest.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def resource(): ...
+"#,
+                ),
+                (
+                    "/src/project/conftest.py",
+                    r#"
+import pytest
+
+@pytest.fixture
+def consumer(resource): ...
+"#,
+                ),
+            ],
+        );
+
+        let fixture = test.function("consumer");
+
+        assert_snapshot!(fixture.fixture_resolution("resource"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/project/conftest.py:5:14
+          |
+        5 | def consumer(resource): ...
+          |              ^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/conftest.py:5:5
+          |
+        5 | def resource(): ...
+          |     --------
+        ");
+    }
+
+    #[test]
+    fn creating_conftest_updates_fixture_resolution() {
+        let mut test = PytestTestCase::new(
+            "/src/project/test_example.py",
+            r#"
+def test_use(resource): ...
+"#,
+        );
+
+        assert_snapshot!(test.function("test_use").fixture_resolution("resource"), @"No fixture resolved for parameter `resource`");
+
+        test.write_file(
+            "/src/project/conftest.py",
+            r#"
+import pytest
+
+@pytest.fixture
+def resource(): ...
+"#,
+        );
+        assert_snapshot!(test.function("test_use").fixture_resolution("resource"), @"
+        info[pytest-fixture]: Resolve fixture for parameter
+         --> src/project/test_example.py:2:14
+          |
+        2 | def test_use(resource): ...
+          |              ^^^^^^^^ fixture requested here
+        info: Found 1 fixture
+         --> src/project/conftest.py:5:5
+          |
+        5 | def resource(): ...
+          |     --------
+        ");
+    }
+
     struct PytestTestCase {
         db: TestDb,
         path: &'static str,
@@ -2289,6 +2562,23 @@ def test_use(unreachable, typing_only, typing_only_declaration, typing_only_reex
                 db: pytest_db_with_files(files),
                 path,
             }
+        }
+
+        fn with_files_and_src_roots(
+            path: &'static str,
+            files: &[(&'static str, &'static str)],
+            src_roots: Vec<SystemPathBuf>,
+        ) -> Self {
+            Self {
+                db: pytest_db_with_files_and_src_roots(files, src_roots),
+                path,
+            }
+        }
+
+        fn write_file(&mut self, path: &'static str, source: &'static str) {
+            self.db
+                .write_file(path, source)
+                .expect("valid pytest test file update");
         }
 
         fn function<'test>(&'test self, name: &str) -> PytestTestFunction<'test> {
@@ -2398,7 +2688,15 @@ def test_use(unreachable, typing_only, typing_only_declaration, typing_only_reex
     }
 
     fn pytest_db_with_files(files: &[(&'static str, &'static str)]) -> TestDb {
+        pytest_db_with_files_and_src_roots(files, vec![SystemPathBuf::from("/src")])
+    }
+
+    fn pytest_db_with_files_and_src_roots(
+        files: &[(&'static str, &'static str)],
+        src_roots: Vec<SystemPathBuf>,
+    ) -> TestDb {
         let mut builder = TestDbBuilder::new()
+            .with_src_roots(src_roots)
             .with_third_party_packages()
             .with_file(
                 "/.venv/lib/python3.13/site-packages/_pytest/__init__.pyi",


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This extends the model originally introduced in https://github.com/astral-sh/ruff/pull/27443 to support resolving pytest fixtures defined in a [hierarchy of `conftest.py` files](https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files). 

These changes remain unused until https://github.com/astral-sh/ruff/pull/27444.

## Test Plan

See included tests.
<!-- How was it tested? -->
