### PR TITLE
[pyflakes/pyupgrade] Skip string rules inside string type definitions (#10586)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F541.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F541.py
@@ -42,3 +42,8 @@ f"{{{{x}}}}"
 (""f""r"")
 f"{v:{f"0.2f"}}"
 f"\{{x}}"
+
+# Don't flag f-strings inside string type definitions (forward references).
+# https://github.com/astral-sh/ruff/issues/10586
+x: "Literal[f'']" = ""
+y: "Literal[f'{1}']" = ""

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP025.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP025.py
@@ -32,3 +32,14 @@ f"foo" u"bar"  # OK
 ""u"hi"
 """"""""""""""""""""u"hi"
 ""U"helloooo"
+# https://github.com/astral-sh/ruff/issues/10586
+# A unicode prefix inside a string type definition (forward reference) is part
+# of the type expression and must not be flagged.
+import typing_extensions as te
+
+A: "te.Literal[u'x', '\r\n', '\r']" = "\n"
+B: list["te.Literal[u'x']"] = []
+
+
+def f(x: "te.Literal[u'x']") -> "te.Literal[u'y']":
+    return u"y"  # UP025 (runtime string, outside the annotation)

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
@@ -169,3 +169,7 @@ print("%02X" % 1)
 "%(1)s" % {1: 2, "1": 2}
 
 "%(and)s" % {"and": 2}
+
+# Don't flag printf-style formatting inside string type definitions (forward references).
+# https://github.com/astral-sh/ruff/issues/10586
+x: "Literal['%s' % 'a']" = ""

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP032_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP032_0.py
@@ -281,3 +281,7 @@ if __name__ == "__main__":
 
 # Raw string with \N{...}
 r"\N{angle}AOB = {angle}°".format(angle=180)
+
+# Don't flag str.format inside string type definitions (forward references).
+# https://github.com/astral-sh/ruff/issues/10586
+x: "Literal['{}'.format(1)]" = ""

--- a/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -70,6 +70,14 @@ impl AlwaysFixableViolation for FStringMissingPlaceholders {
 
 /// F541
 pub(crate) fn f_string_missing_placeholders(checker: &Checker, expr: &ast::ExprFString) {
+    // Don't flag f-strings inside a string type definition (forward
+    // reference), e.g. `x: "Literal[f'']"`. The f-string is part of the type
+    // expression, not a runtime string.
+    // https://github.com/astral-sh/ruff/issues/10586
+    if checker.semantic().in_string_type_definition() {
+        return;
+    }
+
     if expr.value.f_strings().any(|f_string| {
         f_string
             .elements

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F541_F541.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F541_F541.py.snap
@@ -346,9 +346,13 @@ F541 [*] f-string without any placeholders
 43 | f"{v:{f"0.2f"}}"
 44 | f"\{{x}}"
    | ^^^^^^^^^
+45 |
+46 | # Don't flag f-strings inside string type definitions (forward references).
+   |
 help: Remove extraneous `f` prefix
    |
 43 | f"{v:{f"0.2f"}}"
    - f"\{{x}}"
 44 + "\{x}"
+45 |
    |

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -403,6 +403,14 @@ impl FStringConversion {
 
 /// UP032
 pub(crate) fn f_strings(checker: &Checker, call: &ast::ExprCall, summary: &FormatSummary) {
+    // Don't flag `str.format` inside a string type definition (forward
+    // reference), e.g. `x: "Literal['{}'.format(1)]"`. The string is part of
+    // the type expression, not a runtime string.
+    // https://github.com/astral-sh/ruff/issues/10586
+    if checker.semantic().in_string_type_definition() {
+        return;
+    }
+
     if summary.has_nested_parts {
         return;
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -372,6 +372,14 @@ pub(crate) fn printf_string_formatting(
     bin_op: &ast::ExprBinOp,
     string_expr: &ast::ExprStringLiteral,
 ) {
+    // Don't flag printf-style formatting inside a string type definition
+    // (forward reference), e.g. `x: "Literal['%s' % 'a']"`. The string is part
+    // of the type expression, not a runtime string.
+    // https://github.com/astral-sh/ruff/issues/10586
+    if checker.semantic().in_string_type_definition() {
+        return;
+    }
+
     let right = &*bin_op.right;
 
     let mut num_positional_arguments = 0;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -41,6 +41,13 @@ impl AlwaysFixableViolation for UnicodeKindPrefix {
 
 /// UP025
 pub(crate) fn unicode_kind_prefix(checker: &Checker, string: &StringLiteral) {
+    // Don't flag string literals inside a string type definition (forward
+    // reference), e.g. `x: "Literal[u'x']"`. The `u` prefix is part of the
+    // type expression, not a redundant prefix on a runtime string.
+    // https://github.com/astral-sh/ruff/issues/10586
+    if checker.semantic().in_string_type_definition() {
+        return;
+    }
     if string.flags.prefix().is_unicode() {
         let mut diagnostic = checker.report_diagnostic(UnicodeKindPrefix, string.range);
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP025.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP025.py.snap
@@ -307,6 +307,7 @@ UP025 [*] Remove unicode literals from strings
 33 | """"""""""""""""""""u"hi"
    |                     ^^^^^
 34 | ""U"helloooo"
+35 | # https://github.com/astral-sh/ruff/issues/10586
    |
 help: Remove unicode prefix
    |
@@ -323,9 +324,26 @@ UP025 [*] Remove unicode literals from strings
 33 | """"""""""""""""""""u"hi"
 34 | ""U"helloooo"
    |   ^^^^^^^^^^^
+35 | # https://github.com/astral-sh/ruff/issues/10586
+36 | # A unicode prefix inside a string type definition (forward reference) is part
+   |
 help: Remove unicode prefix
    |
 33 | """"""""""""""""""""u"hi"
    - ""U"helloooo"
 34 + "" "helloooo"
+35 | # https://github.com/astral-sh/ruff/issues/10586
+   |
+
+UP025 [*] Remove unicode literals from strings
+  --> UP025.py:45:12
+   |
+44 | def f(x: "te.Literal[u'x']") -> "te.Literal[u'y']":
+45 |     return u"y"  # UP025 (runtime string, outside the annotation)
+   |            ^^^^
+help: Remove unicode prefix
+   |
+44 | def f(x: "te.Literal[u'x']") -> "te.Literal[u'y']":
+   -     return u"y"  # UP025 (runtime string, outside the annotation)
+45 +     return "y"  # UP025 (runtime string, outside the annotation)
    |

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
@@ -902,25 +902,6 @@ help: Replace with format specifiers
 note: This is an unsafe fix and may change runtime behavior
 
 UP031 [*] Use format specifiers instead of percent format
-   --> UP031_0.py:131:5
-    |
-129 | # Not a valid type annotation but this test shouldn't result in a panic.
-130 | # Refer: https://github.com/astral-sh/ruff/issues/11736
-131 | x: "'%s + %s' % (1, 2)"
-    |     ^^^^^^^^^^^^^^^^^^
-132 |
-133 | # See: https://github.com/astral-sh/ruff/issues/12421
-    |
-help: Replace with format specifiers
-    |
-130 | # Refer: https://github.com/astral-sh/ruff/issues/11736
-    - x: "'%s + %s' % (1, 2)"
-131 + x: "'{} + {}'.format(1, 2)"
-132 |
-    |
-note: This is an unsafe fix and may change runtime behavior
-
-UP031 [*] Use format specifiers instead of percent format
    --> UP031_0.py:134:7
     |
 133 | # See: https://github.com/astral-sh/ruff/issues/12421
@@ -1212,4 +1193,7 @@ UP031 Use format specifiers instead of percent format
 170 |
 171 | "%(and)s" % {"and": 2}
     | ^^^^^^^^^
+172 |
+173 | # Don't flag printf-style formatting inside string type definitions (forward references).
+    |
 help: Replace with format specifiers

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
@@ -1202,24 +1202,6 @@ help: Convert to f-string
     |
 
 UP032 [*] Use f-string instead of `format` call
-   --> UP032_0.py:270:5
-    |
-268 | # Not a valid type annotation but this test shouldn't result in a panic.
-269 | # Refer: https://github.com/astral-sh/ruff/issues/11736
-270 | x: "'{} + {}'.format(x, y)"
-    |     ^^^^^^^^^^^^^^^^^^^^^^
-271 |
-272 | # Regression https://github.com/astral-sh/ruff/issues/21000
-    |
-help: Convert to f-string
-    |
-269 | # Refer: https://github.com/astral-sh/ruff/issues/11736
-    - x: "'{} + {}'.format(x, y)"
-270 + x: "f'{x} + {y}'"
-271 |
-    |
-
-UP032 [*] Use f-string instead of `format` call
    --> UP032_0.py:276:14
     |
 274 | if __name__ == "__main__":
@@ -1259,9 +1241,13 @@ UP032 [*] Use f-string instead of `format` call
 282 | # Raw string with \N{...}
 283 | r"\N{angle}AOB = {angle}°".format(angle=180)
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+284 |
+285 | # Don't flag str.format inside string type definitions (forward references).
+    |
 help: Convert to f-string
     |
 282 | # Raw string with \N{...}
     - r"\N{angle}AOB = {angle}°".format(angle=180)
 283 + rf"\N{180}AOB = {180}°"
+284 |
     |


### PR DESCRIPTION
## Summary

Fixes #10586.

String rules (rules that inspect string literals' content or quote style) fire
false positives inside *string type definitions* (forward references), e.g.
`x: "Literal[f'x']"`. The forward reference is re-parsed as an expression and
re-walked, so these rules see the strings inside the annotation and may even
produce fixes that corrupt the type annotation (e.g. rewriting
`x: "'%s + %s' % (1, 2)"` into a `format` call).

This PR covers the remaining rules still affected, using the existing
`checker.semantic().in_string_type_definition()` guard (same pattern as the
already-merged fixes below):

- `UP025` (unicode string prefixes)
- `F541` (f-string without any placeholders)
- `UP031` (printf-style formatting)
- `UP032` (`str.format` → f-string)

Rules already handled by prior PRs are out of scope:
[#15405](https://github.com/astral-sh/ruff/pull/15405) (`SIM222`/`SIM223`),
[#16122](https://github.com/astral-sh/ruff/pull/16122) (`RUF001`-`RUF003`),
[#16054](https://github.com/astral-sh/ruff/pull/16054) (`RUF027`), and the
flake8-quotes rules (`Q000`/`Q002`/`Q004`).

This also removes two pre-existing false positives in the `UP031_0` /
`UP032_0` fixtures (introduced by #11736) whose "safe" fixes would rewrite the
type annotation itself.

## Test Plan

`cargo nextest run` for `ruff_linter` (2794 passed, 0 failed) and
`cargo insta test`.

> **AI-assisted disclosure**: this PR was drafted with AI assistance (code and
> tests). The author has reviewed and verified every change and takes full
> responsibility for the contribution.
