### PR TITLE
[ty] Stabilize recursive gradual type alias materialization

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1138,6 +1138,37 @@ def _(left: Recursive, right: EnumValue):
     reveal_type(left == right)  # revealed: bool
 ```
 
+## Recursive aliases containing gradual generic branches
+
+Equality narrowing must terminate when a recursive sequence alias contains a mapping with a gradual
+key.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+type RecursiveMappingKey = Sequence[RecursiveMappingKey] | Mapping[Any, int]
+
+def narrow_recursive_mapping_key(value: RecursiveMappingKey) -> None:
+    assert value == 0
+    _ = value
+```
+
+A gradual mapping value also must not cause recursive materialization to unfold indefinitely.
+
+```py
+type RecursiveMappingValue = Sequence[RecursiveMappingValue] | Mapping[int, Any]
+
+def narrow_recursive_mapping_value(value: RecursiveMappingValue) -> None:
+    assert value == 0
+    _ = value
+```
+
 ## Known built-in equality behavior
 
 `bool`, `LiteralString`, `TypedDict`, and final classes that inherit `object.__eq__` have known

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -977,6 +977,16 @@ static_assert(not is_subtype_of(type[Any], type[Arbitrary]))
 static_assert(is_subtype_of(type[Any], type[object]))
 ```
 
+A covariant specialization whose argument is a recursive alias remains a subtype of the same
+specialization with `object`. A gradual invariant branch must not cause recursive materialization to
+unfold indefinitely.
+
+```pyi
+type RecursiveGradual = Covariant[RecursiveGradual] | Invariant[Any]
+
+static_assert(is_subtype_of(Covariant[RecursiveGradual], Covariant[object]))
+```
+
 ## Callable
 
 The general principle is that a callable type is a subtype of another if it's more flexible in what

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1121,6 +1121,11 @@ def _(
 `Top[T]` and `Bottom[T]` are always fully static types. Therefore, they have only one
 materialization (themselves) and applying `Top` or `Bottom` again does nothing.
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 from typing import Any
 from ty_extensions import Top, Bottom, static_assert
@@ -1131,6 +1136,66 @@ static_assert(is_equivalent_to(Bottom[Top[list[Any]]], Top[list[Any]]))
 
 static_assert(is_equivalent_to(Bottom[Bottom[list[Any]]], Bottom[list[Any]]))
 static_assert(is_equivalent_to(Top[Bottom[list[Any]]], Bottom[list[Any]]))
+```
+
+The same is true when a covariant specialization contains a recursive alias with a gradual invariant
+branch. Materializing the recursive branch again must not unfold another layer.
+
+```py
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Invariant[T]:
+    value: T
+
+type Recursive = Covariant[Recursive] | Invariant[Any]
+
+static_assert(is_equivalent_to(Top[Covariant[Recursive]], Top[Top[Covariant[Recursive]]]))
+static_assert(is_equivalent_to(Bottom[Covariant[Recursive]], Bottom[Bottom[Covariant[Recursive]]]))
+static_assert(is_equivalent_to(Top[Covariant[Recursive]], Bottom[Top[Covariant[Recursive]]]))
+static_assert(is_equivalent_to(Bottom[Covariant[Recursive]], Top[Bottom[Covariant[Recursive]]]))
+```
+
+Both branches retain the requested materialization polarity.
+
+```py
+def recursive_materializations(top: Top[Recursive], bottom: Bottom[Recursive]) -> None:
+    reveal_type(top)  # revealed: Covariant[Top[Recursive]] | Top[Invariant[Any]]
+    reveal_type(bottom)  # revealed: Covariant[Bottom[Recursive]] | Bottom[Invariant[Any]]
+```
+
+Nested recursive aliases preserve their materialization polarity in displays and diagnostics.
+
+```py
+def nested_recursive_materializations(top: Top[Covariant[Recursive]], bottom: Bottom[Covariant[Recursive]]) -> None:
+    reveal_type(top)  # revealed: Covariant[Top[Recursive]]
+    reveal_type(bottom)  # revealed: Covariant[Bottom[Recursive]]
+
+    # error: [invalid-assignment] "Object of type `Covariant[Top[Recursive]]` is not assignable to `Covariant[Bottom[Recursive]]`"
+    bottom = top
+```
+
+Explicitly constructed recursive aliases preserve the same materialized identity.
+
+```py
+from typing_extensions import TypeAliasType
+
+ManualRecursive = TypeAliasType("ManualRecursive", "Covariant[ManualRecursive] | Invariant[Any]")
+
+static_assert(is_equivalent_to(Top[Covariant[ManualRecursive]], Top[Top[Covariant[ManualRecursive]]]))
+```
+
+Materialization also preserves the specialization of a recursive generic alias.
+
+```py
+type GenericRecursive[T] = Covariant[GenericRecursive[T]] | Invariant[Any] | T
+
+static_assert(is_equivalent_to(Top[GenericRecursive[int]], Top[Top[GenericRecursive[int]]]))
+static_assert(not is_equivalent_to(Top[GenericRecursive[int]], Top[GenericRecursive[str]]))
+
+def generic_recursive_materialization(value: Top[Covariant[GenericRecursive[int]]]) -> None:
+    reveal_type(value)  # revealed: Covariant[Top[GenericRecursive[int]]]
 ```
 
 ## Subtyping

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -492,10 +492,10 @@ pub(crate) struct FindLegacyTypeVars;
 type SpecializationVisitor<'db> = CycleDetector<'db, VisitSpecialization, Type<'db>, (), 3>;
 struct VisitSpecialization;
 
