### PR TITLE
[ty] Reuse primer commands in memory reports

### DIFF
--- a/scripts/memory_report.py
+++ b/scripts/memory_report.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -244,36 +245,43 @@ def render_summary(projects: list[ProjectComparison]) -> str:
     return "\n".join(lines)
 
 
-def setup_project(*, name: str, dest: Path) -> Path:
+def setup_project(*, name: str, dest: Path) -> tuple[Path, list[str]]:
     """Clone a project and install its mypy-primer dependencies."""
     project_path = dest / name
+    setup_script = Path(__file__).with_name("setup_primer_project.py")
+    setup_command = [
+        "uv",
+        "run",
+        "--locked",
+        "--python",
+        sys.executable,
+        "--script",
+        str(setup_script),
+    ]
+
     if project_path.exists():
         print(f"Project {name} already exists at {project_path}", file=sys.stderr)
-        return project_path
+    else:
+        print(f"Setting up {name} and its dependencies...", file=sys.stderr)
+        subprocess.run(
+            [*setup_command, name, str(project_path)],
+            check=True,
+            stdout=sys.stderr,
+        )
 
-    setup_script = Path(__file__).with_name("setup_primer_project.py")
-    print(f"Setting up {name} and its dependencies...", file=sys.stderr)
-    subprocess.run(
-        [
-            "uv",
-            "run",
-            "--locked",
-            "--python",
-            sys.executable,
-            "--script",
-            str(setup_script),
-            name,
-            str(project_path),
-        ],
+    ty_command = subprocess.run(
+        [*setup_command, "--print-ty-command", name, str(project_path)],
         check=True,
-        stdout=sys.stderr,
+        capture_output=True,
+        text=True,
     )
-    return project_path
+    return project_path, shlex.split(ty_command.stdout)
 
 
 def run_ty_memory_check(
     *,
     ty_path: str,
+    ty_command: list[str],
     project_path: Path,
     output_path: Path,
 ) -> None:
@@ -283,8 +291,14 @@ def run_ty_memory_check(
     env["TY_MAX_PARALLELISM"] = "1"  # For deterministic memory numbers
 
     print(f"Running {ty_path} on {project_path.name}...", file=sys.stderr)
+    command = [
+        str(Path(ty_path).resolve()) if argument == "{ty}" else argument
+        for argument in ty_command
+    ]
     result = subprocess.run(
-        [ty_path, "check", "--project", str(project_path), "--exit-zero"],
+        command,
+        cwd=project_path,
+        check=True,
         capture_output=True,
         text=True,
         env=env,
@@ -306,18 +320,24 @@ def run_memory_tests(
     new_reports_dir.mkdir(parents=True, exist_ok=True)
 
     for project_name in KNOWN_PROJECTS:
-        project_path = setup_project(name=project_name, dest=projects_dir)
+        project_path, ty_command = setup_project(name=project_name, dest=projects_dir)
 
         # Run old ty
         old_report_path = old_reports_dir / f"{project_name}.json"
         run_ty_memory_check(
-            ty_path=old_ty, project_path=project_path, output_path=old_report_path
+            ty_path=old_ty,
+            ty_command=ty_command,
+            project_path=project_path,
+            output_path=old_report_path,
         )
 
         # Run new ty
         new_report_path = new_reports_dir / f"{project_name}.json"
         run_ty_memory_check(
-            ty_path=new_ty, project_path=project_path, output_path=new_report_path
+            ty_path=new_ty,
+            ty_command=ty_command,
+            project_path=project_path,
+            output_path=new_report_path,
         )
 
 

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -93,12 +93,20 @@ def main() -> None:
         "--exclude-newer",
         help="Limit dependency resolution to packages uploaded before this timestamp",
     )
+    parser.add_argument(
+        "--print-ty-command",
+        action="store_true",
+        help="Print the project-specific ty command without setting up the project",
+    )
     args = parser.parse_args()
 
     project = find_project(args.project)
     revision = args.revision or project.revision
 
     target_dir = Path(args.directory or project.name).resolve()
+    if args.print_ty_command:
+        print(get_ty_command(project, ty_binary="{ty}", venv_dir=target_dir / ".venv"))
+        return
 
     # Use a full clone only when a historical ecosystem report revision must be checked out.
     clone_cmd = [


### PR DESCRIPTION
## Summary

I was confused why prefect shows a memory regression on my script PRs when the ecosystem analyzer didn't show any changes. It turns out, the memory report checked the whole prefect repo whereas the ecossytem analyzer only checked certain paths. 

This PR uses mypy-primer's project-specific ty commands in memory reports so they check the same paths and environments as ecosystem analysis.

## Test Plan

## Memory usage report

### Summary

| Project | Old | New | Diff | Outcome |
|---------|-----|-----|------|---------|
| flake8 | 40.29MB | 40.25MB | -0.08% (31.05kB) | ⬇️ |
| trio | 94.97MB | 93.82MB | -1.21% (1.15MB) | ⬇️ |
| sphinx | 208.80MB | 168.02MB | -19.53% (40.78MB) | ⬇️ |
| prefect | 668.90MB | 451.11MB | -32.56% (217.79MB) | ⬇️ |

### Significant changes

<details>
<summary>Click to expand detailed breakdown</summary>

### flake8

| Name | Old | New | Diff | Outcome |
|------|-----|-----|------|---------|
| `parsed_module` | 15.27MB | 15.35MB | +0.51% (79.11kB) |⏫ |
| `semantic_index` | 10.68MB | 10.66MB | -0.17% (18.29kB) |⬇️ |
| `source_text` | 2.24MB | 2.23MB | -0.53% (12.25kB) |⬇️ |
| `infer_definition_types` | 1.07MB | 1.06MB | -0.82% (9.05kB) |⬇️ |
| `check_file_impl` | 36.69kB | 29.69kB | -19.10% (7.01kB) |⬇️ |
| `when_constraint_set_assignable_to_owned_impl` | 164.73kB | 158.41kB | -3.83% (6.31kB) |⬇️ |
| `infer_scope_types_impl` | 541.98kB | 535.71kB | -1.16% (6.27kB) |⬇️ |
| `StringLiteralType` | 198.99kB | 193.12kB | -2.95% (5.87kB) |⬇️ |
| `infer_expression_types_impl` | 768.64kB | 764.08kB | -0.59% (4.57kB) |⬇️ |
| `Definition` | 2.45MB | 2.45MB | -0.18% (4.45kB) |⬇️ |
| `assignable_solutions_impl` | 14.67kB | 12.58kB | -14.27% (2.09kB) |⬇️ |
| `TypePair` | 233.06kB | 231.00kB | -0.88% (2.06kB) |⬇️ |
| `TupleType` | 108.05kB | 106.08kB | -1.82% (1.97kB) |⬇️ |
| `member_lookup_with_policy_inner` | 323.97kB | 322.14kB | -0.56% (1.83kB) |⬇️ |
| `File` | 41.61kB | 39.80kB | -4.35% (1.81kB) |⬇️ |
| `MemberLookupKey` | 278.54kB | 276.91kB | -0.58% (1.62kB) |⬇️ |
| `Type<'db>::class_member_with_policy_inner_` | 263.58kB | 262.04kB | -0.58% (1.54kB) |⬇️ |
| `Specialization` | 251.17kB | 249.92kB | -0.50% (1.25kB) |⬇️ |
| `assignable_solutions_impl::interned_arguments` | 12.49kB | 11.27kB | -9.76% (1.22kB) |⬇️ |
| `suppressions` | 13.90kB | 12.82kB | -7.76% (1.08kB) |⬇️ |
| `absolute_desperate_search_paths` | 1.55kB | 508.00B | -68.09% (1.06kB) |⬇️ |
| `Expression` | 613.56kB | 612.56kB | -0.16% (1.00kB) |⬇️ |
| `Type<'db>::apply_specialization_inner_::interned_arguments` | 220.70kB | 219.77kB | -0.42% (960.00B) |⬇️ |
| `FunctionType` | 313.77kB | 312.88kB | -0.28% (912.00B) |⬇️ |
| `function_known_decorators` | 157.10kB | 156.27kB | -0.52% (844.00B) |⬇️ |
| `Type<'db>::cached_materialization_::interned_arguments` | 67.97kB | 67.19kB | -1.15% (800.00B) |⬇️ |
| `OverloadLiteral` | 117.91kB | 117.30kB | -0.52% (624.00B) |⬇️ |
| `BoundTypeVarInstance` | 60.67kB | 60.07kB | -0.99% (616.00B) |⬇️ |
| `Type<'db>::apply_specialization_inner_` | 139.49kB | 138.92kB | -0.41% (584.00B) |⬇️ |
| `FunctionType<'db>::signature_` | 352.61kB | 352.06kB | -0.16% (563.00B) |⬇️ |
| `place_by_id` | 152.34kB | 151.82kB | -0.34% (536.00B) |⬇️ |
| `enum_metadata` | 47.51kB | 46.99kB | -1.09% (528.00B) |⬇️ |
| `CallableType` | 293.85kB | 293.37kB | -0.16% (496.00B) |⬇️ |
| `Type<'db>::cached_materialization_` | 42.99kB | 42.51kB | -1.13% (496.00B) |⬇️ |
| `ScopeId` | 294.88kB | 294.41kB | -0.16% (480.00B) |⬇️ |
| `directory_listing_query` | 8.78kB | 8.36kB | -4.80% (432.00B) |⬇️ |
| `place_by_id::interned_arguments` | 127.48kB | 127.05kB | -0.33% (432.00B) |⬇️ |
| `ProgramFile` | 11.39kB | 10.97kB | -3.70% (432.00B) |⬇️ |
| `BoundMethodType` | 67.66kB | 67.27kB | -0.58% (400.00B) |⬇️ |
| `resolve_module_query` | 14.28kB | 13.91kB | -2.63% (384.00B) |⬇️ |
| `TypeVarInstance` | 22.69kB | 22.31kB | -1.65% (384.00B) |⬇️ |
| `PythonFile` | 10.19kB | 9.81kB | -3.68% (384.00B) |⬇️ |
| `file_settings` | 8.84kB | 8.46kB | -4.24% (384.00B) |⬇️ |
| `desperately_resolve_module` | 656.00B | 288.00B | -56.10% (368.00B) |⬇️ |
| `GenericAlias` | 113.27kB | 112.92kB | -0.31% (360.00B) |⬇️ |
| `ImplicitAttributeName` | 29.02kB | 28.68kB | -1.18% (352.00B) |⬇️ |
| `IntersectionType` | 69.88kB | 69.55kB | -0.47% (336.00B) |⬇️ |
| `should_check_file` | 4.38kB | 4.05kB | -7.50% (336.00B) |⬇️ |
| `script_metadata` | 7.67kB | 7.34kB | -4.28% (336.00B) |⬇️ |
| `StaticClassLiteral<'db>::implicit_attribute_inner_` | 44.69kB | 44.38kB | -0.68% (312.00B) |⬇️ |
| `ModuleNameIngredient` | 12.12kB | 11.84kB | -2.32% (288.00B) |⬇️ |
| `desperately_resolve_module::interned_arguments` | 576.00B | 288.00B | -50.00% (288.00B) |⬇️ |
| `MaterializedProtocolType` | 1.97kB | 1.69kB | -14.29% (288.00B) |⬇️ |
| `Project` | 23.30kB | 23.57kB | +1.17% (279.00B) |⏫ |
| `is_redundant_with_impl` | 82.29kB | 82.05kB | -0.28% (240.00B) |⬇️ |
| `StaticClassLiteral` | 37.50kB | 37.27kB | -0.62% (240.00B) |⬇️ |
| `UnionType` | 75.48kB | 75.27kB | -0.29% (224.00B) |⬇️ |
| `ResolverFile` | 2.95kB | 2.74kB | -7.14% (216.00B) |⬇️ |
| `ModuleLiteralType` | 22.71kB | 22.50kB | -0.93% (216.00B) |⬇️ |
| `StaticClassLiteral<'db>::try_mro_` | 313.02kB | 312.83kB | -0.06% (192.00B) |⬇️ |
| `TypeVarSetInner` | 31.30kB | 31.12kB | -0.57% (184.00B) |⬇️ |
| `infer_deferred_types` | 285.32kB | 285.48kB | +0.06% (172.00B) |⏫ |
| `ExpressionWithContext` | 19.06kB | 18.91kB | -0.82% (160.00B) |⬇️ |
| `GenericContext` | 58.25kB | 58.10kB | -0.26% (156.00B) |⬇️ |
| `BoundMethodType<'db>::bound_signatures_` | 40.34kB | 40.19kB | -0.37% (152.00B) |⬇️ |
| `implicit_attribute_names` | 14.56kB | 14.42kB | -0.97% (144.00B) |⬇️ |
| `StaticClassLiteral<'db>::try_mro_::interned_arguments` | 103.15kB | 103.01kB | -0.14% (144.00B) |⬇️ |
| `is_equivalent_to_object_inner::interned_arguments` | 11.12kB | 11.00kB | -1.12% (128.00B) |⬇️ |
| `try_call_dunder_get_inner` | 15.89kB | 15.77kB | -0.74% (120.00B) |⬇️ |
| `relative_desperate_search_paths` | 120.00B | 0.00B | -100.00% (120.00B) |⬇️ |
| `try_call_dunder_get_inner::interned_arguments` | 16.52kB | 16.41kB | -0.66% (112.00B) |⬇️ |
| `enum_class_literal` | 7.59kB | 7.48kB | -1.44% (112.00B) |⬇️ |
| `is_equivalent_to_object_inner` | 9.99kB | 9.88kB | -1.09% (112.00B) |⬇️ |
| `use_def_map` | 28.81kB | 28.72kB | -0.33% (96.00B) |⬇️ |
| `StaticClassLiteral<'db>::generic_context_` | 17.54kB | 17.45kB | -0.53% (96.00B) |⬇️ |
| `place_table` | 22.52kB | 22.42kB | -0.42% (96.00B) |⬇️ |
| `TypeVarInference` | 44.58kB | 44.48kB | -0.21% (96.00B) |⬇️ |
| `Type<'db>::expand_eagerly__::interned_arguments` | 2.50kB | 2.42kB | -3.12% (80.00B) |⬇️ |
| `all_narrowing_constraints_for_expression` | 106.73kB | 106.81kB | +0.07% (80.00B) |⏫ |
| `loop_header_reachability` | 9.62kB | 9.70kB | +0.81% (80.00B) |⏫ |
| `infer_statement_types_impl` | 31.06kB | 31.13kB | +0.23% (72.00B) |⏫ |
| `analyze_non_terminal_call::interned_arguments` | 27.28kB | 27.21kB | -0.26% (72.00B) |⬇️ |
| `remove_self_inner::interned_arguments` | 4.99kB | 4.92kB | -1.41% (72.00B) |⬇️ |
| `file_to_module` | 2.12kB | 2.06kB | -2.94% (64.00B) |⬇️ |
| `StaticClassLiteral<'db>::own_fields_inner_` | 9.38kB | 9.43kB | +0.58% (56.00B) |⏫ |
| `code_generator_of_static_class` | 19.12kB | 19.17kB | +0.29% (56.00B) |⏫ |
| `try_metaclass_inner` | 26.41kB | 26.46kB | +0.21% (56.00B) |⏫ |
| `inferable_typevars_inner` | 8.54kB | 8.49kB | -0.55% (48.00B) |⬇️ |
| `Type<'db>::expand_eagerly__` | 1.50kB | 1.45kB | -3.12% (48.00B) |⬇️ |
| `remove_self_inner` | 2.77kB | 2.73kB | -1.41% (40.00B) |⬇️ |
| `infer_expression_type_impl` | 20.93kB | 20.89kB | -0.19% (40.00B) |⬇️ |
| `analyze_non_terminal_call` | 34.28kB | 34.24kB | -0.11% (40.00B) |⬇️ |
| `BoundMethodType<'db>::into_callable_type_` | 12.70kB | 12.66kB | -0.31% (40.00B) |⬇️ |
| `specialization_inner` | 19.32kB | 19.28kB | -0.20% (40.00B) |⬇️ |
| `infer_unpack_types` | 27.20kB | 27.22kB | +0.09% (24.00B) |⏫ |
| `lookup_dunder_new_inner` | 10.76kB | 10.77kB | +0.15% (16.00B) |⏫ |
| `is_possibly_constraint_set_assignable` | 13.21kB | 13.20kB | -0.06% (8.00B) |⬇️ |
| `ClassType<'db>::nearest_disjoint_base_` | 1.88kB | 1.88kB | +0.42% (8.00B) |⏫ |

### trio

| Name | Old | New | Diff | Outcome |
|------|-----|-----|------|---------|
| `semantic_index` | 20.52MB | 20.22MB | -1.45% (304.39kB) |⬇️ |
| `parsed_module` | 23.87MB | 23.72MB | -0.64% (155.63kB) |⬇️ |
| `infer_expression_types_impl` | 5.32MB | 5.22MB | -1.81% (98.84kB) |⬇️ |
| `source_text` | 4.49MB | 4.42MB | -1.53% (70.38kB) |⬇️ |
| `infer_definition_types` | 4.51MB | 4.44MB | -1.49% (68.53kB) |⬇️ |
| `Definition` | 4.35MB | 4.29MB | -1.34% (59.61kB) |⬇️ |
| `infer_scope_types_impl` | 2.99MB | 2.94MB | -1.60% (49.08kB) |⬇️ |
| `Expression` | 1.56MB | 1.53MB | -1.84% (29.50kB) |⬇️ |
| `check_file_impl` | 638.10kB | 610.25kB | -4.36% (27.85kB) |⬇️ |
| `CallableType` | 1.42MB | 1.39MB | -1.81% (26.18kB) |⬇️ |
| `FunctionType` | 1.25MB | 1.23MB | -1.75% (22.44kB) |⬇️ |
| `member_lookup_with_policy_inner` | 1.45MB | 1.43MB | -1.37% (20.41kB) |⬇️ |
| `Type<'db>::apply_specialization_inner_::interned_arguments` | 1.20MB | 1.18MB | -1.42% (17.42kB) |⬇️ |
| `StringLiteralType` | 540.39kB | 524.16kB | -3.00% (16.23kB) |⬇️ |
| `MemberLookupKey` | 1.15MB | 1.14MB | -1.26% (14.88kB) |⬇️ |
| `Type<'db>::class_member_with_policy_inner_` | 1.17MB | 1.16MB | -0.96% (11.54kB) |⬇️ |
| `Type<'db>::apply_specialization_inner_` | 803.09kB | 791.84kB | -1.40% (11.24kB) |⬇️ |
| `place_by_id` | 623.04kB | 613.47kB | -1.54% (9.57kB) |⬇️ |
| `Specialization` | 1.03MB | 1.02MB | -0.86% (9.05kB) |⬇️ |
| `when_constraint_set_assignable_to_owned_impl` | 976.84kB | 969.20kB | -0.78% (7.63kB) |⬇️ |
| `place_by_id::interned_arguments` | 500.13kB | 492.68kB | -1.49% (7.45kB) |⬇️ |
| `ScopeId` | 496.29kB | 488.91kB | -1.49% (7.38kB) |⬇️ |
| `OverloadLiteral` | 423.21kB | 416.00kB | -1.70% (7.21kB) |⬇️ |
| `FunctionType<'db>::signature_` | 1.20MB | 1.19MB | -0.55% (6.70kB) |⬇️ |
| `analyze_non_terminal_call::interned_arguments` | 294.33kB | 287.65kB | -2.27% (6.68kB) |⬇️ |
| `infer_deferred_types` | 1.29MB | 1.28MB | -0.45% (5.89kB) |⬇️ |
| `TypePair` | 969.84kB | 964.31kB | -0.57% (5.53kB) |⬇️ |
| `File` | 102.76kB | 97.44kB | -5.18% (5.33kB) |⬇️ |
| `analyze_non_terminal_call` | 422.87kB | 417.60kB | -1.25% (5.27kB) |⬇️ |
| `TupleType` | 199.53kB | 194.89kB | -2.33% (4.64kB) |⬇️ |
| `BoundMethodType` | 284.61kB | 280.39kB | -1.48% (4.22kB) |⬇️ |
| `StaticClassLiteral<'db>::try_mro_` | 931.58kB | 927.38kB | -0.45% (4.20kB) |⬇️ |
| `all_narrowing_constraints_for_expression` | 641.71kB | 638.30kB | -0.53% (3.41kB) |⬇️ |
| `suppressions` | 31.11kB | 27.81kB | -10.60% (3.30kB) |⬇️ |
| `TypeVarInference` | 267.98kB | 264.73kB | -1.21% (3.25kB) |⬇️ |
| `use_def_map` | 109.18kB | 106.09kB | -2.83% (3.09kB) |⬇️ |
| `function_known_decorators` | 370.78kB | 367.80kB | -0.80% (2.98kB) |⬇️ |
| `GenericAlias` | 392.48kB | 389.95kB | -0.64% (2.53kB) |⬇️ |
| `BoundTypeVarInstance` | 229.45kB | 226.96kB | -1.09% (2.49kB) |⬇️ |
| `resolve_module_query` | 79.39kB | 77.02kB | -2.99% (2.38kB) |⬇️ |
| `IntersectionType` | 277.95kB | 275.73kB | -0.80% (2.23kB) |⬇️ |
| `UnionType` | 295.95kB | 293.77kB | -0.74% (2.19kB) |⬇️ |
| `ModuleLiteralType` | 54.28kB | 52.31kB | -3.63% (1.97kB) |⬇️ |
| `Type<'db>::cached_materialization_::interned_arguments` | 303.59kB | 301.64kB | -0.64% (1.95kB) |⬇️ |
| `BoundMethodType<'db>::bound_signatures_` | 199.41kB | 197.47kB | -0.97% (1.94kB) |⬇️ |
| `absolute_desperate_search_paths` | 6.53kB | 4.62kB | -29.30% (1.91kB) |⬇️ |
| `ModuleNameIngredient` | 56.77kB | 55.11kB | -2.92% (1.66kB) |⬇️ |
| `desperately_resolve_module` | 22.55kB | 20.91kB | -7.28% (1.64kB) |⬇️ |
| `GenericContext` | 193.77kB | 192.36kB | -0.73% (1.41kB) |⬇️ |
| `ProgramFile` | 22.50kB | 21.09kB | -6.25% (1.41kB) |⬇️ |
| `infer_unpack_types` | 96.39kB | 94.99kB | -1.45% (1.40kB) |⬇️ |
| `StaticClassLiteral<'db>::try_mro_::interned_arguments` | 316.12kB | 314.79kB | -0.42% (1.34kB) |⬇️ |
| `specialization_inner` | 122.20kB | 120.86kB | -1.09% (1.34kB) |⬇️ |
| `Type<'db>::cached_materialization_` | 211.66kB | 210.36kB | -0.62% (1.30kB) |⬇️ |
| `directory_listing_query` | 21.43kB | 20.15kB | -5.98% (1.28kB) |⬇️ |
| `is_redundant_with_impl` | 326.96kB | 325.70kB | -0.39% (1.27kB) |⬇️ |
| `place_table` | 69.78kB | 68.52kB | -1.80% (1.26kB) |⬇️ |
| `PythonFile` | 20.56kB | 19.31kB | -6.08% (1.25kB) |⬇️ |
| `file_settings` | 18.18kB | 17.00kB | -6.49% (1.18kB) |⬇️ |
| `desperately_resolve_module::interned_arguments` | 20.46kB | 19.34kB | -5.50% (1.12kB) |⬇️ |
| `script_metadata` | 15.80kB | 14.77kB | -6.52% (1.03kB) |⬇️ |
| `ExpressionWithContext` | 52.97kB | 51.95kB | -1.92% (1.02kB) |⬇️ |
| `should_check_file` | 9.19kB | 8.20kB | -10.71% (1008.00B) |⬇️ |
| `enum_metadata` | 151.20kB | 150.29kB | -0.60% (928.00B) |⬇️ |
| `assignable_solutions_impl` | 111.28kB | 110.38kB | -0.81% (920.00B) |⬇️ |
| `global_scope` | 13.52kB | 12.63kB | -6.53% (904.00B) |⬇️ |
| `assignable_solutions_impl::interned_arguments` | 80.34kB | 79.52kB | -1.01% (832.00B) |⬇️ |
| `TypeVarSetInner` | 137.49kB | 136.70kB | -0.58% (812.00B) |⬇️ |
| `BoundMethodType<'db>::into_callable_type_` | 62.09kB | 61.33kB | -1.23% (784.00B) |⬇️ |
| `FileModule` | 32.66kB | 32.16kB | -1.53% (512.00B) |⬇️ |
| `try_call_bin_op_return_type_impl` | 26.09kB | 25.59kB | -1.89% (504.00B) |⬇️ |
| `Unpack` | 32.27kB | 31.78kB | -1.53% (504.00B) |⬇️ |
| `TypeVarInstance` | 73.69kB | 73.22kB | -0.64% (480.00B) |⬇️ |
| `is_possibly_constraint_set_assignable` | 84.04kB | 83.58kB | -0.55% (472.00B) |⬇️ |
| `try_metaclass_inner` | 61.57kB | 61.14kB | -0.70% (440.00B) |⬇️ |
| `ResolverFile` | 10.90kB | 10.48kB | -3.87% (432.00B) |⬇️ |
| `protocol_apply_self_with_receiver::interned_arguments` | 138.94kB | 138.53kB | -0.29% (416.00B) |⬇️ |
| `StaticClassLiteral` | 85.78kB | 85.43kB | -0.41% (360.00B) |⬇️ |
| `StaticClassLiteral<'db>::implicit_attribute_inner_` | 100.36kB | 100.02kB | -0.33% (344.00B) |⬇️ |
| `loop_header_reachability` | 79.20kB | 78.87kB | -0.41% (332.00B) |⬇️ |
| `try_call_dunder_get_inner` | 110.73kB | 110.41kB | -0.28% (320.00B) |⬇️ |
| `union_from_two_elements` | 36.87kB | 36.57kB | -0.81% (304.00B) |⬇️ |
| `code_generator_of_static_class` | 44.60kB | 44.30kB | -0.67% (304.00B) |⬇️ |
| `try_call_bin_op_return_type_impl::interned_arguments` | 19.97kB | 19.69kB | -1.41% (288.00B) |⬇️ |
| `explicit_bases_inner` | 43.25kB | 42.98kB | -0.63% (280.00B) |⬇️ |
| `inferable_typevars_inner` | 33.30kB | 33.03kB | -0.82% (280.00B) |⬇️ |
| `StaticClassLiteral<'db>::variance_of_owner_::interned_arguments` | 44.95kB | 44.69kB | -0.57% (264.00B) |⬇️ |
| `ImplicitAttributeName` | 64.68kB | 64.42kB | -0.40% (264.00B) |⬇️ |
| `try_call_dunder_get_inner::interned_arguments` | 144.48kB | 144.27kB | -0.15% (224.00B) |⬇️ |
| `intersection_from_two_elements` | 71.12kB | 70.91kB | -0.31% (224.00B) |⬇️ |
| `lookup_dunder_new_inner` | 45.53kB | 45.33kB | -0.45% (208.00B) |⬇️ |
| `ProtocolInterface` | 189.00kB | 188.80kB | -0.10% (200.00B) |⬇️ |
| `implicit_attribute_names` | 42.76kB | 42.56kB | -0.46% (200.00B) |⬇️ |
| `overloads_and_implementation_inner` | 25.87kB | 25.67kB | -0.76% (200.00B) |⬇️ |
| `inheritance_cycle_inner` | 23.05kB | 22.87kB | -0.81% (192.00B) |⬇️ |
| `StaticClassLiteral<'db>::generic_context_` | 40.64kB | 40.46kB | -0.44% (184.00B) |⬇️ |
| `instance_flags_inner` | 26.85kB | 26.67kB | -0.67% (184.00B) |⬇️ |
| `enum_class_literal` | 26.58kB | 26.40kB | -0.68% (184.00B) |⬇️ |
| `protocol_apply_self_with_receiver` | 54.67kB | 54.51kB | -0.30% (168.00B) |⬇️ |
| `file_to_module` | 8.23kB | 8.06kB | -1.99% (168.00B) |⬇️ |
| `Project` | 24.12kB | 24.28kB | +0.64% (159.00B) |⏫ |
| `StaticClassLiteral<'db>::variance_of_owner_` | 21.97kB | 21.84kB | -0.60% (136.00B) |⬇️ |
| `inherited_legacy_generic_context_inner` | 25.80kB | 25.67kB | -0.48% (128.00B) |⬇️ |
| `BytesLiteralType` | 15.47kB | 15.34kB | -0.80% (127.00B) |⬇️ |
| `cached_protocol_interface` | 55.79kB | 55.67kB | -0.21% (120.00B) |⬇️ |
| `bound_typevar_default_type` | 14.16kB | 14.06kB | -0.66% (96.00B) |⬇️ |
| `TypeVarIdentity` | 20.37kB | 20.28kB | -0.42% (88.00B) |⬇️ |
| `lookup_dunder_new_inner::interned_arguments` | 25.23kB | 25.16kB | -0.31% (80.00B) |⬇️ |
| `remove_self_inner::interned_arguments` | 22.22kB | 22.15kB | -0.32% (72.00B) |⬇️ |
| `is_equivalent_to_object_inner::interned_arguments` | 32.81kB | 32.75kB | -0.19% (64.00B) |⬇️ |
| `remove_self_inner` | 12.34kB | 12.30kB | -0.32% (40.00B) |⬇️ |
| `is_equivalent_to_object_inner` | 31.59kB | 31.57kB | -0.07% (24.00B) |⬇️ |
| `infer_statement_types_impl` | 62.00kB | 61.98kB | -0.03% (16.00B) |⬇️ |
| `TupleType<'db>::to_class_type_` | 41.66kB | 41.65kB | -0.04% (16.00B) |⬇️ |
| `StaticClassLiteral<'db>::typed_dict_module_` | 304.00B | 320.00B | +5.26% (16.00B) |⏫ |
| `enum_class_key_profile` | 5.65kB | 5.63kB | -0.28% (16.00B) |⬇️ |
| `ClassType<'db>::nearest_disjoint_base_` | 17.36kB | 17.38kB | +0.09% (16.00B) |⏫ |
| `analyze_non_terminal_call_range` | 9.85kB | 9.84kB | -0.16% (16.00B) |⬇️ |
| `FunctionType<'db>::last_definition_signature_` | 19.02kB | 19.01kB | -0.04% (8.00B) |⬇️ |
| `ClassType<'db>::into_callable_with_receiver_` | 9.91kB | 9.91kB | -0.08% (8.00B) |⬇️ |
| `infer_expression_type_impl` | 43.59kB | 43.59kB | +0.02% (8.00B) |⏫ |
| `effective_superclass_variable_kind` | 22.02kB | 22.01kB | -0.04% (8.00B) |⬇️ |

### sphinx

| Name | Old | New | Diff | Outcome |
|------|-----|-----|------|---------|
| `semantic_index` | 42.27MB | 34.05MB | -19.46% (8.22MB) |⬇️ |
| `parsed_module` | 42.53MB | 36.99MB | -13.04% (5.55MB) |⬇️ |
| `infer_expression_types_impl` | 16.84MB | 11.41MB | -32.22% (5.43MB) |⬇️ |
| `infer_definition_types` | 14.06MB | 10.77MB | -23.38% (3.29MB) |⬇️ |
| `infer_scope_types_impl` | 8.42MB | 6.07MB | -27.98% (2.36MB) |⬇️ |
| `source_text` | 8.37MB | 6.25MB | -25.37% (2.12MB) |⬇️ |
| `Definition` | 8.74MB | 7.30MB | -16.51% (1.44MB) |⬇️ |
| `Expression` | 3.46MB | 2.49MB | -28.01% (993.00kB) |⬇️ |
| `StringLiteralType` | 1.98MB | 1.09MB | -44.77% (906.09kB) |⬇️ |
| `infer_deferred_types` | 2.81MB | 2.11MB | -24.95% (717.38kB) |⬇️ |
| `TypePair` | 2.71MB | 2.10MB | -22.69% (629.91kB) |⬇️ |
| `member_lookup_with_policy_inner` | 5.36MB | 4.80MB | -10.31% (565.73kB) |⬇️ |
| `Type<'db>::class_member_with_policy_inner_` | 3.34MB | 2.82MB | -15.51% (529.80kB) |⬇️ |
| `function_known_decorators` | 1.30MB | 819.71kB | -38.65% (516.38kB) |⬇️ |
| `MemberLookupKey` | 3.43MB | 2.95MB | -14.01% (491.29kB) |⬇️ |
| `all_narrowing_constraints_for_expression` | 2.61MB | 2.23MB | -14.40% (385.02kB) |⬇️ |
| `TupleType` | 701.61kB | 331.98kB | -52.68% (369.62kB) |⬇️ |
| `FunctionType` | 2.16MB | 1.84MB | -14.95% (330.61kB) |⬇️ |
| `Specialization` | 1.88MB | 1.57MB | -16.41% (316.70kB) |⬇️ |
| `StaticClassLiteral<'db>::try_mro_` | 2.18MB | 1.87MB | -14.06% (313.77kB) |⬇️ |
| `CallableType` | 1.96MB | 1.67MB | -14.87% (298.74kB) |⬇️ |
| `check_file_impl` | 591.31kB | 310.89kB | -47.42% (280.42kB) |⬇️ |
| `is_redundant_with_impl` | 1.02MB | 764.12kB | -26.66% (277.84kB) |⬇️ |
| `Type<'db>::apply_specialization_inner_::interned_arguments` | 2.02MB | 1.77MB | -12.48% (258.67kB) |⬇️ |
| `FunctionType<'db>::signature_` | 2.11MB | 1.86MB | -11.50% (248.03kB) |⬇️ |
| `analyze_non_terminal_call::interned_arguments` | 578.74kB | 336.59kB | -41.84% (242.16kB) |⬇️ |
| `OverloadLiteral` | 920.97kB | 689.91kB | -25.09% (231.05kB) |⬇️ |
| `analyze_non_terminal_call` | 684.59kB | 456.20kB | -33.36% (228.39kB) |⬇️ |
| `when_constraint_set_assignable_to_owned_impl` | 1.63MB | 1.41MB | -13.37% (222.54kB) |⬇️ |
| `place_by_id` | 1.35MB | 1.15MB | -14.77% (204.03kB) |⬇️ |
| `place_by_id::interned_arguments` | 1.09MB | 949.29kB | -14.81% (165.09kB) |⬇️ |
| `Type<'db>::apply_specialization_inner_` | 1.28MB | 1.12MB | -12.49% (164.14kB) |⬇️ |
| `UnionType` | 804.53kB | 641.86kB | -20.22% (162.67kB) |⬇️ |
| `IntersectionType` | 773.75kB | 621.46kB | -19.68% (152.29kB) |⬇️ |
| `BoundMethodType` | 1012.11kB | 863.59kB | -14.67% (148.52kB) |⬇️ |
| `GenericAlias` | 810.63kB | 663.19kB | -18.19% (147.45kB) |⬇️ |
| `ScopeId` | 854.61kB | 713.59kB | -16.50% (141.02kB) |⬇️ |
| `Type<'db>::cached_materialization_::interned_arguments` | 488.12kB | 375.08kB | -23.16% (113.05kB) |⬇️ |
| `StaticClassLiteral<'db>::try_mro_::interned_arguments` | 722.11kB | 619.17kB | -14.26% (102.94kB) |⬇️ |
| `use_def_map` | 287.92kB | 199.59kB | -30.68% (88.34kB) |⬇️ |
| `BoundMethodType<'db>::bound_signatures_` | 488.62kB | 402.94kB | -17.54% (85.68kB) |⬇️ |
| `try_call_bin_op_return_type_impl` | 152.38kB | 78.05kB | -48.77% (74.32kB) |⬇️ |
| `Type<'db>::cached_materialization_` | 318.73kB | 247.18kB | -22.45% (71.55kB) |⬇️ |
| `protocol_apply_self_with_receiver::interned_arguments` | 502.63kB | 435.91kB | -13.28% (66.73kB) |⬇️ |
| `infer_unpack_types` | 321.34kB | 258.10kB | -19.68% (63.24kB) |⬇️ |
| `enum_metadata` | 392.51kB | 337.03kB | -14.13% (55.48kB) |⬇️ |
| `TypeVarInference` | 411.91kB | 358.02kB | -13.08% (53.89kB) |⬇️ |
| `File` | 198.86kB | 145.37kB | -26.90% (53.49kB) |⬇️ |
| `ProtocolInterface` | 388.91kB | 342.77kB | -11.86% (46.14kB) |⬇️ |
| `BoundTypeVarInstance` | 756.25kB | 711.39kB | -5.93% (44.86kB) |⬇️ |
| `infer_statement_types_impl` | 545.45kB | 504.19kB | -7.56% (41.26kB) |⬇️ |
| `TupleType<'db>::to_class_type_` | 93.94kB | 52.77kB | -43.83% (41.17kB) |⬇️ |
| `try_call_bin_op_return_type_impl::interned_arguments` | 107.06kB | 67.88kB | -36.60% (39.19kB) |⬇️ |
| `try_call_dunder_get_inner::interned_arguments` | 383.91kB | 344.75kB | -10.20% (39.16kB) |⬇️ |
| `suppressions` | 80.55kB | 45.73kB | -43.24% (34.83kB) |⬇️ |
| `StaticClassLiteral<'db>::implicit_attribute_inner_` | 632.16kB | 598.73kB | -5.29% (33.43kB) |⬇️ |
| `place_table` | 191.57kB | 159.08kB | -16.96% (32.49kB) |⬇️ |
| `absolute_desperate_search_paths` | 35.11kB | 3.86kB | -89.00% (31.24kB) |⬇️ |
| `ExpressionWithContext` | 338.28kB | 309.14kB | -8.61% (29.14kB) |⬇️ |
| `try_call_dunder_get_inner` | 335.19kB | 306.64kB | -8.52% (28.55kB) |⬇️ |
| `StaticClassLiteral` | 205.20kB | 177.30kB | -13.59% (27.89kB) |⬇️ |
| `ModuleLiteralType` | 125.16kB | 97.31kB | -22.25% (27.84kB) |⬇️ |
| `ImplicitAttributeName` | 485.61kB | 459.03kB | -5.47% (26.58kB) |⬇️ |
| `protocol_apply_self_with_receiver` | 196.40kB | 170.26kB | -13.31% (26.14kB) |⬇️ |
| `specialization_inner` | 171.20kB | 148.75kB | -13.11% (22.45kB) |⬇️ |
| `GenericContext` | 192.63kB | 170.92kB | -11.27% (21.71kB) |⬇️ |
| `file_settings` | 44.95kB | 24.54kB | -45.41% (20.41kB) |⬇️ |
| `Unpack` | 90.63kB | 71.09kB | -21.57% (19.55kB) |⬇️ |
| `TypeVarInstance` | 162.84kB | 143.53kB | -11.86% (19.31kB) |⬇️ |
| `try_metaclass_inner` | 181.38kB | 162.87kB | -10.20% (18.51kB) |⬇️ |
| `BoundMethodType<'db>::into_callable_type_` | 128.14kB | 110.98kB | -13.39% (17.16kB) |⬇️ |
| `implicit_attribute_names` | 142.03kB | 125.10kB | -11.92% (16.94kB) |⬇️ |
| `assignable_solutions_impl` | 158.29kB | 141.52kB | -10.59% (16.77kB) |⬇️ |
| `ProgramFile` | 46.12kB | 30.94kB | -32.93% (15.19kB) |⬇️ |
| `is_possibly_constraint_set_assignable` | 120.24kB | 105.14kB | -12.56% (15.10kB) |⬇️ |
| `TypeVarSetInner` | 143.63kB | 129.04kB | -10.16% (14.59kB) |⬇️ |
| `code_generator_of_static_class` | 128.30kB | 113.95kB | -11.18% (14.34kB) |⬇️ |
| `lookup_dunder_new_inner` | 122.27kB | 108.02kB | -11.65% (14.25kB) |⬇️ |
| `assignable_solutions_impl::interned_arguments` | 122.89kB | 108.98kB | -11.32% (13.91kB) |⬇️ |
| `PythonFile` | 41.19kB | 27.81kB | -32.47% (13.38kB) |⬇️ |
| `intersection_from_two_elements` | 257.69kB | 244.40kB | -5.16% (13.29kB) |⬇️ |
| `StaticClassLiteral<'db>::generic_context_` | 101.09kB | 88.07kB | -12.88% (13.02kB) |⬇️ |
| `analyze_non_terminal_call_range` | 22.09kB | 10.01kB | -54.69% (12.08kB) |⬇️ |
| `explicit_bases_inner` | 118.36kB | 106.59kB | -9.95% (11.77kB) |⬇️ |
| `protocol_bind_self::interned_arguments` | 97.20kB | 85.42kB | -12.11% (11.77kB) |⬇️ |
| `script_metadata` | 32.85kB | 21.38kB | -34.93% (11.48kB) |⬇️ |
| `should_check_file` | 24.45kB | 14.05kB | -42.51% (10.39kB) |⬇️ |
| `union_from_two_elements` | 114.20kB | 103.90kB | -9.02% (10.30kB) |⬇️ |
| `desperately_resolve_module` | 11.98kB | 1.68kB | -85.98% (10.30kB) |⬇️ |
| `enum_class_literal` | 70.79kB | 60.59kB | -14.40% (10.20kB) |⬇️ |
| `desperately_resolve_module::interned_arguments` | 11.81kB | 1.62kB | -86.31% (10.20kB) |⬇️ |
| `ScopeWithContext` | 41.17kB | 31.09kB | -24.48% (10.08kB) |⬇️ |
| `ResolverFile` | 17.65kB | 7.80kB | -55.78% (9.84kB) |⬇️ |
| `cached_protocol_interface` | 103.53kB | 94.04kB | -9.17% (9.49kB) |⬇️ |
| `directory_listing_query` | 50.97kB | 41.52kB | -18.55% (9.46kB) |⬇️ |
| `resolve_module_query` | 83.08kB | 73.73kB | -11.25% (9.34kB) |⬇️ |
| `member_lookup_with_policy_and_receiver_inner` | 83.59kB | 74.34kB | -11.07% (9.25kB) |⬇️ |
| `instance_flags_inner` | 76.34kB | 67.93kB | -11.01% (8.41kB) |⬇️ |
| `is_equivalent_to_object_inner::interned_arguments` | 67.12kB | 58.81kB | -12.38% (8.31kB) |⬇️ |
| `global_scope` | 27.70kB | 19.43kB | -29.86% (8.27kB) |⬇️ |
| `inherited_legacy_generic_context_inner` | 76.22kB | 68.38kB | -10.28% (7.84kB) |⬇️ |
| `lookup_dunder_new_inner::interned_arguments` | 57.19kB | 49.77kB | -12.98% (7.42kB) |⬇️ |
| `inheritance_cycle_inner` | 67.81kB | 60.75kB | -10.41% (7.06kB) |⬇️ |
| `effective_superclass_variable_kind` | 116.78kB | 109.72kB | -6.05% (7.06kB) |⬇️ |
| `is_equivalent_to_object_inner` | 58.73kB | 51.86kB | -11.69% (6.87kB) |⬇️ |
| `effective_superclass_variable_kind::interned_arguments` | 98.91kB | 92.38kB | -6.60% (6.53kB) |⬇️ |
| `ModuleNameIngredient` | 47.57kB | 41.17kB | -13.46% (6.40kB) |⬇️ |
| `member_lookup_with_policy_and_receiver_inner::interned_arguments` | 40.47kB | 34.14kB | -15.64% (6.33kB) |⬇️ |
| `BytesLiteralType` | 7.64kB | 1.48kB | -80.58% (6.16kB) |⬇️ |
| `FileModule` | 50.94kB | 44.88kB | -11.89% (6.06kB) |⬇️ |
| `StaticClassLiteral<'db>::variance_of_owner_::interned_arguments` | 51.39kB | 45.55kB | -11.37% (5.84kB) |⬇️ |
| `loop_header_reachability` | 247.95kB | 242.40kB | -2.24% (5.55kB) |⬇️ |
| `protocol_bind_self` | 44.18kB | 38.83kB | -12.11% (5.35kB) |⬇️ |
| `PropertyInstanceType` | 34.84kB | 29.86kB | -14.29% (4.98kB) |⬇️ |
| `ClassType<'db>::nearest_disjoint_base_` | 57.82kB | 52.84kB | -8.61% (4.98kB) |⬇️ |
| `analyze_non_terminal_call_range::interned_arguments` | 6.41kB | 2.27kB | -64.63% (4.14kB) |⬇️ |
| `inferable_typevars_inner` | 31.19kB | 27.15kB | -12.95% (4.04kB) |⬇️ |
| `infer_expression_type_impl` | 205.50kB | 201.59kB | -1.90% (3.91kB) |⬇️ |
| `UnionTypeInstance` | 21.78kB | 18.06kB | -17.07% (3.72kB) |⬇️ |
| `non_terminal_call_predicates` | 7.06kB | 3.47kB | -50.83% (3.59kB) |⬇️ |
| `TypeIsType` | 16.50kB | 13.15kB | -20.31% (3.35kB) |⬇️ |
| `GenericAlias<'db>::variance_of_owner_::interned_arguments` | 34.80kB | 31.54kB | -9.38% (3.27kB) |⬇️ |
| `StaticClassLiteral<'db>::own_fields_inner_` | 42.86kB | 39.93kB | -6.85% (2.93kB) |⬇️ |
| `Type<'db>::is_data_descriptor_impl_::interned_arguments` | 24.92kB | 22.03kB | -11.60% (2.89kB) |⬇️ |
| `StaticClassLiteral<'db>::variance_of_owner_` | 26.38kB | 23.51kB | -10.90% (2.88kB) |⬇️ |
| `non_recursive_protocol_interface::interned_arguments` | 25.70kB | 22.86kB | -11.04% (2.84kB) |⬇️ |
| `StaticClassLiteral<'db>::fields_inner_` | 22.52kB | 19.89kB | -11.68% (2.63kB) |⬇️ |
| `TypeVarIdentity` | 15.81kB | 13.32kB | -15.76% (2.49kB) |⬇️ |
| `is_function_definition::interned_arguments` | 35.06kB | 33.06kB | -5.70% (2.00kB) |⬇️ |
| `StatementInner` | 19.41kB | 17.45kB | -10.14% (1.97kB) |⬇️ |
| `overloads_and_implementation_inner` | 49.66kB | 47.75kB | -3.84% (1.91kB) |⬇️ |
| `BoundSuperType` | 27.32kB | 25.59kB | -6.32% (1.73kB) |⬇️ |
| `is_open_file_impl` | 6.17kB | 4.45kB | -27.85% (1.72kB) |⬇️ |
| `GenericAlias<'db>::variance_of_owner_` | 18.10kB | 16.39kB | -9.45% (1.71kB) |⬇️ |
| `Type<'db>::expand_eagerly__` | 9.96kB | 8.33kB | -16.39% (1.63kB) |⬇️ |
| `is_function_definition` | 29.27kB | 27.73kB | -5.26% (1.54kB) |⬇️ |
| `Type<'db>::is_data_descriptor_impl_` | 12.84kB | 11.34kB | -11.63% (1.49kB) |⬇️ |
| `remove_self_inner::interned_arguments` | 14.62kB | 13.22kB | -9.62% (1.41kB) |⬇️ |
| `StaticClassLiteral<'db>::has_own_comparison_methods_` | 11.11kB | 9.71kB | -12.59% (1.40kB) |⬇️ |
| `non_recursive_protocol_interface` | 11.92kB | 10.63kB | -10.81% (1.29kB) |⬇️ |
| `Type<'db>::expand_eagerly__::interned_arguments` | 14.06kB | 12.81kB | -8.89% (1.25kB) |⬇️ |
| `FunctionType<'db>::last_definition_signature_` | 3.31kB | 2.16kB | -34.91% (1.16kB) |⬇️ |
| `InternedType` | 2.39kB | 1.27kB | -47.06% (1.12kB) |⬇️ |
| `EnumClassLiteral` | 3.45kB | 2.41kB | -30.09% (1.04kB) |⬇️ |
| `ClassType<'db>::abstract_methods_` | 3.24kB | 2.21kB | -31.81% (1.03kB) |⬇️ |
| `bound_typevar_default_type` | 12.68kB | 11.66kB | -8.01% (1.02kB) |⬇️ |
| `MaterializedProtocolType` | 11.81kB | 10.83kB | -8.33% (1008.00B) |⬇️ |
| `StaticClassLiteral<'db>::decorators_inner_` | 10.68kB | 9.76kB | -8.63% (944.00B) |⬇️ |
| `PEP695TypeAliasType<'db>::raw_value_type_` | 4.37kB | 3.52kB | -19.50% (872.00B) |⬇️ |
| `remove_self_inner` | 8.12kB | 7.34kB | -9.62% (800.00B) |⬇️ |
| `class_based_items` | 2.96kB | 2.21kB | -25.43% (772.00B) |⬇️ |
| `EnumLiteralType` | 3.12kB | 2.42kB | -22.50% (720.00B) |⬇️ |
| `FunctoolsPartialInstance` | 864.00B | 144.00B | -83.33% (720.00B) |⬇️ |
| `NamedTupleSpec` | 824.00B | 192.00B | -76.70% (632.00B) |⬇️ |
| `FunctionType<'db>::last_definition_raw_signature_` | 888.00B | 328.00B | -63.06% (560.00B) |⬇️ |
| `StaticClassLiteral<'db>::own_fields_inner_::interned_arguments` | 4.06kB | 3.59kB | -11.54% (480.00B) |⬇️ |
| `StaticClassLiteral<'db>::fields_inner_::interned_arguments` | 1.80kB | 1.33kB | -26.09% (480.00B) |⬇️ |
| `DynamicNamedTupleLiteral<'db>::mro_` | 696.00B | 232.00B | -66.67% (464.00B) |⬇️ |
| `file_to_module` | 6.12kB | 5.70kB | -6.90% (432.00B) |⬇️ |
| `enum_ignored_names` | 1.02kB | 656.00B | -36.92% (384.00B) |⬇️ |
| `class_based_openness` | 1.47kB | 1.12kB | -23.40% (352.00B) |⬇️ |
| `ExplicitAnyInstanceClass` | 320.00B | 0.00B | -100.00% (320.00B) |⬇️ |
| `DynamicNamedTupleLiteral` | 410.00B | 96.00B | -76.59% (314.00B) |⬇️ |
| `PEP695TypeAliasType` | 4.64kB | 4.38kB | -5.56% (264.00B) |⬇️ |
| `ClassType<'db>::into_callable_with_receiver_` | 9.14kB | 8.91kB | -2.56% (240.00B) |⬇️ |
| `PEP695TypeAliasType<'db>::generic_context_` | 3.31kB | 3.12kB | -5.66% (192.00B) |⬇️ |
| `DataclassParams` | 480.00B | 288.00B | -40.00% (192.00B) |⬇️ |
| `FunctionType<'db>::last_definition_raw_signature_::interned_arguments` | 256.00B | 64.00B | -75.00% (192.00B) |⬇️ |
| `DynamicClassLiteral` | 733.00B | 552.00B | -24.69% (181.00B) |⬇️ |
| `Project` | 66.31kB | 66.48kB | +0.24% (165.00B) |⏫ |
| `DynamicClassLiteral<'db>::try_mro_` | 688.00B | 528.00B | -23.26% (160.00B) |⬇️ |
| `ClassType<'db>::into_callable_with_receiver_::interned_arguments` | 5.94kB | 5.78kB | -2.63% (160.00B) |⬇️ |
| `top_materialized_upper_bound_inner` | 2.16kB | 2.02kB | -6.50% (144.00B) |⬇️ |
| `known_class_to_class_literal` | 3.68kB | 3.54kB | -3.82% (144.00B) |⬇️ |
| `KnownClassArgument` | 3.19kB | 3.06kB | -3.92% (128.00B) |⬇️ |
| `StaticClassLiteral<'db>::typed_dict_module_` | 440.00B | 312.00B | -29.09% (128.00B) |⬇️ |
| `TypeVarInstance<'db>::lazy_default_unchecked_` | 1.67kB | 1.55kB | -7.48% (128.00B) |⬇️ |
| `TypeVarInstance<'db>::lazy_bound_unchecked_` | 2.22kB | 2.09kB | -5.63% (128.00B) |⬇️ |
| `exists_at_runtime` | 4.29kB | 4.17kB | -2.73% (120.00B) |⬇️ |
| `NewType` | 96.00B | 0.00B | -100.00% (96.00B) |⬇️ |
| `merge_inner::interned_arguments` | 11.04kB | 10.97kB | -0.64% (72.00B) |⬇️ |
| `exported_names` | 4.62kB | 4.56kB | -1.35% (64.00B) |⬇️ |
| `known_class_to_instance` | 2.12kB | 2.06kB | -2.58% (56.00B) |⬇️ |
| `all_narrowing_constraints_for_pattern` | 2.13kB | 2.09kB | -2.20% (48.00B) |⬇️ |
| `all_negative_narrowing_constraints_for_pattern` | 2.09kB | 2.05kB | -2.24% (48.00B) |⬇️ |
| `merge_inner` | 7.36kB | 7.31kB | -0.64% (48.00B) |⬇️ |
| `StarImportPlaceholderPredicate` | 12.56kB | 12.52kB | -0.37% (48.00B) |⬇️ |
| `enum_class_key_profile` | 1.42kB | 1.41kB | -1.10% (16.00B) |⬇️ |

### prefect

| Name | Old | New | Diff | Outcome |
|------|-----|-----|------|---------|
| `semantic_index` | 136.93MB | 87.15MB | -36.35% (49.77MB) |⬇️ |
| `infer_definition_types` | 60.38MB | 34.56MB | -42.76% (25.82MB) |⬇️ |
| `infer_expression_types_impl` | 47.14MB | 23.36MB | -50.44% (23.78MB) |⬇️ |
| `infer_scope_types_impl` | 35.99MB | 18.77MB | -47.86% (17.23MB) |⬇️ |
| `source_text` | 32.07MB | 21.87MB | -31.80% (10.20MB) |⬇️ |
| `Definition` | 25.87MB | 17.45MB | -32.57% (8.43MB) |⬇️ |
| `parsed_module` | 94.21MB | 85.90MB | -8.82% (8.31MB) |⬇️ |
| `check_file_impl` | 12.39MB | 7.06MB | -43.00% (5.33MB) |⬇️ |
| `Expression` | 10.91MB | 6.53MB | -40.15% (4.38MB) |⬇️ |
| `FunctionType` | 9.63MB | 5.46MB | -43.31% (4.17MB) |⬇️ |
| `Type<'db>::class_member_with_policy_inner_` | 12.50MB | 8.68MB | -30.54% (3.82MB) |⬇️ |
| `member_lookup_with_policy_inner` | 14.53MB | 10.74MB | -26.08% (3.79MB) |⬇️ |
| `CallableType` | 11.24MB | 7.99MB | -28.93% (3.25MB) |⬇️ |
| `function_known_decorators` | 5.43MB | 2.24MB | -58.72% (3.19MB) |⬇️ |
| `MemberLookupKey` | 9.95MB | 6.81MB | -31.53% (3.14MB) |⬇️ |
| `all_narrowing_constraints_for_expression` | 7.43MB | 4.52MB | -39.14% (2.91MB) |⬇️ |
| `Type<'db>::apply_specialization_inner_::interned_arguments` | 7.30MB | 5.13MB | -29.71% (2.17MB) |⬇️ |
| `Specialization` | 6.52MB | 4.56MB | -30.07% (1.96MB) |⬇️ |
| `FunctionType<'db>::signature_` | 6.30MB | 4.38MB | -30.51% (1.92MB) |⬇️ |
| `infer_deferred_types` | 6.77MB | 4.88MB | -27.94% (1.89MB) |⬇️ |
| `StaticClassLiteral<'db>::try_mro_` | 6.88MB | 5.07MB | -26.23% (1.80MB) |⬇️ |
| `TypePair` | 9.46MB | 7.70MB | -18.55% (1.75MB) |⬇️ |
| `OverloadLiteral` | 3.29MB | 1.54MB | -53.15% (1.75MB) |⬇️ |
| `place_by_id` | 5.37MB | 3.64MB | -32.22% (1.73MB) |⬇️ |
| `when_constraint_set_assignable_to_owned_impl` | 6.96MB | 5.25MB | -24.50% (1.70MB) |⬇️ |
| `StringLiteralType` | 6.05MB | 4.41MB | -27.09% (1.64MB) |⬇️ |
| `Type<'db>::apply_specialization_inner_` | 4.90MB | 3.41MB | -30.32% (1.49MB) |⬇️ |
| `place_by_id::interned_arguments` | 4.17MB | 2.80MB | -32.90% (1.37MB) |⬇️ |
| `BoundMethodType` | 3.23MB | 2.01MB | -37.78% (1.22MB) |⬇️ |
| `analyze_non_terminal_call::interned_arguments` | 1.75MB | 855.77kB | -52.18% (933.82kB) |⬇️ |
| `analyze_non_terminal_call` | 1.89MB | 1020.67kB | -47.25% (914.12kB) |⬇️ |
| `ScopeId` | 2.44MB | 1.55MB | -36.41% (908.83kB) |⬇️ |
| `BoundTypeVarInstance` | 2.02MB | 1.15MB | -42.77% (883.61kB) |⬇️ |
| `GenericAlias` | 2.58MB | 1.78MB | -31.15% (824.20kB) |⬇️ |
| `is_redundant_with_impl` | 4.06MB | 3.35MB | -17.36% (721.19kB) |⬇️ |
| `StaticClassLiteral<'db>::try_mro_::interned_arguments` | 2.14MB | 1.52MB | -29.15% (640.27kB) |⬇️ |
| `use_def_map` | 1.21MB | 648.12kB | -47.88% (595.44kB) |⬇️ |
| `enum_metadata` | 1.74MB | 1.17MB | -32.81% (585.47kB) |⬇️ |
| `Type<'db>::cached_materialization_::interned_arguments` | 1.93MB | 1.37MB | -28.61% (564.14kB) |⬇️ |
| `BoundMethodType<'db>::bound_signatures_` | 1.79MB | 1.25MB | -30.55% (560.93kB) |⬇️ |
| `IntersectionType` | 2.07MB | 1.56MB | -24.96% (529.84kB) |⬇️ |
| `StaticClassLiteral<'db>::fields_inner_` | 1.33MB | 838.84kB | -38.57% (526.76kB) |⬇️ |
| `UnionType` | 1.86MB | 1.36MB | -27.07% (515.20kB) |⬇️ |
| `has_before_or_plain_field_validator` | 1.20MB | 789.87kB | -35.62% (436.96kB) |⬇️ |
| `TypeVarInference` | 1.47MB | 1.05MB | -28.49% (429.48kB) |⬇️ |
| `Type<'db>::cached_materialization_` | 1.42MB | 1.03MB | -27.87% (405.80kB) |⬇️ |
| `TupleType` | 1.24MB | 877.50kB | -30.77% (390.06kB) |⬇️ |
| `protocol_apply_self_with_receiver::interned_arguments` | 992.47kB | 690.02kB | -30.47% (302.45kB) |⬇️ |
| `place_table` | 784.88kB | 490.30kB | -37.53% (294.58kB) |⬇️ |
| `try_call_dunder_get_inner::interned_arguments` | 1.62MB | 1.34MB | -17.08% (283.28kB) |⬇️ |
| `infer_statement_types_impl` | 914.21kB | 653.94kB | -28.47% (260.27kB) |⬇️ |
| `StaticClassLiteral` | 821.25kB | 562.50kB | -31.51% (258.75kB) |⬇️ |
| `infer_unpack_types` | 666.75kB | 428.57kB | -35.72% (238.17kB) |⬇️ |
| `ExpressionWithContext` | 718.28kB | 496.88kB | -30.82% (221.41kB) |⬇️ |
| `try_call_dunder_get_inner` | 1.30MB | 1.08MB | -16.66% (221.06kB) |⬇️ |
| `ProtocolInterface` | 957.33kB | 767.64kB | -19.81% (189.69kB) |⬇️ |
| `TypeVarInstance` | 487.22kB | 304.97kB | -37.41% (182.25kB) |⬇️ |
| `lookup_dunder_new_inner` | 455.48kB | 275.35kB | -39.55% (180.12kB) |⬇️ |
| `specialization_inner` | 623.31kB | 450.16kB | -27.78% (173.15kB) |⬇️ |
| `File` | 767.27kB | 601.98kB | -21.54% (165.29kB) |⬇️ |
| `absolute_desperate_search_paths` | 663.46kB | 500.39kB | -24.58% (163.07kB) |⬇️ |
| `intersection_from_two_elements` | 675.02kB | 543.69kB | -19.46% (131.33kB) |⬇️ |
| `implicit_attribute_names` | 476.36kB | 347.13kB | -27.13% (129.23kB) |⬇️ |
| `is_possibly_constraint_set_assignable` | 478.47kB | 350.48kB | -26.75% (127.98kB) |⬇️ |
| `ModuleLiteralType` | 415.90kB | 294.54kB | -29.18% (121.36kB) |⬇️ |
| `suppressions` | 354.54kB | 234.66kB | -33.81% (119.88kB) |⬇️ |
| `StaticClassLiteral<'db>::generic_context_` | 410.48kB | 291.92kB | -28.88% (118.56kB) |⬇️ |
| `enum_class_literal` | 341.55kB | 223.45kB | -34.58% (118.11kB) |⬇️ |
| `protocol_apply_self_with_receiver` | 384.11kB | 267.23kB | -30.43% (116.88kB) |⬇️ |
| `StaticClassLiteral<'db>::own_fields_inner_` | 997.99kB | 885.16kB | -11.31% (112.83kB) |⬇️ |
| `BoundMethodType<'db>::into_callable_type_` | 384.98kB | 280.67kB | -27.09% (104.30kB) |⬇️ |
| `try_metaclass_inner` | 646.44kB | 543.80kB | -15.88% (102.63kB) |⬇️ |
| `assignable_solutions_impl` | 601.45kB | 505.25kB | -15.99% (96.20kB) |⬇️ |
| `desperately_resolve_module` | 395.77kB | 300.18kB | -24.15% (95.59kB) |⬇️ |
| `ScopeWithContext` | 167.42kB | 77.97kB | -53.43% (89.45kB) |⬇️ |
| `assignable_solutions_impl::interned_arguments` | 445.96kB | 359.84kB | -19.31% (86.12kB) |⬇️ |
| `has_before_or_plain_field_validator::interned_arguments` | 253.83kB | 168.98kB | -33.43% (84.84kB) |⬇️ |
| `desperately_resolve_module::interned_arguments` | 251.44kB | 166.78kB | -33.67% (84.66kB) |⬇️ |
| `Unpack` | 224.23kB | 148.99kB | -33.55% (75.23kB) |⬇️ |
| `TypeVarSetInner` | 529.84kB | 459.49kB | -13.28% (70.35kB) |⬇️ |
| `code_generator_of_static_class` | 452.08kB | 388.36kB | -14.09% (63.72kB) |⬇️ |
| `lookup_dunder_new_inner::interned_arguments` | 163.28kB | 100.39kB | -38.52% (62.89kB) |⬇️ |
| `StaticClassLiteral<'db>::implicit_attribute_inner_` | 866.62kB | 804.03kB | -7.22% (62.59kB) |⬇️ |
| `explicit_bases_inner` | 419.63kB | 357.71kB | -14.76% (61.92kB) |⬇️ |
| `member_lookup_with_policy_and_receiver_inner` | 310.06kB | 253.95kB | -18.10% (56.12kB) |⬇️ |
| `try_call_bin_op_return_type_impl` | 114.78kB | 59.93kB | -47.79% (54.85kB) |⬇️ |
| `union_from_two_elements` | 280.90kB | 229.30kB | -18.37% (51.59kB) |⬇️ |
| `ImplicitAttributeName` | 606.62kB | 555.88kB | -8.36% (50.74kB) |⬇️ |
| `loop_header_reachability` | 299.09kB | 249.63kB | -16.53% (49.45kB) |⬇️ |
| `cached_protocol_interface` | 247.53kB | 199.14kB | -19.55% (48.39kB) |⬇️ |
| `file_settings` | 145.83kB | 98.16kB | -32.69% (47.67kB) |⬇️ |
| `GenericContext` | 543.47kB | 495.96kB | -8.74% (47.51kB) |⬇️ |
| `ProgramFile` | 161.23kB | 115.52kB | -28.35% (45.70kB) |⬇️ |
| `inherited_legacy_generic_context_inner` | 284.96kB | 239.38kB | -16.00% (45.59kB) |⬇️ |
| `protocol_bind_self::interned_arguments` | 197.05kB | 153.48kB | -22.11% (43.57kB) |⬇️ |
| `model_config` | 157.66kB | 114.91kB | -27.11% (42.75kB) |⬇️ |
| `instance_flags_inner` | 279.23kB | 237.16kB | -15.07% (42.08kB) |⬇️ |
| `inheritance_cycle_inner` | 267.68kB | 226.87kB | -15.25% (40.81kB) |⬇️ |
| `PythonFile` | 144.06kB | 103.44kB | -28.20% (40.62kB) |⬇️ |
| `ClassType<'db>::nearest_disjoint_base_` | 368.62kB | 329.07kB | -10.73% (39.55kB) |⬇️ |
| `try_call_bin_op_return_type_impl::interned_arguments` | 82.69kB | 45.66kB | -44.78% (37.03kB) |⬇️ |
| `resolve_module_query` | 319.02kB | 282.15kB | -11.56% (36.87kB) |⬇️ |
| `ResolverFile` | 116.72kB | 79.95kB | -31.51% (36.77kB) |⬇️ |
| `directory_listing_query` | 143.71kB | 107.51kB | -25.19% (36.20kB) |⬇️ |
| `script_metadata` | 121.07kB | 85.73kB | -29.19% (35.34kB) |⬇️ |
| `should_check_file` | 104.73kB | 70.16kB | -33.00% (34.56kB) |⬇️ |
| `is_equivalent_to_object_inner::interned_arguments` | 167.75kB | 136.12kB | -18.85% (31.62kB) |⬇️ |
| `StaticClassLiteral<'db>::fields_inner_::interned_arguments` | 74.22kB | 45.78kB | -38.32% (28.44kB) |⬇️ |
| `global_scope` | 99.50kB | 71.15kB | -28.49% (28.35kB) |⬇️ |
| `is_equivalent_to_object_inner` | 148.76kB | 120.98kB | -18.68% (27.78kB) |⬇️ |
| `is_root_model` | 78.23kB | 53.96kB | -31.02% (24.27kB) |⬇️ |
| `ModuleNameIngredient` | 197.56kB | 173.55kB | -12.15% (24.01kB) |⬇️ |
| `StaticClassLiteral<'db>::own_fields_inner_::interned_arguments` | 115.00kB | 91.95kB | -20.04% (23.05kB) |⬇️ |
| `TupleType<'db>::to_class_type_` | 106.44kB | 83.98kB | -21.10% (22.46kB) |⬇️ |
| `member_lookup_with_policy_and_receiver_inner::interned_arguments` | 126.88kB | 104.77kB | -17.43% (22.11kB) |⬇️ |
| `protocol_bind_self` | 89.57kB | 69.77kB | -22.11% (19.80kB) |⬇️ |
| `effective_superclass_variable_kind` | 201.51kB | 183.03kB | -9.17% (18.48kB) |⬇️ |
| `StaticClassLiteral<'db>::variance_of_owner_::interned_arguments` | 125.21kB | 106.82kB | -14.69% (18.39kB) |⬇️ |
| `GenericAlias<'db>::variance_of_owner_::interned_arguments` | 95.99kB | 78.55kB | -18.17% (17.45kB) |⬇️ |
| `StaticClassLiteral<'db>::decorators_inner_` | 42.30kB | 25.81kB | -38.98% (16.49kB) |⬇️ |
| `inferable_typevars_inner` | 111.61kB | 96.60kB | -13.45% (15.01kB) |⬇️ |
| `StarImportPlaceholderPredicate` | 88.83kB | 74.30kB | -16.36% (14.53kB) |⬇️ |
| `Project` | 50.39kB | 36.56kB | -27.46% (13.84kB) |⬇️ |
| `non_recursive_protocol_interface::interned_arguments` | 53.37kB | 40.48kB | -24.15% (12.89kB) |⬇️ |
| `UnionTypeInstance` | 78.76kB | 65.88kB | -16.36% (12.88kB) |⬇️ |
| `effective_superclass_variable_kind::interned_arguments` | 137.07kB | 125.04kB | -8.78% (12.03kB) |⬇️ |
| `is_open_file_impl` | 22.81kB | 11.99kB | -47.43% (10.82kB) |⬇️ |
| `infer_expression_type_impl` | 260.87kB | 250.46kB | -3.99% (10.41kB) |⬇️ |
| `StatementInner` | 47.74kB | 37.41kB | -21.65% (10.34kB) |⬇️ |
| `StaticClassLiteral<'db>::variance_of_owner_` | 68.14kB | 58.70kB | -13.85% (9.44kB) |⬇️ |
| `GenericAlias<'db>::variance_of_owner_` | 48.20kB | 39.25kB | -18.57% (8.95kB) |⬇️ |
| `FileModule` | 149.89kB | 141.07kB | -5.88% (8.82kB) |⬇️ |
| `Type<'db>::expand_eagerly__::interned_arguments` | 85.39kB | 76.72kB | -10.16% (8.67kB) |⬇️ |
| `ClassType<'db>::into_callable_with_receiver_` | 31.94kB | 23.98kB | -24.90% (7.95kB) |⬇️ |
| `Type<'db>::is_data_descriptor_impl_::interned_arguments` | 55.78kB | 48.05kB | -13.87% (7.73kB) |⬇️ |
| `BytesLiteralType` | 12.97kB | 5.52kB | -57.42% (7.45kB) |⬇️ |
| `exported_names` | 35.75kB | 28.71kB | -19.71% (7.05kB) |⬇️ |
| `non_recursive_protocol_interface` | 24.43kB | 18.52kB | -24.21% (5.91kB) |⬇️ |
| `Type<'db>::expand_eagerly__` | 51.88kB | 46.09kB | -11.16% (5.79kB) |⬇️ |
| `merge_inner::interned_arguments` | 37.34kB | 31.78kB | -14.88% (5.55kB) |⬇️ |
| `remove_self_inner::interned_arguments` | 60.89kB | 55.55kB | -8.78% (5.34kB) |⬇️ |
| `MaterializedProtocolType` | 38.18kB | 32.98kB | -13.63% (5.20kB) |⬇️ |
| `Type<'db>::is_data_descriptor_impl_` | 31.43kB | 26.27kB | -16.43% (5.16kB) |⬇️ |
| `ClassType<'db>::into_callable_with_receiver_::interned_arguments` | 17.97kB | 13.59kB | -24.35% (4.38kB) |⬇️ |
| `PropertyInstanceType` | 64.80kB | 60.73kB | -6.27% (4.06kB) |⬇️ |
| `DynamicClassLiteral` | 4.38kB | 353.00B | -92.13% (4.04kB) |⬇️ |
| `merge_inner` | 24.89kB | 21.19kB | -14.88% (3.70kB) |⬇️ |
| `class_mro_literals` | 10.65kB | 6.97kB | -34.56% (3.68kB) |⬇️ |
| `ClassType<'db>::abstract_methods_` | 86.00kB | 82.38kB | -4.21% (3.62kB) |⬇️ |
| `TypeIsType` | 16.07kB | 12.46kB | -22.46% (3.61kB) |⬇️ |
| `bound_typevar_default_type` | 45.50kB | 42.27kB | -7.11% (3.23kB) |⬇️ |
| `is_function_definition::interned_arguments` | 30.50kB | 27.38kB | -10.25% (3.12kB) |⬇️ |
| `StaticClassLiteral<'db>::has_own_comparison_methods_` | 19.41kB | 16.29kB | -16.10% (3.12kB) |⬇️ |
| `remove_self_inner` | 33.83kB | 30.86kB | -8.78% (2.97kB) |⬇️ |
| `BoundSuperType` | 27.62kB | 24.68kB | -10.66% (2.95kB) |⬇️ |
| `analyze_non_terminal_call_range` | 18.16kB | 15.42kB | -15.10% (2.74kB) |⬇️ |
| `DynamicClassLiteral<'db>::try_mro_` | 3.09kB | 376.00B | -88.13% (2.73kB) |⬇️ |
| `is_function_definition` | 25.42kB | 22.76kB | -10.48% (2.66kB) |⬇️ |
| `EnumClassLiteral` | 33.88kB | 31.44kB | -7.20% (2.44kB) |⬇️ |
| `file_to_module` | 22.12kB | 19.72kB | -10.88% (2.41kB) |⬇️ |
| `EnumLiteralType` | 39.61kB | 37.27kB | -5.92% (2.34kB) |⬇️ |
| `class_based_items` | 37.14kB | 34.95kB | -5.88% (2.18kB) |⬇️ |
| `enum_class_key_profile` | 17.37kB | 15.24kB | -12.24% (2.12kB) |⬇️ |
| `overloads_and_implementation_inner` | 59.34kB | 57.41kB | -3.25% (1.93kB) |⬇️ |
| `InternedType` | 14.13kB | 12.45kB | -11.94% (1.69kB) |⬇️ |
| `FunctoolsPartialInstance` | 5.55kB | 3.87kB | -30.38% (1.69kB) |⬇️ |
| `SynthesizedTypedDictType` | 3.32kB | 1.73kB | -47.83% (1.59kB) |⬇️ |
| `relative_desperate_search_paths` | 10.63kB | 9.17kB | -13.74% (1.46kB) |⬇️ |
| `TypeGuardType` | 7.99kB | 6.79kB | -15.05% (1.20kB) |⬇️ |
| `non_terminal_call_predicates` | 7.15kB | 6.03kB | -15.73% (1.12kB) |⬇️ |
| `EnumComplementType` | 11.06kB | 9.97kB | -9.89% (1.09kB) |⬇️ |
| `code_generator_of_dynamic_class` | 1.09kB | 56.00B | -94.96% (1.03kB) |⬇️ |
| `dunder_all_names` | 16.40kB | 15.37kB | -6.29% (1.03kB) |⬇️ |
| `TypeVarIdentity` | 45.28kB | 44.25kB | -2.28% (1.03kB) |⬇️ |
| `enum_ignored_names` | 10.28kB | 9.34kB | -9.12% (960.00B) |⬇️ |
| `analyze_non_terminal_call_range::interned_arguments` | 4.69kB | 3.98kB | -15.00% (720.00B) |⬇️ |
| `class_based_openness` | 11.02kB | 10.38kB | -5.88% (664.00B) |⬇️ |
| `FieldInstance` | 20.91kB | 20.28kB | -3.03% (648.00B) |⬇️ |
| `enum_class_key_profile::interned_arguments` | 3.94kB | 3.44kB | -12.70% (512.00B) |⬇️ |
| `same_enum_comparison_profile::interned_arguments` | 3.81kB | 3.44kB | -9.84% (384.00B) |⬇️ |
| `same_enum_comparison_profile` | 2.86kB | 2.58kB | -9.84% (288.00B) |⬇️ |
| `StaticClassLiteral<'db>::typed_dict_module_` | 1.97kB | 1.73kB | -12.30% (248.00B) |⬇️ |
| `deferred_explicit_bases` | 208.00B | 0.00B | -100.00% (208.00B) |⬇️ |
| `DynamicTypedDictLiteral` | 686.00B | 510.00B | -25.66% (176.00B) |⬇️ |
| `TypeVarInstance<'db>::lazy_bound_unchecked_` | 13.52kB | 13.35kB | -1.21% (168.00B) |⬇️ |
| `TypeFormType` | 5.27kB | 5.13kB | -2.67% (144.00B) |⬇️ |
| `top_materialized_upper_bound_inner` | 3.64kB | 3.50kB | -3.86% (144.00B) |⬇️ |
| `TypeVarConstraints` | 2.50kB | 2.38kB | -4.69% (120.00B) |⬇️ |
| `DynamicTypedDictLiteral<'db>::mro_` | 416.00B | 312.00B | -25.00% (104.00B) |⬇️ |
| `DataclassParams` | 480.00B | 384.00B | -20.00% (96.00B) |⬇️ |
| `PEP695TypeAliasType` | 968.00B | 880.00B | -9.09% (88.00B) |⬇️ |
| `FunctionType<'db>::last_definition_signature_` | 57.91kB | 57.98kB | +0.13% (80.00B) |⏫ |
| `exists_at_runtime` | 4.70kB | 4.62kB | -1.66% (80.00B) |⬇️ |
| `known_class_to_class_literal` | 4.06kB | 3.99kB | -1.73% (72.00B) |⬇️ |
| `TypeVarInstance<'db>::lazy_constraints_unchecked_` | 1.13kB | 1.07kB | -5.52% (64.00B) |⬇️ |
| `KnownClassArgument` | 3.50kB | 3.44kB | -1.79% (64.00B) |⬇️ |
| `known_class_to_instance` | 2.17kB | 2.12kB | -2.52% (56.00B) |⬇️ |
| `deferred_functional_typed_dict_openness` | 200.00B | 144.00B | -28.00% (56.00B) |⬇️ |
| `PEP695TypeAliasType<'db>::raw_value_type_` | 616.00B | 560.00B | -9.09% (56.00B) |⬇️ |
| `PEP695TypeAliasType<'db>::generic_context_` | 528.00B | 480.00B | -9.09% (48.00B) |⬇️ |
| `FunctionType<'db>::last_definition_raw_signature_` | 26.41kB | 26.43kB | +0.09% (24.00B) |⏫ |

</details>

