### PR TITLE
[ty] Reduce alias and parameter AST size

### DIFF
--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -140,7 +140,7 @@ pub(crate) fn make_redundant_alias<'a>(
             aliases
                 .iter()
                 .find(|alias| alias.asname.is_none() && *name == alias.name.id)
-                .map(|alias| Edit::range_replacement(format!("{name} as {name}"), alias.range))
+                .map(|alias| Edit::range_replacement(format!("{name} as {name}"), alias.range()))
         })
         .collect()
 }

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
@@ -136,7 +136,7 @@ pub(crate) fn fastapi_non_annotated_dependency(
                 default,
                 kind: dependency,
                 name: parameter.name(),
-                range: parameter.range,
+                range: parameter.range(),
             };
             seen_default = create_diagnostic(
                 checker,

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
@@ -378,49 +378,47 @@ pub(crate) fn suspicious_imports(checker: &Checker, stmt: &Stmt) {
     match stmt {
         Stmt::Import(ast::StmtImport { names, .. }) => {
             for name in names {
+                let range = name.range();
                 match name.name.as_str() {
                     "telnetlib" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousTelnetlibImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousTelnetlibImport, range);
                     }
                     "ftplib" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousFtplibImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousFtplibImport, range);
                     }
                     "pickle" | "cPickle" | "dill" | "shelve" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousPickleImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousPickleImport, range);
                     }
                     "subprocess" => {
-                        checker
-                            .report_diagnostic_if_enabled(SuspiciousSubprocessImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousSubprocessImport, range);
                     }
                     "xml.etree.cElementTree" | "xml.etree.ElementTree" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousXmlEtreeImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousXmlEtreeImport, range);
                     }
                     "xml.sax" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousXmlSaxImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousXmlSaxImport, range);
                     }
                     "xml.dom.expatbuilder" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousXmlExpatImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousXmlExpatImport, range);
                     }
                     "xml.dom.minidom" => {
-                        checker
-                            .report_diagnostic_if_enabled(SuspiciousXmlMinidomImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousXmlMinidomImport, range);
                     }
                     "xml.dom.pulldom" => {
-                        checker
-                            .report_diagnostic_if_enabled(SuspiciousXmlPulldomImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousXmlPulldomImport, range);
                     }
                     "lxml" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousLxmlImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousLxmlImport, range);
                     }
                     "xmlrpc" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousXmlrpcImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousXmlrpcImport, range);
                     }
                     "Crypto.Cipher" | "Crypto.Hash" | "Crypto.IO" | "Crypto.Protocol"
                     | "Crypto.PublicKey" | "Crypto.Random" | "Crypto.Signature" | "Crypto.Util" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousPycryptoImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousPycryptoImport, range);
                     }
                     "pyghmi" => {
-                        checker.report_diagnostic_if_enabled(SuspiciousPyghmiImport, name.range);
+                        checker.report_diagnostic_if_enabled(SuspiciousPyghmiImport, range);
                     }
                     _ => {}
                 }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/multiple_imports_on_one_line.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/multiple_imports_on_one_line.rs
