### PR TITLE
[ty] Add helper extension methods for half-range and equality constraints

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
@@ -29,8 +29,8 @@ python-version = "3.13"
 from ty_extensions._internal import ConstraintSet
 
 def absorption[T]() -> None:
-    scalar = ConstraintSet.range(str, T, object)
-    tuple_ = ConstraintSet.range(tuple[str, ...], T, object)
+    scalar = ConstraintSet.lower_bound(str, T)
+    tuple_ = ConstraintSet.lower_bound(tuple[str, ...], T)
 
     # revealed: tuple[Solution[T=str]]
     reveal_type((scalar & (scalar | tuple_)).solutions_for(T, inferable=tuple[T]))
@@ -70,9 +70,9 @@ def bindings_reverse_source[T, U, V]() -> None:
     reveal_type(constraints.solutions(inferable=tuple[T, U, V]))
 
 def bindings_absorbed[T, U, X]() -> None:
-    t = ConstraintSet.range(str, T, object)
-    u = ConstraintSet.range(bytes, U, object)
-    x = ConstraintSet.range(int, X, object)
+    t = ConstraintSet.lower_bound(str, T)
+    u = ConstraintSet.lower_bound(bytes, U)
+    x = ConstraintSet.lower_bound(int, X)
 
     # ((X ≥ int) ∧ (T ≥ str) ∧ (U ≥ bytes)) | ((U ≥ bytes) ∧ (T ≥ str))
     constraints = (x & t & u) | (u & t)
@@ -88,14 +88,13 @@ and vice versa. Because we combine them with union, we are allowed to _either_ f
 `T` and `U`, _or_ find a solution for `V`. We are not _obligated_ to find a solution for all three.
 
 ```py
-from typing import Never
 from ty_extensions._internal import ConstraintSet
 
 def nested_transitive[T, U, V]() -> None:
     # ((T ≤ list[U]) ∧ (U ≤ int) ∧ (list[int] ≤ T)) | (bytes ≤ V)
     constraints = (
-        ConstraintSet.range(Never, T, list[U]) & ConstraintSet.range(Never, U, int) & ConstraintSet.range(list[int], T, object)
-    ) | ConstraintSet.range(bytes, V, object)
+        ConstraintSet.upper_bound(T, list[U]) & ConstraintSet.upper_bound(U, int) & ConstraintSet.lower_bound(list[int], T)
+    ) | ConstraintSet.lower_bound(bytes, V)
 
     # TODO: sometimes: revealed tuple[Solution[T=list[int]], Solution[T=Never], Solution[]]
     # TODO: sometimes: revealed tuple[Solution[T=list[int]], Solution[T=list[int]], Solution[]]
@@ -127,14 +126,11 @@ includes both sides of the union, so any solution that includes `bytes ≤ U` sh
 solution for `T`.
 
 ```py
-from typing import Never
 from ty_extensions._internal import ConstraintSet
 
 def negated_alternative[T, U]() -> None:
     # ¬((T ≤ int) ∨ (T ≤ str)) | (bytes ≤ U)
-    constraints = ~(ConstraintSet.range(Never, T, int) | ConstraintSet.range(Never, T, str)) | ConstraintSet.range(
-        bytes, U, object
-    )
+    constraints = ~(ConstraintSet.upper_bound(T, int) | ConstraintSet.upper_bound(T, str)) | ConstraintSet.lower_bound(bytes, U)
 
     # TODO: sometimes: revealed tuple[Solution[], Solution[T=Never], Solution[]]
     # revealed: tuple[Solution[], Solution[]]
@@ -155,15 +151,14 @@ Constructing the constraints in the opposite source order makes the derived unio
 elements should not be reordered merely because the TDD-variable order changes.
 
 ```py
-from typing import Never
 from ty_extensions._internal import ConstraintSet
 
 def derived_solution[U, T]() -> None:
     # (U ≤ int) ∧ (int ≤ T) ∧ ((T ≤ int) | (T ≤ str))
     constraints = (
-        ConstraintSet.range(Never, U, int)
-        & ConstraintSet.range(int, T, object)
-        & (ConstraintSet.range(Never, T, int) | ConstraintSet.range(Never, T, str))
+        ConstraintSet.upper_bound(U, int)
+        & ConstraintSet.lower_bound(int, T)
+        & (ConstraintSet.upper_bound(T, int) | ConstraintSet.upper_bound(T, str))
     )
 
     # TODO: The derived relationship should not leave an inferable `U` in the solution for `T`.
@@ -174,7 +169,7 @@ def derived_solution[U, T]() -> None:
 
     # TODO: The derived relationship should not leave an inferable `T` in the solution for `U`.
     # TODO: revealed: tuple[Solution[U=int]]
-    # revealed: tuple[Solution[U=Never]]
+    # revealed: tuple[Solution[U=int & T@derived_solution]]
     reveal_type(constraints.solutions_for(U, inferable=tuple[T, U]))
 ```
 
@@ -185,13 +180,12 @@ range or two linked constraints. Logical equivalence and solution-element order 
 in both declaration orders.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def orientation_st[S, T]() -> None:
-    lower = ConstraintSet.range(Never, S, T)
-    upper = ConstraintSet.range(S, T, object)
+    lower = ConstraintSet.upper_bound(S, T)
+    upper = ConstraintSet.lower_bound(S, T)
     # TODO: sometimes: error [static-assert-error] "Static assertion error: argument evaluates to `False`"
     static_assert(lower == upper)
 
@@ -200,8 +194,8 @@ def orientation_st[S, T]() -> None:
     static_assert(equality_st == equality_ts)
 
 def orientation_ts[T, S]() -> None:
-    lower = ConstraintSet.range(Never, S, T)
-    upper = ConstraintSet.range(S, T, object)
+    lower = ConstraintSet.upper_bound(S, T)
+    upper = ConstraintSet.lower_bound(S, T)
     # TODO: sometimes: error [static-assert-error] "Static assertion error: argument evaluates to `False`"
     static_assert(lower == upper)
 
@@ -211,11 +205,11 @@ def orientation_ts[T, S]() -> None:
 
 def chain_stu[S, T, U]() -> None:
     chain = ConstraintSet.range(S, T, U)
-    linked = ConstraintSet.range(Never, S, T) & ConstraintSet.range(Never, T, U)
+    linked = ConstraintSet.upper_bound(S, T) & ConstraintSet.upper_bound(T, U)
     # TODO: sometimes: error [static-assert-error] "Static assertion error: argument evaluates to `False`"
     static_assert(chain == linked)
 
-    constraints = chain & ConstraintSet.range(int, S, object) & ConstraintSet.range(Never, U, int)
+    constraints = chain & ConstraintSet.lower_bound(int, S) & ConstraintSet.upper_bound(U, int)
     # TODO: inferable typevars should not remain in these concrete solutions.
     # TODO: sometimes: revealed tuple[Solution[S=int | U@chain_stu | T@chain_stu]]
     # revealed: tuple[Solution[S=int | T@chain_stu | U@chain_stu]]
@@ -227,11 +221,11 @@ def chain_stu[S, T, U]() -> None:
 
 def chain_uts[U, T, S]() -> None:
     chain = ConstraintSet.range(S, T, U)
-    linked = ConstraintSet.range(Never, S, T) & ConstraintSet.range(Never, T, U)
+    linked = ConstraintSet.upper_bound(S, T) & ConstraintSet.upper_bound(T, U)
     # TODO: sometimes: error [static-assert-error] "Static assertion error: argument evaluates to `False`"
     static_assert(chain == linked)
 
-    constraints = chain & ConstraintSet.range(int, S, object) & ConstraintSet.range(Never, U, int)
+    constraints = chain & ConstraintSet.lower_bound(int, S) & ConstraintSet.upper_bound(U, int)
     # TODO: inferable typevars should not remain in these concrete solutions.
     # TODO: sometimes: revealed tuple[Solution[S=int | U@chain_uts | T@chain_uts]]
     # revealed: tuple[Solution[S=int | T@chain_uts | U@chain_uts]]
@@ -249,14 +243,13 @@ leak onto the surviving paths. Universal abstraction of an alternative must like
 unrelated branch.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def noninferable_nested[T, U, V]() -> None:
     constraints = (
-        ConstraintSet.range(Never, T, list[U]) & ConstraintSet.range(Never, U, int) & ConstraintSet.range(list[int], T, object)
-    ) | ConstraintSet.range(bytes, V, object)
+        ConstraintSet.upper_bound(T, list[U]) & ConstraintSet.upper_bound(U, int) & ConstraintSet.lower_bound(list[int], T)
+    ) | ConstraintSet.lower_bound(bytes, V)
 
     # `U` is deliberately non-inferable here.
     # TODO: We should not include a solution for non-inferable U.
@@ -273,18 +266,16 @@ def noninferable_nested[T, U, V]() -> None:
     reveal_type(constraints.solutions_for(V, inferable=tuple[T, V]))
 
     quantified = constraints.for_all(tuple[T, U])
-    expected = ConstraintSet.range(bytes, V, object)
+    expected = ConstraintSet.lower_bound(bytes, V)
     static_assert(quantified == expected)
     # revealed: tuple[Solution[V=bytes]]
     reveal_type(quantified.solutions_for(V, inferable=tuple[V]))
 
 def noninferable_negated[T, U]() -> None:
-    constraints = ~(ConstraintSet.range(Never, T, int) | ConstraintSet.range(Never, T, str)) | ConstraintSet.range(
-        bytes, U, object
-    )
+    constraints = ~(ConstraintSet.upper_bound(T, int) | ConstraintSet.upper_bound(T, str)) | ConstraintSet.lower_bound(bytes, U)
 
     quantified = constraints.for_all(tuple[T])
-    expected = ConstraintSet.range(bytes, U, object)
+    expected = ConstraintSet.lower_bound(bytes, U)
     static_assert(quantified == expected)
     # revealed: tuple[Solution[U=bytes]]
     reveal_type(quantified.solutions_for(U, inferable=tuple[U]))
@@ -397,7 +388,7 @@ sequent fuel budget. The remaining solution, its element order, and the elements
 truncated diagnostic display must not depend on which implications were encountered first.
 
 ```py
-from typing import Literal, Never
+from typing import Literal
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -443,18 +434,18 @@ def high_fanout[
         & ConstraintSet.range(Literal[11], L11, P)
     )
     upper = (
-        ConstraintSet.range(Never, P, R0)
-        & ConstraintSet.range(Never, P, R1)
-        & ConstraintSet.range(Never, P, R2)
-        & ConstraintSet.range(Never, P, R3)
-        & ConstraintSet.range(Never, P, R4)
-        & ConstraintSet.range(Never, P, R5)
-        & ConstraintSet.range(Never, P, R6)
-        & ConstraintSet.range(Never, P, R7)
-        & ConstraintSet.range(Never, P, R8)
-        & ConstraintSet.range(Never, P, R9)
-        & ConstraintSet.range(Never, P, R10)
-        & ConstraintSet.range(Never, P, R11)
+        ConstraintSet.upper_bound(P, R0)
+        & ConstraintSet.upper_bound(P, R1)
+        & ConstraintSet.upper_bound(P, R2)
+        & ConstraintSet.upper_bound(P, R3)
+        & ConstraintSet.upper_bound(P, R4)
+        & ConstraintSet.upper_bound(P, R5)
+        & ConstraintSet.upper_bound(P, R6)
+        & ConstraintSet.upper_bound(P, R7)
+        & ConstraintSet.upper_bound(P, R8)
+        & ConstraintSet.upper_bound(P, R9)
+        & ConstraintSet.upper_bound(P, R10)
+        & ConstraintSet.upper_bound(P, R11)
     )
     inferable = tuple[
         P,
@@ -507,7 +498,7 @@ def high_fanout[
     # revealed: tuple[Solution[R11=L1@high_fanout | Literal[2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | L2@high_fanout | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout | P@high_fanout]]
     reveal_type(result)
 
-    impossible = constraints & ConstraintSet.range(Never, R11, Literal[0])
+    impossible = constraints & ConstraintSet.upper_bound(R11, Literal[0])
     # TODO: sometimes: error [static-assert-error] "Static assertion error: argument evaluates to `False`"
     static_assert(not impossible.satisfied_by_all_typevars(inferable=inferable))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
@@ -53,19 +53,19 @@ from ty_extensions._internal import ConstraintSet
 
 def bindings_tuv[T, U, V]() -> None:
     # (T = int) ∧ (U = str) ∧ (V = bytes)
-    constraints = ConstraintSet.range(int, T, int) & ConstraintSet.range(str, U, str) & ConstraintSet.range(bytes, V, bytes)
+    constraints = ConstraintSet.equality(T, int) & ConstraintSet.equality(U, str) & ConstraintSet.equality(V, bytes)
     # revealed: tuple[Solution[T=int, U=str, V=bytes]]
     reveal_type(constraints.solutions(inferable=tuple[T, U, V]))
 
 def bindings_vtu[V, T, U]() -> None:
     # (T = int) ∧ (U = str) ∧ (V = bytes)
-    constraints = ConstraintSet.range(int, T, int) & ConstraintSet.range(str, U, str) & ConstraintSet.range(bytes, V, bytes)
+    constraints = ConstraintSet.equality(T, int) & ConstraintSet.equality(U, str) & ConstraintSet.equality(V, bytes)
     # revealed: tuple[Solution[T=int, U=str, V=bytes]]
     reveal_type(constraints.solutions(inferable=tuple[T, U, V]))
 
 def bindings_reverse_source[T, U, V]() -> None:
     # (V = bytes) ∧ (U = str) ∧ (T = int)
-    constraints = ConstraintSet.range(bytes, V, bytes) & ConstraintSet.range(str, U, str) & ConstraintSet.range(int, T, int)
+    constraints = ConstraintSet.equality(V, bytes) & ConstraintSet.equality(U, str) & ConstraintSet.equality(T, int)
     # revealed: tuple[Solution[V=bytes, U=str, T=int]]
     reveal_type(constraints.solutions(inferable=tuple[T, U, V]))
 
@@ -189,8 +189,8 @@ def orientation_st[S, T]() -> None:
     # TODO: sometimes: error [static-assert-error] "Static assertion error: argument evaluates to `False`"
     static_assert(lower == upper)
 
-    equality_st = ConstraintSet.range(T, S, T)
-    equality_ts = ConstraintSet.range(S, T, S)
+    equality_st = ConstraintSet.equality(S, T)
+    equality_ts = ConstraintSet.equality(T, S)
     static_assert(equality_st == equality_ts)
 
 def orientation_ts[T, S]() -> None:
@@ -199,8 +199,8 @@ def orientation_ts[T, S]() -> None:
     # TODO: sometimes: error [static-assert-error] "Static assertion error: argument evaluates to `False`"
     static_assert(lower == upper)
 
-    equality_st = ConstraintSet.range(T, S, T)
-    equality_ts = ConstraintSet.range(S, T, S)
+    equality_st = ConstraintSet.equality(S, T)
+    equality_ts = ConstraintSet.equality(T, S)
     static_assert(equality_st == equality_ts)
 
 def chain_stu[S, T, U]() -> None:
@@ -323,7 +323,7 @@ def listify[T](value: T) -> list[T]:
     return [value]
 
 def invariant_callable[U, V]() -> None:
-    constraints = ConstraintSet.range(bool, U, int) & ConstraintSet.range(int, V, int)
+    constraints = ConstraintSet.range(bool, U, int) & ConstraintSet.equality(V, int)
     # TODO: no error. Existential reduction of the callable's fresh typevar is currently lossy.
     # TODO: sometimes: no error
     # error: [static-assert-error]

--- a/crates/ty_python_semantic/resources/mdtest/regression/derived_constraint_cycles.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/derived_constraint_cycles.md
@@ -171,14 +171,13 @@ Structural fuel is charged only for depth introduced by a derivation. Propagatin
 concrete bound through a typevar therefore remains cheap.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 type Deep = tuple[tuple[tuple[tuple[tuple[tuple[tuple[tuple[tuple[tuple[int]]]]]]]]]]
 
 def check_deep_bound[T, U]():
-    constraints = ConstraintSet.range(Never, T, U) & ConstraintSet.range(Never, U, Deep)
+    constraints = ConstraintSet.upper_bound(T, U) & ConstraintSet.upper_bound(U, Deep)
     static_assert(constraints.implies_subtype_of(T, Deep))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -86,13 +86,13 @@ def _[T]() -> None:
     static_assert(not ConstraintSet.range(Base, T, Unrelated))
 ```
 
-The lower and upper bound can be the same type, in which case the typevar can only be specialized to
+When the lower and upper bounds are the same type, `equality` requires the typevar to specialize to
 that specific type.
 
 ```py
 def _[T]() -> None:
     # (T@_ = Base)
-    ConstraintSet.range(Base, T, Base)
+    ConstraintSet.equality(T, Base)
 ```
 
 Constraints can only refer to fully static types, so the lower and upper bounds are transformed into
