### PR TITLE
[ty] Track flow-sensitive instance attribute presence

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1389,6 +1389,28 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         }
         let use_id = self.current_ast_ids_mut().record_use(expr);
         self.current_use_def_map_mut().record_use(place_id, use_id);
+
+        if let ScopedPlaceId::Symbol(symbol_id) = place_id
+            && self
+                .current_first_parameter_name
+                .is_some_and(|first| self.current_place_table().symbol(symbol_id).name() == first)
+        {
+            let members: SmallVec<[_; 4]> = self
+                .current_place_table()
+                .associated_place_ids(place_id)
+                .iter()
+                .copied()
+                .filter(|member| {
+                    let member = self.current_place_table().member(*member);
+                    member.is_instance_attribute() && member.is_presence_observed()
+                })
+                .collect();
+
+            for member in members {
+                self.current_use_def_map_mut()
+                    .record_associated_place_use(member.into(), use_id);
+            }
+        }
     }
 
     fn record_place_definition(&mut self, place_id: ScopedPlaceId, expr: &'ast ast::Expr) {
@@ -4717,6 +4739,44 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     {
                         *unpack_position = UnpackPosition::Other;
                     }
+                }
+            }
+            ast::Expr::Call(call) => {
+                let associated_member = if call
+                    .func
+                    .as_name_expr()
+                    .is_some_and(|function| function.id == "hasattr")
+                    && call.arguments.keywords.is_empty()
+                    && let [receiver, ast::Expr::StringLiteral(attribute)] = &*call.arguments.args
+                    && let Some(method_scope_id) = self.is_method_or_eagerly_executed_in_method()
+                    && self.current_first_parameter_name.is_some_and(|first| {
+                        receiver.as_name_expr().is_some_and(|name| name.id == first)
+                            && !self.is_symbol_bound_in_intermediate_eager_scopes(
+                                first,
+                                method_scope_id,
+                            )
+                    })
+                    && let Some(receiver_place) = PlaceExpr::try_from_expr(receiver)
+                    && self
+                        .current_place_table()
+                        .place_id((&receiver_place).into())
+                        .is_some()
+                    && let Some(PlaceExpr::Member(mut member)) =
+                        PlaceExpr::from_named_attribute(receiver, attribute.value.to_str())
+                {
+                    member.mark_presence_observed();
+                    Some((receiver, self.add_place(PlaceExpr::Member(member))))
+                } else {
+                    None
+                };
+
+                walk_expr(self, expr);
+
+                if let Some((receiver, member)) = associated_member
+                    && let Some(use_id) = self.current_ast_ids().try_use_id(receiver)
+                {
+                    self.current_use_def_map_mut()
+                        .record_associated_place_use(member, use_id);
                 }
             }
             ast::Expr::Named(node) => {

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -57,6 +57,14 @@ impl Member {
         self.flags.insert(MemberFlags::IS_INSTANCE_ATTRIBUTE);
     }
 
+    pub(super) fn mark_presence_observed(&mut self) {
+        self.flags.insert(MemberFlags::IS_PRESENCE_OBSERVED);
+    }
+
+    pub(super) fn is_presence_observed(&self) -> bool {
+        self.flags.contains(MemberFlags::IS_PRESENCE_OBSERVED)
+    }
+
     /// Is the place an instance attribute?
     pub fn is_instance_attribute(&self) -> bool {
         let is_instance_attribute = self.flags.contains(MemberFlags::IS_INSTANCE_ATTRIBUTE);
@@ -136,6 +144,7 @@ bitflags! {
         const IS_BOUND              = 1 << 0;
         const IS_DECLARED           = 1 << 1;
         const IS_INSTANCE_ATTRIBUTE = 1 << 2;
+        const IS_PRESENCE_OBSERVED  = 1 << 3;
     }
 }
 
@@ -307,6 +316,23 @@ impl MemberExprBuilder {
         segments.push(SegmentInfo::new(kind, start_offset));
 
         Some(MemberExprBuilder { path, segments })
+    }
+
+    /// Extend a receiver place with an attribute whose name is known separately.
+    ///
+    /// Attribute-presence checks expose the member name as a string rather than as an
+    /// `ExprAttribute`, but they still observe the same receiver-member place.
+    pub(super) fn visit_named_attribute(
+        receiver: &ast::Expr,
+        attribute: &str,
+    ) -> Option<MemberExprBuilder> {
+        let mut receiver = Self::visit_expr(receiver.into())?;
+        let start_offset = receiver.path.text_len();
+        receiver.path = CharStr::concat(&[receiver.path.as_str(), attribute]);
+        receiver
+            .segments
+            .push(SegmentInfo::new(SegmentKind::Attribute, start_offset));
+        Some(receiver)
     }
 
     fn subscript_part(subscript_slice: &ast::Expr) -> Option<(SegmentKind, MemberPathPart<'_>)> {

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -52,6 +52,14 @@ impl PlaceExpr {
         PlaceExpr::Symbol(Symbol::new(name.id.clone()))
     }
 
+    /// Create the member place observed through a separately supplied attribute name.
+    ///
+    /// For example, `hasattr(value, "name")` observes the same place as `value.name`.
+    pub fn from_named_attribute(receiver: &ast::Expr, attribute: &str) -> Option<Self> {
+        MemberExprBuilder::visit_named_attribute(receiver, attribute)
+            .and_then(Self::try_from_member_expr)
+    }
+
     /// Tries to create a `PlaceExpr` from an expression.
     ///
     /// Returns `None` if the expression is not a valid place expression and `Some` otherwise.
@@ -705,6 +713,19 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
                     places.insert(place);
                 }
             }
+        }
+
+        if expr_call
+            .func
+            .as_name_expr()
+            .is_some_and(|function| function.id == "hasattr")
+            && expr_call.arguments.keywords.is_empty()
+            && let [receiver, ast::Expr::StringLiteral(attribute)] = &*expr_call.arguments.args
+            && let Some(member) =
+                PlaceExpr::from_named_attribute(receiver, attribute.value.to_str())
+            && let Some(place) = self.places.place_id((&member).into())
+        {
+            places.insert(place);
         }
 
         // `bool(expr)` can delegate to narrowing `expr` itself, e.g. `bool(x is not None)`

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -613,10 +613,10 @@ struct UseDefMapExtra {
     /// [`Bindings`] reaching a [`ScopedUseId`].
     bindings_by_use: FrozenIndexVec<ScopedUseId, InternedBindingsId>,
 
-    /// [`Bindings`] for each member reaching a [`ScopedUseId`].
+    /// Member identities and their bindings reaching a [`ScopedUseId`].
     ///
-    /// This is only used for kwargs expressions, whose corresponding `bindings_by_use` entry
-    /// is empty.
+    /// A keyword splat uses these as its complete member snapshot; an ordinary receiver use can
+    /// also retain associated instance-member states alongside its own binding.
     multi_bindings_by_use: MultiBindingsByUse,
 
     /// Retained [`PlaceState`] values for each member.
@@ -822,11 +822,13 @@ impl Default for RangeInfo {
     }
 }
 
