### PR TITLE
[ty] Report deprecated unary operations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -455,6 +455,56 @@ def f(x: MyBits | NoBits):
     ~x
 ```
 
+#### Unions and intersections
+
+A union reports a deprecated operator when any alternative is deprecated. An intersection reports
+deprecated operators only when every applicable implementation is deprecated.
+
+```py
+from typing_extensions import deprecated
+
+class Deprecated:
+    @deprecated("old inversion")
+    def __invert__(self) -> int:
+        return 1
+
+class AlsoDeprecated:
+    @deprecated("another old inversion")
+    def __invert__(self) -> int:
+        return 2
+
+class Ordinary:
+    def __invert__(self) -> int:
+        return 3
+
+def mixed_union(value: Deprecated | Ordinary) -> None:
+    ~value  # error: [deprecated] "old inversion"
+
+def mixed_intersection(value: Deprecated) -> None:
+    if isinstance(value, Ordinary):
+        ~value
+
+def deprecated_intersection(value: Deprecated) -> None:
+    if isinstance(value, AlsoDeprecated):
+        # error: [deprecated] "old inversion"
+        # error: [deprecated] "old inversion"
+        ~value
+```
+
+A gradually typed comparison can produce an intersection of `bool` and `Any`. The unknown
+alternative might provide a nondeprecated operator, so inverting it should not warn.
+
+```py
+from typing import Any
+
+def gradual_intersection(value: Any) -> None:
+    if value is None:
+        return
+
+    mask = value == 0
+    ~mask
+```
+
 #### Bool literals
 
 `bool.__invert__` is one such case in typeshed. This applies both to `bool` literals and to
@@ -494,19 +544,53 @@ def f(value: T) -> None:
 ```
 
 Deprecation reporting for one constraint does not depend on whether another constraint supports the
-operator.
-
-E.g. `Third`, which has no `__invert__` implemented, comes first in the constraint list, but
-`First`'s deprecation is still reported.
+operator or on the order of the constraints.
 
 ```py
 class Third: ...
 
 U = TypeVar("U", Third, First)
+V = TypeVar("V", First, Third)
 
 def g(value: U) -> None:
     # error: [unsupported-operator]
     # error: [deprecated]
+    ~value
+
+def h(value: V) -> None:
+    # error: [unsupported-operator]
+    # error: [deprecated]
+    ~value
+```
+
+A constraint that is itself a union may contain a deprecated operator even when that operator is
+missing from another union member.
+
+```py
+W = TypeVar("W", First | Third, Second)
+
+def nested_union(value: W) -> None:
+    # error: [unsupported-operator]
+    # error: [deprecated] "first"
+    # error: [deprecated] "second"
+    ~value
+```
+
+A deprecated operator should also be reported when its signature cannot accept the implicit unary
+call.
+
+```py
+class Invalid:
+    @deprecated("invalid inversion")
+    def __invert__(self, required: int) -> int:
+        return required
+
+X = TypeVar("X", Invalid, Second)
+
+def invalid_operator(value: X) -> None:
+    # error: [unsupported-operator]
+    # error: [deprecated] "invalid inversion"
+    # error: [deprecated] "second"
     ~value
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -465,7 +465,6 @@ def f(value: T) -> None:
     ~value
 ```
 
-
 ## Overloads
 
 Overloads can be deprecated, but only trigger warnings when invoked.

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -471,6 +471,23 @@ def f(value: T) -> None:
     ~value
 ```
 
+Deprecation reporting for one constraint does not depend on whether another constraint supports the
+operator
+
+E.g. `Third`, which has no `__invert__` implemented, comes first in the constraint list, but
+`First`'s deprecation is still reported.
+
+```py
+class Third: ...
+
+U = TypeVar("U", Third, First)
+
+def g(value: U) -> None:
+    # error: [unsupported-operator]
+    # error: [deprecated]
+    ~value
+```
+
 ## Overloads
 
 Overloads can be deprecated, but only trigger warnings when invoked.

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -412,8 +412,8 @@ y = MyInt(2)
 z = x + y  # TODO error: [deprecated] "MyInt `+` support is broken"
 ```
 
-Unlike binary operators, unary operators like `~` already fire a diagnostic when their dunder is
-deprecated.
+If a dunder like `__invert__` is deprecated, then the equivalent `~` operator should fire a
+diagnostic.
 
 ```py
 from typing_extensions import deprecated

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -427,8 +427,8 @@ x = MyBits()
 ~x  # error: [deprecated] "MyBits `~` support is broken"
 ```
 
