### PR TITLE
[ty] Include inherited object members in protocol comparisons

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -307,5 +307,5 @@ error[invalid-return-type]: Return type does not match returned value
 5 |     return 1
   |            ^ expected `Generator[int, int, None]`, found `Literal[1]`
 info: type `Literal[1]` is not assignable to protocol `Generator[int, int, None]`
-info: └── protocol member `__iter__` is not defined on type `Literal[1]`
+info: └── protocol member `__next__` is not defined on type `Literal[1]`
 ```

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4855,6 +4855,53 @@ static_assert(not is_assignable_to(MethodPSuper, MethodPUnrelated))
 static_assert(not is_assignable_to(MethodPSuper, MethodPSub))
 ```
 
+## Object members in protocol-to-protocol comparisons
+
+A protocol inherits ordinary `object` members even when they are not part of its declared interface.
+Those inherited members can satisfy compatible requirements on another protocol.
+
+```py
+from collections.abc import Hashable, Iterator
+from typing import Literal, Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+class HasValue(Protocol):
+    value: int
+
+class HasValueAndRepr(Protocol):
+    value: int
+
+    def __repr__(self) -> str: ...
+
+static_assert(is_assignable_to(HasValue, HasValueAndRepr))
+static_assert(is_subtype_of(HasValue, HasValueAndRepr))
+```
+
+An inherited method must still have a compatible signature.
+
+```py
+class HasValueAndPreciseRepr(Protocol):
+    value: int
+
+    def __repr__(self) -> Literal["precise"]: ...
+
+static_assert(not is_assignable_to(HasValue, HasValueAndPreciseRepr))
+```
+
+Unlike other inherited `object` methods, `__hash__` can be disabled by a subclass. Protocols must
+explicitly require a callable `__hash__` before they can satisfy a hashability requirement.
+
+```py
+class HasValueAndHash(Protocol):
+    value: int
+
+    def __hash__(self) -> int: ...
+
+static_assert(not is_assignable_to(HasValue, HasValueAndHash))
+static_assert(not is_assignable_to(Iterator[int], Hashable))
+```
+
 ## Subtyping between protocols with method members and protocols with non-method members
 
 A protocol with a method member can be considered a subtype of a protocol with a read-only

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -646,21 +646,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return result;
         }
 
-        let structurally_satisfied = if let Type::ProtocolInstance(source_protocol) = ty {
-            self.check_protocol_interface_pair(
-                db,
-                ty,
-                source_protocol.interface(db),
-                protocol.interface(db),
-            )
-        } else {
-            protocol
-                .interface(db)
-                .members(db)
-                .when_all(db, self.constraints, |member| {
-                    self.type_satisfies_protocol_member(db, ty, &member)
-                })
-        };
+        let structurally_satisfied =
+            self.check_type_satisfies_protocol_interface(db, ty, protocol.interface(db));
+
         if let Some(context) = self.report_context()
             && structurally_satisfied.is_never_satisfied(db, env)
         {
@@ -670,6 +658,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             });
         }
         result.or(db, self.constraints, || structurally_satisfied)
+    }
+
+    /// Checks a complete or filtered protocol interface through ordinary member lookup.
+    fn check_type_satisfies_protocol_interface(
+        &self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        interface: ProtocolInterfaceView<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        interface
+            .members_by_structural_priority(db)
+            .when_all(db, self.constraints, |member| {
+                self.type_satisfies_protocol_member(db, ty, &member)
+            })
     }
 
     /// Tries to relate the finite members of two specializations of the same protocol.
@@ -726,13 +728,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        Some(self.check_protocol_interface_pair(
+        Some(self.check_type_satisfies_protocol_interface(
             db,
             ty,
-            ProtocolInterfaceView::new(
-                source_non_recursive,
-                source_interface.materialization_kind(),
-            ),
             ProtocolInterfaceView::new(
                 target_non_recursive,
                 target_interface.materialization_kind(),
@@ -888,12 +886,7 @@ fn non_recursive_protocol_constraints<'db>(
             &signature_relation_visitor,
             &materialization_visitor,
         );
-        checker.check_protocol_interface_pair(
-            db,
-            Type::ProtocolInstance(source),
-            source.interface(db),
-            target,
-        )
+        checker.check_type_satisfies_protocol_interface(db, Type::ProtocolInstance(source), target)
     })
 }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2,7 +2,7 @@ use crate::{Program, ProgramEnvironment};
 use std::fmt::Write;
 use std::{collections::BTreeMap, ops::Deref};
 
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 
 use ruff_python_ast::name::Name;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -348,6 +348,23 @@ pub(super) struct ProtocolInterfaceView<'db> {
     materialization: Option<MaterializationKind>,
 }
 
+/// Cache the order shared by every structural comparison against this interface.
+///
+/// Store names rather than member data so materialized views can reuse the same ordering without
+/// duplicating their interface members in Salsa's cache.
+#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
+fn protocol_member_names_by_structural_priority<'db>(
+    db: &'db dyn Db,
+    interface: ProtocolInterface<'db>,
+) -> Box<[Name]> {
+    let env = ProgramEnvironment::from_program(interface.program(db));
+    interface
+        .members(db)
+        .sorted_by_cached_key(|member| member.structural_member_priority(db, &env))
+        .map(|member| Name::new(member.name()))
+        .collect()
+}
+
 impl<'db> ProtocolInterfaceView<'db> {
     pub(super) const fn new(
         interface: ProtocolInterface<'db>,
@@ -382,6 +399,25 @@ impl<'db> ProtocolInterfaceView<'db> {
                 data,
                 materialization: self.materialization,
             })
+    }
+
+    /// Checks finite requirements before members that can recursively expand a protocol.
+    pub(super) fn members_by_structural_priority<'a>(
+        self,
+        db: &'db dyn Db,
+    ) -> impl Iterator<Item = ProtocolMember<'a, 'db>>
+    where
+        'db: 'a,
+    {
+        if self.member_count(db) < 2 {
+            return Either::Left(self.members(db));
+        }
+
+        Either::Right(
+            protocol_member_names_by_structural_priority(db, self.interface)
+                .iter()
+                .filter_map(move |name| self.member_by_name(db, name)),
+        )
     }
 
     pub(super) fn member_count(self, db: &'db dyn Db) -> usize {
@@ -2422,6 +2458,31 @@ fn protocol_member_read_type<'db>(
         return Some(ty);
     }
 
