### PR TITLE
[ty] Update flaky primer projects

### DIFF
--- a/crates/ty_python_semantic/resources/primer/flaky.txt
+++ b/crates/ty_python_semantic/resources/primer/flaky.txt
@@ -1,4 +1,2 @@
-Expression
-scikit-build-core
-dd-trace-py
+meson
 steam.py


### PR DESCRIPTION
## Summary

- Add `meson` to the flaky primer project list. It appears to have a nondeterministic `unsound-return-statement` diagnostic, unfortunately.
- Remove `Expression`, `dd-trace-py`, and `scikit-build-core`, which no longer need repeated flaky-project analysis.
- Keep `steam.py` marked as flaky.

## Verification

I ran each removed project 50 times with the same pinned `ecosystem-analyzer` and `mypy-primer` revisions and ty configuration used by CI (`--flaky-runs 50`):

- `Expression`: 314 stable diagnostics, 0 flaky diagnostics.
- `dd-trace-py`: 11,831 stable diagnostics, 0 flaky diagnostics.
- `scikit-build-core`: 288 stable diagnostics, 0 flaky diagnostics.
