### PR TITLE
Ignore unicode prefixes inside string type definitions (#10586)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP025.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP025.py
@@ -32,3 +32,14 @@ f"foo" u"bar"  # OK
 ""u"hi"
 """"""""""""""""""""u"hi"
 ""U"helloooo"
+# https://github.com/astral-sh/ruff/issues/10586
+# A unicode prefix inside a string type definition (forward reference) is part
+# of the type expression and must not be flagged.
+import typing_extensions as te
+
+A: "te.Literal[u'x', '\r\n', '\r']" = "\n"
+B: list["te.Literal[u'x']"] = []
+
+
+def f(x: "te.Literal[u'x']") -> "te.Literal[u'y']":
+    return u"y"  # UP025 (runtime string, outside the annotation)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -41,6 +41,13 @@ impl AlwaysFixableViolation for UnicodeKindPrefix {
 
 /// UP025
 pub(crate) fn unicode_kind_prefix(checker: &Checker, string: &StringLiteral) {
+    // Don't flag string literals inside a string type definition (forward
+    // reference), e.g. `x: "Literal[u'x']"`. The `u` prefix is part of the
+    // type expression, not a redundant prefix on a runtime string.
+    // https://github.com/astral-sh/ruff/issues/10586
+    if checker.semantic().in_string_type_definition() {
+        return;
+    }
     if string.flags.prefix().is_unicode() {
         let mut diagnostic = checker.report_diagnostic(UnicodeKindPrefix, string.range);
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP025.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP025.py.snap
@@ -307,6 +307,7 @@ UP025 [*] Remove unicode literals from strings
 33 | """"""""""""""""""""u"hi"
    |                     ^^^^^
 34 | ""U"helloooo"
+35 | # https://github.com/astral-sh/ruff/issues/10586
    |
 help: Remove unicode prefix
    |
@@ -323,9 +324,26 @@ UP025 [*] Remove unicode literals from strings
 33 | """"""""""""""""""""u"hi"
 34 | ""U"helloooo"
    |   ^^^^^^^^^^^
+35 | # https://github.com/astral-sh/ruff/issues/10586
+36 | # A unicode prefix inside a string type definition (forward reference) is part
+   |
 help: Remove unicode prefix
    |
 33 | """"""""""""""""""""u"hi"
    - ""U"helloooo"
 34 + "" "helloooo"
+35 | # https://github.com/astral-sh/ruff/issues/10586
+   |
+
+UP025 [*] Remove unicode literals from strings
+  --> UP025.py:45:12
+   |
+44 | def f(x: "te.Literal[u'x']") -> "te.Literal[u'y']":
+45 |     return u"y"  # UP025 (runtime string, outside the annotation)
+   |            ^^^^
+help: Remove unicode prefix
+   |
+44 | def f(x: "te.Literal[u'x']") -> "te.Literal[u'y']":
+   -     return u"y"  # UP025 (runtime string, outside the annotation)
+45 +     return "y"  # UP025 (runtime string, outside the annotation)
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<Fixes #10586.

This PR fixes the false positive caused by unicode prefixes inside string type definitions.
The change adds a guard in the string type definition handling logic to avoid reporting unicode prefixes in this case.
>

## Test Plan

< Added regression tests for unicode prefixes inside string type definitions.
  Ran the relevant test suite successfully.>