@@ -75,7 +75,7 @@ fn split_imports(
             .iter()
             .map(|alias| {
                 let Alias {
-                    range: _,
+                    range_end: _,
                     node_index: _,
                     name,
                     asname,
@@ -100,7 +100,7 @@ fn split_imports(
             .iter()
             .map(|alias| {
                 let Alias {
-                    range: _,
+                    range_end: _,
                     node_index: _,
                     name,
                     asname,

--- a/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
@@ -91,7 +91,7 @@ pub(crate) fn manual_from_import(checker: &Checker, stmt: &Stmt, alias: &Alias, 
             names: vec![Alias {
                 name: asname.clone(),
                 asname: None,
-                range: TextRange::default(),
+                range_end: asname.end(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             }],
             level: 0,

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -649,9 +649,9 @@ Comprehension = {}
 Arguments = {}
 Parameters = {}
 Parameter = {}
-ParameterWithDefault = {}
+ParameterWithDefault = { custom_range = true }
 Keyword = {}
-Alias = {}
+Alias = { custom_range = true }
 WithItem = {}
 MatchCase = {}
 Decorator = {}

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -4044,19 +4044,7 @@ impl ruff_text_size::Ranged for crate::Parameter {
     }
 }
 
-impl ruff_text_size::Ranged for crate::ParameterWithDefault {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
 impl ruff_text_size::Ranged for crate::Keyword {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
-impl ruff_text_size::Ranged for crate::Alias {
     fn range(&self) -> ruff_text_size::TextRange {
         self.range
     }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -376,7 +376,7 @@ impl ast::ParameterWithDefault {
         V: SourceOrderVisitor<'a> + ?Sized,
     {
         let ast::ParameterWithDefault {
-            range: _,
+            range_end: _,
             node_index: _,
             parameter,
             default,
@@ -413,7 +413,7 @@ impl Alias {
         V: SourceOrderVisitor<'a> + ?Sized,
     {
         let ast::Alias {
-            range: _,
+            range_end: _,
             node_index: _,
             name,
             asname,

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2857,14 +2857,41 @@ pub struct Keyword {
     pub value: Expr,
 }
 
+/// An import alias whose start offset is derived from its name.
+///
+/// The alias and its name must start at the same offset, including during error
+/// recovery.
+///
 /// See also [alias](https://docs.python.org/3/library/ast.html#ast.alias)
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct Alias {
-    pub range: TextRange,
+    pub range_end: TextSize,
     pub node_index: AtomicNodeIndex,
     pub name: Identifier,
     pub asname: Option<Identifier>,
+}
+
+impl Ranged for Alias {
+    fn range(&self) -> TextRange {
+        TextRange::new(self.name.start(), self.range_end)
+    }
+}
+
+#[expect(
+    clippy::missing_fields_in_debug,
+    reason = "`range_end` is represented by the reconstructed `range` field"
+)]
+impl fmt::Debug for Alias {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Alias")
+            .field("range", &self.range())
+            .field("node_index", &self.node_index)
+            .field("name", &self.name)
+            .field("asname", &self.asname)
+            .finish()
+    }
 }
 
 /// See also [withitem](https://docs.python.org/3/library/ast.html#ast.withitem)
@@ -3118,7 +3145,7 @@ impl<'a> AnyParameterRef<'a> {
 impl Ranged for AnyParameterRef<'_> {
     fn range(&self) -> TextRange {
         match self {
-            Self::NonVariadic(param) => param.range,
+            Self::NonVariadic(param) => param.range(),
             Self::Variadic(param) => param.range,
         }
     }
@@ -3442,14 +3469,39 @@ impl FusedIterator for ParametersSourceOrderIterator<'_> {}
 /// An alternative type of AST `arg`. This is used for each function argument that might have a default value.
 /// Used by `Arguments` original type.
 ///
+/// Its start offset is derived from `parameter`, so both nodes must start at the
+/// same offset, including during error recovery.
+///
 /// NOTE: This type is different from original Python AST.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct ParameterWithDefault {
-    pub range: TextRange,
+    pub range_end: TextSize,
     pub node_index: AtomicNodeIndex,
     pub parameter: Parameter,
     pub default: Option<Box<Expr>>,
+}
+
+impl Ranged for ParameterWithDefault {
+    fn range(&self) -> TextRange {
+        TextRange::new(self.parameter.start(), self.range_end)
+    }
+}
+
+#[expect(
+    clippy::missing_fields_in_debug,
+    reason = "`range_end` is represented by the reconstructed `range` field"
+)]
+impl fmt::Debug for ParameterWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ParameterWithDefault")
+            .field("range", &self.range())
+            .field("node_index", &self.node_index)
+            .field("parameter", &self.parameter)
+            .field("default", &self.default)
+            .finish()
+    }
 }
 
 impl ParameterWithDefault {
@@ -3933,7 +3985,7 @@ impl From<bool> for Singleton {
 #[cfg(test)]
 mod tests {
     use crate::generated::*;
-    use crate::{Arguments, Mod, Parameters};
+    use crate::{Alias, Arguments, Mod, ParameterWithDefault, Parameters};
 
     #[test]
     #[cfg(target_pointer_width = "64")]
@@ -3945,7 +3997,9 @@ mod tests {
         assert_eq!(std::mem::size_of::<Mod>(), 32);
         assert_eq!(std::mem::size_of::<Pattern>(), 72);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
+        assert_eq!(std::mem::size_of::<ParameterWithDefault>(), 72);
         assert_eq!(std::mem::size_of::<Arguments>(), 40);
+        assert_eq!(std::mem::size_of::<Alias>(), 72);
         assert_eq!(std::mem::size_of::<Expr>(), 64);
         assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);

--- a/crates/ruff_python_formatter/src/other/alias.rs
+++ b/crates/ruff_python_formatter/src/other/alias.rs
@@ -11,7 +11,7 @@ pub struct FormatAlias;
 impl FormatNodeRule<Alias> for FormatAlias {
     fn fmt_fields(&self, item: &Alias, f: &mut PyFormatter) -> FormatResult<()> {
         let Alias {
-            range: _,
+            range_end: _,
             node_index: _,
             name,
             asname,

--- a/crates/ruff_python_formatter/src/other/parameter_with_default.rs
+++ b/crates/ruff_python_formatter/src/other/parameter_with_default.rs
@@ -11,7 +11,7 @@ pub struct FormatParameterWithDefault;
 impl FormatNodeRule<ParameterWithDefault> for FormatParameterWithDefault {
     fn fmt_fields(&self, item: &ParameterWithDefault, f: &mut PyFormatter) -> FormatResult<()> {
         let ParameterWithDefault {
-            range: _,
+            range_end: _,
             node_index: _,
             parameter,
             default,

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -382,7 +382,7 @@ pub(crate) fn find_parameter_separators(
         let after_parameters = parameters
             .args
             .last()
-            .map(|arg| arg.range.end())
+            .map(Ranged::end)
             .or(slash.map(|(_, slash)| slash.end()));
         if let Some(preceding_end) = after_parameters {
             let range = TextRange::new(preceding_end, parameters.end());

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -783,7 +783,7 @@ impl<'src> Parser<'src> {
                     node_index: AtomicNodeIndex::NONE,
                 },
                 asname: None,
-                range,
+                range_end: range.end(),
                 node_index: AtomicNodeIndex::NONE,
             };
         }
@@ -792,6 +792,7 @@ impl<'src> Parser<'src> {
             ImportStyle::Import => self.parse_dotted_name(),
             ImportStyle::ImportFrom => self.parse_identifier(),
         };
+        debug_assert_eq!(start, name.start());
 
         let asname = if self.eat(TokenKind::As) {
             if self.at_name_or_soft_keyword() {
@@ -815,7 +816,7 @@ impl<'src> Parser<'src> {
         };
 
         ast::Alias {
-            range: self.node_range(start),
+            range_end: self.node_range(start).end(),
             name,
             asname,
             node_index: AtomicNodeIndex::NONE,
@@ -3268,6 +3269,7 @@ impl<'src> Parser<'src> {
         function_kind: FunctionKind,
     ) -> ast::ParameterWithDefault {
         let parameter = self.parse_parameter(start, function_kind, AllowStarAnnotation::No);
+        debug_assert_eq!(start, parameter.start());
 
         let default = if self.eat(TokenKind::Equal) {
             if self.at_expr() {
@@ -3297,7 +3299,7 @@ impl<'src> Parser<'src> {
         };
 
         ast::ParameterWithDefault {
-            range: self.node_range(start),
+            range_end: self.node_range(start).end(),
             parameter,
             default,
             node_index: AtomicNodeIndex::NONE,

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -154,7 +154,7 @@ impl SemanticSyntaxChecker {
                                 SemanticSyntaxErrorKind::FutureFeatureNotDefined(
                                     name.name.to_string(),
                                 ),
-                                name.range,
+                                name.range(),
                             );
                         }
                     }

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -102,7 +102,7 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
         let ast::Alias {
             name,
             asname,
-            range: _,
+            range_end: _,
             node_index: _,
         } = alias;
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -959,7 +959,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_parameter_with_default(&mut self, parameter_with_default: &ast::ParameterWithDefault) {
         let ast::ParameterWithDefault {
-            range: _,
+            range_end: _,
             node_index: _,
             parameter,
             default: _,
@@ -1017,7 +1017,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ast::ParameterWithDefault {
             parameter,
             default,
-            range: _,
+            range_end: _,
             node_index: _,
         } = parameter_with_default;
 
@@ -1335,7 +1335,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ast::ParameterWithDefault {
             parameter,
             default,
-            range: _,
+            range_end: _,
             node_index: _,
         } = parameter_with_default;
 

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -167,7 +167,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         definition: Definition<'db>,
     ) {
         let ast::Alias {
-            range: _,
+            range_end: _,
             node_index: _,
             name,
             asname,


### PR DESCRIPTION
## Summary

This PR reduces `Alias` and `ParameterWithDefault` from 80 to 72 bytes by storing only their end offsets and deriving their start offsets from their nested `Identifier` and `Parameter` nodes.

The parser documents and asserts the required invariants: aliases and parameters must start at the same offsets as the nested nodes used to reconstruct their ranges, including during error recovery. This follow-up separates those tradeoffs from #27591 so their memory and performance impact can be evaluated independently.