-`bool.__invert__` is one such case in typeshed: `~` on a `bool` is deprecated and will be removed in
-Python 3.16. This applies both to `bool` literals and to arbitrary values of type `bool`.
+`bool.__invert__` is one such case in typeshed.
+This applies both to `bool` literals and to arbitrary values of type `bool`.
 
 ```py
 ~True  # error: [deprecated]

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -441,6 +441,31 @@ def f(x: bool):
     ~x  # error: [deprecated]
 ```
 
+Type variables constraints also should be checked.
+
+```py
+from typing import TypeVar
+from typing_extensions import deprecated
+
+class First:
+    @deprecated("first")
+    def __invert__(self) -> int:
+        return 42
+
+class Second:
+    @deprecated("second")
+    def __invert__(self) -> int:
+        return 42
+
+T = TypeVar("T", First, Second)
+
+def f(value: T) -> None:
+    # error: [deprecated] "first"
+    # error: [deprecated] "second"
+    ~value
+```
+
+
 ## Overloads
 
 Overloads can be deprecated, but only trigger warnings when invoked.

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -494,7 +494,7 @@ def f(value: T) -> None:
 ```
 
 Deprecation reporting for one constraint does not depend on whether another constraint supports the
-operator
+operator.
 
 E.g. `Third`, which has no `__invert__` implemented, comes first in the constraint list, but
 `First`'s deprecation is still reported.

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -433,6 +433,28 @@ x = MyBits()
 ~x  # error: [deprecated] "MyBits `~` support is broken"
 ```
 
+#### Possibly unbound operator
+
+If the operand's type is a union and the dunder is missing on some members, it's possibly unbound.
+This should still report the deprecation on the members where it is found and is deprecated,
+alongside `unsupported-operator` diagnostic.
+
+```py
+from typing_extensions import deprecated
+
+class MyBits:
+    @deprecated("MyBits `~` support is broken")
+    def __invert__(self):
+        return self
+
+class NoBits: ...
+
+def f(x: MyBits | NoBits):
+    # error: [unsupported-operator]
+    # error: [deprecated]
+    ~x
+```
+
 #### Bool literals
 
 `bool.__invert__` is one such case in typeshed. This applies both to `bool` literals and to

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -427,8 +427,8 @@ x = MyBits()
 ~x  # error: [deprecated] "MyBits `~` support is broken"
 ```
 
-`bool.__invert__` is one such case in typeshed.
-This applies both to `bool` literals and to arbitrary values of type `bool`.
+`bool.__invert__` is one such case in typeshed. This applies both to `bool` literals and to
+arbitrary values of type `bool`.
 
 ```py
 ~True  # error: [deprecated]

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -393,6 +393,8 @@ AliasClass()  # error: [deprecated] "Use OtherType instead"
 
 ## Dunders
 
+### Binary operators
+
 If a dunder like `__add__` is deprecated, then the equivalent syntactic sugar like `+` should fire a
 diagnostic.
 
@@ -411,6 +413,8 @@ x = MyInt(1)
 y = MyInt(2)
 z = x + y  # TODO error: [deprecated] "MyInt `+` support is broken"
 ```
+
+### Unary operators
 
 If a dunder like `__invert__` is deprecated, then the equivalent `~` operator should fire a
 diagnostic.

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -419,6 +419,8 @@ z = x + y  # TODO error: [deprecated] "MyInt `+` support is broken"
 If a dunder like `__invert__` is deprecated, then the equivalent `~` operator should fire a
 diagnostic.
 
+#### Custom operator
+
 ```py
 from typing_extensions import deprecated
 
@@ -431,6 +433,8 @@ x = MyBits()
 ~x  # error: [deprecated] "MyBits `~` support is broken"
 ```
 
+#### Bool literals
+
 `bool.__invert__` is one such case in typeshed. This applies both to `bool` literals and to
 arbitrary values of type `bool`.
 
@@ -441,7 +445,9 @@ def f(x: bool):
     ~x  # error: [deprecated]
 ```
 
-Type variables constraints also should be checked.
+#### Constrained TypeVars
+
+Type variable constraints also should be checked.
 
 ```py
 from typing import TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -412,6 +412,31 @@ y = MyInt(2)
 z = x + y  # TODO error: [deprecated] "MyInt `+` support is broken"
 ```
 
