### PR TITLE
[ty] Support forward references in simple stub assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -76,16 +76,16 @@ VALUE = 7
 reveal_type(AliasValue)  # revealed: Literal[7]
 ```
 
-## Stub assignments preserve earlier bindings
+## Stub assignments include later bindings
 
-A stub assignment should use an existing earlier binding instead of a later reassignment.
+A deferred stub assignment sees both earlier and later bindings in the same scope.
 
 ```pyi
 VALUE = 1
 Alias = VALUE
 VALUE = 2
 
-reveal_type(Alias)  # revealed: Literal[1]
+reveal_type(Alias)  # revealed: Literal[1, 2]
 reveal_type(VALUE)  # revealed: Literal[2]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -52,21 +52,11 @@ def use_alias(value: Alias) -> None:
 
 A union alias in a stub may refer to classes defined after the assignment.
 
-`aliases.pyi`:
-
 ```pyi
 UnionAlias = Target | Other
 
 class Target: ...
 class Other: ...
-```
-
-The imported union alias preserves both class references as a value and in a type expression.
-
-`main.py`:
-
-```py
-from aliases import UnionAlias
 
 reveal_type(UnionAlias)  # revealed: <types.UnionType special-form 'Target | Other'>
 
@@ -78,18 +68,10 @@ def use_alias(value: UnionAlias) -> None:
 
 A stub assignment may refer to an ordinary value defined later in the same file.
 
-`aliases.pyi`:
-
 ```pyi
 AliasValue = VALUE
 
 VALUE = 7
-```
-
-`main.py`:
-
-```py
-from aliases import AliasValue
 
 reveal_type(AliasValue)  # revealed: Literal[7]
 ```
@@ -98,18 +80,10 @@ reveal_type(AliasValue)  # revealed: Literal[7]
 
 A stub assignment should use an existing earlier binding instead of a later reassignment.
 
-`aliases.pyi`:
-
 ```pyi
 VALUE = 1
 Alias = VALUE
 VALUE = 2
-```
-
-`main.py`:
-
-```py
-from aliases import Alias, VALUE
 
 reveal_type(Alias)  # revealed: Literal[1]
 reveal_type(VALUE)  # revealed: Literal[2]
@@ -119,17 +93,9 @@ reveal_type(VALUE)  # revealed: Literal[2]
 
 Reassigning a stub variable to itself should resolve its previous binding without creating a cycle.
 
-`aliases.pyi`:
-
 ```pyi
 SelfValue = 3
 SelfValue = SelfValue
-```
-
-`main.py`:
-
-```py
-from aliases import SelfValue
 
 reveal_type(SelfValue)  # revealed: Literal[3]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -76,16 +76,16 @@ VALUE = 7
 reveal_type(AliasValue)  # revealed: Literal[7]
 ```
 
-## Stub assignments include later bindings
+## Stub assignments preserve existing bindings
 
-A deferred stub assignment sees both earlier and later bindings in the same scope.
+An already-defined name is resolved at the assignment even if it is rebound later.
 
 ```pyi
 VALUE = 1
 Alias = VALUE
 VALUE = 2
 
-reveal_type(Alias)  # revealed: Literal[1, 2]
+reveal_type(Alias)  # revealed: Literal[1]
 reveal_type(VALUE)  # revealed: Literal[2]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -17,6 +17,171 @@ def f(x: MyInt):
 f(1)
 ```
 
