### PR TITLE
[ty] Expose strict analysis options in the playground

### DIFF
--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -292,6 +292,10 @@ export const DEFAULT_SETTINGS = JSON.stringify(
     environment: {
       "python-version": "3.14",
     },
+    analysis: {
+      "strict-equality-semantics": false,
+      "strict-generic-narrowing": false,
+    },
     rules: {
       "experimental-syntax": "ignore",
       "undefined-reveal": "ignore",


### PR DESCRIPTION
## Summary

Expose `strict-equality-semantics` and `strict-generic-narrowing` in the default playground configuration so that users (and I) can easily change them when necessary.
