### PR TITLE
[ty] Infer precise TypedDict key-membership truthiness

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/membership_test.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/membership_test.md
@@ -122,6 +122,111 @@ reveal_type(42 in AlwaysFalse())  # revealed: Literal[False]
 reveal_type(42 not in AlwaysFalse())  # revealed: Literal[True]
 ```
 
+## Required and optional `TypedDict` keys
+
+A required key is always present, while an optional key may or may not be present.
+
+```py
+from typing_extensions import NotRequired, TypedDict
+
+class Items(TypedDict):
+    required: int
+    optional: NotRequired[int]
+
+def membership(items: Items) -> None:
+    reveal_type("required" in items)  # revealed: Literal[True]
+    reveal_type("required" not in items)  # revealed: Literal[False]
+    reveal_type("optional" in items)  # revealed: bool
+    reveal_type("optional" not in items)  # revealed: bool
+```
+
+## Absent keys in closed `TypedDict`s
+
+A closed `TypedDict` cannot contain an undeclared key or an optional key whose value type is
+uninhabited. Declaring `extra_items=Never` closes a `TypedDict` in the same way as `closed=True`.
+
+```py
+from typing_extensions import Never, NotRequired, TypedDict
+
+class Closed(TypedDict, closed=True):
+    present: int
+    impossible: NotRequired[Never]
+
+class ClosedByExtraItems(TypedDict, extra_items=Never):
+    present: int
+
+def closed_membership(closed: Closed, closed_by_extra_items: ClosedByExtraItems) -> None:
+    reveal_type("missing" in closed)  # revealed: Literal[False]
+    reveal_type("missing" not in closed)  # revealed: Literal[True]
+    reveal_type("impossible" in closed)  # revealed: Literal[False]
+    reveal_type("impossible" not in closed)  # revealed: Literal[True]
+    reveal_type("missing" in closed_by_extra_items)  # revealed: Literal[False]
+    reveal_type("missing" not in closed_by_extra_items)  # revealed: Literal[True]
+```
+
+## Undeclared keys in open `TypedDict`s
+
+Open `TypedDict`s and `TypedDict`s with nonempty extra items may contain keys that their schemas do
+not declare.
+
+```py
+from typing_extensions import TypedDict
+
+class Open(TypedDict):
+    present: int
+
+class ExtraItems(TypedDict, extra_items=int):
+    present: int
+
+def open_membership(open_items: Open, extra_items: ExtraItems) -> None:
+    reveal_type("missing" in open_items)  # revealed: bool
+    reveal_type("missing" not in open_items)  # revealed: bool
+    reveal_type("missing" in extra_items)  # revealed: bool
+    reveal_type("missing" not in extra_items)  # revealed: bool
+```
+
+## `TypedDict` membership with unions and non-literal keys
+
+Membership remains ambiguous when either the key or the `TypedDict` can vary between a present and
+an absent alternative. A key missing from every closed alternative is always absent.
+
+```py
+from typing_extensions import Literal, TypedDict
+
+class Left(TypedDict, closed=True):
+    left: int
+
+class Right(TypedDict, closed=True):
+    right: int
+
+def union_membership(
+    left: Left,
+    either: Left | Right,
+    literal_key: Literal["left", "missing"],
+    unknown_key: str,
+) -> None:
+    reveal_type("missing" in either)  # revealed: Literal[False]
+    reveal_type("missing" not in either)  # revealed: Literal[True]
+    reveal_type("left" in either)  # revealed: bool
+    reveal_type(literal_key in left)  # revealed: bool
+    reveal_type(unknown_key in left)  # revealed: bool
+```
+
+## Functional closed `TypedDict` membership
+
+Functional `TypedDict` definitions expose the same key-presence information as class-based
+definitions.
+
+```py
+from typing_extensions import TypedDict
+
+Closed = TypedDict("Closed", {"present": int}, closed=True)
+
+def functional_membership(closed: Closed) -> None:
+    reveal_type("present" in closed)  # revealed: Literal[True]
+    reveal_type("missing" in closed)  # revealed: Literal[False]
+```
+
 ## No Fallback for `__contains__`
 
 If `__contains__` is implemented, checking membership of a type it doesn't accept is an error; it

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5180,7 +5180,7 @@ def _(p: Person) -> None:
     reveal_type(p.setdefault("name", "Alice"))  # revealed: str
 
     # __contains__
-    reveal_type("name" in p)  # revealed: bool
+    reveal_type("name" in p)  # revealed: Literal[True]
 
     # __setitem__
     p["name"] = "Alice"

--- a/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
@@ -390,6 +390,28 @@ mod tests {
     }
 
     #[test]
+    fn reports_impossible_typed_dict_key_membership() -> anyhow::Result<()> {
+        let source = r#"
+            from typing_extensions import TypedDict
+
+            class Items(TypedDict, closed=True):
+                present: int
+
+            def f(items: Items) -> None:
+                if "missing" in items:
+                    print("missing")
+                if "present" not in items:
+                    print("present")
+            "#;
+
+        let diagnostics = UnreachableTest::new().render(source)?;
+        assert_eq!(diagnostics.matches("Code is unreachable").count(), 2);
+        assert!(diagnostics.contains("print(\"missing\")"));
+        assert!(diagnostics.contains("print(\"present\")"));
+        Ok(())
+    }
+
+    #[test]
     fn reports_statically_empty_loop_bodies() -> anyhow::Result<()> {
         let source = r#"
             while False:

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -1035,6 +1035,16 @@ fn infer_membership_test_comparison<'db>(
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
     let env = &context.program_environment();
+
+    if let Some(key) = left.as_string_literal()
+        && let Some(typed_dict) = right.as_typed_dict()
+    {
+        let truthiness = typed_dict
+            .key_membership_truthiness(db, key.value(db))
+            .negate_if(op.is_not_in());
+        return Ok(Type::from_truthiness(db, env, truthiness));
+    }
+
     let compare_result_opt = match right.try_call_dunder(
         db,
         env,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -7,9 +7,7 @@ use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
 use crate::types::tuple::{TupleLength, TupleSpec, TupleSpecBuilder, TupleType, TupleUnpacker};
-use crate::types::typed_dict::{
-    TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
-};
+use crate::types::typed_dict::{TypedDictFieldBuilder, TypedDictSchema, TypedDictType};
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -4040,9 +4038,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             } else {
                 let requires_key = |td: TypedDictType<'db>| -> bool {
-                    td.items(db)
-                        .get(key)
-                        .is_some_and(TypedDictField::is_required)
+                    td.key_membership_truthiness(db, key).is_always_true()
                 };
 
                 let resolved_rhs_type = rhs_type.resolve_type_alias(db);
@@ -4813,6 +4809,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             Type::Union(union) => union.map(db, &self.env, |element| {
                 self.narrow_with_present_key(*element, key)
             }),
+            Type::TypedDict(typed_dict)
+                if typed_dict
+                    .key_membership_truthiness(db, key)
+                    .is_always_false() =>
+            {
+                Type::Never
+            }
             resolved if typeddict_declares_key(db, resolved, key) => resolved,
             // TODO: Extend this to subtypes of `Mapping[str, object]` whose membership and
             // subscript operations obey the `Mapping` contract.

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -27,6 +27,7 @@ use crate::types::class::FieldKind;
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
 use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
 use crate::{Db, ProgramEnvironment};
+use ty_python_core::Truthiness;
 use ty_python_core::definition::Definition;
 
 bitflags! {
@@ -358,6 +359,20 @@ impl<'db> TypedDictType<'db> {
                 builder.add(Type::string_literal(db, name))
             })
             .build()
+    }
+
+    /// Returns whether a literal string key must, cannot, or might be present.
+    ///
+    /// An undeclared key can still exist in an implicitly open `TypedDict` or one with explicit
+    /// extra items. An optional field with an uninhabited value type can never be present.
+    pub(crate) fn key_membership_truthiness(self, db: &'db dyn Db, key: &str) -> Truthiness {
+        match self.items(db).get(key) {
+            Some(field) if field.is_required() => Truthiness::AlwaysTrue,
+            Some(field) if field.may_be_present(db) => Truthiness::Ambiguous,
+            Some(_) => Truthiness::AlwaysFalse,
+            None if self.openness(db).is_closed() => Truthiness::AlwaysFalse,
+            None => Truthiness::Ambiguous,
+        }
     }
 
     /// Returns the field exposed by a literal key.


### PR DESCRIPTION
## Summary

- Infer precise boolean literals for guaranteed-present and guaranteed-absent TypedDict keys while preserving `bool` for optional keys, open schemas, extra items, and non-literal keys.
- Share TypedDict key-membership truthiness with narrowing so impossible membership branches are recognized by reachability analysis and surfaced as existing IDE unreachable-code hints.

Closes astral-sh/ty#4210.

## Test plan

- Add membership mdtests covering required and optional keys, closed and open TypedDicts, `extra_items=Never`, `NotRequired[Never]`, `in` and `not in`, union and non-literal keys, and functional TypedDict definitions.
- Update the existing functional TypedDict expectation for membership in a required key.
- Add a reachability regression covering absent closed-schema keys and negated membership checks for required keys.