@@ -159,6 +159,23 @@ def inferred_solution[T]() -> None:
     reveal_type(ConstraintSet.range(Never, T, int).solutions_for(T, inferable=tuple[T]))
 ```
 
+### Equality
+
+An equality constraint requires the type variable to specialize exactly to the specified type. It is
+equivalent to an explicit range with that type as both bounds.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+def _[T]() -> None:
+    equality = ConstraintSet.equality(T, int)
+    static_assert(equality == ConstraintSet.range(int, T, int))
+
+    # revealed: tuple[Solution[T=int]]
+    reveal_type(equality.solutions_for(T, inferable=tuple[T]))
+```
+
 ### Negated range
 
 A _negated range_ constraint is the opposite of a range constraint: it requires the typevar to _not_
@@ -222,7 +239,7 @@ type other than that specific type.
 ```pyi
 def _[T]() -> None:
     # (T@_ ≠ Base)
-    ~ConstraintSet.range(Base, T, Base)
+    ~ConstraintSet.equality(T, Base)
 ```
 
 Constraints can only refer to fully static types, so the lower and upper bounds are transformed into
@@ -308,7 +325,7 @@ def _[T]() -> None:
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Sub, T, Base) & ConstraintSet.range(Base, T, Super)
-    expected = ConstraintSet.range(Base, T, Base)
+    expected = ConstraintSet.equality(T, Base)
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Sub, T, Super) & ConstraintSet.range(Sub, T, Super)
@@ -564,7 +581,7 @@ def union[T]():
     union_constraint = ConstraintSet.upper_bound(T, Base) | ConstraintSet.upper_bound(T, Other)
 
     # (T = Base | Other) satisfies (T ≤ Base | Other) but not (T ≤ Base ∨ T ≤ Other)
-    specialization = ConstraintSet.range(Base | Other, T, Base | Other)
+    specialization = ConstraintSet.equality(T, Base | Other)
     static_assert(specialization.satisfies(union_type))
     static_assert(not specialization.satisfies(union_constraint))
 
@@ -585,7 +602,7 @@ def union[T]():
     union_constraint = ConstraintSet.lower_bound(Base, T) | ConstraintSet.lower_bound(Other, T)
 
     # (T = Base) satisfies (Base ≤ T ∨ Other ≤ T) but not (Base | Other ≤ T)
-    specialization = ConstraintSet.range(Base, T, Base)
+    specialization = ConstraintSet.equality(T, Base)
     static_assert(not specialization.satisfies(union_type))
     static_assert(specialization.satisfies(union_constraint))
 
@@ -677,7 +694,7 @@ def _[T]() -> None:
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Sub, T, Base) | ~ConstraintSet.range(Base, T, Super)
-    expected = ~ConstraintSet.range(Base, T, Base)
+    expected = ~ConstraintSet.equality(T, Base)
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Sub, T, Super) | ~ConstraintSet.range(Sub, T, Super)
@@ -789,14 +806,14 @@ the constraint, and the other the bound.
 ```py
 def f[S, T]():
     # (S@f = T@f)
-    c1 = ConstraintSet.range(T, S, T)
-    c2 = ConstraintSet.range(S, T, S)
+    c1 = ConstraintSet.equality(S, T)
+    c2 = ConstraintSet.equality(T, S)
     static_assert(c1 == c2)
 
 def f[T, S]():
     # (S@f = T@f)
-    c1 = ConstraintSet.range(T, S, T)
-    c2 = ConstraintSet.range(S, T, S)
+    c1 = ConstraintSet.equality(S, T)
+    c2 = ConstraintSet.equality(T, S)
     static_assert(c1 == c2)
 ```
 
@@ -855,7 +872,7 @@ def same_typevar[T]():
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
-    constraints = ConstraintSet.range(T, T, T)
+    constraints = ConstraintSet.equality(T, T)
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 ```
@@ -904,14 +921,14 @@ from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def preserves_remaining_conjunct[T, U]() -> None:
-    t_int = ConstraintSet.range(int, T, int)
-    u_str = ConstraintSet.range(str, U, str)
+    t_int = ConstraintSet.equality(T, int)
+    u_str = ConstraintSet.equality(U, str)
     quantified = (t_int & u_str).exists(tuple[U])
     static_assert(quantified == t_int)
 
 def satisfies_uncertain_disjunct[T, U]() -> None:
-    t_int = ConstraintSet.range(int, T, int)
-    u_str = ConstraintSet.range(str, U, str)
+    t_int = ConstraintSet.equality(T, int)
+    u_str = ConstraintSet.equality(U, str)
     quantified = (t_int | u_str).exists(tuple[U])
     static_assert(quantified == ConstraintSet.always())
 
@@ -931,14 +948,14 @@ from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def preserves_uncertain_disjunct[T, U]() -> None:
-    t_int = ConstraintSet.range(int, T, int)
-    u_str = ConstraintSet.range(str, U, str)
+    t_int = ConstraintSet.equality(T, int)
+    u_str = ConstraintSet.equality(U, str)
     quantified = (t_int | u_str).for_all(tuple[U])
     static_assert(quantified == t_int)
 
 def removes_multiple_typevars[T, U]() -> None:
-    t_int = ConstraintSet.range(int, T, int)
-    u_str = ConstraintSet.range(str, U, str)
+    t_int = ConstraintSet.equality(T, int)
+    u_str = ConstraintSet.equality(U, str)
     quantified = (t_int | u_str).for_all(tuple[T, U])
     static_assert(quantified == ConstraintSet.never())
 
@@ -956,8 +973,8 @@ from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def quantifier_order[S, T]() -> None:
-    source_is_int = ConstraintSet.range(int, S, int)
-    target_is_int = ConstraintSet.range(int, T, int)
+    source_is_int = ConstraintSet.equality(S, int)
+    target_is_int = ConstraintSet.equality(T, int)
     equal = source_is_int.satisfies(target_is_int) & target_is_int.satisfies(source_is_int)
 
     # ∀T.∃S.equal(S, T)

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -49,22 +49,20 @@ def _[T]() -> None:
     ConstraintSet.range(Sub, T, Super)
 ```
 
-Every type is a supertype of `Never`, so a lower bound of `Never` is the same as having no lower
-bound.
+Every type is a supertype of `Never`, so `upper_bound` can omit the lower bound.
 
 ```py
 def _[T]() -> None:
     # (T@_ ≤ Base)
-    ConstraintSet.range(Never, T, Base)
+    ConstraintSet.upper_bound(T, Base)
 ```
 
-Similarly, every type is a subtype of `object`, so an upper bound of `object` is the same as having
-no upper bound.
+Similarly, every type is a subtype of `object`, so `lower_bound` can omit the upper bound.
 
 ```py
 def _[T]() -> None:
     # (Base ≤ T@_)
-    ConstraintSet.range(Base, T, object)
+    ConstraintSet.lower_bound(Base, T)
 ```
 
 And a range constraint with a lower bound of `Never` and an upper bound of `object` allows the
@@ -103,7 +101,7 @@ their bottom and top materializations, respectively.
 ```py
 def _[T]() -> None:
     constraints = ConstraintSet.range(Base, T, Any)
-    expected = ConstraintSet.range(Base, T, object)
+    expected = ConstraintSet.lower_bound(Base, T)
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Sequence[Base], T, Sequence[Any])
@@ -111,12 +109,54 @@ def _[T]() -> None:
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Any, T, Base)
-    expected = ConstraintSet.range(Never, T, Base)
+    expected = ConstraintSet.upper_bound(T, Base)
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Sequence[Any], T, Sequence[Base])
     expected = ConstraintSet.range(Sequence[Never], T, Sequence[Base])
     static_assert(constraints == expected)
+```
+
+### Lower bound
+
+A lower-bound constraint requires the type variable to be a supertype of its bound without providing
+upper-bound evidence.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet, is_constraint_set_assignable_to
+
+def _[T]() -> None:
+    expected = is_constraint_set_assignable_to(int, T)
+    static_assert(ConstraintSet.lower_bound(int, T) == expected)
+```
+
+### Upper bound
+
+An upper-bound constraint requires the type variable to be a subtype of its bound without providing
+lower-bound evidence.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet, is_constraint_set_assignable_to
+
+def _[T]() -> None:
+    expected = is_constraint_set_assignable_to(T, int)
+    static_assert(ConstraintSet.upper_bound(T, int) == expected)
+```
+
+Unlike an explicit two-sided range, an upper-bound constraint does not supply `Never` as lower-bound
+inference evidence.
+
+```py
+from typing import Never
+
+def inferred_solution[T]() -> None:
+    # revealed: tuple[Solution[T=int]]
+    reveal_type(ConstraintSet.upper_bound(T, int).solutions_for(T, inferable=tuple[T]))
+
+    # revealed: tuple[Solution[T=Never]]
+    reveal_type(ConstraintSet.range(Never, T, int).solutions_for(T, inferable=tuple[T]))
 ```
 
 ### Negated range
@@ -142,22 +182,20 @@ def _[T]() -> None:
     ~ConstraintSet.range(Sub, T, Super)
 ```
 
-Every type is a supertype of `Never`, so a lower bound of `Never` is the same as having no lower
-bound.
+Every type is a supertype of `Never`, so `upper_bound` can omit the lower bound.
 
 ```pyi
 def _[T]() -> None:
     # ¬(T@_ ≤ Base)
-    ~ConstraintSet.range(Never, T, Base)
+    ~ConstraintSet.upper_bound(T, Base)
 ```
 
-Similarly, every type is a subtype of `object`, so an upper bound of `object` is the same as having
-no upper bound.
+Similarly, every type is a subtype of `object`, so `lower_bound` can omit the upper bound.
 
 ```pyi
 def _[T]() -> None:
     # ¬(Base ≤ T@_)
-    ~ConstraintSet.range(Base, T, object)
+    ~ConstraintSet.lower_bound(Base, T)
 ```
 
 And a negated range constraint with _both_ a lower bound of `Never` and an upper bound of `object`
@@ -193,7 +231,7 @@ their bottom and top materializations, respectively.
 ```pyi
 def _[T]() -> None:
     constraints = ~ConstraintSet.range(Base, T, Any)
-    expected = ~ConstraintSet.range(Base, T, object)
+    expected = ~ConstraintSet.lower_bound(Base, T)
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Sequence[Base], T, Sequence[Any])
@@ -201,7 +239,7 @@ def _[T]() -> None:
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Any, T, Base)
-    expected = ~ConstraintSet.range(Never, T, Base)
+    expected = ~ConstraintSet.upper_bound(T, Base)
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Sequence[Any], T, Sequence[Base])
@@ -213,8 +251,8 @@ A negated _type_ is not the same thing as a negated _range_.
 
 ```pyi
 def _[T]() -> None:
-    negated_type = ConstraintSet.range(Never, T, ~int)
-    negated_constraint = ~ConstraintSet.range(Never, T, int)
+    negated_type = ConstraintSet.upper_bound(T, ~int)
+    negated_constraint = ~ConstraintSet.upper_bound(T, int)
     static_assert(negated_type != negated_constraint)
 ```
 
@@ -283,7 +321,7 @@ If they don't overlap, the intersection is empty.
 ```pyi
 def _[T]() -> None:
     static_assert(not ConstraintSet.range(SubSub, T, Sub) & ConstraintSet.range(Base, T, Super))
-    static_assert(not ConstraintSet.range(SubSub, T, Sub) & ConstraintSet.range(Unrelated, T, object))
+    static_assert(not ConstraintSet.range(SubSub, T, Sub) & ConstraintSet.lower_bound(Unrelated, T))
 ```
 
 Expanding on this, when intersecting two upper bounds constraints (`(T ≤ Base) ∧ (T ≤ Other)`), we
@@ -291,16 +329,14 @@ intersect the upper bounds. Any type that satisfies both `T ≤ Base` and `T ≤
 satisfy their intersection `T ≤ Base & Other`, and vice versa.
 
 ```pyi
-from typing import Never
-
 # This is not final, so it's possible for a subclass to inherit from both Base and Other.
 class Other: ...
 
 def upper_bounds[T]():
     # (T@upper_bounds ≤ Base & Other)
-    intersection_type = ConstraintSet.range(Never, T, Base & Other)
+    intersection_type = ConstraintSet.upper_bound(T, Base & Other)
     # (T@upper_bounds ≤ Base) ∧ (T@upper_bounds ≤ Other)
-    intersection_constraint = ConstraintSet.range(Never, T, Base) & ConstraintSet.range(Never, T, Other)
+    intersection_constraint = ConstraintSet.upper_bound(T, Base) & ConstraintSet.upper_bound(T, Other)
     static_assert(intersection_type == intersection_constraint)
 ```
 
@@ -311,9 +347,9 @@ bounds. Any type that satisfies both `Base ≤ T` and `Other ≤ T` must necessa
 ```pyi
 def lower_bounds[T]():
     # (Base | Other ≤ T@lower_bounds)
-    union_type = ConstraintSet.range(Base | Other, T, object)
+    union_type = ConstraintSet.lower_bound(Base | Other, T)
     # (Base ≤ T@upper_bounds) ∧ (Other ≤ T@upper_bounds)
-    intersection_constraint = ConstraintSet.range(Base, T, object) & ConstraintSet.range(Other, T, object)
+    intersection_constraint = ConstraintSet.lower_bound(Base, T) & ConstraintSet.lower_bound(Other, T)
     static_assert(union_type == intersection_constraint)
 ```
 
@@ -324,7 +360,7 @@ the negated range constraint provide a "hole" of types that should not be includ
 the intersection as removing the hole from the range constraint.
 
 ```py
-from typing import final, Never
+from typing import final
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -350,7 +386,7 @@ anything; the intersection is the positive range.
 
 ```py
 def _[T]() -> None:
-    constraints = ConstraintSet.range(Sub, T, Base) & ~ConstraintSet.range(Never, T, Unrelated)
+    constraints = ConstraintSet.range(Sub, T, Base) & ~ConstraintSet.upper_bound(T, Unrelated)
     expected = ConstraintSet.range(Sub, T, Base)
     static_assert(constraints == expected)
 
@@ -410,7 +446,7 @@ def _[T]() -> None:
     # ¬(Base ≤ T@_ ≤ Super) ∧ ¬(SubSub ≤ T@_ ≤ Sub))
     ~ConstraintSet.range(SubSub, T, Sub) & ~ConstraintSet.range(Base, T, Super)
     # ¬(SubSub ≤ T@_ ≤ Sub) ∧ ¬(Unrelated ≤ T@_)
-    ~ConstraintSet.range(SubSub, T, Sub) & ~ConstraintSet.range(Unrelated, T, object)
+    ~ConstraintSet.range(SubSub, T, Sub) & ~ConstraintSet.lower_bound(Unrelated, T)
 ```
 
 In particular, the following does not simplify, even though it seems like it could simplify to
@@ -493,7 +529,7 @@ def _[T]() -> None:
     # (Base ≤ T@_ ≤ Super) ∨ (SubSub ≤ T@_ ≤ Sub)
     ConstraintSet.range(SubSub, T, Sub) | ConstraintSet.range(Base, T, Super)
     # (SubSub ≤ T@_ ≤ Sub) ∨ (Unrelated ≤ T@_)
-    ConstraintSet.range(SubSub, T, Sub) | ConstraintSet.range(Unrelated, T, object)
+    ConstraintSet.range(SubSub, T, Sub) | ConstraintSet.lower_bound(Unrelated, T)
 ```
 
 In particular, the following does not simplify, even though it seems like it could simplify to
@@ -518,16 +554,14 @@ as `T = Base | Other`) that satisfy the union type, but not the union constraint
 that satisfies the union constraint satisfies the union type.
 
 ```py
-from typing import Never
-
 # This is not final, so it's possible for a subclass to inherit from both Base and Other.
 class Other: ...
 
 def union[T]():
     # (T@union ≤ Base | Other)
-    union_type = ConstraintSet.range(Never, T, Base | Other)
+    union_type = ConstraintSet.upper_bound(T, Base | Other)
     # (T@union ≤ Base) ∨ (T@union ≤ Other)
-    union_constraint = ConstraintSet.range(Never, T, Base) | ConstraintSet.range(Never, T, Other)
+    union_constraint = ConstraintSet.upper_bound(T, Base) | ConstraintSet.upper_bound(T, Other)
 
     # (T = Base | Other) satisfies (T ≤ Base | Other) but not (T ≤ Base ∨ T ≤ Other)
     specialization = ConstraintSet.range(Base | Other, T, Base | Other)
