### PR TITLE
[ty] Resolve uv from PATH before workspace discovery

### DIFF
--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -137,8 +137,8 @@ impl System for TestSystem {
         self.system().cache_dir()
     }
 
-    fn which(&self, name: &str) -> WhichResult {
-        self.system().which(name)
+    fn which(&self, _name: &str) -> WhichResult {
+        Err(WhichError::CannotFindBinaryPath)
     }
 
     fn run_command(

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -137,8 +137,8 @@ impl System for TestSystem {
         self.system().cache_dir()
     }
 
-    fn which(&self, _name: &str) -> WhichResult {
-        Err(WhichError::CannotFindBinaryPath)
+    fn which(&self, name: &str) -> WhichResult {
+        self.system().which(name)
     }
 
     fn run_command(

--- a/crates/ty/tests/cli/uv_workspace.rs
+++ b/crates/ty/tests/cli/uv_workspace.rs
@@ -73,6 +73,10 @@ fn command_with_uv(case: &CliTest, virtual_env: Option<&Path>) -> anyhow::Result
         .env("UV_PYTHON_DOWNLOADS", "never")
         .env("TY_OUTPUT_FORMAT", "concise")
         .env("PATH", std::env::var_os("PATH").unwrap_or_default());
+    #[cfg(windows)]
+    if let Some(path_ext) = std::env::var_os("PATHEXT") {
+        command.env("PATHEXT", path_ext);
+    }
     if let Some(virtual_env) = virtual_env {
         command.env("VIRTUAL_ENV", virtual_env);
     }

--- a/crates/ty/tests/cli/uv_workspace.rs
+++ b/crates/ty/tests/cli/uv_workspace.rs
@@ -333,12 +333,12 @@ fn uv_workspace_discovery_is_opt_in() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Failures to invoke uv are visible by default instead of silently disabling integration.
+/// Failures to locate uv are visible by default instead of silently disabling integration.
 #[test]
 fn warns_when_uv_workspace_metadata_cannot_be_loaded() -> anyhow::Result<()> {
     let case = workspace_case()?.with_filter(
-        "program not found",
-        "No such file or directory (os error 2)",
+        "no path to search and provided name is not an absolute path",
+        "cannot find binary path",
     );
     case.write_file("packages/member/member.py", "value: int = 1")?;
 
@@ -347,7 +347,8 @@ fn warns_when_uv_workspace_metadata_cannot_be_loaded() -> anyhow::Result<()> {
         .current_dir(case.root().join("packages/member"))
         .arg(".")
         .env("TY_UV", "1")
-        .env("UV", "missing-uv-executable")
+        .env_remove("UV")
+        .env("PATH", "")
         .env("TY_OUTPUT_FORMAT", "concise");
 
     assert_cmd_snapshot!(command, @"
@@ -357,7 +358,7 @@ fn warns_when_uv_workspace_metadata_cannot_be_loaded() -> anyhow::Result<()> {
     All checks passed!
 
     ----- stderr -----
-    WARN Failed to invoke `uv workspace metadata`: No such file or directory (os error 2)
+    WARN Failed to invoke `uv workspace metadata`: failed to resolve uv executable: cannot find binary path
     ");
 
     Ok(())

--- a/crates/ty_project/src/metadata/uv.rs
+++ b/crates/ty_project/src/metadata/uv.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use pep440_rs::Version;
-use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ruff_db::system::{System, SystemPath, SystemPathBuf, WhichError};
 use ruff_ranged_value::{RangedValue, ValueSource};
 use serde::Deserialize;
 use thiserror::Error;
@@ -21,9 +21,14 @@ impl UvWorkspace {
         path: &SystemPath,
         system: &dyn System,
     ) -> Result<Self, UvWorkspaceError> {
-        let uv = system
-            .env_var(EnvVars::UV)
-            .unwrap_or_else(|_| "uv".to_string());
+        let uv = match system.env_var(EnvVars::UV) {
+            Ok(uv) => uv,
+            Err(_) => system
+                .which("uv")
+                .map(SystemPathBuf::into_string)
+                .map_err(uv_executable_error)
+                .map_err(UvWorkspaceError::Invocation)?,
+        };
 
         // `uv check` has already selected and synchronized the environment. Keep this query
         // read-only so package selection and `--isolated` aren't overwritten by a second sync.
@@ -84,6 +89,13 @@ impl UvWorkspace {
     pub(super) fn python_version(&self) -> Option<&RangedValue<SupportedPythonVersion>> {
         self.python_version.as_ref()
     }
+}
+
+fn uv_executable_error(error: WhichError) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("failed to resolve uv executable: {error}"),
+    )
 }
 
 fn resolve_python_version(
@@ -166,6 +178,7 @@ struct WorkspacePython {
 #[cfg(test)]
 mod tests {
     use ruff_db::system::{SystemPath, TestSystem};
+    use ty_static::EnvVars;
 
     use super::{UvWorkspace, UvWorkspaceError};
 
@@ -176,6 +189,18 @@ mod tests {
         assert!(matches!(
             UvWorkspace::from_metadata(b"{", &system),
             Err(UvWorkspaceError::InvalidMetadata(_))
+        ));
+    }
+
+    #[test]
+    fn explicit_uv_override_skips_path_lookup() {
+        let system = TestSystem::default();
+        system.set_env_var(EnvVars::UV, "/custom/uv");
+
+        assert!(matches!(
+            UvWorkspace::discover(SystemPath::new("/app"), &system),
+            Err(UvWorkspaceError::Invocation(error))
+                if error.kind() == std::io::ErrorKind::Unsupported
         ));
     }
 


### PR DESCRIPTION
## Summary

Resolve the default `uv` executable through the system PATH before workspace discovery, so a missing executable is reported without attempting a command. An explicit `UV` override remains authoritative and bypasses PATH lookup.

The benefits now are limited, but the script's integration will start to call uv more commonly. It's then preferred to resolve uv once, and skip all invocations if uv is entirely missing (there are still other cases for which the uv call can fail, but we should at least rule out the common one of uv is not available).

## Test Plan

Testing: Added focused unit and CLI coverage and ran ty_project tests and Clippy.