### PR TITLE
[ty] Fix `invalid-yield` false negatives by using constraint sets to infer the yield, send and return types of a generator function

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -25,6 +25,7 @@ BA = "BA" # acronym for "Bad Allowed", used in testing.
 jod = "jod" # e.g., `jod-thread`
 Numer = "Numer" # Library name 'NumerBlox' in "Who's Using Ruff?"
 CPY = "CPY"  # it's a Ruff rule category
+"asend" = "asend"  # e.g. the `asend` method of async generators
 
 [default]
 extend-ignore-re = [

--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -267,3 +267,79 @@ async def test(x: Intersection[Coroutine[object, object, A], Coroutine[object, o
     y = await x
     reveal_type(y)  # revealed: A & B
 ```
+
+## Regression test: awaiting optional generic values
+
+An early version of <https://github.com/astral-sh/ruff/pull/27598> caused synthesized generic type
+variables to "leak" out into revealed types in examples such as the following snippet that involve
+type variables in unions with `None`. This is a regression test for that issue:
+
+```py
+import asyncio
+from typing import TypeVar
+
+T = TypeVar("T")
+
+async def awaited_value(value: T | None) -> T | None:
+    result = await asyncio.sleep(0, value)
+    reveal_type(result)  # revealed: None | T@awaited_value
+    return result
+
+async def awaited_assignment(value: T | None) -> None:
+    result: T | None = await asyncio.sleep(0, value)
+```
+
+Narrowing an awaited optional generic value also preserves the type variable's bound, allowing its
+attributes, indexing methods, and compatible function parameters to be used.
+
+```py
+class Resource:
+    def use(self) -> None: ...
+    def __getitem__(self, index: int) -> int:
+        return index
+
+R = TypeVar("R", bound=Resource)
+
+def accept(value: R) -> None: ...
+async def awaited_operations(value: R | None) -> None:
+    result = await asyncio.sleep(0, value)
+    if result is not None:
+        reveal_type(result)  # revealed: R@awaited_operations
+        result.use()
+        result[0]
+        accept(result)
+```
+
+## Regression test: custom awaitable iterators
+
+An early version of the generator type-argument inference introduced by
+<https://github.com/astral-sh/ruff/pull/27598> incorrectly assumed that an iterator with no declared
+return type would return `None`. The `__await__` method is allowed to return `Iterator` rather than
+`Generator`, but `Iterator` does not expose the eventual return value carried by `StopIteration`.
+Such an `await` must therefore be accepted, and its result must be inferred as `Unknown` rather than
+assumed to be `None`.
+
+```py
+from collections.abc import Iterable, Iterator
+
+class CustomAwaitable:
+    def __await__(self) -> Iterator[None]:
+        yield
+
+async def main(value: CustomAwaitable) -> None:
+    result = await value
+    reveal_type(result)  # revealed: Unknown
+```
+
+Accepting an iterator with an unknown return value must not relax the requirement that `__await__`
+returns an iterator. An `Iterable` without an iterator's `__next__` method is not a valid return
+type, so awaiting the following object must produce `invalid-await`.
+
+```py
+class InvalidAwaitable:
+    def __await__(self) -> Iterable[int]:
+        return [1]
+
+async def invalid(value: InvalidAwaitable) -> None:
+    await value  # error: [invalid-await]
+```

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -134,6 +134,60 @@ def persons(f: bool) -> Generator[None, None, Person]:
         return {"name": 42}
 ```
 
+## Structurally compatible generator protocols
+
+A protocol does not need to explicitly inherit from `Generator` for ty to infer its yield, send, and
+return types from its methods.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from types import TracebackType
+from typing import Generator, Protocol, overload
+
+class StructuralGenerator(Protocol):
+    def __iter__(self) -> Generator[int, bytes, str]: ...
+    def __next__(self) -> int: ...
+    def send(self, value: bytes, /) -> int: ...
+    @overload
+    def throw(
+        self,
+        typ: type[BaseException],
+        val: object = None,
+        traceback: TracebackType | None = None,
+        /,
+    ) -> int: ...
+    @overload
+    def throw(
+        self,
+        typ: BaseException,
+        val: None = None,
+        traceback: TracebackType | None = None,
+        /,
+    ) -> int: ...
+    def close(self) -> str | None: ...
+
+def structural_generator() -> StructuralGenerator:
+    sent = yield 1
+    reveal_type(sent)  # revealed: bytes
+    return "done"
+
+def delegated_generator() -> Generator[int, bytes, None]:
+    result = yield from structural_generator()
+    reveal_type(result)  # revealed: str
+
+def invalid_structural_yield() -> StructuralGenerator:
+    yield "wrong"  # error: [invalid-yield]
+    return "done"
+
+def invalid_structural_return() -> StructuralGenerator:
+    yield 1
+    return 42  # error: [invalid-return-type]
+```
+
 ## `yield` expression send type inference
 
 ```py
@@ -162,11 +216,6 @@ async def async_generator_default() -> AsyncGenerator[int]:
 async def async_generator_send_str() -> AsyncGenerator[int, str]:
     x = yield 1
     reveal_type(x)  # revealed: str
-
-def mixing_generator_async_generator() -> Generator[int, int, None] | AsyncGenerator[int, str]:
-    x = yield 1
-    reveal_type(x)  # revealed: int | str
-    return None
 ```
 
 `Iterator`, `Iterable`, and custom equivalent protocols have no send type or return type. Using one
@@ -323,7 +372,11 @@ def returns_str() -> str:  # error: [invalid-return-type]
 
 def sync_returns_async_generator() -> AsyncGenerator[int, str]:  # error: [invalid-return-type]
     x = yield 1
-    reveal_type(x)  # revealed: str
+    reveal_type(x)  # revealed: Unknown
+
+async def async_returns_sync_generator() -> Generator[int, str, None]:  # error: [invalid-return-type]
+    x = yield 1
+    reveal_type(x)  # revealed: Unknown
 ```
 
 ### Invalid return type

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -69,6 +69,27 @@ def generator() -> Generator[str]:
     reveal_type(result)  # revealed: Unknown
 ```
 
+## `yield from` with an iterable annotation
+
+Unlike `Generator[YieldT, SendT, ReturnT]`, `Iterable[YieldT]` and `Iterator[YieldT]` have no type
+parameter describing the value carried by `StopIteration` when iteration ends. That value becomes
+the result of `yield from`, so ty must infer `Unknown` rather than incorrectly assuming `None`.
+Returning that result from a generator annotated as returning `int` must therefore remain valid.
+
+```py
+from collections.abc import Generator, Iterable, Iterator
+
+def delegated_iterable(values: Iterable[int]) -> Generator[int, None, int]:
+    result = yield from values
+    reveal_type(result)  # revealed: Unknown
+    return result
+
+def delegated_iterator(values: Iterator[int]) -> Generator[int, None, int]:
+    result = yield from values
+    reveal_type(result)  # revealed: Unknown
+    return result
+```
+
 ## `yield from` with a generator that return `types.GeneratorType`
 
 `types.GeneratorType` is a nominal type that implements the `typing.Generator` protocol:
@@ -109,6 +130,29 @@ def persons() -> Iterator[Person]:
     yield {"name": 42}
 ```
 
+Prior to <https://github.com/astral-sh/ruff/pull/27598>, ty incorrectly rejected generator functions
+like the one below. The `wrap` function requires its keys and values to share the same `K` type
+parameter. Although the keys here use `object` and the values use `str`, the generator promises to
+yield `Values[Any]`, so `Any` can accommodate both. The old implementation ignored that promise,
+expected `Values[object]`, and incorrectly rejected `Values[str]`.
+
+```py
+from collections.abc import Iterable
+from typing import Any, Generic, TypeVar
+
+K = TypeVar("K")
+
+class Keys(Generic[K]): ...
+class Values(Generic[K]): ...
+
+def wrap(keys: Keys[K], values: Values[K]) -> Values[K]:
+    return values
+
+def sources(keys: Keys[object], values: Values[str]) -> Iterable[Values[Any]]:
+    # Regression: this used to emit [invalid-argument-type] because ty expected `Values[object]`.
+    yield wrap(keys, values)
+```
+
 This also works with `yield from`, where the iterable expression is inferred with the outer
 generator's yield type as type context:
 
@@ -137,7 +181,7 @@ def persons(f: bool) -> Generator[None, None, Person]:
 ## `yield` expression send type inference
 
 ```py
-from typing import AsyncGenerator, AsyncIterator, Generator, Iterator
+from typing import AsyncGenerator, AsyncIterator, AsyncIterable, Iterable, Protocol, Generator, Iterator
 
 def unannotated():
     x = yield 1
@@ -162,18 +206,32 @@ async def async_generator_default() -> AsyncGenerator[int]:
 async def async_generator_send_str() -> AsyncGenerator[int, str]:
     x = yield 1
     reveal_type(x)  # revealed: str
-
-def mixing_generator_async_generator() -> Generator[int, int, None] | AsyncGenerator[int, str]:
-    x = yield 1
-    reveal_type(x)  # revealed: int | str
-    return None
 ```
 
-`Iterator` has no send type or return type, It is equivalent to using `Generator` with send set to
-`None` and return type to `Unknown`.
+Using a union of `Generator` and `AsyncGenerator` in a return type is invalid, as a function can
+only ever be a synchronous generator function or an asynchronous generator function.
+`Generator | AsyncGenerator` is not assignable to any of `Generator`, `AsyncGenerator`, `Iterable`
+or `AsyncIterable`, so a type checker cannot reasonably infer the yield, send and return types of
+the generator function. Our behaviour on the following snippet matches pyright and pycroscope,
+though it differs from mypy, zuban and pyrefly as of 2026/08/08:
+
+```py
+def mixing_generator_async_generator() -> Generator[int, int, None] | AsyncGenerator[int, str]:
+    # TODO: we should warn the user somehow that we're falling back to `Unknown` here instead
+    # of inferring it silently.
+    x = yield 1
+    reveal_type(x)  # revealed: Unknown
+```
+
+`Iterator`, `Iterable`, and custom equivalent protocols have no send type or return type. Using one
+of these is equivalent to using `Generator` with send set to `None` and return type to `Unknown`.
 
 ```py
 def iterator_send_none() -> Iterator[int]:
+    x = yield 1
+    reveal_type(x)  # revealed: None
+
+def iterable_send_none() -> Iterable[int]:
     x = yield 1
     reveal_type(x)  # revealed: None
 
@@ -181,9 +239,59 @@ async def async_iterator_send_none() -> AsyncIterator[int]:
     x = yield 1
     reveal_type(x)  # revealed: None
 
+async def async_iterable_send_none() -> AsyncIterable[int]:
+    x = yield 1
+    reveal_type(x)  # revealed: None
+
 def iterator_yield_from() -> Generator[int, None, int]:
     yield from iterator_send_none()
     return 1
+
+class CustomIteratorProtocol(Protocol):
+    def __iter__(self) -> Iterator[int]: ...
+
+def custom_proto_send_none() -> CustomIteratorProtocol:
+    x = yield 1
+    reveal_type(x)  # revealed: None
+```
+
+## Unions of generator send types
+
+Generator send types are contravariant, so a value sent into a union of generators must be accepted
+by every member. That means that the inferred type of a `yield` expression inside the generator (the
+inferred type of a value sent *into* the generator) will be an intersection of the send types in the
+return-type union:
+
+```py
+from collections.abc import AsyncGenerator, Generator
+
+class Foo: ...
+class Bar: ...
+
+def generator_union() -> Generator[int, Foo, None] | Generator[int, Bar, None]:
+    received = yield 1
+    reveal_type(received)  # revealed: Foo & Bar
+```
+
+The same rule applies to asynchronous generators.
+
+```py
+async def async_generator_union() -> AsyncGenerator[int, Foo] | AsyncGenerator[int, Bar]:
+    received = yield 1
+    reveal_type(received)  # revealed: Foo & Bar
+```
+
+If the send types in the union are disjoint, this can therefore result in us inferring `Never` as
+the result of a `yield` expression and inferring the remaining code in the function as being
+unreachable. This is correct -- since we would reject any inhabited type from being sent into the
+generator, the generator can logically never accept any values being sent into it, so any code
+following the `yield` expression must be unreachable as a result:
+
+```py
+def generator_union_disjoint() -> Generator[int, int, None] | Generator[int, str, None]:
+    received = yield 1
+    reveal_type(received)  # revealed: Never
+    1 + "foo"  # no error (this region is inferred as unreachable)
 ```
 
 ## Generator type aliases
@@ -239,6 +347,185 @@ def outer_aliased_generator() -> FullGeneratorAlias[int, bytes, None]:
     reveal_type(result)  # revealed: str
 ```
 
+## Structurally compatible generator protocols
+
+A protocol does not need to explicitly inherit from `Generator` for ty to infer its yield, send, and
+return types from its methods.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from types import TracebackType
+from typing import Generator, Protocol, overload
+
+class StructuralGenerator(Protocol):
+    def __iter__(self) -> Generator[int, bytes, str]: ...
+    def __next__(self) -> int: ...
+    def send(self, value: bytes, /) -> int: ...
+    @overload
+    def throw(
+        self,
+        typ: type[BaseException],
+        val: object = None,
+        traceback: TracebackType | None = None,
+        /,
+    ) -> int: ...
+    @overload
+    def throw(
+        self,
+        typ: BaseException,
+        val: None = None,
+        traceback: TracebackType | None = None,
+        /,
+    ) -> int: ...
+    def close(self) -> str | None: ...
+
+def structural_generator() -> StructuralGenerator:
+    sent = yield 1
+    reveal_type(sent)  # revealed: bytes
+    return "done"
+
+def delegated_generator() -> Generator[int, bytes, None]:
+    result = yield from structural_generator()
+    reveal_type(result)  # revealed: str
+
+def invalid_structural_yield() -> StructuralGenerator:
+    yield "wrong"  # error: [invalid-yield]
+    return "done"
+
+def invalid_structural_return() -> StructuralGenerator:
+    yield 1
+    return 42  # error: [invalid-return-type]
+```
+
+## Iterable protocols with generator send methods
+
+A protocol can expose a generator's `send` method without declaring every other `Generator` method.
+When such a protocol is used as a generator function's return annotation, the type accepted by
+`send` determines the type of the `yield` expression, even if `send` advertises a return type that
+is broader than the iterator's yielded type.
+
+```py
+from collections.abc import AsyncIterator, Awaitable, Iterator
+from typing import Protocol, TypeVar
+
+class Sendable(Protocol):
+    def __iter__(self) -> Iterator[int]: ...
+    def send(self, value: bytes, /) -> object: ...
+
+def generator() -> Sendable:
+    received = yield 1
+    reveal_type(received)  # revealed: bytes
+    received.decode()
+```
+
+The send type remains precise when the yielded and sent values share a type variable.
+
+```py
+T = TypeVar("T")
+
+class Correlated(Protocol[T]):
+    def __iter__(self) -> Iterator[T]: ...
+    def send(self, value: T, /) -> T: ...
+
+def correlated(value: T) -> Correlated[T]:
+    received = yield value
+    reveal_type(received)  # revealed: T@correlated
+```
+
+The same rule applies to asynchronous iterable protocols exposing an `asend` method: its awaitable
+return type can be broader than the async iterator's yielded type.
+
+```py
+class AsyncSendable(Protocol):
+    def __aiter__(self) -> AsyncIterator[int]: ...
+    def asend(self, value: bytes, /) -> Awaitable[object]: ...
+
+async def async_generator() -> AsyncSendable:
+    received = yield 1
+    reveal_type(received)  # revealed: bytes
+    received.decode()
+```
+
+The correlation is also preserved when `asend` returns an awaitable of the yielded type.
+
+```py
+class AsyncCorrelated(Protocol[T]):
+    def __aiter__(self) -> AsyncIterator[T]: ...
+    def asend(self, value: T, /) -> Awaitable[T]: ...
+
+async def async_correlated(value: T) -> AsyncCorrelated[T]:
+    received = yield value
+    reveal_type(received)  # revealed: T@async_correlated
+```
+
+## Intersections of generator types
+
+An intersection of generator types should intersect their yield and return types. Until
+<https://github.com/astral-sh/ty/issues/2799> is fixed, the constraint solver incorrectly combines
+the specializations using unions, so incompatible yields and returns are accepted.
+
+```py
+from collections.abc import AsyncGenerator, Generator
+from ty_extensions import Intersection
+
+def incompatible_yield() -> Intersection[Generator[int, None, None], Generator[str, None, None]]:
+    # TODO: This should emit [invalid-yield].
+    yield 1
+
+def incompatible_return() -> Intersection[Generator[int, None, int], Generator[int, None, str]]:
+    yield 1
+    # TODO: This should emit [invalid-return-type].
+    return 1
+
+async def incompatible_async_yield() -> Intersection[AsyncGenerator[int, None], AsyncGenerator[str, None]]:
+    # TODO: This should emit [invalid-yield].
+    yield 1
+```
+
+## Regression test: generic generator yield and return types
+
+An early version of the generator type-argument solver introduced by
+<https://github.com/astral-sh/ruff/pull/27598> confused a generator's generic yield type with its
+independently annotated send and return types. Here, the generator yields values of type `T`, but
+its send and return types are both `None`: the `yield` expression must therefore have type `None`,
+and returning a value of type `T` must be rejected.
+
+```py
+from collections.abc import Generator
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def generator_return(value: T) -> Generator[T, None, None]:
+    sent = yield value
+    reveal_type(sent)  # revealed: None
+
+    # error: [invalid-return-type] "Return type does not match returned value: expected `None`, found `T@generator_return`"
+    return value
+```
+
+## Regression test: delegating to a generic generator expression
+
+An early version of the generator type-argument inference introduced by
+<https://github.com/astral-sh/ruff/pull/27598> emitted a spurious `invalid-yield` diagnostic when a
+generator delegated to a generator expression over generic values. The generator expression below
+yields values of type `T`, matching the enclosing generator's `Iterator[T]` annotation, so
+`yield from` must be accepted.
+
+```py
+from collections.abc import Iterable, Iterator
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def delegated(values: Iterable[T]) -> Iterator[T]:
+    yield from (value for value in values)
+```
+
 ## Error cases
 
 ### Non-iterable type
@@ -253,7 +540,7 @@ def generator() -> Generator[None]:
 ### Invalid `yield` type
 
 ```py
-from typing import Generator
+from typing import Generator, Iterable, Iterator, Protocol
 
 def invalid_generator() -> Generator[int, None, None]:
     # snapshot: invalid-yield
@@ -271,6 +558,32 @@ error[invalid-yield]: Yield expression type does not match annotation
   |           ^^ expression of type `Literal[""]`, expected `int`
 ```
 
+More examples:
+
+```py
+def invalid_iterator() -> Iterator[None]:
+    yield ""  # error: [invalid-yield]
+
+def invalid_iterable() -> Iterable[None]:
+    yield ""  # error: [invalid-yield]
+
+class CustomIteratorProto(Protocol):
+    def __iter__(self) -> Iterator[int]: ...
+
+def invalid_custom_proto() -> CustomIteratorProto:
+    yield ""  # snapshot: invalid-yield
+```
+
+```snapshot
+error[invalid-yield]: Yield expression type does not match annotation
+  --> src/mdtest_snippet.py:16:11
+   |
+15 | def invalid_custom_proto() -> CustomIteratorProto:
+   |                               ------------------- Function annotated with yield type `int` here
+16 |     yield ""  # snapshot: invalid-yield
+   |           ^^ expression of type `Literal[""]`, expected `int`
+```
+
 ### Invalid annotation
 
 ```py
@@ -282,7 +595,11 @@ def returns_str() -> str:  # error: [invalid-return-type]
 
 def sync_returns_async_generator() -> AsyncGenerator[int, str]:  # error: [invalid-return-type]
     x = yield 1
-    reveal_type(x)  # revealed: str
+    reveal_type(x)  # revealed: Unknown
+
+async def async_returns_sync_generator() -> Generator[int, str, None]:  # error: [invalid-return-type]
+    x = yield 1
+    reveal_type(x)  # revealed: Unknown
 ```
 
 ### Invalid return type

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -137,7 +137,7 @@ def persons(f: bool) -> Generator[None, None, Person]:
 ## `yield` expression send type inference
 
 ```py
-from typing import AsyncGenerator, AsyncIterator, Generator, Iterator
+from typing import AsyncGenerator, AsyncIterator, AsyncIterable, Iterable, Protocol, Generator, Iterator
 
 def unannotated():
     x = yield 1
@@ -169,11 +169,15 @@ def mixing_generator_async_generator() -> Generator[int, int, None] | AsyncGener
     return None
 ```
 
-`Iterator` has no send type or return type, It is equivalent to using `Generator` with send set to
-`None` and return type to `Unknown`.
+`Iterator`, `Iterable`, and custom equivalent protocols have no send type or return type. Using one
+fo these is equivalent to using `Generator` with send set to `None` and return type to `Unknown`.
 
 ```py
 def iterator_send_none() -> Iterator[int]:
+    x = yield 1
+    reveal_type(x)  # revealed: None
+
+def iterable_send_none() -> Iterable[int]:
     x = yield 1
     reveal_type(x)  # revealed: None
 
@@ -181,9 +185,20 @@ async def async_iterator_send_none() -> AsyncIterator[int]:
     x = yield 1
     reveal_type(x)  # revealed: None
 
+async def async_iterable_send_none() -> AsyncIterable[int]:
+    x = yield 1
+    reveal_type(x)  # revealed: None
+
 def iterator_yield_from() -> Generator[int, None, int]:
     yield from iterator_send_none()
     return 1
+
+class CustomIteratorProtocol(Protocol):
+    def __iter__(self) -> Iterator[int]: ...
+
+def custom_proto_send_none() -> CustomIteratorProtocol:
+    x = yield 1
+    reveal_type(x)  # revealed: None
 ```
 
 ## Generator type aliases
@@ -253,7 +268,7 @@ def generator() -> Generator[None]:
 ### Invalid `yield` type
 
 ```py
-from typing import Generator
+from typing import Generator, Iterable, Iterator, Protocol
 
 def invalid_generator() -> Generator[int, None, None]:
     # snapshot: invalid-yield
@@ -269,6 +284,32 @@ error[invalid-yield]: Yield expression type does not match annotation
 4 |     # snapshot: invalid-yield
 5 |     yield ""
   |           ^^ expression of type `Literal[""]`, expected `int`
+```
+
+More examples:
+
+```py
+def invalid_iterator() -> Iterator[None]:
+    yield ""  # error: [invalid-yield]
+
+def invalid_iterable() -> Iterable[None]:
+    yield ""  # error: [invalid-yield]
+
+class CustomIteratorProto(Protocol):
+    def __iter__(self) -> Iterator[int]: ...
+
+def invalid_custom_proto() -> CustomIteratorProto:
+    yield ""  # snapshot: invalid-yield
+```
+
+```snapshot
+error[invalid-yield]: Yield expression type does not match annotation
+  --> src/mdtest_snippet.py:16:11
+   |
+15 | def invalid_custom_proto() -> CustomIteratorProto:
+   |                               ------------------- Function annotated with yield type `int` here
+16 |     yield ""  # snapshot: invalid-yield
+   |           ^^ expression of type `Literal[""]`, expected `int`
 ```
 
 ### Invalid annotation

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -64,7 +64,7 @@ use crate::types::call::bind::ConstructorCallableKind;
 use crate::types::call::{Binding, Bindings, CallArguments, CallableBinding};
 pub(crate) use crate::types::callable::{CallableType, CallableTypes};
 pub(crate) use crate::types::class_base::ClassBase;
-use crate::types::constraints::ConstraintSetBuilder;
+use crate::types::constraints::{ConstraintSetBuilder, Solutions};
 use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 use crate::types::diagnostic::{
     INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_dunder_get_call, report_bad_dunder_getattr_call,
@@ -115,9 +115,7 @@ pub(crate) use special_form::TypedDictModule;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{
-    EvaluationMode, ProgramFile, Truthiness, place_table, semantic_index, use_def_map,
-};
+use ty_python_core::{ProgramFile, Truthiness, place_table, semantic_index, use_def_map};
 
 mod attribute_write;
 mod bool;
@@ -1470,24 +1468,13 @@ fn recursive_type_normalize_type_guard_like<'db, T: TypeGuardLike<'db>>(
 struct GeneratorTypes<'db> {
     yield_ty: Type<'db>,
     send_ty: Type<'db>,
-    return_ty: Option<Type<'db>>,
+    return_ty: Type<'db>,
 }
 
-impl<'db> GeneratorTypes<'db> {
-    /// Apply a generator's materialization with the variance of each operation.
-    fn materialize(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        kind: MaterializationKind,
-    ) -> Self {
-        let visitor = ApplyTypeMappingVisitor::new(env);
-        Self {
-            yield_ty: self.yield_ty.materialize(db, kind, &visitor),
-            send_ty: self.send_ty.materialize(db, kind.flip(), &visitor),
-            return_ty: self.return_ty.map(|ty| ty.materialize(db, kind, &visitor)),
-        }
-    }
+#[derive(Debug, Clone, Copy)]
+struct AsyncGeneratorTypes<'db> {
+    yield_ty: Type<'db>,
+    send_ty: Type<'db>,
 }
 
 fn object_type_form(db: &dyn Db) -> Type<'_> {
@@ -6719,145 +6706,183 @@ impl<'db> Type<'db> {
             TypeContext::default(),
         );
         match await_result {
-            Ok(bindings) => {
-                let return_type = bindings.return_type(db, env);
-                Ok(return_type.generator_return_type(db, env).ok_or_else(|| {
-                    AwaitError::InvalidReturnType(return_type, Box::new(bindings))
-                })?)
-            }
+            Ok(bindings) => bindings
+                .try_map_return_type(db, env, |ty| ty.generator_return_type(db, env))
+                .ok_or_else(|| {
+                    AwaitError::InvalidReturnType(bindings.return_type(db, env), Box::new(bindings))
+                }),
             Err(call_error) => Err(AwaitError::Call(call_error)),
         }
     }
 
-    /// Get the return type of a `yield from …` expression where `self` is the type of the generator.
-    ///
-    /// This corresponds to the `ReturnT` parameter of the generic `typing.Generator[YieldT, SendT, ReturnT]`
-    /// protocol.
+    /// Infer the yield, send, and return types represented by a synchronous generator or iterable.
     fn generator_types(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        mode: EvaluationMode,
     ) -> Option<GeneratorTypes<'db>> {
-        // TODO: Ideally, we would first try to upcast `self` to an instance of `Generator` and *then*
-        // match on the protocol instance to get the `ReturnType` type parameter. For now, implement
-        // an ad-hoc solution that works for protocols and instances of classes that explicitly inherit
-        // from the `Generator` protocol, such as `types.GeneratorType`.
-
-        let from_class_base = |base: ClassBase<'db>| {
-            let class = base.into_class()?;
-            let (_, Some(specialization)) = class.static_class_literal_specialized(db, None)?
-            else {
-                return None;
-            };
-
-            if class.is_known(db, KnownClass::Generator)
-                && let [yield_ty, send_ty, return_ty] = specialization.types(db)
-            {
-                Some(GeneratorTypes {
-                    yield_ty: *yield_ty,
-                    send_ty: *send_ty,
-                    return_ty: Some(*return_ty),
-                })
-            } else if class.is_known(db, KnownClass::AsyncGenerator)
-                && let [yield_ty, send_ty] = specialization.types(db)
-            {
-                Some(GeneratorTypes {
-                    yield_ty: *yield_ty,
-                    send_ty: *send_ty,
-                    return_ty: None,
-                })
-            } else {
-                None
-            }
-        };
-
-        let nominal_result = match self {
-            Type::NominalInstance(instance) => instance
-                .class(db, env)
-                .iter_mro(db)
-                .find_map(from_class_base),
-            Type::ProtocolInstance(protocol) => protocol
-                .class_origin(db)
-                .and_then(|class| class.iter_mro(db).find_map(from_class_base))
-                .map(|types| {
-                    protocol
-                        .materialization_kind(db)
-                        .map_or(types, |kind| types.materialize(db, env, kind))
-                }),
-            Type::TypeAlias(alias) => alias.value_type(db).generator_types(db, env, mode),
-            Type::Union(union) => {
-                let mut yield_builder = UnionBuilder::new(db, env);
-                let mut send_builder = UnionBuilder::new(db, env);
-                let mut return_builder = Some(UnionBuilder::new(db, env));
-
-                for ty in union.elements(db) {
-                    let gt = ty.generator_types(db, env, mode)?;
-                    yield_builder = yield_builder.add(gt.yield_ty);
-                    send_builder = send_builder.add(gt.send_ty);
-                    match gt.return_ty {
-                        Some(ty) => return_builder = return_builder.map(|b| b.add(ty)),
-                        None => return_builder = None,
-                    }
-                }
-
-                Some(GeneratorTypes {
-                    yield_ty: yield_builder.build(),
-                    send_ty: send_builder.build(),
-                    return_ty: return_builder.map(UnionBuilder::build),
-                })
-            }
-            Type::Intersection(intersection) => {
-                // Using `positive()` rather than `positive_elements_or_object()` is safe
-                // here because `object` is not a generator, so falling back to it would
-                // still return `None`.
-                let mut yield_builder = IntersectionBuilder::new(db, env);
-                let mut send_builder = IntersectionBuilder::new(db, env);
-                let mut return_builder = Some(IntersectionBuilder::new(db, env));
-                let mut any_success = false;
-
-                for ty in intersection.positive(db) {
-                    let Some(gt) = ty.generator_types(db, env, mode) else {
-                        continue;
-                    };
-                    any_success = true;
-                    yield_builder = yield_builder.add_positive(gt.yield_ty);
-                    send_builder = send_builder.add_positive(gt.send_ty);
-                    match gt.return_ty {
-                        Some(ty) => {
-                            return_builder = return_builder.map(|b| b.add_positive(ty));
-                        }
-                        None => return_builder = None,
-                    }
-                }
-
-                if !any_success {
-                    return None;
-                }
-
-                Some(GeneratorTypes {
-                    yield_ty: yield_builder.build(),
-                    send_ty: send_builder.build(),
-                    return_ty: return_builder.map(IntersectionBuilder::build),
-                })
-            }
-            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(GeneratorTypes {
+        if matches!(self, Type::Dynamic(_) | Type::Divergent(_) | Type::Never) {
+            return Some(GeneratorTypes {
                 yield_ty: self,
                 send_ty: self,
-                return_ty: Some(self),
-            }),
-            _ => None,
-        };
-
-        if let Some(nominal_result) = nominal_result {
-            return Some(nominal_result);
+                return_ty: self,
+            });
         }
 
-        let generator_class = match mode {
-            EvaluationMode::Sync => KnownClass::Generator,
-            EvaluationMode::Async => KnownClass::AsyncGenerator,
-        };
+        let yield_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("YieldT"),
+            TypeVarVariance::Covariant,
+        );
+        let send_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("SendT"),
+            TypeVarVariance::Contravariant,
+        );
+        let return_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("ReturnT"),
+            TypeVarVariance::Covariant,
+        );
 
+        let generator_spec = [
+            Type::TypeVar(yield_t),
+            Type::TypeVar(send_t),
+            Type::TypeVar(return_t),
+        ];
+        let generator_ty = KnownClass::Generator.to_specialized_instance(db, env, &generator_spec);
+        let solutions =
+            self.infer_generator_type_arguments(db, env, generator_ty, [yield_t, send_t, return_t]);
+
+        if let Some([yield_ty, send_ty, return_ty]) = solutions {
+            return Some(GeneratorTypes {
+                yield_ty,
+                send_ty,
+                return_ty,
+            });
+        }
+
+        let yield_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("YieldT2"),
+            TypeVarVariance::Covariant,
+        );
+        let iterable_ty =
+            KnownClass::Iterable.to_specialized_instance(db, env, &[Type::TypeVar(yield_t)]);
+        let yield_ty = self.iterable_generator_yield_type(
+            db,
+            env,
+            KnownClass::Generator,
+            iterable_ty,
+            yield_t,
+        )?;
+        let none = Type::none(db, env);
+        Some(GeneratorTypes {
+            yield_ty,
+            send_ty: none,
+            return_ty: none,
+        })
+    }
+
+    /// Infer the yield and send types represented by an asynchronous generator or iterable.
+    fn async_generator_types(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<AsyncGeneratorTypes<'db>> {
+        if matches!(self, Type::Dynamic(_) | Type::Divergent(_) | Type::Never) {
+            return Some(AsyncGeneratorTypes {
+                yield_ty: self,
+                send_ty: self,
+            });
+        }
+
+        let yield_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("YieldT"),
+            TypeVarVariance::Covariant,
+        );
+        let send_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("SendT"),
+            TypeVarVariance::Contravariant,
+        );
+        let generator_spec = [Type::TypeVar(yield_t), Type::TypeVar(send_t)];
+        let generator_ty =
+            KnownClass::AsyncGenerator.to_specialized_instance(db, env, &generator_spec);
+        if let Some([yield_ty, send_ty]) =
+            self.infer_generator_type_arguments(db, env, generator_ty, [yield_t, send_t])
+        {
+            return Some(AsyncGeneratorTypes { yield_ty, send_ty });
+        }
+
+        let yield_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("YieldT2"),
+            TypeVarVariance::Covariant,
+        );
+        let iterable_ty =
+            KnownClass::AsyncIterable.to_specialized_instance(db, env, &[Type::TypeVar(yield_t)]);
+        let yield_ty = self.iterable_generator_yield_type(
+            db,
+            env,
+            KnownClass::AsyncGenerator,
+            iterable_ty,
+            yield_t,
+        )?;
+        Some(AsyncGeneratorTypes {
+            yield_ty,
+            send_ty: Type::none(db, env),
+        })
+    }
+
+    /// Solve the type variables that make this type assignable to a synthetic protocol instance.
+    fn infer_generator_type_arguments<const N: usize>(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        target: Type<'db>,
+        typevars: [BoundTypeVarInstance<'db>; N],
+    ) -> Option<[Type<'db>; N]> {
+        let inferable = TypeVarSet::from_typevars(db, typevars);
+        let constraints = ConstraintSetBuilder::new();
+        match self
+            .assignable_solutions_with_inferable(db, env, target, inferable)
+            .solve(db, env, &constraints)
+        {
+            Solutions::Unsatisfiable => None,
+            Solutions::Unconstrained => Some([Type::unknown(); N]),
+            Solutions::Constrained(solutions) => Some(typevars.map(|typevar| {
+                let mut types = solutions.iter().filter_map(|solution| {
+                    solution
+                        .iter()
+                        .find(|binding| binding.bound_typevar == typevar)
+                        .map(|binding| binding.solution)
+                });
+                let first = types.next().unwrap_or_else(Type::unknown);
+                UnionType::from_elements(db, env, iter::once(first).chain(types))
+            })),
+        }
+    }
+
+    /// Infer an iterable's yield type only if its annotation can describe a generator instance.
+    fn iterable_generator_yield_type(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        generator_class: KnownClass,
+        iterable_ty: Type<'db>,
+        yield_t: BoundTypeVarInstance<'db>,
+    ) -> Option<Type<'db>> {
+        // An iterable annotation can describe a generator, but a concrete iterable such as `str`
+        // cannot. Avoid extracting a yield type from annotations that reject generator instances.
         if !generator_class
             .to_instance_unknown(db, env)
             .is_assignable_to(db, env, self)
@@ -6865,16 +6890,8 @@ impl<'db> Type<'db> {
             return None;
         }
 
-        self.try_iterate_with_mode(db, env, mode)
-            .map(|tuple| {
-                let none = Type::none(db, env);
-                GeneratorTypes {
-                    yield_ty: tuple.homogeneous_element_type(db, env),
-                    send_ty: none,
-                    return_ty: Some(none),
-                }
-            })
-            .ok()
+        self.infer_generator_type_arguments(db, env, iterable_ty, [yield_t])
+            .map(|[yield_ty]| yield_ty)
     }
 
     fn generator_return_type(
@@ -6882,17 +6899,16 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Type<'db>> {
-        self.generator_types(db, env, EvaluationMode::Sync)
-            .and_then(|generator_types| generator_types.return_ty)
+        self.generator_types(db, env)
+            .map(|generator_types| generator_types.return_ty)
     }
 
     fn generator_send_type(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        mode: EvaluationMode,
     ) -> Option<Type<'db>> {