+    // Reuse declared protocol members to avoid the generic member lookup, descriptor dispatch,
+    // and Salsa interning otherwise required on this common comparison path.
+    if let Type::ProtocolInstance(source_protocol) = ty
+        && let Some(source_member) = source_protocol
+            .interface(db)
+            .member_by_name(db, member.name)
+    {
+        let read = source_member.access(db, env, access).read?;
+
+        if source_member.is_method() {
+            let Type::Callable(callable) = read.resolve(db, env)?.ty() else {
+                return None;
+            };
+
+            let callable = if member.is_method() {
+                callable
+            } else {
+                protocol_apply_self_with_receiver(db, env.program(db), callable, ty, ty)
+            };
+            return Some(Type::Callable(callable));
+        }
+
+        return read.bind_self(db, env, ty);
+    }
+
     // Module-level functions and ordinary methods on class objects are matched through direct
     // member access. Special instance methods still use special-method lookup on the meta-type.
     let place = if access == ProtocolMemberAccessMode::Instance
@@ -2475,7 +2536,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
         let requirement = attribute_write_requirement(db, env, ty, member_name);
-        self.check_property_write_requirement(db, &requirement, member_name, value_ty)
+        let result = self.check_property_write_requirement(db, &requirement, member_name, value_ty);
+
+        if let Some(context) = self.report_context()
+            && result.is_never_satisfied(db, env)
+        {
+            let error = match requirement {
+                AttributeWriteRequirement::ProtocolMember { write: None, .. } => {
+                    ErrorContext::ProtocolMemberNotWritable
+                }
+                _ => ErrorContext::ProtocolMemberWriteTypeIncompatible { target: value_ty },
+            };
+            context.push(error);
+        }
+
+        result
     }
 
     fn check_property_write_requirement(
@@ -2927,22 +3002,39 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             && member.is_instance_method()
             && required.read.is_some()
         {
-            // The instance-side check is authoritative for the signature of a method
-            // implementation. Class access only establishes that the member is present. Callable
-            // types and several callable literal forms do not expose a useful `__call__` member
-            // through their meta-type.
+            // The instance-side check establishes the method's signature without expanding its
+            // recursive receiver twice. Class access must additionally distinguish a method
+            // descriptor from a plain callable class attribute, which cannot bind that receiver.
+            if member.name == "__call__" {
+                return self.always();
+            }
+
+            if protocol_member_read_type(
+                db,
+                self.env,
+                ty,
+                receiver_ty,
+                member,
+                ProtocolMemberAccessMode::Class,
+            )
+            .is_none()
+            {
+                return self.never();
+            }
+
+            // TODO special-casing `ClassVar`s shouldn't be necessary here, this should naturally
+            // fall out of more generalised checks.
+            let qualifiers = if let Type::ProtocolInstance(protocol) = ty
+                && let Some(source_member) = protocol.interface(db).member_by_name(db, member.name)
+            {
+                source_member.qualifiers()
+            } else {
+                receiver_ty.member(db, self.env, member.name).qualifiers
+            };
+
             return ConstraintSet::from_bool(
                 self.constraints,
-                member.name == "__call__"
-                    || protocol_member_read_type(
-                        db,
-                        self.env,
-                        ty,
-                        receiver_ty,
-                        member,
-                        ProtocolMemberAccessMode::Class,
-                    )
-                    .is_some(),
+                !qualifiers.contains(TypeQualifiers::CLASS_VAR),
             );
         }
 
@@ -2969,16 +3061,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     write
                         .bind_compatibility_type(db, env, fallback_ty)
                         .when_some_and(db, self.constraints, |write_ty| {
-                            let result =
-                                self.check_property_write(db, receiver_ty, member.name, write_ty);
-                            if let Some(context) = self.report_context()
-                                && result.is_never_satisfied(db, env)
-                            {
-                                context.push(ErrorContext::ProtocolMemberWriteTypeIncompatible {
-                                    target: write_ty,
-                                });
-                            }
-                            result
+                            self.check_property_write(db, receiver_ty, member.name, write_ty)
                         })
                 },
             )
@@ -2993,6 +3076,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         member: &ProtocolMember<'_, 'db>,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
+        let class_receiver_ty = ty
+            .as_protocol_instance()
+            .map(|protocol| protocol.to_meta_type(db, env))
+            .unwrap_or_else(|| ty.to_meta_type(db, env));
         let instance_access =
             member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Instance);
         if let Some(context) = self.report_context() {
@@ -3014,7 +3101,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     db,
                     env,
                     ty,
-                    ty.to_meta_type(db, env),
+                    class_receiver_ty,
                     member,
                     ProtocolMemberAccessMode::Class,
                 )
