### PR TITLE
Mark FURB103 autofix as always-unsafe

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB103_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB103_0.py
@@ -162,3 +162,11 @@ with open("tmp_path/pyproject.toml", "w") as f:
         other = 1.234
         """,
     ))
+
+# See: https://github.com/astral-sh/ruff/issues/26920
+# Writing `bytes` into a text-mode file raises `TypeError` *after* `open("w")`
+# has already truncated the file, so data is lost. `Path.write_text` type-checks
+# before opening and does not truncate on a wrong-type argument, which is why the
+# fix below must be unsafe.
+with open("file.txt", "w") as f:
+    f.write(b"\103")

--- a/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
@@ -35,7 +35,13 @@ use crate::{FixAvailability, Locator, Violation};
 /// ```
 ///
 /// ## Fix Safety
-/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the original expression.
+/// This rule's fix is marked as unsafe because the rewrite can change runtime
+/// behavior when the `write` argument does not match the open mode. `open(path, "w")`
+/// truncates the file *before* `write` runs, so if `write` raises (for example,
+/// passing `bytes` to a text-mode file), the file is already truncated and data is
+/// lost. The replacement `Path(path).write_text(...)` type-checks the argument
+/// *before* opening the file, so on a wrong-type argument the file is not truncated.
+/// Marking the fix unsafe avoids silently changing this behavior.
 ///
 /// ## References
 /// - [Python documentation: `Path.write_bytes`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.write_bytes)
@@ -231,11 +237,13 @@ fn generate_fix(
 
     let replacement = format!("{target}.{suggestion}");
 
-    let applicability = if checker.comment_ranges().intersects(with_stmt.range()) {
-        Applicability::Unsafe
-    } else {
-        Applicability::Safe
-    };
+    // The fix is always unsafe: `open(path, "w")` truncates the file *before* `write`
+    // runs, so a `write` that raises (e.g. passing `bytes` to a text-mode file) still
+    // leaves the file truncated. The replacement `Path(path).write_text(...)` type
+    // checks the argument before opening the file, so a wrong-type argument no longer
+    // truncates the file. Marking the fix unsafe avoids silently changing that
+    // behavior (see astral-sh/ruff#26920).
+    let applicability = Applicability::Unsafe;
 
     Some(Fix::applicable_edits(
         Edit::range_replacement(replacement, with_stmt.range()),

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB103_FURB103_0.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB103_FURB103_0.py.snap
@@ -20,6 +20,7 @@ help: Replace with `Path("file.txt").write_text("test")`
 13 + pathlib.Path("file.txt").write_text("test")
 14 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_bytes(foobar)`
   --> FURB103_0.py:16:6
@@ -40,6 +41,7 @@ help: Replace with `Path("file.txt").write_bytes(foobar)`
 17 + pathlib.Path("file.txt").write_bytes(foobar)
 18 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_bytes(b"abc")`
   --> FURB103_0.py:20:6
@@ -60,6 +62,7 @@ help: Replace with `Path("file.txt").write_bytes(b"abc")`
 21 + pathlib.Path("file.txt").write_bytes(b"abc")
 22 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, encoding="utf8")`
   --> FURB103_0.py:24:6
@@ -80,6 +83,7 @@ help: Replace with `Path("file.txt").write_text(foobar, encoding="utf8")`
 25 + pathlib.Path("file.txt").write_text(foobar, encoding="utf8")
 26 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, errors="ignore")`
   --> FURB103_0.py:28:6
@@ -100,6 +104,7 @@ help: Replace with `Path("file.txt").write_text(foobar, errors="ignore")`
 29 + pathlib.Path("file.txt").write_text(foobar, errors="ignore")
 30 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar)`
   --> FURB103_0.py:32:6
@@ -120,6 +125,7 @@ help: Replace with `Path("file.txt").write_text(foobar)`
 33 + pathlib.Path("file.txt").write_text(foobar)
 34 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 `open` and `write` should be replaced by `Path(foo()).write_bytes(bar())`
   --> FURB103_0.py:36:6
@@ -184,6 +190,7 @@ help: Replace with `Path("file.txt").write_text(foobar, newline="\r\n")`
 59 + pathlib.Path("file.txt").write_text(foobar, newline="\r\n")
 60 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, newline="\r\n")`
   --> FURB103_0.py:66:6
@@ -205,6 +212,7 @@ help: Replace with `Path("file.txt").write_text(foobar, newline="\r\n")`
 67 + pathlib.Path("file.txt").write_text(foobar, newline="\r\n")
 68 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, newline="\r\n")`
   --> FURB103_0.py:74:6
@@ -226,6 +234,7 @@ help: Replace with `Path("file.txt").write_text(foobar, newline="\r\n")`
 75 + pathlib.Path("file.txt").write_text(foobar, newline="\r\n")
 76 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("test.json")....`
    --> FURB103_0.py:154:6
@@ -248,6 +257,7 @@ help: Replace with `Path("test.json")....`
 155 + pathlib.Path("test.json").write_bytes(json.dumps(data, indent=4).encode("utf-8"))
 156 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("tmp_path/pyproject.toml")....`
    --> FURB103_0.py:158:6
@@ -270,3 +280,26 @@ help: Replace with `Path("tmp_path/pyproject.toml")....`
 159 + pathlib.Path("tmp_path/pyproject.toml").write_text(dedent(
 160 |         """
     |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(b"\103")`
+   --> FURB103_0.py:171:6
+    |
+169 | # before opening and does not truncate on a wrong-type argument, which is why the
+170 | # fix below must be unsafe.
+171 | with open("file.txt", "w") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+172 |     f.write(b"\103")
+    |
+help: Replace with `Path("file.txt").write_text(b"\103")`
+    |
+150 | import json
+151 + import pathlib
+152 |
+--------------------------------------------------------------------------------
+171 | # fix below must be unsafe.
+    - with open("file.txt", "w") as f:
+    -     f.write(b"\103")
+172 + pathlib.Path("file.txt").write_text(b"\103")
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB103_FURB103_1.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB103_FURB103_1.py.snap
@@ -18,6 +18,7 @@ help: Replace with `Path("file.txt").write_text("test")`
 3 + Path("file.txt").write_text("test")
 4 |
   |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `Path.open()` followed by `write()` can be replaced by `Path("file.txt").write_bytes(b"test")`
  --> FURB103_1.py:6:6
@@ -36,6 +37,7 @@ help: Replace with `Path("file.txt").write_bytes(b"test")`
 6 + Path("file.txt").write_bytes(b"test")
 7 |
   |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `Path.open()` followed by `write()` can be replaced by `Path("file.txt").write_text("test")`
   --> FURB103_1.py:9:6
@@ -54,6 +56,7 @@ help: Replace with `Path("file.txt").write_text("test")`
 9  + Path("file.txt").write_text("test")
 10 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `Path.open()` followed by `write()` can be replaced by `Path("file.txt").write_text("test", encoding="utf8")`
   --> FURB103_1.py:12:6
@@ -72,6 +75,7 @@ help: Replace with `Path("file.txt").write_text("test", encoding="utf8")`
 12 + Path("file.txt").write_text("test", encoding="utf8")
 13 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `Path.open()` followed by `write()` can be replaced by `Path("file.txt").write_text("test", errors="ignore")`
   --> FURB103_1.py:15:6
@@ -90,6 +94,7 @@ help: Replace with `Path("file.txt").write_text("test", errors="ignore")`
 15 + Path("file.txt").write_text("test", errors="ignore")
 16 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `Path.open()` followed by `write()` can be replaced by `Path(foo()).write_text("test")`
   --> FURB103_1.py:18:6
@@ -108,6 +113,7 @@ help: Replace with `Path(foo()).write_text("test")`
 18 + Path(foo()).write_text("test")
 19 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `Path.open()` followed by `write()` can be replaced by `p.write_text("test")`
   --> FURB103_1.py:22:6
@@ -125,6 +131,7 @@ help: Replace with `p.write_text("test")`
 22 + p.write_text("test")
 23 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `Path.open()` followed by `write()` can be replaced by `Path("foo", "bar", "baz").write_text("test")`
   --> FURB103_1.py:25:6
@@ -142,3 +149,4 @@ help: Replace with `Path("foo", "bar", "baz").write_text("test")`
    -     f.write("test")
 25 + Path("foo", "bar", "baz").write_text("test")
    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB103_FURB103_2.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB103_FURB103_2.py.snap
@@ -20,6 +20,7 @@ help: Replace with `Path("file.txt").write_text("\n", encoding="utf-8")`
 4 + pathlib.Path("file.txt").write_text("\n", encoding="utf-8")
 5 | f = object()
   |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text("\n")`
   --> FURB103_2.py:16:10