-        self.generator_types(db, env, mode)
+        self.generator_types(db, env)
             .map(|generator_types| generator_types.send_ty)
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -115,7 +115,9 @@ pub(crate) use special_form::TypedDictModule;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{ProgramFile, Truthiness, place_table, semantic_index, use_def_map};
+use ty_python_core::{
+    EvaluationMode, ProgramFile, Truthiness, place_table, semantic_index, use_def_map,
+};
 
 mod attribute_write;
 mod bool;
@@ -1466,8 +1468,8 @@ fn recursive_type_normalize_type_guard_like<'db, T: TypeGuardLike<'db>>(
 #[derive(Debug, Clone, Copy)]
 #[expect(clippy::struct_field_names)]
 struct GeneratorTypes<'db> {
-    yield_ty: Option<Type<'db>>,
-    send_ty: Option<Type<'db>>,
+    yield_ty: Type<'db>,
+    send_ty: Type<'db>,
     return_ty: Option<Type<'db>>,
 }
 
@@ -1481,10 +1483,8 @@ impl<'db> GeneratorTypes<'db> {
     ) -> Self {
         let visitor = ApplyTypeMappingVisitor::new(env);
         Self {
-            yield_ty: self.yield_ty.map(|ty| ty.materialize(db, kind, &visitor)),
-            send_ty: self
-                .send_ty
-                .map(|ty| ty.materialize(db, kind.flip(), &visitor)),
+            yield_ty: self.yield_ty.materialize(db, kind, &visitor),
+            send_ty: self.send_ty.materialize(db, kind.flip(), &visitor),
             return_ty: self.return_ty.map(|ty| ty.materialize(db, kind, &visitor)),
         }
     }