+Unlike binary operators, unary operators like `~` already fire a diagnostic when their dunder is
+deprecated.
+
+```py
+from typing_extensions import deprecated
+
+class MyBits:
+    @deprecated("MyBits `~` support is broken")
+    def __invert__(self):
+        return self
+
+x = MyBits()
+~x  # error: [deprecated] "MyBits `~` support is broken"
+```
+
+`bool.__invert__` is one such case in typeshed: `~` on a `bool` is deprecated and will be removed in
+Python 3.16. This applies both to `bool` literals and to arbitrary values of type `bool`.
+
+```py
+~True  # error: [deprecated]
+
+def f(x: bool):
+    ~x  # error: [deprecated]
+```
+
 ## Overloads
 
 Overloads can be deprecated, but only trigger warnings when invoked.

--- a/crates/ty_python_semantic/resources/mdtest/unary/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/unary/integers.md
@@ -21,5 +21,9 @@ reveal_type(-True)  # revealed: Literal[-1]
 ```py
 reveal_type(~0)  # revealed: Literal[-1]
 reveal_type(~1)  # revealed: Literal[-2]
-reveal_type(~True)  # revealed: Literal[-2]
+
+# `~` on a `bool` is deprecated and will be removed in Python 3.16.
+# error: [deprecated]
+# revealed: Literal[-2]
+reveal_type(~True)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/unary/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/unary/integers.md
@@ -22,7 +22,7 @@ reveal_type(-True)  # revealed: Literal[-1]
 reveal_type(~0)  # revealed: Literal[-1]
 reveal_type(~1)  # revealed: Literal[-2]
 
-# `~` on a `bool` is deprecated and will be removed in Python 3.16.
+# `~` on a `bool` is currently deprecated in typeshed.
 # error: [deprecated]
 # revealed: Literal[-2]
 reveal_type(~True)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -453,7 +453,7 @@ impl<'db> BindingsElement<'db> {
         self.items.iter_mut()
     }
 
-    fn callables(&self) -> impl Iterator<Item = &CallableBinding<'db>> {
+    fn callables(&self) -> impl Iterator<Item = &CallableBinding<'db>> + Clone {
         self.items.iter().map(CallableItem::callable)
     }
 
@@ -889,6 +889,13 @@ impl<'db> Bindings<'db> {
 
     pub(crate) fn has_implicit_dunder_init_is_possibly_unbound(&self) -> bool {
         self.implicit_dunder_init_is_possibly_unbound
+    }
+
+    /// Returns the callable bindings for each union element without flattening intersections.
+    pub(crate) fn iter_union_elements(
+        &self,
+    ) -> impl Iterator<Item = impl Iterator<Item = &CallableBinding<'db>> + Clone> + '_ {
+        self.elements.iter().map(BindingsElement::callables)
     }
 
     /// Returns an iterator over all `CallableBinding`s, flattening the two-level structure.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10743,7 +10743,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             (ast::UnaryOp::Invert, Type::LiteralValue(literal)) => match literal.kind() {
                 LiteralValueTypeKind::Int(value) => Type::int_literal(!value.as_i64()),
-                LiteralValueTypeKind::Bool(value) => Type::int_literal(!i64::from(value)),
+                LiteralValueTypeKind::Bool(value) => {
+                    // `~bool` is deprecated and will be removed in Python 3.16.
+                    // Then it will become unavailable and the fallback will report it
+                    // as `unsupported-operator`.
+                    if let Some(dunder) = operand_type
+                        .member_lookup_with_policy(
+                            db,
+                            env,
+                            "__invert__",
+                            MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                        )
+                        .place
+                        .ignore_possibly_undefined()
+                    {
+                        self.check_deprecated(unary, dunder);
+                        Type::int_literal(!i64::from(value))
+                    } else {
+                        fallback_unary_expression_type()
+                    }
+                }
                 _ => fallback_unary_expression_type(),
             },
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10702,7 +10702,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 CallArguments::none(),
                 TypeContext::default(),
             ) {
-                Ok(outcome) => outcome.return_type(db, env),
+                Ok(outcome) => {
+                    for callable in outcome.iter_flat() {
+                        self.check_deprecated(unary, callable.callable_type);
+                    }
+                    outcome.return_type(db, env)
+                }
                 Err(e) => {
                     self.report_unsupported_unary_operator(
                         unary,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10749,9 +10749,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (ast::UnaryOp::Invert, Type::LiteralValue(literal)) => match literal.kind() {
                 LiteralValueTypeKind::Int(value) => Type::int_literal(!value.as_i64()),
                 LiteralValueTypeKind::Bool(value) => {
-                    // `~bool` is deprecated and will be removed in Python 3.16.
-                    // Then it will become unavailable and the fallback will report it
-                    // as `unsupported-operator`.
+                    // `~bool` is currently deprecated in typeshed.
                     if let Some(dunder) = operand_type
                         .member_lookup_with_policy(
                             db,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10753,7 +10753,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // similarly check for deprecation of dunder methods on all our literal
                     // type fast paths, but we choose not to pay that extra cost, since it is
                     // implausible that e.g. `int.__neg__` would ever be deprecated.
-                    if let Some(dunder) = operand_type
+                    if let Some(dunder) = literal
+                        .fallback_instance(db, env)
                         .member_lookup_with_policy(
                             db,
                             env,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9605,6 +9605,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 
+    /// Report a deprecated callable only when its union alternative has no non-deprecated
+    /// intersection member that could provide the implementation instead.
+    fn check_deprecated_bindings<T: Ranged>(&self, ranged: &T, bindings: &Bindings<'db>) {
+        let db = self.db();
+
+        for callables in bindings.iter_union_elements() {
+            if callables.clone().all(|callable| {
+                let ty = match callable.callable_type {
+                    Type::BoundMethod(bound) => Type::FunctionLiteral(bound.function(db)),
+                    ty => ty,
+                };
+                ty.is_deprecated(db)
+            }) {
+                for callable in callables {
+                    self.check_deprecated(ranged, callable.callable_type);
+                }
+            }
+        }
+    }
+
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
         let db = self.db();
         let ast::ExprName {
@@ -10703,9 +10723,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 TypeContext::default(),
             ) {
                 Ok(outcome) => {
-                    for callable in outcome.iter_flat() {
-                        self.check_deprecated(unary, callable.callable_type);
-                    }
+                    self.check_deprecated_bindings(unary, &outcome);
                     outcome.return_type(db, env)
                 }
                 Err(e) => {
@@ -10715,9 +10733,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         CallDunderError::MethodNotAvailable => None,
                     };
                     if let Some(bindings) = bindings {
-                        for callable in bindings.iter_flat() {
-                            self.check_deprecated(unary, callable.callable_type);
-                        }
+                        self.check_deprecated_bindings(unary, bindings);
                     }
                     self.report_unsupported_unary_operator(
                         unary,
@@ -10834,9 +10850,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 )
                             })
                             .collect();
-                        for outcome in outcomes.iter().filter_map(|outcome| outcome.as_ref().ok()) {
-                            for callable in outcome.iter_flat() {
-                                self.check_deprecated(unary, callable.callable_type);
+                        for outcome in &outcomes {
+                            let bindings = match outcome {
+                                Ok(bindings) => Some(bindings),
+                                // A method can be deprecated even if it is missing from some
+                                // union members or its signature rejects the implicit call.
+                                // Preserve those bindings so the deprecation is reported
+                                // alongside the unsupported-operator diagnostic.
+                                Err(
+                                    CallDunderError::PossiblyUnbound { bindings, .. }
+                                    | CallDunderError::CallError(_, bindings, _),
+                                ) => Some(bindings.as_ref()),
+                                // A completely missing method has no bindings to inspect.
+                                Err(CallDunderError::MethodNotAvailable) => None,
+                            };
+                            if let Some(bindings) = bindings {
+                                self.check_deprecated_bindings(unary, bindings);
                             }
                         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10809,27 +10809,39 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 match tvar.typevar(self.db()).bound_or_constraints(db, env) {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                        match Self::map_constrained_typevar_constraints(
+                        // Call the dunder method for every constraint up front so deprecation
+                        // reporting doesn't depend on whether any constraint fails.
+                        let outcomes: Vec<_> = constraints
+                            .elements(db)
+                            .iter()
+                            .map(|constraint| {
+                                constraint.try_call_dunder(
+                                    db,
+                                    env,
+                                    unary_dunder_method,
+                                    CallArguments::none(),
+                                    TypeContext::default(),
+                                )
+                            })
+                            .collect();
+                        for outcome in outcomes.iter().filter_map(|outcome| outcome.as_ref().ok()) {
+                            for callable in outcome.iter_flat() {
+                                self.check_deprecated(unary, callable.callable_type);
+                            }
+                        }
+
+                        let mut outcomes = outcomes.into_iter();
+                        let result = Self::map_constrained_typevar_constraints(
                             db,
                             env,
                             operand_type,
                             constraints,
-                            |constraint| {
-                                let outcome = constraint
-                                    .try_call_dunder(
-                                        db,
-                                        env,
-                                        unary_dunder_method,
-                                        CallArguments::none(),
-                                        TypeContext::default(),
-                                    )
-                                    .ok()?;
-                                for callable in outcome.iter_flat() {
-                                    self.check_deprecated(unary, callable.callable_type);
-                                }
+                            |_constraint| {
+                                let outcome = outcomes.next()?.ok()?;
                                 Some(outcome.return_type(db, env))
                             },
-                        ) {
+                        );
+                        match result {
                             Some(ty) => ty,
                             None => {
                                 // At least one constraint failed; report error.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10749,7 +10749,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (ast::UnaryOp::Invert, Type::LiteralValue(literal)) => match literal.kind() {
                 LiteralValueTypeKind::Int(value) => Type::int_literal(!value.as_i64()),
                 LiteralValueTypeKind::Bool(value) => {
-                    // `~bool` is currently deprecated in typeshed.
+                    // `~bool` is currently deprecated in typeshed. Technically we should
+                    // similarly check for deprecation of dunder methods on all our literal
+                    // type fast paths, but we choose not to pay that extra cost, since it is
+                    // implausible that e.g. `int.__neg__` would ever be deprecated.
                     if let Some(dunder) = operand_type
                         .member_lookup_with_policy(
                             db,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10709,6 +10709,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     outcome.return_type(db, env)
                 }
                 Err(e) => {
+                    let bindings = match &e {
+                        CallDunderError::PossiblyUnbound { bindings, .. } => Some(bindings),
+                        CallDunderError::CallError(_, bindings, _) => Some(bindings),
+                        CallDunderError::MethodNotAvailable => None,
+                    };
+                    if let Some(bindings) = bindings {
+                        for callable in bindings.iter_flat() {
+                            self.check_deprecated(unary, callable.callable_type);
+                        }
+                    }
                     self.report_unsupported_unary_operator(
                         unary,
                         op,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10761,10 +10761,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .ignore_possibly_undefined()
                     {
                         self.check_deprecated(unary, dunder);
-                        Type::int_literal(!i64::from(value))
-                    } else {
-                        fallback_unary_expression_type()
                     }
+                    Type::int_literal(!i64::from(value))
                 }
                 _ => fallback_unary_expression_type(),
             },

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10815,7 +10815,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             operand_type,
                             constraints,
                             |constraint| {
-                                constraint
+                                let outcome = constraint
                                     .try_call_dunder(
                                         db,
                                         env,
@@ -10823,8 +10823,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         CallArguments::none(),
                                         TypeContext::default(),
                                     )
-                                    .map(|outcome| outcome.return_type(db, env))
-                                    .ok()
+                                    .ok()?;
+                                for callable in outcome.iter_flat() {
+                                    self.check_deprecated(unary, callable.callable_type);
+                                }
+                                Some(outcome.return_type(db, env))
                             },
                         ) {
                             Some(ty) => ty,


### PR DESCRIPTION
## Summary

Adding support for deprecated unary operations, supported cases:
- flagging general deprecated unary dunder methods on any class
- flagging `__invert__` as deprecated for `Literal[True]`, `Literal[False]`, while preserving the bitwise math applied to the underlying value
- flagging deprecated unary ops on type variables constraints

Known issues (both will be addressed separately):
- flagging deprecated `__bool__` during `not x` unary operation is not considered
- possibly duplicated `deprecated` diagnostics in case of unions, when deprecated method on both classes is coming from the same common ancestor

Some examples:

```python
# Reported before this PR as `deprecated`
True.__invert__ # deprecated


