### PR TITLE
[ty] Avoid deriving sequents for typevars with concrete bounds

### DIFF
--- a/crates/ruff_benchmark/benches/ty_constraint_set.rs
+++ b/crates/ruff_benchmark/benches/ty_constraint_set.rs
@@ -559,6 +559,51 @@ f(x, x, x, x, x, x, x, x, x, x)
         );
     });
 }
+
+fn benchmark_mixed_many_invariant_typevars(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let code = r#"
+from __future__ import annotations
+
+class Invariant[T]:
+    x: T
+
+class Constructed[T]:
+    def __new__[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, U](
+        cls,
+        box1: Invariant[T1],
+        box2: Invariant[T2],
+        box3: Invariant[T3],
+        box4: Invariant[T4],
+        box5: Invariant[T5],
+        box6: Invariant[T6],
+        box7: Invariant[T7],
+        box8: Invariant[T8],
+        box9: Invariant[T9],
+        box10: Invariant[T10],
+        box11: Invariant[U],
+    ) -> Constructed[tuple[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, U]]:
+        raise NotImplementedError
+
+def f[T](y: Invariant[T]) -> None:
+    x = Invariant[int]()
+    Constructed(x, x, x, x, x, x, x, x, x, x, y)
+"#;
+
+    criterion.bench_function("ty_micro[mixed_many_invariant_typevars]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(code),
+            |case| {
+                let Case { db } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_pydantic_core_schema_dict(criterion: &mut Criterion) {
     const NUM_CORE_SCHEMA_VARIANTS: usize = 24;
 
@@ -620,6 +665,7 @@ criterion_group!(
     benchmark_sequence_literal_union_access,
     benchmark_invariant_generic_union_bound,
     benchmark_many_invariant_typevars,
+    benchmark_mixed_many_invariant_typevars,
     benchmark_pydantic_core_schema_dict,
 );
 criterion_main!(constraint_set);

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -89,6 +89,41 @@ def get_int[T]() -> int:
 reveal_type(get_int())  # revealed: int
 ```
 
+## Generic call with independent and dependent arguments
+
+Concrete arguments must not erase a type variable inferred from another argument.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+class Invariant[T]:
+    item: T
+
+class Bounded[T: int]:
+    item: T
+
+def combine[A, B, U](first: Invariant[A], second: Invariant[B], dependent: Invariant[U]) -> tuple[A, B, U]:
+    raise NotImplementedError
+
+class Constructed[T]:
+    def __new__[A, B, U](cls, first: Invariant[A], second: Invariant[B], dependent: Invariant[U]) -> Constructed[tuple[A, B, U]]:
+        raise NotImplementedError
+
+def infer[T](dependent: Invariant[T]) -> None:
+    concrete = Invariant[int]()
+    reveal_type(combine(concrete, concrete, dependent))  # revealed: tuple[int, int, T@infer]
+    reveal_type(Constructed(concrete, concrete, dependent))  # revealed: Constructed[tuple[int, int, T@infer]]
+
+    bounded = Invariant[Bounded[int]]()
+    reveal_type(combine(bounded, bounded, dependent))  # revealed: tuple[Bounded[int], Bounded[int], T@infer]
+    reveal_type(Constructed(bounded, bounded, dependent))  # revealed: Constructed[tuple[Bounded[int], Bounded[int], T@infer]]
+```
+
 ## Generic callable chains
 
 Inferring a chain of generic callable parameters should discard internal typevar artifacts from

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -186,11 +186,11 @@ def _(a: A, b: B, x: A | B):
     reveal_type(takes_in_supports_foo(x))  # revealed: A | B
 ```
 
-## Bound violations inferred through protocols
+## Incompatible bounds inferred through protocols
 
-If matching a protocol argument infers a type that violates a type variable's bound, the call should
-report that violation once. Another argument may independently infer a valid type for the same type
-variable, but should not cause a second error for the protocol argument.
+If matching a protocol argument infers incompatible bounds, the call should report an error for that
+argument. Another argument may independently infer a valid type for the same type variable, but
+should not cause a second error for the protocol argument.
 
 ```py
 from typing import Protocol
@@ -211,7 +211,7 @@ class Bad:
 def f[T: A](x: P[T, T], value: T) -> None:
     raise NotImplementedError
 
-# error: [invalid-argument-type] "Argument to function `f` is incorrect: Argument type `C` does not satisfy upper bound `A` of type variable `T`"
+# error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `P[B, B]`, found `Bad`"
 f(Bad(), B())
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -6150,6 +6150,15 @@ def check(value: Left[int]) -> None:
     expect_right2(value)  # error: [invalid-argument-type]
 ```
 
+Generic-call inference must also avoid expanding recursive protocol members when checking whether
+its argument constraints are independent:
+
+```py
+def accept[U, V](outer: U, recursive: V) -> None: ...
+def infer[T](outer: T, recursive: C[int]) -> None:
+    accept(outer, recursive)
+```
+
 ### Recursive legacy generic protocol
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
@@ -145,15 +145,15 @@ def negated_alternative[T, U]() -> None:
     reveal_type(constraints.solutions(inferable=tuple[T, U]))
 ```
 
-## Derived solution element order
+## Independent concrete solutions are stable
 
-Constructing the constraints in the opposite source order makes the derived union observable. Its
-elements should not be reordered merely because the TDD-variable order changes.
+Independent type variables with concrete bounds should not acquire relationships merely because
+their bounds contain the same concrete type.
 
 ```py
 from ty_extensions._internal import ConstraintSet
 
-def derived_solution[U, T]() -> None:
+def independent_solution[U, T]() -> None:
     # (U ≤ int) ∧ (int ≤ T) ∧ ((T ≤ int) | (T ≤ str))
     constraints = (
         ConstraintSet.upper_bound(U, int)
@@ -161,15 +161,10 @@ def derived_solution[U, T]() -> None:
         & (ConstraintSet.upper_bound(T, int) | ConstraintSet.upper_bound(T, str))
     )
 
-    # TODO: The derived relationship should not leave an inferable `U` in the solution for `T`.
-    # TODO: revealed: tuple[Solution[T=int]]
-    # TODO: sometimes: revealed tuple[Solution[T=int | U@derived_solution]]
-    # revealed: tuple[Solution[T=U@derived_solution | int]]
+    # revealed: tuple[Solution[T=int]]
     reveal_type(constraints.solutions_for(T, inferable=tuple[T, U]))
 
-    # TODO: The derived relationship should not leave an inferable `T` in the solution for `U`.
-    # TODO: revealed: tuple[Solution[U=int]]
-    # revealed: tuple[Solution[U=int & T@derived_solution]]
+    # revealed: tuple[Solution[U=int]]
     reveal_type(constraints.solutions_for(U, inferable=tuple[T, U]))
 ```
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -110,8 +110,8 @@ use crate::types::constraints::support::{Support, SupportId};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarSet};
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::{
-    AnyOverTypeResult, TypeCollector, TypeKind, TypeVisitor, any_over_type, try_any_over_type,
-    walk_non_atomic_type, walk_type_with_recursion_guard,
+    TypeCollector, TypeKind, TypeVisitor, any_over_type, walk_non_atomic_type,
+    walk_type_with_recursion_guard,
 };
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, IntersectionType, Type, TypeContext,
@@ -1328,6 +1328,10 @@ impl<'db> ConstraintSetStorage<'db> {
                 false
             }
 
+            fn notify_skipped_lazy_type_attributes(&self) {
+                self.support.borrow_mut().mark_incomplete();
+            }
+
             fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
                 for ty in alias.specialization(db).types(db) {
                     self.visit_type(db, *ty);
@@ -1889,15 +1893,6 @@ impl<'db> ConstraintBounds<'db> {
             !bound.has_typevar(db, env)
                 && !bound.has_unspecialized_type_var(db, env)
                 && bound.bottom_materialization(db, env) == bound.top_materialization(db, env)
-        })
-    }
-
-    fn has_incomplete_support(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
-        iter::chain(self.lower, self.upper).any(|bound| {
-            matches!(
-                try_any_over_type(db, env, bound, |_| false),
-                AnyOverTypeResult::SkippedLazyTypeAttributes
-            )
         })
     }
 
@@ -4703,7 +4698,7 @@ impl InteriorNode {
         });
 
         if !self.node().is_single_conjunction(storage) {
-            return PathAssignments::new(constraints, FxHashSet::default(), FxHashSet::default());
+            return PathAssignments::new(constraints, FxHashSet::default());
         }
 
         let mut independent_typevars = FxHashSet::default();
@@ -4720,23 +4715,7 @@ impl InteriorNode {
 
         independent_typevars.retain(|typevar| !dependent_typevars.contains(typevar));
 
-        let mut incomplete_support_constraints = FxHashSet::default();
-        if !independent_typevars.is_empty() {
-            incomplete_support_constraints.extend(constraints.iter().copied().filter(
-                |constraint| {
-                    storage
-                        .constraint_data(*constraint)
-                        .bounds
-                        .has_incomplete_support(db, env)
-                },
-            ));
-        }
-
-        PathAssignments::new(
-            constraints,
-            independent_typevars,
-            incomplete_support_constraints,
-        )
+        PathAssignments::new(constraints, independent_typevars)
     }
 }
 
