### PR TITLE
[ty] Preserve contextual inference for declarations in loops

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -73,18 +73,13 @@ A declaration inside a loop provides context to assignments that reach it from a
 
 ### While loops
 
-A declaration inside a `while` loop applies to dictionary literals assigned in each iteration.
+A declaration inside a `while` loop applies to list literals assigned in each iteration.
 
 ```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    value: int
-
 while True:
-    record: Record
-    record = {"value": 1}
-    reveal_type(record)  # revealed: Record
+    values: list[object]
+    values = [1]
+    reveal_type(values)  # revealed: list[object]
 ```
 
 ### For loops
@@ -92,15 +87,10 @@ while True:
 The same declaration context applies to assignments in a `for` loop.
 
 ```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    value: int
-
 for _ in range(2):
-    record: Record
-    record = {"value": 1}
-    reveal_type(record)  # revealed: Record
+    values: list[object]
+    values = [1]
+    reveal_type(values)  # revealed: list[object]
 ```
 
 ### Nested dictionary values
@@ -140,15 +130,10 @@ while True:
 String annotations provide their resolved type when a loop-carried assignment needs context.
 
 ```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    value: int
-
 while True:
-    record: "Record"
-    record = {"value": 1}
-    reveal_type(record)  # revealed: Record
+    values: "list[object]"
+    values = [1]
+    reveal_type(values)  # revealed: list[object]
 ```
 
 ### Deferred forward references

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -67,6 +67,132 @@ def f() -> list[Literal[1]]:
     return [1]
 ```
 
+## Loop-carried assignment context
+
+A declaration inside a loop provides context to assignments that reach it from an earlier iteration.
+
+### While loops
+
+A declaration inside a `while` loop applies to dictionary literals assigned in each iteration.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+while True:
+    record: Record
+    record = {"value": 1}
+    reveal_type(record)  # revealed: Record
+```
+
+### For loops
+
+The same declaration context applies to assignments in a `for` loop.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+for _ in range(2):
+    record: Record
+    record = {"value": 1}
+    reveal_type(record)  # revealed: Record
+```
+
+### Nested dictionary values
+
+A declaration inside a loop also provides context for values nested within a dictionary literal.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    values: list[float]
+
+while True:
+    record: Record
+    record = {"values": [1]}
+    reveal_type(record)  # revealed: Record
+```
+
+### Invalid dictionary values
+
+An incompatible dictionary item is reported at the assignment, not at the declaration.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+while True:
+    record: Record
+    record = {"value": "invalid"}  # error: [invalid-argument-type]
+    reveal_type(record)  # revealed: Record
+```
+
+### Stringified annotations
+
+String annotations provide their resolved type when a loop-carried assignment needs context.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+while True:
+    record: "Record"
+    record = {"value": 1}
+    reveal_type(record)  # revealed: Record
+```
+
+### Deferred forward references
+
+Deferred annotations resolve a `TypedDict` defined after the loop before inferring its dictionary
+assignments.
+
+```py
+from __future__ import annotations
+from typing import TypedDict
+
+for _ in range(2):
+    record: Record
+    record = {"value": 1}
+    reveal_type(record)  # revealed: Record
+
+    invalid: Record
+    invalid = {"value": "invalid"}  # error: [invalid-argument-type]
+
+class Record(TypedDict):
+    value: int
+```
+
+### Deferred forward references on Python 3.14
+
+Annotations are deferred by default in Python 3.14 and later.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import TypedDict
+
+for _ in range(2):
+    record: Record
+    record = {"value": 1}
+    reveal_type(record)  # revealed: Record
+
+class Record(TypedDict):
+    value: int
+```
+
 ## Collection literals
 
 ### Basic

--- a/crates/ty_python_semantic/resources/mdtest/declaration/error.md
+++ b/crates/ty_python_semantic/resources/mdtest/declaration/error.md
@@ -12,16 +12,11 @@ x: str  # error: [invalid-declaration] "Cannot declare type `str` for inferred t
 An incompatible binding that predates the loop must still invalidate a declaration inside it.
 
 ```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    value: int
