### PR TITLE
Enable BOLT for Linux x86-64 Ruff releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -19,6 +19,7 @@ on:
       # And when we change this workflow itself...
       - .github/workflows/build-binaries.yml
       - scripts/build_ruff_pgo.py
+      - scripts/build_ruff_bolt.py
 
 concurrency:
   group: build-binaries-${{ github.ref }}
@@ -283,6 +284,39 @@ jobs:
       - name: "Install LLVM profiling tools"
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: rustup component add llvm-tools-preview
+      - name: "Install LLVM BOLT"
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: |
+          set -euo pipefail
+
+          BOLT_ROOT="${RUNNER_TEMP}/llvm-bolt"
+          BOLT_VERSION="22.1.8~++20260714014902+ca7933e47d3a-1~exp1~20260714135019.80"
+          BOLT_BASE_URL="https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-22"
+
+          mkdir -p "${BOLT_ROOT}"
+
+          curl --fail --location --retry 3 \
+            --output "${BOLT_ROOT}/bolt-22.deb" \
+            "${BOLT_BASE_URL}/bolt-22_${BOLT_VERSION}_amd64.deb"
+          curl --fail --location --retry 3 \
+            --output "${BOLT_ROOT}/libbolt-22-dev.deb" \
+            "${BOLT_BASE_URL}/libbolt-22-dev_${BOLT_VERSION}_amd64.deb"
+
+          printf '%s  %s\n' \
+            '97a9e4e8d2b2219757c38abef93e913793ebc64580aa51207bd23941c44ec070' \
+            "${BOLT_ROOT}/bolt-22.deb" \
+            '48639dafeb45892eec58f5d8a2d0d612ce791a2f713f06c794b71d6a72fa582d' \
+            "${BOLT_ROOT}/libbolt-22-dev.deb" \
+            | sha256sum --check
+
+          dpkg-deb --extract "${BOLT_ROOT}/bolt-22.deb" "${BOLT_ROOT}"
+          dpkg-deb --extract "${BOLT_ROOT}/libbolt-22-dev.deb" "${BOLT_ROOT}"
+
+          "${BOLT_ROOT}/usr/lib/llvm-22/bin/llvm-bolt" --version
+          "${BOLT_ROOT}/usr/lib/llvm-22/bin/merge-fdata" --version
+          test -f "${BOLT_ROOT}/usr/lib/llvm-22/lib/libbolt_rt_instr.a"
+
+          echo "${BOLT_ROOT}/usr/lib/llvm-22/bin" >> "${GITHUB_PATH}"
       - name: "Train PGO Ruff"
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
@@ -291,7 +325,8 @@ jobs:
             --target-dir "${{ github.workspace }}/target/ruff-pgo" \
             --train-only
 
-          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/target/ruff-pgo/ruff.profdata" >> "$GITHUB_ENV"
+          echo "RUSTFLAGS=${RUSTFLAGS:+${RUSTFLAGS} }-Cprofile-use=${{ github.workspace }}/target/ruff-pgo/ruff.profdata -C link-arg=-Wl,--emit-relocs" >> "$GITHUB_ENV"
+          echo "MATURIN_STRIP=false" >> "$GITHUB_ENV"
       - name: "Prep README.md"
         run: python scripts/transform_readme.py --target pypi
       - name: "Build wheels"
@@ -301,6 +336,14 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: 2_17
           args: --release --locked --out dist --compatibility pypi
