### PR TITLE
Enable PGO for macOS ARM64 Ruff releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -116,6 +116,10 @@ jobs:
   macos-aarch64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'namespace-profile-macos-15' || 'macos-15' }}
+    env:
+      # Use Rust's bundled Mach-O LLD, which supports ICF.
+      # ICF reduces the macOS aarch64 ruff binary size by ~0.8%.
+      RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -125,6 +129,14 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: arm64
+      - name: "Install LLVM profiling tools"
+        run: rustup component add llvm-tools-preview
+      - name: "Train PGO Ruff"
+        run: |
+          python scripts/build_ruff_pgo.py \
+            --target aarch64-apple-darwin \
+            --target-dir "${{ github.workspace }}/target/ruff-pgo" \
+            --train-only
       - name: "Prep README.md"
         run: python scripts/transform_readme.py --target pypi
       - name: "Build wheels - aarch64"
@@ -134,9 +146,10 @@ jobs:
           target: aarch64
           args: --release --locked --out dist --compatibility pypi
         env:
-          # Use Rust's bundled Mach-O LLD, which supports ICF.
-          # ICF reduces the macOS aarch64 ruff binary size by ~0.8%.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
+          RUSTFLAGS: "${{ env.RUSTFLAGS }} -Cprofile-use=${{ github.workspace }}/target/ruff-pgo/ruff.profdata"
+          # Apple Clang cannot consume profile data from rustc's LLVM version.
+          CFLAGS: "-fno-profile-generate -fno-profile-use"
+          CXXFLAGS: "-fno-profile-generate -fno-profile-use"
       - name: "Test wheel - aarch64"
         run: |
           pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall


### PR DESCRIPTION
## Summary

This PR enables PGO for Ruff's macOS ARM64 releases, following the approach outlined in https://github.com/astral-sh/ruff/pull/27570. For macOS, `ruff check` gets 8.3% faster on the holdout set, `ruff format` gets 5.4% faster, and the release binary gets 1.1% smaller.
