### PR TITLE
[flake8-bugbear] Avoid unsafe B006 fixes for multiline strings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_multiline_string.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_multiline_string.py
@@ -1,0 +1,16 @@
+def multiline_string_default(
+    value=[
+        """first line
+        second line"""
+    ]
+):
+    return value
+
+
+def multiline_fstring_default(
+    value=[
+        f"""first {1}
+        second {2}"""
+    ]
+):
+    return value

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -49,6 +49,7 @@ mod tests {
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_8.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_9.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_B008.py"))]
+    #[test_case(Rule::MutableArgumentDefault, Path::new("B006_multiline_string.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_1.pyi"))]
     #[test_case(Rule::NoExplicitStacklevel, Path::new("B028.py"))]
     #[test_case(Rule::RaiseLiteral, Path::new("B016.py"))]
@@ -95,6 +96,7 @@ mod tests {
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_8.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_9.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_B008.py"))]
+    #[test_case(Rule::MutableArgumentDefault, Path::new("B006_multiline_string.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_1.pyi"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::name::QualifiedName;
-use ruff_python_ast::token::parenthesized_range;
+use ruff_python_ast::token::{parenthesized_range, TokenKind};
 use ruff_python_ast::{self as ast, Expr, ParameterWithDefault};
 use ruff_python_semantic::SemanticModel;
 use ruff_python_semantic::analyze::function_type::is_stub;
@@ -176,6 +176,26 @@ fn move_initialization(
     // If the function is a stub, this is the only necessary edit.
     if is_stub(function_def, checker.semantic()) {
         return Some(Fix::unsafe_edit(default_edit));
+    }
+
+    // The preview fix preserves the original expression source, so avoid changing the
+    // indentation inside multiline string literals.
+    if is_b006_unsafe_fix_preserve_assignment_expr_enabled(checker.settings())
+        && checker.tokens().in_range(default.range()).iter().any(|token| {
+            matches!(
+                token.kind(),
+                TokenKind::String
+                    | TokenKind::FStringStart
+                    | TokenKind::FStringMiddle
+                    | TokenKind::FStringEnd
+                    | TokenKind::TStringStart
+                    | TokenKind::TStringMiddle
+                    | TokenKind::TStringEnd
+            ) && token.is_triple_quoted_string()
+                && locator.contains_line_break(token.range())
+        })
+    {
+        return None;
     }
 
     // Add an `if`, to set the argument to its original value if still `None`.

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_multiline_string.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_multiline_string.py.snap
@@ -1,0 +1,58 @@
+---
+source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+---
+B006 [*] Do not use mutable data structures for argument defaults
+ --> B006_multiline_string.py:2:11
+  |
+1 |   def multiline_string_default(
+2 |       value=[
+  |  ___________^
+3 | |         """first line
+4 | |         second line"""
+5 | |     ]
+  | |_____^
+6 |   ):
+7 |       return value
+  |
+help: Replace with `None`; initialize within function
+  |
+1 | def multiline_string_default(
+  -     value=[
+  -         """first line
+  -         second line"""
+  -     ]
+2 +     value=None
+3 | ):
+4 +     if value is None:
+5 +         value = ["""first line\n        second line"""]
+6 |     return value
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
+  --> B006_multiline_string.py:11:11
+   |
+10 |   def multiline_fstring_default(
+11 |       value=[
+   |  ___________^
+12 | |         f"""first {1}
+13 | |         second {2}"""
+14 | |     ]
+   | |_____^
+15 |   ):
+16 |       return value
+   |
+help: Replace with `None`; initialize within function
+   |
+10 | def multiline_fstring_default(
+   -     value=[
+   -         f"""first {1}
+   -         second {2}"""
+   -     ]
+11 +     value=None
+12 | ):
+13 +     if value is None:
+14 +         value = [f"""first {1}\n        second {2}"""]
+15 |     return value
+   |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__preview__B006_B006_multiline_string.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__preview__B006_B006_multiline_string.py.snap
@@ -1,0 +1,32 @@
+---
+source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+---
+B006 Do not use mutable data structures for argument defaults
+ --> B006_multiline_string.py:2:11
+  |
+1 |   def multiline_string_default(
+2 |       value=[
+  |  ___________^
+3 | |         """first line
+4 | |         second line"""
+5 | |     ]
+  | |_____^
+6 |   ):
+7 |       return value
+  |
+help: Replace with `None`; initialize within function
+
+B006 Do not use mutable data structures for argument defaults
+  --> B006_multiline_string.py:11:11
+   |
+10 |   def multiline_fstring_default(
+11 |       value=[
+   |  ___________^
+12 | |         f"""first {1}
+13 | |         second {2}"""
+14 | |     ]
+   | |_____^
+15 |   ):
+16 |       return value
+   |
+help: Replace with `None`; initialize within function


### PR DESCRIPTION
Fixes #27022

The B006 preview autofix could change the contents of a triple-quoted multiline string when rewriting a mutable default. Skip the fix when the default expression contains a multiline string literal, while retaining diagnostics and safe fixes for other expressions. Adds fixture and snapshots.

Validation: `cargo test -p ruff_linter` passed (2817 tests, 4 ignored; doc-tests passed). `git diff --check` passed.