# Reported after this PR:
def test(a: bool):
    ~a  # deprecated

~True  # deprecated


from typing_extensions import deprecated

class A:
    @deprecated("deprecated!")
    def __invert__(self):
        ...

~A()  # deprecated
```

<details>
<summary>
Example diagnostics
</summary>

```python
warning[deprecated]: The function `__invert__` is deprecated
 --> example_bool:2:6
  |
2 | True.__invert__ # deprecated
  |      ^^^^^^^^^^ Will throw an error in Python 3.16. Use `not` for logical negation of bools instead.

warning[deprecated]: The function `__invert__` is deprecated
 --> example_bool:7:5
  |
7 |     ~a  # deprecated
  |     ^^ Will throw an error in Python 3.16. Use `not` for logical negation of bools instead.

warning[deprecated]: The function `__invert__` is deprecated
 --> example_bool:9:1
  |
9 | ~True  # deprecated
  | ^^^^^ Will throw an error in Python 3.16. Use `not` for logical negation of bools instead.

warning[deprecated]: The function `__invert__` is deprecated
  --> example_bool:19:1
   |
19 | ~A()  # deprecated
   | ^^^^ deprecated!

Found 4 diagnostics
```
</details>


## Test Plan

Added mdtests to `deprecated.md`, updated `integers.md` test to consider deprecation diagnostic. All previous tests also pass.
