### PR TITLE
[ty] Avoid order-dependent inference for guarded attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4865,6 +4865,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "test-case",
+ "thin-vec",
  "thiserror 2.0.19",
  "tracing",
  "ty_module_resolver",

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -32,7 +32,7 @@ bitflags = { workspace = true }
 char_str = { workspace = true }
 compact_str = { workspace = true }
 drop_bomb = { workspace = true }
-get-size2 = { workspace = true, features = ["indexmap", "ordermap"] }
+get-size2 = { workspace = true, features = ["indexmap", "ordermap", "thin-vec"] }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
@@ -47,6 +47,7 @@ static_assertions = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
+thin-vec = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -385,6 +385,80 @@ class Cached:
 reveal_type(Cached().metadata)  # revealed: int
 ```
 
+## Guarded instance attributes when the base is checked first
+
+A guarded bound-method initializer remains valid, while another initializer still reports an
+attribute that is missing from the base class.
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self):
+        if not hasattr(self, "x"):
+            self.x = self.__str__
+        if not hasattr(self, "z"):
+            self.z = self.y  # error: [unresolved-attribute]
+```
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+
+    def z(self): ...
+    def y(self): ...
+```
+
+## Guarded instance attributes when the subclass is checked first
+
+Checking the subclass first preserves the valid initializer and the missing-attribute diagnostic.
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+
+    def z(self): ...
+    def y(self): ...
+```
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self):
+        if not hasattr(self, "x"):
+            self.x = self.__str__
+        if not hasattr(self, "z"):
+            self.z = self.y  # error: [unresolved-attribute]
+```
+
+## Assignments in the opposite guard branch do not initialize an attribute
+
+Assigning an existing attribute when `hasattr` succeeds does not initialize it in the opposite
+branch. That branch remains unreachable and cannot create another instance attribute.
+
+```py
+class C:
+    def __init__(self):
+        self.x = 1
+
+    def update(self):
+        if hasattr(self, "x"):
+            self.x = 2
+        else:
+            self.y = self.missing
+
+C().y  # error: [unresolved-attribute]
+```
+
 ## Decorator defined on a base class with constrained typevars, accessed from a subclass with decorated generic parameters
 
 This example was minimized from

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6109,7 +6109,8 @@ the key, because "extra items" are allowed by default. For example, even though 
 define a `"foo"` field, it could be _assigned to_ with another `TypedDict` that does:
 
 ```py
-from typing_extensions import Literal
+from collections.abc import Mapping
+from typing_extensions import Literal, TypeGuard
 
 class Foo(TypedDict):
     foo: int
@@ -6142,9 +6143,52 @@ static_assert(is_assignable_to(FooBar, Bar))
 
 def dictionary_union(u: Foo | dict[Literal["a", "b"], int]):
     if "c" in u:
-        # TODO: This should stop erroring if we prove that the `dict` arm cannot contain `"c"`.
-        # error: [invalid-argument-type]
         reveal_type(u["c"])  # revealed: object
+
+def mapping_union(u: Foo | Mapping[Literal["a", "b"], int]):
+    if "c" in u:
+        reveal_type(u["c"])  # revealed: object
+
+def mapping_only(
+    mapping: Mapping[Literal["a", "b"], int],
+    broad_mapping: Mapping[str, int],
+):
+    if "c" in mapping:
+        reveal_type(mapping["c"])  # revealed: object
+    if "c" in broad_mapping:
+        reveal_type(broad_mapping["c"])  # revealed: int
+
+def multiple_membership_tests(u: Foo | Bar):
+    has_foo = "foo" in u
+    has_bar = "bar" in u
+    if has_foo and has_bar:
+        reveal_type(u["foo"])  # revealed: object
+        reveal_type(u["bar"])  # revealed: object
+
+def nested_membership_tests(u: Foo | Bar):
+    if "foo" in u:
+        if "bar" in u:
+            reveal_type(u["foo"])  # revealed: object
+            reveal_type(u["bar"])  # revealed: object
+
+def multiple_mapping_membership_tests(mapping: Mapping[Literal["a", "b"], int]):
+    has_c = "c" in mapping
+    has_d = "d" in mapping
+    if has_c and has_d:
+        reveal_type(mapping["c"])  # revealed: object
+        reveal_type(mapping["d"])  # revealed: object
+
+def guard_object(value: object) -> TypeGuard[object]:
+    return True
+
+def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
+    has_c = "c" in u
+    if guard_object(u) and has_c:
+        reveal_type(u["c"])  # revealed: object
+    if has_c and guard_object(u):
+        reveal_type(u)  # revealed: object
+    if "c" in u and guard_object(u):
+        reveal_type(u)  # revealed: object
 
 def literal_union(u: Foo | Literal["abc"]):
     if "a" in u:
@@ -6156,6 +6200,51 @@ def literal_union_key_access(obj: Foo | Literal["a"]):
         # Membership in a string does not imply that the string supports subscripting with that key.
         # error: [invalid-argument-type]
         reveal_type(obj["a"])  # revealed: object
+```
+
+Present-key constraints retain union-arm correlation when multiple membership tests are combined.
+This example also guards against constructing the Cartesian product of the eight union arms for each
+of the six predicates:
+
+```py
+from typing import TypedDict
+
+class Membership0(TypedDict):
+    item0: int
+
+class Membership1(TypedDict):
+    item1: int
+
+class Membership2(TypedDict):
+    item2: int
+
+class Membership3(TypedDict):
+    item3: int
+
+class Membership4(TypedDict):
+    item4: int
+
+class Membership5(TypedDict):
+    item5: int
+
+class Membership6(TypedDict):
+    item6: int
+
+class Membership7(TypedDict):
+    item7: int
+
+def multiple_union_membership_tests(
+    u: Membership0 | Membership1 | Membership2 | Membership3 | Membership4 | Membership5 | Membership6 | Membership7,
+):
+    has_key0 = "key0" in u
+    has_key1 = "key1" in u
+    has_key2 = "key2" in u
+    has_key3 = "key3" in u
+    has_key4 = "key4" in u
+    has_key5 = "key5" in u
+    if has_key0 and has_key1 and has_key2 and has_key3 and has_key4 and has_key5:
+        reveal_type(u["key0"])  # revealed: object
+        reveal_type(u["key5"])  # revealed: object
 ```
 
 This still accepts guarded key access in the branch, without pretending that an open `TypedDict`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6205,6 +6205,11 @@ def mapping_membership_remains_true(u: Foo | Mapping[Literal["a", "b"], int]):
         if "x" not in u:
             reveal_type(u)  # revealed: Never
 
+def mapping_membership_disjunction(mapping: Mapping[Literal["a"], int]):
+    if "c" in mapping or "d" in mapping:
+        if "c" not in mapping:
+            reveal_type(mapping["d"])  # revealed: object
+
 def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
     has_c = "c" in u
     if guard_object(u) and has_c:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6218,6 +6218,32 @@ def mapping_membership_disjunction(mapping: Mapping[Literal["a"], int]):
         if "c" not in mapping:
             reveal_type(mapping["d"])  # revealed: object
 
+class AlwaysContains(Mapping[str, int]):
+    def __contains__(self, key: object, /) -> Literal[True]:
+        return True
+
+class SometimesContains(Mapping[str, int]): ...
+
+class Target:
+    target: int
+
+def guard_target(value: object) -> TypeGuard[Target]:
+    return True
+
+def absent_membership_preserves_typeguard(value: AlwaysContains | SometimesContains):
+    lacks_x = "x" not in value
+    if guard_target(value) and lacks_x:
+        reveal_type(value)  # revealed: Target
+        reveal_type(value.target)  # revealed: int
+
+def guard_always_or_target(value: object) -> TypeGuard[AlwaysContains | Target]:
+    return True
+
+def absent_membership_applies_to_typeguard(value: SometimesContains):
+    lacks_x = "x" not in value
+    if guard_always_or_target(value) and lacks_x:
+        reveal_type(value)  # revealed: Target
+
 def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
     has_c = "c" in u
     if guard_object(u) and has_c:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5180,7 +5180,7 @@ def _(p: Person) -> None:
     reveal_type(p.setdefault("name", "Alice"))  # revealed: str
 
     # __contains__
-    reveal_type("name" in p)  # revealed: Literal[True]
+    reveal_type("name" in p)  # revealed: bool
 
     # __setitem__
     p["name"] = "Alice"
@@ -5200,8 +5200,6 @@ from typing import TypedDict
 Partial = TypedDict("Partial", {"name": str, "extra": int}, total=False)
 
 def _(p: Partial) -> None:
-    reveal_type("name" in p)  # revealed: bool
-    reveal_type("unknown" in p)  # revealed: bool
     reveal_type(p.get("name"))  # revealed: str | None
     reveal_type(p.get("name", "default"))  # revealed: str
     reveal_type(p.pop("name"))  # revealed: str
@@ -6123,14 +6121,14 @@ class Bar(TypedDict):
 def disappointment(u: Foo | Bar, v: Literal["foo"]):
     if "foo" in u:
         # We don't narrow to just `Foo` here...
-        reveal_type(u)  # revealed: Foo | (Bar & <Protocol with members '__contains__', '__getitem__'>)
+        reveal_type(u)  # revealed: Foo | (Bar & <TypedDict with items 'foo'>)
         reveal_type(u["foo"])  # revealed: object
     else:
         # ...(even though we *can* narrow it here)...
         reveal_type(u)  # revealed: Bar
 
     if v in u:
-        reveal_type(u)  # revealed: Foo | (Bar & <Protocol with members '__contains__', '__getitem__'>)
+        reveal_type(u)  # revealed: Foo | (Bar & <TypedDict with items 'foo'>)
         reveal_type(u["foo"])  # revealed: object
     else:
         reveal_type(u)  # revealed: Bar
@@ -6257,7 +6255,7 @@ def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
 
 def literal_union(u: Foo | Literal["abc"]):
     if "a" in u:
-        # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Literal["abc"] & <Protocol with members '__contains__'>)
+        # revealed: (Foo & <TypedDict with items 'a'>) | (Literal["abc"] & <Protocol with members '__contains__'>)
         reveal_type(u)
 
 def literal_union_key_access(obj: Foo | Literal["a"]):
@@ -6352,8 +6350,9 @@ def _(t: Bar, u: Foo | Intersection[Bar, Any], v: Intersection[Bar, Any], w: Lit
     if "bar" not in u:
         reveal_type(u)  # revealed: Foo
     else:
-        # `Foo` is open, so it may contain an undeclared `"bar"` key.
-        reveal_type(u)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
+        # TODO: This should simplify to `Foo | (Bar & Any)`, since `Foo` is a
+        # subtype of the synthesized protocol.
+        reveal_type(u)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
 
     if "bar" not in v:
         reveal_type(v)  # revealed: Never
@@ -6363,12 +6362,12 @@ def _(t: Bar, u: Foo | Intersection[Bar, Any], v: Intersection[Bar, Any], w: Lit
     if w not in u:
         reveal_type(u)  # revealed: Foo
     else:
-        reveal_type(u)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
+        reveal_type(u)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
 
     if "bar" not in (u2 := u):
         reveal_type(u2)  # revealed: Foo
     else:
-        reveal_type(u2)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
+        reveal_type(u2)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
 ```
 
 With `closed=True`, the narrowing that we couldn't do above becomes possible, because a [closed]
@@ -6636,7 +6635,7 @@ def test_in(x: ThingWithBaz):
     if "baz" not in x:
         reveal_type(x)  # revealed: Foo
     else:
-        reveal_type(x)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | Baz
+        reveal_type(x)  # revealed: (Foo & <TypedDict with items 'baz'>) | Baz
 ```
 
 Nested PEP 695 type aliases (an alias referring to another alias) also work:
@@ -6665,7 +6664,7 @@ def test_nested_in(x: OuterWithBaz):
     if "baz" not in x:
         reveal_type(x)  # revealed: Foo
     else:
-        reveal_type(x)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | Baz
+        reveal_type(x)  # revealed: (Foo & <TypedDict with items 'baz'>) | Baz
 ```
 
 ## Only annotated declarations are allowed in the class body

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5180,7 +5180,7 @@ def _(p: Person) -> None:
     reveal_type(p.setdefault("name", "Alice"))  # revealed: str
 
     # __contains__
-    reveal_type("name" in p)  # revealed: bool
+    reveal_type("name" in p)  # revealed: Literal[True]
 
     # __setitem__
     p["name"] = "Alice"
@@ -5200,6 +5200,8 @@ from typing import TypedDict
 Partial = TypedDict("Partial", {"name": str, "extra": int}, total=False)
 
 def _(p: Partial) -> None:
+    reveal_type("name" in p)  # revealed: bool
+    reveal_type("unknown" in p)  # revealed: bool
     reveal_type(p.get("name"))  # revealed: str | None
     reveal_type(p.get("name", "default"))  # revealed: str
     reveal_type(p.pop("name"))  # revealed: str
@@ -6121,14 +6123,14 @@ class Bar(TypedDict):
 def disappointment(u: Foo | Bar, v: Literal["foo"]):
     if "foo" in u:
         # We don't narrow to just `Foo` here...
-        reveal_type(u)  # revealed: Foo | (Bar & <TypedDict with items 'foo'>)
+        reveal_type(u)  # revealed: Foo | (Bar & <Protocol with members '__contains__', '__getitem__'>)
         reveal_type(u["foo"])  # revealed: object
     else:
         # ...(even though we *can* narrow it here)...
         reveal_type(u)  # revealed: Bar
 
     if v in u:
-        reveal_type(u)  # revealed: Foo | (Bar & <TypedDict with items 'foo'>)
+        reveal_type(u)  # revealed: Foo | (Bar & <Protocol with members '__contains__', '__getitem__'>)
         reveal_type(u["foo"])  # revealed: object
     else:
         reveal_type(u)  # revealed: Bar
@@ -6255,7 +6257,7 @@ def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
 
 def literal_union(u: Foo | Literal["abc"]):
     if "a" in u:
-        # revealed: (Foo & <TypedDict with items 'a'>) | (Literal["abc"] & <Protocol with members '__contains__'>)
+        # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Literal["abc"] & <Protocol with members '__contains__'>)
         reveal_type(u)
 
 def literal_union_key_access(obj: Foo | Literal["a"]):