-
-record = {"value": 1}
+values = [1]
 
 while True:
-    record: Record  # error: [invalid-declaration]
-    record = {"value": 1}
+    values: list[object]  # error: [invalid-declaration]
+    values = [1]
 ```
 
 ## Incompatible declarations

--- a/crates/ty_python_semantic/resources/mdtest/declaration/error.md
+++ b/crates/ty_python_semantic/resources/mdtest/declaration/error.md
@@ -7,6 +7,105 @@ x = 1
 x: str  # error: [invalid-declaration] "Cannot declare type `str` for inferred type `Literal[1]`"
 ```
 
+## Declarations in while loops provide assignment context
+
+A declaration inside a loop also applies to assignments that reach the declaration from the previous
+iteration.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+while True:
+    record: Record
+    record = {"value": 1}
+    reveal_type(record)  # revealed: Record
+```
+
+## Declarations in for loops provide assignment context
+
+The same declaration context applies when assignments reach a declaration from an earlier `for` loop
+iteration.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+for _ in range(2):
+    record: Record
+    record = {"value": 1}
+    reveal_type(record)  # revealed: Record
+```
+
+## Declarations in loops provide nested assignment context
+
+A declaration inside a loop also provides context for values nested within a dictionary literal.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    values: list[float]
+
+while True:
+    record: Record
+    record = {"values": [1]}
+    reveal_type(record)  # revealed: Record
+```
+
+## Declarations in loops reject invalid assignments
+
+An incompatible dictionary item is still reported at the assignment, not at the declaration.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+while True:
+    record: Record
+    record = {"value": "invalid"}  # error: [invalid-argument-type]
+    reveal_type(record)  # revealed: Record
+```
+
+## Declarations in loops reject incompatible earlier bindings
+
+An incompatible binding that predates the loop must still invalidate a declaration inside it.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+record = {"value": 1}
+
+while True:
+    record: Record  # error: [invalid-declaration]
+    record = {"value": 1}
+```
+
+## Stringified declarations in loops provide assignment context
+
+String annotations still provide their resolved type when a loop-carried assignment needs context.
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict):
+    value: int
+
+while True:
+    record: "Record"
+    record = {"value": 1}
+    reveal_type(record)  # revealed: Record
+```
+
 ## Incompatible declarations
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/declaration/error.md
+++ b/crates/ty_python_semantic/resources/mdtest/declaration/error.md
@@ -7,72 +7,6 @@ x = 1
 x: str  # error: [invalid-declaration] "Cannot declare type `str` for inferred type `Literal[1]`"
 ```
 
-## Declarations in while loops provide assignment context
-
-A declaration inside a loop also applies to assignments that reach the declaration from the previous
-iteration.
-
-```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    value: int
-
-while True:
-    record: Record
-    record = {"value": 1}
-    reveal_type(record)  # revealed: Record
-```
-
-## Declarations in for loops provide assignment context
-
-The same declaration context applies when assignments reach a declaration from an earlier `for` loop
-iteration.
-
-```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    value: int
-
-for _ in range(2):
-    record: Record
-    record = {"value": 1}
-    reveal_type(record)  # revealed: Record
-```
-
-## Declarations in loops provide nested assignment context
-
-A declaration inside a loop also provides context for values nested within a dictionary literal.
-
-```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    values: list[float]
-
-while True:
-    record: Record
-    record = {"values": [1]}
-    reveal_type(record)  # revealed: Record
-```
-
-## Declarations in loops reject invalid assignments
-
-An incompatible dictionary item is still reported at the assignment, not at the declaration.
-
-```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    value: int
-
-while True:
-    record: Record
-    record = {"value": "invalid"}  # error: [invalid-argument-type]
-    reveal_type(record)  # revealed: Record
-```
-
 ## Declarations in loops reject incompatible earlier bindings
 
 An incompatible binding that predates the loop must still invalidate a declaration inside it.
@@ -88,22 +22,6 @@ record = {"value": 1}
 while True:
     record: Record  # error: [invalid-declaration]
     record = {"value": 1}
-```
-
-## Stringified declarations in loops provide assignment context
-
-String annotations still provide their resolved type when a loop-carried assignment needs context.
-
-```py
-from typing import TypedDict
-
-class Record(TypedDict):
-    value: int
-
-while True:
-    record: "Record"
-    record = {"value": 1}
-    reveal_type(record)  # revealed: Record
 ```
 
 ## Incompatible declarations

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1397,6 +1397,31 @@ impl<'db> DefinitionInference<'db> {
                         DefinitionTypes::Binding(Type::instance(db, &env, divergent_collection));
                 }
             }