+      - name: "Optimize Ruff with BOLT"
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: |
+          python scripts/build_ruff_bolt.py \
+            --target "${{ matrix.target }}" \
+            --target-dir "${{ github.workspace }}/target/ruff-pgo" \
+            --wheels-dir "${{ github.workspace }}/dist" \
+            --binary "${{ github.workspace }}/target/${{ matrix.target }}/release/ruff"
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/scripts/build_ruff_bolt.py
+++ b/scripts/build_ruff_bolt.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Apply BOLT optimization to Ruff's Linux executable and its existing wheel."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import copy
+import csv
+import hashlib
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+
+from build_ruff_pgo import REPOSITORY_ROOT, run, rustc_host
+
+ELF_MAGIC = b"\x7fELF"
+IN_PLACE_MESSAGE = "BOLT-INFO: using original .text for new code"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--target-dir", type=Path, required=True)
+    parser.add_argument("--wheels-dir", type=Path, required=True)
+    parser.add_argument("--binary", type=Path)
+    args = parser.parse_args()
+
+    target_dir = args.target_dir.resolve()
+    wheels_dir = args.wheels_dir.resolve()
+    binary = (
+        args.binary or REPOSITORY_ROOT / "target" / args.target / "release" / "ruff"
+    ).resolve()
+    corpus_arguments = target_dir / "ruff-pgo.args"
+    pgo_profile = target_dir / "ruff.profdata"
+    for required in (binary, corpus_arguments, pgo_profile):
+        if not required.is_file():
+            raise RuntimeError(f"Missing BOLT prerequisite: {required}")
+
+    host = rustc_host()
+    if args.target != host:
+        parser.error(f"BOLT training requires host target {host}, got {args.target}")
+
+    wheels = sorted(wheels_dir.glob("ruff-*.whl"))
+    if not wheels:
+        raise RuntimeError(f"No Ruff wheels found in {wheels_dir}")
+
+    bolt = find_executable("llvm-bolt")
+    merge_fdata = bolt.parent / "merge-fdata"
+    if not executable(merge_fdata):
+        merge_fdata = find_executable("merge-fdata")
+    runtime = bolt.parent.parent / "lib" / "libbolt_rt_instr.a"
+    if not runtime.is_file():
+        raise RuntimeError(f"BOLT instrumentation runtime not found: {runtime}")
+
+    sysroot = subprocess.run(
+        ["rustc", "--print", "sysroot"],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    llvm_strip = Path(sysroot) / "lib" / "rustlib" / host / "bin" / "llvm-strip"
+    if not executable(llvm_strip):
+        raise RuntimeError(
+            f"Rust LLVM strip not found: {llvm_strip}; "
+            "run `rustup component add llvm-tools-preview`"
+        )
+
+    readelf = find_executable("readelf")
+    validate_input(readelf, binary)
+    original_version = version(binary)
+    environment = os.environ.copy()
+    bolt_dir = target_dir / "bolt"
+    bolt_dir.mkdir(parents=True, exist_ok=True)
+    instrumented = bolt_dir / "ruff.instrumented"
+    profile_prefix = bolt_dir / "ruff.fdata"
+    merged_profile = bolt_dir / "ruff.merged.fdata"
+    optimized = bolt_dir / "ruff.bolt.unstripped"
+    for profile in bolt_dir.glob("ruff.fdata*"):
+        if profile.is_file():
+            profile.unlink()
+
+    print("Instrumenting Ruff with BOLT", flush=True)
+    run(
+        [
+            str(bolt),
+            str(binary),
+            "-instrument",
+            f"--instrumentation-file={profile_prefix}",
+            "--instrumentation-file-append-pid",
+            f"--runtime-instrumentation-lib={runtime}",
+            "-o",
+            str(instrumented),
+        ],
+        environment=environment,
+    )
+
+    common_arguments = [
+        "--isolated",
+        "--target-version",
+        "py314",
+        "--no-cache",
+        "--silent",
+    ]
+    run(
+        [
+            str(instrumented),
+            "check",
+            *common_arguments,
+            "--exit-zero",
+            f"@{corpus_arguments}",
+        ],
+        environment=environment,
+    )
+    run(
+        [
+            str(instrumented),
+            "format",
+            *common_arguments,
+            "--check",
+            f"@{corpus_arguments}",
+        ],
+        environment=environment,
+        allowed_exit_codes=(0, 1),
+    )
+
+    profiles = sorted(bolt_dir.glob("ruff.fdata*"))
+    if len(profiles) < 2 or any(profile.stat().st_size == 0 for profile in profiles):
+        raise RuntimeError("Expected complete BOLT profiles from check and format")
+    print(f"Merging {len(profiles)} BOLT profiles", flush=True)
+    with merged_profile.open("wb") as output:
+        subprocess.run(
+            [str(merge_fdata), *map(str, profiles)],
+            cwd=REPOSITORY_ROOT,
+            env=environment,
+            stdout=output,
+            check=True,
+        )
+    if merged_profile.stat().st_size == 0:
+        raise RuntimeError("BOLT profile merger produced an empty profile")
+
+    command = [
+        str(bolt),
+        str(binary),
+        f"-data={merged_profile}",
+        "-o",
+        str(optimized),
+        "-reorder-blocks=ext-tsp",
+        "-reorder-functions=cdsort",
+        "-split-functions",
+        "-split-strategy=cdsplit",
+        "-split-all-cold",
+        "-jump-tables=move",
+        "-icf=all",
+        "-dyno-stats",
+        "--use-old-text",
+        "--no-huge-pages",
+    ]
+    print("Optimizing Ruff with BOLT", flush=True)
+    result = subprocess.run(
+        command,
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    print(result.stdout, end="", flush=True)
+    if result.returncode:
+        raise subprocess.CalledProcessError(result.returncode, command)
+    if IN_PLACE_MESSAGE not in result.stdout:
+        raise RuntimeError("BOLT could not reuse the original executable code")
+
+    temporary_binary = temporary_path(binary.parent, ".ruff-bolt-", ".tmp")
+    staged_wheels: list[tuple[Path, Path]] = []
+    try:
+        run(
+            [
+                str(llvm_strip),
+                "--strip-all",
+                "-o",
+                str(temporary_binary),
+                str(optimized),
+            ],
+            environment=environment,
+        )
+        temporary_binary.chmod(binary.stat().st_mode & 0o777)
+        validate_security(readelf, temporary_binary)
+        if version(temporary_binary) != original_version:
+            raise RuntimeError("BOLT changed Ruff's executable version")
+
+        smoke_input = bolt_dir / "smoke.py"
+        smoke_input.write_text("value = 1\n", encoding="utf-8")
+        run(
+            [
+                str(temporary_binary),
+                "check",
+                "--isolated",
+                "--no-cache",
+                "--silent",
+                str(smoke_input),
+            ],
+            environment=environment,
+        )
+        run(
+            [
+                str(temporary_binary),
+                "format",
+                "--isolated",
+                "--no-cache",
+                "--check",
+                "--silent",
+                str(smoke_input),
+            ],
+            environment=environment,
+        )
+
+        for wheel in wheels:
+            staged_wheels.append((wheel, rebuild_wheel(wheel, temporary_binary)))
+
+        for wheel, staged in staged_wheels:
+            staged.replace(wheel)
+        temporary_binary.replace(binary)
+        print(f"BOLT-optimized Ruff: {binary} ({binary.stat().st_size} bytes)")
+    finally:
+        temporary_binary.unlink(missing_ok=True)
+        for _, staged in staged_wheels:
+            staged.unlink(missing_ok=True)
+
+
+def executable(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def find_executable(name: str) -> Path:
+    for candidate in (name, f"{name}-22"):
+        if resolved := shutil.which(candidate):
+            return Path(resolved).resolve()
+    raise RuntimeError(f"Required executable not found on PATH: {name}")
+
+
+def validate_input(readelf: Path, binary: Path) -> None:
+    output = subprocess.run(
+        [str(readelf), "--sections", "--wide", str(binary)],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    if ".symtab" not in output:
+        raise RuntimeError(f"BOLT input lacks symbols: {binary}")
+    if ".real.text" not in output and ".rel.text" not in output:
+        raise RuntimeError(
+            f"BOLT input lacks text relocations: {binary}; "
+            "link with `-Clink-arg=-Wl,--emit-relocs`"
+        )
+
+
+def validate_security(readelf: Path, binary: Path) -> None:
+    output = subprocess.run(
+        [str(readelf), "--program-headers", "--wide", str(binary)],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    stack = next((line for line in output.splitlines() if "GNU_STACK" in line), "")
+    if not stack or "E" in stack.split()[-2]:
+        raise RuntimeError("BOLT executable has a missing or executable GNU stack")
+    if "GNU_RELRO" not in output:
+        raise RuntimeError("BOLT executable no longer has GNU RELRO protection")
+
+
+def version(binary: Path) -> str:
+    return subprocess.run(
+        [str(binary), "--version"],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def temporary_path(directory: Path, prefix: str, suffix: str) -> Path:
+    with tempfile.NamedTemporaryFile(
+        dir=directory, prefix=prefix, suffix=suffix, delete=False
+    ) as temporary:
+        return Path(temporary.name)
+
+
+def rebuild_wheel(wheel: Path, binary: Path) -> Path:
+    binary_data = binary.read_bytes()
+    staged = temporary_path(wheel.parent, f".{wheel.name}.", ".tmp")
+    try:
+        with zipfile.ZipFile(wheel) as original:
+            members = original.infolist()
+            names = [member.filename for member in members if not member.is_dir()]
+            if len(names) != len(set(names)):
+                raise RuntimeError(f"Wheel has duplicate entries: {wheel}")
+
+            records = [name for name in names if name.endswith(".dist-info/RECORD")]
+            executables = []
+            for member in members:
+                if member.is_dir() or PurePosixPath(member.filename).name != "ruff":
+                    continue
+                with original.open(member) as stream:
+                    if stream.read(len(ELF_MAGIC)) == ELF_MAGIC:
+                        executables.append(member.filename)
+            if len(records) != 1 or len(executables) != 1:
+                raise RuntimeError(f"Wheel must have one RECORD and Ruff ELF: {wheel}")
+
+            record_name = records[0]
+            binary_name = executables[0]
+            content = {
+                member.filename: (
+                    binary_data
+                    if member.filename == binary_name
+                    else original.read(member)
+                )
+                for member in members
+                if not member.is_dir() and member.filename != record_name
+            }
+            rows = [
+                [name, "", ""]
+                if name == record_name
+                else [name, record_hash(content[name]), str(len(content[name]))]
+                for name in names
+            ]
+            record_stream = io.StringIO(newline="")
+            csv.writer(record_stream, lineterminator="\n").writerows(rows)
+            content[record_name] = record_stream.getvalue().encode("utf-8")
+
+            with zipfile.ZipFile(staged, mode="w") as rebuilt:
+                rebuilt.comment = original.comment
+                for member in members:
+                    rebuilt.writestr(
+                        copy.copy(member),
+                        b"" if member.is_dir() else content[member.filename],
+                        compress_type=member.compress_type,
+                        compresslevel=(
+                            6 if member.compress_type == zipfile.ZIP_DEFLATED else None
+                        ),
+                    )
+
+        validate_wheel(staged, binary_name, binary_data, names)
+        print(f"Staged BOLT-optimized wheel: {wheel.name}", flush=True)
+        return staged
+    except BaseException:
+        staged.unlink(missing_ok=True)
+        raise
+
+
+def record_hash(data: bytes) -> str:
+    encoded = base64.urlsafe_b64encode(hashlib.sha256(data).digest())
+    return f"sha256={encoded.rstrip(b'=').decode('ascii')}"
+
+
+def validate_wheel(
+    wheel: Path, binary_name: str, binary_data: bytes, expected_names: list[str]
+) -> None:
+    with zipfile.ZipFile(wheel) as archive:
+        names = [
+            member.filename for member in archive.infolist() if not member.is_dir()
+        ]
+        if names != expected_names:
+            raise RuntimeError("Repacked wheel changed its archive members")
+        record_name = next(name for name in names if name.endswith(".dist-info/RECORD"))
+        records = list(csv.reader(io.StringIO(archive.read(record_name).decode())))
+        if len(records) != len(names) or {row[0] for row in records} != set(names):
+            raise RuntimeError("Repacked wheel has incomplete RECORD entries")
+        for row in records:
+            if len(row) != 3:
+                raise RuntimeError("Repacked wheel has malformed RECORD entries")
+            name, digest, size = row
+            if name == record_name:
+                if digest or size:
+                    raise RuntimeError("Wheel RECORD must not hash itself")
+                continue
+            data = archive.read(name)
+            if digest != record_hash(data) or size != str(len(data)):
+                raise RuntimeError(f"Wheel RECORD does not match {name}")
+
+        if archive.read(binary_name) != binary_data:
+            raise RuntimeError("Repacked wheel does not contain the BOLT executable")
+        if not (archive.getinfo(binary_name).external_attr >> 16) & 0o111:
+            raise RuntimeError("Repacked Ruff wheel lost executable permissions")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (
+        OSError,
+        RuntimeError,
+        subprocess.CalledProcessError,
+        zipfile.BadZipFile,
+    ) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/build_ruff_bolt.py
+++ b/scripts/build_ruff_bolt.py
@@ -10,6 +10,7 @@ import csv
 import hashlib
 import io
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -256,7 +257,7 @@ def validate_input(readelf: Path, binary: Path) -> None:
     ).stdout
     if ".symtab" not in output:
         raise RuntimeError(f"BOLT input lacks symbols: {binary}")
-    if ".real.text" not in output and ".rel.text" not in output:
+    if not re.search(r"\.rel(?:a)?\.text", output):
         raise RuntimeError(
             f"BOLT input lacks text relocations: {binary}; "
             "link with `-Clink-arg=-Wl,--emit-relocs`"

--- a/scripts/build_ruff_bolt.py
+++ b/scripts/build_ruff_bolt.py
@@ -1,5 +1,9 @@
-#!/usr/bin/env python3
 """Apply BOLT optimization to Ruff's Linux executable and its existing wheel."""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Add post-link LLVM BOLT optimization to the existing Linux x86-64 Ruff release build after compiler PGO and fat LTO. This is stacked on #27574; macOS, Windows, Linux ARM64, and all other targets remain compiler-PGO-only or retain their existing release behavior.

The manylinux build preserves symbols and linker relocations, then instruments the linked executable and trains `ruff check` and `ruff format` on the same eight immutable ecosystem projects already used by Ruff and ty PGO. BOLT reorders hot functions and basic blocks using the collected binary profile.

The optimized executable uses `--use-old-text --no-huge-pages` to reuse the original code section instead of publishing BOLT's much larger default duplicate-text layout. The helper requires in-place rewriting to succeed, preserves GNU stack and RELRO hardening, smoke-tests the result, strips with the Rust toolchain's `llvm-strip`, and atomically rebuilds wheel `RECORD` entries. The wheel and standalone archive contain the same optimized binary.

LLVM BOLT 22 and its instrumentation runtime are fetched from the official LLVM repository with pinned SHA-256 digests. The dependency-free helper follows the same PEP 723 script conventions as the compiler-PGO helper.

## Linux x86-64 production-artifact measurements

Compared the actual standalone release binaries uploaded by this PR and its immediate PGO-only parent. Both contain identical Ruff 0.16.2 sources, the same Rust toolchain and manylinux build configuration, and the current shared eight-project PGO corpus. Benchmarks covered 5,396 held-out Python and stub files totaling 90.57 MB and used eight physical AMD EPYC cores, three warmup pairs, and 20 alternating baseline/candidate pairs per workload.

| Held-out project | `ruff check` | `ruff format` |
| --- | ---: | ---: |
| Django | 1.62% faster | 0.35% faster |
| pandas | 0.70% faster | 1.43% faster |
| scikit-learn | 0.86% faster | 1.00% faster |
| SciPy | 1.06% faster | 1.77% faster |
| SymPy | 2.13% faster | 1.46% faster |
| Geometric mean | **1.28% faster** | **1.20% faster** |

Across all ten workloads, BOLT improves wall time by **1.24%** and CPU time by **1.91%** beyond compiler PGO. Paired bootstrap confidence intervals are 0.36–1.75% for wall time and 1.59–2.03% for CPU time. The BOLT binary won 133 of 200 wall-time comparisons and 184 of 200 CPU-time comparisons.

The effect is smaller than compiler PGO because PGO and fat LTO already optimize the same workload: BOLT's production dynamic statistics show only **0.7% fewer executed instructions**, while loads, stores, and function-call counts remain unchanged. BOLT reduces taken conditional branches by 22.5%, but that mostly improves layout rather than eliminating work.

Additional no-build BOLT strategy comparisons did not uncover a better compact layout: `hfsort+` produced a byte-for-byte identical executable, `profile2` increased compressed size by another 4.10%, disabling function splitting increased executable size by 1.89%, and `--lite` could not satisfy the required in-place rewrite.

| Artifact | PGO | PGO + BOLT | Increase |
| --- | ---: | ---: | ---: |
| Stripped executable | 26,111,360 bytes | 27,397,944 bytes | **4.93%** |
| Standalone release `.tar.gz` | 10,573,500 bytes | 11,417,642 bytes | **7.98%** |
| manylinux wheel | 10,981,512 bytes | 11,468,195 bytes | **4.43%** |

BOLT successfully rewrites executable code in-place but still appends regenerated exception/unwind metadata and jump-table data: the new `.gcc_except_table`, `.eh_frame_hdr`, and relocated `.rodata` account for nearly all executable growth. The production rewrite has 73 KB of remaining text-section capacity and adds 45 seconds to the release job. It fails if a future binary cannot fit rather than silently using a much larger fallback layout.

ARM64 BOLT remains intentionally disabled: the previous ARM experiment inserted 24,430 branch-range stubs, increased the executable by 11.2%, and improved wall time by only 0.08%.