@@ -6737,6 +6737,7 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        mode: EvaluationMode,
     ) -> Option<GeneratorTypes<'db>> {
         // TODO: Ideally, we would first try to upcast `self` to an instance of `Generator` and *then*
         // match on the protocol instance to get the `ReturnType` type parameter. For now, implement
@@ -6754,34 +6755,24 @@ impl<'db> Type<'db> {
                 && let [yield_ty, send_ty, return_ty] = specialization.types(db)
             {
                 Some(GeneratorTypes {
-                    yield_ty: Some(*yield_ty),
-                    send_ty: Some(*send_ty),
+                    yield_ty: *yield_ty,
+                    send_ty: *send_ty,
                     return_ty: Some(*return_ty),
                 })
             } else if class.is_known(db, KnownClass::AsyncGenerator)
                 && let [yield_ty, send_ty] = specialization.types(db)
             {
                 Some(GeneratorTypes {
-                    yield_ty: Some(*yield_ty),
-                    send_ty: Some(*send_ty),
+                    yield_ty: *yield_ty,
+                    send_ty: *send_ty,
                     return_ty: None,
-                })
-            } else if (class.is_known(db, KnownClass::Iterator)
-                || class.is_known(db, KnownClass::AsyncIterator))
-                && let [yield_ty] = specialization.types(db)
-            {
-                let none = Type::none(db, env);
-                Some(GeneratorTypes {
-                    yield_ty: Some(*yield_ty),
-                    send_ty: Some(none),
-                    return_ty: Some(none),
                 })
             } else {
                 None
             }
         };
 
