### PR TITLE
[ty] Enable missing ecosystem analysis rules

### DIFF
--- a/.github/ty-ecosystem.toml
+++ b/.github/ty-ecosystem.toml
@@ -3,7 +3,9 @@
 
 # Enable off-by-default rules.
 [rules]
+blanket-ignore-comment = "warn"
 division-by-zero = "warn"
+missing-type-argument = "warn"
 possibly-missing-attribute = "warn"
 possibly-missing-import = "warn"
 possibly-unresolved-reference = "warn"


### PR DESCRIPTION
Enable `blanket-ignore-comment` and `missing-type-argument` in the shared ecosystem-analysis configuration.

These rules are disabled by default and were missing from both the scheduled ecosystem report and pull-request ecosystem diffs. `missing-override-decorator` remains the only intentionally excluded disabled-by-default rule.