@@ -6350,9 +6352,8 @@ def _(t: Bar, u: Foo | Intersection[Bar, Any], v: Intersection[Bar, Any], w: Lit
     if "bar" not in u:
         reveal_type(u)  # revealed: Foo
     else:
-        # TODO: This should simplify to `Foo | (Bar & Any)`, since `Foo` is a
-        # subtype of the synthesized protocol.
-        reveal_type(u)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
+        # `Foo` is open, so it may contain an undeclared `"bar"` key.
+        reveal_type(u)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
 
     if "bar" not in v:
         reveal_type(v)  # revealed: Never
@@ -6362,12 +6363,12 @@ def _(t: Bar, u: Foo | Intersection[Bar, Any], v: Intersection[Bar, Any], w: Lit
     if w not in u:
         reveal_type(u)  # revealed: Foo
     else:
-        reveal_type(u)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
+        reveal_type(u)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
 
     if "bar" not in (u2 := u):
         reveal_type(u2)  # revealed: Foo
     else:
-        reveal_type(u2)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
+        reveal_type(u2)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
 ```
 
 With `closed=True`, the narrowing that we couldn't do above becomes possible, because a [closed]
@@ -6384,12 +6385,14 @@ class ClosedBar(TypedDict, closed=True):
 
 def _(u: ClosedFoo | ClosedBar, v: Literal["foo"]):
     if "foo" in u:
-        reveal_type(u)  # revealed: ClosedFoo
+        # TODO: should be `ClosedFoo`
+        reveal_type(u)  # revealed: ClosedFoo | (ClosedBar & <Protocol with members '__contains__', '__getitem__'>)
     else:
         reveal_type(u)  # revealed: ClosedBar
 
     if v in u:
-        reveal_type(u)  # revealed: ClosedFoo
+        # TODO: should be `ClosedFoo`
+        reveal_type(u)  # revealed: ClosedFoo | (ClosedBar & <Protocol with members '__contains__', '__getitem__'>)
     else:
         reveal_type(u)  # revealed: ClosedBar
 ```
@@ -6409,7 +6412,8 @@ def _(
     if "bar" not in u:
         reveal_type(u)  # revealed: ClosedFoo
     else:
-        reveal_type(u)  # revealed: ClosedBar & Any
+        # TODO: should be `ClosedBar & Any`
+        reveal_type(u)  # revealed: (ClosedFoo & <Protocol with members '__contains__', '__getitem__'>) | (ClosedBar & Any)
 
     if "bar" not in v:
         reveal_type(v)  # revealed: Never
@@ -6419,7 +6423,8 @@ def _(
     if w not in u:
         reveal_type(u)  # revealed: ClosedFoo
     else:
-        reveal_type(u)  # revealed: ClosedBar & Any
+        # TODO: should be `ClosedBar & Any`
+        reveal_type(u)  # revealed: (ClosedFoo & <Protocol with members '__contains__', '__getitem__'>) | (ClosedBar & Any)
 ```
 
 ## Narrowing tagged unions of `TypedDict`s with `match` statements
@@ -6631,7 +6636,7 @@ def test_in(x: ThingWithBaz):
     if "baz" not in x:
         reveal_type(x)  # revealed: Foo
     else:
-        reveal_type(x)  # revealed: (Foo & <TypedDict with items 'baz'>) | Baz
+        reveal_type(x)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | Baz
 ```
 
 Nested PEP 695 type aliases (an alias referring to another alias) also work:
@@ -6660,7 +6665,7 @@ def test_nested_in(x: OuterWithBaz):
     if "baz" not in x:
         reveal_type(x)  # revealed: Foo
     else:
-        reveal_type(x)  # revealed: (Foo & <TypedDict with items 'baz'>) | Baz
+        reveal_type(x)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | Baz
 ```
 
 ## Only annotated declarations are allowed in the class body

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6181,6 +6181,11 @@ def multiple_mapping_membership_tests(mapping: Mapping[Literal["a", "b"], int]):
 def guard_object(value: object) -> TypeGuard[object]:
     return True
 
+def no_op_membership_and_typeguard(value: Foo):
+    has_foo = "foo" in value
+    if guard_object(value) and has_foo:
+        reveal_type(value)  # revealed: object
+
 def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
     has_c = "c" in u
     if guard_object(u) and has_c:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6193,6 +6193,8 @@ def membership_after_typeguard(value: Foo | Literal["abc"]):
     has_z = "z" in value
     if guard_bar(value) and has_z:
         reveal_type(value["z"])  # revealed: object
+    if has_z and guard_bar(value):
+        reveal_type(value["z"])  # revealed: object
 
 class OptionalKey(TypedDict):
     x: NotRequired[int]
@@ -6215,6 +6217,8 @@ def guard_mapping_or_target(value: object) -> TypeGuard[AlwaysContains | Target]
 def absent_key_after_typeguard(value: SometimesContains):
     lacks_x = "x" not in value
     if guard_mapping_or_target(value) and lacks_x:
+        reveal_type(value)  # revealed: Target
+    if lacks_x and guard_mapping_or_target(value):
         reveal_type(value)  # revealed: Target
 
 def mapping_membership_after_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6110,7 +6110,7 @@ define a `"foo"` field, it could be _assigned to_ with another `TypedDict` that 
 
 ```py
 from collections.abc import Mapping
-from typing_extensions import Literal, TypeGuard, TypeIs
+from typing_extensions import Literal, NotRequired, TypeGuard, TypeIs
 
 class Foo(TypedDict):
     foo: int
@@ -6193,6 +6193,14 @@ def membership_applies_to_typeguard_replacement(value: Foo | Literal["abc"]):
     has_z = "z" in value
     if guard_bar(value) and has_z:
         reveal_type(value["z"])  # revealed: object
+
+class OptionalKey(TypedDict):
+    x: NotRequired[int]
+
+def optional_membership_applies_to_typeguard_replacement(value: OptionalKey):
+    has_x = "x" in value
+    if guard_bar(value) and has_x:
+        reveal_type(value["x"])  # revealed: object
 
 def is_mapping(
     value: Foo | Mapping[Literal["a", "b"], int],

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6186,6 +6186,14 @@ def no_op_membership_and_typeguard(value: Foo):
     if guard_object(value) and has_foo:
         reveal_type(value)  # revealed: object
 
+def guard_bar(value: object) -> TypeGuard[Bar]:
+    return True
+
+def membership_applies_to_typeguard_replacement(value: Foo | Literal["abc"]):
+    has_z = "z" in value
+    if guard_bar(value) and has_z:
+        reveal_type(value["z"])  # revealed: object
+
 def is_mapping(
     value: Foo | Mapping[Literal["a", "b"], int],
 ) -> TypeIs[Mapping[Literal["a", "b"], int]]:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6110,7 +6110,7 @@ define a `"foo"` field, it could be _assigned to_ with another `TypedDict` that 
 
 ```py
 from collections.abc import Mapping
-from typing_extensions import Literal, TypeGuard
+from typing_extensions import Literal, TypeGuard, TypeIs
 
 class Foo(TypedDict):
     foo: int
@@ -6185,6 +6185,17 @@ def no_op_membership_and_typeguard(value: Foo):
     has_foo = "foo" in value
     if guard_object(value) and has_foo:
         reveal_type(value)  # revealed: object
+
+def is_mapping(
+    value: Foo | Mapping[Literal["a", "b"], int],
+) -> TypeIs[Mapping[Literal["a", "b"], int]]:
+    return True
+
+def mapping_membership_remains_true(u: Foo | Mapping[Literal["a", "b"], int]):
+    has_x = "x" in u
+    if has_x and is_mapping(u):
+        if "x" not in u:
+            reveal_type(u)  # revealed: Never
 
 def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
     has_c = "c" in u

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5180,7 +5180,7 @@ def _(p: Person) -> None:
     reveal_type(p.setdefault("name", "Alice"))  # revealed: str
 
     # __contains__
-    reveal_type("name" in p)  # revealed: bool
+    reveal_type("name" in p)  # revealed: Literal[True]
 
     # __setitem__
     p["name"] = "Alice"
@@ -5200,6 +5200,8 @@ from typing import TypedDict
 Partial = TypedDict("Partial", {"name": str, "extra": int}, total=False)
 
 def _(p: Partial) -> None:
+    reveal_type("name" in p)  # revealed: bool
+    reveal_type("unknown" in p)  # revealed: bool
     reveal_type(p.get("name"))  # revealed: str | None
     reveal_type(p.get("name", "default"))  # revealed: str
     reveal_type(p.pop("name"))  # revealed: str
@@ -6121,14 +6123,14 @@ class Bar(TypedDict):
 def disappointment(u: Foo | Bar, v: Literal["foo"]):
     if "foo" in u:
         # We don't narrow to just `Foo` here...
-        reveal_type(u)  # revealed: Foo | (Bar & <TypedDict with items 'foo'>)
+        reveal_type(u)  # revealed: Foo | (Bar & <Protocol with members '__contains__', '__getitem__'>)
         reveal_type(u["foo"])  # revealed: object
     else:
         # ...(even though we *can* narrow it here)...
         reveal_type(u)  # revealed: Bar
 
     if v in u:
-        reveal_type(u)  # revealed: Foo | (Bar & <TypedDict with items 'foo'>)
+        reveal_type(u)  # revealed: Foo | (Bar & <Protocol with members '__contains__', '__getitem__'>)
         reveal_type(u["foo"])  # revealed: object
     else:
         reveal_type(u)  # revealed: Bar
@@ -6255,7 +6257,7 @@ def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
 
 def literal_union(u: Foo | Literal["abc"]):
     if "a" in u:
-        # revealed: (Foo & <TypedDict with items 'a'>) | (Literal["abc"] & <Protocol with members '__contains__'>)
+        # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Literal["abc"] & <Protocol with members '__contains__'>)
         reveal_type(u)
 
 def literal_union_key_access(obj: Foo | Literal["a"]):
@@ -6350,9 +6352,8 @@ def _(t: Bar, u: Foo | Intersection[Bar, Any], v: Intersection[Bar, Any], w: Lit
     if "bar" not in u:
         reveal_type(u)  # revealed: Foo
     else:
-        # TODO: This should simplify to `Foo | (Bar & Any)`, since `Foo` is a
-        # subtype of the synthesized protocol.
-        reveal_type(u)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
+        # `Foo` is open, so it may contain an undeclared `"bar"` key.
+        reveal_type(u)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
 
     if "bar" not in v:
         reveal_type(v)  # revealed: Never
@@ -6362,12 +6363,12 @@ def _(t: Bar, u: Foo | Intersection[Bar, Any], v: Intersection[Bar, Any], w: Lit
     if w not in u:
         reveal_type(u)  # revealed: Foo
     else:
-        reveal_type(u)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
+        reveal_type(u)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
 
     if "bar" not in (u2 := u):
         reveal_type(u2)  # revealed: Foo
     else:
-        reveal_type(u2)  # revealed: (Foo & <TypedDict with items 'bar'>) | (Bar & Any)
+        reveal_type(u2)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Bar & Any)
 ```
 
 With `closed=True`, the narrowing that we couldn't do above becomes possible, because a [closed]
@@ -6635,7 +6636,7 @@ def test_in(x: ThingWithBaz):
     if "baz" not in x:
         reveal_type(x)  # revealed: Foo
     else:
-        reveal_type(x)  # revealed: (Foo & <TypedDict with items 'baz'>) | Baz
+        reveal_type(x)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | Baz
 ```
 
 Nested PEP 695 type aliases (an alias referring to another alias) also work:
@@ -6664,7 +6665,7 @@ def test_nested_in(x: OuterWithBaz):
     if "baz" not in x:
         reveal_type(x)  # revealed: Foo
     else:
-        reveal_type(x)  # revealed: (Foo & <TypedDict with items 'baz'>) | Baz
+        reveal_type(x)  # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | Baz
 ```
 
 ## Only annotated declarations are allowed in the class body

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5200,8 +5200,6 @@ from typing import TypedDict
 Partial = TypedDict("Partial", {"name": str, "extra": int}, total=False)
 
 def _(p: Partial) -> None:
-    reveal_type("name" in p)  # revealed: bool
-    reveal_type("unknown" in p)  # revealed: bool
     reveal_type(p.get("name"))  # revealed: str | None
     reveal_type(p.get("name", "default"))  # revealed: str
     reveal_type(p.pop("name"))  # revealed: str
@@ -6112,7 +6110,7 @@ define a `"foo"` field, it could be _assigned to_ with another `TypedDict` that 
 
 ```py
 from collections.abc import Mapping
-from typing_extensions import Literal, NotRequired, TypeGuard, TypeIs
+from typing_extensions import Literal, NotRequired, TypeGuard
 
 class Foo(TypedDict):
     foo: int
@@ -6142,7 +6140,12 @@ class FooBar(TypedDict):
 
 static_assert(is_assignable_to(FooBar, Foo))
 static_assert(is_assignable_to(FooBar, Bar))
+```
 
+A successful membership check permits subscript access even when the key is not included in the
+annotated key type:
+
+```py
 def dictionary_union(u: Foo | dict[Literal["a", "b"], int]):
     if "c" in u:
         reveal_type(u["c"])  # revealed: object
@@ -6151,47 +6154,42 @@ def mapping_union(u: Foo | Mapping[Literal["a", "b"], int]):
     if "c" in u:
         reveal_type(u["c"])  # revealed: object
 
-def mapping_only(
-    mapping: Mapping[Literal["a", "b"], int],
-    broad_mapping: Mapping[str, int],
-):
+def mapping_membership(mapping: Mapping[Literal["a", "b"], int]):
     if "c" in mapping:
         reveal_type(mapping["c"])  # revealed: object
-    if "c" in broad_mapping:
-        reveal_type(broad_mapping["c"])  # revealed: int
+```
 
-def multiple_membership_tests(u: Foo | Bar):
+When a condition checks multiple keys, each successful check is retained:
+
+```py
+def combined_typed_dict_checks(u: Foo | Bar):
     has_foo = "foo" in u
     has_bar = "bar" in u
     if has_foo and has_bar:
         reveal_type(u["foo"])  # revealed: object
-        reveal_type(u["bar"])  # revealed: object
 
-def nested_membership_tests(u: Foo | Bar):
-    if "foo" in u:
-        if "bar" in u:
-            reveal_type(u["foo"])  # revealed: object
-            reveal_type(u["bar"])  # revealed: object
-
-def multiple_mapping_membership_tests(mapping: Mapping[Literal["a", "b"], int]):
+def combined_mapping_checks(mapping: Mapping[Literal["a", "b"], int]):
     has_c = "c" in mapping
     has_d = "d" in mapping
     if has_c and has_d:
         reveal_type(mapping["c"])  # revealed: object
-        reveal_type(mapping["d"])  # revealed: object
 
+def either_key_is_present(mapping: Mapping[Literal["a"], int]):
+    if "c" in mapping or "d" in mapping:
+        if "c" not in mapping:
+            reveal_type(mapping["d"])  # revealed: object
+```
+
+Membership checks still apply after a `TypeGuard` replaces the original type:
+
+```py
 def guard_object(value: object) -> TypeGuard[object]:
     return True
-
-def no_op_membership_and_typeguard(value: Foo):
-    has_foo = "foo" in value
-    if guard_object(value) and has_foo:
-        reveal_type(value)  # revealed: object
 
 def guard_bar(value: object) -> TypeGuard[Bar]:
     return True
 
-def membership_applies_to_typeguard_replacement(value: Foo | Literal["abc"]):
+def membership_after_typeguard(value: Foo | Literal["abc"]):
     has_z = "z" in value
     if guard_bar(value) and has_z:
         reveal_type(value["z"])  # revealed: object
@@ -6199,62 +6197,36 @@ def membership_applies_to_typeguard_replacement(value: Foo | Literal["abc"]):
 class OptionalKey(TypedDict):
     x: NotRequired[int]
 
-def optional_membership_applies_to_typeguard_replacement(value: OptionalKey):
+def optional_key_after_typeguard(value: OptionalKey):
     has_x = "x" in value
     if guard_bar(value) and has_x:
         reveal_type(value["x"])  # revealed: object
-
-def is_mapping(
-    value: Foo | Mapping[Literal["a", "b"], int],
-) -> TypeIs[Mapping[Literal["a", "b"], int]]:
-    return True
-
-def mapping_membership_remains_true(u: Foo | Mapping[Literal["a", "b"], int]):
-    has_x = "x" in u
-    if has_x and is_mapping(u):
-        if "x" not in u:
-            reveal_type(u)  # revealed: Never
-
-def mapping_membership_disjunction(mapping: Mapping[Literal["a"], int]):
-    if "c" in mapping or "d" in mapping:
-        if "c" not in mapping:
-            reveal_type(mapping["d"])  # revealed: object
 
 class AlwaysContains(Mapping[str, int]):
     def __contains__(self, key: object, /) -> Literal[True]:
         return True
 
 class SometimesContains(Mapping[str, int]): ...
+class Target: ...
 
-class Target:
-    target: int
-
-def guard_target(value: object) -> TypeGuard[Target]:
+def guard_mapping_or_target(value: object) -> TypeGuard[AlwaysContains | Target]:
     return True
 
-def absent_membership_preserves_typeguard(value: AlwaysContains | SometimesContains):
+def absent_key_after_typeguard(value: SometimesContains):
     lacks_x = "x" not in value
-    if guard_target(value) and lacks_x:
-        reveal_type(value)  # revealed: Target
-        reveal_type(value.target)  # revealed: int
-
-def guard_always_or_target(value: object) -> TypeGuard[AlwaysContains | Target]:
-    return True
-
-def absent_membership_applies_to_typeguard(value: SometimesContains):
-    lacks_x = "x" not in value
-    if guard_always_or_target(value) and lacks_x:
+    if guard_mapping_or_target(value) and lacks_x:
         reveal_type(value)  # revealed: Target
 
-def membership_and_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
+def mapping_membership_after_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
     has_c = "c" in u
     if guard_object(u) and has_c:
         reveal_type(u["c"])  # revealed: object
-    if has_c and guard_object(u):
-        reveal_type(u)  # revealed: object
-    if "c" in u and guard_object(u):
-        reveal_type(u)  # revealed: object
+```
 
+For other objects, a successful membership check does not imply that the same value can be used as a
+subscript:
+
+```py
 def literal_union(u: Foo | Literal["abc"]):
     if "a" in u:
         # revealed: (Foo & <Protocol with members '__contains__', '__getitem__'>) | (Literal["abc"] & <Protocol with members '__contains__'>)
@@ -6265,51 +6237,6 @@ def literal_union_key_access(obj: Foo | Literal["a"]):
         # Membership in a string does not imply that the string supports subscripting with that key.
         # error: [invalid-argument-type]
         reveal_type(obj["a"])  # revealed: object
-```
-
-Present-key constraints retain union-arm correlation when multiple membership tests are combined.
-This example also guards against constructing the Cartesian product of the eight union arms for each
-of the six predicates:
-
-```py
-from typing import TypedDict
-
-class Membership0(TypedDict):
-    item0: int
-
-class Membership1(TypedDict):
-    item1: int
-
-class Membership2(TypedDict):
-    item2: int
-
-class Membership3(TypedDict):
-    item3: int
-
-class Membership4(TypedDict):
-    item4: int
-
-class Membership5(TypedDict):
-    item5: int
-
-class Membership6(TypedDict):
-    item6: int
-
-class Membership7(TypedDict):
-    item7: int
-
-def multiple_union_membership_tests(
-    u: Membership0 | Membership1 | Membership2 | Membership3 | Membership4 | Membership5 | Membership6 | Membership7,
-):
-    has_key0 = "key0" in u
-    has_key1 = "key1" in u
-    has_key2 = "key2" in u
-    has_key3 = "key3" in u
-    has_key4 = "key4" in u
-    has_key5 = "key5" in u
-    if has_key0 and has_key1 and has_key2 and has_key3 and has_key4 and has_key5:
-        reveal_type(u["key0"])  # revealed: object
-        reveal_type(u["key5"])  # revealed: object
 ```
 
 This still accepts guarded key access in the branch, without pretending that an open `TypedDict`
@@ -6385,14 +6312,12 @@ class ClosedBar(TypedDict, closed=True):
 
 def _(u: ClosedFoo | ClosedBar, v: Literal["foo"]):
     if "foo" in u:
-        # TODO: should be `ClosedFoo`
-        reveal_type(u)  # revealed: ClosedFoo | (ClosedBar & <Protocol with members '__contains__', '__getitem__'>)
+        reveal_type(u)  # revealed: ClosedFoo
     else:
         reveal_type(u)  # revealed: ClosedBar
 
     if v in u:
-        # TODO: should be `ClosedFoo`
-        reveal_type(u)  # revealed: ClosedFoo | (ClosedBar & <Protocol with members '__contains__', '__getitem__'>)
+        reveal_type(u)  # revealed: ClosedFoo
     else:
         reveal_type(u)  # revealed: ClosedBar
 ```
@@ -6412,8 +6337,7 @@ def _(
     if "bar" not in u:
         reveal_type(u)  # revealed: ClosedFoo
     else:
-        # TODO: should be `ClosedBar & Any`
-        reveal_type(u)  # revealed: (ClosedFoo & <Protocol with members '__contains__', '__getitem__'>) | (ClosedBar & Any)
+        reveal_type(u)  # revealed: ClosedBar & Any
 
     if "bar" not in v:
         reveal_type(v)  # revealed: Never
@@ -6423,8 +6347,7 @@ def _(
     if w not in u:
         reveal_type(u)  # revealed: ClosedFoo
     else:
-        # TODO: should be `ClosedBar & Any`
-        reveal_type(u)  # revealed: (ClosedFoo & <Protocol with members '__contains__', '__getitem__'>) | (ClosedBar & Any)
+        reveal_type(u)  # revealed: ClosedBar & Any
 ```
 
 ## Narrowing tagged unions of `TypedDict`s with `match` statements

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2653,8 +2653,9 @@ def _(item: Item | str) -> None:
 ```
 
 A successful membership test for an undeclared key narrows each union member to an intersection with
-a synthesized `TypedDict`. Its mapping methods should retain their precise types, and copying the
-narrowed union should remain efficient even when each member has a distinct optional field:
+a synthesized protocol that records membership and subscript access. Its mapping methods should
+retain their precise types, and copying the narrowed union should remain efficient even when each
+member has a distinct optional field:
 
 ```py
 from typing import NotRequired
@@ -2693,7 +2694,7 @@ def _(item: MembershipItem) -> None:
 
 def _(item: MembershipA) -> None:
     if "missing" in item:
-        reveal_type(item.copy())  # revealed: MembershipA & <TypedDict with items 'missing'>
+        reveal_type(item.copy())  # revealed: MembershipA & <Protocol with members '__contains__', '__getitem__'>
 ```
 
 Adding a regular dictionary to the union should not make copying it slow:
@@ -6110,7 +6111,7 @@ define a `"foo"` field, it could be _assigned to_ with another `TypedDict` that 
 
 ```py
 from collections.abc import Mapping
-from typing_extensions import Literal, NotRequired, TypeGuard
+from typing_extensions import Final, Literal, NotRequired, TypeGuard
 
 class Foo(TypedDict):
     foo: int
@@ -6167,12 +6168,14 @@ def combined_typed_dict_checks(u: Foo | Bar):
     has_bar = "bar" in u
     if has_foo and has_bar:
         reveal_type(u["foo"])  # revealed: object
+        reveal_type(u["bar"])  # revealed: object
 
 def combined_mapping_checks(mapping: Mapping[Literal["a", "b"], int]):
     has_c = "c" in mapping
     has_d = "d" in mapping
     if has_c and has_d:
         reveal_type(mapping["c"])  # revealed: object
+        reveal_type(mapping["d"])  # revealed: object
 
 def either_key_is_present(mapping: Mapping[Literal["a"], int]):
     if "c" in mapping or "d" in mapping:
@@ -6180,7 +6183,9 @@ def either_key_is_present(mapping: Mapping[Literal["a"], int]):
             reveal_type(mapping["d"])  # revealed: object
 ```
 
-Membership checks still apply after a `TypeGuard` replaces the original type:
+Membership checks that occur after a `TypeGuard` still apply to the replacement type. However, a
+`TypeGuard` discards membership facts from preceding conditions, along with all other previously
+known type information:
 
 ```py
 def guard_object(value: object) -> TypeGuard[object]:
@@ -6194,7 +6199,7 @@ def membership_after_typeguard(value: Foo | Literal["abc"]):
     if guard_bar(value) and has_z:
         reveal_type(value["z"])  # revealed: object
     if has_z and guard_bar(value):
-        reveal_type(value["z"])  # revealed: object
+        value["z"]  # error: [invalid-key]
 
 class OptionalKey(TypedDict):
     x: NotRequired[int]
@@ -6219,12 +6224,32 @@ def absent_key_after_typeguard(value: SometimesContains):
     if guard_mapping_or_target(value) and lacks_x:
         reveal_type(value)  # revealed: Target
     if lacks_x and guard_mapping_or_target(value):
-        reveal_type(value)  # revealed: Target
+        reveal_type(value)  # revealed: AlwaysContains | Target
 
 def mapping_membership_after_typeguard(u: Foo | Mapping[Literal["a", "b"], int]):
     has_c = "c" in u
     if guard_object(u) and has_c:
         reveal_type(u["c"])  # revealed: object
+```
+
+Precomputed refinements, such as filtering a union by a nominal tag, preserve preceding membership
+facts:
+
+```py
+class UserSettings(Mapping[Literal["user_id"], int]):
+    kind: Final[Literal["user"]] = "user"
+
+class SystemSettings(Mapping[Literal["system_id"], int]):
+    kind: Final[Literal["system"]] = "system"
+
+def read_timeout(settings: UserSettings | SystemSettings) -> object:
+    has_timeout = "timeout" in settings
+    is_user_settings = settings.kind == "user"
+
+    if has_timeout and is_user_settings:
+        return settings["timeout"]
+
+    raise KeyError("timeout")
 ```
 
 For other objects, a successful membership check does not imply that the same value can be used as a

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -39,7 +39,6 @@ pub(super) fn synthesize_typed_dict_method<'db>(
     let instance_ty = Type::TypedDict(typed_dict);
     match method_name {
         "__init__" => Some(synthesize_typed_dict_init(db, env, typed_dict, fields())),
-        "__contains__" => Some(synthesize_typed_dict_contains(db, env, instance_ty, fields())),
         "__getitem__" => Some(synthesize_typed_dict_getitem(db, env, typed_dict, fields())),
         "__setitem__" => Some(synthesize_typed_dict_setitem(db, env, typed_dict, fields())),
         "__delitem__" => Some(synthesize_typed_dict_delitem(db, env, typed_dict, fields())),
@@ -126,43 +125,6 @@ impl<'db> TypedDictFields<'db> {
             ),
         }
     }
-}
-
-/// Synthesize the `__contains__` method for a `TypedDict`.
-fn synthesize_typed_dict_contains<'db>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    instance_ty: Type<'db>,
-    fields: TypedDictFields<'db>,
-) -> Type<'db> {
-    let overloads = fields
-        .iter()
-        .filter(|(_, field)| field.is_required())
-        .map(|(field_name, _)| {
-            let parameters = [
-                Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(instance_ty),
-                Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(Type::string_literal(db, field_name)),
-            ];
-            Signature::new(Parameters::standard(parameters), Type::bool_literal(true))
-        })
-        .chain(std::iter::once(Signature::new(
-            Parameters::standard([
-                Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(instance_ty),
-                Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(Type::object()),
-            ]),
-            KnownClass::Bool.to_instance(db, env),
-        )));
-
-    Type::Callable(CallableType::new(
-        db,
-        CallableSignature::from_overloads(overloads),
-        CallableTypeKind::FunctionLike,
-        CallableFunctionProvenance::None,
-    ))
 }
 
 /// Synthesize the `__init__` method for a `TypedDict`.
@@ -1065,7 +1027,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
             return member.inner;
         }
 
-        // Fall back to TypedDictFallback for methods like items, keys, etc.
+        // Fall back to TypedDictFallback for methods like __contains__, items, keys, etc.
         // This mirrors the behavior of StaticClassLiteral::typed_dict_member.
         typed_dict_class_member(
             db,

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -39,6 +39,7 @@ pub(super) fn synthesize_typed_dict_method<'db>(
     let instance_ty = Type::TypedDict(typed_dict);
     match method_name {
         "__init__" => Some(synthesize_typed_dict_init(db, env, typed_dict, fields())),
+        "__contains__" => Some(synthesize_typed_dict_contains(db, env, instance_ty, fields())),
         "__getitem__" => Some(synthesize_typed_dict_getitem(db, env, typed_dict, fields())),
         "__setitem__" => Some(synthesize_typed_dict_setitem(db, env, typed_dict, fields())),
         "__delitem__" => Some(synthesize_typed_dict_delitem(db, env, typed_dict, fields())),
@@ -125,6 +126,43 @@ impl<'db> TypedDictFields<'db> {
             ),
         }
     }
+}
+
+/// Synthesize the `__contains__` method for a `TypedDict`.
+fn synthesize_typed_dict_contains<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    instance_ty: Type<'db>,
+    fields: TypedDictFields<'db>,
+) -> Type<'db> {
+    let overloads = fields
+        .iter()
+        .filter(|(_, field)| field.is_required())
+        .map(|(field_name, _)| {
+            let parameters = [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(Type::string_literal(db, field_name)),
+            ];
+            Signature::new(Parameters::standard(parameters), Type::bool_literal(true))
+        })
+        .chain(std::iter::once(Signature::new(
+            Parameters::standard([
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(Type::object()),
+            ]),
+            KnownClass::Bool.to_instance(db, env),
+        )));
+
+    Type::Callable(CallableType::new(
+        db,
+        CallableSignature::from_overloads(overloads),
+        CallableTypeKind::FunctionLike,
+        CallableFunctionProvenance::None,
+    ))
 }
 
 /// Synthesize the `__init__` method for a `TypedDict`.
@@ -1027,7 +1065,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
             return member.inner;
         }
 
-        // Fall back to TypedDictFallback for methods like __contains__, items, keys, etc.
+        // Fall back to TypedDictFallback for methods like items, keys, etc.
         // This mirrors the behavior of StaticClassLiteral::typed_dict_member.
         typed_dict_class_member(
             db,

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -39,7 +39,12 @@ pub(super) fn synthesize_typed_dict_method<'db>(
     let instance_ty = Type::TypedDict(typed_dict);
     match method_name {
         "__init__" => Some(synthesize_typed_dict_init(db, env, typed_dict, fields())),
-        "__contains__" => Some(synthesize_typed_dict_contains(db, env, instance_ty, fields())),
+        "__contains__" => Some(synthesize_typed_dict_contains(
+            db,
+            env,
+            instance_ty,
+            fields(),
+        )),
         "__getitem__" => Some(synthesize_typed_dict_getitem(db, env, typed_dict, fields())),
         "__setitem__" => Some(synthesize_typed_dict_setitem(db, env, typed_dict, fields())),
         "__delitem__" => Some(synthesize_typed_dict_delitem(db, env, typed_dict, fields())),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -738,7 +738,7 @@ impl<'db> PresentKeyConstraint<'db> {
         }
 
         if key_membership_implies_subscript(db, env, self.source) {
-            Some(mapping_key_getitem_protocol(db, env, self.key.value(db)))
+            Some(mapping_present_key_protocol(db, env, self.key.value(db)))
         } else {
             Some(key_membership_contains_protocol(db, env, self.key.value(db)))
         }
@@ -5142,7 +5142,7 @@ fn narrow_with_present_key<'db>(
             Type::TypedDict(required_typeddict_key(db, key, Type::object())),
         ),
         resolved if is_mapping_subtype(db, env, resolved) => {
-            constrain(ty, mapping_key_getitem_protocol(db, env, key))
+            constrain(ty, mapping_present_key_protocol(db, env, key))
         }
         _ => constrain(ty, key_membership_contains_protocol(db, env, key)),
     }
@@ -5195,15 +5195,16 @@ fn required_typeddict_key<'db>(
     TypedDictType::from_schema_items(db, schema)
 }
 
-/// Return a synthesized protocol that represents safe subscript access for a present key on a
-/// `Mapping` subtype. This assumes that `Mapping` implementations honor the contract between
-/// membership and subscript access.
-fn mapping_key_getitem_protocol<'db>(
+/// Return a synthesized protocol that records a present key on a `Mapping` subtype.
+///
+/// This preserves both the proven membership result and safe subscript access, assuming that
+/// `Mapping` implementations honor the contract between the two operations.
+fn mapping_present_key_protocol<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     key: &str,
 ) -> Type<'db> {
-    let signature = Signature::new(
+    let getitem_signature = Signature::new(
         Parameters::standard([
             Parameter::positional_only(Some(Name::new_static("self"))),
             Parameter::positional_only(Some(Name::new_static("key")))
@@ -5211,11 +5212,28 @@ fn mapping_key_getitem_protocol<'db>(
         ]),
         Type::object(),
     );
+    let contains_signature = Signature::new(
+        Parameters::standard([
+            Parameter::positional_only(Some(Name::new_static("self"))),
+            Parameter::positional_only(Some(Name::new_static("key")))
+                .with_annotated_type(Type::string_literal(db, key)),
+        ]),
+        Type::bool_literal(true),
+    );
 
     Type::protocol_with_methods(
         db,
         env,
-        [("__getitem__", CallableType::function_like(db, signature))],
+        [
+            (
+                "__getitem__",
+                CallableType::function_like(db, getitem_signature),
+            ),
+            (
+                "__contains__",
+                CallableType::function_like(db, contains_signature),
+            ),
+        ],
     )
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4208,8 +4208,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             && let Some(key) = inference.expression_type(&**left).as_string_literal()
             && let rhs_expr = comparators[0].expression_value()
             && let rhs_type = inference.expression_type(&comparators[0])
-            && (is_or_contains_typeddict(db, rhs_type)
-                || is_or_contains_mapping(db, &self.env, rhs_type))
+            && is_or_contains_mapping(db, &self.env, rhs_type)
         {
             let constraint = if is_positive == (ops[0] == ast::CmpOp::In) {
                 NarrowingConstraint::present_key(rhs_type, key)
@@ -5182,9 +5181,9 @@ fn is_mapping_subtype<'db>(
 
 /// Return whether successful membership implies that subscripting with the same key is valid.
 ///
-/// `TypedDict` and `Mapping` provide this relationship; an arbitrary `__contains__`
-/// implementation does not. Every arm of a union must provide the relationship before it can be
-/// carried across replacement narrowing.
+/// `Mapping` provides this relationship; an arbitrary `__contains__` implementation does not.
+/// Every arm of a union must provide the relationship before it can be carried across replacement
+/// narrowing.
 fn key_membership_implies_subscript<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -5195,7 +5194,7 @@ fn key_membership_implies_subscript<'db>(
             .elements(db)
             .iter()
             .all(|element| key_membership_implies_subscript(db, env, *element)),
-        resolved => is_or_contains_typeddict(db, resolved) || is_mapping_subtype(db, env, resolved),
+        resolved => is_mapping_subtype(db, env, resolved),
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -734,7 +734,7 @@ impl<'db> PresentKeyConstraint<'db> {
         replacement: Type<'db>,
     ) -> Type<'db> {
         let narrowed = narrow_with_present_key(db, env, self.source, self.key.value(db));
-        if narrowed == self.source || narrowed == self.source.resolve_type_alias(db) {
+        if key_is_always_present(db, env, self.source, self.key) {
             return replacement;
         }
         if narrowed.is_never() {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry
 
 use crate::reachability::{narrow_type_by_constraint, type_narrowed_by_previous_patterns};
 use crate::subscript::PyIndex;
+use crate::types::call::CallArguments;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
@@ -37,7 +38,6 @@ use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use super::UnionType;
-use super::call::CallArguments;
 use super::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use super::equality::{
     ComparisonSoundnessPolicy, equality_exclusion_constraint, equality_truthiness,
@@ -4116,48 +4116,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     NarrowingConstraint::present_key(rhs_type, key),
                 );
             } else {
-                let requires_key = |td: TypedDictType<'db>| -> bool {
-                    td.items(db)
-                        .get(key.value(db))
-                        .is_some_and(TypedDictField::is_required)
-                };
-
                 let resolved_rhs_type = rhs_type.resolve_type_alias(db);
 
                 let narrowed = match resolved_rhs_type {
-                    Type::TypedDict(td) => {
-                        if requires_key(td) {
-                            Type::Never
-                        } else {
-                            resolved_rhs_type
-                        }
-                    }
-                    Type::Intersection(intersection) => {
-                        if intersection
-                            .positive(db)
-                            .iter()
-                            .copied()
-                            .filter_map(Type::as_typed_dict)
-                            .any(requires_key)
-                        {
-                            Type::Never
-                        } else {
-                            resolved_rhs_type
-                        }
-                    }
                     Type::Union(union) => {
-                        // remove all members of the union that would require the key
-                        union.filter(db, |ty| match ty {
-                            Type::TypedDict(td) => !requires_key(*td),
-                            Type::Intersection(intersection) => !intersection
-                                .positive(db)
-                                .iter()
-                                .copied()
-                                .filter_map(Type::as_typed_dict)
-                                .any(requires_key),
-                            _ => true,
-                        })
+                        // Remove all members of the union that prove the key is present.
+                        union.filter(db, |ty| !key_is_always_present(db, &self.env, *ty, key))
                     }
+                    ty if key_is_always_present(db, &self.env, ty, key) => Type::Never,
                     _ => resolved_rhs_type,
                 };
 
@@ -5169,6 +5135,45 @@ fn typeddict_declares_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> boo
         Type::TypeAlias(alias) => typeddict_declares_key(db, alias.value_type(db), key),
         _ => false,
     }
+}
+
+/// Return whether a negative membership test for `key` contradicts `ty`.
+fn key_is_always_present<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+    key: StringLiteralType<'db>,
+) -> bool {
+    let required_typed_dict_key = |typed_dict: TypedDictType<'db>| {
+        typed_dict
+            .items(db)
+            .get(key.value(db))
+            .is_some_and(TypedDictField::is_required)
+    };
+
+    let has_required_typed_dict_key = match ty {
+        Type::TypedDict(typed_dict) => required_typed_dict_key(typed_dict),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .copied()
+            .filter_map(Type::as_typed_dict)
+            .any(required_typed_dict_key),
+        _ => false,
+    };
+
+    has_required_typed_dict_key
+        || ty
+            .try_call_dunder(
+                db,
+                env,
+                "__contains__",
+                CallArguments::positional([Type::string_literal(db, key.value(db))]),
+                TypeContext::default(),
+            )
+            .is_ok_and(|bindings| {
+                bindings.return_type(db, env).bool(db, env) == Truthiness::AlwaysTrue
+            })
 }
 
 /// Return a synthesized `TypedDict` that represents safe subscript access for a present key on a

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -28,6 +28,7 @@ use ty_python_core::predicate::{
     PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
     SubjectElementPatternPredicate,
 };
+use ty_python_core::reachability_constraints::ScopedReachabilityConstraintId;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
 
@@ -3438,6 +3439,59 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         place_table(db, self.scope())
     }
 
+    /// Returns whether this predicate controls an assignment to the given member.
+    fn predicate_initializes_member(&self, member: ScopedPlaceId) -> bool {
+        let db = self.db;
+        let scope = self.scope();
+        let index = semantic_index(db, scope.program_file(db));
+        let use_def = index.use_def_map(scope.file_scope_id(db));
+        let constraints = use_def.reachability_constraints();
+        let predicates = use_def.predicates();
+        let is_terminal = |constraint| {
+            matches!(
+                constraint,
+                ScopedReachabilityConstraintId::ALWAYS_TRUE
+                    | ScopedReachabilityConstraintId::AMBIGUOUS
+                    | ScopedReachabilityConstraintId::ALWAYS_FALSE
+            )
+        };
+
+        let mut initialized_by_predicate = false;
+        for binding in use_def.reachable_bindings(member) {
+            if binding.binding.definition().is_none() {
+                continue;
+            }
+
+            if binding.reachability_constraint == ScopedReachabilityConstraintId::ALWAYS_TRUE {
+                return false;
+            }
+            if is_terminal(binding.reachability_constraint) {
+                continue;
+            }
+
+            let node = constraints.get_interior_node(binding.reachability_constraint);
+            let predicate = predicates[node.atom()];
+            let opposing_branch = if self.is_positive == predicate.is_positive {
+                node.if_false()
+            } else {
+                node.if_true()
+            };
+
+            if predicate.node != self.predicate
+                || opposing_branch != ScopedReachabilityConstraintId::ALWAYS_FALSE
+                || ![node.if_true(), node.if_ambiguous(), node.if_false()]
+                    .into_iter()
+                    .all(is_terminal)
+            {
+                return false;
+            }
+
+            initialized_by_predicate = true;
+        }
+
+        initialized_by_predicate
+    }
+
     fn scope(&self) -> ScopeId<'db> {
         let db = self.db;
         match self.predicate {
@@ -4446,9 +4500,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let [first_arg, second_arg] = &*expr_call.arguments.args else {
                     return None;
                 };
-                let first_arg = PlaceExpr::try_from_expr(first_arg)?;
+                let first_arg_place = PlaceExpr::try_from_expr(first_arg)?;
                 let function = function_type.known(db)?;
-                let place = self.expect_place(&first_arg);
+                let place = self.expect_place(&first_arg_place);
 
                 if function == KnownFunction::HasAttr {
                     let attr = inference
@@ -4457,6 +4511,42 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         .value(db);
 
                     if !is_identifier(attr) {
+                        return None;
+                    }
+
+                    let places = self.places();
+                    let receiver = inference.expression_type(first_arg);
+                    if !is_positive
+                        && let Some(member) = places.member_id_by_instance_attribute_name(attr)
+                        && places.place(member).is_bound()
+                        && places
+                            .parents(places.place(member))
+                            .any(|parent| parent == place)
+                        && matches!(receiver, Type::TypeVar(typevar) if typevar.typevar(db).is_self(db))
+                        && matches!(
+                            self.predicate,
+                            PredicateNode::Expression(expression)
+                                if !matches!(
+                                    expression.node_ref(db).node(self.module),
+                                    ast::Expr::BoolOp(_)
+                                )
+                        )
+                        && self.predicate_initializes_member(member.into())
+                        && !receiver.nominal_class(db, &self.env).is_some_and(|class| {
+                            class
+                                .iter_mro(db)
+                                .filter_map(ClassBase::into_class)
+                                .filter_map(|base| base.static_class_literal(db))
+                                .any(|(base, _)| {
+                                    let places = place_table(db, base.body_scope(db));
+                                    places
+                                        .symbol_id(attr)
+                                        .is_some_and(|symbol| places.symbol(symbol).is_bound())
+                                })
+                        })
+                    {
+                        // An implicit attribute cannot establish its own absence while its
+                        // initializer is being inferred.
                         return None;
                     }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -716,6 +716,7 @@ impl<'db> NarrowingOperation<'db> {
 struct Conjunctions<'db> {
     conjuncts: SmallVec<[NarrowingOperation<'db>; 2]>,
     present_keys: SmallVec<[PresentKeyConstraint<'db>; 1]>,
+    absent_keys: SmallVec<[AbsentKeyConstraint<'db>; 1]>,
 }
 
 /// A deferred key-presence operation. Keeping union arms inside `source` avoids expanding one DNF
@@ -754,11 +755,35 @@ impl<'db> PresentKeyConstraint<'db> {
     }
 }
 
+/// A deferred key-absence operation. Keeping the filtered source out of the conjunction prevents
+/// it from replacing a preceding `TypeGuard` result.
+#[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::Update, get_size2::GetSize)]
+struct AbsentKeyConstraint<'db> {
+    source: Type<'db>,
+    key: StringLiteralType<'db>,
+}
+
+impl<'db> AbsentKeyConstraint<'db> {
+    fn apply_after_replacement(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        replacement: Type<'db>,
+    ) -> Type<'db> {
+        if narrow_with_absent_key(db, env, self.source, self.key).is_never() {
+            Type::Never
+        } else {
+            narrow_with_absent_key(db, env, replacement, self.key)
+        }
+    }
+}
+
 impl<'db> Conjunctions<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
             conjuncts: smallvec![NarrowingOperation::Intersection(ty)],
             present_keys: smallvec![],
+            absent_keys: smallvec![],
         }
     }
 
@@ -766,6 +791,7 @@ impl<'db> Conjunctions<'db> {
         Self {
             conjuncts: smallvec![NarrowingOperation::GenericFiltering(ty)],
             present_keys: smallvec![],
+            absent_keys: smallvec![],
         }
     }
 
@@ -773,6 +799,15 @@ impl<'db> Conjunctions<'db> {
         Self {
             conjuncts: smallvec![],
             present_keys: smallvec![PresentKeyConstraint { source, key }],
+            absent_keys: smallvec![],
+        }
+    }
+
+    fn absent_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
+        Self {
+            conjuncts: smallvec![],
+            present_keys: smallvec![],
+            absent_keys: smallvec![AbsentKeyConstraint { source, key }],
         }
     }
 
@@ -801,6 +836,12 @@ impl<'db> Conjunctions<'db> {
             }
         }
 
+        for absent_key in other.absent_keys {
+            if !self.absent_keys.contains(&absent_key) {
+                self.absent_keys.push(absent_key);
+            }
+        }
+
         self
     }
 
@@ -810,7 +851,8 @@ impl<'db> Conjunctions<'db> {
         env: &ProgramEnvironment<'db>,
         is_replacement: bool,
     ) -> Type<'db> {
-        if self.present_keys.is_empty() && self.conjuncts.len() == 1 {
+        if self.present_keys.is_empty() && self.absent_keys.is_empty() && self.conjuncts.len() == 1
+        {
             return self.conjuncts[0].ty();
         }
 
@@ -831,9 +873,15 @@ impl<'db> Conjunctions<'db> {
             for present_key in self.present_keys {
                 current = present_key.apply_after_replacement(db, env, current);
             }
+            for absent_key in self.absent_keys {
+                current = absent_key.apply_after_replacement(db, env, current);
+            }
         } else {
             for present_key in self.present_keys {
                 current = narrow_with_present_key(db, env, current, present_key.key.value(db));
+            }
+            for absent_key in self.absent_keys {
+                current = narrow_with_absent_key(db, env, current, absent_key.key);
             }
         }
 
@@ -1175,6 +1223,13 @@ impl<'db> NarrowingConstraint<'db> {
     fn present_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
         Self {
             intersection_disjuncts: smallvec_inline![Conjunctions::present_key(source, key)],
+            replacement_disjuncts: smallvec![],
+        }
+    }
+
+    fn absent_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
+        Self {
+            intersection_disjuncts: smallvec_inline![Conjunctions::absent_key(source, key)],
             replacement_disjuncts: smallvec![],
         }
     }
@@ -4116,20 +4171,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     NarrowingConstraint::present_key(rhs_type, key),
                 );
             } else {
-                let resolved_rhs_type = rhs_type.resolve_type_alias(db);
-
-                let narrowed = match resolved_rhs_type {
-                    Type::Union(union) => {
-                        // Remove all members of the union that prove the key is present.
-                        union.filter(db, |ty| !key_is_always_present(db, &self.env, *ty, key))
-                    }
-                    ty if key_is_always_present(db, &self.env, ty, key) => Type::Never,
-                    _ => resolved_rhs_type,
-                };
-
-                if narrowed != resolved_rhs_type {
-                    apply_constraint(&mut constraints, NarrowingConstraint::replacement(narrowed));
-                }
+                apply_constraint(
+                    &mut constraints,
+                    NarrowingConstraint::absent_key(rhs_type, key),
+                );
             }
         }
 
@@ -5134,6 +5179,24 @@ fn typeddict_declares_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> boo
             .any(|element| typeddict_declares_key(db, *element, key)),
         Type::TypeAlias(alias) => typeddict_declares_key(db, alias.value_type(db), key),
         _ => false,
+    }
+}
+
+fn narrow_with_absent_key<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+    key: StringLiteralType<'db>,
+) -> Type<'db> {
+    let resolved = ty.resolve_type_alias(db);
+    match resolved {
+        Type::Union(union) => {
+            // Remove all members of the union that prove the key is present.
+            let filtered = union.filter(db, |ty| !key_is_always_present(db, env, *ty, key));
+            if filtered == resolved { ty } else { filtered }
+        }
+        ty if key_is_always_present(db, env, ty, key) => Type::Never,
+        _ => ty,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -713,8 +713,8 @@ impl<'db> NarrowingOperation<'db> {
 }
 
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
-struct Conjunctions<'db> {
-    conjuncts: SmallVec<[NarrowingOperation<'db>; 2]>,
+struct ConstraintConjunction<'db> {
+    type_constraints: SmallVec<[NarrowingOperation<'db>; 2]>,
     present_keys: SmallVec<[PresentKeyConstraint<'db>; 1]>,
     absent_keys: SmallVec<[AbsentKeyConstraint<'db>; 1]>,
 }
@@ -728,6 +728,16 @@ struct PresentKeyConstraint<'db> {
 }
 
 impl<'db> PresentKeyConstraint<'db> {
+    /// Apply this fact without restoring type information discarded by a replacement narrowing.
+    ///
+    /// `source` determines what the original membership test proved, but any resulting key
+    /// constraint is applied to `replacement`:
+    ///
+    /// ```python
+    /// has_x = "x" in value
+    /// if guard_to_bar(value) and has_x:
+    ///     value["x"]  # The key fact applies to `Bar`, not the original type.
+    /// ```
     fn apply_after_replacement(
         self,
         db: &'db dyn Db,
@@ -757,6 +767,12 @@ impl<'db> PresentKeyConstraint<'db> {
 
 /// A deferred key-absence operation. Keeping the filtered source out of the conjunction prevents
 /// it from replacing a preceding `TypeGuard` result.
+///
+/// ```python
+/// lacks_x = "x" not in value
+/// if guard_to_bar(value) and lacks_x:
+///     reveal_type(value)  # Bar, filtered by the key-absence fact
+/// ```
 #[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::Update, get_size2::GetSize)]
 struct AbsentKeyConstraint<'db> {
     source: Type<'db>,
@@ -764,6 +780,11 @@ struct AbsentKeyConstraint<'db> {
 }
 
 impl<'db> AbsentKeyConstraint<'db> {
+    /// Apply this fact to a replacement type without replacing it with the filtered source.
+    ///
+    /// An impossible fact still makes the conjunction `Never`; otherwise, the replacement is
+    /// filtered independently. This preserves `TypeGuard` semantics for aliased conditions such as
+    /// `guard(value) and key_not_in_value`.
     fn apply_after_replacement(
         self,
         db: &'db dyn Db,
@@ -778,10 +799,10 @@ impl<'db> AbsentKeyConstraint<'db> {
     }
 }
 
-impl<'db> Conjunctions<'db> {
+impl<'db> ConstraintConjunction<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
-            conjuncts: smallvec![NarrowingOperation::Intersection(ty)],
+            type_constraints: smallvec![NarrowingOperation::Intersection(ty)],
             present_keys: smallvec![],
             absent_keys: smallvec![],
         }
@@ -789,7 +810,7 @@ impl<'db> Conjunctions<'db> {
 
     fn generic_filtering(ty: Type<'db>) -> Self {
         Self {
-            conjuncts: smallvec![NarrowingOperation::GenericFiltering(ty)],
+            type_constraints: smallvec![NarrowingOperation::GenericFiltering(ty)],
             present_keys: smallvec![],
             absent_keys: smallvec![],
         }
@@ -797,7 +818,7 @@ impl<'db> Conjunctions<'db> {
 
     fn present_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
         Self {
-            conjuncts: smallvec![],
+            type_constraints: smallvec![],
             present_keys: smallvec![PresentKeyConstraint { source, key }],
             absent_keys: smallvec![],
         }
@@ -805,7 +826,7 @@ impl<'db> Conjunctions<'db> {
 
     fn absent_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
         Self {
-            conjuncts: smallvec![],
+            type_constraints: smallvec![],
             present_keys: smallvec![],
             absent_keys: smallvec![AbsentKeyConstraint { source, key }],
         }
@@ -813,20 +834,20 @@ impl<'db> Conjunctions<'db> {
 
     fn and_with(mut self, other: Self) -> Self {
         if self
-            .conjuncts
+            .type_constraints
             .iter()
             .any(|conjunct| conjunct.ty().is_never())
             || other
-                .conjuncts
+                .type_constraints
                 .iter()
                 .any(|conjunct| conjunct.ty().is_never())
         {
             return Self::singleton(Type::Never);
         }
 
-        for conjunct in other.conjuncts {
-            if !self.conjuncts.contains(&conjunct) {
-                self.conjuncts.push(conjunct);
+        for type_constraint in other.type_constraints {
+            if !self.type_constraints.contains(&type_constraint) {
+                self.type_constraints.push(type_constraint);
             }
         }
 
@@ -845,20 +866,27 @@ impl<'db> Conjunctions<'db> {
         self
     }
 
+    /// Materialize this conjunction, applying deferred key facts after ordinary type constraints.
+    ///
+    /// Present-key facts are applied before absent-key facts so contradictory facts for the same
+    /// key evaluate to `Never`. Replacement disjuncts use the source-aware application methods to
+    /// avoid undoing `TypeGuard` narrowing.
     fn evaluate_constraint_type(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         is_replacement: bool,
     ) -> Type<'db> {
-        if self.present_keys.is_empty() && self.absent_keys.is_empty() && self.conjuncts.len() == 1
+        if self.present_keys.is_empty()
+            && self.absent_keys.is_empty()
+            && self.type_constraints.len() == 1
         {
-            return self.conjuncts[0].ty();
+            return self.type_constraints[0].ty();
         }
 
         // Collapse shared union arms before distributing the next constraint over them.
         let mut current = self
-            .conjuncts
+            .type_constraints
             .into_iter()
             .fold(Type::object(), |accumulated, conjunct| match conjunct {
                 NarrowingOperation::Intersection(ty) => {
@@ -1182,14 +1210,14 @@ pub(crate) struct NarrowingConstraint<'db> {
     /// Intersection constraint (from `isinstance()` narrowing comparisons, `TypeIs`, and
     /// similar). We keep these as a disjunction of conjunctions to avoid constructing
     /// union/intersection types while merging constraints.
-    intersection_disjuncts: SmallVec<[Conjunctions<'db>; 1]>,
+    intersection_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]>,
 
     /// "Replacement" constraints: instead of intersecting the previous type with a new type,
     /// the previous type is simply replaced wholesale with the new type. A common use case for
     /// these constraints is `typing.TypeGuard`. We can't eagerly union disjunctions because
     /// `TypeGuard` clobbers the previously-known type; within each replacement disjunct, however,
     /// we may eagerly intersect conjunctions with a later intersection narrowing.
-    replacement_disjuncts: SmallVec<[Conjunctions<'db>; 1]>,
+    replacement_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]>,
 }
 
 impl<'db> NarrowingConstraint<'db> {
@@ -1197,7 +1225,7 @@ impl<'db> NarrowingConstraint<'db> {
     /// intersected with this constraint
     pub(crate) fn intersection(constraint: Type<'db>) -> Self {
         Self {
-            intersection_disjuncts: smallvec_inline![Conjunctions::singleton(constraint)],
+            intersection_disjuncts: smallvec_inline![ConstraintConjunction::singleton(constraint)],
             replacement_disjuncts: smallvec![],
         }
     }
@@ -1206,7 +1234,9 @@ impl<'db> NarrowingConstraint<'db> {
     /// the subject when narrowing it to a subclass.
     fn generic_filtering(constraint: Type<'db>) -> Self {
         Self {
-            intersection_disjuncts: smallvec_inline![Conjunctions::generic_filtering(constraint)],
+            intersection_disjuncts: smallvec_inline![ConstraintConjunction::generic_filtering(
+                constraint
+            )],
             replacement_disjuncts: smallvec![],
         }
     }
@@ -1216,20 +1246,24 @@ impl<'db> NarrowingConstraint<'db> {
     fn replacement(constraint: Type<'db>) -> Self {
         Self {
             intersection_disjuncts: smallvec![],
-            replacement_disjuncts: smallvec_inline![Conjunctions::singleton(constraint)],
+            replacement_disjuncts: smallvec_inline![ConstraintConjunction::singleton(constraint)],
         }
     }
 
     fn present_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
         Self {
-            intersection_disjuncts: smallvec_inline![Conjunctions::present_key(source, key)],
+            intersection_disjuncts: smallvec_inline![ConstraintConjunction::present_key(
+                source, key
+            )],
             replacement_disjuncts: smallvec![],
         }
     }
 
     fn absent_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
         Self {
-            intersection_disjuncts: smallvec_inline![Conjunctions::absent_key(source, key)],
+            intersection_disjuncts: smallvec_inline![ConstraintConjunction::absent_key(
+                source, key
+            )],
             replacement_disjuncts: smallvec![],
         }
     }
@@ -1265,7 +1299,8 @@ impl<'db> NarrowingConstraint<'db> {
             }
         }
 
-        let mut additional_replacement_disjuncts: SmallVec<[Conjunctions<'db>; 1]> = smallvec![];
+        let mut additional_replacement_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]> =
+            smallvec![];
         for replacement_disjunct in &self.replacement_disjuncts {
             for other_intersection_disjunct in &other.intersection_disjuncts {
                 let merged = replacement_disjunct
@@ -1304,11 +1339,11 @@ impl<'db> NarrowingConstraint<'db> {
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
         let mut union = UnionBuilder::new(db, env);
-        for conjunctions in self.replacement_disjuncts {
-            union.add_in_place(conjunctions.evaluate_constraint_type(db, env, true));
+        for conjunction in self.replacement_disjuncts {
+            union.add_in_place(conjunction.evaluate_constraint_type(db, env, true));
         }
-        for conjunctions in self.intersection_disjuncts {
-            union.add_in_place(conjunctions.evaluate_constraint_type(db, env, false));
+        for conjunction in self.intersection_disjuncts {
+            union.add_in_place(conjunction.evaluate_constraint_type(db, env, false));
         }
         union.build()
     }
@@ -5126,6 +5161,11 @@ fn is_mapping_subtype<'db>(
     )
 }
 
+/// Return whether successful membership implies that subscripting with the same key is valid.
+///
+/// `TypedDict` and `Mapping` provide this relationship; an arbitrary `__contains__`
+/// implementation does not. Every arm of a union must provide the relationship before it can be
+/// carried across replacement narrowing.
 fn key_membership_implies_subscript<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -5140,6 +5180,17 @@ fn key_membership_implies_subscript<'db>(
     }
 }
 
+/// Refine `ty` with the fact that the literal `key` is present.
+///
+/// `TypedDict` arms gain a required read-only field, `Mapping` arms gain matching
+/// `__contains__` and `__getitem__` methods, and other arms only gain the successful membership
+/// fact. The distinction prevents code like this from implying invalid subscript access:
+///
+/// ```python
+/// def f(value: Literal["abc"]):
+///     if "a" in value:
+///         value["a"]  # Still invalid: string membership does not imply key subscripting.
+/// ```
 fn narrow_with_present_key<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -5182,6 +5233,10 @@ fn typeddict_declares_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> boo
     }
 }
 
+/// Refine `ty` with the fact that the literal `key` is absent.
+///
+/// Union arms that prove the key is always present are removed. Other arms are retained unchanged:
+/// failing to prove presence is not proof of absence.
 fn narrow_with_absent_key<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -5200,7 +5255,11 @@ fn narrow_with_absent_key<'db>(
     }
 }
 
-/// Return whether a negative membership test for `key` contradicts `ty`.
+/// Return whether `ty` proves that `key` is present, making a negative membership branch
+/// unreachable.
+///
+/// A required `TypedDict` field proves presence directly. Other types prove it when calling
+/// `__contains__` with this literal key has an always-truthy return type.
 fn key_is_always_present<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -5274,6 +5333,12 @@ fn required_typeddict_key<'db>(
 ///
 /// This preserves both the proven membership result and safe subscript access, assuming that
 /// `Mapping` implementations honor the contract between the two operations.
+///
+/// ```python
+/// def f(mapping: Mapping[Literal["a"], int]):
+///     if "b" in mapping:
+///         reveal_type(mapping["b"])  # object
+/// ```
 fn mapping_present_key_protocol<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -896,6 +896,21 @@ impl<'db> ConstraintConjunction<'db> {
         self
     }
 
+    /// Add only the deferred key facts from `other`, leaving its type constraints behind.
+    fn and_with_key_constraints_from(mut self, other: &Self) -> Self {
+        if self.key_constraints.is_empty() {
+            self.key_constraints = other.key_constraints.clone();
+        } else {
+            for key_constraint in &other.key_constraints {
+                if !self.key_constraints.contains(key_constraint) {
+                    self.key_constraints.push(key_constraint.clone());
+                }
+            }
+        }
+
+        self
+    }
+
     /// Materialize this conjunction, applying deferred key facts after ordinary type constraints.
     ///
     /// Present-key facts are applied before absent-key facts so contradictory facts for the same
@@ -1306,14 +1321,17 @@ impl<'db> NarrowingConstraint<'db> {
         // Distribute AND over OR: (A1 | A2 | ...) AND (B1 | B2 | ...)
         // becomes (A1 & B1) | (A1 & B2) | ... | (A2 & B1) | ...
         //
-        // The RHS replacement disjuncts all clobber the LHS disjuncts when they are `and`ed, so
-        // they stay as is.
+        // The RHS replacement disjuncts clobber the LHS type constraints when they are `and`ed,
+        // but facts established by LHS key checks still apply to the replacement type. Combine each
+        // replacement disjunct with the key facts from each LHS disjunct.
         //
         // Each RHS intersection disjunct gets intersected with each LHS disjunct, producing the
         // cartesian product. The merged disjunct retains the LHS kind.
         //
         // The conjunctions still defer constructing the corresponding intersection types.
         let mut other_intersection_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]> =
+            smallvec![];
+        let mut other_replacement_conjunctions: SmallVec<[ConstraintConjunction<'db>; 1]> =
             smallvec![];
         let mut new_disjuncts: SmallVec<[ConstraintDisjunct<'db>; 1]> = smallvec![];
         for disjunct in other.disjuncts {
@@ -1322,7 +1340,21 @@ impl<'db> NarrowingConstraint<'db> {
                     other_intersection_disjuncts.push(disjunct.conjunction);
                 }
                 ConstraintDisjunctKind::Replacement => {
-                    new_disjuncts.push(disjunct);
+                    other_replacement_conjunctions.push(disjunct.conjunction);
+                }
+            }
+        }
+
+        for disjunct in &self.disjuncts {
+            for other_conjunction in &other_replacement_conjunctions {
+                let merged = ConstraintDisjunct {
+                    kind: ConstraintDisjunctKind::Replacement,
+                    conjunction: other_conjunction
+                        .clone()
+                        .and_with_key_constraints_from(&disjunct.conjunction),
+                };
+                if !new_disjuncts.contains(&merged) {
+                    new_disjuncts.push(merged);
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -727,20 +727,29 @@ struct PresentKeyConstraint<'db> {
 }
 
 impl<'db> PresentKeyConstraint<'db> {
-    fn after_replacement(
+    fn apply_after_replacement(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-    ) -> Option<Type<'db>> {
+        replacement: Type<'db>,
+    ) -> Type<'db> {
         let narrowed = narrow_with_present_key(db, env, self.source, self.key.value(db));
         if narrowed == self.source || narrowed == self.source.resolve_type_alias(db) {
-            return None;
+            return replacement;
+        }
+        if narrowed.is_never() {
+            return Type::Never;
         }
 
         if key_membership_implies_subscript(db, env, self.source) {
-            Some(mapping_present_key_protocol(db, env, self.key.value(db)))
+            IntersectionType::from_two_elements(
+                db,
+                env,
+                replacement,
+                mapping_present_key_protocol(db, env, self.key.value(db)),
+            )
         } else {
-            Some(key_membership_contains_protocol(db, env, self.key.value(db)))
+            narrow_with_present_key(db, env, replacement, self.key.value(db))
         }
     }
 }
@@ -820,9 +829,7 @@ impl<'db> Conjunctions<'db> {
 
         if is_replacement {
             for present_key in self.present_keys {
-                if let Some(constraint) = present_key.after_replacement(db, env) {
-                    current = IntersectionType::from_two_elements(db, env, current, constraint);
-                }
+                current = present_key.apply_after_replacement(db, env, current);
             }
         } else {
             for present_key in self.present_keys {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -5214,10 +5214,25 @@ fn narrow_with_present_key<'db>(
         Type::Union(union) => union.map(db, env, |element| {
             narrow_with_present_key(db, env, *element, key)
         }),
+        resolved if closed_typeddict_excludes_key(db, resolved, key) => Type::Never,
         resolved if is_mapping_subtype(db, env, resolved) => {
             constrain(ty, mapping_present_key_protocol(db, env, key))
         }
         _ => constrain(ty, key_membership_contains_protocol(db, env, key)),
+    }
+}
+
+/// Return whether a closed `TypedDict` in `ty` rules out `key`.
+fn closed_typeddict_excludes_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::TypedDict(typed_dict) => {
+            typed_dict.openness(db).is_closed() && !typed_dict.items(db).contains_key(key)
+        }
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| closed_typeddict_excludes_key(db, *element, key)),
+        _ => false,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -717,7 +717,7 @@ impl<'db> NarrowingOperation<'db> {
 /// `value: A | B`, converting each check in `"a" in value and "b" in value` can split both checks
 /// into `A` and `B`; combining them would then create every pairing of those branches. Keeping the
 /// checks here applies them only when the final type is evaluated. It also lets a key fact constrain
-/// a later `TypeGuard` replacement instead of restoring the original type.
+/// a later precomputed refinement instead of restoring the original type.
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct ConstraintConjunction<'db> {
     type_constraints: SmallVec<[NarrowingOperation<'db>; 2]>,
@@ -927,17 +927,17 @@ impl<'db> ConstraintConjunction<'db> {
         }
 
         // Collapse shared union arms before distributing the next constraint over them.
-        let mut current = self
-            .type_constraints
-            .into_iter()
-            .fold(Type::object(), |accumulated, conjunct| match conjunct {
-                NarrowingOperation::Intersection(ty) => {
-                    IntersectionType::from_two_elements(db, env, accumulated, ty)
-                }
-                NarrowingOperation::GenericFiltering(ty) => {
-                    filter_generic_narrowing_constraint(db, env, accumulated, ty)
-                }
-            });
+        let mut current =
+            self.type_constraints
+                .into_iter()
+                .fold(Type::object(), |accumulated, conjunct| match conjunct {
+                    NarrowingOperation::Intersection(ty) => {
+                        IntersectionType::from_two_elements(db, env, accumulated, ty)
+                    }
+                    NarrowingOperation::GenericFiltering(ty) => {
+                        filter_generic_narrowing_constraint(db, env, accumulated, ty)
+                    }
+                });
 
         if self.key_constraints.is_empty() {
             return current;
@@ -1229,8 +1229,8 @@ fn specialize_generic_class_from_solutions<'db>(
 /// Represents narrowing constraints in Disjunctive Normal Form (DNF).
 ///
 /// This is a disjunction (OR) of conjunctions (AND) of constraints.
-/// The DNF representation allows us to properly track "replacement" constraints
-/// (created by `TypeGuard` types and similar) through boolean operations.
+/// The DNF representation allows us to distinguish intersections, precomputed refinements, and
+/// `TypeGuard` replacements through boolean operations.
 ///
 /// For example:
 /// - `f(x) and g(x)` where f returns `TypeIs[A]` and g returns `TypeGuard[B]`
@@ -1262,9 +1262,12 @@ enum ConstraintDisjunctKind {
     /// Intersect the previous type with this disjunct.
     Intersection,
 
-    /// Replace the previous type with this disjunct. A common source of replacement constraints is
-    /// `typing.TypeGuard`.
-    Replacement,
+    /// Replace the previous type with a directly filtered refinement while retaining deferred key
+    /// facts. This is used when narrowing cannot be represented as an intersection.
+    PrecomputedRefinement,
+
+    /// Replace all previously known type information with this disjunct.
+    TypeGuardReplacement,
 }
 
 impl<'db> NarrowingConstraint<'db> {
@@ -1292,11 +1295,19 @@ impl<'db> NarrowingConstraint<'db> {
         )
     }
 
-    /// Create a "replacement" constraint: the previous type will be
-    /// replaced wholesale with this constraint
-    fn replacement(constraint: Type<'db>) -> Self {
+    /// Create a precomputed refinement: the previous type will be replaced with this constraint,
+    /// but preceding deferred key facts will still apply.
+    fn precomputed_refinement(constraint: Type<'db>) -> Self {
         Self::singleton(
-            ConstraintDisjunctKind::Replacement,
+            ConstraintDisjunctKind::PrecomputedRefinement,
+            ConstraintConjunction::singleton(constraint),
+        )
+    }
+
+    /// Create a `TypeGuard` replacement that discards all previously known type information.
+    fn type_guard_replacement(constraint: Type<'db>) -> Self {
+        Self::singleton(
+            ConstraintDisjunctKind::TypeGuardReplacement,
             ConstraintConjunction::singleton(constraint),
         )
     }
@@ -1321,9 +1332,9 @@ impl<'db> NarrowingConstraint<'db> {
         // Distribute AND over OR: (A1 | A2 | ...) AND (B1 | B2 | ...)
         // becomes (A1 & B1) | (A1 & B2) | ... | (A2 & B1) | ...
         //
-        // The RHS replacement disjuncts clobber the LHS type constraints when they are `and`ed,
-        // but facts established by LHS key checks still apply to the replacement type. Combine each
-        // replacement disjunct with the key facts from each LHS disjunct.
+        // RHS `TypeGuard` replacements discard the LHS disjuncts entirely. RHS precomputed
+        // refinements clobber the LHS type constraints, but facts established by LHS key checks
+        // still apply to the refined type.
         //
         // Each RHS intersection disjunct gets intersected with each LHS disjunct, producing the
         // cartesian product. The merged disjunct retains the LHS kind.
@@ -1331,24 +1342,30 @@ impl<'db> NarrowingConstraint<'db> {
         // The conjunctions still defer constructing the corresponding intersection types.
         let mut other_intersection_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]> =
             smallvec![];
-        let mut other_replacement_conjunctions: SmallVec<[ConstraintConjunction<'db>; 1]> =
-            smallvec![];
+        let mut other_precomputed_refinement_conjunctions: SmallVec<
+            [ConstraintConjunction<'db>; 1],
+        > = smallvec![];
         let mut new_disjuncts: SmallVec<[ConstraintDisjunct<'db>; 1]> = smallvec![];
         for disjunct in other.disjuncts {
             match disjunct.kind {
                 ConstraintDisjunctKind::Intersection => {
                     other_intersection_disjuncts.push(disjunct.conjunction);
                 }
-                ConstraintDisjunctKind::Replacement => {
-                    other_replacement_conjunctions.push(disjunct.conjunction);
+                ConstraintDisjunctKind::PrecomputedRefinement => {
+                    other_precomputed_refinement_conjunctions.push(disjunct.conjunction);
+                }
+                ConstraintDisjunctKind::TypeGuardReplacement => {
+                    if !new_disjuncts.contains(&disjunct) {
+                        new_disjuncts.push(disjunct);
+                    }
                 }
             }
         }
 
         for disjunct in &self.disjuncts {
-            for other_conjunction in &other_replacement_conjunctions {
+            for other_conjunction in &other_precomputed_refinement_conjunctions {
                 let merged = ConstraintDisjunct {
-                    kind: ConstraintDisjunctKind::Replacement,
+                    kind: ConstraintDisjunctKind::PrecomputedRefinement,
                     conjunction: other_conjunction
                         .clone()
                         .and_with_key_constraints_from(&disjunct.conjunction),
@@ -1403,7 +1420,7 @@ impl<'db> NarrowingConstraint<'db> {
             union.add_in_place(disjunct.conjunction.evaluate_constraint_type(
                 db,
                 env,
-                disjunct.kind == ConstraintDisjunctKind::Replacement,
+                disjunct.kind != ConstraintDisjunctKind::Intersection,
             ));
         }
         union.build()
@@ -4084,7 +4101,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             });
             if filtered != Type::Union(union) {
                 let place = self.expect_place(&subscript_place_expr);
-                constraints.insert(place, NarrowingConstraint::replacement(filtered));
+                constraints.insert(place, NarrowingConstraint::precomputed_refinement(filtered));
             }
         }
 
@@ -4136,7 +4153,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     insert_narrowing_constraint(
                         &mut constraints,
                         self.expect_place(&target),
-                        NarrowingConstraint::replacement(narrowed),
+                        NarrowingConstraint::precomputed_refinement(narrowed),
                     );
                 }
             };
@@ -4537,7 +4554,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let (_, place) = type_guard.place_info(db)?;
                 Some((
                     place,
-                    NarrowingConstraint::replacement(type_guard.return_type(db)),
+                    NarrowingConstraint::type_guard_replacement(type_guard.return_type(db)),
                 ))
             }
             _ => None,
@@ -5041,7 +5058,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         // Only create a constraint if we actually narrowed something.
         if filtered != Type::Union(union) {
             let place = self.expect_place(&subscript_place_expr);
-            Some((place, NarrowingConstraint::replacement(filtered)))
+            Some((place, NarrowingConstraint::precomputed_refinement(filtered)))
         } else {
             None
         }
@@ -5093,7 +5110,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         let attribute_value_place_expr = PlaceExpr::try_from_expr(attribute_value_expr)?;
         let place = self.expect_place(&attribute_value_place_expr);
-        Some((place, NarrowingConstraint::replacement(narrowed)))
+        Some((place, NarrowingConstraint::precomputed_refinement(narrowed)))
     }
 
     fn narrow_nominal_attribute_by_truthiness(
@@ -5130,7 +5147,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         let attribute_value_place_expr = PlaceExpr::try_from_expr(attribute_value_expr)?;
         let place = self.expect_place(&attribute_value_place_expr);
-        Some((place, NarrowingConstraint::replacement(narrowed)))
+        Some((place, NarrowingConstraint::precomputed_refinement(narrowed)))
     }
 }
 
@@ -5195,11 +5212,7 @@ fn is_or_contains_mapping<'db>(
     }
 }
 
-fn is_mapping_subtype<'db>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    ty: Type<'db>,
-) -> bool {
+fn is_mapping_subtype<'db>(db: &'db dyn Db, env: &ProgramEnvironment<'db>, ty: Type<'db>) -> bool {
     ty.is_subtype_of(
         db,
         env,
@@ -5317,9 +5330,7 @@ fn key_is_always_present<'db>(
             CallArguments::positional([Type::string_literal(db, key.value(db))]),
             TypeContext::default(),
         )
-        .is_ok_and(|bindings| {
-            bindings.return_type(db, env).bool(db, env) == Truthiness::AlwaysTrue
-        })
+        .is_ok_and(|bindings| bindings.return_type(db, env).bool(db, env) == Truthiness::AlwaysTrue)
 }
 
 /// Return a synthesized protocol that records a present key on a `Mapping` subtype.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -8,7 +8,9 @@ use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
 use crate::types::tuple::{TupleLength, TupleSpec, TupleSpecBuilder, TupleType, TupleUnpacker};
-use crate::types::typed_dict::{TypedDictFieldBuilder, TypedDictSchema, TypedDictType};
+use crate::types::typed_dict::{
+    TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
+};
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -5198,8 +5200,9 @@ fn key_membership_implies_subscript<'db>(
 
 /// Refine `ty` with the fact that the literal `key` is present.
 ///
-/// `Mapping` arms gain matching `__contains__` and `__getitem__` methods, while other arms only
-/// gain the successful membership fact.
+/// `TypedDict` arms gain a required read-only field, `Mapping` arms gain matching
+/// `__contains__` and `__getitem__` methods, and other arms only gain the successful membership
+/// fact.
 fn narrow_with_present_key<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -5214,10 +5217,31 @@ fn narrow_with_present_key<'db>(
         Type::Union(union) => union.map(db, env, |element| {
             narrow_with_present_key(db, env, *element, key)
         }),
+        resolved if typeddict_declares_key(db, resolved, key) => ty,
+        resolved if is_or_contains_typeddict(db, resolved) => constrain(
+            ty,
+            Type::TypedDict(required_typeddict_key(db, key, Type::object())),
+        ),
         resolved if is_mapping_subtype(db, env, resolved) => {
             constrain(ty, mapping_present_key_protocol(db, env, key))
         }
         _ => constrain(ty, key_membership_contains_protocol(db, env, key)),
+    }
+}
+
+fn typeddict_declares_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> bool {
+    match ty {
+        Type::TypedDict(typed_dict) => typed_dict.items(db).contains_key(key),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| typeddict_declares_key(db, *element, key)),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .any(|element| typeddict_declares_key(db, *element, key)),
+        Type::TypeAlias(alias) => typeddict_declares_key(db, alias.value_type(db), key),
+        _ => false,
     }
 }
 
@@ -5245,34 +5269,75 @@ fn narrow_with_absent_key<'db>(
 /// Return whether `ty` proves that `key` is present, making a negative membership branch
 /// unreachable.
 ///
-/// Calling `__contains__` with this literal key must have an always-truthy return type.
+/// A required `TypedDict` field proves presence directly. Other types prove it when calling
+/// `__contains__` with this literal key has an always-truthy return type.
 fn key_is_always_present<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
     key: StringLiteralType<'db>,
 ) -> bool {
-    let resolved = ty.resolve_type_alias(db);
-    if let Type::Intersection(intersection) = resolved
-        && intersection
+    let required_typed_dict_key = |typed_dict: TypedDictType<'db>| {
+        typed_dict
+            .items(db)
+            .get(key.value(db))
+            .is_some_and(TypedDictField::is_required)
+    };
+
+    let has_required_typed_dict_key = match ty {
+        Type::TypedDict(typed_dict) => required_typed_dict_key(typed_dict),
+        Type::Intersection(intersection) => intersection
             .positive(db)
             .iter()
-            .any(|element| key_is_always_present(db, env, *element, key))
-    {
-        return true;
-    }
+            .copied()
+            .filter_map(Type::as_typed_dict)
+            .any(required_typed_dict_key),
+        _ => false,
+    };
 
-    resolved
-        .try_call_dunder(
-            db,
-            env,
-            "__contains__",
-            CallArguments::positional([Type::string_literal(db, key.value(db))]),
-            TypeContext::default(),
-        )
-        .is_ok_and(|bindings| {
-            bindings.return_type(db, env).bool(db, env) == Truthiness::AlwaysTrue
-        })
+    has_required_typed_dict_key
+        || ty
+            .try_call_dunder(
+                db,
+                env,
+                "__contains__",
+                CallArguments::positional([Type::string_literal(db, key.value(db))]),
+                TypeContext::default(),
+            )
+            .is_ok_and(|bindings| {
+                bindings.return_type(db, env).bool(db, env) == Truthiness::AlwaysTrue
+            })
+}
+
+/// Return a synthesized `TypedDict` that represents safe subscript access for a present key on a
+/// `TypedDict`-containing type.
+///
+/// For `TypedDict`s, a positive key-membership test proves more than containment: it also makes
+/// string-literal subscript access with that key valid. In the `if` branch below, the `Bar` arm
+/// keeps its original shape but is intersected with this schema so `u["foo"]` is accepted:
+///
+/// ```python
+/// class Foo(TypedDict):
+///     foo: int
+///
+/// class Bar(TypedDict):
+///     bar: int
+///
+/// def f(u: Foo | Bar):
+///     if "foo" in u:
+///         reveal_type(u["foo"])  # object
+/// ```
+fn required_typeddict_key<'db>(
+    db: &'db dyn Db,
+    key: &str,
+    value_ty: Type<'db>,
+) -> TypedDictType<'db> {
+    let field = TypedDictFieldBuilder::new(value_ty)
+        .required(true)
+        .read_only(true)
+        .build();
+    let schema = TypedDictSchema::from_iter([(Name::from(key), field)]);
+    TypedDictType::from_schema_items(db, schema)
 }
 
 /// Return a synthesized protocol that records a present key on a `Mapping` subtype.
@@ -5326,8 +5391,8 @@ fn mapping_present_key_protocol<'db>(
 /// Return a synthesized protocol that records a true key-membership test without implying
 /// subscript access.
 ///
-/// For non-`Mapping` types, `"key" in value` only proves that membership is true. It does not prove
-/// that `value["key"]` is valid:
+/// For non-`TypedDict` types, `"key" in value` only proves that membership is true. It does not
+/// prove that `value["key"]` is valid:
 ///
 /// ```python
 /// def f(s: Literal["abc"]):
@@ -5335,8 +5400,8 @@ fn mapping_present_key_protocol<'db>(
 ///         s["a"]  # Runtime `TypeError`
 /// ```
 ///
-/// Non-`Mapping` union arms therefore receive this `__contains__` protocol instead of the
-/// `__contains__` and `__getitem__` protocol used for `Mapping` arms.
+/// Non-`TypedDict` union arms therefore receive this `__contains__` protocol instead of the
+/// synthesized `TypedDict` used for `TypedDict` arms.
 fn key_membership_contains_protocol<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -8,9 +8,7 @@ use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
 use crate::types::tuple::{TupleLength, TupleSpec, TupleSpecBuilder, TupleType, TupleUnpacker};
-use crate::types::typed_dict::{
-    TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
-};
+use crate::types::typed_dict::{TypedDictFieldBuilder, TypedDictSchema, TypedDictType};
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -5200,9 +5198,8 @@ fn key_membership_implies_subscript<'db>(
 
 /// Refine `ty` with the fact that the literal `key` is present.
 ///
-/// `TypedDict` arms gain a required read-only field, `Mapping` arms gain matching
-/// `__contains__` and `__getitem__` methods, and other arms only gain the successful membership
-/// fact.
+/// `Mapping` arms gain matching `__contains__` and `__getitem__` methods, while other arms only
+/// gain the successful membership fact.
 fn narrow_with_present_key<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -5217,31 +5214,10 @@ fn narrow_with_present_key<'db>(
         Type::Union(union) => union.map(db, env, |element| {
             narrow_with_present_key(db, env, *element, key)
         }),
-        resolved if typeddict_declares_key(db, resolved, key) => ty,
-        resolved if is_or_contains_typeddict(db, resolved) => constrain(
-            ty,
-            Type::TypedDict(required_typeddict_key(db, key, Type::object())),
-        ),
         resolved if is_mapping_subtype(db, env, resolved) => {
             constrain(ty, mapping_present_key_protocol(db, env, key))
         }
         _ => constrain(ty, key_membership_contains_protocol(db, env, key)),
-    }
-}
-
-fn typeddict_declares_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> bool {
-    match ty {
-        Type::TypedDict(typed_dict) => typed_dict.items(db).contains_key(key),
-        Type::Intersection(intersection) => intersection
-            .positive(db)
-            .iter()
-            .any(|element| typeddict_declares_key(db, *element, key)),
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .any(|element| typeddict_declares_key(db, *element, key)),
-        Type::TypeAlias(alias) => typeddict_declares_key(db, alias.value_type(db), key),
-        _ => false,
     }
 }
 
@@ -5269,75 +5245,34 @@ fn narrow_with_absent_key<'db>(
 /// Return whether `ty` proves that `key` is present, making a negative membership branch
 /// unreachable.
 ///
-/// A required `TypedDict` field proves presence directly. Other types prove it when calling
-/// `__contains__` with this literal key has an always-truthy return type.
+/// Calling `__contains__` with this literal key must have an always-truthy return type.
 fn key_is_always_present<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
     key: StringLiteralType<'db>,
 ) -> bool {
-    let required_typed_dict_key = |typed_dict: TypedDictType<'db>| {
-        typed_dict
-            .items(db)
-            .get(key.value(db))
-            .is_some_and(TypedDictField::is_required)
-    };
-
-    let has_required_typed_dict_key = match ty {
-        Type::TypedDict(typed_dict) => required_typed_dict_key(typed_dict),
-        Type::Intersection(intersection) => intersection
+    let resolved = ty.resolve_type_alias(db);
+    if let Type::Intersection(intersection) = resolved
+        && intersection
             .positive(db)
             .iter()
-            .copied()
-            .filter_map(Type::as_typed_dict)
-            .any(required_typed_dict_key),
-        _ => false,
-    };
+            .any(|element| key_is_always_present(db, env, *element, key))
+    {
+        return true;
+    }
 
-    has_required_typed_dict_key
-        || ty
-            .try_call_dunder(
-                db,
-                env,
-                "__contains__",
-                CallArguments::positional([Type::string_literal(db, key.value(db))]),
-                TypeContext::default(),
-            )
-            .is_ok_and(|bindings| {
-                bindings.return_type(db, env).bool(db, env) == Truthiness::AlwaysTrue
-            })
-}
-
-/// Return a synthesized `TypedDict` that represents safe subscript access for a present key on a
-/// `TypedDict`-containing type.
-///
-/// For `TypedDict`s, a positive key-membership test proves more than containment: it also makes
-/// string-literal subscript access with that key valid. In the `if` branch below, the `Bar` arm
-/// keeps its original shape but is intersected with this schema so `u["foo"]` is accepted:
-///
-/// ```python
-/// class Foo(TypedDict):
-///     foo: int
-///
-/// class Bar(TypedDict):
-///     bar: int
-///
-/// def f(u: Foo | Bar):
-///     if "foo" in u:
-///         reveal_type(u["foo"])  # object
-/// ```
-fn required_typeddict_key<'db>(
-    db: &'db dyn Db,
-    key: &str,
-    value_ty: Type<'db>,
-) -> TypedDictType<'db> {
-    let field = TypedDictFieldBuilder::new(value_ty)
-        .required(true)
-        .read_only(true)
-        .build();
-    let schema = TypedDictSchema::from_iter([(Name::from(key), field)]);
-    TypedDictType::from_schema_items(db, schema)
+    resolved
+        .try_call_dunder(
+            db,
+            env,
+            "__contains__",
+            CallArguments::positional([Type::string_literal(db, key.value(db))]),
+            TypeContext::default(),
+        )
+        .is_ok_and(|bindings| {
+            bindings.return_type(db, env).bool(db, env) == Truthiness::AlwaysTrue
+        })
 }
 
 /// Return a synthesized protocol that records a present key on a `Mapping` subtype.
@@ -5391,8 +5326,8 @@ fn mapping_present_key_protocol<'db>(
 /// Return a synthesized protocol that records a true key-membership test without implying
 /// subscript access.
 ///
-/// For non-`TypedDict` types, `"key" in value` only proves that membership is true. It does not
-/// prove that `value["key"]` is valid:
+/// For non-`Mapping` types, `"key" in value` only proves that membership is true. It does not prove
+/// that `value["key"]` is valid:
 ///
 /// ```python
 /// def f(s: Literal["abc"]):
@@ -5400,8 +5335,8 @@ fn mapping_present_key_protocol<'db>(
 ///         s["a"]  # Runtime `TypeError`
 /// ```
 ///
-/// Non-`TypedDict` union arms therefore receive this `__contains__` protocol instead of the
-/// synthesized `TypedDict` used for `TypedDict` arms.
+/// Non-`Mapping` union arms therefore receive this `__contains__` protocol instead of the
+/// `__contains__` and `__getitem__` protocol used for `Mapping` arms.
 fn key_membership_contains_protocol<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -726,6 +726,25 @@ struct PresentKeyConstraint<'db> {
     key: StringLiteralType<'db>,
 }
 
+impl<'db> PresentKeyConstraint<'db> {
+    fn after_replacement(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Type<'db>> {
+        let narrowed = narrow_with_present_key(db, env, self.source, self.key.value(db));
+        if narrowed == self.source || narrowed == self.source.resolve_type_alias(db) {
+            return None;
+        }
+
+        if key_membership_implies_subscript(db, env, self.source) {
+            Some(mapping_key_getitem_protocol(db, env, self.key.value(db)))
+        } else {
+            Some(key_membership_contains_protocol(db, env, self.key.value(db)))
+        }
+    }
+}
+
 impl<'db> Conjunctions<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
@@ -798,21 +817,17 @@ impl<'db> Conjunctions<'db> {
                     filter_generic_narrowing_constraint(db, env, accumulated, ty)
                 }
             });
-        let mut present_keys = self.present_keys.into_iter();
 
-        if is_replacement && let Some(present_key) = present_keys.next() {
-            // A `TypeGuard` replacement discards the previous type, but a later membership test
-            // still needs the source type on which that test was performed.
-            current = IntersectionType::from_two_elements(
-                db,
-                env,
-                current,
-                narrow_with_present_key(db, env, present_key.source, present_key.key.value(db)),
-            );
-        }
-
-        for present_key in present_keys {
-            current = narrow_with_present_key(db, env, current, present_key.key.value(db));
+        if is_replacement {
+            for present_key in self.present_keys {
+                if let Some(constraint) = present_key.after_replacement(db, env) {
+                    current = IntersectionType::from_two_elements(db, env, current, constraint);
+                }
+            }
+        } else {
+            for present_key in self.present_keys {
+                current = narrow_with_present_key(db, env, current, present_key.key.value(db));
+            }
         }
 
         current
@@ -5091,6 +5106,20 @@ fn is_mapping_subtype<'db>(
             .to_instance(db, env)
             .top_materialization(db, env),
     )
+}
+
+fn key_membership_implies_subscript<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| key_membership_implies_subscript(db, env, *element)),
+        resolved => is_or_contains_typeddict(db, resolved) || is_mapping_subtype(db, env, resolved),
+    }
 }
 
 fn narrow_with_present_key<'db>(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -13,12 +13,12 @@ use crate::types::typed_dict::{
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
-    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
-    class_pattern_positional_sources, definite_match_pattern_type_for_subject,
-    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    Parameter, Parameters, Signature, SpecialFormType, StringLiteralType, SubclassOfInner,
+    SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
+    callable_pattern_type, class_pattern_positional_sources,
+    definite_match_pattern_type_for_subject, exact_sequence_pattern_type, infer_expression_types,
+    mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use crate::{Db, ProgramEnvironment};
 use ty_python_core::expression::Expression;