@@ -546,9 +580,9 @@ satisfies the union constraint (`(Base ≤ T) ∨ (Other ≤ T)`) but not the un
 ```py
 def union[T]():
     # (Base | Other ≤ T@union)
-    union_type = ConstraintSet.range(Base | Other, T, object)
+    union_type = ConstraintSet.lower_bound(Base | Other, T)
     # (Base ≤ T@union) ∨ (Other ≤ T@union)
-    union_constraint = ConstraintSet.range(Base, T, object) | ConstraintSet.range(Other, T, object)
+    union_constraint = ConstraintSet.lower_bound(Base, T) | ConstraintSet.lower_bound(Other, T)
 
     # (T = Base) satisfies (Base ≤ T ∨ Other ≤ T) but not (Base | Other ≤ T)
     specialization = ConstraintSet.range(Base, T, Base)
@@ -567,7 +601,7 @@ the negated range constraint provide a "hole" of types that should not be includ
 the union as filling part of the hole with the types from the range constraint.
 
 ```py
-from typing import final, Never
+from typing import final
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -593,7 +627,7 @@ the union is the negative range.
 
 ```py
 def _[T]() -> None:
-    constraints = ~ConstraintSet.range(Sub, T, Base) | ConstraintSet.range(Never, T, Unrelated)
+    constraints = ~ConstraintSet.range(Sub, T, Base) | ConstraintSet.upper_bound(T, Unrelated)
     expected = ~ConstraintSet.range(Sub, T, Base)
     static_assert(constraints == expected)
 
@@ -656,7 +690,7 @@ If the holes don't overlap, the union is always satisfied.
 ```py
 def _[T]() -> None:
     static_assert(~ConstraintSet.range(SubSub, T, Sub) | ~ConstraintSet.range(Base, T, Super))
-    static_assert(~ConstraintSet.range(SubSub, T, Sub) | ~ConstraintSet.range(Unrelated, T, object))
+    static_assert(~ConstraintSet.range(SubSub, T, Sub) | ~ConstraintSet.lower_bound(Unrelated, T))
 ```
 
 ## Negation
@@ -676,9 +710,9 @@ def _[T]() -> None:
     # ¬(Sub ≤ T@_ ≤ Base)
     ~ConstraintSet.range(Sub, T, Base)
     # ¬(T@_ ≤ Base)
-    ~ConstraintSet.range(Never, T, Base)
+    ~ConstraintSet.upper_bound(T, Base)
     # ¬(Sub ≤ T@_)
-    ~ConstraintSet.range(Sub, T, object)
+    ~ConstraintSet.lower_bound(Sub, T)
     # (T@_ ≠ *)
     ~ConstraintSet.range(Never, T, object)
 ```
@@ -694,7 +728,7 @@ def _[T]() -> None:
 ### Negation of constraints involving two variables
 
 ```py
-from typing import final, Never
+from typing import final
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -705,18 +739,18 @@ class Unrelated: ...
 
 def _[T, U]() -> None:
     # ¬(T@_ ≤ Base) ∨ ¬(U@_ ≤ Base)
-    ~(ConstraintSet.range(Never, T, Base) & ConstraintSet.range(Never, U, Base))
+    ~(ConstraintSet.upper_bound(T, Base) & ConstraintSet.upper_bound(U, Base))
 ```
 
 The union of a constraint and its negation should always be satisfiable.
 
 ```py
 def _[T, U]() -> None:
-    c1 = ConstraintSet.range(Never, T, Base) & ConstraintSet.range(Never, U, Base)
+    c1 = ConstraintSet.upper_bound(T, Base) & ConstraintSet.upper_bound(U, Base)
     static_assert(c1 | ~c1)
     static_assert(~c1 | c1)
 
-    c2 = ConstraintSet.range(Unrelated, T, object) & ConstraintSet.range(Unrelated, U, object)
+    c2 = ConstraintSet.lower_bound(Unrelated, T) & ConstraintSet.lower_bound(Unrelated, U)
     static_assert(c2 | ~c2)
     static_assert(~c2 | c2)
 
@@ -733,20 +767,19 @@ being constrained. The other is then the lower or upper bound of the constraint.
 enforce an arbitrary ordering on typevars, and always place the constraint on the "earlier" typevar.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def f[S, T]():
     # (S@f ≤ T@f)
-    c1 = ConstraintSet.range(Never, S, T)
-    c2 = ConstraintSet.range(S, T, object)
+    c1 = ConstraintSet.upper_bound(S, T)
+    c2 = ConstraintSet.lower_bound(S, T)
     static_assert(c1 == c2)
 
 def f[T, S]():
     # (S@f ≤ T@f)
-    c1 = ConstraintSet.range(Never, S, T)
-    c2 = ConstraintSet.range(S, T, object)
+    c1 = ConstraintSet.upper_bound(S, T)
+    c2 = ConstraintSet.lower_bound(S, T)
     static_assert(c1 == c2)
 ```
 
@@ -788,17 +821,16 @@ The ordering of elements in a union or intersection do not affect what types sat
 set.
 
 ```pyi
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def f[T]():
-    c1 = ConstraintSet.range(Never, T, str | int)
-    c2 = ConstraintSet.range(Never, T, int | str)
+    c1 = ConstraintSet.upper_bound(T, str | int)
+    c2 = ConstraintSet.upper_bound(T, int | str)
     static_assert(c1 == c2)
 
-    c1 = ConstraintSet.range(Never, T, str & int)
-    c2 = ConstraintSet.range(Never, T, int & str)
+    c1 = ConstraintSet.upper_bound(T, str & int)
+    c2 = ConstraintSet.upper_bound(T, int & str)
     static_assert(c1 == c2)
 ```
 
@@ -815,11 +847,11 @@ from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def same_typevar[T]():
-    constraints = ConstraintSet.range(Never, T, T)
+    constraints = ConstraintSet.upper_bound(T, T)
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
-    constraints = ConstraintSet.range(T, T, object)
+    constraints = ConstraintSet.lower_bound(T, T)
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
@@ -834,11 +866,11 @@ as shown above.)
 
 ```pyi
 def same_typevar[T]():
-    constraints = ConstraintSet.range(Never, T, T | None)
+    constraints = ConstraintSet.upper_bound(T, T | None)
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
-    constraints = ConstraintSet.range(T & None, T, object)
+    constraints = ConstraintSet.lower_bound(T & None, T)
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
@@ -852,11 +884,11 @@ constraint set can never be satisfied, since every type is disjoint with its neg
 
 ```pyi
 def same_typevar[T]():
-    constraints = ConstraintSet.range(~T & None, T, object)
+    constraints = ConstraintSet.lower_bound(~T & None, T)
     expected = ~ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
-    constraints = ConstraintSet.range(~T, T, object)
+    constraints = ConstraintSet.lower_bound(~T, T)
     expected = ~ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 ```
@@ -868,7 +900,6 @@ do not involve those typevars must remain in the result. The result holds whenev
 valid assignment to the quantified variables satisfies the expression being quantified over.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -885,7 +916,7 @@ def satisfies_uncertain_disjunct[T, U]() -> None:
     static_assert(quantified == ConstraintSet.always())
 
 def no_typevars_is_identity[T]() -> None:
-    constraints = ConstraintSet.range(Never, T, int)
+    constraints = ConstraintSet.upper_bound(T, int)
     static_assert(constraints.exists(tuple[()]) == constraints)
 ```
 
@@ -896,7 +927,6 @@ not involve those typevars must remain in the result. The result holds whenever 
 assignment to the quantified variables satisfies the expression being quantified over.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -913,7 +943,7 @@ def removes_multiple_typevars[T, U]() -> None:
     static_assert(quantified == ConstraintSet.never())
 
 def no_typevars_is_identity[T]() -> None:
-    constraints = ConstraintSet.range(Never, T, int)
+    constraints = ConstraintSet.upper_bound(T, int)
     static_assert(constraints.for_all(tuple[()]) == constraints)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
@@ -31,11 +31,10 @@ Moreover, for concrete types, the answer does not depend on which constraint set
 there isn't a valid specialization for the typevars we are considering.
 
 ```py
-from typing import Never
 from ty_extensions._internal import ConstraintSet
 
 def even_given_constraints[T]():
-    constraints = ConstraintSet.range(Never, T, int)
+    constraints = ConstraintSet.upper_bound(T, int)
     static_assert(constraints.implies_subtype_of(bool, int))
     static_assert(not constraints.implies_subtype_of(bool, str))
 
@@ -62,7 +61,7 @@ def assignability[T]():
     static_assert(constraints == expected)
 
     constraints = is_constraint_set_assignable_to(T, bool)
-    expected = ConstraintSet.range(Never, T, bool)
+    expected = ConstraintSet.upper_bound(T, bool)
     static_assert(constraints == expected)
 
     # TODO: is_assignable_to should eventually work the way is_constraint_set_assignable_to does
@@ -72,7 +71,7 @@ def assignability[T]():
     static_assert(constraints == expected)
 
     constraints = is_constraint_set_assignable_to(T, int)
-    expected = ConstraintSet.range(Never, T, int)
+    expected = ConstraintSet.upper_bound(T, int)
     static_assert(constraints == expected)
 
     constraints = is_assignable_to(T, object)
@@ -85,12 +84,12 @@ def assignability[T]():
 
 def subtyping[T]():
     constraints = is_subtype_of(T, bool)
-    # TODO: expected = ConstraintSet.range(Never, T, bool)
+    # TODO: expected = ConstraintSet.upper_bound(T, bool)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
     constraints = is_subtype_of(T, int)
-    # TODO: expected = ConstraintSet.range(Never, T, int)
+    # TODO: expected = ConstraintSet.upper_bound(T, int)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
@@ -123,22 +122,22 @@ def assignability[T]():
     static_assert(constraints == expected)
 
     constraints = is_assignable_to(T, Covariant[Any])
-    # TODO: expected = ConstraintSet.range(Never, T, Covariant[object])
+    # TODO: expected = ConstraintSet.upper_bound(T, Covariant[object])
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
     constraints = is_assignable_to(Covariant[Any], T)
-    # TODO: expected = ConstraintSet.range(Covariant[Never], T, object)
+    # TODO: expected = ConstraintSet.lower_bound(Covariant[Never], T)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
     constraints = is_assignable_to(T, Contravariant[Any])
-    # TODO: expected = ConstraintSet.range(Never, T, Contravariant[Never])
+    # TODO: expected = ConstraintSet.upper_bound(T, Contravariant[Never])
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
     constraints = is_assignable_to(Contravariant[Any], T)
-    # TODO: expected = ConstraintSet.range(Contravariant[object], T, object)
+    # TODO: expected = ConstraintSet.lower_bound(Contravariant[object], T)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
@@ -154,22 +153,22 @@ def subtyping[T]():
     static_assert(constraints == expected)
 
     constraints = is_subtype_of(T, Covariant[Any])
-    # TODO: expected = ConstraintSet.range(Never, T, Covariant[Never])
+    # TODO: expected = ConstraintSet.upper_bound(T, Covariant[Never])
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
     constraints = is_subtype_of(Covariant[Any], T)
-    # TODO: expected = ConstraintSet.range(Covariant[object], T, object)
+    # TODO: expected = ConstraintSet.lower_bound(Covariant[object], T)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
     constraints = is_subtype_of(T, Contravariant[Any])
-    # TODO: expected = ConstraintSet.range(Never, T, Contravariant[object])
+    # TODO: expected = ConstraintSet.upper_bound(T, Contravariant[object])
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
     constraints = is_subtype_of(Contravariant[Any], T)
-    # TODO: expected = ConstraintSet.range(Contravariant[Never], T, object)
+    # TODO: expected = ConstraintSet.lower_bound(Contravariant[Never], T)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 ```
@@ -193,12 +192,12 @@ def given_constraints[T]():
     static_assert(ConstraintSet.never().implies_subtype_of(T, bool))
     static_assert(ConstraintSet.never().implies_subtype_of(T, str))
 
-    given_int = ConstraintSet.range(Never, T, int)
+    given_int = ConstraintSet.upper_bound(T, int)
     static_assert(given_int.implies_subtype_of(T, int))
     static_assert(not given_int.implies_subtype_of(T, bool))
     static_assert(not given_int.implies_subtype_of(T, str))
 
-    given_bool = ConstraintSet.range(Never, T, bool)
+    given_bool = ConstraintSet.upper_bound(T, bool)
     static_assert(given_bool.implies_subtype_of(T, int))
     static_assert(given_bool.implies_subtype_of(T, bool))
     static_assert(not given_bool.implies_subtype_of(T, str))
@@ -208,7 +207,7 @@ def given_constraints[T]():
     static_assert(given_both.implies_subtype_of(T, bool))
     static_assert(not given_both.implies_subtype_of(T, str))
 
-    given_str = ConstraintSet.range(Never, T, str)
+    given_str = ConstraintSet.upper_bound(T, str)
     static_assert(not given_str.implies_subtype_of(T, int))
     static_assert(not given_str.implies_subtype_of(T, bool))
     static_assert(given_str.implies_subtype_of(T, str))
@@ -222,26 +221,26 @@ BDD logic that is dependent on which variable ordering we end up with.)
 ```py
 def mutually_constrained[T, U]():
     # If [T = U ∧ U ≤ int], then [T ≤ int] must be true as well.
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(T, int))
     static_assert(not given_int.implies_subtype_of(T, bool))
     static_assert(not given_int.implies_subtype_of(T, str))
 
     # If [T ≤ U ∧ U ≤ int], then [T ≤ int] must be true as well.
-    given_int = ConstraintSet.range(Never, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.upper_bound(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(T, int))
     static_assert(not given_int.implies_subtype_of(T, bool))
     static_assert(not given_int.implies_subtype_of(T, str))
 
 def mutually_constrained[U, T]():
     # If [T = U ∧ U ≤ int], then [T ≤ int] must be true as well.
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(T, int))
     static_assert(not given_int.implies_subtype_of(T, bool))
     static_assert(not given_int.implies_subtype_of(T, str))
 
     # If [T ≤ U ∧ U ≤ int], then [T ≤ int] must be true as well.
-    given_int = ConstraintSet.range(Never, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.upper_bound(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(T, int))
     static_assert(not given_int.implies_subtype_of(T, bool))
     static_assert(not given_int.implies_subtype_of(T, str))
@@ -252,7 +251,6 @@ def mutually_constrained[U, T]():
 All of the relationships in the above section also apply when a typevar appears in a compound type.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -271,12 +269,12 @@ def given_constraints[T]():
     static_assert(ConstraintSet.never().implies_subtype_of(Covariant[T], Covariant[str]))
 
     # For a covariant typevar, (T ≤ int) implies that (Covariant[T] ≤ Covariant[int]).
-    given_int = ConstraintSet.range(Never, T, int)
+    given_int = ConstraintSet.upper_bound(T, int)
     static_assert(given_int.implies_subtype_of(Covariant[T], Covariant[int]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[bool]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[str]))
 
-    given_bool = ConstraintSet.range(Never, T, bool)
+    given_bool = ConstraintSet.upper_bound(T, bool)
     static_assert(given_bool.implies_subtype_of(Covariant[T], Covariant[int]))
     static_assert(given_bool.implies_subtype_of(Covariant[T], Covariant[bool]))
     static_assert(not given_bool.implies_subtype_of(Covariant[T], Covariant[str]))
@@ -289,14 +287,14 @@ def given_constraints[T]():
 def mutually_constrained[T, U]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Covariant[T] ≤ Covariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Covariant[T], Covariant[int]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[bool]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[str]))
 
     # If (T ≤ U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Covariant[T] ≤ Covariant[int]).
-    given_int = ConstraintSet.range(Never, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.upper_bound(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Covariant[T], Covariant[int]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[bool]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[str]))
@@ -305,14 +303,14 @@ def mutually_constrained[T, U]():
 def mutually_constrained[U, T]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Covariant[T] ≤ Covariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Covariant[T], Covariant[int]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[bool]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[str]))
 
     # If (T ≤ U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Covariant[T] ≤ Covariant[int]).
-    given_int = ConstraintSet.range(Never, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.upper_bound(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Covariant[T], Covariant[int]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[bool]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[str]))
@@ -337,12 +335,12 @@ def given_constraints[T]():
 
     # For a contravariant typevar, (T ≤ int) implies that (Contravariant[int] ≤ Contravariant[T]).
     # (The order of the comparison is reversed because of contravariance.)
-    given_int = ConstraintSet.range(Never, T, int)
+    given_int = ConstraintSet.upper_bound(T, int)
     static_assert(given_int.implies_subtype_of(Contravariant[int], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[bool], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[str], Contravariant[T]))
 
-    given_bool = ConstraintSet.range(Never, T, int)
+    given_bool = ConstraintSet.upper_bound(T, int)
     static_assert(given_bool.implies_subtype_of(Contravariant[int], Contravariant[T]))
     static_assert(not given_bool.implies_subtype_of(Contravariant[bool], Contravariant[T]))
     static_assert(not given_bool.implies_subtype_of(Contravariant[str], Contravariant[T]))
@@ -350,14 +348,14 @@ def given_constraints[T]():
 def mutually_constrained[T, U]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Contravariant[int] ≤ Contravariant[T]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Contravariant[int], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[bool], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[str], Contravariant[T]))
 
     # If (T ≤ U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Contravariant[int] ≤ Contravariant[T]).
-    given_int = ConstraintSet.range(Never, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.upper_bound(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Contravariant[int], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[bool], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[str], Contravariant[T]))
@@ -366,14 +364,14 @@ def mutually_constrained[T, U]():
 def mutually_constrained[U, T]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Contravariant[int] ≤ Contravariant[T]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Contravariant[int], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[bool], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[str], Contravariant[T]))
 
     # If (T ≤ U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Contravariant[int] ≤ Contravariant[T]).
-    given_int = ConstraintSet.range(Never, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.upper_bound(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Contravariant[int], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[bool], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[str], Contravariant[T]))
@@ -401,7 +399,7 @@ def given_constraints[T]():
     static_assert(ConstraintSet.never().implies_subtype_of(Invariant[T], Invariant[str]))
 
     # For an invariant typevar, (T ≤ int) does not imply that (Invariant[T] ≤ Invariant[int]).
-    given_int = ConstraintSet.range(Never, T, int)
+    given_int = ConstraintSet.upper_bound(T, int)
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[int]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[bool]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[str]))
@@ -423,7 +421,7 @@ def given_constraints[T]():
 def mutually_constrained[T, U]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well. But because T is invariant, that
     # does _not_ imply that (Invariant[T] ≤ Invariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[int]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[bool]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[str]))
@@ -442,7 +440,7 @@ def mutually_constrained[T, U]():
 def mutually_constrained[U, T]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well. But because T is invariant, that
     # does _not_ imply that (Invariant[T] ≤ Invariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(Never, U, int)
+    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[int]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[bool]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[str]))
@@ -571,7 +569,7 @@ def quantifies_callable_typevars_together[V]():
         raise NotImplementedError
 
     actual = ConstraintSet.always().implies_subtype_of(RegularCallableTypeOf[source], RegularCallableTypeOf[target])
-    expected = ConstraintSet.range(int, V, object)
+    expected = ConstraintSet.lower_bound(int, V)
     static_assert(actual == expected)
 ```
 
