### PR TITLE
[ty] Expand type aliases for `Generator` when evaluating a generator function's return/send/yield type

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -186,6 +186,59 @@ def iterator_yield_from() -> Generator[int, None, int]:
     return 1
 ```
 
+## Generator type aliases
+
+ty "sees through" type aliases used as return annotations when inferring a generator's yield type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import AsyncGenerator, Generator, Iterator
+
+type GeneratorAlias[T] = Generator[T]
+
+def invalid_yield() -> GeneratorAlias[int]:
+    yield "foo"  # error: [invalid-yield]
+
+def invalid_return() -> GeneratorAlias[int]:
+    yield 42
+    return "foo"  # error: [invalid-return-type]
+
+type NestedGeneratorAlias[T] = GeneratorAlias[T]
+
+def invalid_nested_yield() -> NestedGeneratorAlias[int]:
+    yield "foo"  # error: [invalid-yield]
+
+type IteratorAlias[T] = Iterator[T]
+
+def invalid_iterator_return() -> IteratorAlias[int]:
+    yield 42
+    return "foo"  # error: [invalid-return-type]
+
+type AsyncGeneratorAlias[T] = AsyncGenerator[T]
+
+async def invalid_async_yield() -> AsyncGeneratorAlias[int]:
+    yield "foo"  # error: [invalid-yield]
+```
+
+The same applies when inferring a generator's return type and send type:
+
+```py
+type FullGeneratorAlias[YieldT, SendT, ReturnT] = Generator[YieldT, SendT, ReturnT]
+
+def inner_aliased_generator() -> FullGeneratorAlias[int, bytes, str]:
+    sent = yield 42
+    reveal_type(sent)  # revealed: bytes
+    return "done"
+
+def outer_aliased_generator() -> FullGeneratorAlias[int, bytes, None]:
+    result = yield from inner_aliased_generator()
+    reveal_type(result)  # revealed: str
+```
+
 ## Error cases
 
 ### Non-iterable type

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6794,6 +6794,7 @@ impl<'db> Type<'db> {
                         .materialization_kind(db)
                         .map_or(types, |kind| types.materialize(db, env, kind))
                 }),
+            Type::TypeAlias(alias) => alias.value_type(db).generator_types(db, env),
             Type::Union(union) => {
                 let mut yield_builder = Some(UnionBuilder::new(db, env));
                 let mut send_builder = Some(UnionBuilder::new(db, env));


### PR DESCRIPTION
## Summary

Expand PEP 695 type aliases before extracting generator type parameters. Aliased generator annotations now validate yielded values and return statements instead of silently skipping those checks.

The same shared fix preserves send-type inference and `yield from` return types, including nested generator aliases, iterator aliases, and asynchronous generator aliases.