+## Forward-referenced class aliases in stubs
+
+A class alias in a stub may refer to a class defined later in the same file, and another alias can
+reuse the same forward reference.
+
+`aliases.pyi`:
+
+```pyi
+Alias = Target
+ChainedAlias = Alias
+
+class Target: ...
+
+def accepts(value: Alias) -> Alias: ...
+```
+
+The imported aliases resolve correctly as values and in type expressions.
+
+`main.py`:
+
+```py
+from aliases import Alias, ChainedAlias, Target, accepts
+
+reveal_type(Alias)  # revealed: <class 'Target'>
+reveal_type(ChainedAlias)  # revealed: <class 'Target'>
+reveal_type(accepts(Target()))  # revealed: Target
+
+def use_alias(value: Alias) -> None:
+    reveal_type(value)  # revealed: Target
+```
+
+## Forward-referenced union aliases in stubs
+
+A union alias in a stub may refer to classes defined after the assignment.
+
+`aliases.pyi`:
+
+```pyi
+UnionAlias = Target | Other
+
+class Target: ...
+class Other: ...
+```
+
+The imported union alias preserves both class references as a value and in a type expression.
+
+`main.py`:
+
+```py
+from aliases import UnionAlias
+
+reveal_type(UnionAlias)  # revealed: <types.UnionType special-form 'Target | Other'>
+
+def use_alias(value: UnionAlias) -> None:
+    reveal_type(value)  # revealed: Target | Other
+```
+
+## Forward-referenced values in stubs
+
+A stub assignment may refer to an ordinary value defined later in the same file.
+
+`aliases.pyi`:
+
+```pyi
+AliasValue = VALUE
+
+VALUE = 7
+```
+
+`main.py`:
+
+```py
+from aliases import AliasValue
+
+reveal_type(AliasValue)  # revealed: Literal[7]
+```
+
+## Stub assignments preserve earlier bindings
+
+A stub assignment should use an existing earlier binding instead of a later reassignment.
+
+`aliases.pyi`:
+
+```pyi
+VALUE = 1
+Alias = VALUE
+VALUE = 2
+```
+
+`main.py`:
+
+```py
+from aliases import Alias, VALUE
+
+reveal_type(Alias)  # revealed: Literal[1]
+reveal_type(VALUE)  # revealed: Literal[2]
+```
+
+## Self-referential stub reassignments
+
+Reassigning a stub variable to itself should resolve its previous binding without creating a cycle.
+
+`aliases.pyi`:
+
+```pyi
+SelfValue = 3
+SelfValue = SelfValue
+```
+
+`main.py`:
+
+```py
+from aliases import SelfValue
+
+reveal_type(SelfValue)  # revealed: Literal[3]
+```
+
+## Forward-referenced aliases as generic bounds
+
+A forward-referenced stub alias used as a generic bound must reject incompatible arguments during
+overload selection.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+`aliases.pyi`:
+
+```pyi
+from typing import overload
+
+Alias = Target
+
+class Target: ...
+
+@overload
+def choose[T: Alias](value: T) -> T: ...
+@overload
+def choose(value: int) -> str: ...
+```
+
+The first overload accepts instances of its bound, while an incompatible integer selects the second
+overload.
+
+`main.py`:
+
+```py
+from aliases import Target, choose
+
+reveal_type(choose(Target()))  # revealed: Target
+reveal_type(choose(1))  # revealed: str
+```
+
+## Forward references in runtime modules
+
+Assignments in runtime Python modules are evaluated eagerly, so a class defined later is not yet
+available.
+
+```py
+Alias = Target  # error: [unresolved-reference]
+
+class Target: ...
+```
+
 ## None
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/import/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/builtins.md
@@ -254,10 +254,9 @@ reveal_type(custom_builtin)  # revealed: Custom
 reveal_type(str)  # revealed: Unknown
 ```
 
-## Unknown builtin (later defined)
+## Forward reference in a builtins stub
 
-`foo` has a type of `Unknown` in this example, as it relies on `bar` which has not been defined at
-that point:
+A simple assignment in a builtins stub may refer to a value defined later in the same file.
 
 ```toml
 [environment]
@@ -278,7 +277,7 @@ def reveal_type(obj, /): ...
 ```
 
 ```py