@@ -616,40 +614,38 @@ def recursive_listify[T](t: T) -> list[T]:
 ### Transitivity can propagate across typevars
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def concrete_pivot[T, U]():
     # If [int ≤ T ∧ T ≤ U], then [int ≤ U] must be true as well.
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(T, U, object)
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.lower_bound(T, U)
     static_assert(constraints.implies_subtype_of(int, U))
 ```
 
 ### Transitivity can propagate across fully static concrete types
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def concrete_pivot[T, U]():
     # If [T ≤ int ∧ int ≤ U], then [T ≤ U] must be true as well.
-    constraints = ConstraintSet.range(Never, T, int) & ConstraintSet.range(int, U, object)
+    constraints = ConstraintSet.upper_bound(T, int) & ConstraintSet.lower_bound(int, U)
     static_assert(constraints.implies_subtype_of(T, U))
 ```
 
 ### Transitivity cannot propagate across non-fully-static concrete types
 
 ```py
-from typing import Any, Never
+from typing import Any
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def concrete_pivot[T, U]():
     # If [T ≤ Any ∧ Any ≤ U], then the two `Any`s might materialize to different types. That means
     # [T ≤ U] is NOT necessarily true.
-    constraints = ConstraintSet.range(Never, T, Any) & ConstraintSet.range(Any, U, object)
+    constraints = ConstraintSet.upper_bound(T, Any) & ConstraintSet.lower_bound(Any, U)
     static_assert(not constraints.implies_subtype_of(T, U))
 ```
 
@@ -659,7 +655,6 @@ When a typevar appears nested inside a covariant generic type in another constra
 propagate the bound "into" the generic type.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -670,7 +665,7 @@ class Covariant[T]:
 def upper_bound[T, U]():
     # If (T ≤ int) ∧ (U ≤ Covariant[T]), then by covariance, Covariant[T] ≤ Covariant[int],
     # and by transitivity, U ≤ Covariant[int].
-    constraints = ConstraintSet.range(Never, T, int) & ConstraintSet.range(Never, U, Covariant[T])
+    constraints = ConstraintSet.upper_bound(T, int) & ConstraintSet.upper_bound(U, Covariant[T])
     static_assert(constraints.implies_subtype_of(U, Covariant[int]))
     static_assert(not constraints.implies_subtype_of(U, Covariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Covariant[str]))
@@ -678,21 +673,21 @@ def upper_bound[T, U]():
 def lower_bound[T, U]():
     # If (int ≤ T ∧ Covariant[T] ≤ U), then by covariance, Covariant[int] ≤ Covariant[T],
     # and by transitivity, Covariant[int] ≤ U. Since bool ≤ int, Covariant[bool] ≤ U also holds.
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Covariant[T], U, object)
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.lower_bound(Covariant[T], U)
     static_assert(constraints.implies_subtype_of(Covariant[int], U))
     static_assert(constraints.implies_subtype_of(Covariant[bool], U))
     static_assert(not constraints.implies_subtype_of(Covariant[str], U))
 
 # Repeat with reversed typevar ordering to verify BDD-ordering independence.
 def upper_bound[U, T]():
-    constraints = ConstraintSet.range(Never, T, int) & ConstraintSet.range(Never, U, Covariant[T])
+    constraints = ConstraintSet.upper_bound(T, int) & ConstraintSet.upper_bound(U, Covariant[T])
     static_assert(constraints.implies_subtype_of(U, Covariant[int]))
     static_assert(not constraints.implies_subtype_of(U, Covariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Covariant[str]))
 
 def lower_bound[U, T]():
     # Since bool ≤ int, Covariant[bool] ≤ U also holds.
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Covariant[T], U, object)
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.lower_bound(Covariant[T], U)
     static_assert(constraints.implies_subtype_of(Covariant[int], U))
     static_assert(constraints.implies_subtype_of(Covariant[bool], U))
     static_assert(not constraints.implies_subtype_of(Covariant[str], U))
@@ -704,7 +699,6 @@ The previous section also works for contravariant generic types, though one of t
 constraints is flipped.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -718,7 +712,7 @@ def upper_bound[T, U]():
     # Note: we need the *lower* bound on T (not the upper) because contravariance flips.
     # Since bool ≤ int, Contravariant[int] ≤ Contravariant[bool], so U ≤ Contravariant[bool]
     # also holds.
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Never, U, Contravariant[T])
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.upper_bound(U, Contravariant[T])
     static_assert(constraints.implies_subtype_of(U, Contravariant[int]))
     static_assert(constraints.implies_subtype_of(U, Contravariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Contravariant[str]))
@@ -728,20 +722,20 @@ def lower_bound[T, U]():
     # Contravariant[int] ≤ Contravariant[T], and by transitivity, Contravariant[int] ≤ U.
     # Contravariant[bool] is a supertype of Contravariant[int] (since bool ≤ int), so
     # Contravariant[bool] ≤ U does NOT hold.
-    constraints = ConstraintSet.range(Never, T, int) & ConstraintSet.range(Contravariant[T], U, object)
+    constraints = ConstraintSet.upper_bound(T, int) & ConstraintSet.lower_bound(Contravariant[T], U)
     static_assert(constraints.implies_subtype_of(Contravariant[int], U))
     static_assert(not constraints.implies_subtype_of(Contravariant[bool], U))
     static_assert(not constraints.implies_subtype_of(Contravariant[str], U))
 
 # Repeat with reversed typevar ordering to verify BDD-ordering independence.
 def upper_bound[U, T]():
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Never, U, Contravariant[T])
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.upper_bound(U, Contravariant[T])
     static_assert(constraints.implies_subtype_of(U, Contravariant[int]))
     static_assert(constraints.implies_subtype_of(U, Contravariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Contravariant[str]))
 
 def lower_bound[U, T]():
-    constraints = ConstraintSet.range(Never, T, int) & ConstraintSet.range(Contravariant[T], U, object)
+    constraints = ConstraintSet.upper_bound(T, int) & ConstraintSet.lower_bound(Contravariant[T], U)
     static_assert(constraints.implies_subtype_of(Contravariant[int], U))
     static_assert(not constraints.implies_subtype_of(Contravariant[bool], U))
     static_assert(not constraints.implies_subtype_of(Contravariant[str], U))
@@ -753,7 +747,6 @@ For invariant type parameters, only an equality constraint on the typevar allows
 one-sided bound (upper or lower only) is not sufficient.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -766,7 +759,7 @@ class Invariant[T]:
 
 def equality_constraint[T, U]():
     # (T = int ∧ U ≤ Invariant[T]) should imply U ≤ Invariant[int].
-    constraints = ConstraintSet.range(int, T, int) & ConstraintSet.range(Never, U, Invariant[T])
+    constraints = ConstraintSet.range(int, T, int) & ConstraintSet.upper_bound(U, Invariant[T])
     static_assert(constraints.implies_subtype_of(U, Invariant[int]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[str]))
@@ -774,7 +767,7 @@ def equality_constraint[T, U]():
 def upper_bound_only[T, U]():
     # (T ≤ int ∧ U ≤ Invariant[T]) should NOT imply U ≤ Invariant[int], because T is invariant
     # and we only have an upper bound, not equality.
-    constraints = ConstraintSet.range(Never, T, int) & ConstraintSet.range(Never, U, Invariant[T])
+    constraints = ConstraintSet.upper_bound(T, int) & ConstraintSet.upper_bound(U, Invariant[T])
     static_assert(not constraints.implies_subtype_of(U, Invariant[int]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[str]))
@@ -782,14 +775,14 @@ def upper_bound_only[T, U]():
 def lower_bound_only[T, U]():
     # (int ≤ T ∧ Invariant[T] ≤ U) should NOT imply Invariant[int] ≤ U, because T is invariant
     # and we only have a lower bound, not equality.
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Invariant[T], U, object)
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.lower_bound(Invariant[T], U)
     static_assert(not constraints.implies_subtype_of(Invariant[int], U))
     static_assert(not constraints.implies_subtype_of(Invariant[bool], U))
     static_assert(not constraints.implies_subtype_of(Invariant[str], U))
 
 # Repeat with reversed typevar ordering.
 def equality_constraint[U, T]():
-    constraints = ConstraintSet.range(int, T, int) & ConstraintSet.range(Never, U, Invariant[T])
+    constraints = ConstraintSet.range(int, T, int) & ConstraintSet.upper_bound(U, Invariant[T])
     static_assert(constraints.implies_subtype_of(U, Invariant[int]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[str]))
@@ -801,7 +794,6 @@ When a typevar is nested inside multiple layers of generics, variances compose. 
 covariant type inside a contravariant type yields contravariant overall.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -816,25 +808,25 @@ class Contravariant[T]:
 def covariant_of_contravariant[T, U]():
     # Covariant[Contravariant[T]]: T is contravariant overall (covariant × contravariant).
     # So a lower bound on T should propagate (flipped).
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Never, U, Covariant[Contravariant[T]])
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.upper_bound(U, Covariant[Contravariant[T]])
     static_assert(constraints.implies_subtype_of(U, Covariant[Contravariant[int]]))
     static_assert(not constraints.implies_subtype_of(U, Covariant[Contravariant[str]]))
 
 def contravariant_of_covariant[T, U]():
     # Contravariant[Covariant[T]]: T is contravariant overall (contravariant × covariant).
     # So a lower bound on T should propagate (flipped).
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Never, U, Contravariant[Covariant[T]])
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.upper_bound(U, Contravariant[Covariant[T]])
     static_assert(constraints.implies_subtype_of(U, Contravariant[Covariant[int]]))
     static_assert(not constraints.implies_subtype_of(U, Contravariant[Covariant[str]]))
 
 # Repeat with reversed typevar ordering.
 def covariant_of_contravariant[U, T]():
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Never, U, Covariant[Contravariant[T]])
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.upper_bound(U, Covariant[Contravariant[T]])
     static_assert(constraints.implies_subtype_of(U, Covariant[Contravariant[int]]))
     static_assert(not constraints.implies_subtype_of(U, Covariant[Contravariant[str]]))
 
 def contravariant_of_covariant[U, T]():
-    constraints = ConstraintSet.range(int, T, object) & ConstraintSet.range(Never, U, Contravariant[Covariant[T]])
+    constraints = ConstraintSet.lower_bound(int, T) & ConstraintSet.upper_bound(U, Contravariant[Covariant[T]])
     static_assert(constraints.implies_subtype_of(U, Contravariant[Covariant[int]]))
     static_assert(not constraints.implies_subtype_of(U, Contravariant[Covariant[str]]))
 ```
@@ -851,7 +843,6 @@ For example, `(Covariant[S] ≤ C) ∧ (S ≤ B)` should imply `Covariant[B] ≤
 typevars.)
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -873,42 +864,42 @@ class Invariant[T]:
 def covariant_upper_bound_into_lower[S, B, C]():
     # (Covariant[S] ≤ C) ∧ (B ≤ S) → (Covariant[B] ≤ C)
     # B ≤ S, so Covariant[B] ≤ Covariant[S], and Covariant[S] ≤ C gives Covariant[B] ≤ C.
-    constraints = ConstraintSet.range(Covariant[S], C, object) & ConstraintSet.range(Never, B, S)
+    constraints = ConstraintSet.lower_bound(Covariant[S], C) & ConstraintSet.upper_bound(B, S)
     static_assert(constraints.implies_subtype_of(Covariant[B], C))
 
 def covariant_lower_bound_into_upper[S, B, C]():
     # (C ≤ Covariant[S]) ∧ (S ≤ B) → (C ≤ Covariant[B])
     # S ≤ B, so Covariant[S] ≤ Covariant[B], and C ≤ Covariant[S] ≤ Covariant[B].
-    constraints = ConstraintSet.range(Never, C, Covariant[S]) & ConstraintSet.range(S, B, object)
+    constraints = ConstraintSet.upper_bound(C, Covariant[S]) & ConstraintSet.lower_bound(S, B)
     static_assert(constraints.implies_subtype_of(C, Covariant[B]))
 
 def contravariant_upper_bound_into_lower[S, B, C]():
     # (Contravariant[S] ≤ C) ∧ (S ≤ B) → (Contravariant[B] ≤ C)
     # S ≤ B gives Contravariant[B] ≤ Contravariant[S], so Contravariant[B] ≤ Contravariant[S] ≤ C.
-    constraints = ConstraintSet.range(Contravariant[S], C, object) & ConstraintSet.range(S, B, object)
+    constraints = ConstraintSet.lower_bound(Contravariant[S], C) & ConstraintSet.lower_bound(S, B)
     static_assert(constraints.implies_subtype_of(Contravariant[B], C))
 
 def contravariant_lower_bound_into_upper[S, B, C]():
     # (C ≤ Contravariant[S]) ∧ (B ≤ S) → (C ≤ Contravariant[B])
     # B ≤ S gives Contravariant[S] ≤ Contravariant[B], so C ≤ Contravariant[S] ≤ Contravariant[B].
-    constraints = ConstraintSet.range(Never, C, Contravariant[S]) & ConstraintSet.range(Never, B, S)
+    constraints = ConstraintSet.upper_bound(C, Contravariant[S]) & ConstraintSet.upper_bound(B, S)
     static_assert(constraints.implies_subtype_of(C, Contravariant[B]))
 
 # Repeat with reversed typevar ordering.
 def covariant_upper_bound_into_lower[C, B, S]():
-    constraints = ConstraintSet.range(Covariant[S], C, object) & ConstraintSet.range(Never, B, S)
+    constraints = ConstraintSet.lower_bound(Covariant[S], C) & ConstraintSet.upper_bound(B, S)
     static_assert(constraints.implies_subtype_of(Covariant[B], C))
 
 def covariant_lower_bound_into_upper[C, B, S]():
-    constraints = ConstraintSet.range(Never, C, Covariant[S]) & ConstraintSet.range(S, B, object)
+    constraints = ConstraintSet.upper_bound(C, Covariant[S]) & ConstraintSet.lower_bound(S, B)
     static_assert(constraints.implies_subtype_of(C, Covariant[B]))
 
 def contravariant_upper_bound_into_lower[C, B, S]():
-    constraints = ConstraintSet.range(Contravariant[S], C, object) & ConstraintSet.range(S, B, object)
+    constraints = ConstraintSet.lower_bound(Contravariant[S], C) & ConstraintSet.lower_bound(S, B)
     static_assert(constraints.implies_subtype_of(Contravariant[B], C))
 
 def contravariant_lower_bound_into_upper[C, B, S]():