@@ -715,18 +715,36 @@ impl<'db> NarrowingOperation<'db> {
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct Conjunctions<'db> {
     conjuncts: SmallVec<[NarrowingOperation<'db>; 2]>,
+    present_keys: SmallVec<[PresentKeyConstraint<'db>; 1]>,
+}
+
+/// A deferred key-presence operation. Keeping union arms inside `source` avoids expanding one DNF
+/// disjunct per arm when multiple membership tests are combined.
+#[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::Update, get_size2::GetSize)]
+struct PresentKeyConstraint<'db> {
+    source: Type<'db>,
+    key: StringLiteralType<'db>,
 }
 
 impl<'db> Conjunctions<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
             conjuncts: smallvec![NarrowingOperation::Intersection(ty)],
+            present_keys: smallvec![],
         }
     }
 
     fn generic_filtering(ty: Type<'db>) -> Self {
         Self {
             conjuncts: smallvec![NarrowingOperation::GenericFiltering(ty)],
+            present_keys: smallvec![],
+        }
+    }
+
+    fn present_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
+        Self {
+            conjuncts: smallvec![],
+            present_keys: smallvec![PresentKeyConstraint { source, key }],
         }
     }
 
@@ -748,16 +766,29 @@ impl<'db> Conjunctions<'db> {
                 self.conjuncts.push(conjunct);
             }
         }
