### PR TITLE
[ty] Stabilize cyclic attribute-presence inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -385,6 +385,70 @@ class Cached:
 reveal_type(Cached().metadata)  # revealed: int
 ```
 
+## Guarded instance attributes when the subclass is checked first
+
+Checking the subclass first preserves both diagnostics in the guarded initializer.
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+```
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self):
+        if not hasattr(self, "x"):
+            self.x = self.__str__  # error: [invalid-assignment]
+            self.missing  # error: [unresolved-attribute]
+```
+
+## Guarded instance attributes when the base is checked first
+
+Checking the base first produces the same diagnostics as checking the subclass first.
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self):
+        if not hasattr(self, "x"):
+            self.x = self.__str__  # error: [invalid-assignment]
+            self.missing  # error: [unresolved-attribute]
+```
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+```
+
+## Existing class attributes keep guarded initializers unreachable
+
+A defined attribute remains present on both its declaring class and its subclasses.
+
+```py
+class Base:
+    x = 1
+
+    def initialize(self):
+        if not hasattr(self, "x"):
+            self.x = self.missing
+
+class Child(Base):
+    def initialize(self):
+        if not hasattr(self, "x"):
+            self.x = self.missing
+```
+
 ## Decorator defined on a base class with constrained typevars, accessed from a subclass with decorated generic parameters
 
 This example was minimized from

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -3764,6 +3764,59 @@ fn callable_has_only_non_never_returns<'db>(db: &'db dyn Db, callable: CallableT
         && signatures.all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+enum AttributePresence {
+    Present,
+    Absent,
+    Uncertain,
+}
+
+/// Establish attribute presence without mistaking an unresolved inference cycle for proof.
+#[salsa::tracked(
+    returns(copy),
+    cycle_result=|_, _, _, _, _| AttributePresence::Uncertain,
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn protocol_member_presence<'db>(
+    db: &'db dyn Db,
+    program: Program<'db>,
+    ty: Type<'db>,
+    protocol: ProtocolInstanceType<'db>,
+) -> AttributePresence {
+    let env = ProgramEnvironment::from_program(program);
+
+    for member in protocol.interface(db).members(db) {
+        if ty
+            .member_lookup_with_policy(
+                db,
+                &env,
+                member.name(),
+                MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+            )
+            .place
+            .is_definitely_bound()
+        {
+            continue;
+        }
+
+        match ty.member(db, &env, member.name()).place {
+            Place::Defined(DefinedPlace {
+                ty: member_ty,
+                definedness: Definedness::AlwaysDefined,
+                ..
+            }) if member_ty.is_divergent() => return AttributePresence::Uncertain,
+            Place::Defined(DefinedPlace {
+                definedness: Definedness::AlwaysDefined,
+                ..
+            }) => {}
+            Place::Defined(_) => return AttributePresence::Uncertain,
+            Place::Undefined => return AttributePresence::Absent,
+        }
+    }
+
+    AttributePresence::Present
+}
+
 /// Protocol compatibility can only succeed if every required member is present.
 ///
 /// Check that necessary condition up front so we can avoid expensive per-member type
@@ -3786,6 +3839,10 @@ pub(super) fn has_all_protocol_members_defined<'db>(
                 && target_interface.members(db).all(|member| {
                     source_interface.includes_member_or_object_fallback(db, env, member.name())
                 })
+        }
+        _ if protocol.class_origin(db).is_none() => {
+            protocol_member_presence(db, env.program(db), ty, protocol)
+                == AttributePresence::Present
         }
         _ => target_interface.members(db).all(|member| {
             matches!(


### PR DESCRIPTION
## Summary

Inferring an implicit instance attribute can re-enter the `hasattr` check guarding its initializer:

```python
# base.py
class Base:
    def __init__(self):
        if not hasattr(self, "x"):
            self.x = self.__str__
            self.missing


# child.py
from base import Base


class Child(Base):
    x = Base.__str__
```

Previously, whether the guarded branch remained reachable depended on which file was checked first, and checking the subclass first could suppress the genuine missing-attribute diagnostic.

Introduce a cycle-aware, three-state presence check for synthesized protocols. Definitely present class and inherited attributes remain present, while unresolved implicit attributes remain uncertain until inference converges. This makes both file orders report the same diagnostics without changing public attribute definedness.

The existing bound-method assignment diagnostic and compatibility between negatively narrowed receivers and named protocols are separate issues and remain out of scope.

Related to https://github.com/astral-sh/ty/issues/4076.