-    constraints = ConstraintSet.range(Never, C, Contravariant[S]) & ConstraintSet.range(Never, B, S)
+    constraints = ConstraintSet.upper_bound(C, Contravariant[S]) & ConstraintSet.upper_bound(B, S)
     static_assert(constraints.implies_subtype_of(C, Contravariant[B]))
 ```
 
@@ -919,7 +910,6 @@ When B's bound _contains_ a typevar (but is not a bare typevar), the same logic 
 TODO: This is not implemented yet, since it requires different detection machinery.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -929,14 +919,14 @@ class Covariant[T]:
 
 def upper_bound_into_lower[B, C]():
     # (Covariant[int] ≤ C) ∧ (B ≤ int) → (Covariant[B] ≤ C)
-    constraints = ConstraintSet.range(Covariant[int], C, object) & ConstraintSet.range(Never, B, int)
+    constraints = ConstraintSet.lower_bound(Covariant[int], C) & ConstraintSet.upper_bound(B, int)
     # TODO: no error
     # error: [static-assert-error]
     static_assert(constraints.implies_subtype_of(Covariant[B], C))
 
 def lower_bound_into_upper[B, C]():
     # (C ≤ Covariant[int]) ∧ (int ≤ B) → (C ≤ Covariant[B])
-    constraints = ConstraintSet.range(Never, C, Covariant[int]) & ConstraintSet.range(int, B, object)
+    constraints = ConstraintSet.upper_bound(C, Covariant[int]) & ConstraintSet.lower_bound(int, B)
     # TODO: no error
     # error: [static-assert-error]
     static_assert(constraints.implies_subtype_of(C, Covariant[B]))
@@ -945,7 +935,6 @@ def lower_bound_into_upper[B, C]():
 ### Nested typevar propagation also works when the replacement is a bare typevar
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -966,39 +955,39 @@ class Invariant[T]:
 
 def covariant_upper[B, S, U]():
     # (B ≤ S) ∧ (U ≤ Covariant[B]) -> (U ≤ Covariant[S])
-    constraints = ConstraintSet.range(Never, B, S) & ConstraintSet.range(Never, U, Covariant[B])
+    constraints = ConstraintSet.upper_bound(B, S) & ConstraintSet.upper_bound(U, Covariant[B])
     static_assert(constraints.implies_subtype_of(U, Covariant[S]))
 
 def covariant_lower[B, S, U]():
     # (S ≤ B) ∧ (Covariant[B] ≤ U) -> (Covariant[S] ≤ U)
-    constraints = ConstraintSet.range(S, B, object) & ConstraintSet.range(Covariant[B], U, object)
+    constraints = ConstraintSet.lower_bound(S, B) & ConstraintSet.lower_bound(Covariant[B], U)
     static_assert(constraints.implies_subtype_of(Covariant[S], U))
 
 def contravariant_upper[B, S, U]():
     # (S ≤ B) ∧ (U ≤ Contravariant[B]) -> (U ≤ Contravariant[S])
-    constraints = ConstraintSet.range(S, B, object) & ConstraintSet.range(Never, U, Contravariant[B])
+    constraints = ConstraintSet.lower_bound(S, B) & ConstraintSet.upper_bound(U, Contravariant[B])
     static_assert(constraints.implies_subtype_of(U, Contravariant[S]))
 
 def contravariant_lower[B, S, U]():
     # (B ≤ S) ∧ (Contravariant[B] ≤ U) -> (Contravariant[S] ≤ U)
-    constraints = ConstraintSet.range(Never, B, S) & ConstraintSet.range(Contravariant[B], U, object)
+    constraints = ConstraintSet.upper_bound(B, S) & ConstraintSet.lower_bound(Contravariant[B], U)
     static_assert(constraints.implies_subtype_of(Contravariant[S], U))
 
 def invariant_upper_requires_equality[B, S, U]():
     # Invariant replacement only holds under equality constraints on B.
-    constraints = ConstraintSet.range(S, B, S) & ConstraintSet.range(Never, U, Invariant[B])
+    constraints = ConstraintSet.range(S, B, S) & ConstraintSet.upper_bound(U, Invariant[B])
     static_assert(constraints.implies_subtype_of(U, Invariant[S]))
 
 def invariant_lower_requires_equality[B, S, U]():
-    constraints = ConstraintSet.range(S, B, S) & ConstraintSet.range(Invariant[B], U, object)
+    constraints = ConstraintSet.range(S, B, S) & ConstraintSet.lower_bound(Invariant[B], U)
     static_assert(constraints.implies_subtype_of(Invariant[S], U))
 
 def invariant_upper_one_sided_is_not_enough[B, S, U]():
-    constraints = ConstraintSet.range(Never, B, S) & ConstraintSet.range(Never, U, Invariant[B])
+    constraints = ConstraintSet.upper_bound(B, S) & ConstraintSet.upper_bound(U, Invariant[B])
     static_assert(not constraints.implies_subtype_of(U, Invariant[S]))
 
 def invariant_lower_one_sided_is_not_enough[B, S, U]():
-    constraints = ConstraintSet.range(S, B, object) & ConstraintSet.range(Invariant[B], U, object)
+    constraints = ConstraintSet.lower_bound(S, B) & ConstraintSet.lower_bound(Invariant[B], U)
     static_assert(not constraints.implies_subtype_of(Invariant[S], U))
 ```
 
@@ -1010,7 +999,6 @@ can decompose the bounds to extract constraints on the nested typevar. For insta
 `Covariant[int] ≤ Covariant[T]` requires `int ≤ T`.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -1091,14 +1079,14 @@ def subclass_lower_bound[T, A]():
 ### Transitivity should not introduce impossible constraints
 
 ```py
-from typing import Never, TypeVar, Union
+from typing import TypeVar, Union
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def impossible_result[A, T, U]():
     constraint_a = ConstraintSet.range(int, A, Union[T, U])
-    constraint_t = ConstraintSet.range(Never, T, str)
-    constraint_u = ConstraintSet.range(Never, U, bytes)
+    constraint_t = ConstraintSet.upper_bound(T, str)
+    constraint_u = ConstraintSet.upper_bound(U, bytes)
 
     # Given (int ≤ A ≤ T | U), we can infer that (int ≤ T) ∨ (int ≤ U). If we intersect that with
     # (T ≤ str), we get false ∨ (int ≤ U) — that is, there is no valid solution for T. Therefore A

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
@@ -143,12 +143,12 @@ def assignability[T]():
 
 def subtyping[T]():
     constraints = is_subtype_of(T, Any)
-    # TODO: expected = ConstraintSet.range(Never, T, Never)
+    # TODO: expected = ConstraintSet.equality(T, Never)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
     constraints = is_subtype_of(Any, T)
-    # TODO: expected = ConstraintSet.range(object, T, object)
+    # TODO: expected = ConstraintSet.equality(T, object)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
@@ -221,7 +221,7 @@ BDD logic that is dependent on which variable ordering we end up with.)
 ```py
 def mutually_constrained[T, U]():
     # If [T = U ∧ U ≤ int], then [T ≤ int] must be true as well.
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(T, int))
     static_assert(not given_int.implies_subtype_of(T, bool))
     static_assert(not given_int.implies_subtype_of(T, str))
@@ -234,7 +234,7 @@ def mutually_constrained[T, U]():
 
 def mutually_constrained[U, T]():
     # If [T = U ∧ U ≤ int], then [T ≤ int] must be true as well.
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(T, int))
     static_assert(not given_int.implies_subtype_of(T, bool))
     static_assert(not given_int.implies_subtype_of(T, str))
@@ -287,7 +287,7 @@ def given_constraints[T]():
 def mutually_constrained[T, U]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Covariant[T] ≤ Covariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Covariant[T], Covariant[int]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[bool]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[str]))
@@ -303,7 +303,7 @@ def mutually_constrained[T, U]():
 def mutually_constrained[U, T]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Covariant[T] ≤ Covariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Covariant[T], Covariant[int]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[bool]))
     static_assert(not given_int.implies_subtype_of(Covariant[T], Covariant[str]))
@@ -348,7 +348,7 @@ def given_constraints[T]():
 def mutually_constrained[T, U]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Contravariant[int] ≤ Contravariant[T]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Contravariant[int], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[bool], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[str], Contravariant[T]))
@@ -364,7 +364,7 @@ def mutually_constrained[T, U]():
 def mutually_constrained[U, T]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well, and therefore
     # (Contravariant[int] ≤ Contravariant[T]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(given_int.implies_subtype_of(Contravariant[int], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[bool], Contravariant[T]))
     static_assert(not given_int.implies_subtype_of(Contravariant[str], Contravariant[T]))
@@ -410,7 +410,7 @@ def given_constraints[T]():
     static_assert(not given_int.implies_subtype_of(Invariant[str], Invariant[T]))
 
     # But (T = int) does imply both.
-    given_int = ConstraintSet.range(int, T, int)
+    given_int = ConstraintSet.equality(T, int)
     static_assert(given_int.implies_subtype_of(Invariant[T], Invariant[int]))
     static_assert(given_int.implies_subtype_of(Invariant[int], Invariant[T]))
     static_assert(not given_int.implies_subtype_of(Invariant[bool], Invariant[T]))
@@ -421,14 +421,14 @@ def given_constraints[T]():
 def mutually_constrained[T, U]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well. But because T is invariant, that
     # does _not_ imply that (Invariant[T] ≤ Invariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[int]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[bool]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[str]))
 
     # If (T = U ∧ U = int), then (T = int) must be true as well. That is an equality constraint, so
     # even though T is invariant, it does imply that (Invariant[T] ≤ Invariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(int, U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.equality(U, int)
     static_assert(given_int.implies_subtype_of(Invariant[T], Invariant[int]))
     static_assert(given_int.implies_subtype_of(Invariant[int], Invariant[T]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[bool]))
@@ -440,14 +440,14 @@ def mutually_constrained[T, U]():
 def mutually_constrained[U, T]():
     # If (T = U ∧ U ≤ int), then (T ≤ int) must be true as well. But because T is invariant, that
     # does _not_ imply that (Invariant[T] ≤ Invariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.upper_bound(U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.upper_bound(U, int)
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[int]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[bool]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[str]))
 
     # If (T = U ∧ U = int), then (T = int) must be true as well. That is an equality constraint, so
     # even though T is invariant, it does imply that (Invariant[T] ≤ Invariant[int]).
-    given_int = ConstraintSet.range(U, T, U) & ConstraintSet.range(int, U, int)
+    given_int = ConstraintSet.equality(T, U) & ConstraintSet.equality(U, int)
     static_assert(given_int.implies_subtype_of(Invariant[T], Invariant[int]))
     static_assert(given_int.implies_subtype_of(Invariant[int], Invariant[T]))
     static_assert(not given_int.implies_subtype_of(Invariant[T], Invariant[bool]))
@@ -586,7 +586,7 @@ def listify[T](t: T) -> list[T]:
     return [t]
 
 def constrained_by_other_typevars[U, V]() -> None:
-    ok = ConstraintSet.range(bool, U, int) & ConstraintSet.range(int, V, int)
+    ok = ConstraintSet.range(bool, U, int) & ConstraintSet.equality(V, int)
     # TODO: no error
     # This does not depend on combining constraints from multiple call arguments. The callable
     # relation introduces constraints involving listify's fresh typevar and then existentially
@@ -596,7 +596,7 @@ def constrained_by_other_typevars[U, V]() -> None:
     # error: [static-assert-error]
     static_assert(ok.implies_subtype_of(TypeOf[listify], Callable[[U], list[V]]))
 
-    bad = ConstraintSet.range(str, U, str) & ConstraintSet.range(int, V, int)
+    bad = ConstraintSet.equality(U, str) & ConstraintSet.equality(V, int)
     static_assert(not bad.implies_subtype_of(TypeOf[listify], Callable[[U], list[V]]))
 
 def recursive_listify[T](t: T) -> list[T]:
@@ -759,7 +759,7 @@ class Invariant[T]:
 
 def equality_constraint[T, U]():
     # (T = int ∧ U ≤ Invariant[T]) should imply U ≤ Invariant[int].
-    constraints = ConstraintSet.range(int, T, int) & ConstraintSet.upper_bound(U, Invariant[T])
+    constraints = ConstraintSet.equality(T, int) & ConstraintSet.upper_bound(U, Invariant[T])
     static_assert(constraints.implies_subtype_of(U, Invariant[int]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[str]))
@@ -782,7 +782,7 @@ def lower_bound_only[T, U]():
 
 # Repeat with reversed typevar ordering.
 def equality_constraint[U, T]():
-    constraints = ConstraintSet.range(int, T, int) & ConstraintSet.upper_bound(U, Invariant[T])
+    constraints = ConstraintSet.equality(T, int) & ConstraintSet.upper_bound(U, Invariant[T])
     static_assert(constraints.implies_subtype_of(U, Invariant[int]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[bool]))
     static_assert(not constraints.implies_subtype_of(U, Invariant[str]))
@@ -975,11 +975,11 @@ def contravariant_lower[B, S, U]():
 
 def invariant_upper_requires_equality[B, S, U]():
     # Invariant replacement only holds under equality constraints on B.
-    constraints = ConstraintSet.range(S, B, S) & ConstraintSet.upper_bound(U, Invariant[B])
+    constraints = ConstraintSet.equality(B, S) & ConstraintSet.upper_bound(U, Invariant[B])
     static_assert(constraints.implies_subtype_of(U, Invariant[S]))
 
 def invariant_lower_requires_equality[B, S, U]():
-    constraints = ConstraintSet.range(S, B, S) & ConstraintSet.lower_bound(Invariant[B], U)
+    constraints = ConstraintSet.equality(B, S) & ConstraintSet.lower_bound(Invariant[B], U)
     static_assert(constraints.implies_subtype_of(Invariant[S], U))
 
 def invariant_upper_one_sided_is_not_enough[B, S, U]():

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1703,7 +1703,7 @@ class OuterCarrier[A_outer]:
 
     def check[R](self) -> None:
         actual = is_constraint_set_assignable_to(RegularCallableTypeOf[OuterCarrier[A_outer].method], Callable[..., R])
-        expected = ConstraintSet.range(A_outer, R, object)
+        expected = ConstraintSet.lower_bound(A_outer, R)
         static_assert(actual == expected)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -41,7 +41,7 @@ class Invariant[T]:
 
 def grounded[X, A]() -> None:
     # ∃X. X = int ∧ A ≤ Invariant[X]
-    body = ConstraintSet.range(int, X, int) & ConstraintSet.upper_bound(A, Invariant[X])
+    body = ConstraintSet.equality(X, int) & ConstraintSet.upper_bound(A, Invariant[X])
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[X=int, A=list[int]]]
@@ -67,7 +67,7 @@ from ty_extensions._internal import ConstraintSet
 
 def relational_bridge[X, U, V]() -> None:
     # ∃X. U ≤ X ∧ X = V
-    body = ConstraintSet.upper_bound(U, X) & ConstraintSet.range(V, X, V)
+    body = ConstraintSet.upper_bound(U, X) & ConstraintSet.equality(X, V)
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[V=object, U=object]]
@@ -183,12 +183,12 @@ class Invariant[T]:
 
 def correlated_outputs[X, Y, Z]() -> None:
     # C₁(X, Y) = (X = int ∧ Y = int) ∨ (X = str ∧ Y = str)
-    c1_int = ConstraintSet.range(int, X, int) & ConstraintSet.range(int, Y, int)
-    c1_str = ConstraintSet.range(str, X, str) & ConstraintSet.range(str, Y, str)
+    c1_int = ConstraintSet.equality(X, int) & ConstraintSet.equality(Y, int)
+    c1_str = ConstraintSet.equality(X, str) & ConstraintSet.equality(Y, str)
     c1 = c1_int | c1_str
 
     # C₂(X, Z) = (Z = Invariant[X])
-    c2 = ConstraintSet.range(Invariant[X], Z, Invariant[X])
+    c2 = ConstraintSet.equality(Z, Invariant[X])
 
     # ∃X. C₁(X, Y) ∧ C₂(X, Z)
     body = c1 & c2
@@ -201,14 +201,14 @@ def correlated_outputs[X, Y, Z]() -> None:
     reveal_type(quantified.solutions(inferable=tuple[Y, Z]))
 
     # (Y = int ∧ Z = Invariant[int]) ∨ (Y = str ∧ Z = Invariant[str])
-    expected_int = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])
-    expected_str = ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    expected_int = ConstraintSet.equality(Y, int) & ConstraintSet.equality(Z, Invariant[int])
+    expected_str = ConstraintSet.equality(Y, str) & ConstraintSet.equality(Z, Invariant[str])
     expected = expected_int | expected_str
     static_assert(quantified == expected)
     static_assert(~quantified == ~expected)
 
     # (Y = int ∧ Z = Invariant[str])