+type AssociatedPlaceBindings = (ScopedPlaceId, Bindings);
+
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize)]
-struct MultiBindingsByUse(ThinVec<(ScopedUseId, Box<[Bindings]>)>);
+struct MultiBindingsByUse(ThinVec<(ScopedUseId, Box<[AssociatedPlaceBindings]>)>);
 
 impl MultiBindingsByUse {
-    fn from_map(map: FxHashMap<ScopedUseId, Vec<Bindings>>) -> Self {
+    fn from_map(map: FxHashMap<ScopedUseId, Vec<AssociatedPlaceBindings>>) -> Self {
         let mut entries = map
             .into_iter()
             .map(|(use_id, bindings)| (use_id, bindings.into_boxed_slice()))
@@ -835,7 +837,7 @@ impl MultiBindingsByUse {
         Self(entries.into_iter().collect())
     }
 
-    fn get(&self, use_id: ScopedUseId) -> Option<&[Bindings]> {
+    fn get(&self, use_id: ScopedUseId) -> Option<&[AssociatedPlaceBindings]> {
         self.0
             .binary_search_by_key(&use_id, |(candidate, _)| *candidate)
             .ok()
@@ -905,14 +907,29 @@ impl<'db> UseDefMap<'db> {
         &self,
         use_id: ScopedUseId,
     ) -> impl Iterator<Item = BindingWithConstraintsIterator<'_, 'db>> {
+        self.associated_bindings_at_use(use_id)
+            .map(|(_, bindings)| bindings)
+    }
+
+    /// Return each associated member and its bindings at this expression use.
+    ///
+    /// Keeping the member identity alongside the snapshot lets later inference update a
+    /// receiver's flow-sensitive attributes after assignments or deletions.
+    pub fn associated_bindings_at_use(
+        &self,
+        use_id: ScopedUseId,
+    ) -> impl Iterator<Item = (ScopedPlaceId, BindingWithConstraintsIterator<'_, 'db>)> {
         self.extra
             .as_deref()
             .and_then(|extra| extra.multi_bindings_by_use.get(use_id))
             .map(|member_bindings| {
-                member_bindings.iter().map(|bindings| {
-                    self.bindings_iterator(
-                        bindings.as_slice(),
-                        BoundnessAnalysis::BasedOnUnboundVisibility,
+                member_bindings.iter().map(|(place, bindings)| {
+                    (
+                        *place,
+                        self.bindings_iterator(
+                            bindings.as_slice(),
+                            BoundnessAnalysis::BasedOnUnboundVisibility,
+                        ),
                     )
                 })
             })
@@ -1781,10 +1798,10 @@ pub(super) struct UseDefMapBuilder<'db> {
 
     /// Live bindings associated with each so-far-recorded use.
     ///
-    /// Unlike `bindings_by_use`, this field supports associating multiple bindings with a
-    /// single use. This is only used for kwargs expressions, whose corresponding `bindings_by_use`
-    /// entry is empty.
-    multi_bindings_by_use: FxHashMap<ScopedUseId, Vec<Bindings>>,
+    /// Unlike `bindings_by_use`, this field supports associating multiple member states with a
+    /// single use. Splatted kwargs use an empty primary binding entry, while attribute-presence
+    /// checks retain the ordinary receiver binding alongside its associated member state.
+    multi_bindings_by_use: FxHashMap<ScopedUseId, Vec<AssociatedPlaceBindings>>,
 
     /// Tracks whether or not the current point in control flow is reachable from the
     /// start of the scope.
@@ -2454,11 +2471,36 @@ impl<'db> UseDefMapBuilder<'db> {
             self.multi_bindings_by_use
                 .entry(use_id)
                 .or_default()
-                .push(bindings);
+                .push((place, bindings));
         }
 
         // Record a placeholder use of the parent expression to preserve the indices of `bindings_by_use`.
         self.record_use_bindings(Bindings::default(), use_id);
+    }
+
+    /// Associate another place's current bindings with an already-recorded expression use.
+    ///
+    /// This preserves the expression's own binding snapshot while also capturing the state of
+    /// a related member at the same point in control flow.
+    pub(super) fn record_associated_place_use(
+        &mut self,
+        place: ScopedPlaceId,
+        use_id: ScopedUseId,
+    ) {
+        let pending = self.pending_reachability.current;
+        let place_state =
+            pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
+        let place_state = self.pending_reachability.materialize_ref_at_use(
+            place_state,
+            pending,
+            &mut self.reachability_constraints,
+        );
+        let bindings = place_state.bindings().clone();
+        self.mark_definition_ids_used(bindings.iter().map(LiveBinding::binding));
+        let associated = self.multi_bindings_by_use.entry(use_id).or_default();
+        if !associated.iter().any(|(existing, _)| *existing == place) {
+            associated.push((place, bindings));
+        }
     }
 
     fn record_use_bindings(&mut self, bindings: Bindings, use_id: ScopedUseId) {
@@ -2840,7 +2882,7 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let interned_declarations =
             interned_declarations.finish(&mut self.reachability_constraints);
-        for bindings in self.multi_bindings_by_use.values_mut().flatten() {
+        for (_, bindings) in self.multi_bindings_by_use.values_mut().flatten() {
             bindings.finish(
                 &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -385,6 +385,70 @@ class Cached:
 reveal_type(Cached().metadata)  # revealed: int
 ```
 
+## Guarded instance attributes when the subclass is checked first
+
+Checking the subclass first preserves both diagnostics in the guarded initializer.
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+```
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self):
+        if not hasattr(self, "x"):
+            self.x = self.__str__  # error: [invalid-assignment]
+            self.missing  # error: [unresolved-attribute]
+```
+
+## Guarded instance attributes when the base is checked first
+
+Checking the base first produces the same diagnostics as checking the subclass first.
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self):
+        if not hasattr(self, "x"):
+            self.x = self.__str__  # error: [invalid-assignment]
+            self.missing  # error: [unresolved-attribute]
+```
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+```
+
+## Existing class attributes keep guarded initializers unreachable
+
+A defined attribute remains present on both its declaring class and its subclasses.
+
+```py
+class Base:
+    x = 1
+
+    def initialize(self):
+        if not hasattr(self, "x"):
+            self.x = self.missing
+
+class Child(Base):
+    def initialize(self):
+        if not hasattr(self, "x"):
+            self.x = self.missing
+```
+
 ## Decorator defined on a base class with constrained typevars, accessed from a subclass with decorated generic parameters
 
 This example was minimized from

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -387,7 +387,8 @@ reveal_type(Cached().metadata)  # revealed: int
 
 ## Guarded instance attributes when the subclass is checked first
 
-Checking the subclass first preserves both diagnostics in the guarded initializer.
+Checking the subclass first keeps the guarded initializer reachable without introducing an invalid
+assignment.
 
 `child.py`:
 
@@ -404,13 +405,13 @@ class Child(Base):
 class Base:
     def __init__(self):
         if not hasattr(self, "x"):
-            self.x = self.__str__  # error: [invalid-assignment]
+            self.x = self.__str__
             self.missing  # error: [unresolved-attribute]
 ```
 
 ## Guarded instance attributes when the base is checked first
 
-Checking the base first produces the same diagnostics as checking the subclass first.
+Checking the base first produces the same genuine missing-attribute diagnostic.
 
 `base.py`:
 
@@ -418,7 +419,7 @@ Checking the base first produces the same diagnostics as checking the subclass f
 class Base:
     def __init__(self):
         if not hasattr(self, "x"):
-            self.x = self.__str__  # error: [invalid-assignment]
+            self.x = self.__str__
             self.missing  # error: [unresolved-attribute]
 ```
 
@@ -429,6 +430,151 @@ from base import Base
 
 class Child(Base):
     x = Base.__str__
+```
+
+## Missing instance attributes do not satisfy protocols before assignment
+
+A receiver guarded by a negative attribute check cannot satisfy a protocol requiring that attribute.
+
+```py
+from typing import Protocol
+
+class HasValue(Protocol):
+    value: int
+
+class Example:
+    def initialize(self) -> None:
+        if not hasattr(self, "value"):
+            before: HasValue = self  # error: [invalid-assignment]
+            self.value = 1
+```
+
+## Contradictory instance-attribute checks are unreachable
+
+Without an intervening assignment, opposite checks on the same receiver cannot both succeed.
+
+```py
+class Example:
+    def initialize(self) -> None:
+        if not hasattr(self, "value"):
+            if hasattr(self, "value"):
+                self.missing
+            self.value = 1
+
+        if hasattr(self, "other"):
+            if not hasattr(self, "other"):
+                self.missing
+            self.other = 1
+```
+
+## Assigned instance attributes satisfy subsequent protocols
+
+Assigning the missing attribute updates the receiver before its later protocol check.
+
+```py
+from typing import Protocol
+
+class HasValue(Protocol):
+    value: int
+
+class Example:
+    def initialize(self) -> None:
+        if not hasattr(self, "value"):
+            self.value = 1
+            after: HasValue = self
+```
+
+## Conditionally assigned instance attributes remain possibly absent
+
+A conditional assignment does not satisfy an attribute requirement until another presence check
+confirms that the assignment occurred.
+
+```py
+from typing import Protocol
+
+class HasValue(Protocol):
+    value: int
+
+class Example:
+    def initialize(self, condition: bool) -> None:
+        if not hasattr(self, "value"):
+            if condition:
+                self.value = 1
+
+            before: HasValue = self  # error: [invalid-assignment]
+
+            if hasattr(self, "value"):
+                present: HasValue = self
+            else:
+                absent: HasValue = self  # error: [invalid-assignment]
+```
+
+## Inherited instance attributes when the base is checked first
+
+Checking the base first preserves the same inherited attribute type.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+`base.py`:
+
+```py
+class Base:
+    values = ["a"]
+
+class Parent(Base):
+    def __init__(self):
+        if self.values:
+            self.values = [*self.values]
+
+    def get_values(self) -> list[str]:
+        return self.values
+```
+
+`child.py`:
+
+```py
+from base import Parent
+
+class Child(Parent):
+    def __init__(self):
+        self.values = self.values + ["b"]
+```
+
+## Inherited instance attributes when the subclass is checked first
+
+A self-referential instance assignment first reads the inherited class attribute.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+`child.py`:
+
+```py
+from base import Parent
+
+class Child(Parent):
+    def __init__(self):
+        self.values = self.values + ["b"]
+```
+
+`base.py`:
+
+```py
+class Base:
+    values = ["a"]
+
+class Parent(Base):
+    def __init__(self):
+        if self.values:
+            self.values = [*self.values]
+
+    def get_values(self) -> list[str]:
+        return self.values
 ```
 
 ## Existing class attributes keep guarded initializers unreachable

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -105,7 +105,7 @@ use crate::types::visitor::{any_over_type, dynamic_content};
 use crate::{Db, FxOrderSet, HasType, NameKind, Program, SemanticModel};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};
-use instance::Protocol;
+use instance::{MemberPresence, Protocol};
 pub use instance::{NominalInstanceType, ProtocolInstanceType};
 pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
@@ -1905,6 +1905,164 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Record whether a member is present on this receiver at the current point in control flow.
+    ///
+    /// A type variable retains its identity while its upper bound or constraints carry the
+    /// receiver-local fact. This lets ordinary member lookup and structural comparisons observe
+    /// the refinement without changing the public shape of the type.
+    pub(super) fn with_member_presence(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+        present: bool,
+    ) -> Type<'db> {
+        let presence = if present {
+            MemberPresence::Present
+        } else {
+            MemberPresence::Absent
+        };
+        self.map_member_presence(db, env, name, Some(presence))
+    }
+
+    /// Record that a member was initialized on only some paths reaching this receiver.
+    pub(super) fn with_possible_member_presence(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+    ) -> Type<'db> {
+        self.map_member_presence(db, env, name, Some(MemberPresence::PossiblyAbsent))
+    }
+
+    /// Discard a receiver-local member-presence fact when its state is no longer certain.
+    pub(super) fn without_member_presence(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+    ) -> Type<'db> {
+        self.map_member_presence(db, env, name, None)
+    }
+
+    fn map_member_presence(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+        presence: Option<MemberPresence>,
+    ) -> Type<'db> {
+        match self {
+            Type::NominalInstance(instance) => Type::NominalInstance(match presence {
+                Some(MemberPresence::Present) => instance.with_member_presence(db, name, true),
+                Some(MemberPresence::Absent) => instance.with_member_presence(db, name, false),
+                Some(MemberPresence::PossiblyAbsent) => {
+                    instance.with_possible_member_presence(db, name)
+                }
+                None => instance.without_member_presence(db, name),
+            }),
+            Type::TypeVar(typevar) => Type::TypeVar(typevar.map_bound_or_constraints(
+                db,
+                |bound_or_constraints| {
+                    bound_or_constraints.map(|bound_or_constraints| match bound_or_constraints {
+                        TypeVarBoundOrConstraints::UpperBound(bound) => {
+                            TypeVarBoundOrConstraints::UpperBound(
+                                bound.map_member_presence(db, env, name, presence),
+                            )
+                        }
+                        TypeVarBoundOrConstraints::Constraints(constraints) => {
+                            TypeVarBoundOrConstraints::Constraints(constraints.map(
+                                db,
+                                |constraint| {
+                                    constraint.map_member_presence(db, env, name, presence)
+                                },
+                            ))
+                        }
+                    })
+                },
+            )),
+            Type::Union(union) => union.map(db, env, |element| {
+                element.map_member_presence(db, env, name, presence)
+            }),
+            _ => self,
+        }
+    }
+
+    /// Return a member-presence fact shared by all possible values of this receiver.
+    pub(super) fn member_presence(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+    ) -> Option<bool> {
+        if let Type::NominalInstance(instance) = self {
+            return instance.member_presence(db, name);
+        }
+
+        match self.member_presence_state(db, env, name) {
+            Some(MemberPresence::Present) => Some(true),
+            Some(MemberPresence::Absent) => Some(false),
+            Some(MemberPresence::PossiblyAbsent) | None => None,
+        }
+    }
+
+    /// Return whether any possible receiver retains a flow-sensitive fact for this member.
+    pub(super) fn has_member_presence_fact(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+    ) -> bool {
+        match self {
+            Type::NominalInstance(instance) => instance.has_member_presence_fact(db, name),
+            Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db, env) {
+                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    bound.has_member_presence_fact(db, env, name)
+                }
+                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+                    .elements(db)
+                    .iter()
+                    .any(|element| element.has_member_presence_fact(db, env, name)),
+                None => false,
+            },
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .any(|element| element.has_member_presence_fact(db, env, name)),
+            _ => false,
+        }
+    }
+
+    /// Return a receiver-local member state shared by every possible value of this type.
+    fn member_presence_state(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+    ) -> Option<MemberPresence> {
+        let common_presence = |elements: &[Type<'db>]| {
+            let mut elements = elements.iter();
+            let presence = elements.next()?.member_presence_state(db, env, name)?;
+            elements
+                .all(|element| element.member_presence_state(db, env, name) == Some(presence))
+                .then_some(presence)
+        };
+
+        match self {
+            Type::NominalInstance(instance) => instance.member_presence_state(db, name),
+            Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db, env)? {
+                TypeVarBoundOrConstraints::UpperBound(bound) => {
+                    bound.member_presence_state(db, env, name)
+                }
+                TypeVarBoundOrConstraints::Constraints(constraints) => {
+                    common_presence(constraints.elements(db))
+                }
+            },
+            Type::Union(union) => common_presence(union.elements(db)),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if this type may contain preferred type mappings when provided as type context
     /// during generic call inference.
     ///
@@ -3593,9 +3751,16 @@ impl<'db> Type<'db> {
 
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Place::bound(self).into(),
 
-            Type::NominalInstance(instance) => {
-                instance.class(db, env).instance_member(db, env, name)
-            }
+            Type::NominalInstance(instance) => match instance.member_presence_state(db, name) {
+                Some(MemberPresence::Absent) => Place::Undefined.into(),
+                Some(MemberPresence::PossiblyAbsent) => Self::with_definedness(
+                    instance.class(db, env).instance_member(db, env, name),
+                    Definedness::PossiblyUndefined,
+                ),
+                Some(MemberPresence::Present) | None => {
+                    instance.class(db, env).instance_member(db, env, name)
+                }
+            },
             Type::NewTypeInstance(newtype) => newtype
                 .concrete_base_type(db)
                 .instance_member(db, env, name),
@@ -5212,10 +5377,33 @@ impl<'db> Type<'db> {
             }
         }
 
+        let presence = receiver
+            .unwrap_or(self)
+            .member_presence_state(db, env, name);
+        if presence == Some(MemberPresence::Absent) {
+            return Place::Undefined.into();
+        }
+
         let key = MemberLookupKey::new(db, env.program(db), self, name, policy);
-        match receiver {
+        let result = match receiver {
             Some(receiver) => member_lookup_with_policy_and_receiver_inner(db, key, receiver),
             None => member_lookup_with_policy_inner(db, key),
+        };
+
+        if presence != Some(MemberPresence::PossiblyAbsent) {
+            return result;
+        }
+
+        match result {
+            Ok(member) => Ok(Self::with_definedness(
+                member,
+                Definedness::PossiblyUndefined,
+            )),
+            Err(error) => Err(MemberLookupError::new(
+                db,
+                Self::with_definedness(error.fallback_member(db), Definedness::PossiblyUndefined),
+                error.kind(db),
+            )),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9676,7 +9676,82 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         });
 
-        ty.inner_type()
+        let mut ty = ty.inner_type();
+        let scope = self.scope().file_scope_id(db);
+        let Some(use_id) = constraint_keys.iter().find_map(|(constraint_scope, key)| {
+            if *constraint_scope == scope
+                && let ConstraintKey::UseId(use_id) = key
+            {
+                Some(*use_id)
+            } else {
+                None
+            }
+        }) else {
+            return ty;
+        };
+        let use_def = self.index.use_def_map(scope);
+        let places = self.index.place_table(scope);
+
+        for (place, bindings) in use_def.associated_bindings_at_use(use_id) {
+            let PlaceExprRef::Member(member) = places.place(place) else {
+                continue;
+            };
+            let Some(attribute) = member.as_instance_attribute() else {
+                continue;
+            };
+            if !ty.has_member_presence_fact(db, env, attribute) {
+                continue;
+            }
+
+            let has_deleted_binding = bindings
+                .clone()
+                .any(|binding| matches!(binding.binding, DefinitionState::Deleted));
+            let member_bindings = bindings.clone();
+            let member = place_from_bindings_with_reachability_cache(
+                db,
+                env,
+                bindings,
+                self.reachability_cache(),
+            )
+            .place;
+
+            if member.is_definitely_bound() {
+                ty = ty.with_member_presence(db, env, attribute, true);
+            } else if member.is_undefined() && has_deleted_binding {
+                ty = ty.with_member_presence(db, env, attribute, false);
+            } else if matches!(member, Place::Defined(_)) {
+                let possible_ty = ty.with_possible_member_presence(db, env, attribute);
+                let narrowed_presence = places.symbol_id(symbol_name).and_then(|receiver| {
+                    let mut common_presence = None;
+
+                    for binding in member_bindings {
+                        let narrowed = binding.narrowing_constraint.narrow(
+                            db,
+                            env,
+                            possible_ty,
+                            receiver.into(),
+                        );
+                        if narrowed.is_never() {
+                            continue;
+                        }
+
+                        let presence = narrowed.member_presence(db, env, attribute)?;
+                        if common_presence.is_some_and(|previous| previous != presence) {
+                            return None;
+                        }
+                        common_presence = Some(presence);
+                    }
+
+                    common_presence
+                });
+
+                ty = narrowed_presence.map_or(possible_ty, |present| {
+                    possible_ty.with_member_presence(db, env, attribute, present)
+                });
+            }
+        }
+
+        ty
     }
 
     fn infer_local_place_load(
@@ -10304,12 +10379,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let mut assigned_type = None;
+        let mut inherited_member = None;
         if let Some(place_expr) = PlaceExpr::try_from_expr(attribute) {
             let (resolved, keys) = self.infer_place_load(
                 PlaceExprRef::from(&place_expr),
                 ast::ExprRef::Attribute(attribute),
             );
             constraint_keys.extend(keys);
+
+            let place_table = self.index.place_table(self.scope().file_scope_id(db));
+            if resolved.place.is_undefined()
+                && let Some(place_id) = place_table.place_id(PlaceExprRef::from(&place_expr))
+                && let place = place_table.place(place_id)
+                && place.is_bound()
+                && matches!(place, PlaceExprRef::Member(member) if member.is_instance_attribute())
+            {
+                // A slot assigned later in this method cannot shadow an already-present class
+                // attribute before that assignment. Consulting the completed instance summary
+                // here would make the read depend on its own future write.
+                inherited_member = value_type
+                    .member_lookup_with_policy_and_receiver(
+                        db,
+                        env,
+                        &attr.id,
+                        MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                        None,
+                    )
+                    .ok()
+                    .filter(|member| member.place.is_definitely_bound());
+            }
+
             if let Place::Defined(DefinedPlace {
                 ty,
                 definedness: Definedness::AlwaysDefined,
@@ -10319,11 +10418,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 assigned_type = Some(ty);
             }
         }
-        let fallback_place = value_type
-            .try_member_lookup(db, env, &attr.id)
-            .unwrap_or_else(|error| {
-                error.report_diagnostic(&self.context, value_type, attribute, assigned_type);
-                error.fallback_member(db)
+        let fallback_place = inherited_member
+            .unwrap_or_else(|| {
+                value_type
+                    .try_member_lookup(db, env, &attr.id)
+                    .unwrap_or_else(|error| {
+                        error.report_diagnostic(
+                            &self.context,
+                            value_type,
+                            attribute,
+                            assigned_type,
+                        );
+                        error.fallback_member(db)
+                    })
             })
             .map_type(|ty| {
                 self.narrow_expr_with_applicable_constraints(attribute, ty, &constraint_keys)

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -33,8 +33,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         emit_diagnostics: bool,
     ) -> bool {
         let db = self.db();
-        let requirement =
-            attribute_write_requirement(db, self.program_environment(), object_ty, attribute);
+        let env = self.program_environment();
+        // A write can create a member that was absent immediately before the assignment. Resolve
+        // its declared write requirements against the receiver's underlying class, while leaving
+        // the original receiver refinement intact when inferring the right-hand side.
+        let write_receiver = object_ty.without_member_presence(db, env, attribute);
+        let requirement = attribute_write_requirement(db, env, write_receiver, attribute);
         let mut evaluator = AssignmentAttributeWriteEvaluator {
             builder: self,
             target,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -204,6 +204,14 @@ pub struct NominalInstanceType<'db>(
     NominalInstanceInner<'db>,
 );
 
+/// The flow-sensitive presence of one member on a particular receiver.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+pub(super) enum MemberPresence {
+    Present,
+    Absent,
+    PossiblyAbsent,
+}
+
 pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     nominal: NominalInstanceType<'db>,
@@ -217,6 +225,9 @@ pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db
         NominalInstanceInner::NonTuple(class) => {
             visitor.visit_type(db, class.class(db).into());
         }
+        NominalInstanceInner::Refined(refined) => {
+            walk_nominal_instance_type(db, refined.base(db), visitor);
+        }
         NominalInstanceInner::SysVersionInfo => {}
     }
 }
@@ -226,6 +237,128 @@ impl<'db> NominalInstanceType<'db> {
         Self(NominalInstanceInner::NonTuple(
             NominalInstanceClass::from_class(db, class),
         ))
+    }
+
+    /// Refine this instance with the observed presence or absence of a member.
+    ///
+    /// Facts describe one receiver at a point in control flow, not the public shape of its class.
+    /// Updating an existing fact models a later assignment or deletion without stacking wrappers.
+    pub(super) fn with_member_presence(self, db: &'db dyn Db, name: &str, present: bool) -> Self {
+        self.with_member_presence_state(
+            db,
+            name,
+            if present {
+                MemberPresence::Present
+            } else {
+                MemberPresence::Absent
+            },
+        )
+    }
+
+    /// Retain that a member may be missing after control-flow paths merge.
+    pub(super) fn with_possible_member_presence(self, db: &'db dyn Db, name: &str) -> Self {
+        self.with_member_presence_state(db, name, MemberPresence::PossiblyAbsent)
+    }
+
+    fn with_member_presence_state(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        presence: MemberPresence,
+    ) -> Self {
+        let (base, mut facts) = match self.0 {
+            NominalInstanceInner::Refined(refined) => {
+                (refined.base(db), refined.facts(db).to_vec())
+            }
+            NominalInstanceInner::NonTuple(NominalInstanceClass::Plain(_)) => (self, Vec::new()),
+            // An explicit `Any` base can provide arbitrary attributes, while dedicated tuple,
+            // object, and version-info representations rely on their existing special behavior.
+            NominalInstanceInner::NonTuple(NominalInstanceClass::InheritsFromExplicitAny(_))
+            | NominalInstanceInner::ExactTuple(_)
+            | NominalInstanceInner::Object
+            | NominalInstanceInner::SysVersionInfo => return self,
+        };
+
+        match facts.binary_search_by(|(fact_name, _)| fact_name.as_str().cmp(name)) {
+            Ok(index) if facts[index].1 == presence => return self,
+            Ok(index) => facts[index].1 = presence,
+            Err(index) => facts.insert(index, (Name::new(name), presence)),
+        }
+
+        Self(NominalInstanceInner::Refined(RefinedNominalInstance::new(
+            db,
+            base,
+            facts.into_boxed_slice(),
+        )))
+    }
+
+    /// Return the receiver-local presence fact for `name`, if one is known.
+    pub(super) fn member_presence(self, db: &'db dyn Db, name: &str) -> Option<bool> {
+        match self.member_presence_state(db, name)? {
+            MemberPresence::Present => Some(true),
+            MemberPresence::Absent => Some(false),
+            MemberPresence::PossiblyAbsent => None,
+        }
+    }
+
+    /// Return the full receiver-local presence state, including an uncertain state.
+    pub(super) fn member_presence_state(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<MemberPresence> {
+        let NominalInstanceInner::Refined(refined) = self.0 else {
+            return None;
+        };
+        let facts = refined.facts(db);
+        facts
+            .binary_search_by(|(fact_name, _)| fact_name.as_str().cmp(name))
+            .ok()
+            .map(|index| facts[index].1)
+    }
+
+    /// Return whether this receiver carries any presence fact for the member.
+    pub(super) fn has_member_presence_fact(self, db: &'db dyn Db, name: &str) -> bool {
+        self.member_presence_state(db, name).is_some()
+    }
+
+    /// Forget one receiver-local fact while retaining facts for other members.
+    pub(super) fn without_member_presence(self, db: &'db dyn Db, name: &str) -> Self {
+        let NominalInstanceInner::Refined(refined) = self.0 else {
+            return self;
+        };
+        let facts = refined.facts(db);
+        let Ok(index) = facts.binary_search_by(|(fact_name, _)| fact_name.as_str().cmp(name))
+        else {
+            return self;
+        };
+
+        if facts.len() == 1 {
+            return refined.base(db);
+        }
+
+        let mut facts = facts.to_vec();
+        facts.remove(index);
+        Self(NominalInstanceInner::Refined(RefinedNominalInstance::new(
+            db,
+            refined.base(db),
+            facts.into_boxed_slice(),
+        )))
+    }
+
+    /// Remove receiver-local facts while preserving this instance's nominal class.
+    pub(super) fn unrefined(self, db: &'db dyn Db) -> Self {
+        match self.0 {
+            NominalInstanceInner::Refined(refined) => refined.base(db),
+            _ => self,
+        }
+    }
+
+    fn member_presence_facts(self, db: &'db dyn Db) -> &'db [(Name, MemberPresence)] {
+        match self.0 {
+            NominalInstanceInner::Refined(refined) => refined.facts(db),
+            _ => &[],
+        }
     }
 
     /// Return whether this instance's class inherits from an explicit `Any` base.
@@ -270,6 +403,7 @@ impl<'db> NominalInstanceType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => tuple.to_class_type(db),
             NominalInstanceInner::NonTuple(class) => class.class(db),
+            NominalInstanceInner::Refined(refined) => refined.base(db).class(db, env),
             NominalInstanceInner::SysVersionInfo => {
                 sys_version_info_class(db, env).unwrap_or_else(|| ClassType::object(db, env))
             }
@@ -292,6 +426,7 @@ impl<'db> NominalInstanceType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(_) => Some(KnownClass::Tuple),
             NominalInstanceInner::NonTuple(class) => class.class(db).known(db),
+            NominalInstanceInner::Refined(refined) => refined.base(db).known_class(db),
             NominalInstanceInner::SysVersionInfo => Some(KnownClass::VersionInfo),
             NominalInstanceInner::Object => Some(KnownClass::Object),
         }
@@ -321,6 +456,7 @@ impl<'db> NominalInstanceType<'db> {
                 Some(Cow::Owned(TupleSpec::version_info_spec(db, env)))
             }
             NominalInstanceInner::Object => None,
+            NominalInstanceInner::Refined(refined) => refined.base(db).tuple_spec(db, env),
             NominalInstanceInner::NonTuple(class) => {
                 let class = class.class(db);
                 // Avoid an expensive MRO traversal for common stdlib classes.
@@ -360,6 +496,7 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::ExactTuple(_) => true,
             NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => false,
             NominalInstanceInner::NonTuple(class) => class.class(db).is_generic(),
+            NominalInstanceInner::Refined(refined) => refined.base(db).is_definition_generic(db),
         }
     }
 
@@ -377,6 +514,7 @@ impl<'db> NominalInstanceType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
             NominalInstanceInner::NonTuple(_)
+            | NominalInstanceInner::Refined(_)
             | NominalInstanceInner::SysVersionInfo
             | NominalInstanceInner::Object => None,
         }
@@ -390,6 +528,7 @@ impl<'db> NominalInstanceType<'db> {
     pub(crate) fn slice_literal(self, db: &'db dyn Db) -> Option<SliceLiteral> {
         let class = match self.0 {
             NominalInstanceInner::NonTuple(class) => class.class(db),
+            NominalInstanceInner::Refined(refined) => return refined.base(db).slice_literal(db),
             NominalInstanceInner::ExactTuple(_)
             | NominalInstanceInner::SysVersionInfo
             | NominalInstanceInner::Object => return None,
@@ -448,6 +587,14 @@ impl<'db> NominalInstanceType<'db> {
                     class.with_class(db, transformed),
                 )))
             }
+            NominalInstanceInner::Refined(refined) => {
+                let base = refined
+                    .base(db)
+                    .recursive_type_normalized_impl(db, env, div, nested)?;
+                Some(Self(NominalInstanceInner::Refined(
+                    RefinedNominalInstance::new(db, base, refined.facts(db).clone()),
+                )))
+            }
         }
     }
 
@@ -465,6 +612,7 @@ impl<'db> NominalInstanceType<'db> {
                 .known(db)
                 .map(KnownClass::is_singleton)
                 .unwrap_or_else(|| is_single_member_enum(db, class.class(db).class_literal(db))),
+            NominalInstanceInner::Refined(refined) => refined.base(db).is_singleton(db),
         }
     }
 
@@ -494,6 +642,22 @@ impl<'db> NominalInstanceType<'db> {
                     class.with_class(db, transformed),
                 )))
             }