+        } else if let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) {
+            let program_file = definition.program_file(db);
+            let python_file = program_file.python_file(db);
+            let module = parsed_module(db, python_file).load(db);
+            let index = semantic_index(db, program_file);
+
+            if assignment.value(&module).is_none()
+                && index
+                    .use_def_map(definition.file_scope(db))
+                    .bindings_at_definition(definition)
+                    .any(|binding| {
+                        binding
+                            .binding
+                            .is_defined_and(|binding| binding.kind(db).is_loop_header())
+                    })
+            {
+                // Loop-carried assignments need this annotation as context before validating
+                // the declaration can infer their binding types.
+                let annotation = assignment.annotation(&module);
+                let expression = index.expression(annotation);
+                let declared_type =
+                    infer_same_file_expression_type(db, expression, TypeContext::default());
+
+                types = DefinitionTypes::Declaration(TypeAndQualifiers::declared(declared_type));
+            }
         }
 
         Self {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1424,7 +1424,7 @@ impl<'db> DefinitionInference<'db> {
                     index,
                     &module,
                 )
-                .finish_annotated_assignment_cycle_initial(
+                .infer_annotated_assignment_cycle_initial(
                     definition,
                     assignment,
                     cycle_recovery,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1415,12 +1415,20 @@ impl<'db> DefinitionInference<'db> {
             {
                 // Loop-carried assignments need this annotation as context before validating
                 // the declaration can infer their binding types.
-                let annotation = assignment.annotation(&module);
-                let expression = index.expression(annotation);
-                let declared_type =
-                    infer_same_file_expression_type(db, expression, TypeContext::default());
-
-                types = DefinitionTypes::Declaration(TypeAndQualifiers::declared(declared_type));
+                return TypeInferenceBuilder::new(
+                    db,
+                    &env,
+                    InferenceRegion::Definition(definition),
+                    python_file.file(db),
+                    program_file,
+                    index,
+                    &module,
+                )
+                .finish_annotated_assignment_cycle_initial(
+                    definition,
+                    assignment,
+                    cycle_recovery,
+                );
             }
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4236,6 +4236,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         declared
     }
 
+    /// Initialize a declaration cycle without discarding its annotation diagnostics or metadata.
+    pub(super) fn infer_annotated_assignment_cycle_initial(
+        mut self,
+        definition: Definition<'db>,
+        assignment: &AnnotatedAssignmentDefinitionKind,
+        cycle_recovery: Type<'db>,
+    ) -> DefinitionInference<'db> {
+        let declared = self.infer_annotated_assignment_annotation(assignment);
+        self.declarations.insert(definition, declared);
+        self.cycle_recovery = Some(cycle_recovery);
+        self.finish_inferred_definition(definition)
+    }
+
     /// Infer the types in an annotated assignment definition.
     fn infer_annotated_assignment_definition(
         &mut self,
@@ -11334,19 +11347,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         definition: Definition<'db>,
     ) -> DefinitionInference<'db> {
         self.infer_region();
-        self.finish_inferred_definition(definition)
-    }
-
-    /// Initialize a declaration cycle without discarding its annotation diagnostics or metadata.
-    pub(super) fn finish_annotated_assignment_cycle_initial(
-        mut self,
-        definition: Definition<'db>,
-        assignment: &AnnotatedAssignmentDefinitionKind,
-        cycle_recovery: Type<'db>,
-    ) -> DefinitionInference<'db> {
-        let declared = self.infer_annotated_assignment_annotation(assignment);
-        self.declarations.insert(definition, declared);
-        self.cycle_recovery = Some(cycle_recovery);
         self.finish_inferred_definition(definition)
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4218,6 +4218,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    /// Infer an annotated assignment's annotation using the file's deferred-annotation semantics.
+    fn infer_annotated_assignment_annotation(
+        &mut self,
+        assignment: &AnnotatedAssignmentDefinitionKind,
+    ) -> TypeAndQualifiers<'db> {
+        let annotation = assignment.annotation(self.module());
+
+        // Pydantic supports field specifiers in annotations via `Annotated[T, Field(...)]`.
+        self.setup_dataclass_field_specifiers();
+        let declared = self.infer_annotation_expression_allow_pep_613(
+            annotation,
+            DeferredExpressionState::from(self.defer_annotations()),
+        );
+        self.dataclass_field_specifiers.clear();
+
+        declared
+    }
+
     /// Infer the types in an annotated assignment definition.
     fn infer_annotated_assignment_definition(
         &mut self,
@@ -4265,13 +4283,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let annotation = assignment.annotation(self.module());
-        // Pydantic supports field specifiers in annotations via `Annotated[T, Field(...)]`.
-        self.setup_dataclass_field_specifiers();
-        let mut declared = self.infer_annotation_expression_allow_pep_613(
-            annotation,
-            DeferredExpressionState::from(self.defer_annotations()),
-        );
-        self.dataclass_field_specifiers.clear();
+        let mut declared = self.infer_annotated_assignment_annotation(assignment);
 
         // P.args and P.kwargs are only valid as annotations on *args and **kwargs,
         // not as variable annotations. Check both resolved type and AST form.
@@ -11322,7 +11334,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         definition: Definition<'db>,
     ) -> DefinitionInference<'db> {
         self.infer_region();