-    invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    invalid_cross = ConstraintSet.equality(Y, int) & ConstraintSet.equality(Z, Invariant[str])
     static_assert(not (quantified & invalid_cross))
     # revealed: None
     reveal_type((quantified & invalid_cross).solutions(inferable=tuple[Y, Z]))
@@ -233,7 +233,7 @@ class Invariant[T]:
 def finite_domain[X: (int, str), Y, Z]() -> None:
     # ∃X ∈ {int, str}. C(X, Y, Z)
     # C(X, Y, Z) = (Y = X) ∧ (Z = Invariant[X])
-    body = ConstraintSet.range(X, Y, X) & ConstraintSet.range(Invariant[X], Z, Invariant[X])
+    body = ConstraintSet.equality(Y, X) & ConstraintSet.equality(Z, Invariant[X])
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
@@ -244,8 +244,8 @@ def finite_domain[X: (int, str), Y, Z]() -> None:
     reveal_type(quantified.solutions(inferable=tuple[Y, Z]))
 
     # (Y = int ∧ Z = Invariant[int]) ∨ (Y = str ∧ Z = Invariant[str])
-    expected_int = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])
-    expected_str = ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    expected_int = ConstraintSet.equality(Y, int) & ConstraintSet.equality(Z, Invariant[int])
+    expected_str = ConstraintSet.equality(Y, str) & ConstraintSet.equality(Z, Invariant[str])
     expected = expected_int | expected_str
     # TODO: no error
     # error: [static-assert-error]
@@ -255,13 +255,13 @@ def finite_domain[X: (int, str), Y, Z]() -> None:
     static_assert(~quantified == ~expected)
 
     # (Y = int ∧ Z = Invariant[str])
-    invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    invalid_cross = ConstraintSet.equality(Y, int) & ConstraintSet.equality(Z, Invariant[str])
     static_assert(not (quantified & invalid_cross))
     # revealed: None
     reveal_type((quantified & invalid_cross).solutions(inferable=tuple[Y, Z]))
 
     # (Y = bytes ∧ Z = Invariant[bytes])
-    invalid_domain = ConstraintSet.range(bytes, Y, bytes) & ConstraintSet.range(Invariant[bytes], Z, Invariant[bytes])
+    invalid_domain = ConstraintSet.equality(Y, bytes) & ConstraintSet.equality(Z, Invariant[bytes])
     static_assert(not (quantified & invalid_domain))
     # TODO: revealed: None
     # revealed: tuple[Solution[Z=Invariant[Y@finite_domain] | Invariant[bytes], Y=bytes]]
@@ -281,10 +281,10 @@ from ty_extensions._internal import ConstraintSet
 
 def alternation[X: (int, str), Y: (int, str)]() -> None:
     # R(X, Y) = (X = int ∧ Y = int) ∨ (X = str ∧ Y = str)
-    x_int = ConstraintSet.range(int, X, int)
-    x_str = ConstraintSet.range(str, X, str)
-    y_int = ConstraintSet.range(int, Y, int)
-    y_str = ConstraintSet.range(str, Y, str)
+    x_int = ConstraintSet.equality(X, int)
+    x_str = ConstraintSet.equality(X, str)
+    y_int = ConstraintSet.equality(Y, int)
+    y_str = ConstraintSet.equality(Y, str)
     relation = (x_int & y_int) | (x_str & y_str)
 
     # ∀Y. ∃X. R(X, Y)

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -30,7 +30,6 @@ implicit upper bound of `object`), but the only _satisfying_ assignment is `X = 
 result should be equivalent to `A ≤ Invariant[int]`.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -42,18 +41,18 @@ class Invariant[T]:
 
 def grounded[X, A]() -> None:
     # ∃X. X = int ∧ A ≤ Invariant[X]
-    body = ConstraintSet.range(int, X, int) & ConstraintSet.range(Never, A, Invariant[X])
+    body = ConstraintSet.range(int, X, int) & ConstraintSet.upper_bound(A, Invariant[X])
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[X=int, A=list[int]]]
-    # revealed: tuple[Solution[X=int, A=Never]]
+    # revealed: tuple[Solution[X=int, A=Invariant[int] & Invariant[X@grounded]]]
     reveal_type(body.solutions(inferable=tuple[X, A]))
     # TODO: revealed: tuple[Solution[A=list[int]]]
-    # revealed: tuple[Solution[A=Never]]
+    # revealed: tuple[Solution[A=Invariant[int]]]
     reveal_type(quantified.solutions(inferable=tuple[A]))
 
     # A ≤ Invariant[int]
-    expected = ConstraintSet.range(Never, A, Invariant[int])
+    expected = ConstraintSet.upper_bound(A, Invariant[int])
     static_assert(quantified == expected)
     static_assert(~quantified == ~expected)
 ```
@@ -63,21 +62,20 @@ def grounded[X, A]() -> None:
 There is an `X` satisfying `U ≤ X ∧ X = V` exactly when `U ≤ V`.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def relational_bridge[X, U, V]() -> None:
     # ∃X. U ≤ X ∧ X = V
-    body = ConstraintSet.range(Never, U, X) & ConstraintSet.range(V, X, V)
+    body = ConstraintSet.upper_bound(U, X) & ConstraintSet.range(V, X, V)
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[V=object, U=object]]
-    # revealed: tuple[Solution[U=Never, V=U@relational_bridge]]
+    # revealed: tuple[Solution[V=U@relational_bridge, U=V@relational_bridge]]
     reveal_type(quantified.solutions(inferable=tuple[U, V]))
 
     # U ≤ V
-    expected = ConstraintSet.range(Never, U, V)
+    expected = ConstraintSet.upper_bound(U, V)
     static_assert(quantified == expected)
     static_assert(~quantified == ~expected)
 ```
@@ -89,7 +87,6 @@ both `A` and `B`. `A = Invariant[str]` and `B ≤ int` cannot satisfy the expres
 satisfy its negation.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -101,22 +98,22 @@ class Invariant[T]:
 
 def inverse_image[X, A, B]() -> None:
     # ∃X. A ≤ Invariant[X] ∧ X ≤ B
-    body = ConstraintSet.range(Never, A, Invariant[X]) & ConstraintSet.range(Never, X, B)
+    body = ConstraintSet.upper_bound(A, Invariant[X]) & ConstraintSet.upper_bound(X, B)
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[A=Invariant[object], B=object, X=object]]
-    # revealed: tuple[Solution[A=Never, X=Never, B=X@inverse_image]]
+    # revealed: tuple[Solution[A=Invariant[X@inverse_image], B=X@inverse_image, X=B@inverse_image]]
     reveal_type(body.solutions(inferable=tuple[X, A, B]))
     # TODO: revealed: tuple[Solution[A=Invariant[object], B=object]]
     # revealed: tuple[()]
     reveal_type(quantified.solutions(inferable=tuple[A, B]))
 
     # Invariant[str] ≤ A ∧ B ≤ int
-    invalid = ConstraintSet.range(Invariant[str], A, object) & ConstraintSet.range(Never, B, int)
+    invalid = ConstraintSet.lower_bound(Invariant[str], A) & ConstraintSet.upper_bound(B, int)
     # revealed: None
     reveal_type((body & invalid).solutions(inferable=tuple[X, A, B]))
     # TODO: revealed: None
-    # revealed: tuple[Solution[A=Invariant[str], B=Never]]
+    # revealed: tuple[Solution[A=Invariant[str], B=int]]
     reveal_type((quantified & invalid).solutions(inferable=tuple[A, B]))
 
     static_assert(not (quantified & invalid))
@@ -132,7 +129,6 @@ satisfy the expression. `A ≥ int` and `B ≤ Invariant[str]` cannot satisfy it
 its negation.
 
 ```py
-from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -144,7 +140,7 @@ class Invariant[T]:
 
 def witness_sensitive[X, A, B]() -> None:
     # ∃X. A ≤ X ∧ Invariant[X] ≤ B
-    body = ConstraintSet.range(A, X, object) & ConstraintSet.range(Invariant[X], B, object)
+    body = ConstraintSet.lower_bound(A, X) & ConstraintSet.lower_bound(Invariant[X], B)
     quantified = body.exists(tuple[X])
 
     # Each solution for A and B depends on the compatible choice of X.
@@ -156,11 +152,11 @@ def witness_sensitive[X, A, B]() -> None:
     reveal_type(quantified.solutions(inferable=tuple[A, B]))
 
     # int ≤ A ∧ B ≤ Invariant[str]
-    invalid = ConstraintSet.range(int, A, object) & ConstraintSet.range(Never, B, Invariant[str])
+    invalid = ConstraintSet.lower_bound(int, A) & ConstraintSet.upper_bound(B, Invariant[str])
     # revealed: None
     reveal_type((body & invalid).solutions(inferable=tuple[X, A, B]))
     # TODO: revealed: None
-    # revealed: tuple[Solution[A=int, B=Never]]
+    # revealed: tuple[Solution[A=int, B=Invariant[str]]]
     reveal_type((quantified & invalid).solutions(inferable=tuple[A, B]))
 
     static_assert(not (quantified & invalid))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/satisfied_by_all_typevars.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/satisfied_by_all_typevars.md
@@ -49,7 +49,7 @@ set. In a non-inferable position, that means the constraint set must be satisfie
 type.
 
 ```py
-from typing import final, Never
+from typing import final
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
@@ -68,24 +68,24 @@ def unbounded[T]():
     static_assert(not ConstraintSet.never().satisfied_by_all_typevars())
 
     # (T = Never) is a valid specialization, which satisfies (T ≤ Unrelated).
-    static_assert(ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Base) is a valid specialization, which does not satisfy (T ≤ Unrelated).
-    static_assert(not ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars())
 
     # (T = Base) is a valid specialization, which satisfies (T ≤ Super).
-    static_assert(ConstraintSet.range(Never, T, Super).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Super).satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Unrelated) is a valid specialization, which does not satisfy (T ≤ Super).
-    static_assert(not ConstraintSet.range(Never, T, Super).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Super).satisfied_by_all_typevars())
 
     # (T = Base) is a valid specialization, which satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Unrelated) is a valid specialization, which does not satisfy (T ≤ Base).
-    static_assert(not ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars())
 
     # (T = Sub) is a valid specialization, which satisfies (T ≤ Sub).
-    static_assert(ConstraintSet.range(Never, T, Sub).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Sub).satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Unrelated) is a valid specialization, which does not satisfy (T ≤ Sub).
-    static_assert(not ConstraintSet.range(Never, T, Sub).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Sub).satisfied_by_all_typevars())
 ```
 
 ## Typevar with an upper bound
@@ -115,23 +115,23 @@ def bounded[T: Base]():
     static_assert(not ConstraintSet.never().satisfied_by_all_typevars())
 
     # (T = Base) is a valid specialization, which satisfies (T ≤ Super).
-    static_assert(ConstraintSet.range(Never, T, Super).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Super).satisfied_by_all_typevars(inferable=tuple[T]))
     # Every valid specialization satisfies (T ≤ Base). Since (Base ≤ Super), every valid
     # specialization also satisfies (T ≤ Super).
-    static_assert(ConstraintSet.range(Never, T, Super).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, Super).satisfied_by_all_typevars())
 
     # (T = Base) is a valid specialization, which satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
     # Every valid specialization satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars())
 
     # (T = Sub) is a valid specialization, which satisfies (T ≤ Sub).
-    static_assert(ConstraintSet.range(Never, T, Sub).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Sub).satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Base) is a valid specialization, which does not satisfy (T ≤ Sub).
-    static_assert(not ConstraintSet.range(Never, T, Sub).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Sub).satisfied_by_all_typevars())
 
     # (T = Never) is a valid specialization, which satisfies (T ≤ Unrelated).
-    constraints = ConstraintSet.range(Never, T, Unrelated)
+    constraints = ConstraintSet.upper_bound(T, Unrelated)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Base) is a valid specialization, which does not satisfy (T ≤ Unrelated).
     static_assert(not constraints.satisfied_by_all_typevars())
@@ -163,18 +163,18 @@ def bounded_by_gradual[T: Any]():
 
     # If we choose Base as the materialization for the upper bound, then (T = Base) is a valid
     # specialization, which satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
     # We are free to choose any materialization of the upper bound, and only have to show that the
     # constraint set holds for that one materialization. Having chosen one materialization, we then
     # have to show that the constraint set holds for all valid specializations of that
     # materialization. If we choose Never as the materialization, then all valid specializations
     # must satisfy (T ≤ Never). That means there is only one valid specialization, (T = Never),
     # which satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars())
 
     # If we choose Unrelated as the materialization, then (T = Unrelated) is a valid specialization,
     # which satisfies (T ≤ Unrelated).
-    constraints = ConstraintSet.range(Never, T, Unrelated)
+    constraints = ConstraintSet.upper_bound(T, Unrelated)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose Never as the materialization, then (T = Never) is the only valid specialization,
     # which satisfies (T ≤ Unrelated).
@@ -206,7 +206,7 @@ def bounded_by_gradual[T: list[Any]]():
 
     # If we choose list[Base] as the materialization of the upper bound, then (T = list[Base]) is a
     # valid specialization, which satisfies (T ≤ list[Base]).
-    static_assert(ConstraintSet.range(Never, T, list[Base]).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, list[Base]).satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose Base as the materialization, then all valid specializations must satisfy
     # (T ≤ list[Base]).
     # We are free to choose any materialization of the upper bound, and only have to show that the
@@ -214,11 +214,11 @@ def bounded_by_gradual[T: list[Any]]():
     # have to show that the constraint set holds for all valid specializations of that
     # materialization. If we choose list[Base] as the materialization, then all valid specializations
     # must satisfy (T ≤ list[Base]), which is exactly the constraint set that we need to satisfy.
-    static_assert(ConstraintSet.range(Never, T, list[Base]).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, list[Base]).satisfied_by_all_typevars())
 
     # If we choose Unrelated as the materialization, then (T = list[Unrelated]) is a valid
     # specialization, which satisfies (T ≤ list[Unrelated]).
-    constraints = ConstraintSet.range(Never, T, list[Unrelated])
+    constraints = ConstraintSet.upper_bound(T, list[Unrelated])
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose Unrelated as the materialization, then all valid specializations must satisfy
     # (T ≤ list[Unrelated]).
@@ -261,36 +261,36 @@ def constrained[T: (Base, Unrelated)]():
     static_assert(not ConstraintSet.never().satisfied_by_all_typevars())
 
     # (T = Unrelated) is a valid specialization, which satisfies (T ≤ Unrelated).
-    static_assert(ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Base) is a valid specialization, which does not satisfy (T ≤ Unrelated).
-    static_assert(not ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars())
 
     # (T = Base) is a valid specialization, which satisfies (T ≤ Super).
-    static_assert(ConstraintSet.range(Never, T, Super).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Super).satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Unrelated) is a valid specialization, which does not satisfy (T ≤ Super).
-    static_assert(not ConstraintSet.range(Never, T, Super).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Super).satisfied_by_all_typevars())
 
     # (T = Base) is a valid specialization, which satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Unrelated) is a valid specialization, which does not satisfy (T ≤ Base).
-    static_assert(not ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars())
 
     # Neither (T = Base) nor (T = Unrelated) satisfy (T ≤ Sub).
-    static_assert(not ConstraintSet.range(Never, T, Sub).satisfied_by_all_typevars(inferable=tuple[T]))
-    static_assert(not ConstraintSet.range(Never, T, Sub).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Sub).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(not ConstraintSet.upper_bound(T, Sub).satisfied_by_all_typevars())
 
     # (T = Base) and (T = Unrelated) both satisfy (T ≤ Super ∨ T ≤ Unrelated).
-    constraints = ConstraintSet.range(Never, T, Super) | ConstraintSet.range(Never, T, Unrelated)
+    constraints = ConstraintSet.upper_bound(T, Super) | ConstraintSet.upper_bound(T, Unrelated)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     static_assert(constraints.satisfied_by_all_typevars())
 
     # (T = Base) and (T = Unrelated) both satisfy (T ≤ Base ∨ T ≤ Unrelated).
-    constraints = ConstraintSet.range(Never, T, Base) | ConstraintSet.range(Never, T, Unrelated)
+    constraints = ConstraintSet.upper_bound(T, Base) | ConstraintSet.upper_bound(T, Unrelated)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     static_assert(constraints.satisfied_by_all_typevars())
 
     # (T = Unrelated) is a valid specialization, which satisfies (T ≤ Sub ∨ T ≤ Unrelated).
-    constraints = ConstraintSet.range(Never, T, Sub) | ConstraintSet.range(Never, T, Unrelated)
+    constraints = ConstraintSet.upper_bound(T, Sub) | ConstraintSet.upper_bound(T, Unrelated)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Base) is a valid specialization, which does not satisfy (T ≤ Sub ∨ T ≤ Unrelated).
     static_assert(not constraints.satisfied_by_all_typevars())