+            NominalInstanceInner::Refined(refined) => {
+                let transformed =
+                    refined
+                        .base(db)
+                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                match transformed {
+                    Type::NominalInstance(base) => Type::NominalInstance(Self(
+                        NominalInstanceInner::Refined(RefinedNominalInstance::new(
+                            db,
+                            base.unrefined(db),
+                            refined.facts(db).clone(),
+                        )),
+                    )),
+                    transformed => transformed,
+                }
+            }
         }
     }
 
@@ -512,6 +676,15 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => {}
             NominalInstanceInner::NonTuple(class) => {
                 class.class(db).find_legacy_typevars_impl(
+                    db,
+                    env,
+                    binding_context,
+                    typevars,
+                    visitor,
+                );
+            }
+            NominalInstanceInner::Refined(refined) => {
+                refined.base(db).find_legacy_typevars_impl(
                     db,
                     env,
                     binding_context,
@@ -774,6 +947,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: NominalInstanceType<'db>,
         target: NominalInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if target
+            .member_presence_facts(db)
+            .iter()
+            .any(|(name, target_presence)| {
+                !matches!(
+                    (source.member_presence_state(db, name), target_presence),
+                    (_, MemberPresence::PossiblyAbsent)
+                        | (Some(MemberPresence::Present), MemberPresence::Present)
+                        | (Some(MemberPresence::Absent), MemberPresence::Absent)
+                )
+            })
+        {
+            return self.never();
+        }
+
         match (source.0, target.0) {
             (_, NominalInstanceInner::Object) => self.always(),
             (
@@ -917,6 +1105,20 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: NominalInstanceType<'db>,
         right: NominalInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if left
+            .member_presence_facts(db)
+            .iter()
+            .any(|(name, left_presence)| {
+                matches!(
+                    (left_presence, right.member_presence_state(db, name)),
+                    (MemberPresence::Present, Some(MemberPresence::Absent))
+                        | (MemberPresence::Absent, Some(MemberPresence::Present))
+                )
+            })
+        {
+            return self.always();
+        }
+
         let mut result = self.never();
         if left.is_object() || right.is_object() {
             return result;
@@ -1000,6 +1202,21 @@ impl<'db> NominalInstanceClass<'db> {
     }
 }
 
+/// A nominal class together with flow-sensitive facts about one receiver's members.
+///
+/// The base remains unrefined, and facts are sorted by name. Consequently, equivalent control-flow
+/// states share one interned value regardless of the order in which attributes were observed.
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+struct RefinedNominalInstance<'db> {
+    #[returns(copy)]
+    base: NominalInstanceType<'db>,
+    #[returns(ref)]
+    facts: Box<[(Name, MemberPresence)]>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for RefinedNominalInstance<'_> {}
+
 /// [`NominalInstanceType`] is split into several variants internally as a pure optimization to
 /// avoid having to materialize the [`ClassType`] for tuple instances where it would be unnecessary
 /// (this is somewhat expensive!).
@@ -1022,6 +1239,8 @@ enum NominalInstanceInner<'db> {
     /// This variant includes types that are subtypes of "exact tuple" types,
     /// because they represent "all instances of a class that is a tuple subclass".
     NonTuple(NominalInstanceClass<'db>),
+    /// A nominal instance with receiver-local attribute-presence facts.
+    Refined(RefinedNominalInstance<'db>),
     /// The singleton `sys.version_info` value.
     SysVersionInfo,
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry};
 
+use crate::place::place_from_bindings;
 use crate::reachability::{narrow_type_by_constraint, type_narrowed_by_previous_patterns};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
@@ -11,17 +12,18 @@ use crate::types::typed_dict::{TypedDictFieldBuilder, TypedDictSchema, TypedDict
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
-    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
-    class_pattern_positional_sources, definite_match_pattern_type_for_subject,
-    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    MemberLookupPolicy, Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner,
+    SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
+    callable_pattern_type, class_pattern_positional_sources,
+    definite_match_pattern_type_for_subject, exact_sequence_pattern_type, infer_expression_types,
+    mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use crate::{Db, ProgramEnvironment};
+use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
-use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
+use ty_python_core::place::{PlaceExpr, PlaceExprRef, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
     CallableAndCallExpr, ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicate,
     PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
@@ -4208,6 +4210,63 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         Some(constraints)
     }
 
+    /// Return the receiver and any known attribute-presence fact at a guarded use.
+    ///
+    /// An uninitialized local slot does not prove absence: the receiver may already have been
+    /// initialized by another method or its caller. In that case, the guard remains uncertain.
+    fn instance_attribute_presence_at_call(
+        &self,
+        expression: Expression<'db>,
+        receiver: &ast::Expr,
+        attribute: &str,
+        inference: &ExpressionInference<'db>,
+    ) -> Option<(Type<'db>, Option<bool>)> {
+        let receiver_name = receiver.as_name_expr()?;
+        let member_place = PlaceExpr::from_named_attribute(receiver, attribute)?;
+        let places = self.places();
+        let member_place_id = places.place_id(&member_place)?;
+        if !matches!(
+            places.place(member_place_id),
+            PlaceExprRef::Member(member) if member.is_instance_attribute()
+        ) {
+            return None;
+        }
+
+        let db = self.db;
+        let program_file = expression.program_file(db);
+        let index = semantic_index(db, program_file);
+        let use_def = index.use_def_map(self.scope().file_scope_id(db));
+        let use_id = receiver_name.scoped_use_id(db, program_file);
+        let bindings = use_def
+            .associated_bindings_at_use(use_id)
+            .find_map(|(place, bindings)| (place == member_place_id).then_some(bindings))?;
+        let local_member = place_from_bindings(db, &self.env, bindings).place;
+        let receiver_ty = inference.expression_type(receiver);
+
+        if local_member.is_definitely_bound() {
+            return Some((
+                receiver_ty.with_member_presence(db, &self.env, attribute, true),
+                Some(true),
+            ));
+        }
+
+        if let Some(is_present) = receiver_ty.member_presence(db, &self.env, attribute) {
+            return Some((receiver_ty, Some(is_present)));
+        }
+
+        let is_present = receiver_ty
+            .member_lookup_with_policy_and_receiver(
+                db,
+                &self.env,
+                attribute,
+                MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                None,
+            )
+            .is_ok_and(|member| member.place.is_definitely_bound());
+
+        Some((receiver_ty, is_present.then_some(true)))
+    }
+
     fn evaluate_expr_call(
         &mut self,
         expr_call: &ast::ExprCall,
@@ -4253,10 +4312,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             }
             Type::FunctionLiteral(function_type) if expr_call.arguments.keywords.is_empty() => {
-                let [first_arg, second_arg] = &*expr_call.arguments.args else {
+                let [first_arg_expr, second_arg] = &*expr_call.arguments.args else {
                     return None;
                 };
-                let first_arg = PlaceExpr::try_from_expr(first_arg)?;
+                let first_arg = PlaceExpr::try_from_expr(first_arg_expr)?;
                 let function = function_type.known(db)?;
                 let place = self.expect_place(&first_arg);
 
@@ -4268,6 +4327,27 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
                     if !is_identifier(attr) {
                         return None;
+                    }
+
+                    if let Some((receiver_ty, is_present)) = self
+                        .instance_attribute_presence_at_call(
+                            expression,
+                            first_arg_expr,
+                            attr,
+                            inference,
+                        )
+                    {
+                        let constraint = match is_present {
+                            Some(is_present) if is_present != is_positive => {
+                                NarrowingConstraint::intersection(Type::Never)
+                            }
+                            Some(_) => return None,
+                            None => NarrowingConstraint::replacement(
+                                receiver_ty.with_member_presence(db, &self.env, attr, is_positive),
+                            ),
+                        };
+
+                        return Some(NarrowingConstraints::from_iter([(place, constraint)]));
                     }
 
                     // Since `hasattr` only checks if an attribute is readable,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -3764,59 +3764,6 @@ fn callable_has_only_non_never_returns<'db>(db: &'db dyn Db, callable: CallableT
         && signatures.all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
-enum AttributePresence {
-    Present,
-    Absent,
-    Uncertain,
-}
-
-/// Establish attribute presence without mistaking an unresolved inference cycle for proof.
-#[salsa::tracked(
-    returns(copy),
-    cycle_result=|_, _, _, _, _| AttributePresence::Uncertain,
-    heap_size=ruff_memory_usage::heap_size
-)]
-fn protocol_member_presence<'db>(
-    db: &'db dyn Db,
-    program: Program<'db>,
-    ty: Type<'db>,
-    protocol: ProtocolInstanceType<'db>,
-) -> AttributePresence {
-    let env = ProgramEnvironment::from_program(program);
-
-    for member in protocol.interface(db).members(db) {
-        if ty
-            .member_lookup_with_policy(
-                db,
-                &env,
-                member.name(),
-                MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-            )
-            .place
-            .is_definitely_bound()
-        {
-            continue;
-        }
-
-        match ty.member(db, &env, member.name()).place {
-            Place::Defined(DefinedPlace {
-                ty: member_ty,
-                definedness: Definedness::AlwaysDefined,
-                ..
-            }) if member_ty.is_divergent() => return AttributePresence::Uncertain,
-            Place::Defined(DefinedPlace {
-                definedness: Definedness::AlwaysDefined,
-                ..
-            }) => {}
-            Place::Defined(_) => return AttributePresence::Uncertain,
-            Place::Undefined => return AttributePresence::Absent,
-        }
-    }
-
-    AttributePresence::Present
-}
-
 /// Protocol compatibility can only succeed if every required member is present.
 ///
 /// Check that necessary condition up front so we can avoid expensive per-member type
@@ -3839,10 +3786,6 @@ pub(super) fn has_all_protocol_members_defined<'db>(
                 && target_interface.members(db).all(|member| {
                     source_interface.includes_member_or_object_fallback(db, env, member.name())
                 })
-        }
-        _ if protocol.class_origin(db).is_none() => {
-            protocol_member_presence(db, env.program(db), ty, protocol)
-                == AttributePresence::Present
         }
         _ => target_interface.members(db).all(|member| {
             matches!(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -3764,6 +3764,59 @@ fn callable_has_only_non_never_returns<'db>(db: &'db dyn Db, callable: CallableT
         && signatures.all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+enum AttributePresence {
+    Present,
+    Absent,
+    Uncertain,
+}
+
+/// Establish attribute presence without mistaking an unresolved inference cycle for proof.
+#[salsa::tracked(
+    returns(copy),
+    cycle_result=|_, _, _, _, _| AttributePresence::Uncertain,
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn protocol_member_presence<'db>(
+    db: &'db dyn Db,
+    program: Program<'db>,
+    ty: Type<'db>,
+    protocol: ProtocolInstanceType<'db>,
+) -> AttributePresence {
+    let env = ProgramEnvironment::from_program(program);
+
+    for member in protocol.interface(db).members(db) {
+        if ty
+            .member_lookup_with_policy(
+                db,
+                &env,
+                member.name(),
+                MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+            )
+            .place
+            .is_definitely_bound()
+        {
+            continue;
+        }
+
+        match ty.member(db, &env, member.name()).place {
+            Place::Defined(DefinedPlace {
+                ty: member_ty,
+                definedness: Definedness::AlwaysDefined,
+                ..
+            }) if member_ty.is_divergent() => return AttributePresence::Uncertain,
+            Place::Defined(DefinedPlace {
+                definedness: Definedness::AlwaysDefined,
+                ..
+            }) => {}
+            Place::Defined(_) => return AttributePresence::Uncertain,
+            Place::Undefined => return AttributePresence::Absent,
+        }
+    }
+
+    AttributePresence::Present
+}
+
 /// Protocol compatibility can only succeed if every required member is present.
 ///
 /// Check that necessary condition up front so we can avoid expensive per-member type
@@ -3786,6 +3839,10 @@ pub(super) fn has_all_protocol_members_defined<'db>(
                 && target_interface.members(db).all(|member| {
                     source_interface.includes_member_or_object_fallback(db, env, member.name())
                 })
+        }
+        _ if protocol.class_origin(db).is_none() => {
+            protocol_member_presence(db, env.program(db), ty, protocol)
+                == AttributePresence::Present
         }
         _ => target_interface.members(db).all(|member| {
             matches!(


### PR DESCRIPTION
## Summary

(Probably slop, want to see the ecosystem impact.)

Previously, we inferred implicit instance attributes from the completed class shape even while evaluating code that runs before the attribute has been assigned. This conflated the public shape of an initialized instance with the state of a particular receiver at the current point in control flow.

For `hasattr`, an existence check could recursively depend on the assignment guarded by that same check. Depending on which query entered the cycle first, we could discard a reachable branch, emit a bogus bound-method assignment error, or accept a receiver that does not satisfy a required protocol.

For inherited attributes, the same problem caused the right-hand side of an assignment to read its own not-yet-initialized instance slot instead of the inherited class member:

```py
# base.py
class Base:
    values = ["a"]


class Parent(Base):
    def __init__(self):
        if self.values:
            self.values = [*self.values]

    def get_values(self) -> list[str]:
        return self.values


# child.py
from base import Parent


class Child(Parent):
    def __init__(self):
        self.values = self.values + ["b"]
```

We now track attribute presence as `Present`, `Absent`, or `PossiblyAbsent` on flow-refined nominal instances while preserving `Self` through its upper bound. The semantic index records attribute-existence checks as member uses, receiver snapshots update across assignments, deletions, and conditional joins, and ordinary member lookup exposes definite or possible absence to protocol checking. Reads of a locally assigned instance member before its first reaching write resolve an independently defined class or inherited member before consulting completed implicit-instance state.

This removes the anonymous-protocol cycle-recovery workaround without adding attribute-specific subtype, intersection, normalization, or cycle-initialization exceptions. Both file orders are covered for the guarded initializer and inherited-attribute cases, alongside contradictory guards, required protocols before and after assignments, and conditional initialization.

Closes https://github.com/astral-sh/ty/issues/4076.

Closes https://github.com/astral-sh/ty/issues/4221.
