### PR TITLE
[ty] Inline short AST string literals

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -66,7 +66,7 @@ fn logging_f_string(
                             // If the literal text contains a '%' placeholder, bail out: mixing
                             // f-string interpolation with '%' placeholders is ambiguous for our
                             // automatic conversion, so don't offer a fix for this case.
-                            if lit.value.as_ref().contains('%') {
+                            if lit.value.as_str().contains('%') {
                                 return;
                             }
                             format_string.push_str(lit.value.as_ref());

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -318,7 +318,7 @@ fn elts_to_csv(elts: &[Expr], generator: Generator, flags: StringLiteralFlags) -
                 }
                 acc
             })
-            .into_boxed_str(),
+            .into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         flags,
@@ -369,7 +369,7 @@ fn check_names(checker: &Checker, call: &ExprCall, expr: &Expr, argvalues: &Expr
                                 .iter()
                                 .map(|name| {
                                     Expr::from(ast::StringLiteral {
-                                        value: Box::from(*name),
+                                        value: (*name).into(),
                                         range: TextRange::default(),
                                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                                         flags: checker.default_string_flags(),
@@ -401,7 +401,7 @@ fn check_names(checker: &Checker, call: &ExprCall, expr: &Expr, argvalues: &Expr
                                 .iter()
                                 .map(|name| {
                                     Expr::from(ast::StringLiteral {
-                                        value: Box::from(*name),
+                                        value: (*name).into(),
                                         range: TextRange::default(),
                                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                                         flags: checker.default_string_flags(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -233,7 +233,7 @@ fn check_os_environ_subscript(checker: &Checker, expr: &Expr) {
         slice.range(),
     );
     let node = ast::StringLiteral {
-        value: capital_env_var.into_boxed_str(),
+        value: capital_env_var.into(),
         flags: checker.default_string_flags().with_prefix({
             if env_var.is_unicode() {
                 StringLiteralPrefix::Unicode

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
@@ -179,7 +179,7 @@ fn construct_replacement(elts: &[&str], flags: StringLiteralFlags) -> Expr {
             .map(|elt| {
                 let element_flags = replace_flags(elt, flags);
                 Expr::from(StringLiteral {
-                    value: Box::from(*elt),
+                    value: (*elt).into(),
                     range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                     flags: element_flags,

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -429,7 +429,7 @@ impl<'a> QuoteAnnotator<'a> {
         generator.expr(&Expr::from(ast::StringLiteral {
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            value: annotation.into_boxed_str(),
+            value: annotation.into(),
             flags: self.flags,
         }))
     }

--- a/crates/ruff_linter/src/rules/flynt/helpers.rs
+++ b/crates/ruff_linter/src/rules/flynt/helpers.rs
@@ -16,7 +16,7 @@ fn to_interpolated_string_interpolation_element(inner: &Expr) -> ast::Interpolat
 /// Convert a string to a [`ast::InterpolatedStringLiteralElement `].
 pub(super) fn to_interpolated_string_literal_element(s: &str) -> ast::InterpolatedStringElement {
     ast::InterpolatedStringElement::Literal(ast::InterpolatedStringLiteralElement {
-        value: Box::from(s),
+        value: s.into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     })
@@ -63,7 +63,7 @@ pub(super) fn to_interpolated_string_element(
             node_index,
         }) => Some(ast::InterpolatedStringElement::Literal(
             ast::InterpolatedStringLiteralElement {
-                value: value.to_string().into_boxed_str(),
+                value: value.to_str().into(),
                 range: *range,
                 node_index: node_index.clone(),
             },

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -107,7 +107,7 @@ fn build_fstring(joiner: &str, joinees: &[Expr], flags: FStringFlags) -> Option<
         }
 
         let node = ast::StringLiteral {
-            value: content.into_boxed_str(),
+            value: content.into(),
             flags,
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -185,7 +185,7 @@ fn generate_keyword_fix(checker: &Checker, call: &ast::ExprCall) -> Fix {
         &format!(
             "encoding={}",
             checker.generator().expr(&Expr::from(ast::StringLiteral {
-                value: Box::from("utf-8"),
+                value: "utf-8".into(),
                 flags: checker.default_string_flags(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -39,7 +39,7 @@ impl LiteralType {
     fn as_zero_value_expr(self, checker: &Checker) -> Expr {
         match self {
             LiteralType::Str => ast::StringLiteral {
-                value: Box::default(),
+                value: "".into(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 flags: checker.default_string_flags(),

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -560,7 +560,7 @@ impl<'a> From<&'a ast::InterpolatedStringElement> for ComparableInterpolatedStri
             ast::InterpolatedStringElement::Literal(ast::InterpolatedStringLiteralElement {
                 value,
                 ..
-            }) => Self::Literal(value.as_ref().into()),
+            }) => Self::Literal(value.as_str().into()),
             ast::InterpolatedStringElement::Interpolation(formatted_value) => {
                 formatted_value.into()
             }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -14,6 +14,7 @@ use std::slice::{Iter, IterMut};
 use std::sync::OnceLock;
 
 use bitflags::bitflags;
+use compact_str::CompactString;
 use thin_vec::ThinVec;
 
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
@@ -354,7 +355,7 @@ pub struct InterpolatedElement {
 pub struct InterpolatedStringLiteralElement {
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
-    pub value: Box<str>,
+    pub value: CompactString,
 }
 
 impl InterpolatedStringLiteralElement {
@@ -1700,7 +1701,7 @@ impl fmt::Debug for StringLiteralFlags {
 pub struct StringLiteral {
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
-    pub value: Box<str>,
+    pub value: CompactString,
     pub flags: StringLiteralFlags,
 }
 
@@ -3936,7 +3937,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprDict>(), 40);
         assert_eq!(std::mem::size_of::<ExprDictComp>(), 56);
         assert_eq!(std::mem::size_of::<ExprEllipsisLiteral>(), 12);
-        assert_eq!(std::mem::size_of::<ExprFString>(), 56);
+        assert_eq!(std::mem::size_of::<ExprFString>(), 64);
         assert_eq!(std::mem::size_of::<ExprGenerator>(), 48);
         assert_eq!(std::mem::size_of::<ExprIf>(), 40);
         assert_eq!(std::mem::size_of::<ExprIpyEscapeCommand>(), 32);

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -66,7 +66,7 @@ impl Transformer for Normalizer {
 
                 if can_join {
                     string.value = ast::StringLiteralValue::single(ast::StringLiteral {
-                        value: Box::from(string.value.to_str()),
+                        value: string.value.to_str().into(),
                         range: string.range,
                         flags: StringLiteralFlags::empty(),
                         node_index: AtomicNodeIndex::NONE,
@@ -115,10 +115,7 @@ impl Transformer for Normalizer {
                             if let Some(InterpolatedStringElement::Literal(existing_literal)) =
                                 self.elements.last_mut()
                             {
-                                let value = std::mem::take(&mut existing_literal.value);
-                                let mut value = value.into_string();
-                                value.push_str(literal);
-                                existing_literal.value = value.into_boxed_str();
+                                existing_literal.value.push_str(literal);
                                 existing_literal.range =
                                     TextRange::new(existing_literal.start(), range.end());
                             } else {
@@ -233,21 +230,21 @@ impl Transformer for Normalizer {
                 "<DOCTEST-CODE-SNIPPET: Removed by normalizer>\n",
             )
             .into_owned()
-            .into_boxed_str();
+            .into();
         string_literal.value = STRIP_RST_BLOCKS
             .replace_all(
                 &string_literal.value,
                 "<RSTBLOCK-CODE-SNIPPET: Removed by normalizer>\n",
             )
             .into_owned()
-            .into_boxed_str();
+            .into();
         string_literal.value = STRIP_MARKDOWN_BLOCKS
             .replace_all(
                 &string_literal.value,
                 "<MARKDOWN-CODE-SNIPPET: Removed by normalizer>\n",
             )
             .into_owned()
-            .into_boxed_str();
+            .into();
         // Normalize a string by (2) stripping any leading and trailing space from each
         // line, and (3) removing any blank lines from the start and end of the string.
         string_literal.value = string_literal
@@ -258,6 +255,6 @@ impl Transformer for Normalizer {
             .join("\n")
             .trim()
             .to_owned()
-            .into_boxed_str();
+            .into();
     }
 }

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -367,7 +367,7 @@ impl<'src> StringParser<'src> {
         }
 
         Ok(ast::InterpolatedStringLiteralElement {
-            value: value.into_boxed_str(),
+            value: value.into_boxed_str().into(),
             range: self.range,
             node_index: AtomicNodeIndex::NONE,
         })
@@ -495,7 +495,7 @@ impl<'src> StringParser<'src> {
         }
 
         Ok(StringType::Str(ast::StringLiteral {
-            value: value.into_boxed_str(),
+            value: value.into_boxed_str().into(),
             range: self.range,
             flags: self.flags.into(),
             node_index: AtomicNodeIndex::NONE,

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -616,7 +616,7 @@ impl<'a> LocalReferencesFinder<'a> {
         let [part] = string_expr.value.as_slice() else {
             return;
         };
-        if part.value.as_ref() != self.target_text {
+        if part.value.as_str() != self.target_text {
             return;
         }
 


### PR DESCRIPTION
## Summary

Store regular string literals and interpolated-string literal segments in `CompactString` instead of `Box<str>`, avoiding separate heap allocations for short values.

Update parser construction, Ruff rule autofixes, formatter normalization, AST comparison, and ty IDE references to use the new representation. Formatter normalization can now append directly to an existing literal instead of converting through an intermediate `String`.

`CompactString` increases `ExprFString` from 56 to 64 bytes on 64-bit targets; the enclosing `Expr` remains 72 bytes on `main`. This isolates the allocation-versus-layout tradeoff from the separate expression-size reduction in #27591.