@@ -6432,9 +6411,6 @@ pub(crate) struct PathAssignments {
     /// discovery.
     independent_typevars: FxHashSet<TypeVarId>,
 
-    /// Constraints whose lazy attributes may hide relationships absent from their support.
-    incomplete_support_constraints: FxHashSet<ConstraintId>,
-
     /// Derived assignments that have been queued up to be added to the current path.
     assignment_queue: VecDeque<(ConstraintAssignment, AssignmentFuel)>,
 
@@ -6502,7 +6478,6 @@ impl PathAssignments {
     fn new(
         constraints: impl IntoIterator<Item = ConstraintId>,
         independent_typevars: FxHashSet<TypeVarId>,
-        incomplete_support_constraints: FxHashSet<ConstraintId>,
     ) -> Self {
         let discovered = constraints
             .into_iter()
@@ -6515,7 +6490,6 @@ impl PathAssignments {
             discovered,
             elaborated_pairs: FxHashSet::default(),
             independent_typevars,
-            incomplete_support_constraints,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
             assignment_queue: VecDeque::default(),
             new_assignments: FxIndexMap::default(),
@@ -6820,16 +6794,6 @@ impl PathAssignments {
             return;
         }
 
-        if existing.is_none()
-            && !self.independent_typevars.is_empty()
-            && storage
-                .constraint_data(constraint)
-                .bounds
-                .has_incomplete_support(db, env)
-        {
-            self.incomplete_support_constraints.insert(constraint);
-        }
-
         let single_map = SequentMap::for_constraint(db, env, storage, constraint);
         self.sequents.extend_from_slice(&single_map.sequents);
 
@@ -6848,8 +6812,8 @@ impl PathAssignments {
                     .iter()
                     .chain(constraint_support.iter())
                     .any(|typevar| self.independent_typevars.contains(&typevar))
-                && !self.incomplete_support_constraints.contains(existing)
-                && !self.incomplete_support_constraints.contains(&constraint)
+                && existing_support.is_complete()
+                && constraint_support.is_complete()
             {
                 continue;
             }
@@ -8802,9 +8766,7 @@ mod tests {
     ) -> PathAssignments {
         let mut storage = builder.storage.borrow_mut();
         match node.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => {
-                PathAssignments::new([], FxHashSet::default(), FxHashSet::default())
-            }
+            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([], FxHashSet::default()),
             Node::Interior(interior) => {
                 interior.path_assignments(db, env, &mut storage, source_order)
             }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1885,6 +1885,14 @@ impl<'db> ConstraintBounds<'db> {
         self.upper.is_some()
     }
 
+    fn is_concrete(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
+        iter::chain(self.lower, self.upper).all(|bound| {
+            !bound.has_typevar(db, env)
+                && !bound.has_unspecialized_type_var(db, env)
+                && bound.bottom_materialization(db, env) == bound.top_materialization(db, env)
+        })
+    }
+
     fn materialized_lower(self) -> Type<'db> {
         self.lower.unwrap_or(Type::Never)
     }
@@ -2814,7 +2822,7 @@ impl NodeId {
             Node::AlwaysTrue => true,
             Node::AlwaysFalse => false,
             Node::Interior(interior) => {
-                let mut path = interior.path_assignments(storage, source_order);
+                let mut path = interior.path_assignments(db, env, storage, source_order);
                 path.visit_negated(db, env, storage, self, &mut IsNeverSatisfiedVisitor)
                     .is_continue()
             }
@@ -2880,7 +2888,7 @@ impl NodeId {
                 let result = if simple_conjunction_is_satisfiable(storage, self) {
                     false
                 } else {
-                    let mut path = interior.path_assignments(storage, source_order);
+                    let mut path = interior.path_assignments(db, env, storage, source_order);
                     path.visit(db, env, storage, self, &mut IsNeverSatisfiedVisitor)
                         .is_continue()
                 };
@@ -4018,56 +4026,41 @@ impl<'db> PathBounds<'db> {
         }
 
         let mut source_orders = storage.calculate_source_orders(source_order);
-        let (node, independent_constraints) =
-            Self::split_independent_bounds(db, env, storage, &source_orders, node, inferable);
-
         let (node, derived_source_order) =
             node.remove_noninferable(db, env, storage, inferable, source_order);
         source_orders.extend(storage.calculate_source_orders(derived_source_order));
-        let mut paths = match node.node() {
-            Node::AlwaysTrue if independent_constraints.is_empty() => {
-                return PathBounds::Unconstrained;
-            }
-            Node::AlwaysTrue => vec![independent_constraints],
+        let interior = match node.node() {
+            Node::AlwaysTrue => return PathBounds::Unconstrained,
             Node::AlwaysFalse => return PathBounds::Unsatisfiable,
-            Node::Interior(interior) => {
-                // Sort the constraints in each path by their `source_order`s, to ensure that we
-                // construct any unions or intersections in our type mappings in a stable order.
-                // Constraints might come out of `PathAssignment`s with identical `source_order`s,
-                // but if they do, those "tied" constraints will still be ordered in a stable way.
-                // So we need a stable sort to retain that stable per-tie ordering.
-                let mut collect_visitor = CollectVisitor {
-                    source_orders: &source_orders,
-                    sorted_paths: Vec::new(),
-                };
-                // Sequent discovery must also happen in source order. Sorting the collected paths
-                // below is too late: sequent pairs are not commutative, and TDD traversal order can
-                // otherwise discard gradual evidence before solution extraction.
-                let path_source_order =
-                    storage.ordered_source_order(source_order, derived_source_order);
-                let mut path = interior.path_assignments(storage, path_source_order);
-                let _ = path.visit(db, env, storage, node, &mut collect_visitor);
-
-                for path in &mut collect_visitor.sorted_paths {
-                    path.extend(independent_constraints.iter().copied());
-                    path.sort_by_key(|(_, source_order)| *source_order);
-                }
-
-                collect_visitor.sorted_paths
-            }
+            Node::Interior(interior) => interior,
         };
 
-        paths.sort_by(|path1, path2| {
+        // Sort the constraints in each path by their `source_order`s, to ensure that we construct
+        // any unions or intersections in our type mappings in a stable order. Constraints might
+        // come out of `PathAssignment`s with identical `source_order`s, but if they do, those
+        // "tied" constraints will still be ordered in a stable way. So we need a stable sort to
+        // retain that stable per-tie ordering.
+        let mut collect_visitor = CollectVisitor {
+            source_orders: &source_orders,
+            sorted_paths: Vec::new(),
+        };
+        // Sequent discovery must also happen in source order. Sorting the collected paths below
+        // is too late: sequent pairs are not commutative, and TDD traversal order can otherwise
+        // discard gradual evidence before solution extraction.
+        let path_source_order = storage.ordered_source_order(source_order, derived_source_order);
+        let mut path = interior.path_assignments(db, env, storage, path_source_order);
+        let _ = path.visit(db, env, storage, node, &mut collect_visitor);
+        collect_visitor.sorted_paths.sort_by(|path1, path2| {
             let source_orders1 = path1.iter().map(|(_, source_order)| *source_order);
             let source_orders2 = path2.iter().map(|(_, source_order)| *source_order);
             source_orders1.cmp(source_orders2)
         });
 
-        let mut result = Vec::with_capacity(paths.len());
+        let mut result = Vec::with_capacity(collect_visitor.sorted_paths.len());
         let mut mappings: FxIndexMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
             FxIndexMap::default();
 
-        for path in paths {
+        for path in collect_visitor.sorted_paths {
             mappings.clear();
             for (constraint, _) in path {
                 let constraint = storage.constraint_data(constraint);
@@ -4101,205 +4094,6 @@ impl<'db> PathBounds<'db> {
         }
 
         PathBounds::Constrained(result.into_boxed_slice())
-    }
-
-    /// Removes concrete constraints that hold on every path and are independent of other bounds.
-    ///
-    /// The removed constraints can be accumulated directly into every residual solution. If every
-    /// constraint is independent, the residual is `true` and no sequent analysis is necessary.
-    fn split_independent_bounds(
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        storage: &mut ConstraintSetStorage<'db>,
-        source_orders: &FxIndexSet<ConstraintId>,
-        node: NodeId,
-        inferable: TypeVarSet<'db>,
-    ) -> (NodeId, Vec<(ConstraintId, usize)>) {
-        let mut constraints = FxIndexSet::default();
-        node.for_each_unique_constraint(storage, &mut |constraint| {
-            constraints.insert(constraint);
-        });
-
-        if constraints.is_empty() {
-            return (node, Vec::new());
-        }
-
-        let Some(mandatory_constraints) =
-            Self::mandatory_positive_constraints(storage, node, &mut FxHashMap::default())
-        else {
-            return (node, Vec::new());
-        };
-
-        let mut independent_typevars = FxHashSet::default();
-        let mut dependent_typevars = FxHashSet::default();
-        for constraint_id in &constraints {
-            let constraint = storage.constraint_data(*constraint_id);
-            let typevar = storage.typevar_id(db, constraint.typevar);
-            let is_dependent = !mandatory_constraints.contains(constraint_id)
-                || !constraint.typevar.is_inferable(db, inferable)
-                || iter::chain(constraint.bounds.lower, constraint.bounds.upper).any(|bound| {
-                    bound.has_typevar(db, env)
-                        || bound.has_unspecialized_type_var(db, env)
-                        || bound.bottom_materialization(db, env)
-                            != bound.top_materialization(db, env)
-                });
-
-            if is_dependent {
-                dependent_typevars.extend(storage.constraint_support(*constraint_id).iter());
-            } else {
-                independent_typevars.insert(typevar);
-            }
-        }
-        independent_typevars.retain(|typevar| !dependent_typevars.contains(typevar));
-
-        if independent_typevars.is_empty() {
-            return (node, Vec::new());
-        }
-
-        let mut independent_constraints = Vec::with_capacity(constraints.len());
-        for constraint_id in constraints {
-            let constraint = storage.constraint_data(constraint_id);
-            let typevar = storage.typevar_id(db, constraint.typevar);
-            if independent_typevars.contains(&typevar) {
-                let source_order = source_orders
-                    .get_index_of(&constraint_id)
-                    .expect("every TDD constraint should have a source order");
-                independent_constraints.push((constraint_id, source_order));
-            }
-        }
-        independent_constraints.sort_by_key(|(_, source_order)| *source_order);
-
-        let residual = Self::remove_independent_constraints(
-            db,
-            storage,
-            node,
-            &independent_typevars,
-            &mut FxHashMap::default(),
-        );
-
-        (residual, independent_constraints)
-    }
-
-    /// Finds positive constraints shared by every structurally satisfiable path.
-    fn mandatory_positive_constraints(
-        storage: &ConstraintSetStorage<'db>,
-        node: NodeId,
-        cache: &mut FxHashMap<NodeId, Option<FxHashSet<ConstraintId>>>,
-    ) -> Option<FxHashSet<ConstraintId>> {
-        if let Some(mandatory) = cache.get(&node) {
-            return mandatory.clone();
-        }
-
-        let mut prefix = FxHashSet::default();
-        let mut current = node;
-        let mandatory = loop {
-            match current.node() {
-                Node::AlwaysTrue => break Some(prefix),
-                Node::AlwaysFalse => break None,
-                Node::Interior(_) => {
-                    let interior = storage.interior_node_data(current);
-                    if interior.if_uncertain == ALWAYS_FALSE && interior.if_false == ALWAYS_FALSE {
-                        prefix.insert(interior.constraint);
-                        current = interior.if_true;
-                        continue;
-                    }
-
-                    let mut mandatory: Option<FxHashSet<ConstraintId>> = None;
-                    for (branch, positive) in [
-                        (interior.if_true, true),
-                        (interior.if_uncertain, false),
-                        (interior.if_false, false),
-                    ] {
-                        let Some(mut branch_constraints) =
-                            Self::mandatory_positive_constraints(storage, branch, cache)
-                        else {
-                            continue;
-                        };
-
-                        if positive {
-                            branch_constraints.insert(interior.constraint);
-                        }
-
-                        if let Some(mandatory) = &mut mandatory {
-                            mandatory.retain(|constraint| branch_constraints.contains(constraint));
-                        } else {
-                            mandatory = Some(branch_constraints);
-                        }
-                    }
-
-                    break mandatory.map(|mut mandatory| {
-                        mandatory.extend(prefix);
-                        mandatory
-                    });
-                }
-            }
-        };
-
-        cache.insert(node, mandatory.clone());
-        mandatory
-    }
-
-    /// Removes already-extracted positive constraints without disturbing the remaining diagram.
-    fn remove_independent_constraints(
-        db: &'db dyn Db,
-        storage: &mut ConstraintSetStorage<'db>,
-        node: NodeId,
-        independent_typevars: &FxHashSet<TypeVarId>,
-        cache: &mut FxHashMap<NodeId, NodeId>,
-    ) -> NodeId {
-        if let Some(residual) = cache.get(&node) {
-            return *residual;
-        }
-
-        let residual = match node.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => node,
-            Node::Interior(_) => {
-                let interior = storage.interior_node_data(node);
-                let constraint = storage.constraint_data(interior.constraint);
-                let typevar = storage.typevar_id(db, constraint.typevar);
-                if independent_typevars.contains(&typevar) {
-                    Self::remove_independent_constraints(
-                        db,
-                        storage,
-                        interior.if_true,
-                        independent_typevars,
-                        cache,
-                    )
-                } else {
-                    let if_true = Self::remove_independent_constraints(
-                        db,
-                        storage,
-                        interior.if_true,
-                        independent_typevars,
-                        cache,
-                    );
-                    let if_uncertain = Self::remove_independent_constraints(
-                        db,
-                        storage,
-                        interior.if_uncertain,
-                        independent_typevars,
-                        cache,
-                    );
-                    let if_false = Self::remove_independent_constraints(
-                        db,
-                        storage,
-                        interior.if_false,
-                        independent_typevars,
-                        cache,
-                    );
-                    NodeId::with_uncertain(
-                        storage,
-                        interior.constraint,
-                        if_true,
-                        if_uncertain,
-                        if_false,
-                    )
-                }
-            }
-        };
-
-        cache.insert(node, residual);
-        residual
     }
 
     pub(crate) fn solve(
@@ -4961,7 +4755,7 @@ impl InteriorNode {
             }
         }
 
-        let mut path = self.path_assignments(storage, source_order);
+        let mut path = self.path_assignments(db, env, storage, source_order);
         let mut visitor = AbstractVisitor { should_remove };
         let ControlFlow::Continue(result) = path.visit(db, env, storage, self.node(), &mut visitor);
         result
@@ -5039,9 +4833,11 @@ impl InteriorNode {
         result
     }
 
-    fn path_assignments(
+    fn path_assignments<'db>(
         self,
-        storage: &mut ConstraintSetStorage<'_>,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
@@ -5061,7 +4857,25 @@ impl InteriorNode {
                 .expect("every BDD constraint should have a source-order entry")
         });
 
-        PathAssignments::new(constraints)
+        if !self.node().is_single_conjunction(storage) {
+            return PathAssignments::new(storage, constraints, FxHashSet::default());
+        }
+
+        let mut independent_typevars = FxHashSet::default();
+        let mut dependent_typevars = FxHashSet::default();
+        for constraint_id in &constraints {
+            let constraint = storage.constraint_data(*constraint_id);
+            let typevar = storage.typevar_id(db, constraint.typevar);
+            if constraint.bounds.is_concrete(db, env) {
+                independent_typevars.insert(typevar);
+            } else {
+                dependent_typevars.extend(storage.constraint_support(*constraint_id).iter());
+            }
+        }
+
+        independent_typevars.retain(|typevar| !dependent_typevars.contains(typevar));
+
+        PathAssignments::new(storage, constraints, independent_typevars)
     }
 
     /// Returns a simplified version of a BDD.
@@ -7192,6 +7006,13 @@ pub(crate) struct PathAssignments {
     /// Constraint pairs that we have already checked and added to `sequents`.
     elaborated_pairs: FxHashSet<(ConstraintId, ConstraintId)>,
 
+    /// Type variables mentioned only by concrete constraints in the original conjunction.
+    independent_typevars: FxHashSet<TypeVarId>,
+    /// Source-order indices of constraints mentioning each type variable.
+    constraint_indices_by_typevar: FxHashMap<TypeVarId, SmallVec<[usize; 2]>>,
+    /// Source-order indices of constraints mentioning no independent type variables.
+    dependent_constraint_indices: SmallVec<[usize; 8]>,
+
     /// Derived assignments that have been queued up to be added to the current path.
     assignment_queue: VecDeque<(ConstraintAssignment, AssignmentFuel)>,
 
@@ -7256,20 +7077,57 @@ impl Ord for AssignmentFuel {
 }
 
 impl PathAssignments {
-    fn new(constraints: impl IntoIterator<Item = ConstraintId>) -> Self {
-        let discovered = constraints
-            .into_iter()
-            .map(|constraint| (constraint, false))
-            .collect();
-        Self {
+    fn new(
+        storage: &ConstraintSetStorage<'_>,
+        constraints: impl IntoIterator<Item = ConstraintId>,
+        independent_typevars: FxHashSet<TypeVarId>,
+    ) -> Self {
+        let mut path = Self {
             sequents: Vec::default(),
             assignments: FxIndexMap::default(),
             additional_fuels: Vec::default(),
-            discovered,
+            discovered: FxIndexMap::default(),
             elaborated_pairs: FxHashSet::default(),
+            independent_typevars,
+            constraint_indices_by_typevar: FxHashMap::default(),
+            dependent_constraint_indices: SmallVec::new(),
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
             assignment_queue: VecDeque::default(),
             new_assignments: FxIndexMap::default(),
+        };
+
+        for constraint in constraints {
+            let (index, previous) = path.discovered.insert_full(constraint, false);
+            if previous.is_none() {
+                path.index_constraint(storage, constraint, index);
+            }
+        }
+
+        path
+    }
+
+    fn index_constraint(
+        &mut self,
+        storage: &ConstraintSetStorage<'_>,
+        constraint: ConstraintId,
+        index: usize,
+    ) {
+        if self.independent_typevars.is_empty() {
+            self.dependent_constraint_indices.push(index);
+            return;
+        }
+
+        let mut independent = false;
+        for typevar in storage.constraint_support(constraint).iter() {
+            independent |= self.independent_typevars.contains(&typevar);
+            self.constraint_indices_by_typevar
+                .entry(typevar)
+                .or_default()
+                .push(index);
+        }
+
+        if !independent {
+            self.dependent_constraint_indices.push(index);
         }
     }
 
@@ -7571,22 +7429,44 @@ impl PathAssignments {
             return;
         }
 
+        if existing.is_none() {
+            self.index_constraint(storage, constraint, constraint_index);
+        }
+
         let single_map = SequentMap::for_constraint(db, env, storage, constraint);
         self.sequents.extend_from_slice(&single_map.sequents);
 
-        for (existing_index, (existing, _)) in self.discovered.iter().enumerate() {
-            if *existing == constraint {
+        let mut candidates: SmallVec<[usize; 8]> = SmallVec::new();
+        let mut independent = false;
+        for typevar in storage.constraint_support(constraint).iter() {
+            independent |= self.independent_typevars.contains(&typevar);
+            if let Some(indices) = self.constraint_indices_by_typevar.get(&typevar) {
+                candidates.extend(indices.iter().copied());
+            }
+        }
+
+        if !independent {
+            candidates.extend(self.dependent_constraint_indices.iter().copied());
+        }
+        candidates.sort_unstable();
+        candidates.dedup();
+
+        for existing_index in candidates {
+            let Some((&existing, _)) = self.discovered.get_index(existing_index) else {
+                continue;
+            };
+            if existing == constraint {
                 continue;
             }
 
-            if SequentMap::pair_cannot_produce_sequents(db, env, storage, *existing, constraint) {
+            if SequentMap::pair_cannot_produce_sequents(db, env, storage, existing, constraint) {
                 continue;
             }
 
             let (a, b) = if existing_index < constraint_index {
-                (*existing, constraint)
+                (existing, constraint)
             } else {
-                (constraint, *existing)
+                (constraint, existing)
             };
             if !self.elaborated_pairs.insert((a, b)) {
                 // We've already elaborated this pair of constraints.
@@ -8560,7 +8440,7 @@ mod tests {
     }
 
     #[test]
-    fn simple_lower_bound_conjunction_skips_sequent_analysis() {
+    fn simple_lower_bound_conjunction_analyzes_matching_typevar() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -8574,13 +8454,7 @@ mod tests {
             || ConstraintSet::constrain_typevar_lower_bound(db, &env, &builder, t, str),
         );
         let inferable = TypeVarSet::from_typevars(db, [t]);
-        let (single_sequents, pair_sequents) = {
-            let storage = builder.storage.borrow();
-            (
-                storage.single_sequent_cache.len(),
-                storage.pair_sequent_cache.len(),
-            )
-        };
+        let pair_sequents = builder.storage.borrow().pair_sequent_cache.len();
 
         let solutions = set.solutions(db, &env, &builder, inferable);
         assert_eq!(
@@ -8592,12 +8466,11 @@ mod tests {
         );
 
         let storage = builder.storage.borrow();
-        assert_eq!(storage.single_sequent_cache.len(), single_sequents);
-        assert_eq!(storage.pair_sequent_cache.len(), pair_sequents);
+        assert_eq!(storage.pair_sequent_cache.len(), pair_sequents + 1);
     }
 
     #[test]
-    fn simple_exact_bound_conjunction_skips_sequent_analysis() {
+    fn simple_exact_bound_conjunction_skips_pair_sequent_analysis() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -8611,13 +8484,7 @@ mod tests {
             || ConstraintSet::constrain_typevar(db, &env, &builder, u, int, int),
         );
         let inferable = TypeVarSet::from_typevars(db, [t, u]);
-        let (single_sequents, pair_sequents) = {
-            let storage = builder.storage.borrow();
-            (
-                storage.single_sequent_cache.len(),
-                storage.pair_sequent_cache.len(),
-            )
-        };
+        let pair_sequents = builder.storage.borrow().pair_sequent_cache.len();
 
         let Solutions::Constrained(solutions) = set.solutions(db, &env, &builder, inferable) else {
             panic!("expected constrained solutions");
@@ -8634,12 +8501,11 @@ mod tests {
         }));
 
         let storage = builder.storage.borrow();
-        assert_eq!(storage.single_sequent_cache.len(), single_sequents);
         assert_eq!(storage.pair_sequent_cache.len(), pair_sequents);
     }
 
     #[test]
-    fn simple_unsatisfiable_exact_bound_conjunction_skips_sequent_analysis() {
+    fn simple_unsatisfiable_exact_bound_conjunction_analyzes_matching_typevar() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -8653,13 +8519,7 @@ mod tests {
             || ConstraintSet::constrain_typevar(db, &env, &builder, t, str, str),
         );
         let inferable = TypeVarSet::from_typevars(db, [t]);
-        let (single_sequents, pair_sequents) = {
-            let storage = builder.storage.borrow();
-            (
-                storage.single_sequent_cache.len(),
-                storage.pair_sequent_cache.len(),
-            )
-        };
+        let pair_sequents = builder.storage.borrow().pair_sequent_cache.len();
 
         assert_eq!(
             set.solutions(db, &env, &builder, inferable),
@@ -8667,8 +8527,7 @@ mod tests {
         );
 
         let storage = builder.storage.borrow();
-        assert_eq!(storage.single_sequent_cache.len(), single_sequents);
-        assert_eq!(storage.pair_sequent_cache.len(), pair_sequents);
+        assert_eq!(storage.pair_sequent_cache.len(), pair_sequents + 1);
     }
 
     #[test]
@@ -9666,16 +9525,20 @@ mod tests {
         }
     }
 
-    fn path_assignments_for(
-        builder: &ConstraintSetBuilder<'_>,
+    fn path_assignments_for<'db>(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &ConstraintSetBuilder<'db>,
         node: NodeId,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
+        let mut storage = builder.storage.borrow_mut();
         match node.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([]),
+            Node::AlwaysTrue | Node::AlwaysFalse => {
+                PathAssignments::new(&storage, [], FxHashSet::default())
+            }
             Node::Interior(interior) => {
-                let mut storage = builder.storage.borrow_mut();
-                interior.path_assignments(&mut storage, source_order)
+                interior.path_assignments(db, env, &mut storage, source_order)
             }
         }
     }
@@ -9684,6 +9547,7 @@ mod tests {
     fn path_assignments_follow_constraint_source_order() {
         let db = setup_db();
         let db = &db;
+        let env = db.program_environment();
         let t = create_typevar(db, "T");
         let u = create_typevar(db, "U");
         let builder = ConstraintSetBuilder::new();
@@ -9693,7 +9557,7 @@ mod tests {
         // Construct the set in the opposite order from constraint creation. This ensures the
         // initializer follows the sidecar rather than either TDD traversal or constraint IDs.
         let set = u_str.and(db, &builder, || t_int);
-        let path = path_assignments_for(&builder, set.node, set.source_order);
+        let path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
         let storage = builder.storage.borrow();
         let expected =
             [u_str.node, t_int.node].map(|node| storage.interior_node_data(node).constraint);
@@ -9751,7 +9615,7 @@ mod tests {
             tautology,
             transitive,
         ] {
-            let mut path = path_assignments_for(&builder, set.node, set.source_order);
+            let mut path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
             let mut fold = ReconstructPathFold { break_at: None };
             let mut storage = builder.storage.borrow_mut();
             let ControlFlow::Continue((reconstructed, reconstructed_source_order)) =
@@ -9788,7 +9652,7 @@ mod tests {
             PathFoldBreak::Impossible,
             PathFoldBreak::Combine,
         ] {
-            let mut path = path_assignments_for(&builder, set.node, set.source_order);
+            let mut path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
             let mut aborting_fold = ReconstructPathFold {
                 break_at: Some(break_at),
             };

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2814,7 +2814,7 @@ impl NodeId {
             Node::AlwaysTrue => true,
             Node::AlwaysFalse => false,
             Node::Interior(interior) => {
-                let mut path = interior.path_assignments(db, env, storage, source_order);
+                let mut path = interior.path_assignments(storage, source_order);
                 path.visit_negated(db, env, storage, self, &mut IsNeverSatisfiedVisitor)
                     .is_continue()
             }
@@ -2880,7 +2880,7 @@ impl NodeId {
                 let result = if simple_conjunction_is_satisfiable(storage, self) {
                     false
                 } else {
-                    let mut path = interior.path_assignments(db, env, storage, source_order);
+                    let mut path = interior.path_assignments(storage, source_order);
                     path.visit(db, env, storage, self, &mut IsNeverSatisfiedVisitor)
                         .is_continue()
                 };
@@ -4018,52 +4018,56 @@ impl<'db> PathBounds<'db> {
         }
 
         let mut source_orders = storage.calculate_source_orders(source_order);
-        if let Some(path_bounds) = Self::compute_simple_bound_conjunction(
-            db,
-            env,
-            storage,
-            &source_orders,
-            node,
-            inferable,
-        ) {
-            return path_bounds;
-        }
+        let (node, independent_constraints) =
+            Self::split_independent_bounds(db, env, storage, &source_orders, node, inferable);
 
         let (node, derived_source_order) =
             node.remove_noninferable(db, env, storage, inferable, source_order);
         source_orders.extend(storage.calculate_source_orders(derived_source_order));
-        let interior = match node.node() {
-            Node::AlwaysTrue => return PathBounds::Unconstrained,
+        let mut paths = match node.node() {
+            Node::AlwaysTrue if independent_constraints.is_empty() => {
+                return PathBounds::Unconstrained;
+            }
+            Node::AlwaysTrue => vec![independent_constraints],
             Node::AlwaysFalse => return PathBounds::Unsatisfiable,
-            Node::Interior(interior) => interior,
+            Node::Interior(interior) => {
+                // Sort the constraints in each path by their `source_order`s, to ensure that we
+                // construct any unions or intersections in our type mappings in a stable order.
+                // Constraints might come out of `PathAssignment`s with identical `source_order`s,
+                // but if they do, those "tied" constraints will still be ordered in a stable way.
+                // So we need a stable sort to retain that stable per-tie ordering.
+                let mut collect_visitor = CollectVisitor {
+                    source_orders: &source_orders,
+                    sorted_paths: Vec::new(),
+                };
+                // Sequent discovery must also happen in source order. Sorting the collected paths
+                // below is too late: sequent pairs are not commutative, and TDD traversal order can
+                // otherwise discard gradual evidence before solution extraction.
+                let path_source_order =
+                    storage.ordered_source_order(source_order, derived_source_order);
+                let mut path = interior.path_assignments(storage, path_source_order);
+                let _ = path.visit(db, env, storage, node, &mut collect_visitor);
+
+                for path in &mut collect_visitor.sorted_paths {
+                    path.extend(independent_constraints.iter().copied());
+                    path.sort_by_key(|(_, source_order)| *source_order);
+                }
+
+                collect_visitor.sorted_paths
+            }
         };
 
-        // Sort the constraints in each path by their `source_order`s, to ensure that we construct
-        // any unions or intersections in our type mappings in a stable order. Constraints might
-        // come out of `PathAssignment`s with identical `source_order`s, but if they do, those
-        // "tied" constraints will still be ordered in a stable way. So we need a stable sort to
-        // retain that stable per-tie ordering.
-        let mut collect_visitor = CollectVisitor {
-            source_orders: &source_orders,
-            sorted_paths: Vec::new(),
-        };
-        // Sequent discovery must also happen in source order. Sorting the collected paths below
-        // is too late: sequent pairs are not commutative, and TDD traversal order can otherwise
-        // discard gradual evidence before solution extraction.
-        let path_source_order = storage.ordered_source_order(source_order, derived_source_order);
-        let mut path = interior.path_assignments(db, env, storage, path_source_order);
-        let _ = path.visit(db, env, storage, node, &mut collect_visitor);
-        collect_visitor.sorted_paths.sort_by(|path1, path2| {
+        paths.sort_by(|path1, path2| {
             let source_orders1 = path1.iter().map(|(_, source_order)| *source_order);
             let source_orders2 = path2.iter().map(|(_, source_order)| *source_order);
             source_orders1.cmp(source_orders2)
         });
 
-        let mut result = Vec::with_capacity(collect_visitor.sorted_paths.len());
+        let mut result = Vec::with_capacity(paths.len());
         let mut mappings: FxIndexMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
             FxIndexMap::default();
 
-        for path in collect_visitor.sorted_paths {
+        for path in paths {
             mappings.clear();
             for (constraint, _) in path {
                 let constraint = storage.constraint_data(constraint);
@@ -4099,79 +4103,203 @@ impl<'db> PathBounds<'db> {
         PathBounds::Constrained(result.into_boxed_slice())
     }
 
-    /// Accumulates a conjunction of concrete bound constraints without constructing a
-    /// [`PathAssignments`] or its sequent map.
+    /// Removes concrete constraints that hold on every path and are independent of other bounds.
     ///
-    /// There are no relationships to derive between these constraints, as the upper and lower
-    /// bounds do not contain typevars. The normal solution-selection logic still validates each
-    /// accumulated bound against the typevar's declared bound or constraints.
-    fn compute_simple_bound_conjunction(
+    /// The removed constraints can be accumulated directly into every residual solution. If every
+    /// constraint is independent, the residual is `true` and no sequent analysis is necessary.
+    fn split_independent_bounds(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         storage: &mut ConstraintSetStorage<'db>,
         source_orders: &FxIndexSet<ConstraintId>,
         node: NodeId,
         inferable: TypeVarSet<'db>,
-    ) -> Option<Self> {
-        match node.node() {
-            Node::AlwaysTrue => return Some(PathBounds::Unconstrained),
-            Node::AlwaysFalse => return Some(PathBounds::Unsatisfiable),
-            Node::Interior(_) => {}
+    ) -> (NodeId, Vec<(ConstraintId, usize)>) {
+        let mut constraints = FxIndexSet::default();
+        node.for_each_unique_constraint(storage, &mut |constraint| {
+            constraints.insert(constraint);
+        });
+
+        if constraints.is_empty() {
+            return (node, Vec::new());
         }
 
-        let mut constraints = Vec::default();
+        let Some(mandatory_constraints) =
+            Self::mandatory_positive_constraints(storage, node, &mut FxHashMap::default())
+        else {
+            return (node, Vec::new());
+        };
+
+        let mut independent_typevars = FxHashSet::default();
+        let mut dependent_typevars = FxHashSet::default();
+        for constraint_id in &constraints {
+            let constraint = storage.constraint_data(*constraint_id);
+            let typevar = storage.typevar_id(db, constraint.typevar);
+            let is_dependent = !mandatory_constraints.contains(constraint_id)
+                || !constraint.typevar.is_inferable(db, inferable)
+                || iter::chain(constraint.bounds.lower, constraint.bounds.upper).any(|bound| {
+                    bound.has_typevar(db, env)
+                        || bound.has_unspecialized_type_var(db, env)
+                        || bound.bottom_materialization(db, env)
+                            != bound.top_materialization(db, env)
+                });
+
+            if is_dependent {
+                dependent_typevars.extend(storage.constraint_support(*constraint_id).iter());
+            } else {
+                independent_typevars.insert(typevar);
+            }
+        }
+        independent_typevars.retain(|typevar| !dependent_typevars.contains(typevar));
+
+        if independent_typevars.is_empty() {
+            return (node, Vec::new());
+        }
+
+        let mut independent_constraints = Vec::with_capacity(constraints.len());
+        for constraint_id in constraints {
+            let constraint = storage.constraint_data(constraint_id);
+            let typevar = storage.typevar_id(db, constraint.typevar);
+            if independent_typevars.contains(&typevar) {
+                let source_order = source_orders
+                    .get_index_of(&constraint_id)
+                    .expect("every TDD constraint should have a source order");
+                independent_constraints.push((constraint_id, source_order));
+            }
+        }
+        independent_constraints.sort_by_key(|(_, source_order)| *source_order);
+
+        let residual = Self::remove_independent_constraints(
+            db,
+            storage,
+            node,
+            &independent_typevars,
+            &mut FxHashMap::default(),
+        );
+
+        (residual, independent_constraints)
+    }
+
+    /// Finds positive constraints shared by every structurally satisfiable path.
+    fn mandatory_positive_constraints(
+        storage: &ConstraintSetStorage<'db>,
+        node: NodeId,
+        cache: &mut FxHashMap<NodeId, Option<FxHashSet<ConstraintId>>>,
+    ) -> Option<FxHashSet<ConstraintId>> {
+        if let Some(mandatory) = cache.get(&node) {
+            return mandatory.clone();
+        }
+
+        let mut prefix = FxHashSet::default();
         let mut current = node;
-        loop {
+        let mandatory = loop {
             match current.node() {
-                Node::AlwaysTrue => break,
-                Node::AlwaysFalse => return None,
+                Node::AlwaysTrue => break Some(prefix),
+                Node::AlwaysFalse => break None,
                 Node::Interior(_) => {
                     let interior = storage.interior_node_data(current);
-                    if interior.if_uncertain != ALWAYS_FALSE || interior.if_false != ALWAYS_FALSE {
-                        return None;
+                    if interior.if_uncertain == ALWAYS_FALSE && interior.if_false == ALWAYS_FALSE {
+                        prefix.insert(interior.constraint);
+                        current = interior.if_true;
+                        continue;
                     }
 
-                    let constraint = storage.constraint_data(interior.constraint);
-                    if !constraint.typevar.is_inferable(db, inferable) {
-                        return None;
+                    let mut mandatory: Option<FxHashSet<ConstraintId>> = None;
+                    for (branch, positive) in [
+                        (interior.if_true, true),
+                        (interior.if_uncertain, false),
+                        (interior.if_false, false),
+                    ] {
+                        let Some(mut branch_constraints) =
+                            Self::mandatory_positive_constraints(storage, branch, cache)
+                        else {
+                            continue;
+                        };
+
+                        if positive {
+                            branch_constraints.insert(interior.constraint);
+                        }
+
+                        if let Some(mandatory) = &mut mandatory {
+                            mandatory.retain(|constraint| branch_constraints.contains(constraint));
+                        } else {
+                            mandatory = Some(branch_constraints);
+                        }
                     }
 
-                    if iter::chain(constraint.bounds.lower, constraint.bounds.upper).any(|bound| {
-                        bound.has_typevar(db, env) || bound.has_unspecialized_type_var(db, env)
-                    }) {
-                        return None;
-                    }
-
-                    current = interior.if_true;
-                    constraints.push((
-                        constraint.typevar,
-                        constraint.bounds,
-                        source_orders
-                            .get_index_of(&interior.constraint)
-                            .expect("every TDD constraint should have a source order"),
-                    ));
+                    break mandatory.map(|mut mandatory| {
+                        mandatory.extend(prefix);
+                        mandatory
+                    });
                 }
             }
+        };
+
+        cache.insert(node, mandatory.clone());
+        mandatory
+    }
+
+    /// Removes already-extracted positive constraints without disturbing the remaining diagram.
+    fn remove_independent_constraints(
+        db: &'db dyn Db,
+        storage: &mut ConstraintSetStorage<'db>,
+        node: NodeId,
+        independent_typevars: &FxHashSet<TypeVarId>,
+        cache: &mut FxHashMap<NodeId, NodeId>,
+    ) -> NodeId {
+        if let Some(residual) = cache.get(&node) {
+            return *residual;
         }
 
-        let mut mappings: FxIndexMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
-            FxIndexMap::default();
-        constraints.sort_by_key(|(_, _, source_order)| *source_order);
-        for (typevar, constraint, _) in constraints {
-            let bounds = mappings.entry(typevar).or_default();
-            if let Some(lower) = constraint.lower {
-                bounds.add_lower(db, env, lower);
+        let residual = match node.node() {
+            Node::AlwaysTrue | Node::AlwaysFalse => node,
+            Node::Interior(_) => {
+                let interior = storage.interior_node_data(node);
+                let constraint = storage.constraint_data(interior.constraint);
+                let typevar = storage.typevar_id(db, constraint.typevar);
+                if independent_typevars.contains(&typevar) {
+                    Self::remove_independent_constraints(
+                        db,
+                        storage,
+                        interior.if_true,
+                        independent_typevars,
+                        cache,
+                    )
+                } else {
+                    let if_true = Self::remove_independent_constraints(
+                        db,
+                        storage,
+                        interior.if_true,
+                        independent_typevars,
+                        cache,
+                    );
+                    let if_uncertain = Self::remove_independent_constraints(
+                        db,
+                        storage,
+                        interior.if_uncertain,
+                        independent_typevars,
+                        cache,
+                    );
+                    let if_false = Self::remove_independent_constraints(
+                        db,
+                        storage,
+                        interior.if_false,
+                        independent_typevars,
+                        cache,
+                    );
+                    NodeId::with_uncertain(
+                        storage,
+                        interior.constraint,
+                        if_true,
+                        if_uncertain,
+                        if_false,
+                    )
+                }
             }
-            if let Some(upper) = constraint.upper {
-                bounds.add_upper(db, env, upper);
-            }
-        }
+        };
 
-        let path = mappings
-            .drain(..)
-            .map(|(bound_typevar, bounds)| bounds.finish(db, env, bound_typevar))
-            .collect();
-        Some(PathBounds::Constrained(Box::new([path])))
+        cache.insert(node, residual);
+        residual
     }
 
     pub(crate) fn solve(
@@ -4833,7 +4961,7 @@ impl InteriorNode {
             }
         }
 
-        let mut path = self.path_assignments(db, env, storage, source_order);
+        let mut path = self.path_assignments(storage, source_order);
         let mut visitor = AbstractVisitor { should_remove };
         let ControlFlow::Continue(result) = path.visit(db, env, storage, self.node(), &mut visitor);
         result
@@ -4911,11 +5039,9 @@ impl InteriorNode {
         result
     }
 
-    fn path_assignments<'db>(
+    fn path_assignments(
         self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        storage: &mut ConstraintSetStorage<'db>,
+        storage: &mut ConstraintSetStorage<'_>,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
@@ -4935,33 +5061,7 @@ impl InteriorNode {
                 .expect("every BDD constraint should have a source-order entry")
         });
 
-        if !self.node().is_single_conjunction(storage) {
-            return PathAssignments::new(constraints, FxHashSet::default());
-        }
-
-        let mut independent_typevars = FxHashSet::default();
-        let mut dependent_typevars = FxHashSet::default();
-        for constraint_id in &constraints {
-            let constraint = storage.constraint_data(*constraint_id);
-            let typevar = storage.typevar_id(db, constraint.typevar);
-            let has_relational_bound =
-                iter::chain(constraint.bounds.lower, constraint.bounds.upper).any(|bound| {
-                    bound.has_typevar(db, env)
-                        || bound.has_unspecialized_type_var(db, env)
-                        || bound.bottom_materialization(db, env)
-                            != bound.top_materialization(db, env)
-                });
-
-            if has_relational_bound {
-                dependent_typevars.extend(storage.constraint_support(*constraint_id).iter());
-            } else {
-                independent_typevars.insert(typevar);
-            }
-        }
-
-        independent_typevars.retain(|typevar| !dependent_typevars.contains(typevar));
-
-        PathAssignments::new(constraints, independent_typevars)
+        PathAssignments::new(constraints)
     }
 
     /// Returns a simplified version of a BDD.
@@ -7092,10 +7192,6 @@ pub(crate) struct PathAssignments {
     /// Constraint pairs that we have already checked and added to `sequents`.
     elaborated_pairs: FxHashSet<(ConstraintId, ConstraintId)>,
 
-    /// Type variables mentioned only by concrete constraints in the original diagram.
-    /// Deriving relationships to unrelated type variables cannot affect those constraints.
-    independent_typevars: FxHashSet<TypeVarId>,
-
     /// Derived assignments that have been queued up to be added to the current path.
     assignment_queue: VecDeque<(ConstraintAssignment, AssignmentFuel)>,
 
@@ -7160,10 +7256,7 @@ impl Ord for AssignmentFuel {
 }
 
 impl PathAssignments {
-    fn new(
-        constraints: impl IntoIterator<Item = ConstraintId>,
-        independent_typevars: FxHashSet<TypeVarId>,
-    ) -> Self {
+    fn new(constraints: impl IntoIterator<Item = ConstraintId>) -> Self {
         let discovered = constraints
             .into_iter()
             .map(|constraint| (constraint, false))
@@ -7174,7 +7267,6 @@ impl PathAssignments {
             additional_fuels: Vec::default(),
             discovered,
             elaborated_pairs: FxHashSet::default(),
-            independent_typevars,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
             assignment_queue: VecDeque::default(),
             new_assignments: FxIndexMap::default(),
@@ -7484,17 +7576,6 @@ impl PathAssignments {
 
         for (existing_index, (existing, _)) in self.discovered.iter().enumerate() {
             if *existing == constraint {
-                continue;
-            }
-
-            let existing_support = storage.constraint_support(*existing);
-            let constraint_support = storage.constraint_support(constraint);
-            if !existing_support.overlaps_with(constraint_support)
-                && existing_support
-                    .iter()
-                    .chain(constraint_support.iter())
-                    .any(|typevar| self.independent_typevars.contains(&typevar))
-            {
                 continue;
             }
 
@@ -9585,18 +9666,16 @@ mod tests {
         }
     }
 
-    fn path_assignments_for<'db>(
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        builder: &ConstraintSetBuilder<'db>,
+    fn path_assignments_for(
+        builder: &ConstraintSetBuilder<'_>,
         node: NodeId,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
         match node.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([], FxHashSet::default()),
+            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([]),
             Node::Interior(interior) => {
                 let mut storage = builder.storage.borrow_mut();
-                interior.path_assignments(db, env, &mut storage, source_order)
+                interior.path_assignments(&mut storage, source_order)
             }
         }
     }
@@ -9605,7 +9684,6 @@ mod tests {
     fn path_assignments_follow_constraint_source_order() {
         let db = setup_db();
         let db = &db;
-        let env = db.program_environment();
         let t = create_typevar(db, "T");
         let u = create_typevar(db, "U");
         let builder = ConstraintSetBuilder::new();
@@ -9615,7 +9693,7 @@ mod tests {
         // Construct the set in the opposite order from constraint creation. This ensures the
         // initializer follows the sidecar rather than either TDD traversal or constraint IDs.
         let set = u_str.and(db, &builder, || t_int);
-        let path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
+        let path = path_assignments_for(&builder, set.node, set.source_order);
         let storage = builder.storage.borrow();
         let expected =
             [u_str.node, t_int.node].map(|node| storage.interior_node_data(node).constraint);
@@ -9673,7 +9751,7 @@ mod tests {
             tautology,
             transitive,
         ] {
-            let mut path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
+            let mut path = path_assignments_for(&builder, set.node, set.source_order);
             let mut fold = ReconstructPathFold { break_at: None };
             let mut storage = builder.storage.borrow_mut();
             let ControlFlow::Continue((reconstructed, reconstructed_source_order)) =
@@ -9710,7 +9788,7 @@ mod tests {
             PathFoldBreak::Impossible,
             PathFoldBreak::Combine,
         ] {
-            let mut path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
+            let mut path = path_assignments_for(&builder, set.node, set.source_order);
             let mut aborting_fold = ReconstructPathFold {
                 break_at: Some(break_at),
             };

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1884,6 +1884,14 @@ impl<'db> ConstraintBounds<'db> {
         (lower == upper).then_some(lower)
     }
 
+    fn is_concrete(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
+        iter::chain(self.lower, self.upper).all(|bound| {
+            !bound.has_typevar(db, env)
+                && !bound.has_unspecialized_type_var(db, env)
+                && bound.bottom_materialization(db, env) == bound.top_materialization(db, env)
+        })
+    }
+
     fn materialized_lower(self) -> Type<'db> {
         self.lower.unwrap_or(Type::Never)
     }
@@ -2823,7 +2831,7 @@ impl NodeId {
             Node::AlwaysTrue => true,
             Node::AlwaysFalse => false,
             Node::Interior(interior) => {
-                let mut path = interior.path_assignments(storage, source_order);
+                let mut path = interior.path_assignments(db, env, storage, source_order);
                 path.visit_negated(db, env, storage, self, &mut IsNeverSatisfiedVisitor)
                     .is_continue()
             }
@@ -2889,7 +2897,7 @@ impl NodeId {
                 let result = if simple_conjunction_is_satisfiable(storage, self) {
                     false
                 } else {
-                    let mut path = interior.path_assignments(storage, source_order);
+                    let mut path = interior.path_assignments(db, env, storage, source_order);
                     path.visit(db, env, storage, self, &mut IsNeverSatisfiedVisitor)
                         .is_continue()
                 };
@@ -3873,7 +3881,7 @@ impl<'db> PathBounds<'db> {
         // is too late: sequent pairs are not commutative, and TDD traversal order can otherwise
         // discard gradual evidence before solution extraction.
         let path_source_order = storage.ordered_source_order(source_order, derived_source_order);
-        let mut path = interior.path_assignments(storage, path_source_order);
+        let mut path = interior.path_assignments(db, env, storage, path_source_order);
         let _ = path.visit(db, env, storage, node, &mut collect_visitor);
         collect_visitor.sorted_paths.sort_by(|path1, path2| {
             let source_orders1 = path1.iter().map(|(_, source_order)| *source_order);
@@ -4655,15 +4663,17 @@ impl InteriorNode {
             }
         }
 
-        let mut path = self.path_assignments(storage, source_order);
+        let mut path = self.path_assignments(db, env, storage, source_order);
         let mut visitor = AbstractVisitor { should_remove };
         let ControlFlow::Continue(result) = path.visit(db, env, storage, self.node(), &mut visitor);
         result
     }
 
-    fn path_assignments(
+    fn path_assignments<'db>(
         self,
-        storage: &mut ConstraintSetStorage<'_>,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
@@ -4682,7 +4692,50 @@ impl InteriorNode {
                 .get_index_of(constraint)
                 .expect("every BDD constraint should have a source-order entry")
         });
-        PathAssignments::new(constraints)
+
+        if !self.node().is_single_conjunction(storage) {
+            return PathAssignments::new(constraints, FxHashSet::default());
+        }
+
+        let mut independent_typevars = FxHashSet::default();
+        let mut dependent_typevars = FxHashSet::default();
+        for constraint_id in &constraints {
+            let constraint = storage.constraint_data(*constraint_id);
+            let typevar = storage.typevar_id(db, constraint.typevar);
+            if constraint.bounds.is_concrete(db, env) {
+                independent_typevars.insert(typevar);
+            } else {
+                dependent_typevars.extend(storage.constraint_support(*constraint_id).iter());
+            }
+        }
+
+        independent_typevars.retain(|typevar| !dependent_typevars.contains(typevar));
+
+        if !independent_typevars.is_empty()
+            && constraints.iter().any(|constraint_id| {
+                let constraint = storage.constraint_data(*constraint_id);
+                let support = storage.constraint_support(*constraint_id);
+
+                iter::chain(constraint.bounds.lower, constraint.bounds.upper).any(|bound| {
+                    any_over_type(db, env, bound, true, |ty| {
+                        let Type::TypeVar(typevar) = ty else {
+                            return false;
+                        };
+
+                        !support.iter().any(|supported| {
+                            storage.typevar_data(supported) == typevar.identity(db)
+                        })
+                    })
+                })
+            })
+        {
+            // Constraint support intentionally does not evaluate lazy attributes such as type
+            // aliases and protocol members. Nested sequent discovery does inspect them, however,
+            // so an incomplete support set cannot safely prove that two constraints are independent.
+            independent_typevars.clear();
+        }
+
+        PathAssignments::new(constraints, independent_typevars)
     }
 }
 
@@ -6374,6 +6427,10 @@ pub(crate) struct PathAssignments {
     /// Constraint pairs that we have already checked and added to `sequents`.
     elaborated_pairs: FxHashSet<(ConstraintId, ConstraintId)>,
 
+    /// Type variables that only involve concrete constraints and so do not participate in sequent
+    /// discovery.
+    independent_typevars: FxHashSet<TypeVarId>,
+
     /// Derived assignments that have been queued up to be added to the current path.
     assignment_queue: VecDeque<(ConstraintAssignment, AssignmentFuel)>,
 
@@ -6438,7 +6495,10 @@ impl Ord for AssignmentFuel {
 }
 
 impl PathAssignments {
-    fn new(constraints: impl IntoIterator<Item = ConstraintId>) -> Self {
+    fn new(
+        constraints: impl IntoIterator<Item = ConstraintId>,
+        independent_typevars: FxHashSet<TypeVarId>,
+    ) -> Self {
         let discovered = constraints
             .into_iter()
             .map(|constraint| (constraint, false))
@@ -6449,6 +6509,7 @@ impl PathAssignments {
             additional_fuels: Vec::default(),
             discovered,
             elaborated_pairs: FxHashSet::default(),
+            independent_typevars,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
             assignment_queue: VecDeque::default(),
             new_assignments: FxIndexMap::default(),
@@ -6758,6 +6819,20 @@ impl PathAssignments {
 
         for (existing_index, (existing, _)) in self.discovered.iter().enumerate() {
             if *existing == constraint {
+                continue;
+            }
+
+            let existing_support = storage.constraint_support(*existing);
+            let constraint_support = storage.constraint_support(constraint);
+
+            // Independent typevars must be checked for disjoint or invalid constraints, but are
+            // otherwise already constrained and do not participate in sequent discovery.
+            if !existing_support.overlaps_with(constraint_support)
+                && existing_support
+                    .iter()
+                    .chain(constraint_support.iter())
+                    .any(|typevar| self.independent_typevars.contains(&typevar))
+            {
                 continue;
             }
 
@@ -8334,7 +8409,7 @@ mod tests {
     }
 
     #[test]
-    fn constraint_ordering_changes_derived_upper_bound_display() {
+    fn constraint_ordering_preserves_independent_concrete_solutions() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -8360,12 +8435,7 @@ mod tests {
                     .and(storage, int_t)
                     .and(storage, u_int)
             },
-            // TODO: Constraint-ID permutations can still change which equivalent upper-bound
-            // intersection is constructed first.
-            [
-                "never=false always=false merged=[T=int | U, U=T & int] paths=[T=int | U, U=T & int]",
-                "never=false always=false merged=[T=int | U, U=int & T] paths=[T=int | U, U=int & T]",
-            ],
+            ["never=false always=false merged=[T=int, U=int] paths=[T=int, U=int]"],
         );
     }
 
@@ -8705,16 +8775,18 @@ mod tests {
         }
     }
 
-    fn path_assignments_for(
-        builder: &ConstraintSetBuilder<'_>,
+    fn path_assignments_for<'db>(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &ConstraintSetBuilder<'db>,
         node: NodeId,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
+        let mut storage = builder.storage.borrow_mut();
         match node.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([]),
+            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([], FxHashSet::default()),
             Node::Interior(interior) => {
-                let mut storage = builder.storage.borrow_mut();
-                interior.path_assignments(&mut storage, source_order)
+                interior.path_assignments(db, env, &mut storage, source_order)
             }
         }
     }
@@ -8723,6 +8795,7 @@ mod tests {
     fn path_assignments_follow_constraint_source_order() {
         let db = setup_db();
         let db = &db;
+        let env = db.program_environment();
         let t = create_typevar(db, "T");
         let u = create_typevar(db, "U");
         let builder = ConstraintSetBuilder::new();
@@ -8732,7 +8805,7 @@ mod tests {
         // Construct the set in the opposite order from constraint creation. This ensures the
         // initializer follows the sidecar rather than either TDD traversal or constraint IDs.
         let set = u_str.and(db, &builder, || t_int);
-        let path = path_assignments_for(&builder, set.node, set.source_order);
+        let path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
         let storage = builder.storage.borrow();
         let expected =
             [u_str.node, t_int.node].map(|node| storage.interior_node_data(node).constraint);
@@ -8790,7 +8863,7 @@ mod tests {
             tautology,
             transitive,
         ] {
-            let mut path = path_assignments_for(&builder, set.node, set.source_order);
+            let mut path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
             let mut fold = ReconstructPathFold { break_at: None };
             let mut storage = builder.storage.borrow_mut();
             let ControlFlow::Continue((reconstructed, reconstructed_source_order)) =
@@ -8827,7 +8900,7 @@ mod tests {
             PathFoldBreak::Impossible,
             PathFoldBreak::Combine,
         ] {
-            let mut path = path_assignments_for(&builder, set.node, set.source_order);
+            let mut path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
             let mut aborting_fold = ReconstructPathFold {
                 break_at: Some(break_at),
             };

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -110,8 +110,8 @@ use crate::types::constraints::support::{Support, SupportId};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarSet};
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::{
-    TypeCollector, TypeKind, TypeVisitor, any_over_type, walk_non_atomic_type,
-    walk_type_with_recursion_guard,
+    AnyOverTypeResult, TypeCollector, TypeKind, TypeVisitor, any_over_type, try_any_over_type,
+    walk_non_atomic_type, walk_type_with_recursion_guard,
 };
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, IntersectionType, Type, TypeContext,
@@ -1889,6 +1889,15 @@ impl<'db> ConstraintBounds<'db> {
             !bound.has_typevar(db, env)
                 && !bound.has_unspecialized_type_var(db, env)
                 && bound.bottom_materialization(db, env) == bound.top_materialization(db, env)
+        })
+    }
+
+    fn has_incomplete_support(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
+        iter::chain(self.lower, self.upper).any(|bound| {
+            matches!(
+                try_any_over_type(db, env, bound, |_| false),
+                AnyOverTypeResult::SkippedLazyTypeAttributes
+            )
         })
     }
 
@@ -4694,7 +4703,7 @@ impl InteriorNode {
         });
 
         if !self.node().is_single_conjunction(storage) {
-            return PathAssignments::new(constraints, FxHashSet::default());
+            return PathAssignments::new(constraints, FxHashSet::default(), FxHashSet::default());
         }
 
         let mut independent_typevars = FxHashSet::default();
@@ -4711,31 +4720,23 @@ impl InteriorNode {
 
         independent_typevars.retain(|typevar| !dependent_typevars.contains(typevar));
 
-        if !independent_typevars.is_empty()
-            && constraints.iter().any(|constraint_id| {
-                let constraint = storage.constraint_data(*constraint_id);
-                let support = storage.constraint_support(*constraint_id);
-
-                iter::chain(constraint.bounds.lower, constraint.bounds.upper).any(|bound| {
-                    any_over_type(db, env, bound, true, |ty| {
-                        let Type::TypeVar(typevar) = ty else {
-                            return false;
-                        };
-
-                        !support.iter().any(|supported| {
-                            storage.typevar_data(supported) == typevar.identity(db)
-                        })
-                    })
-                })
-            })
-        {
-            // Constraint support intentionally does not evaluate lazy attributes such as type
-            // aliases and protocol members. Nested sequent discovery does inspect them, however,
-            // so an incomplete support set cannot safely prove that two constraints are independent.
-            independent_typevars.clear();
+        let mut incomplete_support_constraints = FxHashSet::default();
+        if !independent_typevars.is_empty() {
+            incomplete_support_constraints.extend(constraints.iter().copied().filter(
+                |constraint| {
+                    storage
+                        .constraint_data(*constraint)
+                        .bounds
+                        .has_incomplete_support(db, env)
+                },
+            ));
         }
 
-        PathAssignments::new(constraints, independent_typevars)
+        PathAssignments::new(
+            constraints,
+            independent_typevars,
+            incomplete_support_constraints,
+        )
     }
 }
 
@@ -6431,6 +6432,9 @@ pub(crate) struct PathAssignments {
     /// discovery.
     independent_typevars: FxHashSet<TypeVarId>,
 
+    /// Constraints whose lazy attributes may hide relationships absent from their support.
+    incomplete_support_constraints: FxHashSet<ConstraintId>,
+
     /// Derived assignments that have been queued up to be added to the current path.
     assignment_queue: VecDeque<(ConstraintAssignment, AssignmentFuel)>,
 
@@ -6498,6 +6502,7 @@ impl PathAssignments {
     fn new(
         constraints: impl IntoIterator<Item = ConstraintId>,
         independent_typevars: FxHashSet<TypeVarId>,
+        incomplete_support_constraints: FxHashSet<ConstraintId>,
     ) -> Self {
         let discovered = constraints
             .into_iter()
@@ -6510,6 +6515,7 @@ impl PathAssignments {
             discovered,
             elaborated_pairs: FxHashSet::default(),
             independent_typevars,
+            incomplete_support_constraints,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
             assignment_queue: VecDeque::default(),
             new_assignments: FxIndexMap::default(),
@@ -6814,6 +6820,16 @@ impl PathAssignments {
             return;
         }
 
+        if existing.is_none()
+            && !self.independent_typevars.is_empty()
+            && storage
+                .constraint_data(constraint)
+                .bounds
+                .has_incomplete_support(db, env)
+        {
+            self.incomplete_support_constraints.insert(constraint);
+        }
+
         let single_map = SequentMap::for_constraint(db, env, storage, constraint);
         self.sequents.extend_from_slice(&single_map.sequents);
 
@@ -6832,6 +6848,8 @@ impl PathAssignments {
                     .iter()
                     .chain(constraint_support.iter())
                     .any(|typevar| self.independent_typevars.contains(&typevar))
+                && !self.incomplete_support_constraints.contains(existing)
+                && !self.incomplete_support_constraints.contains(&constraint)
             {
                 continue;
             }
@@ -8784,7 +8802,9 @@ mod tests {
     ) -> PathAssignments {
         let mut storage = builder.storage.borrow_mut();
         match node.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([], FxHashSet::default()),
+            Node::AlwaysTrue | Node::AlwaysFalse => {
+                PathAssignments::new([], FxHashSet::default(), FxHashSet::default())
+            }
             Node::Interior(interior) => {
                 interior.path_assignments(db, env, &mut storage, source_order)
             }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2814,7 +2814,7 @@ impl NodeId {
             Node::AlwaysTrue => true,
             Node::AlwaysFalse => false,
             Node::Interior(interior) => {
-                let mut path = interior.path_assignments(storage, source_order);
+                let mut path = interior.path_assignments(db, env, storage, source_order);
                 path.visit_negated(db, env, storage, self, &mut IsNeverSatisfiedVisitor)
                     .is_continue()
             }
@@ -2880,7 +2880,7 @@ impl NodeId {
                 let result = if simple_conjunction_is_satisfiable(storage, self) {
                     false
                 } else {
-                    let mut path = interior.path_assignments(storage, source_order);
+                    let mut path = interior.path_assignments(db, env, storage, source_order);
                     path.visit(db, env, storage, self, &mut IsNeverSatisfiedVisitor)
                         .is_continue()
                 };
@@ -4051,7 +4051,7 @@ impl<'db> PathBounds<'db> {
         // is too late: sequent pairs are not commutative, and TDD traversal order can otherwise
         // discard gradual evidence before solution extraction.
         let path_source_order = storage.ordered_source_order(source_order, derived_source_order);
-        let mut path = interior.path_assignments(storage, path_source_order);
+        let mut path = interior.path_assignments(db, env, storage, path_source_order);
         let _ = path.visit(db, env, storage, node, &mut collect_visitor);
         collect_visitor.sorted_paths.sort_by(|path1, path2| {
             let source_orders1 = path1.iter().map(|(_, source_order)| *source_order);
@@ -4833,7 +4833,7 @@ impl InteriorNode {
             }
         }
 
-        let mut path = self.path_assignments(storage, source_order);
+        let mut path = self.path_assignments(db, env, storage, source_order);
         let mut visitor = AbstractVisitor { should_remove };
         let ControlFlow::Continue(result) = path.visit(db, env, storage, self.node(), &mut visitor);
         result
@@ -4911,9 +4911,11 @@ impl InteriorNode {
         result
     }
 
-    fn path_assignments(
+    fn path_assignments<'db>(
         self,
-        storage: &mut ConstraintSetStorage<'_>,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
@@ -4932,7 +4934,34 @@ impl InteriorNode {
                 .get_index_of(constraint)
                 .expect("every BDD constraint should have a source-order entry")
         });
-        PathAssignments::new(constraints)
+
+        if !self.node().is_single_conjunction(storage) {
+            return PathAssignments::new(constraints, FxHashSet::default());
+        }
+
+        let mut independent_typevars = FxHashSet::default();
+        let mut dependent_typevars = FxHashSet::default();
+        for constraint_id in &constraints {
+            let constraint = storage.constraint_data(*constraint_id);
+            let typevar = storage.typevar_id(db, constraint.typevar);
+            let has_relational_bound =
+                iter::chain(constraint.bounds.lower, constraint.bounds.upper).any(|bound| {
+                    bound.has_typevar(db, env)
+                        || bound.has_unspecialized_type_var(db, env)
+                        || bound.bottom_materialization(db, env)
+                            != bound.top_materialization(db, env)
+                });
+
+            if has_relational_bound {
+                dependent_typevars.extend(storage.constraint_support(*constraint_id).iter());
+            } else {
+                independent_typevars.insert(typevar);
+            }
+        }
+
+        independent_typevars.retain(|typevar| !dependent_typevars.contains(typevar));
+
+        PathAssignments::new(constraints, independent_typevars)
     }
 
     /// Returns a simplified version of a BDD.
@@ -7063,6 +7092,10 @@ pub(crate) struct PathAssignments {
     /// Constraint pairs that we have already checked and added to `sequents`.
     elaborated_pairs: FxHashSet<(ConstraintId, ConstraintId)>,
 
+    /// Type variables mentioned only by concrete constraints in the original diagram.
+    /// Deriving relationships to unrelated type variables cannot affect those constraints.
+    independent_typevars: FxHashSet<TypeVarId>,
+
     /// Derived assignments that have been queued up to be added to the current path.
     assignment_queue: VecDeque<(ConstraintAssignment, AssignmentFuel)>,
 
@@ -7127,7 +7160,10 @@ impl Ord for AssignmentFuel {
 }
 
 impl PathAssignments {
-    fn new(constraints: impl IntoIterator<Item = ConstraintId>) -> Self {
+    fn new(
+        constraints: impl IntoIterator<Item = ConstraintId>,
+        independent_typevars: FxHashSet<TypeVarId>,
+    ) -> Self {
         let discovered = constraints
             .into_iter()
             .map(|constraint| (constraint, false))
@@ -7138,6 +7174,7 @@ impl PathAssignments {
             additional_fuels: Vec::default(),
             discovered,
             elaborated_pairs: FxHashSet::default(),
+            independent_typevars,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
             assignment_queue: VecDeque::default(),
             new_assignments: FxIndexMap::default(),
@@ -7447,6 +7484,17 @@ impl PathAssignments {
 
         for (existing_index, (existing, _)) in self.discovered.iter().enumerate() {
             if *existing == constraint {
+                continue;
+            }
+
+            let existing_support = storage.constraint_support(*existing);
+            let constraint_support = storage.constraint_support(constraint);
+            if !existing_support.overlaps_with(constraint_support)
+                && existing_support
+                    .iter()
+                    .chain(constraint_support.iter())
+                    .any(|typevar| self.independent_typevars.contains(&typevar))
+            {
                 continue;
             }
 
@@ -9171,7 +9219,7 @@ mod tests {
     }
 
     #[test]
-    fn constraint_ordering_changes_derived_upper_bound_display() {
+    fn constraint_ordering_preserves_independent_concrete_solutions() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -9197,12 +9245,7 @@ mod tests {
                     .and(storage, int_t)
                     .and(storage, u_int)
             },
-            // TODO: Constraint-ID permutations can still change which equivalent upper-bound
-            // intersection is constructed first.
-            [
-                "never=false always=false merged=[T=int | U, U=T & int] paths=[T=int | U, U=T & int]",
-                "never=false always=false merged=[T=int | U, U=int & T] paths=[T=int | U, U=int & T]",
-            ],
+            ["never=false always=false merged=[T=int, U=int] paths=[T=int, U=int]"],
         );
     }
 
@@ -9542,16 +9585,18 @@ mod tests {
         }
     }
 
-    fn path_assignments_for(
-        builder: &ConstraintSetBuilder<'_>,
+    fn path_assignments_for<'db>(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &ConstraintSetBuilder<'db>,
         node: NodeId,
         source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
         match node.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([]),
+            Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([], FxHashSet::default()),
             Node::Interior(interior) => {
                 let mut storage = builder.storage.borrow_mut();
-                interior.path_assignments(&mut storage, source_order)
+                interior.path_assignments(db, env, &mut storage, source_order)
             }
         }
     }
@@ -9560,6 +9605,7 @@ mod tests {
     fn path_assignments_follow_constraint_source_order() {
         let db = setup_db();
         let db = &db;
+        let env = db.program_environment();
         let t = create_typevar(db, "T");
         let u = create_typevar(db, "U");
         let builder = ConstraintSetBuilder::new();
@@ -9569,7 +9615,7 @@ mod tests {
         // Construct the set in the opposite order from constraint creation. This ensures the
         // initializer follows the sidecar rather than either TDD traversal or constraint IDs.
         let set = u_str.and(db, &builder, || t_int);
-        let path = path_assignments_for(&builder, set.node, set.source_order);
+        let path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
         let storage = builder.storage.borrow();
         let expected =
             [u_str.node, t_int.node].map(|node| storage.interior_node_data(node).constraint);
@@ -9627,7 +9673,7 @@ mod tests {
             tautology,
             transitive,
         ] {
-            let mut path = path_assignments_for(&builder, set.node, set.source_order);
+            let mut path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
             let mut fold = ReconstructPathFold { break_at: None };
             let mut storage = builder.storage.borrow_mut();
             let ControlFlow::Continue((reconstructed, reconstructed_source_order)) =
@@ -9664,7 +9710,7 @@ mod tests {
             PathFoldBreak::Impossible,
             PathFoldBreak::Combine,
         ] {
-            let mut path = path_assignments_for(&builder, set.node, set.source_order);
+            let mut path = path_assignments_for(db, &env, &builder, set.node, set.source_order);
             let mut aborting_fold = ReconstructPathFold {
                 break_at: Some(break_at),
             };

--- a/crates/ty_python_semantic/src/types/constraints/support.rs
+++ b/crates/ty_python_semantic/src/types/constraints/support.rs
@@ -64,11 +64,6 @@ impl Support {
             })
         })
     }
-
-    /// Returns whether this support contains any type variables in common with `other`.
-    pub(super) fn overlaps_with(&self, other: &Self) -> bool {
-        std::iter::zip(&self.chunks, &other.chunks).any(|(lhs, rhs)| (*lhs & *rhs) != 0)
-    }
 }
 
 impl BitOrAssign<&Self> for Support {

--- a/crates/ty_python_semantic/src/types/constraints/support.rs
+++ b/crates/ty_python_semantic/src/types/constraints/support.rs
@@ -64,6 +64,11 @@ impl Support {
             })
         })
     }
+
+    /// Returns whether this support contains any type variables in common with `other`.
+    pub(super) fn overlaps_with(&self, other: &Self) -> bool {
+        std::iter::zip(&self.chunks, &other.chunks).any(|(lhs, rhs)| (*lhs & *rhs) != 0)
+    }
 }
 
 impl BitOrAssign<&Self> for Support {

--- a/crates/ty_python_semantic/src/types/constraints/support.rs
+++ b/crates/ty_python_semantic/src/types/constraints/support.rs
@@ -20,6 +20,7 @@ pub(super) struct SupportId;
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) struct Support {
     chunks: SmallVec<[usize; 2]>,
+    has_skipped_lazy_attributes: bool,
 }
 
 const CHUNK_SIZE: usize = usize::BITS as usize;
@@ -69,6 +70,16 @@ impl Support {
     pub(super) fn overlaps_with(&self, other: &Self) -> bool {
         std::iter::zip(&self.chunks, &other.chunks).any(|(lhs, rhs)| (*lhs & *rhs) != 0)
     }
+
+    /// Records that lazy type attributes may contain additional type variables.
+    pub(super) fn mark_incomplete(&mut self) {
+        self.has_skipped_lazy_attributes = true;
+    }
+
+    /// Returns whether all type attributes were inspected while collecting this support.
+    pub(super) fn is_complete(&self) -> bool {
+        !self.has_skipped_lazy_attributes
+    }
 }
 
 impl BitOrAssign<&Self> for Support {
@@ -79,6 +90,7 @@ impl BitOrAssign<&Self> for Support {
         for (lhs, rhs) in std::iter::zip(&mut self.chunks, &rhs.chunks) {
             *lhs |= *rhs;
         }
+        self.has_skipped_lazy_attributes |= rhs.has_skipped_lazy_attributes;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1074,6 +1074,7 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
     } else {
         match protocol.inner {
             Protocol::FromClass(_) | Protocol::Materialized(_) => {
+                visitor.notify_skipped_lazy_type_attributes();
                 if let Some((_, Some(specialization))) = protocol
                     .class_origin(db)
                     .and_then(|class| class.static_class_literal(db))

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -263,7 +263,11 @@ pub(crate) fn walk_newtype_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Si
     let base = if visitor.should_visit_lazy_type_attributes() {
         Some(newtype.base(db))
     } else {
-        newtype.eager_base(db)
+        let base = newtype.eager_base(db);
+        if base.is_none() {
+            visitor.notify_skipped_lazy_type_attributes();
+        }
+        base
     };
     if let Some(base) = base {
         visitor.visit_type(db, base.instance_type(db, visitor.program_environment()));

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -311,6 +311,7 @@ pub(super) fn walk_type_alias_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     visitor: &V,
 ) {
     if !visitor.should_visit_lazy_type_attributes() {
+        visitor.notify_skipped_lazy_type_attributes();
         return;
     }
     match type_alias {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1293,6 +1293,7 @@ pub(crate) fn walk_typed_dict_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
         visitor.visit_type(db, defining_class.into());
 
         if !visitor.should_visit_lazy_type_attributes() {
+            visitor.notify_skipped_lazy_type_attributes();
             return;
         }
     }

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -165,11 +165,15 @@ pub(super) fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
         typevar.bound_or_constraints(db, visitor.program_environment())
     } else {
         match typevar._bound_or_constraints(db) {
-            _ if visitor.should_visit_lazy_type_attributes() => {
-                typevar.bound_or_constraints(db, visitor.program_environment())
-            }
             Some(TypeVarBoundOrConstraintsEvaluation::Eager(bound_or_constraints)) => {
                 Some(bound_or_constraints)
+            }
+            Some(
+                TypeVarBoundOrConstraintsEvaluation::LazyUpperBound
+                | TypeVarBoundOrConstraintsEvaluation::LazyConstraints,
+            ) => {
+                visitor.notify_skipped_lazy_type_attributes();
+                None
             }
             _ => None,
         }
@@ -181,6 +185,10 @@ pub(super) fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     } else {
         match typevar._default(db) {
             Some(TypeVarDefaultEvaluation::Eager(default_type)) => Some(default_type),
+            Some(TypeVarDefaultEvaluation::Lazy) => {
+                visitor.notify_skipped_lazy_type_attributes();
+                None
+            }
             _ => None,
         }
     } {

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -42,6 +42,9 @@ pub(crate) trait TypeVisitor<'db> {
     /// Should the visitor trigger inference of and visit lazily-inferred type attributes?
     fn should_visit_lazy_type_attributes(&self) -> bool;
 
+    /// Notify the visitor that lazily-inferred type attributes were not visited.
+    fn notify_skipped_lazy_type_attributes(&self) {}
+
     fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>);
 
     fn visit_union_type(&self, db: &'db dyn Db, union: UnionType<'db>) {
@@ -573,7 +576,7 @@ fn any_over_type_impl<'db, F, T>(
     ty: Type<'db>,
     should_visit_lazy_type_attributes: bool,
     query: F,
-) -> T
+) -> TypeTraversalResult<T>
 where
     T: Copy + Default + PartialEq,
     F: Fn(Type<'db>) -> T,
@@ -583,6 +586,7 @@ where
         query: &'a dyn Fn(Type<'db>) -> U,
         recursion_guard: TypeCollector<'db>,
         found_matching_type: Cell<U>,
+        skipped_lazy_type_attributes: Cell<bool>,
         should_visit_lazy_type_attributes: bool,
     }
 
@@ -596,6 +600,10 @@ where
 
         fn should_visit_lazy_type_attributes(&self) -> bool {
             self.should_visit_lazy_type_attributes
+        }
+
+        fn notify_skipped_lazy_type_attributes(&self) {
+            self.skipped_lazy_type_attributes.set(true);
         }
 
         fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
@@ -618,10 +626,50 @@ where
         query: &query,
         recursion_guard: TypeCollector::default(),
         found_matching_type: Cell::default(),
+        skipped_lazy_type_attributes: Cell::new(false),
         should_visit_lazy_type_attributes,
     };
     visitor.visit_type(db, ty);
-    visitor.found_matching_type.get()
+    TypeTraversalResult {
+        value: visitor.found_matching_type.get(),
+        skipped_lazy_type_attributes: visitor.skipped_lazy_type_attributes.get(),
+    }
+}
+
+struct TypeTraversalResult<T> {
+    value: T,
+    skipped_lazy_type_attributes: bool,
+}
+
+/// The result of searching a type without evaluating lazily-inferred type attributes.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum AnyOverTypeResult {
+    /// A matching type was found.
+    Match,
+    /// No matching type was found and the type was fully inspected.
+    NoMatch,
+    /// No matching type was found, but lazily-inferred attributes were not inspected.
+    SkippedLazyTypeAttributes,
+}
+
+/// Return whether `ty`, or any eagerly available nested type, matches `query`.
+///
+/// Unlike [`any_over_type`], this reports when the traversal is incomplete because evaluating a
+/// lazy type attribute would be required.
+pub(super) fn try_any_over_type<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+    query: impl Fn(Type<'db>) -> bool,
+) -> AnyOverTypeResult {
+    let result = any_over_type_impl(db, env, ty, false, query);
+    if result.value {
+        AnyOverTypeResult::Match
+    } else if result.skipped_lazy_type_attributes {
+        AnyOverTypeResult::SkippedLazyTypeAttributes
+    } else {
+        AnyOverTypeResult::NoMatch
+    }
 }
 
 /// Return `true` if `ty`, or any of the types contained in `ty`, match the closure passed in.
@@ -639,7 +687,7 @@ pub(super) fn any_over_type<'db>(
     should_visit_lazy_type_attributes: bool,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query).value
 }
 
 /// Recurse into a type and calls the passed-in closure on every nested type
@@ -665,7 +713,7 @@ pub(super) fn find_over_type<'db, T>(
 where
     T: Copy + PartialEq,
 {
-    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query).value
 }
 
 #[cfg(test)]

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -576,7 +576,7 @@ fn any_over_type_impl<'db, F, T>(
     ty: Type<'db>,
     should_visit_lazy_type_attributes: bool,
     query: F,
-) -> TypeTraversalResult<T>
+) -> T
 where
     T: Copy + Default + PartialEq,
     F: Fn(Type<'db>) -> T,
@@ -586,7 +586,6 @@ where
         query: &'a dyn Fn(Type<'db>) -> U,
         recursion_guard: TypeCollector<'db>,
         found_matching_type: Cell<U>,
-        skipped_lazy_type_attributes: Cell<bool>,
         should_visit_lazy_type_attributes: bool,
     }
 
@@ -600,10 +599,6 @@ where
 
         fn should_visit_lazy_type_attributes(&self) -> bool {
             self.should_visit_lazy_type_attributes
-        }
-
-        fn notify_skipped_lazy_type_attributes(&self) {
-            self.skipped_lazy_type_attributes.set(true);
         }
 
         fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
@@ -626,50 +621,10 @@ where
         query: &query,
         recursion_guard: TypeCollector::default(),
         found_matching_type: Cell::default(),
-        skipped_lazy_type_attributes: Cell::new(false),
         should_visit_lazy_type_attributes,
     };
     visitor.visit_type(db, ty);
-    TypeTraversalResult {
-        value: visitor.found_matching_type.get(),
-        skipped_lazy_type_attributes: visitor.skipped_lazy_type_attributes.get(),
-    }
-}
-
-struct TypeTraversalResult<T> {
-    value: T,
-    skipped_lazy_type_attributes: bool,
-}
-
-/// The result of searching a type without evaluating lazily-inferred type attributes.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(super) enum AnyOverTypeResult {
-    /// A matching type was found.
-    Match,
-    /// No matching type was found and the type was fully inspected.
-    NoMatch,
-    /// No matching type was found, but lazily-inferred attributes were not inspected.
-    SkippedLazyTypeAttributes,
-}
-
-/// Return whether `ty`, or any eagerly available nested type, matches `query`.
-///
-/// Unlike [`any_over_type`], this reports when the traversal is incomplete because evaluating a
-/// lazy type attribute would be required.
-pub(super) fn try_any_over_type<'db>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    ty: Type<'db>,
-    query: impl Fn(Type<'db>) -> bool,
-) -> AnyOverTypeResult {
-    let result = any_over_type_impl(db, env, ty, false, query);
-    if result.value {
-        AnyOverTypeResult::Match
-    } else if result.skipped_lazy_type_attributes {
-        AnyOverTypeResult::SkippedLazyTypeAttributes
-    } else {
-        AnyOverTypeResult::NoMatch
-    }
+    visitor.found_matching_type.get()
 }
 
 /// Return `true` if `ty`, or any of the types contained in `ty`, match the closure passed in.
@@ -687,7 +642,7 @@ pub(super) fn any_over_type<'db>(
     should_visit_lazy_type_attributes: bool,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query).value
+    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query)
 }
 
 /// Recurse into a type and calls the passed-in closure on every nested type
@@ -713,7 +668,7 @@ pub(super) fn find_over_type<'db, T>(
 where
     T: Copy + PartialEq,
 {
-    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query).value
+    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The constraint solver has a fast-path that bypasses the full solver when all type variables are bounded by concrete types. This was necessary to fix exponential blowup in the sequent map with a large number of type variables with no transitive relationships. https://github.com/astral-sh/ty/issues/3989. However, introducing a single relationship between type variables bypasses the fast path, making it possible to observe similar exponential blowup, as seen in https://github.com/astral-sh/ruff/pull/26680. This PR adds a short-circuit in the full solver to avoid sequent discovery for the subset of typevars that have concrete bounds.

Note that I attempted to remove the fast-path entirely now that we have a more general fix, but it reintroduced a small regression due to the general extra work that the full solver performs. A followup may be able to close the gap entirely. There are some differences in behavior and diagnostics between the two paths that should eventually be addressed as well.