-/// How a generic type has been specialized.
+/// Whether a type represents the upper or lower bound of a gradual type.
 ///
-/// This matters only if there is at least one invariant or constrained type parameter.
-/// For example, we represent `Top[list[Any]]` as a `GenericAlias` with
+/// For generic specializations, this matters only if there is at least one invariant or constrained
+/// type parameter. For example, we represent `Top[list[Any]]` as a `GenericAlias` with
 /// `MaterializationKind` set to Top, which we denote as `Top[list[Any]]`.
 /// A type `Top[list[T]]` includes all fully static list types `list[U]` where `U` is
 /// a supertype of `Bottom[T]` and a subtype of `Top[T]`.
@@ -503,6 +503,9 @@ struct VisitSpecialization;
 /// Similarly, there is `Bottom[list[Any]]`.
 /// This type is harder to make sense of in a set-theoretic framework, but
 /// it is a subtype of all materializations of `list[Any]`.
+///
+/// Recursive type aliases also retain their materialization kind so that materializing the alias
+/// body preserves stable recursive references.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum MaterializationKind {
     Top,
@@ -7647,6 +7650,13 @@ impl<'db> Type<'db> {
 
             Type::TypeAlias(alias) => {
                 match type_mapping {
+                    TypeMapping::Materialize(_) if alias.materialization_kind(db).is_some() =>
+                    {
+                        self
+                    }
+                    TypeMapping::EagerExpansion if alias.materialization_kind(db).is_some() => {
+                        alias.value_type(db).expand_eagerly(db, visitor.env)
+                    }
                     // For EagerExpansion, expand the raw value type. This path relies on Salsa's cycle
                     // detection rather than the visitor's cycle detection, because the visitor tracks
                     // Type values and `RecursiveList` is different from `RecursiveList[T]`.
@@ -7691,9 +7701,20 @@ impl<'db> Type<'db> {
                         });
 
                         // If the type mapping does not result in any change to this type alias, keep the
-                        // alias node instead of eagerly expanding it.
-                        if alias.value_type(db) == mapped {
+                        // alias node instead of eagerly expanding it. A recursive backedge also returns
+                        // the alias itself, and fully static aliases must retain their original identity.
+                        if mapped == self || alias.value_type(db) == mapped {
                             self
+                        } else if let TypeMapping::Materialize(materialization_kind) = type_mapping
+                            && matches!(
+                                self.to_type_identity(db),
+                                cyclic::TypeIdentity::RecursiveTypeAlias(_)
+                            )
+                        {
+                            Type::TypeAlias(alias.with_materialization_kind(
+                                db,
+                                Some(*materialization_kind),
+                            ))
                         } else {
                             mapped
                         }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1543,15 +1543,29 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                 f.write_char('>')
             }
             Type::TypeAlias(alias) => {
+                let materialization_kind = alias.materialization_kind(db);
+                if let Some(kind) = materialization_kind {
+                    let (name, form) = match kind {
+                        MaterializationKind::Top => ("Top", SpecialFormType::Top),
+                        MaterializationKind::Bottom => ("Bottom", SpecialFormType::Bottom),
+                    };
+                    f.with_type(Type::SpecialForm(form)).write_str(name)?;
+                    f.write_char('[')?;
+                }
+
                 alias
                     .display_with(db, self.settings.clone())
                     .fmt_detailed(f)?;
-                match alias.specialization(db) {
-                    None => Ok(()),
-                    Some(specialization) => specialization
+                if let Some(specialization) = alias.specialization(db) {
+                    specialization
                         .display_short(db, self.env, TupleSpecialization::No, self.settings.clone())
-                        .fmt_detailed(f),
+                        .fmt_detailed(f)?;
                 }
+
+                if materialization_kind.is_some() {
+                    f.write_char(']')?;
+                }
+                Ok(())
             }
             Type::NewTypeInstance(newtype) => f.with_type(self.ty).write_str(newtype.name(db)),
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2081,7 +2081,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let type_alias_ty =
             Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
-                PEP695TypeAliasType::new(self.db(), alias_name, rhs_scope, None),
+                PEP695TypeAliasType::new(self.db(), alias_name, rhs_scope, None, None),
             )));
 
         self.store_expression_type(&type_alias.name, type_alias_ty);