+
+        for present_key in other.present_keys {
+            if !self.present_keys.contains(&present_key) {
+                self.present_keys.push(present_key);
+            }
+        }
+
         self
     }
 
-    fn evaluate_constraint_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        if self.conjuncts.len() == 1 {
+    fn evaluate_constraint_type(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        is_replacement: bool,
+    ) -> Type<'db> {
+        if self.present_keys.is_empty() && self.conjuncts.len() == 1 {
             return self.conjuncts[0].ty();
         }
 
         // Collapse shared union arms before distributing the next constraint over them.
-        self.conjuncts
+        let mut current = self
+            .conjuncts
             .into_iter()
             .fold(Type::object(), |accumulated, conjunct| match conjunct {
                 NarrowingOperation::Intersection(ty) => {
@@ -766,7 +797,25 @@ impl<'db> Conjunctions<'db> {
                 NarrowingOperation::GenericFiltering(ty) => {
                     filter_generic_narrowing_constraint(db, env, accumulated, ty)
                 }
-            })
+            });
+        let mut present_keys = self.present_keys.into_iter();
+
+        if is_replacement && let Some(present_key) = present_keys.next() {
+            // A `TypeGuard` replacement discards the previous type, but a later membership test
+            // still needs the source type on which that test was performed.
+            current = IntersectionType::from_two_elements(
+                db,
+                env,
+                current,
+                narrow_with_present_key(db, env, present_key.source, present_key.key.value(db)),
+            );
+        }
+
+        for present_key in present_keys {
+            current = narrow_with_present_key(db, env, current, present_key.key.value(db));
+        }
+
+        current
     }
 }
 
