### PR TITLE
[ty] Avoid deadlock when scheduling watch checks

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -285,6 +285,10 @@ struct MainLoop {
     /// Receiver for the messages sent **to** the main loop.
     receiver: crossbeam_channel::Receiver<MainLoopMessage>,
 
+    /// Capacity-one channel used to coalesce pending workspace checks.
+    check_sender: crossbeam_channel::Sender<()>,
+    check_receiver: crossbeam_channel::Receiver<()>,
+
     /// The file system watcher, if running in watch mode.
     watcher: Option<ProjectWatcher>,
 
@@ -300,6 +304,7 @@ struct MainLoop {
 impl MainLoop {
     fn new(mode: MainLoopMode, printer: Printer) -> (Self, MainLoopCancellationToken) {
         let (sender, receiver) = crossbeam_channel::bounded(10);
+        let (check_sender, check_receiver) = crossbeam_channel::bounded(1);
 
         let cancellation_token_source = CancellationTokenSource::new();
         let cancellation_token = cancellation_token_source.token();
@@ -309,6 +314,8 @@ impl MainLoop {
                 mode,
                 sender: sender.clone(),
                 receiver,
+                check_sender,
+                check_receiver,
                 watcher: None,
                 printer,
                 cancellation_token,
@@ -332,7 +339,7 @@ impl MainLoop {
     }
 
     fn run(self, db: &mut ProjectDatabase) -> Result<ExitStatus> {
-        self.sender.send(MainLoopMessage::CheckWorkspace).unwrap();
+        self.request_check();
 
         let result = self.main_loop(db);
 
@@ -341,13 +348,22 @@ impl MainLoop {
         result
     }
 
+    fn request_check(&self) {
+        // A pending request already represents a check of the latest database revision.
+        let _ = self.check_sender.try_send(());
+    }
+
     fn main_loop(mut self, db: &mut ProjectDatabase) -> Result<ExitStatus> {
-        // Schedule the first check.
         tracing::debug!("Starting main loop");
 
         let mut revision = 0u64;
 
-        while let Ok(message) = self.receiver.recv() {
+        // Apply all queued changes before starting a pending check because every applied change
+        // cancels the running check.
+        while let Ok(message) = crossbeam_channel::select_biased! {
+            recv(self.receiver) -> message => message,
+            recv(self.check_receiver) -> request => request.map(|()| MainLoopMessage::CheckWorkspace),
+        } {
             match message {
                 MainLoopMessage::CheckWorkspace => {
                     let db = db.clone();
@@ -485,7 +501,7 @@ impl MainLoop {
                         watcher.update(db);
                     }
 
-                    self.sender.send(MainLoopMessage::CheckWorkspace).unwrap();
+                    self.request_check();
                 }
                 MainLoopMessage::Exit => {
                     // Cancel any pending queries and wait for them to complete.


### PR DESCRIPTION
## Summary

`ty check --watch` uses a bounded queue to apply back pressure when it gets overloaded. This is mainly important to apply back pressure to the file watcher, so that we don't queue an infinite number of file watch events. 

However, we used the same queue to schedule the next check when handling a file watcher event. This could lead to a dead-lock when:

* the queue is already full
* ty handles a file watcher event
* the file watcher queues a new event (the queue is full again!)
* ty now schedules a `CheckWorkspace`, using the blocking `send`. 


ty now deadlocks, because the queue is already full and there's no other consumer taking items from the queue. 

This PR uses a separate queue for scheduling checking, to avoid the deadlock. 

This PR does not address file watcher events starving the workspace check. That is, a continuous stream of file watcher events will prevent `CheckWorkspace` from ever running (or it starts and gets immediately cancelled again). We can look into suspending file watcher events if they keep starving check, when it comes up in user reports.


This PR is in prep for the script's uv support. It introduced a similar case, which is when I noticed this deadlock.