@@ -333,24 +333,24 @@ def constrained_by_gradual[T: (Base, Any)]():
 
     # If we choose Unrelated as the materialization of the gradual constraint, then (T = Unrelated)
     # is a valid specialization, which satisfies (T ≤ Unrelated).
-    static_assert(ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
     # No matter which materialization we choose, (T = Base) is a valid specialization, which does
     # not satisfy (T ≤ Unrelated).
-    static_assert(not ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars())
 
     # If we choose Super as the materialization, then (T = Super) is a valid specialization, which
     # satisfies (T ≤ Super).
-    static_assert(ConstraintSet.range(Never, T, Super).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Super).satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose Never as the materialization, then (T = Base) and (T = Never) are the only valid
     # specializations, both of which satisfy (T ≤ Super).
-    static_assert(ConstraintSet.range(Never, T, Super).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, Super).satisfied_by_all_typevars())
 
     # If we choose Base as the materialization, then (T = Base) is a valid specialization, which
     # satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose Never as the materialization, then (T = Base) and (T = Never) are the only valid
     # specializations, both of which satisfy (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars())
 
 def constrained_by_two_gradual[T: (Any, Any)]():
     static_assert(ConstraintSet.always().satisfied_by_all_typevars(inferable=tuple[T]))
@@ -361,17 +361,17 @@ def constrained_by_two_gradual[T: (Any, Any)]():
 
     # If we choose Unrelated as the materialization of either constraint, then (T = Unrelated) is a
     # valid specialization, which satisfies (T ≤ Unrelated).
-    static_assert(ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose Unrelated as the materialization of both constraints, then (T = Unrelated) is the
     # only valid specialization, which satisfies (T ≤ Unrelated).
-    static_assert(ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars())
 
     # If we choose Base as the materialization of either constraint, then (T = Base) is a valid
     # specialization, which satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose Never as the materialization of both constraints, then (T = Never) is the only
     # valid specialization, which satisfies (T ≤ Base).
-    static_assert(ConstraintSet.range(Never, T, Base).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, Base).satisfied_by_all_typevars())
 ```
 
 When a constraint is a more complex gradual type, we are still free to choose any materialization
@@ -391,33 +391,33 @@ def constrained_by_gradual[T: (list[Base], list[Any])]():
     # No matter which materialization we choose, every valid specialization will be of the form
     # (T = list[X]). Because Unrelated is final, it is disjoint from all lists. There is therefore
     # no materialization or specialization that satisfies (T ≤ Unrelated).
-    static_assert(not ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
-    static_assert(not ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(not ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars())
 
     # If we choose list[Super] as the materialization, then (T = list[Super]) is a valid
     # specialization, which satisfies (T ≤ list[Super]).
-    static_assert(ConstraintSet.range(Never, T, list[Super]).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, list[Super]).satisfied_by_all_typevars(inferable=tuple[T]))
     # No matter which materialization we choose, (T = list[Base]) is a valid specialization, which
     # does not satisfy (T ≤ list[Super]).
-    static_assert(not ConstraintSet.range(Never, T, list[Super]).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, list[Super]).satisfied_by_all_typevars())
 
     # If we choose list[Base] as the materialization, then (T = list[Base]) is a valid
     # specialization, which satisfies (T ≤ list[Base]).
-    static_assert(ConstraintSet.range(Never, T, list[Base]).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, list[Base]).satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose list[Base] as the materialization, then all valid specializations must satisfy
     # (T ≤ list[Base]).
-    static_assert(ConstraintSet.range(Never, T, list[Base]).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, list[Base]).satisfied_by_all_typevars())
 
     # If we choose list[Sub] as the materialization, then (T = list[Sub]) is a valid specialization,
     # which # satisfies (T ≤ list[Sub]).
-    static_assert(ConstraintSet.range(Never, T, list[Sub]).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, list[Sub]).satisfied_by_all_typevars(inferable=tuple[T]))
     # No matter which materialization we choose, (T = list[Base]) is a valid specialization, which
     # does not satisfy (T ≤ list[Sub]).
-    static_assert(not ConstraintSet.range(Never, T, list[Sub]).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, list[Sub]).satisfied_by_all_typevars())
 
     # If we choose list[Unrelated] as the materialization, then (T = list[Unrelated]) is a valid
     # specialization, which satisfies (T ≤ list[Unrelated]).
-    constraints = ConstraintSet.range(Never, T, list[Unrelated])
+    constraints = ConstraintSet.upper_bound(T, list[Unrelated])
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # No matter which materialization we choose, (T = list[Base]) is a valid specialization, which
     # does not satisfy (T ≤ list[Unrelated]).
@@ -442,33 +442,33 @@ def constrained_by_two_gradual[T: (list[Any], list[Any])]():
     # No matter which materialization we choose, every valid specialization will be of the form
     # (T = list[X]). Because Unrelated is final, it is disjoint from all lists. There is therefore
     # no materialization or specialization that satisfies (T ≤ Unrelated).
-    static_assert(not ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
-    static_assert(not ConstraintSet.range(Never, T, Unrelated).satisfied_by_all_typevars())
+    static_assert(not ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(not ConstraintSet.upper_bound(T, Unrelated).satisfied_by_all_typevars())
 
     # If we choose list[Super] as the materialization, then (T = list[Super]) is a valid
     # specialization, which satisfies (T ≤ list[Super]).
-    static_assert(ConstraintSet.range(Never, T, list[Super]).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, list[Super]).satisfied_by_all_typevars(inferable=tuple[T]))
     # No matter which materialization we choose, (T = list[Base]) is a valid specialization, which
     # does not satisfy (T ≤ list[Super]).
-    static_assert(ConstraintSet.range(Never, T, list[Super]).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, list[Super]).satisfied_by_all_typevars())
 
     # If we choose list[Base] as the materialization, then (T = list[Base]) is a valid
     # specialization, which satisfies (T ≤ list[Base]).
-    static_assert(ConstraintSet.range(Never, T, list[Base]).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, list[Base]).satisfied_by_all_typevars(inferable=tuple[T]))
     # If we choose Base as the materialization, then all valid specializations must satisfy
     # (T ≤ list[Base]).
-    static_assert(ConstraintSet.range(Never, T, list[Base]).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, list[Base]).satisfied_by_all_typevars())
 
     # If we choose list[Sub] as the materialization, then (T = list[Sub]) is a valid specialization,
     # which satisfies (T ≤ list[Sub]).
-    static_assert(ConstraintSet.range(Never, T, list[Sub]).satisfied_by_all_typevars(inferable=tuple[T]))
+    static_assert(ConstraintSet.upper_bound(T, list[Sub]).satisfied_by_all_typevars(inferable=tuple[T]))
     # No matter which materialization we choose, (T = list[Base]) is a valid specialization, which
     # does not satisfy (T ≤ list[Sub]).
-    static_assert(ConstraintSet.range(Never, T, list[Sub]).satisfied_by_all_typevars())
+    static_assert(ConstraintSet.upper_bound(T, list[Sub]).satisfied_by_all_typevars())
 
     # If we choose list[Unrelated] as the materialization, then (T = list[Unrelated]) is a valid
     # specialization, which satisfies (T ≤ list[Unrelated]).
-    constraints = ConstraintSet.range(Never, T, list[Unrelated])
+    constraints = ConstraintSet.upper_bound(T, list[Unrelated])
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # No matter which materialization we choose, (T = list[Base]) is a valid specialization, which
     # does not satisfy (T ≤ list[Unrelated]).

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/satisfied_by_all_typevars.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/satisfied_by_all_typevars.md
@@ -138,7 +138,7 @@ def bounded[T: Base]():
 
     # Never is the only type that satisfies both (T ≤ Base) and (T ≤ Unrelated). So there is no
     # valid specialization that satisfies (T ≤ Unrelated ∧ T ≠ Never).
-    constraints = constraints & ~ConstraintSet.range(Never, T, Never)
+    constraints = constraints & ~ConstraintSet.equality(T, Never)
     static_assert(not constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     static_assert(not constraints.satisfied_by_all_typevars())
 ```
@@ -182,7 +182,7 @@ def bounded_by_gradual[T: Any]():
 
     # If we choose Unrelated as the materialization, then (T = Unrelated) is a valid specialization,
     # which satisfies (T ≤ Unrelated ∧ T ≠ Never).
-    constraints = constraints & ~ConstraintSet.range(Never, T, Never)
+    constraints = constraints & ~ConstraintSet.equality(T, Never)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # There is no upper bound that we can choose to satisfy this constraint set in non-inferable
     # position. (T = Never) will be a valid assignment no matter what, and that does not satisfy
@@ -226,7 +226,7 @@ def bounded_by_gradual[T: list[Any]]():
 
     # If we choose Unrelated as the materialization, then (T = list[Unrelated]) is a valid
     # specialization, which satisfies (T ≤ list[Unrelated] ∧ T ≠ Never).
-    constraints = constraints & ~ConstraintSet.range(Never, T, Never)
+    constraints = constraints & ~ConstraintSet.equality(T, Never)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # There is no upper bound that we can choose to satisfy this constraint set in non-inferable
     # position. (T = Never) will be a valid assignment no matter what, and that does not satisfy
@@ -296,18 +296,18 @@ def constrained[T: (Base, Unrelated)]():
     static_assert(not constraints.satisfied_by_all_typevars())
 
     # (T = Unrelated) is a valid specialization, which satisfies (T = Super ∨ T = Unrelated).
-    constraints = ConstraintSet.range(Super, T, Super) | ConstraintSet.range(Unrelated, T, Unrelated)
+    constraints = ConstraintSet.equality(T, Super) | ConstraintSet.equality(T, Unrelated)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Base) is a valid specialization, which does not satisfy (T = Super ∨ T = Unrelated).
     static_assert(not constraints.satisfied_by_all_typevars())
 
     # (T = Base) and (T = Unrelated) both satisfy (T = Base ∨ T = Unrelated).
-    constraints = ConstraintSet.range(Base, T, Base) | ConstraintSet.range(Unrelated, T, Unrelated)
+    constraints = ConstraintSet.equality(T, Base) | ConstraintSet.equality(T, Unrelated)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     static_assert(constraints.satisfied_by_all_typevars())
 
     # (T = Unrelated) is a valid specialization, which satisfies (T = Sub ∨ T = Unrelated).
-    constraints = ConstraintSet.range(Sub, T, Sub) | ConstraintSet.range(Unrelated, T, Unrelated)
+    constraints = ConstraintSet.equality(T, Sub) | ConstraintSet.equality(T, Unrelated)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # (T = Base) is a valid specialization, which does not satisfy (T = Sub ∨ T = Unrelated).
     static_assert(not constraints.satisfied_by_all_typevars())
@@ -425,7 +425,7 @@ def constrained_by_gradual[T: (list[Base], list[Any])]():
 
     # If we choose list[Unrelated] as the materialization, then (T = list[Unrelated]) is a valid
     # specialization, which satisfies (T ≤ list[Unrelated] ∧ T ≠ Never).
-    constraints = constraints & ~ConstraintSet.range(Never, T, Never)
+    constraints = constraints & ~ConstraintSet.equality(T, Never)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # There is no materialization that we can choose to satisfy this constraint set in non-inferable
     # position. (T = Never) will be a valid assignment no matter what, and that does not satisfy
@@ -476,7 +476,7 @@ def constrained_by_two_gradual[T: (list[Any], list[Any])]():
 
     # If we choose list[Unrelated] as the materialization, then (T = list[Unrelated]) is a valid
     # specialization, which satisfies (T ≤ list[Unrelated] ∧ T ≠ Never).
-    constraints = constraints & ~ConstraintSet.range(Never, T, Never)
+    constraints = constraints & ~ConstraintSet.equality(T, Never)
     static_assert(constraints.satisfied_by_all_typevars(inferable=tuple[T]))
     # There is no constraint that we can choose to satisfy this constraint set in non-inferable
     # position. (T = Never) will be a valid assignment no matter what, and that does not satisfy

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4679,6 +4679,14 @@ impl<'db> Type<'db> {
                     .into()
                 }
                 Type::ClassLiteral(class)
