### PR TITLE
[ty] Discard excess parser collection capacity

### DIFF
--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -807,6 +807,7 @@ impl<'src> Parser<'src> {
     ) -> Vec<T> {
         let mut elements = Vec::with_capacity(capacity);
         self.parse_comma_separated_list(recovery_context_kind, |p| elements.push(parse_element(p)));
+        elements.shrink_to_fit();
         elements
     }
 


### PR DESCRIPTION
## Summary

Discard spare capacity from comma-separated parser collections before retaining them in the AST.

These vectors are complete when returned, so their growth capacity is no longer needed. This matches the existing `shrink_to_fit` behavior for other parser-owned collections.

Extracted from #27591.