-        match self {
+        let nominal_result = match self {
             Type::NominalInstance(instance) => instance
                 .class(db, env)
                 .iter_mro(db)
@@ -6794,22 +6785,16 @@ impl<'db> Type<'db> {
                         .materialization_kind(db)
                         .map_or(types, |kind| types.materialize(db, env, kind))
                 }),
-            Type::TypeAlias(alias) => alias.value_type(db).generator_types(db, env),
+            Type::TypeAlias(alias) => alias.value_type(db).generator_types(db, env, mode),
             Type::Union(union) => {
-                let mut yield_builder = Some(UnionBuilder::new(db, env));
-                let mut send_builder = Some(UnionBuilder::new(db, env));
+                let mut yield_builder = UnionBuilder::new(db, env);
+                let mut send_builder = UnionBuilder::new(db, env);
                 let mut return_builder = Some(UnionBuilder::new(db, env));
 
                 for ty in union.elements(db) {
-                    let gt = ty.generator_types(db, env)?;
-                    match gt.yield_ty {
-                        Some(ty) => yield_builder = yield_builder.map(|b| b.add(ty)),
-                        None => yield_builder = None,
-                    }
-                    match gt.send_ty {
-                        Some(ty) => send_builder = send_builder.map(|b| b.add(ty)),
-                        None => send_builder = None,
-                    }
+                    let gt = ty.generator_types(db, env, mode)?;
+                    yield_builder = yield_builder.add(gt.yield_ty);
+                    send_builder = send_builder.add(gt.send_ty);
                     match gt.return_ty {
                         Some(ty) => return_builder = return_builder.map(|b| b.add(ty)),
                         None => return_builder = None,
@@ -6817,8 +6802,8 @@ impl<'db> Type<'db> {
                 }
 
                 Some(GeneratorTypes {
-                    yield_ty: yield_builder.map(UnionBuilder::build),
-                    send_ty: send_builder.map(UnionBuilder::build),
+                    yield_ty: yield_builder.build(),
+                    send_ty: send_builder.build(),
                     return_ty: return_builder.map(UnionBuilder::build),
                 })
             }
@@ -6826,28 +6811,18 @@ impl<'db> Type<'db> {
                 // Using `positive()` rather than `positive_elements_or_object()` is safe
                 // here because `object` is not a generator, so falling back to it would
                 // still return `None`.
-                let mut yield_builder = Some(IntersectionBuilder::new(db, env));
-                let mut send_builder = Some(IntersectionBuilder::new(db, env));
+                let mut yield_builder = IntersectionBuilder::new(db, env);
+                let mut send_builder = IntersectionBuilder::new(db, env);
                 let mut return_builder = Some(IntersectionBuilder::new(db, env));
                 let mut any_success = false;
 
                 for ty in intersection.positive(db) {
-                    let Some(gt) = ty.generator_types(db, env) else {
+                    let Some(gt) = ty.generator_types(db, env, mode) else {
                         continue;
                     };
                     any_success = true;
-                    match gt.yield_ty {
-                        Some(ty) => {
-                            yield_builder = yield_builder.map(|b| b.add_positive(ty));
-                        }
-                        None => yield_builder = None,
-                    }
-                    match gt.send_ty {
-                        Some(ty) => {
-                            send_builder = send_builder.map(|b| b.add_positive(ty));
-                        }
-                        None => send_builder = None,
-                    }
+                    yield_builder = yield_builder.add_positive(gt.yield_ty);
+                    send_builder = send_builder.add_positive(gt.send_ty);
                     match gt.return_ty {
                         Some(ty) => {
                             return_builder = return_builder.map(|b| b.add_positive(ty));
@@ -6861,18 +6836,45 @@ impl<'db> Type<'db> {
                 }
 
                 Some(GeneratorTypes {
-                    yield_ty: yield_builder.map(IntersectionBuilder::build),
-                    send_ty: send_builder.map(IntersectionBuilder::build),
+                    yield_ty: yield_builder.build(),
+                    send_ty: send_builder.build(),
                     return_ty: return_builder.map(IntersectionBuilder::build),
                 })
             }
-            ty @ (Type::Dynamic(_) | Type::Divergent(_) | Type::Never) => Some(GeneratorTypes {
-                yield_ty: Some(ty),
-                send_ty: Some(ty),
-                return_ty: Some(ty),
+            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(GeneratorTypes {
+                yield_ty: self,
+                send_ty: self,
+                return_ty: Some(self),
             }),
             _ => None,
+        };
+
+        if let Some(nominal_result) = nominal_result {
+            return Some(nominal_result);
         }
+
+        let generator_class = match mode {
+            EvaluationMode::Sync => KnownClass::Generator,
+            EvaluationMode::Async => KnownClass::AsyncGenerator,
+        };
+
+        if !generator_class
+            .to_instance_unknown(db, env)
+            .is_assignable_to(db, env, self)
+        {
+            return None;
+        }
+
+        self.try_iterate_with_mode(db, env, mode)
+            .map(|tuple| {
+                let none = Type::none(db, env);
+                GeneratorTypes {
+                    yield_ty: tuple.homogeneous_element_type(db, env),
+                    send_ty: none,
+                    return_ty: Some(none),
+                }
+            })
+            .ok()
     }
 
     fn generator_return_type(
@@ -6880,7 +6882,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Type<'db>> {
-        self.generator_types(db, env)
+        self.generator_types(db, env, EvaluationMode::Sync)
             .and_then(|generator_types| generator_types.return_ty)
     }
 
@@ -6888,9 +6890,10 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        mode: EvaluationMode,
     ) -> Option<Type<'db>> {
-        self.generator_types(db, env)
-            .and_then(|generator_types| generator_types.send_ty)
+        self.generator_types(db, env, mode)
+            .map(|generator_types| generator_types.send_ty)
     }
 
     /// Return the instance approximation, discarding whether the projection is exact.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -64,7 +64,7 @@ use crate::types::call::bind::ConstructorCallableKind;
 use crate::types::call::{Binding, Bindings, CallArguments, CallableBinding};
 pub(crate) use crate::types::callable::{CallableType, CallableTypes};
 pub(crate) use crate::types::class_base::ClassBase;
-use crate::types::constraints::ConstraintSetBuilder;
+use crate::types::constraints::{ConstraintSetBuilder, Solutions};
 use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 use crate::types::diagnostic::{
     INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_dunder_get_call, report_bad_dunder_getattr_call,
@@ -1466,28 +1466,15 @@ fn recursive_type_normalize_type_guard_like<'db, T: TypeGuardLike<'db>>(
 #[derive(Debug, Clone, Copy)]
 #[expect(clippy::struct_field_names)]
 struct GeneratorTypes<'db> {
-    yield_ty: Option<Type<'db>>,
-    send_ty: Option<Type<'db>>,
+    yield_ty: Type<'db>,
+    send_ty: Type<'db>,
     return_ty: Option<Type<'db>>,
 }
 
-impl<'db> GeneratorTypes<'db> {
-    /// Apply a generator's materialization with the variance of each operation.
-    fn materialize(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        kind: MaterializationKind,
-    ) -> Self {
-        let visitor = ApplyTypeMappingVisitor::new(env);
-        Self {
-            yield_ty: self.yield_ty.map(|ty| ty.materialize(db, kind, &visitor)),
-            send_ty: self
-                .send_ty
-                .map(|ty| ty.materialize(db, kind.flip(), &visitor)),
-            return_ty: self.return_ty.map(|ty| ty.materialize(db, kind, &visitor)),
-        }
-    }
+#[derive(Debug, Clone, Copy)]
+struct AsyncGeneratorTypes<'db> {
+    yield_ty: Type<'db>,
+    send_ty: Type<'db>,
 }
 
 fn object_type_form(db: &dyn Db) -> Type<'_> {
@@ -6720,177 +6707,246 @@ impl<'db> Type<'db> {
         );
         match await_result {
             Ok(bindings) => {
-                let return_type = bindings.return_type(db, env);
-                Ok(return_type.generator_return_type(db, env).ok_or_else(|| {
-                    AwaitError::InvalidReturnType(return_type, Box::new(bindings))
-                })?)
+                let iterator_ty = KnownClass::Iterator.to_instance_unknown(db, env);
+                bindings
+                    .try_map_return_type(db, env, |ty| {
+                        ty.is_assignable_to(db, env, iterator_ty).then(|| {
+                            ty.generator_types(db, env)
+                                .and_then(|generator_types| generator_types.return_ty)
+                                .unwrap_or_else(Type::unknown)
+                        })
+                    })
+                    .ok_or_else(|| {
+                        AwaitError::InvalidReturnType(
+                            bindings.return_type(db, env),
+                            Box::new(bindings),
+                        )
+                    })
             }
             Err(call_error) => Err(AwaitError::Call(call_error)),
         }
     }
 
-    /// Get the return type of a `yield from …` expression where `self` is the type of the generator.
-    ///
-    /// This corresponds to the `ReturnT` parameter of the generic `typing.Generator[YieldT, SendT, ReturnT]`
-    /// protocol.
+    /// Infer the yield, send, and return types represented by a synchronous generator or iterable.
     fn generator_types(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<GeneratorTypes<'db>> {
-        // TODO: Ideally, we would first try to upcast `self` to an instance of `Generator` and *then*
-        // match on the protocol instance to get the `ReturnType` type parameter. For now, implement
-        // an ad-hoc solution that works for protocols and instances of classes that explicitly inherit
-        // from the `Generator` protocol, such as `types.GeneratorType`.
+        if matches!(self, Type::Dynamic(_) | Type::Divergent(_) | Type::Never) {
+            return Some(GeneratorTypes {
+                yield_ty: self,
+                send_ty: self,
+                return_ty: Some(self),
+            });
+        }
 
-        let from_class_base = |base: ClassBase<'db>| {
-            let class = base.into_class()?;
-            let (_, Some(specialization)) = class.static_class_literal_specialized(db, None)?
-            else {
-                return None;
-            };
+        let yield_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("YieldT"),
+            TypeVarVariance::Covariant,
+        );
+        let send_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("SendT"),
+            TypeVarVariance::Contravariant,
+        );
+        let return_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("ReturnT"),
+            TypeVarVariance::Covariant,
+        );
 
-            if class.is_known(db, KnownClass::Generator)
-                && let [yield_ty, send_ty, return_ty] = specialization.types(db)
-            {
-                Some(GeneratorTypes {
-                    yield_ty: Some(*yield_ty),
-                    send_ty: Some(*send_ty),
-                    return_ty: Some(*return_ty),
-                })
-            } else if class.is_known(db, KnownClass::AsyncGenerator)
-                && let [yield_ty, send_ty] = specialization.types(db)
-            {
-                Some(GeneratorTypes {
-                    yield_ty: Some(*yield_ty),
-                    send_ty: Some(*send_ty),
-                    return_ty: None,
-                })
-            } else if (class.is_known(db, KnownClass::Iterator)
-                || class.is_known(db, KnownClass::AsyncIterator))
-                && let [yield_ty] = specialization.types(db)
-            {
-                let none = Type::none(db, env);
-                Some(GeneratorTypes {
-                    yield_ty: Some(*yield_ty),
-                    send_ty: Some(none),
-                    return_ty: Some(none),
-                })
-            } else {
-                None
+        let generator_spec = [
+            Type::TypeVar(yield_t),
+            Type::TypeVar(send_t),
+            Type::TypeVar(return_t),
+        ];
+        let generator_ty = KnownClass::Generator.to_specialized_instance(db, env, &generator_spec);
+        if let Some([yield_ty, send_ty, return_ty]) =
+            self.infer_generator_type_arguments(db, env, generator_ty, [yield_t, send_t, return_t])
+        {
+            return Some(GeneratorTypes {
+                yield_ty,
+                send_ty,
+                return_ty: Some(return_ty),
+            });
+        }
+
+        let iterable_ty =
+            KnownClass::Iterable.to_specialized_instance(db, env, &[Type::TypeVar(yield_t)]);
+        let (yield_ty, send_ty) = self.iterable_generator_types(
+            db,
+            env,
+            KnownClass::Generator,
+            iterable_ty,
+            yield_t,
+            send_t,
+        )?;
+        Some(GeneratorTypes {
+            yield_ty,
+            send_ty,
+            return_ty: None,
+        })
+    }
+
+    /// Infer the yield and send types represented by an asynchronous generator or iterable.
+    fn async_generator_types(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<AsyncGeneratorTypes<'db>> {
+        if matches!(self, Type::Dynamic(_) | Type::Divergent(_) | Type::Never) {
+            return Some(AsyncGeneratorTypes {
+                yield_ty: self,
+                send_ty: self,
+            });
+        }
+
+        let yield_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("YieldT"),
+            TypeVarVariance::Covariant,
+        );
+        let send_t = BoundTypeVarInstance::synthetic(
+            db,
+            env,
+            Name::new_static("SendT"),
+            TypeVarVariance::Contravariant,
+        );
+        let generator_spec = [Type::TypeVar(yield_t), Type::TypeVar(send_t)];
+        let generator_ty =
+            KnownClass::AsyncGenerator.to_specialized_instance(db, env, &generator_spec);
+        if let Some([yield_ty, send_ty]) =
+            self.infer_generator_type_arguments(db, env, generator_ty, [yield_t, send_t])
+        {
+            return Some(AsyncGeneratorTypes { yield_ty, send_ty });
+        }
+
+        let iterable_ty =
+            KnownClass::AsyncIterable.to_specialized_instance(db, env, &[Type::TypeVar(yield_t)]);
+        let (yield_ty, send_ty) = self.iterable_generator_types(
+            db,
+            env,
+            KnownClass::AsyncGenerator,
+            iterable_ty,
+            yield_t,
+            send_t,
+        )?;
+        Some(AsyncGeneratorTypes { yield_ty, send_ty })
+    }
+
+    /// Solve the type variables that make this type assignable to a synthetic protocol instance.
+    fn infer_generator_type_arguments<const N: usize>(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        target: Type<'db>,
+        typevars: [BoundTypeVarInstance<'db>; N],
+    ) -> Option<[Type<'db>; N]> {
+        let inferable = TypeVarSet::from_typevars(db, typevars);
+        let constraints = ConstraintSetBuilder::new();
+        match self
+            .assignable_solutions_with_inferable(db, env, target, inferable)
+            .solve(db, env, &constraints)
+        {
+            Solutions::Unsatisfiable => None,
+            Solutions::Unconstrained => Some([Type::unknown(); N]),
+            Solutions::Constrained(solutions) => {
+                let generic_context = GenericContext::from_typevar_instances(db, env, typevars);
+                let types = typevars.map(|typevar| {
+                    let mut types = solutions.iter().filter_map(|solution| {
+                        solution
+                            .iter()
+                            .find(|binding| binding.bound_typevar == typevar)
+                            .map(|binding| binding.solution)
+                    });
+                    let first = types.next()?;
+                    Some(UnionType::from_elements(
+                        db,
+                        env,
+                        iter::once(first).chain(types),
+                    ))
+                });
+
+                // Solutions can reference other synthetic parameters from the same query. For
+                // example, `SendT = None & ReturnT` and `ReturnT = SendT | None` both resolve to
+                // `None`; recursively specializing them prevents those internal variables from
+                // escaping into inferred generator types.
+                let specialization = generic_context.specialize_recursive(db, types);
+                Some(typevars.map(|typevar| {
+                    specialization
+                        .get(db, typevar)
+                        .unwrap_or_else(Type::unknown)
+                }))
             }
-        };
-
-        match self {
-            Type::NominalInstance(instance) => instance
-                .class(db, env)
-                .iter_mro(db)
-                .find_map(from_class_base),
-            Type::ProtocolInstance(protocol) => protocol
-                .class_origin(db)
-                .and_then(|class| class.iter_mro(db).find_map(from_class_base))
-                .map(|types| {
-                    protocol
-                        .materialization_kind(db)
-                        .map_or(types, |kind| types.materialize(db, env, kind))
-                }),
-            Type::TypeAlias(alias) => alias.value_type(db).generator_types(db, env),
-            Type::Union(union) => {
-                let mut yield_builder = Some(UnionBuilder::new(db, env));
-                let mut send_builder = Some(UnionBuilder::new(db, env));
-                let mut return_builder = Some(UnionBuilder::new(db, env));
-
-                for ty in union.elements(db) {
-                    let gt = ty.generator_types(db, env)?;
-                    match gt.yield_ty {
-                        Some(ty) => yield_builder = yield_builder.map(|b| b.add(ty)),
-                        None => yield_builder = None,
-                    }
-                    match gt.send_ty {
-                        Some(ty) => send_builder = send_builder.map(|b| b.add(ty)),
-                        None => send_builder = None,
-                    }
-                    match gt.return_ty {
-                        Some(ty) => return_builder = return_builder.map(|b| b.add(ty)),
-                        None => return_builder = None,
-                    }
-                }
-
-                Some(GeneratorTypes {
-                    yield_ty: yield_builder.map(UnionBuilder::build),
-                    send_ty: send_builder.map(UnionBuilder::build),
-                    return_ty: return_builder.map(UnionBuilder::build),
-                })
-            }
-            Type::Intersection(intersection) => {
-                // Using `positive()` rather than `positive_elements_or_object()` is safe
-                // here because `object` is not a generator, so falling back to it would
-                // still return `None`.
-                let mut yield_builder = Some(IntersectionBuilder::new(db, env));
-                let mut send_builder = Some(IntersectionBuilder::new(db, env));
-                let mut return_builder = Some(IntersectionBuilder::new(db, env));
-                let mut any_success = false;
-
-                for ty in intersection.positive(db) {
-                    let Some(gt) = ty.generator_types(db, env) else {
-                        continue;
-                    };
-                    any_success = true;
-                    match gt.yield_ty {
-                        Some(ty) => {
-                            yield_builder = yield_builder.map(|b| b.add_positive(ty));
-                        }
-                        None => yield_builder = None,
-                    }
-                    match gt.send_ty {
-                        Some(ty) => {
-                            send_builder = send_builder.map(|b| b.add_positive(ty));
-                        }
-                        None => send_builder = None,
-                    }
-                    match gt.return_ty {
-                        Some(ty) => {
-                            return_builder = return_builder.map(|b| b.add_positive(ty));
-                        }
-                        None => return_builder = None,
-                    }
-                }
-
-                if !any_success {
-                    return None;
-                }
-
-                Some(GeneratorTypes {
-                    yield_ty: yield_builder.map(IntersectionBuilder::build),
-                    send_ty: send_builder.map(IntersectionBuilder::build),
-                    return_ty: return_builder.map(IntersectionBuilder::build),
-                })
-            }
-            ty @ (Type::Dynamic(_) | Type::Divergent(_) | Type::Never) => Some(GeneratorTypes {
-                yield_ty: Some(ty),
-                send_ty: Some(ty),
-                return_ty: Some(ty),
-            }),
-            _ => None,
         }
     }
 
-    fn generator_return_type(
+    /// Infer the yield and send types of an iterable annotation that can describe a generator.
+    ///
+    /// Returns `None` when the annotation cannot describe an instance of `generator_class` or its
+    /// yield type cannot be inferred. Otherwise, returns `(yield_type, send_type)`, where the send
+    /// type comes from the annotation's `send` or `asend` method. If the annotation exposes neither
+    /// method, the send type defaults to the Python `None` type.
+    ///
+    /// ## Why don't we also try to infer the return type?
+    ///
+    /// In principle, we could synthesize a `return_t` type variable and try to infer it from the
+    /// annotation's `__iter__` method. However, this would be significantly more complicated than
+    /// inferring the yield and return types, and also much less useful in practice: the return type
+    /// of a generator is almost never relevant to real-world code.
+    fn iterable_generator_types(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-    ) -> Option<Type<'db>> {
-        self.generator_types(db, env)
-            .and_then(|generator_types| generator_types.return_ty)
-    }
+        generator_class: KnownClass,
+        iterable_ty: Type<'db>,
+        yield_t: BoundTypeVarInstance<'db>,
+        send_t: BoundTypeVarInstance<'db>,
+    ) -> Option<(Type<'db>, Type<'db>)> {
+        // An iterable annotation can describe a generator, but a concrete iterable such as `str`
+        // cannot. Avoid extracting a yield type from annotations that reject generator instances.
+        if !generator_class
+            .to_instance_unknown(db, env)
+            .is_assignable_to(db, env, self)
+        {
+            return None;
+        }
 
-    fn generator_send_type(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Option<Type<'db>> {
-        self.generator_types(db, env)
-            .and_then(|generator_types| generator_types.send_ty)
+        let [yield_ty] = self.infer_generator_type_arguments(db, env, iterable_ty, [yield_t])?;
+
+        let (send_name, send_return_ty) = if generator_class == KnownClass::Generator {
+            ("send", Type::object())
+        } else {
+            (
+                "asend",
+                KnownClass::Awaitable.to_specialized_instance(db, env, &[Type::object()]),
+            )
+        };
+
+        let expected_send_signature = Signature::new(
+            Parameters::standard([
+                Parameter::positional_only(Some(Name::new_static("self"))),
+                Parameter::positional_only(Some(Name::new_static("value")))
+                    .with_annotated_type(Type::TypeVar(send_t)),
+            ]),
+            send_return_ty,
+        );
+
+        let send_method = CallableType::function_like(db, expected_send_signature);
+        let proto_to_test = Type::protocol_with_methods(db, env, [(send_name, send_method)]);
+
+        let send_ty = self
+            .infer_generator_type_arguments(db, env, proto_to_test, [send_t])
+            .map(|[send_ty]| send_ty)
+            .unwrap_or_else(|| Type::none(db, env));
+
+        Some((yield_ty, send_ty))
     }
 
     /// Return the instance approximation, discarding whether the projection is exact.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1384,6 +1384,73 @@ impl<'db> Bindings<'db> {
         )
     }
 
+    /// Applies a fallible transformation to individual return types before combining callable
+    /// intersections and unions.
+    ///
+    /// NOTE: this API is a workaround for <https://github.com/astral-sh/ty/issues/2799>: the
+    /// constraint solver currently combines alternative specializations using a union even when an
+    /// intersection is required. Keeping callable bindings separate avoids that limitation. This
+    /// method should become unnecessary once the solver combines those specializations correctly.
+    ///
+    /// Suppose the callable bindings have the shape `(callable_a & callable_b) | callable_c`, with
+    /// return types `R_a`, `R_b`, and `R_c`, respectively. The usual `return_type` method first
+    /// combines those return types:
+    ///
+    /// ```text
+    /// return_type()                 = (R_a & R_b) | R_c
+    /// try_map_return_type(map)      = (map(R_a) & map(R_b)) | map(R_c)
+    /// map(return_type())            = map((R_a & R_b) | R_c)
+    /// ```
+    ///
+    /// The latter two operations are not equivalent when `map` cannot preserve intersections or
+    /// unions that have already been combined. For example, awaiting an object calls `__await__`
+    /// and extracts the third type argument from the returned `Generator`:
+    ///
+    /// ```py
+    /// from typing import Any, Coroutine
+    /// from ty_extensions import Intersection
+    ///
+    /// class A: ...
+    /// class B: ...
+    ///
+    /// async def f(value: Intersection[Coroutine[Any, Any, A], Coroutine[Any, Any, B]]):
+    ///     reveal_type(await value)  # A & B
+    /// ```
+    ///
+    /// The `__await__` bindings return `Generator[Any, None, A]` and `Generator[Any, None, B]`.
+    /// Extracting their return types separately and then intersecting them produces `A & B`.
+    /// Extracting a return type from the combined generator intersection instead gives the
+    /// constraint solver two alternative solutions, producing `A | B`.
+    ///
+    /// A failed transformation discards one alternative within an intersection. Each union
+    /// element, however, is a possible runtime value, so every union element must retain at least
+    /// one successfully transformed alternative:
+    ///
+    /// ```text
+    /// map(R_a) = Some(A), map(R_b) = None, map(R_c) = Some(C) => Some(A | C)
+    /// map(R_a) = Some(A), map(R_b) = None, map(R_c) = None    => None
+    /// ```
+    pub(crate) fn try_map_return_type(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        mut map: impl FnMut(Type<'db>) -> Option<Type<'db>>,
+    ) -> Option<Type<'db>> {
+        let mut union = UnionBuilder::new(db, env);
+
+        for element in &self.elements {
+            let mut mapped = element
+                .items()
+                .filter(|item| item.is_callable())
+                .filter_map(|item| map(item.return_type(db, env)))
+                .peekable();
+            mapped.peek()?;
+            union.add_in_place(IntersectionType::from_elements(db, env, mapped));
+        }
+
+        Some(union.build())
+    }
+
     /// Returns the inferred type for the argument at the specified index.
     pub(crate) fn type_for_argument<'a>(
         &'a self,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1184,35 +1184,6 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    /// Returns the statement-defined class literal and specialization for this class, with an additional
-    /// specialization applied if the class is generic.
-    pub(crate) fn static_class_literal_specialized(
-        self,
-        db: &'db dyn Db,
-        additional_specialization: Option<Specialization<'db>>,
-    ) -> Option<(StaticClassLiteral<'db>, Option<Specialization<'db>>)> {
-        match self {
-            Self::NonGeneric(ClassLiteral::Static(class)) => Some((class, None)),
-            Self::NonGeneric(
-                ClassLiteral::Dynamic(_)
-                | ClassLiteral::DynamicNamedTuple(_)
-                | ClassLiteral::DynamicTypedDict(_)
-                | ClassLiteral::DynamicEnum(_),
-            ) => None,
-            Self::Generic(generic) => {
-                let origin = generic.origin(db);
-                Some((
-                    origin,
-                    Some(
-                        generic
-                            .specialization(db)
-                            .apply_optional_specialization(db, additional_specialization),
-                    ),
-                ))
-            }
-        }
-    }
-
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db Name {
         self.class_literal(db).name(db)
     }

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -118,6 +118,7 @@ pub enum KnownClass {
     SupportsIndex,
     Iterable,
     Iterator,
+    AsyncIterable,
     AsyncIterator,
     Sequence,
     Mapping,
@@ -261,6 +262,7 @@ impl KnownClass {
             | Self::IntFlag
             | Self::ABCMeta
             | Self::Iterable
+            | Self::AsyncIterable
             | Self::TyExtensionsAsyncIterable
             | Self::TyExtensionsAsyncIterator
             | Self::TyExtensionsIterable
@@ -377,6 +379,7 @@ impl KnownClass {
             | KnownClass::Hashable
             | KnownClass::SupportsIndex
             | KnownClass::Iterable
+            | KnownClass::AsyncIterable
             | KnownClass::TyExtensionsAsyncIterable
             | KnownClass::TyExtensionsAsyncIterator
             | KnownClass::TyExtensionsIterable
@@ -491,6 +494,7 @@ impl KnownClass {
             | KnownClass::Hashable
             | KnownClass::SupportsIndex
             | KnownClass::Iterable
+            | KnownClass::AsyncIterable
             | KnownClass::TyExtensionsAsyncIterable
             | KnownClass::TyExtensionsAsyncIterator
             | KnownClass::TyExtensionsIterable
@@ -606,6 +610,7 @@ impl KnownClass {
             | KnownClass::Hashable
             | KnownClass::SupportsIndex
             | KnownClass::Iterable
+            | KnownClass::AsyncIterable
             | KnownClass::TyExtensionsAsyncIterable
             | KnownClass::TyExtensionsAsyncIterator
             | KnownClass::TyExtensionsIterable
@@ -664,6 +669,7 @@ impl KnownClass {
             | Self::SupportsIndex
             | Self::SupportsKeysAndGetItem
             | Self::Iterable
+            | Self::AsyncIterable
             | Self::TyExtensionsAsyncIterable
             | Self::TyExtensionsAsyncIterator
             | Self::TyExtensionsIterable
@@ -853,6 +859,7 @@ impl KnownClass {
             | KnownClass::Hashable
             | KnownClass::SupportsIndex
             | KnownClass::Iterable
+            | KnownClass::AsyncIterable
             | KnownClass::TyExtensionsAsyncIterable
             | KnownClass::TyExtensionsAsyncIterator
             | KnownClass::TyExtensionsIterable
@@ -973,13 +980,10 @@ impl KnownClass {
             Self::IntFlag => "IntFlag",
             Self::ABCMeta => "ABCMeta",
             Self::Super => "super",
-            Self::Iterable => "Iterable",
-            Self::TyExtensionsAsyncIterable => "AsyncIterable",
-            Self::TyExtensionsAsyncIterator => "AsyncIterator",
-            Self::TyExtensionsIterable => "Iterable",
-            Self::Iterator => "Iterator",
-            Self::TyExtensionsIterator => "Iterator",
-            Self::AsyncIterator => "AsyncIterator",
+            Self::Iterable | Self::TyExtensionsIterable => "Iterable",
+            Self::Iterator | Self::TyExtensionsIterator => "Iterator",
+            Self::AsyncIterable | Self::TyExtensionsAsyncIterable => "AsyncIterable",
+            Self::AsyncIterator | Self::TyExtensionsAsyncIterator => "AsyncIterator",
             Self::Sequence => "Sequence",
             Self::Mapping => "Mapping",
             Self::MutableMapping => "MutableMapping",
@@ -1381,6 +1385,7 @@ impl KnownClass {
             | Self::StdlibAlias
             | Self::Iterable
             | Self::Iterator
+            | Self::AsyncIterable
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
@@ -1535,6 +1540,7 @@ impl KnownClass {
             | Self::Field
             | Self::KwOnly
             | Self::Iterable
+            | Self::AsyncIterable
             | Self::TyExtensionsAsyncIterable
             | Self::TyExtensionsAsyncIterator
             | Self::TyExtensionsIterable
@@ -1622,7 +1628,7 @@ impl KnownClass {
             "TypeVar" => &[Self::TypeVar, Self::ExtensionsTypeVar],
             "Iterable" => &[Self::Iterable, Self::TyExtensionsIterable],
             "Iterator" => &[Self::Iterator, Self::TyExtensionsIterator],
-            "AsyncIterable" => &[Self::TyExtensionsAsyncIterable],
+            "AsyncIterable" => &[Self::AsyncIterable, Self::TyExtensionsAsyncIterable],
             "AsyncIterator" => &[Self::AsyncIterator, Self::TyExtensionsAsyncIterator],
             "Sequence" => &[Self::Sequence],
             "Mapping" => &[Self::Mapping],
@@ -1793,6 +1799,7 @@ impl KnownClass {
             | Self::ParamSpecKwargs
             | Self::Iterable
             | Self::Iterator
+            | Self::AsyncIterable
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -101,7 +101,7 @@ use crate::{Db, FxOrderSet, ProgramEnvironment};
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{FileScopeId, ProgramFile, SemanticIndex, semantic_index};
+use ty_python_core::{EvaluationMode, FileScopeId, ProgramFile, SemanticIndex, semantic_index};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct RecursiveTypeNormalizationKey {
@@ -502,6 +502,21 @@ impl<'db> OverloadLiteral<'db> {
         }
 
         Some(previous_literal)
+    }
+
+    #[salsa::tracked(returns(copy))]
+    pub(crate) fn evaluation_mode(self, db: &'db dyn Db) -> EvaluationMode {
+        if self
+            .body_scope(db)
+            .node(db)
+            .expect_function()
+            .node(&parsed_module(db, self.python_file(db)).load(db))
+            .is_async
+        {
+            EvaluationMode::Async
+        } else {
+            EvaluationMode::Sync
+        }
     }
 
     /// Typed internally-visible signature for this function.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5032,7 +5032,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let file_scope_id = self.scope().file_scope_id(self.db());
                     let context_ty = if file_scope_id.is_generator_function(self.index) {
                         return_ty
-                            .generator_return_type(db, env)
+                            .generator_types(db, env)
+                            .map(|types| types.return_ty.unwrap_or_else(|| Type::none(db, env)))
                             .unwrap_or(return_ty)
                     } else {
                         return_ty
@@ -9366,31 +9367,43 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         .return_ty;
         let return_type_span = enclosing_function.spans(self.db()).return_type;
 
-        let Some(generator_type_params) = declared_return_ty.generator_types(db, env) else {
+        let generator_type_params = if enclosing_function
+            .node(db, self.file(), self.module())
+            .is_async
+        {
+            declared_return_ty
+                .async_generator_types(db, env)
+                .map(|types| (types.yield_ty, types.send_ty))
+        } else {
+            declared_return_ty
+                .generator_types(db, env)
+                .map(|types| (types.yield_ty, types.send_ty))
+        };
+
+        let Some((expected_yield_ty, send_ty)) = generator_type_params else {
             let _ = self.infer_optional_expression(value.as_deref(), TypeContext::default());
             return Type::unknown();
         };
 
-        let expected_yield_ty = generator_type_params.yield_ty;
-        let tcx = TypeContext::new(expected_yield_ty);
+        let tcx = TypeContext::new(Some(expected_yield_ty));
+
         let yielded_ty = self
             .infer_optional_expression(value.as_deref(), tcx)
             .unwrap_or_else(|| Type::none(db, env));
+
         let diagnostic_node: AnyNodeRef = value
             .as_deref()
             .map_or_else(|| yield_expression.into(), AnyNodeRef::from);
 
-        if let Some(expected_yield_ty) = expected_yield_ty {
-            self.validate_generator_yield_type(
-                diagnostic_node,
-                YieldKind::Yield,
-                return_type_span,
-                expected_yield_ty,
-                yielded_ty,
-            );
-        }
+        self.validate_generator_yield_type(
+            diagnostic_node,
+            YieldKind::Yield,
+            return_type_span,
+            expected_yield_ty,
+            yielded_ty,
+        );
 
-        generator_type_params.send_ty.unwrap_or_else(Type::unknown)
+        send_ty
     }
 
     fn infer_yield_from_expression(&mut self, yield_from: &ast::ExprYieldFrom) -> Type<'db> {
@@ -9420,9 +9433,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
         let return_type_span = enclosing_function.spans(self.db()).return_type;
 
-        let tcx = TypeContext::new(outer_expected.yield_ty.map(|yielded_ty| {
-            KnownClass::Iterable.to_specialized_instance(db, env, &[yielded_ty])
-        }));
+        let tcx = TypeContext::new(Some(KnownClass::Iterable.to_specialized_instance(
+            db,
+            env,
+            &[outer_expected.yield_ty],
+        )));
         let iterable_type = self.infer_expression(value, tcx);
 
         let known_inner_yield_type = match iterable_type.try_iterate(db, env) {
@@ -9433,36 +9448,37 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        if let Some(outer_yield_ty) = outer_expected.yield_ty
-            && let Some(known_inner_yield_type) = known_inner_yield_type
-        {
+        if let Some(known_inner_yield_type) = known_inner_yield_type {
             self.validate_generator_yield_type(
                 &**value,
                 YieldKind::YieldFrom,
                 return_type_span.clone(),
-                outer_yield_ty,
+                outer_expected.yield_ty,
                 known_inner_yield_type,
             );
         }
 
-        if let Some(outer_send_ty) = outer_expected.send_ty {
-            let inner_send_ty = iterable_type
-                .generator_send_type(db, env)
-                .unwrap_or_else(|| Type::none(db, env));
-            if !outer_send_ty.is_assignable_to(db, env, inner_send_ty) {
-                report_invalid_generator_yield_type(
-                    &self.context,
-                    value.as_ref(),
-                    return_type_span,
-                    outer_send_ty,
-                    inner_send_ty,
-                    GeneratorMismatchKind::SendType,
-                );
-            }
+        let inner_generator_types = iterable_type.generator_types(db, env);
+        let inner_send_ty = inner_generator_types
+            .map(|types| types.send_ty)
+            .unwrap_or_else(|| Type::none(db, env));
+
+        if !outer_expected
+            .send_ty
+            .is_assignable_to(db, env, inner_send_ty)
+        {
+            report_invalid_generator_yield_type(
+                &self.context,
+                value.as_ref(),
+                return_type_span,
+                outer_expected.send_ty,
+                inner_send_ty,
+                GeneratorMismatchKind::SendType,
+            );
         }
 
-        iterable_type
-            .generator_return_type(db, env)
+        inner_generator_types
+            .and_then(|types| types.return_ty)
             .unwrap_or_else(Type::unknown)
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9340,13 +9340,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         .return_ty;
         let return_type_span = enclosing_function.spans(self.db()).return_type;
 
-        let Some(generator_type_params) = declared_return_ty.generator_types(db, env) else {
+        let mode = enclosing_function
+            .first_overload_or_implementation(db)
+            .evaluation_mode(db);
+
+        let Some(generator_type_params) = declared_return_ty.generator_types(db, env, mode) else {
             let _ = self.infer_optional_expression(value.as_deref(), TypeContext::default());
             return Type::unknown();
         };
 
         let expected_yield_ty = generator_type_params.yield_ty;
-        let tcx = TypeContext::new(expected_yield_ty);
+        let tcx = TypeContext::new(Some(expected_yield_ty));
         let yielded_ty = self
             .infer_optional_expression(value.as_deref(), tcx)
             .unwrap_or_else(|| Type::none(db, env));
@@ -9354,9 +9358,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .as_deref()
             .map_or_else(|| yield_expression.into(), AnyNodeRef::from);
 
-        if let Some(expected_yield_ty) = expected_yield_ty
-            && !yielded_ty.is_assignable_to(db, env, expected_yield_ty)
-        {
+        if !yielded_ty.is_assignable_to(db, env, expected_yield_ty) {
             report_invalid_generator_yield_type(
                 &self.context,
                 diagnostic_node,
@@ -9367,7 +9369,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
         }
 
-        generator_type_params.send_ty.unwrap_or_else(Type::unknown)
+        generator_type_params.send_ty
     }
 
     fn infer_yield_from_expression(&mut self, yield_from: &ast::ExprYieldFrom) -> Type<'db> {
@@ -9391,15 +9393,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         )
         .return_ty;
 
-        let Some(outer_expected) = annotated_return_ty.generator_types(db, env) else {
+        let mode = enclosing_function
+            .first_overload_or_implementation(db)
+            .evaluation_mode(db);
+
+        let Some(outer_expected) = annotated_return_ty.generator_types(db, env, mode) else {
             let _ = self.infer_expression(value, TypeContext::default());
             return Type::unknown();
         };
         let return_type_span = enclosing_function.spans(self.db()).return_type;
 
-        let tcx = TypeContext::new(outer_expected.yield_ty.map(|yielded_ty| {
-            KnownClass::Iterable.to_specialized_instance(db, env, &[yielded_ty])
-        }));
+        let tcx = TypeContext::new(Some(KnownClass::Iterable.to_specialized_instance(
+            db,
+            env,
+            &[outer_expected.yield_ty],
+        )));
         let iterable_type = self.infer_expression(value, tcx);
 
         let inner_yield_ty = iterable_type
@@ -9410,33 +9418,37 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 err.fallback_element_type(db, env)
             });
 
-        if let Some(outer_yield_ty) = outer_expected.yield_ty
-            && !inner_yield_ty.is_assignable_to(db, env, outer_yield_ty)
-        {
+        if !inner_yield_ty.is_assignable_to(db, env, outer_expected.yield_ty) {
             report_invalid_generator_yield_type(
                 &self.context,
                 value.as_ref(),
                 return_type_span.clone(),
-                outer_yield_ty,
+                outer_expected.yield_ty,
                 inner_yield_ty,
                 GeneratorMismatchKind::YieldType,
             );
         }
 
-        if let Some(outer_send_ty) = outer_expected.send_ty {
-            let inner_send_ty = iterable_type
-                .generator_send_type(db, env)
-                .unwrap_or_else(|| Type::none(db, env));
-            if !outer_send_ty.is_assignable_to(db, env, inner_send_ty) {
-                report_invalid_generator_yield_type(
-                    &self.context,
-                    value.as_ref(),
-                    return_type_span,
-                    outer_send_ty,
-                    inner_send_ty,
-                    GeneratorMismatchKind::SendType,
-                );
-            }
+        let mode = enclosing_function
+            .first_overload_or_implementation(db)
+            .evaluation_mode(db);
+
+        let inner_send_ty = iterable_type
+            .generator_send_type(db, env, mode)
+            .unwrap_or_else(|| Type::none(db, env));
+
+        if !outer_expected
+            .send_ty
+            .is_assignable_to(db, env, inner_send_ty)
+        {
+            report_invalid_generator_yield_type(
+                &self.context,
+                value.as_ref(),
+                return_type_span,
+                outer_expected.send_ty,
+                inner_send_ty,
+                GeneratorMismatchKind::SendType,
+            );
         }
 
         iterable_type

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9344,12 +9344,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .first_overload_or_implementation(db)
             .evaluation_mode(db);
 
-        let Some(generator_type_params) = declared_return_ty.generator_types(db, env, mode) else {
+        let generator_type_params = match mode {
+            EvaluationMode::Sync => declared_return_ty
+                .generator_types(db, env)
+                .map(|types| (types.yield_ty, types.send_ty)),
+            EvaluationMode::Async => declared_return_ty
+                .async_generator_types(db, env)
+                .map(|types| (types.yield_ty, types.send_ty)),
+        };
+        let Some((expected_yield_ty, send_ty)) = generator_type_params else {
             let _ = self.infer_optional_expression(value.as_deref(), TypeContext::default());
             return Type::unknown();
         };
 
-        let expected_yield_ty = generator_type_params.yield_ty;
         let tcx = TypeContext::new(Some(expected_yield_ty));
         let yielded_ty = self
             .infer_optional_expression(value.as_deref(), tcx)
@@ -9369,7 +9376,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
         }
 
-        generator_type_params.send_ty
+        send_ty
     }
 
     fn infer_yield_from_expression(&mut self, yield_from: &ast::ExprYieldFrom) -> Type<'db> {
@@ -9393,11 +9400,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         )
         .return_ty;
 
-        let mode = enclosing_function
-            .first_overload_or_implementation(db)
-            .evaluation_mode(db);
-
-        let Some(outer_expected) = annotated_return_ty.generator_types(db, env, mode) else {
+        let Some(outer_expected) = annotated_return_ty.generator_types(db, env) else {
             let _ = self.infer_expression(value, TypeContext::default());
             return Type::unknown();
         };
@@ -9429,12 +9432,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
         }
 
-        let mode = enclosing_function
-            .first_overload_or_implementation(db)
-            .evaluation_mode(db);
-
         let inner_send_ty = iterable_type
-            .generator_send_type(db, env, mode)
+            .generator_send_type(db, env)
             .unwrap_or_else(|| Type::none(db, env));
 
         if !outer_expected

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -277,7 +277,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     );
                 }
 
-                if let Some(expected_return_ty) = declared_ty.generator_return_type(db, env) {
+                if let Some(expected_return_ty) = declared_ty
+                    .generator_types(db, env)
+                    .map(|types| types.return_ty.unwrap_or_else(|| Type::none(db, env)))
+                {
                     for &return_statement in &self.return_types_and_ranges {
                         if !return_statement
                             .ty

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -581,12 +581,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // `Generator` parameters must be compared nominally. The class specialization
             // already materializes each parameter according to its variance, while structural
             // inference through `close() -> ReturnT | None` can infer a spurious `None` on
-            // Python 3.13 and newer.
+            // Python 3.13 and newer. Before Python 3.13, a structural comparison can instead
+            // discard the return parameter altogether, even when a nominal generator subclass
+            // explicitly specializes it.
             // TODO: Remove the Python 3.13+ extension once
             // https://github.com/astral-sh/ty/issues/3596 is fixed.
             if nominal_instance.has_known_class(db, KnownClass::Generator)
-                && source_protocol_as_nominal
+                && (source_protocol_as_nominal
                     .is_some_and(|source| source.has_known_class(db, KnownClass::Generator))
+                    || matches!(ty, Type::NominalInstance(_))
+                        && !nominally_satisfied.is_never_satisfied(db, self.env))
             {
                 return nominally_satisfied;
             }


### PR DESCRIPTION
## Summary

Replace the ad-hoc extraction of generator type arguments with constraint-based inference over the actual synchronous and asynchronous generator protocols. This fixes missed `invalid-yield` diagnostics for generator functions annotated as returning `Iterable`, `AsyncIterable`, or structurally compatible protocols.

Previously, `Type::generator_types` walked the MRO looking for explicitly recognized `Generator`, `AsyncGenerator`, or iterator bases. That approach could not answer the more general question reviewers should keep in mind throughout this PR: given an arbitrary return annotation, which generator specializations are compatible with it?

For example, both of these previously escaped the intended yield checks:

```python
from collections.abc import AsyncIterable, Iterable


def values() -> Iterable[int]:
    yield "wrong"  # invalid-yield


async def async_values() -> AsyncIterable[int]:
    yield "wrong"  # invalid-yield
```

The same problem affected custom structural protocols equivalent to `(Async)Generator`/`(Async)Iterator`/`(Async)Iterable`, nested and generic aliases, return statements, and generic calls appearing inside yielded expressions.

## Implementation walkthrough

### 1. Infer generator specializations by solving protocol constraints

`Type::generator_types` now creates three synthetic type variables and asks the existing constraint solver when the annotation is assignable to `Generator[YieldT, SendT, ReturnT]`. `Type::async_generator_types` performs the equivalent calculation for `AsyncGenerator[YieldT, SendT]`.

The shared `infer_generator_type_arguments` helper builds an inferable type-variable set, computes assignability constraints, solves them, and reconstructs the corresponding specialization. Unconstrained relations become `Unknown`; unsatisfiable relations trigger the iterable fallback.

The synchronous and asynchronous results have separate representations: synchronous generators carry `yield_ty`, `send_ty`, and `return_ty: Option<Type>`, whereas asynchronous generators carry only `yield_ty` and `send_ty`.

### 2. Fall back to structural iterable annotations without guessing missing information

Not every valid generator-function return annotation implements the complete `Generator` or `AsyncGenerator` protocol. If the full relation fails, `iterable_generator_types` solves the yield type against `Iterable[YieldT]` or `AsyncIterable[YieldT]` instead.

Before doing so, it verifies that an actual generator instance can satisfy the annotation. This prevents unrelated concrete iterables such as `str` from being mistaken for valid generator-function return types.

An iterable protocol can still expose `send` or `asend` without declaring unrelated generator methods such as `throw` or `close`. The fallback therefore constructs a small synthetic protocol containing just the relevant method and solves its parameter separately:

```python
from typing import Protocol, Iterable

class Sendable(Protocol):
    def __iter__(self) -> Iterator[int]: ...
    def send(self, value: bytes, /) -> object: ...

def generator() -> Sendable:
    received = yield 1
    reveal_type(received)  # bytes
```

### 3. Apply the inferred types consistently while checking generator bodies

`infer_yield_expression` now chooses the synchronous or asynchronous solver according to the enclosing function, passes the inferred yield type into expression inference, reports `invalid-yield` when the yielded value is incompatible, and returns the inferred send type as the type of the `yield` expression.

Passing the expected yielded type into expression inference also fixes generic-call false positives. For example, a generator promising `Mapping[Any, Any]` can use that expectation when solving a yielded generic call instead of independently widening its key type and rejecting an otherwise valid mapping argument.

`infer_yield_from_expression` uses the outer yield type as context for the delegated iterable, checks both the delegated yield type and the contravariant send type, and returns the inner generator return type when available. The inner generator specialization is computed once and reused for both checks.

Invalid mixtures such as a synchronous function annotated with `AsyncGenerator`, or a return union mixing synchronous and asynchronous generators, now fall back to `Unknown` instead of incorrectly borrowing the send type from the wrong kind of generator.

### 4. Preserve generator return types across versions, aliases, and nominal subclasses

Constraint-based relations naturally see through ordinary and nested generic type aliases, so aliased `Generator`, `AsyncGenerator`, and `Iterator` annotations retain their yield, send, and return information.

The nominal `Generator` relation also needs a narrow special case. On Python 3.13 and newer, structurally inspecting `close() -> ReturnT | None` can introduce a spurious `None`; on earlier versions, structural comparison can lose the return parameter altogether. When the source is a compatible nominal generator or generator protocol, the relation checker keeps the nominal specialization instead.

This preserves explicit return types for `types.GeneratorType` and nominal generator subclasses without abandoning structural inference for genuinely structural protocols.

### 5. Rework awaitable inference without losing intersections

`Type::try_await` now checks that `__await__` returns an actual `Iterator`, extracts the eventual generator return type when one is available, and otherwise returns `Unknown`. Consequently, `__await__ -> Iterator[None]` is valid even though its eventual result is not statically known, whereas `__await__ -> Iterable[int]` is rejected because an iterable need not implement `__next__`.

Awaitable intersections require one additional workaround. Combining the `__await__` return types first and then solving a generator intersection currently turns return-type intersections into unions because of [astral-sh/ty#2799](https://github.com/astral-sh/ty/issues/2799). The new `Bindings::try_map_return_type` maps each callable return independently, intersects successful alternatives within each callable intersection, and unions the resulting outer alternatives.

```python
from typing import Any, Coroutine
from ty_extensions import Intersection


class A: ...
class B: ...


async def example(value: Intersection[Coroutine[Any, Any, A], Coroutine[Any, Any, B]]):
    reveal_type(await value)  # A & B, not A | B
```

Every outer union member must still provide a valid iterator; invalid alternatives inside an intersection can be discarded when another alternative succeeds.

## Known limitations and ecosystem impact

- Intersections of generator annotations still inherit the constraint-solver limitation in [astral-sh/ty#2799](https://github.com/astral-sh/ty/issues/2799); the affected yield and return cases are documented with targeted TODOs.
- The nominal-generator workaround also documents its relationship to [astral-sh/ty#3596](https://github.com/astral-sh/ty/issues/3596).
- Ecosystem analysis finds eight newly reported `invalid-yield` cases, removes an xarray false positive, and makes another xarray diagnostic more precise. The two paasta reports depend on its missing `mypy_extensions` dependency, and beartype exposes a false-positive `unsound-return-statement` for `return (yield from ())`; see the [detailed ecosystem analysis](https://github.com/astral-sh/ruff/pull/27598#issuecomment-5228673381).