@@ -3849,7 +3849,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.deferred.insert(definition);
 
         Type::KnownInstance(KnownInstanceType::TypeAliasType(
-            TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(db, name, definition, None)),
+            TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(
+                db, name, definition, None, None,
+            )),
         ))
     }
 

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -5,7 +5,7 @@ use crate::{
     Db, FxOrderSet,
     types::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, GenericContext,
-        KnownInstanceType, Type, TypeContext, TypeMapping, TypeVarVariance,
+        KnownInstanceType, MaterializationKind, Type, TypeContext, TypeMapping, TypeVarVariance,
         definition_expression_type,
         display::qualified_name_components_from_scope,
         generics::{ApplySpecialization, Specialization, bind_typevar},
@@ -33,6 +33,10 @@ pub struct PEP695TypeAliasType<'db> {
 
     #[returns(copy)]
     pub(super) specialization: Option<Specialization<'db>>,
+
+    /// Keeps recursive references stable while their alias body is materialized lazily.
+    #[returns(copy)]
+    pub(super) materialization_kind: Option<MaterializationKind>,
 }
 
 // The Salsa heap is tracked separately.
@@ -43,7 +47,7 @@ pub(super) fn walk_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> + ?Sized
     type_alias: PEP695TypeAliasType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, type_alias.value_type(db));
+    visitor.visit_type(db, TypeAliasType::PEP695(type_alias).value_type(db));
 }
 
 #[salsa::tracked]
@@ -106,6 +110,7 @@ impl<'db> PEP695TypeAliasType<'db> {
                     self.name(db),
                     self.rhs_scope(db),
                     Some(specialization),
+                    self.materialization_kind(db),
                 )
             }
         }
@@ -144,6 +149,10 @@ pub struct ManualPEP695TypeAliasType<'db> {
 
     #[returns(copy)]
     pub(super) specialization: Option<Specialization<'db>>,
+
+    /// Keeps recursive references stable while their alias body is materialized lazily.
+    #[returns(copy)]
+    pub(super) materialization_kind: Option<MaterializationKind>,
 }
 
 // The Salsa heap is tracked separately.
@@ -154,7 +163,7 @@ pub(super) fn walk_manual_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> +
     type_alias: ManualPEP695TypeAliasType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, type_alias.value_type(db));
+    visitor.visit_type(db, TypeAliasType::ManualPEP695(type_alias).value_type(db));
 }
 
 #[salsa::tracked]
@@ -215,6 +224,7 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
             self.name(db),
             self.definition(db),
             Some(f(generic_context)),
+            self.materialization_kind(db),
         )
     }
 