@@ -1101,6 +1150,13 @@ impl<'db> NarrowingConstraint<'db> {
         }
     }
 
+    fn present_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
+        Self {
+            intersection_disjuncts: smallvec_inline![Conjunctions::present_key(source, key)],
+            replacement_disjuncts: smallvec![],
+        }
+    }
+
     /// Merge two constraints, taking their intersection but respecting "replacement" semantics (with
     /// `other` winning)
     pub(crate) fn merge_constraint_and(&self, other: Self) -> Self {
@@ -1171,12 +1227,11 @@ impl<'db> NarrowingConstraint<'db> {
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
         let mut union = UnionBuilder::new(db, env);
-        for conjunctions in self
-            .replacement_disjuncts
-            .into_iter()
-            .chain(self.intersection_disjuncts)
-        {
-            union.add_in_place(conjunctions.evaluate_constraint_type(db, env));
+        for conjunctions in self.replacement_disjuncts {
+            union.add_in_place(conjunctions.evaluate_constraint_type(db, env, true));
+        }
+        for conjunctions in self.intersection_disjuncts {
+            union.add_in_place(conjunctions.evaluate_constraint_type(db, env, false));
         }
         union.build()
     }
@@ -4012,9 +4067,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             && let Some(key) = inference.expression_type(&**left).as_string_literal()
             && let rhs_expr = comparators[0].expression_value()
             && let rhs_type = inference.expression_type(&comparators[0])
-            && is_or_contains_typeddict(db, rhs_type)
+            && (is_or_contains_typeddict(db, rhs_type)
+                || is_or_contains_mapping(db, &self.env, rhs_type))
         {
-            let key = key.value(db);
             let apply_constraint =
                 |constraints: &mut NarrowingConstraints<'db>,
                  constraint: NarrowingConstraint<'db>| {
@@ -4034,14 +4089,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 };
 
             if is_positive == (ops[0] == ast::CmpOp::In) {
-                let narrowed = self.narrow_with_present_key(rhs_type, key);
-                if narrowed != rhs_type.resolve_type_alias(db) {
-                    apply_constraint(&mut constraints, NarrowingConstraint::replacement(narrowed));
-                }
+                apply_constraint(
+                    &mut constraints,
+                    NarrowingConstraint::present_key(rhs_type, key),
+                );
             } else {
                 let requires_key = |td: TypedDictType<'db>| -> bool {
                     td.items(db)
-                        .get(key)
+                        .get(key.value(db))
                         .is_some_and(TypedDictField::is_required)
                 };
 
@@ -4800,30 +4855,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         Some((place, NarrowingConstraint::intersection(intersection)))
     }
 
-    // TODO: Restructure this helper to return the key-presence constraint and apply it with
-    // `NarrowingConstraint::intersection` at the call site instead of constructing a replacement
-    // type here.
-    fn narrow_with_present_key(&self, ty: Type<'db>, key: &str) -> Type<'db> {
-        let db = self.db;
-        let constrain = |ty, key_presence_constraint| {
-            IntersectionType::from_two_elements(db, &self.env, ty, key_presence_constraint)
-        };
-
-        match ty.resolve_type_alias(db) {
-            Type::Union(union) => union.map(db, &self.env, |element| {
-                self.narrow_with_present_key(*element, key)
-            }),
-            resolved if typeddict_declares_key(db, resolved, key) => resolved,
-            // TODO: Extend this to subtypes of `Mapping[str, object]` whose membership and
-            // subscript operations obey the `Mapping` contract.
-            resolved if is_or_contains_typeddict(db, resolved) => constrain(
-                ty,
-                Type::TypedDict(required_typeddict_key(db, key, Type::object())),
-            ),
-            _ => constrain(ty, key_membership_contains_protocol(db, &self.env, key)),
-        }
-    }
-
     /// Narrow tagged unions of tuples with `Literal` elements.
     ///
     /// Given a subscript expression like `t[0]` where `t` is a union of tuple types, and a
@@ -5034,6 +5065,60 @@ fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     }
 }
 