-reveal_type(foo)  # revealed: Unknown
+reveal_type(foo)  # revealed: Literal[1]
 ```
 
 ## Builtins imported from custom project-level stubs

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -140,6 +140,44 @@ reveal_type(foo3.takes_self_or_int(foo3))  # revealed: Foo3
 reveal_type(foo3.takes_self_or_int(1))  # revealed: int
 ```
 
+## Aliases of conditionally overloaded methods in stubs
+
+An alias assigned to an overloaded stub method retains every applicable overload across separate
+platform-specific branches.
+
+```toml
+[environment]
+python-platform = "linux"
+```
+
+```pyi
+import sys
+from typing import overload
+
+class Window:
+    if sys.platform == "darwin":
+        @overload
+        def method(self) -> str: ...
+
+    else:
+        @overload
+        def method(self) -> int: ...
+
+    if sys.platform == "darwin":
+        @overload
+        def method(self, value: bytes) -> bytes: ...
+
+    else:
+        @overload
+        def method(self, value: float) -> float: ...
+
+    alias = method
+
+window: Window
+reveal_type(window.alias)  # revealed: Overload[() -> int, (value: float) -> float]
+reveal_type(window.alias(1.0))  # revealed: float
+```
+
 ## Explicit receiver annotations
 
 Binding a method filters overloads that explicitly annotate `self` with a type that cannot accept

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3256,6 +3256,43 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    /// Returns whether an alias-shaped expression refers to a later binding in the same scope.
+    fn is_stub_assignment_forward_reference(
+        &self,
+        value: &ast::Expr,
+        definition: Definition<'db>,
+    ) -> bool {
+        match value {
+            ast::Expr::Name(name) if !name.is_invalid() => {
+                let db = self.db();
+                let file_scope_id = self.scope().file_scope_id(db);
+                let use_def = self.index.use_def_map(file_scope_id);
+                let use_id = name.scoped_use_id(db, self.program_file());
+
+                !use_def
+                    .bindings_at_use(use_id)
+                    .any(|binding| binding.binding.definition().is_some())
+                    && self
+                        .index
+                        .place_table(file_scope_id)
+                        .symbol_id(name.id.as_str())
+                        .is_some_and(|symbol| {
+                            use_def.reachable_symbol_bindings(symbol).any(|binding| {
+                                binding
+                                    .binding
+                                    .definition()
+                                    .is_some_and(|candidate| candidate != definition)
+                            })
+                        })
+            }
+            ast::Expr::BinOp(binary) if binary.op == ast::Operator::BitOr => {
+                self.is_stub_assignment_forward_reference(&binary.left, definition)
+                    || self.is_stub_assignment_forward_reference(&binary.right, definition)
+            }
+            _ => false,
+        }
+    }
+
     fn infer_assignment_definition_impl(
         &mut self,
         assignment: &AssignmentDefinitionKind<'db>,
@@ -3386,6 +3423,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     self.store_expression_type(value, ty);
                     ty
+                } else if self.in_stub()
+                    && self.is_stub_assignment_forward_reference(value, definition)
+                {
+                    // Stub assignments that could be implicit type aliases may refer to later
+                    // definitions. Keep existing bindings eager to avoid introducing cycles.
+                    self.infer_expression_with_state(value, tcx, DeferredExpressionState::Deferred)
                 } else {
                     self.infer_expression(value, tcx)
                 };

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3267,10 +3267,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let db = self.db();
                 let file_scope_id = self.scope().file_scope_id(db);
                 let use_def = self.index.use_def_map(file_scope_id);
-                let use_id = name.scoped_use_id(db, self.program_file());
 
                 !use_def
-                    .bindings_at_use(use_id)
+                    .bindings_at_use(name.scoped_use_id(db, self.program_file()))
                     .any(|binding| binding.binding.definition().is_some())
                     && self
                         .index