@@ -43,6 +44,7 @@ help: Replace with `Path("file.txt").write_text("\n")`
 17 +     pathlib.Path("file.txt").write_text("\n")
 18 |     return (f.name for _ in [0])
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text("\n")`
   --> FURB103_2.py:23:10
@@ -66,3 +68,4 @@ help: Replace with `Path("file.txt").write_text("\n")`
 24 +     pathlib.Path("file.txt").write_text("\n")
 25 |     g = {f.name for _ in [0]}
    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__write_whole_file_python_39.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__write_whole_file_python_39.snap
@@ -20,6 +20,7 @@ help: Replace with `Path("file.txt").write_text("test")`
 13 + pathlib.Path("file.txt").write_text("test")
 14 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_bytes(foobar)`
   --> FURB103_0.py:16:6
@@ -40,6 +41,7 @@ help: Replace with `Path("file.txt").write_bytes(foobar)`
 17 + pathlib.Path("file.txt").write_bytes(foobar)
 18 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_bytes(b"abc")`
   --> FURB103_0.py:20:6
@@ -60,6 +62,7 @@ help: Replace with `Path("file.txt").write_bytes(b"abc")`
 21 + pathlib.Path("file.txt").write_bytes(b"abc")
 22 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, encoding="utf8")`
   --> FURB103_0.py:24:6