@@ -330,10 +340,38 @@ impl<'db> TypeAliasType<'db> {
     }
 
     pub fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+        if let Some(materialization_kind) = self.materialization_kind(db) {
+            return self.materialized_value_type(db, materialization_kind);
+        }
+
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.value_type(db),
             TypeAliasType::ManualPEP695(type_alias) => type_alias.value_type(db),
         }
+    }
+
+    /// Materialize the alias body lazily, keeping this alias as the recursive fallback.
+    ///
+    /// Comparing a recursive specialization with its materialization can request this same body
+    /// before it has finished materializing. Returning the already-marked alias closes that cycle
+    /// without losing its materialization polarity.
+    #[salsa::tracked(
+        returns(copy),
+        cycle_initial=|_, _, alias: TypeAliasType<'db>, _| Type::TypeAlias(alias),
+        heap_size=ruff_memory_usage::heap_size
+    )]
+    fn materialized_value_type(
+        self,
+        db: &'db dyn Db,
+        materialization_kind: MaterializationKind,
+    ) -> Type<'db> {
+        let value_type = self.with_materialization_kind(db, None).value_type(db);
+        let env = ProgramEnvironment::from_definition(self.definition(db));
+        value_type.materialize(
+            db,
+            materialization_kind,
+            &ApplyTypeMappingVisitor::new(&env),
+        )
     }
 
     pub(crate) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
@@ -343,7 +381,7 @@ impl<'db> TypeAliasType<'db> {
         }
     }
 
-    /// Returns the alias without an applied specialization.
+    /// Returns the alias without an applied specialization or pending materialization.
     pub(super) fn unspecialized(self, db: &'db dyn Db) -> Self {
         match self {
             TypeAliasType::PEP695(alias) => TypeAliasType::PEP695(PEP695TypeAliasType::new(
@@ -351,10 +389,53 @@ impl<'db> TypeAliasType<'db> {
                 alias.name(db),
                 alias.rhs_scope(db),
                 None,
+                None,
             )),
-            TypeAliasType::ManualPEP695(alias) => TypeAliasType::ManualPEP695(
-                ManualPEP695TypeAliasType::new(db, alias.name(db), alias.definition(db), None),
-            ),
+            TypeAliasType::ManualPEP695(alias) => {
+                TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(
+                    db,
+                    alias.name(db),
+                    alias.definition(db),
+                    None,
+                    None,
+                ))
+            }
+        }
+    }
+
+    pub(super) fn materialization_kind(self, db: &'db dyn Db) -> Option<MaterializationKind> {
+        match self {
+            TypeAliasType::PEP695(alias) => alias.materialization_kind(db),
+            TypeAliasType::ManualPEP695(alias) => alias.materialization_kind(db),
+        }
+    }
+
+    pub(super) fn with_materialization_kind(
+        self,
+        db: &'db dyn Db,
+        materialization_kind: Option<MaterializationKind>,
+    ) -> Self {
+        if self.materialization_kind(db) == materialization_kind {
+            return self;
+        }
+
+        match self {
+            TypeAliasType::PEP695(alias) => TypeAliasType::PEP695(PEP695TypeAliasType::new(
+                db,
+                alias.name(db),
+                alias.rhs_scope(db),
+                alias.specialization(db),
+                materialization_kind,
+            )),
+            TypeAliasType::ManualPEP695(alias) => {
+                TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(
+                    db,
+                    alias.name(db),
+                    alias.definition(db),
+                    alias.specialization(db),
+                    materialization_kind,
+                ))
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Avoid hangs / stack overflows in materializing recursive type aliases. Preserve Top/Bottom polarity explicitly on the alias, materializing the alias body lazily through cycle-safe Salsa queries.
- Retain alias specializations and fully static recursive identities while displaying materialized aliases unambiguously in diagnostics.

Fixes astral-sh/ty#4205.

## Test plan

- Equality narrowing of recursive sequences containing gradual mapping keys or values.
- Subtyping of covariant recursive aliases containing gradual invariant branches.
- Top/Bottom and mixed-polarity idempotence, recursive branch polarity, distinct nested alias displays and assignment diagnostics, manually constructed aliases, and distinguishable generic alias specializations.