@@ -3050,7 +3137,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 self.type_satisfies_protocol_member_access(
                     db,
                     ty,
-                    ty.to_meta_type(db, env),
+                    class_receiver_ty,
                     member,
                     class_access,
                     ProtocolMemberAccessMode::Class,
@@ -3119,157 +3206,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 {
                     context.push(ErrorContext::ProtocolMemberIncompatible {
                         member_name: member.name.into(),
-                    });
-                }
-                result
-            })
-    }
-
-    /// Compares either instance access or class access when relating two protocol members.
-    ///
-    /// Both members bind `Self` to the source protocol type; readable types are compared
-    /// covariantly and writable types contravariantly.
-    fn check_protocol_member_access_pair(
-        &self,
-        db: &'db dyn Db,
-        source_type: Type<'db>,
-        source_member: &ProtocolMember<'_, 'db>,
-        target_member: &ProtocolMember<'_, 'db>,
-        access: ProtocolMemberAccessMode,
-    ) -> ConstraintSet<'db, 'c> {
-        let env = self.env;
-        let source = source_member.access(db, env, access);
-
-        if access == ProtocolMemberAccessMode::Class
-            && source_member.is_method()
-            && target_member.is_instance_method()
-        {
-            // The instance-side check is authoritative for an ordinary method's signature. Class
-            // access only establishes that the source member is also present on the class.
-            return ConstraintSet::from_bool(self.constraints, source.read.is_some());
-        }
-        let target = target_member.access(db, env, access);
-
-        let read_result = match (source.read, target.read) {
-            (_, None) => self.always(),
-            (None, Some(_)) => self.never(),
-            (Some(source), Some(target)) => {
-                let bind_read = |member_type: ProtocolMemberType<'db>,
-                                 member: &ProtocolMember<'_, 'db>| {
-                    let member_type = member_type.resolve(db, env)?;
-                    if member.is_method()
-                        && let Type::Callable(callable) = member_type.ty()
-                    {
-                        Some(Type::Callable(protocol_apply_self_with_receiver(
-                            db,
-                            env.program(db),
-                            callable,
-                            source_type,
-                            source_type,
-                        )))
-                    } else {
-                        member_type.bind_self(db, env, source_type)
-                    }
-                };
-                let (Some(source), Some(target)) = (
-                    bind_read(source, source_member),
-                    bind_read(target, target_member),
-                ) else {
-                    return self.never();
-                };
-                let result = self.check_type_pair(db, source, target);
-                if let Some(context) = self.report_context()
-                    && !target_member.is_method()
-                    && result.is_never_satisfied(db, env)
-                {
-                    context
-                        .push(ErrorContext::ProtocolMemberReadTypeIncompatible { source, target });
-                }
-                result
-            }
-        };
-
-        read_result.and(db, self.constraints, || {
-            match (source.write, target.write) {
-                (_, None) => self.always(),
-                (None, Some(_)) => {
-                    if let Some(context) = self.report_context() {
-                        context.push(ErrorContext::ProtocolMemberNotWritable);
-                    }
-                    self.never()
-                }
-                (Some(source), Some(target)) => {
-                    let (Some(target), Some(source)) = (
-                        target.bind_compatibility_type(db, env, source_type),
-                        source.bind_compatibility_type(db, env, source_type),
-                    ) else {
-                        return self.never();
-                    };
-                    let result = self.check_type_pair(db, target, source);
-                    if let Some(context) = self.report_context()
-                        && result.is_never_satisfied(db, env)
-                    {
-                        context.push(ErrorContext::ProtocolMemberWriteTypeIncompatible { target });
-                    }
-                    result
-                }
-            }
-        })
-    }
-
-    pub(super) fn check_protocol_interface_pair(
-        &self,
-        db: &'db dyn Db,
-        source_type: Type<'db>,
-        source: ProtocolInterfaceView<'db>,
-        target: ProtocolInterfaceView<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        if source.member_count(db) < target.member_count(db)
-            && !self.is_context_collection_enabled()
-        {
-            return self.never();
-        }
-
-        let env = self.env;
-        target
-            .members(db)
-            .sorted_by_cached_key(|member| member.structural_member_priority(db, env))
-            .when_all(db, self.constraints, |target_member| {
-                let source_member = source.member_by_name(db, target_member.name);
-
-                if let Some(context) = self.report_context()
-                    && source_member.is_none()
-                {
-                    context.push(ErrorContext::ProtocolMemberNotDefined {
-                        member_name: target_member.name.into(),
-                        ty: source_type,
-                    });
-                    return self.never();
-                }
-
-                let result = source_member.when_some_and(db, self.constraints, |source_member| {
-                    self.check_protocol_member_access_pair(
-                        db,
-                        source_type,
-                        &source_member,
-                        &target_member,
-                        ProtocolMemberAccessMode::Instance,
-                    )
-                    .and(db, self.constraints, || {
-                        self.check_protocol_member_access_pair(
-                            db,
-                            source_type,
-                            &source_member,
-                            &target_member,
-                            ProtocolMemberAccessMode::Class,
-                        )
-                    })
-                });
-                if let Some(context) = self.report_context()
-                    && result.is_never_satisfied(db, env)
-                {
-                    context.push(ErrorContext::ProtocolMemberIncompatible {
-                        member_name: target_member.name.into(),
                     });
                 }
                 result
@@ -3625,6 +3561,38 @@ fn callable_has_only_non_never_returns<'db>(db: &'db dyn Db, callable: CallableT
         && signatures.all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
 }
 
+/// Count interface members that a protocol can satisfy by inheriting them from `object`.
+///
+/// Walk `object`'s small class scope instead of probing every interface member. Cache the result
+/// because the same target interface is often compared with many source protocols.
+#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+fn inherited_object_protocol_member_count<'db>(
+    db: &'db dyn Db,
+    interface: ProtocolInterface<'db>,
+) -> usize {
+    let env = ProgramEnvironment::from_program(interface.program(db));
+    let object = ClassType::object(db, &env)
+        .class_literal(db)
+        .as_static()
+        .expect("`object` should always be a static class literal");
+
+    place_table(db, object.body_scope(db))
+        .symbols()
+        .filter(|symbol| {
+            let name = symbol.name();
+            name != "__hash__"
+                && interface.includes_member(db, name)
+                && matches!(
+                    Type::object().member(db, &env, name).place,
+                    Place::Defined(DefinedPlace {
+                        definedness: Definedness::AlwaysDefined,
+                        ..
+                    })
+                )
+        })
+        .count()
+}
+
 /// Protocol compatibility can only succeed if every required member is present.
 ///
 /// Check that necessary condition up front so we can avoid expensive per-member type
@@ -3640,11 +3608,32 @@ pub(super) fn has_all_protocol_members_defined<'db>(
     match ty {
         Type::ProtocolInstance(source_protocol) => {
             let source_interface = source_protocol.interface(db);
+            let source_member_count = source_interface.member_count(db);
+            let target_member_count = target_interface.member_count(db);
 
-            source_interface.member_count(db) >= target_interface.member_count(db)
-                && target_interface
-                    .members(db)
-                    .all(|member| source_interface.includes_member(db, member.name()))
+            // The source count includes declared `object` members, so it can miss an early
+            // rejection. That is safe because the complete member check below still determines
+            // whether the protocols are compatible.
+            if source_member_count < target_member_count
+                && source_member_count.saturating_add(inherited_object_protocol_member_count(
+                    db,
+                    target_interface.base(),
+                )) < target_member_count
+            {
+                return false;
+            }
+
+            target_interface.members(db).all(|member| {
+                source_interface.includes_member(db, member.name())
+                    || member.name() != "__hash__"
+                        && matches!(
+                            Type::object().member(db, env, member.name()).place,
+                            Place::Defined(DefinedPlace {
+                                definedness: Definedness::AlwaysDefined,
+                                ..
+                            })
+                        )
+            })
         }
         _ => target_interface.members(db).all(|member| {
             matches!(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1536,41 +1536,62 @@ impl<'db> ProtocolMemberData<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> ProtocolMemberCapabilities<'db> {
-        match self.kind {
-            ProtocolMemberKind::Method(member, kind) => {
-                let instance_method = match (member.ty(), kind) {
-                    (Type::Callable(callable), ProtocolMethodKind::Instance) => member.with_ty(
-                        Type::Callable(protocol_bind_self(db, env.program(db), callable, None)),
-                    ),
-                    _ => member,
-                };
-                ProtocolMemberCapabilities {
-                    instance: ProtocolMemberAccess::new(Some(instance_method), None),
-                    class: ProtocolMemberAccess::new(Some(member), None),
-                }
+        ProtocolMemberCapabilities {
+            instance: self.access(db, env, ProtocolMemberAccessMode::Instance),
+            class: self.access(db, env, ProtocolMemberAccessMode::Class),
+        }
+    }
+
+    /// Derive only the requested access so class access does not bind an unused instance receiver.
+    fn access(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        mode: ProtocolMemberAccessMode,
+    ) -> ProtocolMemberAccess<'db> {
+        match (self.kind, mode) {
+            (
+                ProtocolMemberKind::Method(member, ProtocolMethodKind::Instance),
+                ProtocolMemberAccessMode::Instance,
+            ) => {
+                let member =
+                    match member.ty() {
+                        Type::Callable(callable) => member.with_ty(Type::Callable(
+                            protocol_bind_self(db, env.program(db), callable, None),
+                        )),
+                        _ => member,
+                    };
+                ProtocolMemberAccess::new(Some(member), None)
             }
-            ProtocolMemberKind::Property { read, write } => ProtocolMemberCapabilities {
-                instance: ProtocolMemberAccess::new(read, write),
-                class: ProtocolMemberAccess::NONE,
-            },
-            ProtocolMemberKind::Attribute(member_ty) => {
+            (ProtocolMemberKind::Method(member, _), _) => {
+                ProtocolMemberAccess::new(Some(member), None)
+            }
+            (ProtocolMemberKind::Property { read, write }, ProtocolMemberAccessMode::Instance) => {
+                ProtocolMemberAccess::new(read, write)
+            }
+            (ProtocolMemberKind::Property { .. }, ProtocolMemberAccessMode::Class) => {
+                ProtocolMemberAccess::NONE
+            }
+            (ProtocolMemberKind::Attribute(member_ty), ProtocolMemberAccessMode::Instance) => {
                 let is_class_var = self.qualifiers.contains(TypeQualifiers::CLASS_VAR);
                 let is_final = self.qualifiers.contains(TypeQualifiers::FINAL);
-                ProtocolMemberCapabilities {
-                    instance: ProtocolMemberAccess::new(
-                        Some(member_ty),
-                        (!is_class_var && !is_final)
-                            .then_some(ProtocolMemberWrite::from_type(member_ty)),
-                    ),
-                    class: if is_class_var {
-                        ProtocolMemberAccess::new(
-                            Some(member_ty),
-                            (!is_final).then_some(ProtocolMemberWrite::from_type(member_ty)),
-                        )
-                    } else {
-                        ProtocolMemberAccess::NONE
-                    },
-                }
+                ProtocolMemberAccess::new(
+                    Some(member_ty),
+                    (!is_class_var && !is_final)
+                        .then_some(ProtocolMemberWrite::from_type(member_ty)),
+                )
+            }
+            (ProtocolMemberKind::Attribute(member_ty), ProtocolMemberAccessMode::Class)
+                if self.qualifiers.contains(TypeQualifiers::CLASS_VAR) =>
+            {
+                ProtocolMemberAccess::new(
+                    Some(member_ty),
+                    (!self.qualifiers.contains(TypeQualifiers::FINAL))
+                        .then_some(ProtocolMemberWrite::from_type(member_ty)),
+                )
+            }
+            (ProtocolMemberKind::Attribute(_), ProtocolMemberAccessMode::Class) => {
+                ProtocolMemberAccess::NONE
             }
         }
     }
@@ -2116,11 +2137,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         env: &ProgramEnvironment<'db>,
         mode: ProtocolMemberAccessMode,
     ) -> ProtocolMemberAccess<'db> {
-        let capabilities = self.data.capabilities(db, env);
-        let access = match mode {
-            ProtocolMemberAccessMode::Instance => capabilities.instance,
-            ProtocolMemberAccessMode::Class => capabilities.class,
-        };
+        let access = self.data.access(db, env, mode);
         self.materialization
             .map_or(access, |kind| access.materialize(db, env, kind))
     }
@@ -2447,6 +2464,7 @@ fn protocol_member_read_type<'db>(
     ty: Type<'db>,
     receiver_ty: Type<'db>,
     member: &ProtocolMember<'_, 'db>,
+    source_member: Option<&ProtocolMember<'_, 'db>>,
     access: ProtocolMemberAccessMode,
 ) -> Option<Type<'db>> {
     // A callback protocol describes call syntax. Use the candidate's callable type instead of an
@@ -2460,11 +2478,7 @@ fn protocol_member_read_type<'db>(
 
     // Reuse declared protocol members to avoid the generic member lookup, descriptor dispatch,
     // and Salsa interning otherwise required on this common comparison path.
-    if let Type::ProtocolInstance(source_protocol) = ty
-        && let Some(source_member) = source_protocol
-            .interface(db)
-            .member_by_name(db, member.name)
-    {
+    if let Some(source_member) = source_member {
         let read = source_member.access(db, env, access).read?;
 
         if source_member.is_method() {
@@ -2526,16 +2540,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ///
     /// Resolution is shared with real assignments, but this path evaluates the result using the
     /// active type relation and constraints instead of inferring an expression or emitting an
-    /// assignment diagnostic.
+    /// assignment diagnostic. A previously resolved protocol requirement avoids looking up the
+    /// same declared member again.
     fn check_property_write(
         &self,
         db: &'db dyn Db,
         ty: Type<'db>,
         member_name: &str,
         value_ty: Type<'db>,
+        protocol_requirement: Option<AttributeWriteRequirement<'db>>,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
-        let requirement = attribute_write_requirement(db, env, ty, member_name);
+        let requirement = protocol_requirement
+            .unwrap_or_else(|| attribute_write_requirement(db, env, ty, member_name));
         let result = self.check_property_write_requirement(db, &requirement, member_name, value_ty);
 
         if let Some(context) = self.report_context()
@@ -2863,12 +2880,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         receiver_ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
+        source_member: Option<&ProtocolMember<'_, 'db>>,
         required_ty: ProtocolMemberType<'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
         let Some(attribute_type) =
-            protocol_member_read_type(db, env, ty, receiver_ty, member, access)
+            protocol_member_read_type(db, env, ty, receiver_ty, member, source_member, access)
         else {
             return self.never();
         };
@@ -2995,6 +3013,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         receiver_ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
+        source_member: Option<&ProtocolMember<'_, 'db>>,
         required: ProtocolMemberAccess<'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
@@ -3009,12 +3028,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 return self.always();
             }
 
+            if source_member.is_some_and(ProtocolMember::is_method) {
+                return self.always();
+            }
+
             if protocol_member_read_type(
                 db,
                 self.env,
                 ty,
                 receiver_ty,
                 member,
+                source_member,
                 ProtocolMemberAccessMode::Class,
             )
             .is_none()
@@ -3024,9 +3048,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             // TODO special-casing `ClassVar`s shouldn't be necessary here, this should naturally
             // fall out of more generalised checks.
-            let qualifiers = if let Type::ProtocolInstance(protocol) = ty
-                && let Some(source_member) = protocol.interface(db).member_by_name(db, member.name)
-            {
+            let qualifiers = if let Some(source_member) = source_member {
                 source_member.qualifiers()
             } else {
                 receiver_ty.member(db, self.env, member.name).qualifiers
@@ -3041,7 +3063,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let read_result = required.read.map_or_else(
             || self.always(),
             |required_ty| {
-                self.check_protocol_member_read(db, ty, receiver_ty, member, required_ty, access)
+                self.check_protocol_member_read(
+                    db,
+                    ty,
+                    receiver_ty,
+                    member,
+                    source_member,
+                    required_ty,
+                    access,
+                )
             },
         );
 
@@ -3061,7 +3091,30 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     write
                         .bind_compatibility_type(db, env, fallback_ty)
                         .when_some_and(db, self.constraints, |write_ty| {
-                            self.check_property_write(db, receiver_ty, member.name, write_ty)
+                            let protocol_requirement = source_member.map(|source_member| {
+                                let write = source_member.access(db, env, access).write;
+                                let write = match access {
+                                    ProtocolMemberAccessMode::Instance => write.and_then(|write| {
+                                        write.bind_requirement(db, env, receiver_ty)
+                                    }),
+                                    ProtocolMemberAccessMode::Class => write
+                                        .and_then(|write| {
+                                            write.bind_compatibility_type(db, env, ty)
+                                        })
+                                        .map(ProtocolMemberWriteRequirement::AssignableTo),
+                                };
+                                AttributeWriteRequirement::ProtocolMember {
+                                    write,
+                                    qualifiers: source_member.qualifiers(),
+                                }
+                            });
+                            self.check_property_write(
+                                db,
+                                receiver_ty,
+                                member.name,
+                                write_ty,
+                                protocol_requirement,
+                            )
                         })
                 },
             )
@@ -3076,12 +3129,27 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         member: &ProtocolMember<'_, 'db>,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
-        let class_receiver_ty = ty
-            .as_protocol_instance()
-            .map(|protocol| protocol.to_meta_type(db, env))
-            .unwrap_or_else(|| ty.to_meta_type(db, env));
+        let source_protocol = ty.as_protocol_instance();
+        let source_member = source_protocol
+            .and_then(|protocol| protocol.interface(db).member_by_name(db, member.name));
         let instance_access =
             member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Instance);
+        let class_access =
+            member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Class);
+        // A declared protocol method already guarantees class-side presence. Callback protocols
+        // instead use the candidate's callable type directly, so neither needs a class receiver.
+        let class_access_already_satisfied = member.is_instance_method()
+            && (member.name == "__call__"
+                || source_member
+                    .as_ref()
+                    .is_some_and(ProtocolMember::is_method));
+        let class_receiver_ty = (class_access != ProtocolMemberAccess::NONE
+            && !class_access_already_satisfied)
+            .then(|| {
+                source_protocol
+                    .map(|protocol| protocol.to_meta_type(db, env))
+                    .unwrap_or_else(|| ty.to_meta_type(db, env))
+            });
         if let Some(context) = self.report_context() {
             let instance_read_missing = instance_access.read.is_some()
                 && protocol_member_read_type(
@@ -3090,23 +3158,27 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ty,
                     ty,
                     member,
+                    source_member.as_ref(),
                     ProtocolMemberAccessMode::Instance,
                 )
                 .is_none();
-            let class_access =
-                member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Class);
-            let class_read_missing = class_access.read.is_some()
-                && !(member.is_instance_method() && member.name == "__call__")
-                && protocol_member_read_type(
-                    db,
-                    env,
-                    ty,
-                    class_receiver_ty,
-                    member,
-                    ProtocolMemberAccessMode::Class,
-                )
-                .is_none();
-            if instance_read_missing || class_read_missing {
+            let class_read_missing = || {
+                class_access.read.is_some()
+                    && !(member.is_instance_method() && member.name == "__call__")
+                    && class_receiver_ty.is_some_and(|class_receiver_ty| {
+                        protocol_member_read_type(
+                            db,
+                            env,
+                            ty,
+                            class_receiver_ty,
+                            member,
+                            source_member.as_ref(),
+                            ProtocolMemberAccessMode::Class,
+                        )
+                        .is_none()
+                    })
+            };
+            if instance_read_missing || class_read_missing() {
                 if instance_read_missing
                     && is_class_object_type(ty)
                     && member.is_instance_method()
@@ -3122,27 +3194,30 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
-        let result = self
-            .type_satisfies_protocol_member_access(
-                db,
-                ty,
-                ty,
-                member,
-                instance_access,
-                ProtocolMemberAccessMode::Instance,
-            )
-            .and(db, self.constraints, || {
-                let class_access =
-                    member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Class);
+        let instance_result = self.type_satisfies_protocol_member_access(
+            db,
+            ty,
+            ty,
+            member,
+            source_member.as_ref(),
+            instance_access,
+            ProtocolMemberAccessMode::Instance,
+        );
+        let result = if let Some(class_receiver_ty) = class_receiver_ty {
+            instance_result.and(db, self.constraints, || {
                 self.type_satisfies_protocol_member_access(
                     db,
                     ty,
                     class_receiver_ty,
                     member,
+                    source_member.as_ref(),
                     class_access,
                     ProtocolMemberAccessMode::Class,
                 )
-            });
+            })
+        } else {
+            instance_result
+        };
         if let Some(context) = self.report_context()
             && result.is_never_satisfied(db, env)
         {
@@ -3176,6 +3251,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     return self.always();
                 }
 
+                let source_member = instance_ty
+                    .as_protocol_instance()
+                    .and_then(|protocol| protocol.interface(db).member_by_name(db, member.name));
                 let result = if member.is_method() {
                     required.read.map_or_else(
                         || self.always(),
@@ -3185,6 +3263,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 instance_ty,
                                 meta_ty,
                                 &member,
+                                source_member.as_ref(),
                                 required_ty,
                                 ProtocolMemberAccessMode::Class,
                             )
@@ -3196,6 +3275,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         instance_ty,
                         meta_ty,
                         &member,
+                        source_member.as_ref(),
                         required,
                         ProtocolMemberAccessMode::Class,
                     )

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1536,62 +1536,41 @@ impl<'db> ProtocolMemberData<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> ProtocolMemberCapabilities<'db> {
-        ProtocolMemberCapabilities {
-            instance: self.access(db, env, ProtocolMemberAccessMode::Instance),
-            class: self.access(db, env, ProtocolMemberAccessMode::Class),
-        }
-    }
-
-    /// Derive only the requested access so class access does not bind an unused instance receiver.
-    fn access(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        mode: ProtocolMemberAccessMode,
-    ) -> ProtocolMemberAccess<'db> {
-        match (self.kind, mode) {
-            (
-                ProtocolMemberKind::Method(member, ProtocolMethodKind::Instance),
-                ProtocolMemberAccessMode::Instance,
-            ) => {
-                let member =
-                    match member.ty() {
-                        Type::Callable(callable) => member.with_ty(Type::Callable(
-                            protocol_bind_self(db, env.program(db), callable, None),
-                        )),
-                        _ => member,
-                    };
-                ProtocolMemberAccess::new(Some(member), None)
+        match self.kind {
+            ProtocolMemberKind::Method(member, kind) => {
+                let instance_method = match (member.ty(), kind) {
+                    (Type::Callable(callable), ProtocolMethodKind::Instance) => member.with_ty(
+                        Type::Callable(protocol_bind_self(db, env.program(db), callable, None)),
+                    ),
+                    _ => member,
+                };
+                ProtocolMemberCapabilities {
+                    instance: ProtocolMemberAccess::new(Some(instance_method), None),
+                    class: ProtocolMemberAccess::new(Some(member), None),
+                }
             }
-            (ProtocolMemberKind::Method(member, _), _) => {
-                ProtocolMemberAccess::new(Some(member), None)
-            }
-            (ProtocolMemberKind::Property { read, write }, ProtocolMemberAccessMode::Instance) => {
-                ProtocolMemberAccess::new(read, write)
-            }
-            (ProtocolMemberKind::Property { .. }, ProtocolMemberAccessMode::Class) => {
-                ProtocolMemberAccess::NONE
-            }
-            (ProtocolMemberKind::Attribute(member_ty), ProtocolMemberAccessMode::Instance) => {
+            ProtocolMemberKind::Property { read, write } => ProtocolMemberCapabilities {
+                instance: ProtocolMemberAccess::new(read, write),
+                class: ProtocolMemberAccess::NONE,
+            },
+            ProtocolMemberKind::Attribute(member_ty) => {
                 let is_class_var = self.qualifiers.contains(TypeQualifiers::CLASS_VAR);
                 let is_final = self.qualifiers.contains(TypeQualifiers::FINAL);
-                ProtocolMemberAccess::new(
-                    Some(member_ty),
-                    (!is_class_var && !is_final)
-                        .then_some(ProtocolMemberWrite::from_type(member_ty)),
-                )
-            }
-            (ProtocolMemberKind::Attribute(member_ty), ProtocolMemberAccessMode::Class)
-                if self.qualifiers.contains(TypeQualifiers::CLASS_VAR) =>
-            {
-                ProtocolMemberAccess::new(
-                    Some(member_ty),
-                    (!self.qualifiers.contains(TypeQualifiers::FINAL))
-                        .then_some(ProtocolMemberWrite::from_type(member_ty)),
-                )
-            }
-            (ProtocolMemberKind::Attribute(_), ProtocolMemberAccessMode::Class) => {
-                ProtocolMemberAccess::NONE
+                ProtocolMemberCapabilities {
+                    instance: ProtocolMemberAccess::new(
+                        Some(member_ty),
+                        (!is_class_var && !is_final)
+                            .then_some(ProtocolMemberWrite::from_type(member_ty)),
+                    ),
+                    class: if is_class_var {
+                        ProtocolMemberAccess::new(
+                            Some(member_ty),
+                            (!is_final).then_some(ProtocolMemberWrite::from_type(member_ty)),
+                        )
+                    } else {
+                        ProtocolMemberAccess::NONE
+                    },
+                }
             }
         }
     }
@@ -2137,7 +2116,11 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         env: &ProgramEnvironment<'db>,
         mode: ProtocolMemberAccessMode,
     ) -> ProtocolMemberAccess<'db> {
-        let access = self.data.access(db, env, mode);
+        let capabilities = self.data.capabilities(db, env);
+        let access = match mode {
+            ProtocolMemberAccessMode::Instance => capabilities.instance,
+            ProtocolMemberAccessMode::Class => capabilities.class,
+        };
         self.materialization
             .map_or(access, |kind| access.materialize(db, env, kind))
     }
@@ -2464,7 +2447,6 @@ fn protocol_member_read_type<'db>(
     ty: Type<'db>,
     receiver_ty: Type<'db>,
     member: &ProtocolMember<'_, 'db>,
-    source_member: Option<&ProtocolMember<'_, 'db>>,
     access: ProtocolMemberAccessMode,
 ) -> Option<Type<'db>> {
     // A callback protocol describes call syntax. Use the candidate's callable type instead of an
@@ -2478,7 +2460,11 @@ fn protocol_member_read_type<'db>(
 
     // Reuse declared protocol members to avoid the generic member lookup, descriptor dispatch,
     // and Salsa interning otherwise required on this common comparison path.
-    if let Some(source_member) = source_member {
+    if let Type::ProtocolInstance(source_protocol) = ty
+        && let Some(source_member) = source_protocol
+            .interface(db)
+            .member_by_name(db, member.name)
+    {
         let read = source_member.access(db, env, access).read?;
 
         if source_member.is_method() {
@@ -2540,19 +2526,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ///
     /// Resolution is shared with real assignments, but this path evaluates the result using the
     /// active type relation and constraints instead of inferring an expression or emitting an
-    /// assignment diagnostic. A previously resolved protocol requirement avoids looking up the
-    /// same declared member again.
+    /// assignment diagnostic.
     fn check_property_write(
         &self,
         db: &'db dyn Db,
         ty: Type<'db>,
         member_name: &str,
         value_ty: Type<'db>,
-        protocol_requirement: Option<AttributeWriteRequirement<'db>>,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
-        let requirement = protocol_requirement
-            .unwrap_or_else(|| attribute_write_requirement(db, env, ty, member_name));
+        let requirement = attribute_write_requirement(db, env, ty, member_name);
         let result = self.check_property_write_requirement(db, &requirement, member_name, value_ty);
 
         if let Some(context) = self.report_context()
@@ -2880,13 +2863,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         receiver_ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
-        source_member: Option<&ProtocolMember<'_, 'db>>,
         required_ty: ProtocolMemberType<'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
         let Some(attribute_type) =
-            protocol_member_read_type(db, env, ty, receiver_ty, member, source_member, access)
+            protocol_member_read_type(db, env, ty, receiver_ty, member, access)
         else {
             return self.never();
         };
@@ -3013,7 +2995,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         receiver_ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
-        source_member: Option<&ProtocolMember<'_, 'db>>,
         required: ProtocolMemberAccess<'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
@@ -3028,17 +3009,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 return self.always();
             }
 
-            if source_member.is_some_and(ProtocolMember::is_method) {
-                return self.always();
-            }
-
             if protocol_member_read_type(
                 db,
                 self.env,
                 ty,
                 receiver_ty,
                 member,
-                source_member,
                 ProtocolMemberAccessMode::Class,
             )
             .is_none()
@@ -3048,7 +3024,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             // TODO special-casing `ClassVar`s shouldn't be necessary here, this should naturally
             // fall out of more generalised checks.
-            let qualifiers = if let Some(source_member) = source_member {
+            let qualifiers = if let Type::ProtocolInstance(protocol) = ty
+                && let Some(source_member) = protocol.interface(db).member_by_name(db, member.name)
+            {
                 source_member.qualifiers()
             } else {
                 receiver_ty.member(db, self.env, member.name).qualifiers
@@ -3063,15 +3041,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let read_result = required.read.map_or_else(
             || self.always(),
             |required_ty| {
-                self.check_protocol_member_read(
-                    db,
-                    ty,
-                    receiver_ty,
-                    member,
-                    source_member,
-                    required_ty,
-                    access,
-                )
+                self.check_protocol_member_read(db, ty, receiver_ty, member, required_ty, access)
             },
         );
 
@@ -3091,30 +3061,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     write
                         .bind_compatibility_type(db, env, fallback_ty)
                         .when_some_and(db, self.constraints, |write_ty| {
-                            let protocol_requirement = source_member.map(|source_member| {
-                                let write = source_member.access(db, env, access).write;
-                                let write = match access {
-                                    ProtocolMemberAccessMode::Instance => write.and_then(|write| {
-                                        write.bind_requirement(db, env, receiver_ty)
-                                    }),
-                                    ProtocolMemberAccessMode::Class => write
-                                        .and_then(|write| {
-                                            write.bind_compatibility_type(db, env, ty)
-                                        })
-                                        .map(ProtocolMemberWriteRequirement::AssignableTo),
-                                };
-                                AttributeWriteRequirement::ProtocolMember {
-                                    write,
-                                    qualifiers: source_member.qualifiers(),
-                                }
-                            });
-                            self.check_property_write(
-                                db,
-                                receiver_ty,
-                                member.name,
-                                write_ty,
-                                protocol_requirement,
-                            )
+                            self.check_property_write(db, receiver_ty, member.name, write_ty)
                         })
                 },
             )
@@ -3129,27 +3076,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         member: &ProtocolMember<'_, 'db>,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
-        let source_protocol = ty.as_protocol_instance();
-        let source_member = source_protocol
-            .and_then(|protocol| protocol.interface(db).member_by_name(db, member.name));
+        let class_receiver_ty = ty
+            .as_protocol_instance()
+            .map(|protocol| protocol.to_meta_type(db, env))
+            .unwrap_or_else(|| ty.to_meta_type(db, env));
         let instance_access =
             member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Instance);
-        let class_access =
-            member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Class);
-        // A declared protocol method already guarantees class-side presence. Callback protocols
-        // instead use the candidate's callable type directly, so neither needs a class receiver.
-        let class_access_already_satisfied = member.is_instance_method()
-            && (member.name == "__call__"
-                || source_member
-                    .as_ref()
-                    .is_some_and(ProtocolMember::is_method));
-        let class_receiver_ty = (class_access != ProtocolMemberAccess::NONE
-            && !class_access_already_satisfied)
-            .then(|| {
-                source_protocol
-                    .map(|protocol| protocol.to_meta_type(db, env))
-                    .unwrap_or_else(|| ty.to_meta_type(db, env))
-            });
         if let Some(context) = self.report_context() {
             let instance_read_missing = instance_access.read.is_some()
                 && protocol_member_read_type(
@@ -3158,27 +3090,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ty,
                     ty,
                     member,
-                    source_member.as_ref(),
                     ProtocolMemberAccessMode::Instance,
                 )
                 .is_none();
-            let class_read_missing = || {
-                class_access.read.is_some()
-                    && !(member.is_instance_method() && member.name == "__call__")
-                    && class_receiver_ty.is_some_and(|class_receiver_ty| {
-                        protocol_member_read_type(
-                            db,
-                            env,
-                            ty,
-                            class_receiver_ty,
-                            member,
-                            source_member.as_ref(),
-                            ProtocolMemberAccessMode::Class,
-                        )
-                        .is_none()
-                    })
-            };
-            if instance_read_missing || class_read_missing() {
+            let class_access =
+                member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Class);
+            let class_read_missing = class_access.read.is_some()
+                && !(member.is_instance_method() && member.name == "__call__")
+                && protocol_member_read_type(
+                    db,
+                    env,
+                    ty,
+                    class_receiver_ty,
+                    member,
+                    ProtocolMemberAccessMode::Class,
+                )
+                .is_none();
+            if instance_read_missing || class_read_missing {
                 if instance_read_missing
                     && is_class_object_type(ty)
                     && member.is_instance_method()
@@ -3194,30 +3122,27 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
-        let instance_result = self.type_satisfies_protocol_member_access(
-            db,
-            ty,
-            ty,
-            member,
-            source_member.as_ref(),
-            instance_access,
-            ProtocolMemberAccessMode::Instance,
-        );
-        let result = if let Some(class_receiver_ty) = class_receiver_ty {
-            instance_result.and(db, self.constraints, || {
+        let result = self
+            .type_satisfies_protocol_member_access(
+                db,
+                ty,
+                ty,
+                member,
+                instance_access,
+                ProtocolMemberAccessMode::Instance,
+            )
+            .and(db, self.constraints, || {
+                let class_access =
+                    member.implementation_access(db, env, ty, ProtocolMemberAccessMode::Class);
                 self.type_satisfies_protocol_member_access(
                     db,
                     ty,
                     class_receiver_ty,
                     member,
-                    source_member.as_ref(),
                     class_access,
                     ProtocolMemberAccessMode::Class,
                 )
-            })
-        } else {
-            instance_result
-        };
+            });
         if let Some(context) = self.report_context()
             && result.is_never_satisfied(db, env)
         {
@@ -3251,9 +3176,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     return self.always();
                 }
 
-                let source_member = instance_ty
-                    .as_protocol_instance()
-                    .and_then(|protocol| protocol.interface(db).member_by_name(db, member.name));
                 let result = if member.is_method() {
                     required.read.map_or_else(
                         || self.always(),
@@ -3263,7 +3185,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 instance_ty,
                                 meta_ty,
                                 &member,
-                                source_member.as_ref(),
                                 required_ty,
                                 ProtocolMemberAccessMode::Class,
                             )
@@ -3275,7 +3196,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         instance_ty,
                         meta_ty,
                         &member,
-                        source_member.as_ref(),
                         required,
                         ProtocolMemberAccessMode::Class,
                     )


### PR DESCRIPTION
## Summary

- Route protocol-to-protocol comparisons through ordinary member lookup so inherited `object` methods can satisfy compatible structural requirements.
- Preserve hashability semantics by requiring protocols to explicitly provide a callable `__hash__`.
- Keep recursive protocol comparisons ordered safely and retain distinct diagnostics for read-only protocol members.