### PR TITLE
Add BOLT optimization to PGO Ruff releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -19,6 +19,7 @@ on:
       # And when we change this workflow itself...
       - .github/workflows/build-binaries.yml
       - scripts/build_ruff_pgo.py
+      - scripts/build_ruff_bolt.py
 
 concurrency:
   group: build-binaries-${{ github.ref }}
@@ -243,6 +244,39 @@ jobs:
       - name: "Install LLVM profiling tools"
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: rustup component add llvm-tools-preview
+      - name: "Install LLVM BOLT"
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: |
+          set -euo pipefail
+
+          BOLT_ROOT="${RUNNER_TEMP}/llvm-bolt"
+          BOLT_VERSION="22.1.8~++20260714014902+ca7933e47d3a-1~exp1~20260714135019.80"
+          BOLT_BASE_URL="https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-22"
+
+          mkdir -p "${BOLT_ROOT}"
+
+          curl --fail --location --retry 3 \
+            --output "${BOLT_ROOT}/bolt-22.deb" \
+            "${BOLT_BASE_URL}/bolt-22_${BOLT_VERSION}_amd64.deb"
+          curl --fail --location --retry 3 \
+            --output "${BOLT_ROOT}/libbolt-22-dev.deb" \
+            "${BOLT_BASE_URL}/libbolt-22-dev_${BOLT_VERSION}_amd64.deb"
+
+          printf '%s  %s\n' \
+            '97a9e4e8d2b2219757c38abef93e913793ebc64580aa51207bd23941c44ec070' \
+            "${BOLT_ROOT}/bolt-22.deb" \
+            '48639dafeb45892eec58f5d8a2d0d612ce791a2f713f06c794b71d6a72fa582d' \
+            "${BOLT_ROOT}/libbolt-22-dev.deb" \
+            | sha256sum --check
+
+          dpkg-deb --extract "${BOLT_ROOT}/bolt-22.deb" "${BOLT_ROOT}"
+          dpkg-deb --extract "${BOLT_ROOT}/libbolt-22-dev.deb" "${BOLT_ROOT}"
+
+          "${BOLT_ROOT}/usr/lib/llvm-22/bin/llvm-bolt" --version
+          "${BOLT_ROOT}/usr/lib/llvm-22/bin/merge-fdata" --version
+          test -f "${BOLT_ROOT}/usr/lib/llvm-22/lib/libbolt_rt_instr.a"
+
+          echo "${BOLT_ROOT}/usr/lib/llvm-22/bin" >> "${GITHUB_PATH}"
       - name: "Train PGO Ruff"
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
@@ -251,7 +285,8 @@ jobs:
             --target-dir "${{ github.workspace }}/target/ruff-pgo" \
             --train-only
 
-          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/target/ruff-pgo/ruff.profdata" >> "$GITHUB_ENV"
+          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/target/ruff-pgo/ruff.profdata -C link-arg=-Wl,--emit-relocs" >> "$GITHUB_ENV"
+          echo "MATURIN_STRIP=false" >> "$GITHUB_ENV"
       - name: "Prep README.md"
         run: python scripts/transform_readme.py --target pypi
       - name: "Build wheels"
@@ -261,6 +296,14 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: 2_17
           args: --release --locked --out dist --compatibility pypi
+      - name: "Optimize Ruff with BOLT"
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: |
+          python scripts/build_ruff_bolt.py \
+            --target "${{ matrix.target }}" \
+            --target-dir "${{ github.workspace }}/target/ruff-pgo" \
+            --wheels-dir "${{ github.workspace }}/dist" \
+            --binary "${{ github.workspace }}/target/${{ matrix.target }}/release/ruff"
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -18,6 +18,7 @@ on:
       - pyproject.toml
       # And when we change this workflow itself...
       - .github/workflows/build-binaries.yml
+      - scripts/build_ruff_pgo.py
 
 concurrency:
   group: build-binaries-${{ github.ref }}
@@ -239,6 +240,18 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - name: "Install LLVM profiling tools"
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: rustup component add llvm-tools-preview
+      - name: "Train PGO Ruff"
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: |
+          python scripts/build_ruff_pgo.py \
+            --target "${{ matrix.target }}" \
+            --target-dir "${{ github.workspace }}/target/ruff-pgo" \
+            --train-only
+
+          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/target/ruff-pgo/ruff.profdata" >> "$GITHUB_ENV"
       - name: "Prep README.md"
         run: python scripts/transform_readme.py --target pypi
       - name: "Build wheels"