+                    if name == "equality" && class.is_known(db, KnownClass::ConstraintSet) =>
+                {
+                    Place::bound(Type::KnownBoundMethod(
+                        KnownBoundMethodType::ConstraintSetEquality,
+                    ))
+                    .into()
+                }
+                Type::ClassLiteral(class)
                     if name == "range" && class.is_known(db, KnownClass::ConstraintSet) =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -7402,6 +7410,7 @@ impl<'db> Type<'db> {
                     KnownBoundMethodType::StrStartswith(_)
                         | KnownBoundMethodType::ConstraintSetLowerBound
                         | KnownBoundMethodType::ConstraintSetUpperBound
+                        | KnownBoundMethodType::ConstraintSetEquality
                         | KnownBoundMethodType::ConstraintSetRange
                         | KnownBoundMethodType::ConstraintSetAlways
                         | KnownBoundMethodType::ConstraintSetNever
@@ -7773,6 +7782,7 @@ impl<'db> Type<'db> {
                 KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetLowerBound
                 | KnownBoundMethodType::ConstraintSetUpperBound
+                | KnownBoundMethodType::ConstraintSetEquality
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever
@@ -8070,6 +8080,7 @@ impl<'db> Type<'db> {
                 KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetLowerBound
                 | KnownBoundMethodType::ConstraintSetUpperBound
+                | KnownBoundMethodType::ConstraintSetEquality
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4663,6 +4663,22 @@ impl<'db> Type<'db> {
                 }
 
                 Type::ClassLiteral(class)
+                    if name == "lower_bound" && class.is_known(db, KnownClass::ConstraintSet) =>
+                {
+                    Place::bound(Type::KnownBoundMethod(
+                        KnownBoundMethodType::ConstraintSetLowerBound,
+                    ))
+                    .into()
+                }
+                Type::ClassLiteral(class)
+                    if name == "upper_bound" && class.is_known(db, KnownClass::ConstraintSet) =>
+                {
+                    Place::bound(Type::KnownBoundMethod(
+                        KnownBoundMethodType::ConstraintSetUpperBound,
+                    ))
+                    .into()
+                }
+                Type::ClassLiteral(class)
                     if name == "range" && class.is_known(db, KnownClass::ConstraintSet) =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -7384,6 +7400,8 @@ impl<'db> Type<'db> {
                 )
                 | Type::KnownBoundMethod(
                     KnownBoundMethodType::StrStartswith(_)
+                        | KnownBoundMethodType::ConstraintSetLowerBound
+                        | KnownBoundMethodType::ConstraintSetUpperBound
                         | KnownBoundMethodType::ConstraintSetRange
                         | KnownBoundMethodType::ConstraintSetAlways
                         | KnownBoundMethodType::ConstraintSetNever
@@ -7753,6 +7771,8 @@ impl<'db> Type<'db> {
             | Type::ModuleLiteral(_)
             | Type::KnownBoundMethod(
                 KnownBoundMethodType::StrStartswith(_)
+                | KnownBoundMethodType::ConstraintSetLowerBound
+                | KnownBoundMethodType::ConstraintSetUpperBound
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever
@@ -8048,6 +8068,8 @@ impl<'db> Type<'db> {
             | Type::WrapperDescriptor(_)
             | Type::KnownBoundMethod(
                 KnownBoundMethodType::StrStartswith(_)
+                | KnownBoundMethodType::ConstraintSetLowerBound
+                | KnownBoundMethodType::ConstraintSetUpperBound
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2835,10 +2835,20 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetRange) => {
-                        let [Some(lower), Some(typevar), Some(upper)] = overload.parameter_types()
-                        else {
-                            return;
+                    Type::KnownBoundMethod(
+                        method @ (KnownBoundMethodType::ConstraintSetEquality
+                        | KnownBoundMethodType::ConstraintSetRange),
+                    ) => {
+                        let (lower, typevar, upper) = match (method, overload.parameter_types()) {
+                            (
+                                KnownBoundMethodType::ConstraintSetEquality,
+                                [Some(typevar), Some(value)],
+                            ) => (value, typevar, value),
+                            (
+                                KnownBoundMethodType::ConstraintSetRange,
+                                [Some(lower), Some(typevar), Some(upper)],
+                            ) => (lower, typevar, upper),
+                            _ => return,
                         };
                         let lower = lower.project_type_form(db, env);
                         let typevar = typevar.project_type_form(db, env);

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2790,44 +2790,24 @@ impl<'db> Bindings<'db> {
                         }
                     },
 
-                    Type::KnownBoundMethod(
-                        method @ (KnownBoundMethodType::ConstraintSetLowerBound
-                        | KnownBoundMethodType::ConstraintSetUpperBound),
-                    ) => {
-                        let [Some(first), Some(second)] = overload.parameter_types() else {
+                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetLowerBound) => {
+                        let [Some(lower), Some(typevar)] = overload.parameter_types() else {
                             return;
                         };
-                        let first = first.project_type_form(db, env);
-                        let second = second.project_type_form(db, env);
-                        let is_lower_bound =
-                            matches!(method, KnownBoundMethodType::ConstraintSetLowerBound);
-                        let (typevar, bound) = if is_lower_bound {
-                            (second, first)
-                        } else {
-                            (first, second)
-                        };
+                        let lower = lower.project_type_form(db, env);
+                        let typevar = typevar.project_type_form(db, env);
                         let Type::TypeVar(typevar) = typevar else {
                             return;
                         };
                         let constraints = ConstraintSetBuilder::new();
                         let result = constraints.into_owned(|constraints| {
-                            if is_lower_bound {
-                                ConstraintSet::constrain_typevar_lower_bound(
-                                    db,
-                                    env,
-                                    constraints,
-                                    typevar,
-                                    bound,
-                                )
-                            } else {
-                                ConstraintSet::constrain_typevar_upper_bound(
-                                    db,
-                                    env,
-                                    constraints,
-                                    typevar,
-                                    bound,
-                                )
-                            }
+                            ConstraintSet::constrain_typevar_lower_bound(
+                                db,
+                                env,
+                                constraints,
+                                typevar,
+                                lower,
+                            )
                         });
                         let tracked = InternedConstraintSet::new(db, result);
                         overload.set_return_type(Type::KnownInstance(
@@ -2835,20 +2815,61 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::KnownBoundMethod(
-                        method @ (KnownBoundMethodType::ConstraintSetEquality
-                        | KnownBoundMethodType::ConstraintSetRange),
-                    ) => {
-                        let (lower, typevar, upper) = match (method, overload.parameter_types()) {
-                            (
-                                KnownBoundMethodType::ConstraintSetEquality,
-                                [Some(typevar), Some(value)],
-                            ) => (value, typevar, value),
-                            (
-                                KnownBoundMethodType::ConstraintSetRange,
-                                [Some(lower), Some(typevar), Some(upper)],
-                            ) => (lower, typevar, upper),
-                            _ => return,
+                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetUpperBound) => {
+                        let [Some(typevar), Some(upper)] = overload.parameter_types() else {
+                            return;
+                        };
+                        let typevar = typevar.project_type_form(db, env);
+                        let upper = upper.project_type_form(db, env);
+                        let Type::TypeVar(typevar) = typevar else {
+                            return;
+                        };
+                        let constraints = ConstraintSetBuilder::new();
+                        let result = constraints.into_owned(|constraints| {
+                            ConstraintSet::constrain_typevar_upper_bound(
+                                db,
+                                env,
+                                constraints,
+                                typevar,
+                                upper,
+                            )
+                        });
+                        let tracked = InternedConstraintSet::new(db, result);
+                        overload.set_return_type(Type::KnownInstance(
+                            KnownInstanceType::ConstraintSet(tracked),
+                        ));
+                    }
+
+                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetEquality) => {
+                        let [Some(typevar), Some(value)] = overload.parameter_types() else {
+                            return;
+                        };
+                        let typevar = typevar.project_type_form(db, env);
+                        let value = value.project_type_form(db, env);
+                        let Type::TypeVar(typevar) = typevar else {
+                            return;
+                        };
+                        let constraints = ConstraintSetBuilder::new();
+                        let result = constraints.into_owned(|constraints| {
+                            ConstraintSet::constrain_typevar(
+                                db,
+                                env,
+                                constraints,
+                                typevar,
+                                value,
+                                value,
+                            )
+                        });
+                        let tracked = InternedConstraintSet::new(db, result);
+                        overload.set_return_type(Type::KnownInstance(
+                            KnownInstanceType::ConstraintSet(tracked),
+                        ));
+                    }
+
+                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetRange) => {
+                        let [Some(lower), Some(typevar), Some(upper)] = overload.parameter_types()
+                        else {
+                            return;
                         };
                         let lower = lower.project_type_form(db, env);
                         let typevar = typevar.project_type_form(db, env);

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2790,6 +2790,51 @@ impl<'db> Bindings<'db> {
                         }
                     },
 
+                    Type::KnownBoundMethod(
+                        method @ (KnownBoundMethodType::ConstraintSetLowerBound
+                        | KnownBoundMethodType::ConstraintSetUpperBound),
+                    ) => {
+                        let [Some(first), Some(second)] = overload.parameter_types() else {
+                            return;
+                        };
+                        let first = first.project_type_form(db, env);
+                        let second = second.project_type_form(db, env);
+                        let is_lower_bound =
+                            matches!(method, KnownBoundMethodType::ConstraintSetLowerBound);
+                        let (typevar, bound) = if is_lower_bound {
+                            (second, first)
+                        } else {
+                            (first, second)
+                        };
+                        let Type::TypeVar(typevar) = typevar else {
+                            return;
+                        };
+                        let constraints = ConstraintSetBuilder::new();
+                        let result = constraints.into_owned(|constraints| {
+                            if is_lower_bound {
+                                ConstraintSet::constrain_typevar_lower_bound(
+                                    db,
+                                    env,
+                                    constraints,
+                                    typevar,
+                                    bound,
+                                )
+                            } else {
+                                ConstraintSet::constrain_typevar_upper_bound(
+                                    db,
+                                    env,
+                                    constraints,
+                                    typevar,
+                                    bound,
+                                )
+                            }
+                        });
+                        let tracked = InternedConstraintSet::new(db, result);
+                        overload.set_return_type(Type::KnownInstance(
+                            KnownInstanceType::ConstraintSet(tracked),
+                        ));
+                    }
+
                     Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetRange) => {
                         let [Some(lower), Some(typevar), Some(upper)] = overload.parameter_types()
                         else {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1322,6 +1322,12 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                         )),
                         Some(literal.value(db)),
                     ),
+                    KnownBoundMethodType::ConstraintSetLowerBound => {
+                        return f.write_str("bound method `ConstraintSet.lower_bound`");
+                    }
+                    KnownBoundMethodType::ConstraintSetUpperBound => {
+                        return f.write_str("bound method `ConstraintSet.upper_bound`");
+                    }
                     KnownBoundMethodType::ConstraintSetRange => {
                         return f.write_str("bound method `ConstraintSet.range`");
                     }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1328,6 +1328,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                     KnownBoundMethodType::ConstraintSetUpperBound => {
                         return f.write_str("bound method `ConstraintSet.upper_bound`");
                     }
+                    KnownBoundMethodType::ConstraintSetEquality => {
+                        return f.write_str("bound method `ConstraintSet.equality`");
+                    }
                     KnownBoundMethodType::ConstraintSetRange => {
                         return f.write_str("bound method `ConstraintSet.range`");
                     }

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -222,6 +222,7 @@ pub enum KnownBoundMethodType<'db> {
     // ConstraintSet methods
     ConstraintSetLowerBound,
     ConstraintSetUpperBound,
+    ConstraintSetEquality,
     ConstraintSetRange,
     ConstraintSetAlways,
     ConstraintSetNever,
@@ -264,6 +265,7 @@ pub(super) fn walk_method_wrapper_type<'db, V: visitor::TypeVisitor<'db> + ?Size
         }
         KnownBoundMethodType::ConstraintSetLowerBound
         | KnownBoundMethodType::ConstraintSetUpperBound
+        | KnownBoundMethodType::ConstraintSetEquality
         | KnownBoundMethodType::ConstraintSetRange
         | KnownBoundMethodType::ConstraintSetAlways
         | KnownBoundMethodType::ConstraintSetNever
@@ -315,6 +317,7 @@ impl<'db> KnownBoundMethodType<'db> {
             KnownBoundMethodType::StrStartswith(_)
             | KnownBoundMethodType::ConstraintSetLowerBound
             | KnownBoundMethodType::ConstraintSetUpperBound
+            | KnownBoundMethodType::ConstraintSetEquality
             | KnownBoundMethodType::ConstraintSetRange
             | KnownBoundMethodType::ConstraintSetAlways
             | KnownBoundMethodType::ConstraintSetNever
@@ -340,6 +343,7 @@ impl<'db> KnownBoundMethodType<'db> {
             KnownBoundMethodType::StrStartswith(_) => KnownClass::BuiltinFunctionType,
             KnownBoundMethodType::ConstraintSetLowerBound
             | KnownBoundMethodType::ConstraintSetUpperBound
+            | KnownBoundMethodType::ConstraintSetEquality
             | KnownBoundMethodType::ConstraintSetRange
             | KnownBoundMethodType::ConstraintSetAlways
             | KnownBoundMethodType::ConstraintSetNever
@@ -492,6 +496,18 @@ impl<'db> KnownBoundMethodType<'db> {
                         Parameter::positional_only(Some(Name::new_static("typevar")))
                             .with_annotated_type(object_type_form()),
                         Parameter::positional_only(Some(Name::new_static("upper_bound")))
+                            .with_annotated_type(object_type_form()),
+                    ]),
+                    KnownClass::ConstraintSet.to_instance(db, env),
+                )))
+            }
+
+            KnownBoundMethodType::ConstraintSetEquality => {
+                Either::Right(std::iter::once(Signature::new(
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("typevar")))
+                            .with_annotated_type(object_type_form()),
+                        Parameter::positional_only(Some(Name::new_static("value")))
                             .with_annotated_type(object_type_form()),
                     ]),
                     KnownClass::ConstraintSet.to_instance(db, env),
@@ -672,6 +688,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 KnownBoundMethodType::ConstraintSetUpperBound,
             )
             | (
+                KnownBoundMethodType::ConstraintSetEquality,
+                KnownBoundMethodType::ConstraintSetEquality,
+            )
+            | (
                 KnownBoundMethodType::ConstraintSetRange,
                 KnownBoundMethodType::ConstraintSetRange,
             )
@@ -725,6 +745,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetLowerBound
                 | KnownBoundMethodType::ConstraintSetUpperBound
+                | KnownBoundMethodType::ConstraintSetEquality
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever
@@ -744,6 +765,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetLowerBound
                 | KnownBoundMethodType::ConstraintSetUpperBound
+                | KnownBoundMethodType::ConstraintSetEquality
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -220,6 +220,8 @@ pub enum KnownBoundMethodType<'db> {
     StrStartswith(StringLiteralType<'db>),
 
     // ConstraintSet methods
+    ConstraintSetLowerBound,
+    ConstraintSetUpperBound,
     ConstraintSetRange,
     ConstraintSetAlways,
     ConstraintSetNever,
@@ -260,7 +262,9 @@ pub(super) fn walk_method_wrapper_type<'db, V: visitor::TypeVisitor<'db> + ?Size
                 LiteralValueType::promotable(LiteralValueTypeKind::String(string_literal)).into(),
             );
         }
-        KnownBoundMethodType::ConstraintSetRange
+        KnownBoundMethodType::ConstraintSetLowerBound
+        | KnownBoundMethodType::ConstraintSetUpperBound
+        | KnownBoundMethodType::ConstraintSetRange
         | KnownBoundMethodType::ConstraintSetAlways
         | KnownBoundMethodType::ConstraintSetNever
         | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
@@ -309,6 +313,8 @@ impl<'db> KnownBoundMethodType<'db> {
                 ))
             }
             KnownBoundMethodType::StrStartswith(_)
+            | KnownBoundMethodType::ConstraintSetLowerBound
+            | KnownBoundMethodType::ConstraintSetUpperBound
             | KnownBoundMethodType::ConstraintSetRange
             | KnownBoundMethodType::ConstraintSetAlways
             | KnownBoundMethodType::ConstraintSetNever
@@ -332,7 +338,9 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::PropertyDunderSet(_)
             | KnownBoundMethodType::PropertyDunderDelete(_) => KnownClass::MethodWrapperType,
             KnownBoundMethodType::StrStartswith(_) => KnownClass::BuiltinFunctionType,
-            KnownBoundMethodType::ConstraintSetRange
+            KnownBoundMethodType::ConstraintSetLowerBound
+            | KnownBoundMethodType::ConstraintSetUpperBound
+            | KnownBoundMethodType::ConstraintSetRange
             | KnownBoundMethodType::ConstraintSetAlways
             | KnownBoundMethodType::ConstraintSetNever
             | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
@@ -463,6 +471,30 @@ impl<'db> KnownBoundMethodType<'db> {
                             .with_default_type(Type::none(db, env)),
                     ]),
                     KnownClass::Bool.to_instance(db, env),
+                )))
+            }
+
+            KnownBoundMethodType::ConstraintSetLowerBound => {
+                Either::Right(std::iter::once(Signature::new(
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("lower_bound")))
+                            .with_annotated_type(object_type_form()),
+                        Parameter::positional_only(Some(Name::new_static("typevar")))
+                            .with_annotated_type(object_type_form()),
+                    ]),
+                    KnownClass::ConstraintSet.to_instance(db, env),
+                )))
+            }
+
+            KnownBoundMethodType::ConstraintSetUpperBound => {
+                Either::Right(std::iter::once(Signature::new(
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("typevar")))
+                            .with_annotated_type(object_type_form()),
+                        Parameter::positional_only(Some(Name::new_static("upper_bound")))
+                            .with_annotated_type(object_type_form()),
+                    ]),
+                    KnownClass::ConstraintSet.to_instance(db, env),
                 )))
             }
 
@@ -632,6 +664,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
 
             (
+                KnownBoundMethodType::ConstraintSetLowerBound,
+                KnownBoundMethodType::ConstraintSetLowerBound,
+            )
+            | (
+                KnownBoundMethodType::ConstraintSetUpperBound,
+                KnownBoundMethodType::ConstraintSetUpperBound,
+            )
+            | (
                 KnownBoundMethodType::ConstraintSetRange,
                 KnownBoundMethodType::ConstraintSetRange,
             )
@@ -683,6 +723,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::PropertyDunderSet(_)
                 | KnownBoundMethodType::PropertyDunderDelete(_)
                 | KnownBoundMethodType::StrStartswith(_)
+                | KnownBoundMethodType::ConstraintSetLowerBound
+                | KnownBoundMethodType::ConstraintSetUpperBound
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever
@@ -700,6 +742,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::PropertyDunderSet(_)
                 | KnownBoundMethodType::PropertyDunderDelete(_)
                 | KnownBoundMethodType::StrStartswith(_)
+                | KnownBoundMethodType::ConstraintSetLowerBound
+                | KnownBoundMethodType::ConstraintSetUpperBound
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -258,6 +258,8 @@ impl<'db> Type<'db> {
                 KnownBoundMethodType::FunctionTypeDunderGet(_)
                 | KnownBoundMethodType::FunctionTypeDunderCall(_)
                 | KnownBoundMethodType::StrStartswith(_)
+                | KnownBoundMethodType::ConstraintSetLowerBound
+                | KnownBoundMethodType::ConstraintSetUpperBound
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -260,6 +260,7 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetLowerBound
                 | KnownBoundMethodType::ConstraintSetUpperBound
+                | KnownBoundMethodType::ConstraintSetEquality
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
                 | KnownBoundMethodType::ConstraintSetNever

--- a/crates/ty_vendored/ty_extensions/_internal.pyi
+++ b/crates/ty_vendored/ty_extensions/_internal.pyi
@@ -114,6 +114,13 @@ class ConstraintSet:
         """Returns a constraint set requiring `typevar` to be a subtype of `upper_bound`."""
 
     @staticmethod
+    def equality(
+        typevar: TypeForm[object],
+        value: TypeForm[object],
+    ) -> ConstraintSet:
+        """Returns a constraint set requiring `typevar` to specialize exactly to `value`."""
+
+    @staticmethod
     def range(
         lower_bound: TypeForm[object],
         typevar: TypeForm[object],

--- a/crates/ty_vendored/ty_extensions/_internal.pyi
+++ b/crates/ty_vendored/ty_extensions/_internal.pyi
@@ -100,6 +100,20 @@ class ConstraintSetSolution:
 
 class ConstraintSet:
     @staticmethod
+    def lower_bound(
+        lower_bound: TypeForm[object],
+        typevar: TypeForm[object],
+    ) -> ConstraintSet:
+        """Returns a constraint set requiring `typevar` to be a supertype of `lower_bound`."""
+
+    @staticmethod
+    def upper_bound(
+        typevar: TypeForm[object],
+        upper_bound: TypeForm[object],
+    ) -> ConstraintSet:
+        """Returns a constraint set requiring `typevar` to be a subtype of `upper_bound`."""
+
+    @staticmethod
     def range(
         lower_bound: TypeForm[object],
         typevar: TypeForm[object],


### PR DESCRIPTION
The `ConstraintSet.range` extension method is used in mdtests to create specific constraint sets for testing purposes. This is a simple (but largish) refactoring that adds three additional constructors for certain common constraint shapes: lower-bound-only, upper-bound-only, and equality constraints.