+fn is_or_contains_mapping<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .any(|element| is_or_contains_mapping(db, env, *element)),
+        resolved => is_mapping_subtype(db, env, resolved),
+    }
+}
+
+fn is_mapping_subtype<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+) -> bool {
+    ty.is_subtype_of(
+        db,
+        env,
+        KnownClass::Mapping
+            .to_instance(db, env)
+            .top_materialization(db, env),
+    )
+}
+
+fn narrow_with_present_key<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+    key: &str,
+) -> Type<'db> {
+    let constrain = |ty, key_presence_constraint| {
+        IntersectionType::from_two_elements(db, env, ty, key_presence_constraint)
+    };
+
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => union.map(db, env, |element| {
+            narrow_with_present_key(db, env, *element, key)
+        }),
+        resolved if typeddict_declares_key(db, resolved, key) => ty,
+        resolved if is_or_contains_typeddict(db, resolved) => constrain(
+            ty,
+            Type::TypedDict(required_typeddict_key(db, key, Type::object())),
+        ),
+        resolved if is_mapping_subtype(db, env, resolved) => {
+            constrain(ty, mapping_key_getitem_protocol(db, env, key))
+        }
+        _ => constrain(ty, key_membership_contains_protocol(db, env, key)),
+    }
+}
+
 fn typeddict_declares_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> bool {
     match ty {
         Type::TypedDict(typed_dict) => typed_dict.items(db).contains_key(key),
@@ -5079,6 +5164,30 @@ fn required_typeddict_key<'db>(
         .build();
     let schema = TypedDictSchema::from_iter([(Name::from(key), field)]);
     TypedDictType::from_schema_items(db, schema)
+}
+
+/// Return a synthesized protocol that represents safe subscript access for a present key on a
+/// `Mapping` subtype. This assumes that `Mapping` implementations honor the contract between
+/// membership and subscript access.
+fn mapping_key_getitem_protocol<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    key: &str,
+) -> Type<'db> {
+    let signature = Signature::new(
+        Parameters::standard([
+            Parameter::positional_only(Some(Name::new_static("self"))),
+            Parameter::positional_only(Some(Name::new_static("key")))
+                .with_annotated_type(Type::string_literal(db, key)),
+        ]),
+        Type::object(),
+    );
+
+    Type::protocol_with_methods(
+        db,
+        env,
+        [("__getitem__", CallableType::function_like(db, signature))],
+    )
 }
 
 /// Return a synthesized protocol that records a true key-membership test without implying

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -50,6 +50,7 @@ use ruff_python_ast as ast;
 use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