+        self.finish_inferred_definition(definition)
+    }
 
+    /// Initialize a declaration cycle without discarding its annotation diagnostics or metadata.
+    pub(super) fn finish_annotated_assignment_cycle_initial(
+        mut self,
+        definition: Definition<'db>,
+        assignment: &AnnotatedAssignmentDefinitionKind,
+        cycle_recovery: Type<'db>,
+    ) -> DefinitionInference<'db> {
+        let declared = self.infer_annotated_assignment_annotation(assignment);
+        self.declarations.insert(definition, declared);
+        self.cycle_recovery = Some(cycle_recovery);
+        self.finish_inferred_definition(definition)
+    }
+
+    fn finish_inferred_definition(self, definition: Definition<'db>) -> DefinitionInference<'db> {
         let Self {
             context,
             expressions,


### PR DESCRIPTION
## Summary

Previously, a declaration inside a loop could be validated against a prior iteration's assignment before that assignment received the declaration's contextual type:

```python
from typing import TypedDict

class Record(TypedDict):
    value: int

while True:
    record: Record
    record = {"value": 1}
```

The dictionary was inferred as `dict[str, int]`, so we incorrectly reported `invalid-declaration` and discarded the `TypedDict` context.

We now initialize declaration-only inference cycles with the declared type when a synthetic loop-header binding is visible.

Ordinary assignments already initialize their cycles directly in `DefinitionInference::cycle_initial`; for collection literals, this can seed types such as `list[Divergent]`. Annotated declarations require a separate builder path because resolving the annotation must respect postponed evaluation, Python 3.14 forward references, qualifiers, diagnostics, and metadata. `infer_annotated_assignment_cycle_initial` therefore infers only the annotation and preserves its builder state without performing full region inference.

This applies to both `while` and `for` loops and preserves genuine declaration errors for incompatible pre-loop bindings.

Closes https://github.com/astral-sh/ty/issues/4206.