@@ -3280,8 +3279,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             use_def.reachable_symbol_bindings(symbol).any(|binding| {
                                 binding
                                     .binding
-                                    .definition()
-                                    .is_some_and(|candidate| candidate != definition)
+                                    .is_defined_and(|candidate| candidate != definition)
                             })
                         })
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3256,41 +3256,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    /// Returns whether an alias-shaped expression refers to a later binding in the same scope.
-    fn is_stub_assignment_forward_reference(
-        &self,
-        value: &ast::Expr,
-        definition: Definition<'db>,
-    ) -> bool {
-        match value {
-            ast::Expr::Name(name) if !name.is_invalid() => {
-                let db = self.db();
-                let file_scope_id = self.scope().file_scope_id(db);
-                let use_def = self.index.use_def_map(file_scope_id);
-
-                !use_def
-                    .bindings_at_use(name.scoped_use_id(db, self.program_file()))
-                    .any(|binding| binding.binding.definition().is_some())
-                    && self
-                        .index
-                        .place_table(file_scope_id)
-                        .symbol_id(name.id.as_str())
-                        .is_some_and(|symbol| {
-                            use_def.reachable_symbol_bindings(symbol).any(|binding| {
-                                binding
-                                    .binding
-                                    .is_defined_and(|candidate| candidate != definition)
-                            })
-                        })
-            }
-            ast::Expr::BinOp(binary) if binary.op == ast::Operator::BitOr => {
-                self.is_stub_assignment_forward_reference(&binary.left, definition)
-                    || self.is_stub_assignment_forward_reference(&binary.right, definition)
-            }
-            _ => false,
-        }
-    }
-
     fn infer_assignment_definition_impl(
         &mut self,
         assignment: &AssignmentDefinitionKind<'db>,
@@ -3421,11 +3386,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     self.store_expression_type(value, ty);
                     ty
-                } else if self.in_stub()
-                    && self.is_stub_assignment_forward_reference(value, definition)
-                {
-                    // Stub assignments that could be implicit type aliases may refer to later
-                    // definitions. Keep existing bindings eager to avoid introducing cycles.
+                } else if self.in_stub() {
                     self.infer_expression_with_state(value, tcx, DeferredExpressionState::Deferred)
                 } else {
                     self.infer_expression(value, tcx)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3386,7 +3386,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     self.store_expression_type(value, ty);
                     ty
-                } else if self.in_stub() {
+                } else if self.in_stub()
+                    && value.as_name_expr().is_none_or(|name| {
+                        // Already-bound overloaded functions need their at-use binding set.
+                        !name.is_invalid()
+                            && self
+                                .index
+                                .use_def_map(self.scope().file_scope_id(self.db()))
+                                .bindings_at_use(name.scoped_use_id(self.db(), self.program_file()))
+                                .all(|binding| binding.binding.definition().is_none())
+                    })
+                {
                     self.infer_expression_with_state(value, tcx, DeferredExpressionState::Deferred)
                 } else {
                     self.infer_expression(value, tcx)


### PR DESCRIPTION
## Summary

- Resolve forward references in directly evaluated simple stub assignments using the existing deferred-expression semantics, covering class aliases, union aliases, and ordinary values.
- Preserve at-use resolution for already-bound names so aliases of conditionally overloaded functions retain their complete overload sets; keep runtime-module assignments and specialized call handling unchanged.
- Correct NumPy 2.5.1's `_dtype = dtype` forward alias so `ndarray.view(np.uint32)` selects the dtype overload and infers the proper ndarray dtype.

Fixes https://github.com/astral-sh/ty/issues/3967.
Also fixes https://github.com/astral-sh/ty/issues/4208.

## Test plan

- Added mdtests for forward and chained class aliases, union aliases, value aliases, builtins-stub forward references, generic-bound overload selection, existing bindings, self-reassignment, eager `.py` diagnostics, and aliases of conditionally overloaded methods.
- All 494 semantic mdtests and parser, linter, typeshed, and semantic panic-corpus tests pass.
- Replayed the original NumPy reproduction and affected Porcupine and Bokeh projects: overloaded method calls remain valid while the intended NumPy-related diagnostic improvements are preserved.