--- a/scripts/build_ruff_bolt.py
+++ b/scripts/build_ruff_bolt.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Apply BOLT optimization to Ruff's Linux executable and its existing wheel."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import copy
+import csv
+import hashlib
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+
+from build_ruff_pgo import REPOSITORY_ROOT, run, rustc_host
+
+ELF_MAGIC = b"\x7fELF"
+IN_PLACE_MESSAGE = "BOLT-INFO: using original .text for new code"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--target-dir", type=Path, required=True)
+    parser.add_argument("--wheels-dir", type=Path, required=True)
+    parser.add_argument("--binary", type=Path)
+    args = parser.parse_args()
+
+    target_dir = args.target_dir.resolve()
+    wheels_dir = args.wheels_dir.resolve()
+    binary = (
+        args.binary or REPOSITORY_ROOT / "target" / args.target / "release" / "ruff"
+    ).resolve()
+    corpus_arguments = target_dir / "ruff-pgo.args"
+    pgo_profile = target_dir / "ruff.profdata"
+    for required in (binary, corpus_arguments, pgo_profile):
+        if not required.is_file():
+            raise RuntimeError(f"Missing BOLT prerequisite: {required}")
+
+    host = rustc_host()
+    if args.target != host:
+        parser.error(f"BOLT training requires host target {host}, got {args.target}")
+
+    wheels = sorted(wheels_dir.glob("ruff-*.whl"))
+    if not wheels:
+        raise RuntimeError(f"No Ruff wheels found in {wheels_dir}")
+
+    bolt = find_executable("llvm-bolt")
+    merge_fdata = bolt.parent / "merge-fdata"
+    if not executable(merge_fdata):
+        merge_fdata = find_executable("merge-fdata")
+    runtime = bolt.parent.parent / "lib" / "libbolt_rt_instr.a"
+    if not runtime.is_file():
+        raise RuntimeError(f"BOLT instrumentation runtime not found: {runtime}")
+
+    sysroot = subprocess.run(
+        ["rustc", "--print", "sysroot"],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    llvm_strip = Path(sysroot) / "lib" / "rustlib" / host / "bin" / "llvm-strip"
+    if not executable(llvm_strip):
+        raise RuntimeError(
+            f"Rust LLVM strip not found: {llvm_strip}; "
+            "run `rustup component add llvm-tools-preview`"
+        )
+
+    readelf = find_executable("readelf")
+    validate_input(readelf, binary)
+    original_version = version(binary)
+    environment = os.environ.copy()
+    bolt_dir = target_dir / "bolt"
+    bolt_dir.mkdir(parents=True, exist_ok=True)
+    instrumented = bolt_dir / "ruff.instrumented"
+    profile_prefix = bolt_dir / "ruff.fdata"
+    merged_profile = bolt_dir / "ruff.merged.fdata"
+    optimized = bolt_dir / "ruff.bolt.unstripped"
+    for profile in bolt_dir.glob("ruff.fdata*"):
+        if profile.is_file():
+            profile.unlink()
+
+    print("Instrumenting Ruff with BOLT", flush=True)
+    run(
+        [
+            str(bolt),
+            str(binary),
+            "-instrument",
+            f"--instrumentation-file={profile_prefix}",
+            "--instrumentation-file-append-pid",
+            f"--runtime-instrumentation-lib={runtime}",
+            "-o",
+            str(instrumented),
+        ],
+        environment=environment,
+    )
+
+    common_arguments = [
+        "--isolated",
+        "--target-version",
+        "py314",
+        "--no-cache",
+        "--silent",
+    ]
+    run(
+        [
+            str(instrumented),
+            "check",
+            *common_arguments,
+            "--exit-zero",
+            f"@{corpus_arguments}",
+        ],
+        environment=environment,
+    )
+    run(
+        [
+            str(instrumented),
+            "format",
+            *common_arguments,
+            "--check",
+            f"@{corpus_arguments}",
+        ],
+        environment=environment,
+        allowed_exit_codes=(0, 1),
+    )
+
+    profiles = sorted(bolt_dir.glob("ruff.fdata*"))
+    if len(profiles) < 2 or any(profile.stat().st_size == 0 for profile in profiles):
+        raise RuntimeError("Expected complete BOLT profiles from check and format")
+    print(f"Merging {len(profiles)} BOLT profiles", flush=True)
+    with merged_profile.open("wb") as output:
+        subprocess.run(
+            [str(merge_fdata), *map(str, profiles)],
+            cwd=REPOSITORY_ROOT,
+            env=environment,
+            stdout=output,
+            check=True,
+        )
+    if merged_profile.stat().st_size == 0:
+        raise RuntimeError("BOLT profile merger produced an empty profile")
+
+    command = [
+        str(bolt),
+        str(binary),
+        f"-data={merged_profile}",
+        "-o",
+        str(optimized),
+        "-reorder-blocks=ext-tsp",
+        "-reorder-functions=cdsort",
+        "-split-functions",
+        "-split-strategy=cdsplit",
+        "-split-all-cold",
+        "-jump-tables=move",
+        "-icf=all",
+        "-dyno-stats",
+        "--use-old-text",
+        "--no-huge-pages",
+    ]
+    print("Optimizing Ruff with BOLT", flush=True)
+    result = subprocess.run(
+        command,
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    print(result.stdout, end="", flush=True)
+    if result.returncode:
+        raise subprocess.CalledProcessError(result.returncode, command)
+    if IN_PLACE_MESSAGE not in result.stdout:
+        raise RuntimeError("BOLT could not reuse the original executable code")
+
+    temporary_binary = temporary_path(binary.parent, ".ruff-bolt-", ".tmp")
+    staged_wheels: list[tuple[Path, Path]] = []
+    try:
+        run(
+            [
+                str(llvm_strip),
+                "--strip-all",
+                "-o",
+                str(temporary_binary),
+                str(optimized),
+            ],
+            environment=environment,
+        )
+        temporary_binary.chmod(binary.stat().st_mode & 0o777)
+        validate_security(readelf, temporary_binary)
+        if version(temporary_binary) != original_version:
+            raise RuntimeError("BOLT changed Ruff's executable version")
+
+        smoke_input = bolt_dir / "smoke.py"
+        smoke_input.write_text("value = 1\n", encoding="utf-8")
+        run(
+            [
+                str(temporary_binary),
+                "check",
+                "--isolated",
+                "--no-cache",
+                "--silent",
+                str(smoke_input),
+            ],
+            environment=environment,
+        )
+        run(
+            [
+                str(temporary_binary),
+                "format",
+                "--isolated",
+                "--no-cache",
+                "--check",
+                "--silent",
+                str(smoke_input),
+            ],
+            environment=environment,
+        )
+
+        for wheel in wheels:
+            staged_wheels.append((wheel, rebuild_wheel(wheel, temporary_binary)))
+
+        for wheel, staged in staged_wheels:
+            staged.replace(wheel)
+        temporary_binary.replace(binary)
+        print(f"BOLT-optimized Ruff: {binary} ({binary.stat().st_size} bytes)")
+    finally:
+        temporary_binary.unlink(missing_ok=True)
+        for _, staged in staged_wheels:
+            staged.unlink(missing_ok=True)
+
+
+def executable(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def find_executable(name: str) -> Path:
+    for candidate in (name, f"{name}-22"):
+        if resolved := shutil.which(candidate):
+            return Path(resolved).resolve()
+    raise RuntimeError(f"Required executable not found on PATH: {name}")
+
+
+def validate_input(readelf: Path, binary: Path) -> None:
+    output = subprocess.run(
+        [str(readelf), "--sections", "--wide", str(binary)],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    if ".symtab" not in output:
+        raise RuntimeError(f"BOLT input lacks symbols: {binary}")
+    if ".real.text" not in output and ".rel.text" not in output:
+        raise RuntimeError(
+            f"BOLT input lacks text relocations: {binary}; "
+            "link with `-Clink-arg=-Wl,--emit-relocs`"
+        )
+
+
+def validate_security(readelf: Path, binary: Path) -> None:
+    output = subprocess.run(
+        [str(readelf), "--program-headers", "--wide", str(binary)],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    stack = next((line for line in output.splitlines() if "GNU_STACK" in line), "")
+    if not stack or "E" in stack.split()[-2]:
+        raise RuntimeError("BOLT executable has a missing or executable GNU stack")
+    if "GNU_RELRO" not in output:
+        raise RuntimeError("BOLT executable no longer has GNU RELRO protection")
+
+
+def version(binary: Path) -> str:
+    return subprocess.run(
+        [str(binary), "--version"],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def temporary_path(directory: Path, prefix: str, suffix: str) -> Path:
+    with tempfile.NamedTemporaryFile(
+        dir=directory, prefix=prefix, suffix=suffix, delete=False
+    ) as temporary:
+        return Path(temporary.name)
+
+
+def rebuild_wheel(wheel: Path, binary: Path) -> Path:
+    binary_data = binary.read_bytes()
+    staged = temporary_path(wheel.parent, f".{wheel.name}.", ".tmp")
+    try:
+        with zipfile.ZipFile(wheel) as original:
+            members = original.infolist()
+            names = [member.filename for member in members if not member.is_dir()]
+            if len(names) != len(set(names)):
+                raise RuntimeError(f"Wheel has duplicate entries: {wheel}")
+
+            records = [name for name in names if name.endswith(".dist-info/RECORD")]
+            executables = []
+            for member in members:
+                if member.is_dir() or PurePosixPath(member.filename).name != "ruff":
+                    continue
+                with original.open(member) as stream:
+                    if stream.read(len(ELF_MAGIC)) == ELF_MAGIC:
+                        executables.append(member.filename)
+            if len(records) != 1 or len(executables) != 1:
+                raise RuntimeError(f"Wheel must have one RECORD and Ruff ELF: {wheel}")
+
+            record_name = records[0]
+            binary_name = executables[0]
+            content = {
+                member.filename: (
+                    binary_data
+                    if member.filename == binary_name
+                    else original.read(member)
+                )
+                for member in members
+                if not member.is_dir() and member.filename != record_name
+            }
+            rows = [
+                [name, "", ""]
+                if name == record_name
+                else [name, record_hash(content[name]), str(len(content[name]))]
+                for name in names
+            ]
+            record_stream = io.StringIO(newline="")
+            csv.writer(record_stream, lineterminator="\n").writerows(rows)
+            content[record_name] = record_stream.getvalue().encode("utf-8")
+
+            with zipfile.ZipFile(staged, mode="w") as rebuilt:
+                rebuilt.comment = original.comment
+                for member in members:
+                    rebuilt.writestr(
+                        copy.copy(member),
+                        b"" if member.is_dir() else content[member.filename],
+                        compress_type=member.compress_type,
+                        compresslevel=(
+                            6 if member.compress_type == zipfile.ZIP_DEFLATED else None
+                        ),
+                    )
+
+        validate_wheel(staged, binary_name, binary_data, names)
+        print(f"Staged BOLT-optimized wheel: {wheel.name}", flush=True)
+        return staged
+    except BaseException:
+        staged.unlink(missing_ok=True)
+        raise
+
+
+def record_hash(data: bytes) -> str:
+    encoded = base64.urlsafe_b64encode(hashlib.sha256(data).digest())
+    return f"sha256={encoded.rstrip(b'=').decode('ascii')}"
+
+
+def validate_wheel(
+    wheel: Path, binary_name: str, binary_data: bytes, expected_names: list[str]
+) -> None:
+    with zipfile.ZipFile(wheel) as archive:
+        names = [
+            member.filename for member in archive.infolist() if not member.is_dir()
+        ]
+        if names != expected_names:
+            raise RuntimeError("Repacked wheel changed its archive members")
+        record_name = next(name for name in names if name.endswith(".dist-info/RECORD"))
+        records = list(csv.reader(io.StringIO(archive.read(record_name).decode())))
+        if len(records) != len(names) or {row[0] for row in records} != set(names):
+            raise RuntimeError("Repacked wheel has incomplete RECORD entries")
+        for row in records:
+            if len(row) != 3:
+                raise RuntimeError("Repacked wheel has malformed RECORD entries")
+            name, digest, size = row
+            if name == record_name:
+                if digest or size:
+                    raise RuntimeError("Wheel RECORD must not hash itself")
+                continue
+            data = archive.read(name)
+            if digest != record_hash(data) or size != str(len(data)):
+                raise RuntimeError(f"Wheel RECORD does not match {name}")
+
+        if archive.read(binary_name) != binary_data:
+            raise RuntimeError("Repacked wheel does not contain the BOLT executable")
+        if not (archive.getinfo(binary_name).external_attr >> 16) & 0o111:
+            raise RuntimeError("Repacked Ruff wheel lost executable permissions")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (
+        OSError,
+        RuntimeError,
+        subprocess.CalledProcessError,
+        zipfile.BadZipFile,
+    ) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/build_ruff_bolt.py
+++ b/scripts/build_ruff_bolt.py
@@ -10,6 +10,7 @@ import csv
 import hashlib
 import io
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -256,7 +257,7 @@ def validate_input(readelf: Path, binary: Path) -> None:
     ).stdout
     if ".symtab" not in output:
         raise RuntimeError(f"BOLT input lacks symbols: {binary}")
-    if ".real.text" not in output and ".rel.text" not in output:
+    if not re.search(r"\.rel(?:a)?\.text", output):
         raise RuntimeError(
             f"BOLT input lacks text relocations: {binary}; "
             "link with `-Clink-arg=-Wl,--emit-relocs`"

--- a/scripts/build_ruff_pgo.py
+++ b/scripts/build_ruff_pgo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build Ruff with profile-guided optimization using tracked repository files."""
+"""Build Ruff with profile-guided optimization using pinned ecosystem projects."""
 
 from __future__ import annotations
 
@@ -9,13 +9,89 @@ import shlex
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
-CORPUS_DIRECTORIES = (
-    "crates/ruff_benchmark/resources",
-    "scripts",
-    "python/ruff-ecosystem/ruff_ecosystem",
+EXCLUDED_DIRECTORIES = frozenset({"_tests", "_vendor", "test", "tests"})
+
+
+@dataclass(frozen=True)
+class EcosystemProject:
+    name: str
+    repository: str
+    revision: str
+    source_directories: tuple[str, ...]
+
+
+CORPUS_PROJECTS = (
+    EcosystemProject(
+        name="pytest",
+        repository="pytest-dev/pytest",
+        revision="28e86a6c2ae0173831e4925a4af89b02a2936d09",
+        source_directories=("src/_pytest",),
+    ),
+    EcosystemProject(
+        name="httpx",
+        repository="encode/httpx",
+        revision="b5addb64f0161ff6bfe94c124ef76f6a1fba5254",
+        source_directories=("httpx",),
+    ),
+    EcosystemProject(
+        name="fastapi",
+        repository="fastapi/fastapi",
+        revision="a375f6b948b99fa4260129856bbf11d037f363ef",
+        source_directories=("fastapi",),
+    ),
+    EcosystemProject(
+        name="anyio",
+        repository="agronholm/anyio",
+        revision="ffe91331adb912c5d150f5d373f7cd28a0e96a62",
+        source_directories=("src/anyio",),
+    ),
+    EcosystemProject(
+        name="pip",
+        repository="pypa/pip",
+        revision="d1fd55753405fd728a0751a578e27c1054acdf48",
+        source_directories=("src/pip/_internal",),
+    ),
+    EcosystemProject(
+        name="sphinx",
+        repository="sphinx-doc/sphinx",
+        revision="b06d92e80eed130e1dd4e67cac4afa1267424f1a",
+        source_directories=(
+            "sphinx/builders",
+            "sphinx/ext/autodoc",
+            "sphinx/domains/python",
+        ),
+    ),
+    EcosystemProject(
+        name="astropy",
+        repository="astropy/astropy",
+        revision="b779108c7cec25c840c0f744fdf2a1550441e309",
+        source_directories=("astropy/units",),
+    ),
+    EcosystemProject(
+        name="prefect",
+        repository="PrefectHQ/prefect",
+        revision="db66b14dbaea18e726fc4ea0100fd194383c6c59",
+        source_directories=(
+            "src/prefect/server/models",
+            "src/prefect/concurrency",
+            "src/prefect/events",
+            "src/prefect/input",
+        ),
+    ),
+    EcosystemProject(
+        name="typeshed",
+        repository="python/typeshed",
+        revision="e0efbeef901e9b6998d016e1ab9352678f09ae77",
+        source_directories=(
+            "stdlib/asyncio",
+            "stdlib/collections",
+            "stubs/requests",
+        ),
+    ),
 )
 
 
@@ -42,14 +118,15 @@ def main() -> None:
         action="store_true",
         help="Only produce <target-dir>/ruff.profdata for a subsequent release build",
     )
+    parser.add_argument(
+        "--prepare-corpus",
+        action="store_true",
+        help="Only download and prepare the pinned ecosystem training corpus",
+    )
     args = parser.parse_args()
 
-    host = rustc_host()
-    target = args.target or host
-    if target != host:
-        parser.error(
-            f"PGO training requires the host-native target {host}, got {target}"
-        )
+    if args.prepare_corpus and args.train_only:
+        parser.error("--prepare-corpus and --train-only cannot be used together")
 
     target_dir = (
         args.target_dir
@@ -59,14 +136,29 @@ def main() -> None:
     ).resolve()
     profile_dir = (args.profile_dir or target_dir / "profiles").resolve()
     merged_profile = target_dir / "ruff.profdata"
+
+    environment = os.environ.copy()
+    if args.prepare_corpus:
+        corpus = ecosystem_python_files(target_dir / "corpus", environment=environment)
+        write_corpus_arguments(target_dir, corpus)
+        print(f"Prepared {len(corpus)} ecosystem Python files", flush=True)
+        return
+
+    host = rustc_host()
+    target = args.target or host
+    if target != host:
+        parser.error(
+            f"PGO training requires the host-native target {host}, got {target}"
+        )
+
     profiler = find_llvm_profdata(host, args.llvm_profdata)
-    corpus = tracked_python_files()
+    corpus = ecosystem_python_files(target_dir / "corpus", environment=environment)
+    corpus_arguments = write_corpus_arguments(target_dir, corpus)
 
     profile_dir.mkdir(parents=True, exist_ok=True)
     for profile in profile_dir.glob("ruff-*.profraw"):
         profile.unlink()
 
-    environment = os.environ.copy()
     environment["CARGO_INCREMENTAL"] = "0"
     if target.endswith("-apple-darwin"):
         for variable in ("CFLAGS", "CXXFLAGS"):
@@ -99,9 +191,15 @@ def main() -> None:
         "--no-cache",
         "--silent",
     ]
-    print(f"Training on {len(corpus)} tracked Python files", flush=True)
+    print(f"Training on {len(corpus)} ecosystem Python files", flush=True)
     run(
-        [str(instrumented_binary), "check", *common_arguments, "--exit-zero", *corpus],
+        [
+            str(instrumented_binary),
+            "check",
+            *common_arguments,
+            "--exit-zero",
+            f"@{corpus_arguments}",
+        ],
         environment=training_environment,
     )
     run(
@@ -110,7 +208,7 @@ def main() -> None:
             "format",
             *common_arguments,
             "--check",
-            *corpus,
+            f"@{corpus_arguments}",
         ],
         environment=training_environment,
         allowed_exit_codes=(0, 1),
@@ -192,21 +290,122 @@ def find_llvm_profdata(host: str, override: Path | None) -> Path:
     return profiler
 
 
-def tracked_python_files() -> list[str]:
-    tracked_files = subprocess.run(
-        ["git", "ls-files", "-z", "--", *CORPUS_DIRECTORIES],
-        cwd=REPOSITORY_ROOT,
-        check=True,
-        capture_output=True,
-    ).stdout.split(b"\0")
-    paths = [
-        os.fsdecode(path)
-        for path in tracked_files
-        if path and Path(os.fsdecode(path)).suffix in {".py", ".pyi"}
-    ]
-    if not paths:
-        raise RuntimeError("No tracked Python files found in the Ruff training corpus")
+def ecosystem_python_files(
+    corpus_directory: Path, *, environment: dict[str, str]
+) -> list[str]:
+    corpus_directory.mkdir(parents=True, exist_ok=True)
+    git_environment = environment | {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_LFS_SKIP_SMUDGE": "1",
+    }
+    paths: list[str] = []
+
+    for project in CORPUS_PROJECTS:
+        checkout = corpus_directory / project.name
+        checkout.mkdir(parents=True, exist_ok=True)
+        git = ["git", "-c", f"core.hooksPath={os.devnull}", "-C", str(checkout)]
+
+        if not (checkout / ".git").is_dir():
+            print(f"Preparing {project.repository}@{project.revision}", flush=True)
+            run([*git, "init", "--quiet"], environment=git_environment)
+            run(
+                [
+                    *git,
+                    "remote",
+                    "add",
+                    "origin",
+                    f"https://github.com/{project.repository}.git",
+                ],
+                environment=git_environment,
+            )
+
+        run(
+            [*git, "sparse-checkout", "set", "--cone", *project.source_directories],
+            environment=git_environment,
+        )
+
+        current_revision = subprocess.run(
+            [*git, "rev-parse", "--verify", "HEAD"],
+            cwd=REPOSITORY_ROOT,
+            env=git_environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if (
+            current_revision.returncode != 0
+            or current_revision.stdout.strip() != project.revision
+        ):
+            run(
+                [
+                    *git,
+                    "fetch",
+                    "--quiet",
+                    "--no-tags",
+                    "--no-recurse-submodules",
+                    "--depth=1",
+                    "--filter=blob:none",
+                    "origin",
+                    project.revision,
+                ],
+                environment=git_environment,
+            )
+
+        run(
+            [
+                *git,
+                "checkout",
+                "--quiet",
+                "--detach",
+                "--force",
+                "--no-recurse-submodules",
+                project.revision,
+            ],
+            environment=git_environment,
+        )
+
+        for source_directory in project.source_directories:
+            source = checkout / source_directory
+            if not source.is_dir():
+                raise RuntimeError(
+                    f"Missing training source directory {source_directory!r} "
+                    f"in {project.repository}@{project.revision}"
+                )
+
+        tracked_files = subprocess.run(
+            [*git, "ls-files", "-z", "--", *project.source_directories],
+            cwd=REPOSITORY_ROOT,
+            env=git_environment,
+            check=True,
+            capture_output=True,
+        ).stdout.split(b"\0")
+        project_paths = [
+            str(path)
+            for tracked_file in tracked_files
+            if tracked_file
+            and (path := checkout / os.fsdecode(tracked_file)).suffix in {".py", ".pyi"}
+            and path.is_file()
+            and not path.is_symlink()
+            and not EXCLUDED_DIRECTORIES.intersection(
+                path.relative_to(checkout).parts[:-1]
+            )
+        ]
+
+        if not project_paths:
+            raise RuntimeError(
+                f"No Python training files found in {project.repository}"
+            )
+        paths.extend(sorted(project_paths))
+        print(f"  {project.name}: {len(project_paths)} Python files", flush=True)
+
     return paths
+
+
+def write_corpus_arguments(target_directory: Path, corpus: list[str]) -> Path:
+    arguments = target_directory / "ruff-pgo.args"
+    arguments.write_text("\n".join(corpus) + "\n", encoding="utf-8", newline="\n")
+    return arguments
 
 
 def cargo_command(target: str) -> list[str]:
@@ -237,7 +436,13 @@ def run(
     environment: dict[str, str],
     allowed_exit_codes: tuple[int, ...] = (0,),
 ) -> None:
-    print(f"> {shlex.join(command)}", flush=True)
+    logged_arguments = 16
+    displayed_command = shlex.join(command[:logged_arguments])
+    if len(command) > logged_arguments:
+        displayed_command += (
+            f" ... ({len(command) - logged_arguments} arguments omitted)"
+        )
+    print(f"> {displayed_command}", flush=True)
     completed = subprocess.run(
         command, cwd=REPOSITORY_ROOT, env=environment, check=False
     )

--- a/scripts/build_ruff_pgo.py
+++ b/scripts/build_ruff_pgo.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Build Ruff with profile-guided optimization using tracked repository files."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+CORPUS_DIRECTORIES = (
+    "crates/ruff_benchmark/resources",
+    "scripts",
+    "python/ruff-ecosystem/ruff_ecosystem",
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", help="Host-native Rust target triple")
+    parser.add_argument(
+        "--target-dir",
+        type=Path,
+        help="Cargo target directory (default: CARGO_TARGET_DIR or target/ruff-pgo)",
+    )
+    parser.add_argument(
+        "--profile-dir",
+        type=Path,
+        help="Raw profile directory (default: <target-dir>/profiles)",
+    )
+    parser.add_argument(
+        "--llvm-profdata",
+        type=Path,
+        help="Override the active Rust toolchain's llvm-profdata executable",
+    )
+    parser.add_argument(
+        "--train-only",
+        action="store_true",
+        help="Only produce <target-dir>/ruff.profdata for a subsequent release build",
+    )
+    args = parser.parse_args()
+
+    host = rustc_host()
+    target = args.target or host
+    if target != host:
+        parser.error(
+            f"PGO training requires the host-native target {host}, got {target}"
+        )
+
+    target_dir = (
+        args.target_dir
+        or Path(
+            os.environ.get("CARGO_TARGET_DIR", REPOSITORY_ROOT / "target" / "ruff-pgo")
+        )
+    ).resolve()
+    profile_dir = (args.profile_dir or target_dir / "profiles").resolve()
+    merged_profile = target_dir / "ruff.profdata"
+    profiler = find_llvm_profdata(host, args.llvm_profdata)
+    corpus = tracked_python_files()
+
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    for profile in profile_dir.glob("ruff-*.profraw"):
+        profile.unlink()
+
+    environment = os.environ.copy()
+    environment["CARGO_INCREMENTAL"] = "0"
+    if target.endswith("-apple-darwin"):
+        for variable in ("CFLAGS", "CXXFLAGS"):
+            environment[variable] = append_flags(
+                environment.get(variable), "-fno-profile-generate -fno-profile-use"
+            )
+
+    instrumented_target_dir = target_dir / "instrumented"
+    instrumented_environment = environment | {
+        "CARGO_TARGET_DIR": str(instrumented_target_dir),
+        "RUSTFLAGS": append_flags(
+            environment.get("RUSTFLAGS"), f"-Cprofile-generate={profile_dir}"
+        ),
+    }
+    print("Building instrumented release Ruff", flush=True)
+    run(cargo_command(target), environment=instrumented_environment)
+
+    binary_name = "ruff.exe" if "windows" in target else "ruff"
+    instrumented_binary = instrumented_target_dir / target / "release" / binary_name
+    if not instrumented_binary.is_file():
+        raise RuntimeError(f"Instrumented Ruff binary not found: {instrumented_binary}")
+
+    training_environment = instrumented_environment | {
+        "LLVM_PROFILE_FILE": str(profile_dir / "ruff-%m-%p.profraw")
+    }
+    common_arguments = [
+        "--isolated",
+        "--target-version",
+        "py314",
+        "--no-cache",
+        "--silent",
+    ]
+    print(f"Training on {len(corpus)} tracked Python files", flush=True)
+    run(
+        [str(instrumented_binary), "check", *common_arguments, "--exit-zero", *corpus],
+        environment=training_environment,
+    )
+    run(
+        [
+            str(instrumented_binary),
+            "format",
+            *common_arguments,
+            "--check",
+            *corpus,
+        ],
+        environment=training_environment,
+        allowed_exit_codes=(0, 1),
+    )
+
+    profiles = sorted(profile_dir.glob("ruff-*.profraw"))
+    if not profiles or any(profile.stat().st_size == 0 for profile in profiles):
+        raise RuntimeError(f"No complete Ruff profiling data found in {profile_dir}")
+
+    with tempfile.NamedTemporaryFile(
+        dir=target_dir, prefix="ruff-", suffix=".profdata", delete=False
+    ) as temporary_file:
+        temporary_profile = Path(temporary_file.name)
+    try:
+        run(
+            [
+                str(profiler),
+                "merge",
+                "--output",
+                str(temporary_profile),
+                *map(str, profiles),
+            ],
+            environment=environment,
+        )
+        temporary_profile.replace(merged_profile)
+    finally:
+        temporary_profile.unlink(missing_ok=True)
+    print(f"Merged PGO profile: {merged_profile}", flush=True)
+
+    if args.train_only:
+        return
+
+    optimized_environment = environment | {
+        "CARGO_TARGET_DIR": str(target_dir),
+        "RUSTFLAGS": append_flags(
+            environment.get("RUSTFLAGS"), f"-Cprofile-use={merged_profile}"
+        ),
+    }
+    print("Building optimized release Ruff", flush=True)
+    run(cargo_command(target), environment=optimized_environment)
+    print(
+        f"Optimized Ruff: {target_dir / target / 'release' / binary_name}", flush=True
+    )
+
+
+def rustc_host() -> str:
+    version = subprocess.run(
+        ["rustc", "--version", "--verbose"],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    for line in version.splitlines():
+        if line.startswith("host: "):
+            return line.removeprefix("host: ")
+    raise RuntimeError("Could not determine the active Rust compiler's host target")
+
+
+def find_llvm_profdata(host: str, override: Path | None) -> Path:
+    if override is not None:
+        profiler = override.resolve()
+    else:
+        sysroot = subprocess.run(
+            ["rustc", "--print", "sysroot"],
+            cwd=REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        binary_name = "llvm-profdata.exe" if "windows" in host else "llvm-profdata"
+        profiler = Path(sysroot) / "lib" / "rustlib" / host / "bin" / binary_name
+
+    if not profiler.is_file() or not os.access(profiler, os.X_OK):
+        raise RuntimeError(
+            f"Rust toolchain llvm-profdata not found: {profiler}; "
+            "run `rustup component add llvm-tools-preview`"
+        )
+    return profiler
+
+
+def tracked_python_files() -> list[str]:
+    tracked_files = subprocess.run(
+        ["git", "ls-files", "-z", "--", *CORPUS_DIRECTORIES],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    paths = [
+        os.fsdecode(path)
+        for path in tracked_files
+        if path and Path(os.fsdecode(path)).suffix in {".py", ".pyi"}
+    ]
+    if not paths:
+        raise RuntimeError("No tracked Python files found in the Ruff training corpus")
+    return paths
+
+
+def cargo_command(target: str) -> list[str]:
+    return [
+        "cargo",
+        "rustc",
+        "--release",
+        "--locked",
+        "--package",
+        "ruff",
+        "--bin",
+        "ruff",
+        "--target",
+        target,
+        "--",
+        "-C",
+        "strip=symbols",
+    ]
+
+
+def append_flags(existing: str | None, additional: str) -> str:
+    return " ".join(flag for flag in (existing, additional) if flag)
+
+
+def run(
+    command: list[str],
+    *,
+    environment: dict[str, str],
+    allowed_exit_codes: tuple[int, ...] = (0,),
+) -> None:
+    print(f"> {shlex.join(command)}", flush=True)
+    completed = subprocess.run(
+        command, cwd=REPOSITORY_ROOT, env=environment, check=False
+    )
+    if completed.returncode not in allowed_exit_codes:
+        raise subprocess.CalledProcessError(completed.returncode, command)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error


### PR DESCRIPTION
## Summary

Add post-link LLVM BOLT optimization to the existing Linux x86-64 Ruff release build after compiler PGO and fat LTO. This is stacked on #27574; macOS, Windows, Linux ARM64, and all other targets remain compiler-PGO-only or retain their existing release behavior.

The manylinux build preserves symbols and linker relocations, then instruments the linked executable and trains `ruff check` and `ruff format` on the same eight immutable ecosystem projects already used by Ruff and ty PGO. BOLT reorders hot functions and basic blocks using the collected binary profile.

The optimized executable uses `--use-old-text --no-huge-pages` to reuse the original code section instead of publishing BOLT's much larger default duplicate-text layout. The helper requires in-place rewriting to succeed, preserves GNU stack and RELRO hardening, smoke-tests the result, strips with the Rust toolchain's `llvm-strip`, and atomically rebuilds wheel `RECORD` entries. The wheel and standalone archive contain the same optimized binary.

LLVM BOLT 22 and its instrumentation runtime are fetched from the official LLVM repository with pinned SHA-256 digests. The dependency-free helper follows the same PEP 723 script conventions as the compiler-PGO helper.

## Previous Linux x86-64 measurements

The earlier version of this PR compared matching PGO and PGO+BOLT binaries on five held-out projects using eight physical AMD EPYC cores, five warmup pairs, and 30 alternating baseline/candidate pairs per workload. Those measurements used the previous nine-project training corpus; this rebased version uses the current shared eight-project corpus and should be remeasured.

| Held-out project | `ruff check` | `ruff format` |
| --- | ---: | ---: |
| Django | 1.1% faster | 1.8% faster |
| pandas | 1.2% faster | 2.4% faster |
| scikit-learn | 1.3% faster | 2.5% faster |
| SciPy | 0.9% slower | 1.8% faster |
| SymPy | 0.6% faster | 2.6% faster |
| Geometric mean | **0.7% faster** | **2.2% faster** |

Across all ten workloads, BOLT improved wall time by **1.45%** and CPU time by **2.04%** beyond compiler PGO. The effect is smaller than compiler PGO because PGO and fat LTO already optimize the same workload: BOLT's dynamic statistics showed only **0.7% fewer executed instructions**, while loads, stores, and function-call counts were unchanged. BOLT reduced taken conditional branches by 21.9%, but that mostly improves layout rather than eliminating work.

| Artifact | PGO | PGO + BOLT | Increase |
| --- | ---: | ---: | ---: |
| Stripped executable | 26.10 MB | 26.62 MB | 2.0% |
| Compressed release archive | 10.54 MB | 10.92 MB | 3.6% |

BOLT added approximately 45 seconds of post-link work. The earlier compact rewrite had 65 KB of remaining text-section capacity; the release fails if a future binary cannot fit rather than silently using a much larger fallback layout.

ARM64 BOLT remains intentionally disabled: the previous ARM experiment inserted 24,430 branch-range stubs, increased the executable by 11.2%, and improved wall time by only 0.08%.