+use thin_vec::{ThinVec, thin_vec};
 
 mod containment;
 
@@ -712,16 +713,27 @@ impl<'db> NarrowingOperation<'db> {
     }
 }
 
+/// One conjunction in the DNF representation.
+///
+/// Key membership checks are stored as facts instead of converted into types immediately. For
+/// `value: A | B`, converting each check in `"a" in value and "b" in value` can split both checks
+/// into `A` and `B`; combining them would then create every pairing of those branches. Keeping the
+/// checks here applies them only when the final type is evaluated. It also lets a key fact constrain
+/// a later `TypeGuard` replacement instead of restoring the original type.
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct ConstraintConjunction<'db> {
     type_constraints: SmallVec<[NarrowingOperation<'db>; 2]>,
-    present_keys: SmallVec<[PresentKeyConstraint<'db>; 1]>,
-    absent_keys: SmallVec<[AbsentKeyConstraint<'db>; 1]>,
+    key_constraints: ThinVec<KeyConstraint<'db>>,
 }
 
-/// A deferred key-presence operation. Keeping union arms inside `source` avoids expanding one DNF
-/// disjunct per arm when multiple membership tests are combined.
-#[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::Update, get_size2::GetSize)]
+#[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
+enum KeyConstraint<'db> {
+    Present(PresentKeyConstraint<'db>),
+    Absent(AbsentKeyConstraint<'db>),
+}
+
+/// A deferred fact that `key` is present in `source`.
+#[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct PresentKeyConstraint<'db> {
     source: Type<'db>,
     key: StringLiteralType<'db>,
@@ -739,16 +751,15 @@ impl<'db> PresentKeyConstraint<'db> {
     ///     value["x"]  # The key fact applies to `Bar`, not the original type.
     /// ```
     fn apply_after_replacement(
-        self,
+        &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         replacement: Type<'db>,
     ) -> Type<'db> {
-        let narrowed = narrow_with_present_key(db, env, self.source, self.key.value(db));
         if key_is_always_present(db, env, self.source, self.key) {
             return replacement;
         }
-        if narrowed.is_never() {
+        if narrow_with_present_key(db, env, self.source, self.key.value(db)).is_never() {
             return Type::Never;
         }
 
@@ -763,6 +774,20 @@ impl<'db> PresentKeyConstraint<'db> {
             narrow_with_present_key(db, env, replacement, self.key.value(db))
         }
     }
+
+    fn apply(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        ty: Type<'db>,
+        is_replacement: bool,
+    ) -> Type<'db> {
+        if is_replacement {
+            self.apply_after_replacement(db, env, ty)
+        } else {
+            narrow_with_present_key(db, env, ty, self.key.value(db))
+        }
+    }
 }
 
 /// A deferred key-absence operation. Keeping the filtered source out of the conjunction prevents
@@ -773,20 +798,16 @@ impl<'db> PresentKeyConstraint<'db> {
 /// if guard_to_bar(value) and lacks_x:
 ///     reveal_type(value)  # Bar, filtered by the key-absence fact
 /// ```
-#[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::Update, get_size2::GetSize)]
+#[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct AbsentKeyConstraint<'db> {
     source: Type<'db>,
     key: StringLiteralType<'db>,
 }
 
 impl<'db> AbsentKeyConstraint<'db> {
-    /// Apply this fact to a replacement type without replacing it with the filtered source.
-    ///
-    /// An impossible fact still makes the conjunction `Never`; otherwise, the replacement is
-    /// filtered independently. This preserves `TypeGuard` semantics for aliased conditions such as
-    /// `guard(value) and key_not_in_value`.
+    /// Apply this fact to `replacement`, using `source` only to detect an impossible condition.
     fn apply_after_replacement(
-        self,
+        &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         replacement: Type<'db>,
@@ -797,38 +818,51 @@ impl<'db> AbsentKeyConstraint<'db> {
             narrow_with_absent_key(db, env, replacement, self.key)
         }
     }
+
+    fn apply(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        ty: Type<'db>,
+        is_replacement: bool,
+    ) -> Type<'db> {
+        if is_replacement {
+            self.apply_after_replacement(db, env, ty)
+        } else {
+            narrow_with_absent_key(db, env, ty, self.key)
+        }
+    }
 }
 
 impl<'db> ConstraintConjunction<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
             type_constraints: smallvec![NarrowingOperation::Intersection(ty)],
-            present_keys: smallvec![],
-            absent_keys: smallvec![],
+            key_constraints: thin_vec![],
         }
     }
 
     fn generic_filtering(ty: Type<'db>) -> Self {
         Self {
             type_constraints: smallvec![NarrowingOperation::GenericFiltering(ty)],
-            present_keys: smallvec![],
-            absent_keys: smallvec![],
+            key_constraints: thin_vec![],
         }
     }
 
     fn present_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
         Self {
             type_constraints: smallvec![],
-            present_keys: smallvec![PresentKeyConstraint { source, key }],
-            absent_keys: smallvec![],
+            key_constraints: thin_vec![KeyConstraint::Present(PresentKeyConstraint {
+                source,
+                key,
+            })],
         }
     }
 
     fn absent_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
         Self {
             type_constraints: smallvec![],
-            present_keys: smallvec![],
-            absent_keys: smallvec![AbsentKeyConstraint { source, key }],
+            key_constraints: thin_vec![KeyConstraint::Absent(AbsentKeyConstraint { source, key })],
         }
     }
 