@@ -80,6 +83,7 @@ help: Replace with `Path("file.txt").write_text(foobar, encoding="utf8")`
 25 + pathlib.Path("file.txt").write_text(foobar, encoding="utf8")
 26 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, errors="ignore")`
   --> FURB103_0.py:28:6
@@ -100,6 +104,7 @@ help: Replace with `Path("file.txt").write_text(foobar, errors="ignore")`
 29 + pathlib.Path("file.txt").write_text(foobar, errors="ignore")
 30 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar)`
   --> FURB103_0.py:32:6
@@ -120,6 +125,7 @@ help: Replace with `Path("file.txt").write_text(foobar)`
 33 + pathlib.Path("file.txt").write_text(foobar)
 34 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 `open` and `write` should be replaced by `Path(foo()).write_bytes(bar())`
   --> FURB103_0.py:36:6
@@ -186,6 +192,7 @@ help: Replace with `Path("test.json")....`
 155 + pathlib.Path("test.json").write_bytes(json.dumps(data, indent=4).encode("utf-8"))
 156 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("tmp_path/pyproject.toml")....`
    --> FURB103_0.py:158:6
@@ -208,3 +215,26 @@ help: Replace with `Path("tmp_path/pyproject.toml")....`
 159 + pathlib.Path("tmp_path/pyproject.toml").write_text(dedent(
 160 |         """
     |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(b"\103")`
+   --> FURB103_0.py:171:6
+    |
+169 | # before opening and does not truncate on a wrong-type argument, which is why the
+170 | # fix below must be unsafe.
+171 | with open("file.txt", "w") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+172 |     f.write(b"\103")
+    |
+help: Replace with `Path("file.txt").write_text(b"\103")`
+    |
+150 | import json
+151 + import pathlib
+152 |
+--------------------------------------------------------------------------------
+171 | # fix below must be unsafe.
+    - with open("file.txt", "w") as f:
+    -     f.write(b"\103")
+172 + pathlib.Path("file.txt").write_text(b"\103")
+    |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Fixes #26920.

## Summary

The FURB103 autofix rewrites:

```python
with open("file.txt", "w") as f:
    f.write(x)
```

into:

```python
Path("file.txt").write_text(x)
```

This is a semantic change in the wrong-type case. `open(path, "w")` truncates the file *before* `write` runs, so if `write` raises — for example passing `bytes` to a text-mode file, `f.write(b"\103")` — the file is already truncated and the existing contents are lost. The `Path(path).write_text(...)` replacement type-checks its argument before opening the file, so a wrong-type argument raises before any truncation happens. Autofixing from one to the other silently changes whether the file is destroyed on the error path.

Today the fix is only marked `Unsafe` when comments are attached to the `with` statement; otherwise it is `Safe`. #26920 proposes marking the fix unsafe except when Ruff can prove the argument type matches the open mode. As a conservative first cut, this PR marks the FURB103 autofix `Unsafe` in all cases (a strict subset of the proposed behavior, which the issue calls out as acceptable). This should also help unblock re-stabilization of FURB103, which was reverted the day before the issue was filed.

The change is a one-liner in `generate_fix`: `Applicability::Safe` becomes `Applicability::Unsafe` unconditionally, and the comment-range special case is dropped. I added a regression fixture case (the `f.write(b"\103")` example from the issue) and regenerated the affected snapshots.

## AI disclosure

I used an AI coding assistant during development of this change (locating the rule, drafting the docstring/comment wording, and walking through the snapshot regeneration workflow). The change itself, the test case, and this PR description are my own.

## Test plan

- `cargo build -p ruff_linter`
- `cargo test -p ruff_linter --lib rules::refurb` — 45 passed, 0 failed (with snapshots regenerated via `INSTA_FORCE_PASS=1 INSTA_UPDATE=always`)
- `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings` — clean
- `cargo fmt -p ruff_linter` — no changes