@@ -851,15 +885,13 @@ impl<'db> ConstraintConjunction<'db> {
             }
         }
 
-        for present_key in other.present_keys {
-            if !self.present_keys.contains(&present_key) {
-                self.present_keys.push(present_key);
-            }
-        }
-
-        for absent_key in other.absent_keys {
-            if !self.absent_keys.contains(&absent_key) {
-                self.absent_keys.push(absent_key);
+        if self.key_constraints.is_empty() {
+            self.key_constraints = other.key_constraints;
+        } else {
+            for key_constraint in other.key_constraints {
+                if !self.key_constraints.contains(&key_constraint) {
+                    self.key_constraints.push(key_constraint);
+                }
             }
         }
 
@@ -877,10 +909,7 @@ impl<'db> ConstraintConjunction<'db> {
         env: &ProgramEnvironment<'db>,
         is_replacement: bool,
     ) -> Type<'db> {
-        if self.present_keys.is_empty()
-            && self.absent_keys.is_empty()
-            && self.type_constraints.len() == 1
-        {
+        if self.key_constraints.is_empty() && self.type_constraints.len() == 1 {
             return self.type_constraints[0].ty();
         }
 
@@ -897,19 +926,18 @@ impl<'db> ConstraintConjunction<'db> {
                 }
             });
 
-        if is_replacement {
-            for present_key in self.present_keys {
-                current = present_key.apply_after_replacement(db, env, current);
+        if self.key_constraints.is_empty() {
+            return current;
+        }
+
+        for key_constraint in &self.key_constraints {
+            if let KeyConstraint::Present(present_key) = key_constraint {
+                current = present_key.apply(db, env, current, is_replacement);
             }
-            for absent_key in self.absent_keys {
-                current = absent_key.apply_after_replacement(db, env, current);
-            }
-        } else {
-            for present_key in self.present_keys {
-                current = narrow_with_present_key(db, env, current, present_key.key.value(db));
-            }
-            for absent_key in self.absent_keys {
-                current = narrow_with_absent_key(db, env, current, absent_key.key);
+        }
+        for key_constraint in &self.key_constraints {
+            if let KeyConstraint::Absent(absent_key) = key_constraint {
+                current = absent_key.apply(db, env, current, is_replacement);
             }
         }
 
@@ -1194,78 +1222,84 @@ fn specialize_generic_class_from_solutions<'db>(
 /// For example:
 /// - `f(x) and g(x)` where f returns `TypeIs[A]` and g returns `TypeGuard[B]`
 ///   => and
-///   ===> `NarrowingConstraint { intersection_disjuncts: [A], replacement_disjuncts: [] }`
-///   ===> `NarrowingConstraint { intersection_disjuncts: [], replacement_disjuncts: [B] }`
-///   => `NarrowingConstraint { intersection_disjuncts: [], replacement_disjuncts: [B] }`
+///   ===> an intersection disjunct for `A`
+///   ===> a replacement disjunct for `B`
+///   => a replacement disjunct for `B`
 ///   => evaluates to `B` (`TypeGuard` clobbers any previous type information)
 ///
 /// - `f(x) or g(x)` where f returns `TypeIs[A]` and g returns `TypeGuard[B]`
 ///   => or
-///   ===> `NarrowingConstraint { intersection_disjuncts: [A], replacement_disjuncts: [] }`
-///   ===> `NarrowingConstraint { intersection_disjuncts: [], replacement_disjuncts: [B] }`
-///   => `NarrowingConstraint { intersection_disjuncts: [A], replacement_disjuncts: [B] }`
+///   ===> an intersection disjunct for `A`
+///   ===> a replacement disjunct for `B`
+///   => both disjuncts are retained
 ///   => evaluates to `(P & A) | B`, where `P` is our previously-known type
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct NarrowingConstraint<'db> {
-    /// Intersection constraint (from `isinstance()` narrowing comparisons, `TypeIs`, and
-    /// similar). We keep these as a disjunction of conjunctions to avoid constructing
-    /// union/intersection types while merging constraints.
-    intersection_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]>,
+    disjuncts: SmallVec<[ConstraintDisjunct<'db>; 1]>,
+}
 
-    /// "Replacement" constraints: instead of intersecting the previous type with a new type,
-    /// the previous type is simply replaced wholesale with the new type. A common use case for
-    /// these constraints is `typing.TypeGuard`. We can't eagerly union disjunctions because
-    /// `TypeGuard` clobbers the previously-known type; within each replacement disjunct, however,
-    /// we may eagerly intersect conjunctions with a later intersection narrowing.
-    replacement_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]>,
+#[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
+struct ConstraintDisjunct<'db> {
+    kind: ConstraintDisjunctKind,
+    conjunction: ConstraintConjunction<'db>,
+}
+
+#[derive(Hash, PartialEq, Debug, Eq, Clone, Copy, get_size2::GetSize, salsa::SalsaValue)]
+enum ConstraintDisjunctKind {
+    /// Intersect the previous type with this disjunct.
+    Intersection,
+
+    /// Replace the previous type with this disjunct. A common source of replacement constraints is
+    /// `typing.TypeGuard`.
+    Replacement,
 }
 
 impl<'db> NarrowingConstraint<'db> {
+    fn singleton(kind: ConstraintDisjunctKind, conjunction: ConstraintConjunction<'db>) -> Self {
+        Self {
+            disjuncts: smallvec_inline![ConstraintDisjunct { kind, conjunction }],
+        }
+    }
+
     /// Create an "intersection" constraint: the previous type will be
     /// intersected with this constraint
     pub(crate) fn intersection(constraint: Type<'db>) -> Self {
-        Self {
-            intersection_disjuncts: smallvec_inline![ConstraintConjunction::singleton(constraint)],
-            replacement_disjuncts: smallvec![],
-        }
+        Self::singleton(
+            ConstraintDisjunctKind::Intersection,
+            ConstraintConjunction::singleton(constraint),
+        )
     }
 
     /// Create an intersection constraint that preserves generic arguments already known about
     /// the subject when narrowing it to a subclass.
     fn generic_filtering(constraint: Type<'db>) -> Self {
-        Self {
-            intersection_disjuncts: smallvec_inline![ConstraintConjunction::generic_filtering(
-                constraint
-            )],
-            replacement_disjuncts: smallvec![],
-        }
+        Self::singleton(
+            ConstraintDisjunctKind::Intersection,
+            ConstraintConjunction::generic_filtering(constraint),
+        )
     }
 
     /// Create a "replacement" constraint: the previous type will be
     /// replaced wholesale with this constraint
     fn replacement(constraint: Type<'db>) -> Self {
-        Self {
-            intersection_disjuncts: smallvec![],
-            replacement_disjuncts: smallvec_inline![ConstraintConjunction::singleton(constraint)],
-        }
+        Self::singleton(
+            ConstraintDisjunctKind::Replacement,
+            ConstraintConjunction::singleton(constraint),
+        )
     }
 
     fn present_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
-        Self {
-            intersection_disjuncts: smallvec_inline![ConstraintConjunction::present_key(
-                source, key
-            )],
-            replacement_disjuncts: smallvec![],
-        }
+        Self::singleton(
+            ConstraintDisjunctKind::Intersection,
+            ConstraintConjunction::present_key(source, key),
+        )
     }
 
     fn absent_key(source: Type<'db>, key: StringLiteralType<'db>) -> Self {
-        Self {
-            intersection_disjuncts: smallvec_inline![ConstraintConjunction::absent_key(
-                source, key
-            )],
-            replacement_disjuncts: smallvec![],
-        }
+        Self::singleton(
+            ConstraintDisjunctKind::Intersection,
+            ConstraintConjunction::absent_key(source, key),
+        )
     }
 
     /// Merge two constraints, taking their intersection but respecting "replacement" semantics (with
@@ -1274,60 +1308,56 @@ impl<'db> NarrowingConstraint<'db> {
         // Distribute AND over OR: (A1 | A2 | ...) AND (B1 | B2 | ...)
         // becomes (A1 & B1) | (A1 & B2) | ... | (A2 & B1) | ...
         //
-        // In our representation, the RHS `replacement_disjuncts` will all clobber the LHS disjuncts
-        // when they are `and`ed, so they'll just stay as is.
+        // The RHS replacement disjuncts all clobber the LHS disjuncts when they are `and`ed, so
+        // they stay as is.
         //
-        // The thing we actually need to deal with is the RHS `intersection_disjuncts`. Each RHS
-        // disjunct gets intersected with each LHS disjunct, producing the cartesian product.
-        // This is still deferred as conjunction lists.
+        // Each RHS intersection disjunct gets intersected with each LHS disjunct, producing the
+        // cartesian product. The merged disjunct retains the LHS kind.
         //
-        // We also intersect each LHS `replacement_disjunct` with every RHS intersection disjunct
-        // to form new additional `replacement_disjuncts`.
-        if other.intersection_disjuncts.is_empty() {
-            return other;
-        }
-
-        let mut new_intersection_disjuncts = smallvec![];
-        for intersection_disjunct in &self.intersection_disjuncts {
-            for other_intersection_disjunct in &other.intersection_disjuncts {
-                let merged = intersection_disjunct
-                    .clone()
-                    .and_with(other_intersection_disjunct.clone());
-                if !new_intersection_disjuncts.contains(&merged) {
-                    new_intersection_disjuncts.push(merged);
-                }
-            }
-        }
-
-        let mut additional_replacement_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]> =
+        // The conjunctions still defer constructing the corresponding intersection types.
+        let mut other_intersection_disjuncts: SmallVec<[ConstraintConjunction<'db>; 1]> =
             smallvec![];
-        for replacement_disjunct in &self.replacement_disjuncts {
-            for other_intersection_disjunct in &other.intersection_disjuncts {
-                let merged = replacement_disjunct
-                    .clone()
-                    .and_with(other_intersection_disjunct.clone());
-                if !additional_replacement_disjuncts.contains(&merged) {
-                    additional_replacement_disjuncts.push(merged);
+        let mut new_disjuncts: SmallVec<[ConstraintDisjunct<'db>; 1]> = smallvec![];
+        for disjunct in other.disjuncts {
+            match disjunct.kind {
+                ConstraintDisjunctKind::Intersection => {
+                    other_intersection_disjuncts.push(disjunct.conjunction);
+                }
+                ConstraintDisjunctKind::Replacement => {
+                    new_disjuncts.push(disjunct);
                 }
             }
         }
 
-        let mut new_replacement_disjuncts = other.replacement_disjuncts;
+        if other_intersection_disjuncts.is_empty() {
+            return Self {
+                disjuncts: new_disjuncts,
+            };
+        }
 
-        new_replacement_disjuncts.extend(additional_replacement_disjuncts);
+        for disjunct in &self.disjuncts {
+            for other_conjunction in &other_intersection_disjuncts {
+                let merged = ConstraintDisjunct {
+                    kind: disjunct.kind,
+                    conjunction: disjunct
+                        .conjunction
+                        .clone()
+                        .and_with(other_conjunction.clone()),
+                };
+                if !new_disjuncts.contains(&merged) {
+                    new_disjuncts.push(merged);
+                }
+            }
+        }
 
-        NarrowingConstraint {
-            intersection_disjuncts: new_intersection_disjuncts,
-            replacement_disjuncts: new_replacement_disjuncts,
+        Self {
+            disjuncts: new_disjuncts,
         }
     }
 
     /// Merge two constraints with OR semantics (union/disjunction).
     fn merge_constraint_or(&mut self, other: Self) {
-        self.intersection_disjuncts
-            .extend(other.intersection_disjuncts);
-        self.replacement_disjuncts
-            .extend(other.replacement_disjuncts);
+        self.disjuncts.extend(other.disjuncts);
     }
 
     /// Evaluate the type this effectively constrains to
@@ -1339,11 +1369,12 @@ impl<'db> NarrowingConstraint<'db> {
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
         let mut union = UnionBuilder::new(db, env);
-        for conjunction in self.replacement_disjuncts {
-            union.add_in_place(conjunction.evaluate_constraint_type(db, env, true));
-        }
-        for conjunction in self.intersection_disjuncts {
-            union.add_in_place(conjunction.evaluate_constraint_type(db, env, false));
+        for disjunct in self.disjuncts {
+            union.add_in_place(disjunct.conjunction.evaluate_constraint_type(
+                db,
+                env,
+                disjunct.kind == ConstraintDisjunctKind::Replacement,
+            ));
         }
         union.build()
     }
@@ -4163,9 +4194,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
         }
 
-        // Narrow types when a key membership test proves that a key is present, and narrow unions
-        // and intersections of `TypedDict` when a key membership test proves that a required key is
-        // absent:
+        // Record literal key-membership facts for `TypedDict` and `Mapping` values:
         //
         // class Foo(TypedDict):
         //     foo: int
@@ -4182,34 +4211,24 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             && (is_or_contains_typeddict(db, rhs_type)
                 || is_or_contains_mapping(db, &self.env, rhs_type))
         {
-            let apply_constraint =
-                |constraints: &mut NarrowingConstraints<'db>,
-                 constraint: NarrowingConstraint<'db>| {
-                    let comparator_place = PlaceExpr::try_from_expr(&comparators[0])
-                        .and_then(|place_expr| self.places().place_id(&place_expr));
-                    if let Some(place) = comparator_place {
-                        constraints.insert(place, constraint.clone());
-                    }
-
-                    let value_place = PlaceExpr::try_from_expr(rhs_expr)
-                        .and_then(|place_expr| self.places().place_id(&place_expr));
-                    if value_place != comparator_place
-                        && let Some(place) = value_place
-                    {
-                        constraints.insert(place, constraint);
-                    }
-                };
-
-            if is_positive == (ops[0] == ast::CmpOp::In) {
-                apply_constraint(
-                    &mut constraints,
-                    NarrowingConstraint::present_key(rhs_type, key),
-                );
+            let constraint = if is_positive == (ops[0] == ast::CmpOp::In) {
+                NarrowingConstraint::present_key(rhs_type, key)
             } else {
-                apply_constraint(
-                    &mut constraints,
-                    NarrowingConstraint::absent_key(rhs_type, key),
-                );
+                NarrowingConstraint::absent_key(rhs_type, key)
+            };
+
+            let comparator_place = PlaceExpr::try_from_expr(&comparators[0])
+                .and_then(|place_expr| self.places().place_id(&place_expr));
+            if let Some(place) = comparator_place {
+                constraints.insert(place, constraint.clone());
+            }
+
+            let value_place = PlaceExpr::try_from_expr(rhs_expr)
+                .and_then(|place_expr| self.places().place_id(&place_expr));
+            if value_place != comparator_place
+                && let Some(place) = value_place
+            {
+                constraints.insert(place, constraint);
             }
         }
 
@@ -5184,13 +5203,7 @@ fn key_membership_implies_subscript<'db>(
 ///
 /// `TypedDict` arms gain a required read-only field, `Mapping` arms gain matching
 /// `__contains__` and `__getitem__` methods, and other arms only gain the successful membership
-/// fact. The distinction prevents code like this from implying invalid subscript access:
-///
-/// ```python
-/// def f(value: Literal["abc"]):
-///     if "a" in value:
-///         value["a"]  # Still invalid: string membership does not imply key subscripting.
-/// ```
+/// fact.
 fn narrow_with_present_key<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -5246,7 +5259,6 @@ fn narrow_with_absent_key<'db>(
     let resolved = ty.resolve_type_alias(db);
     match resolved {
         Type::Union(union) => {
-            // Remove all members of the union that prove the key is present.
             let filtered = union.filter(db, |ty| !key_is_always_present(db, env, *ty, key));
             if filtered == resolved { ty } else { filtered }
         }


### PR DESCRIPTION
## Summary

We infer implicit instance attributes from assignments such as:

```python
class C:
    def __init__(self):
        if not hasattr(self, "x"):
            self.x = self.__str__
```

A negative `hasattr` guard normally narrows `self` to `Self & ~Protocol[x]`. When the same guard initializes `x`, simplifying that type requires resolving `x` again, creating a Salsa cycle whose recovered result depends on file-checking order rather than constraint-set ordering.

Avoid the cycle by leaving `self` unnarrowed only when existing use-def reachability proves that the same standalone guard initializes the same implicit instance attribute in the corresponding branch. Preserve normal narrowing for class-backed attributes, previously initialized attributes, compound conditions, and assignments in the opposite branch.

Stacked on #25645.

Closes https://github.com/astral-sh/ty/issues/4076.
