### PR TITLE
[ty] Exclude quantified constraints from semantic type walks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4011,6 +4011,37 @@ class DateTime(Protocol[T]):
         return datetime.now(tz)  # error: [invalid-return-type]
 ```
 
+## Recursive protocol receiver binding with an incompatible override
+
+An incompatible override of a covariant generic protocol method can recursively compare the
+protocol's explicitly annotated receiver with the implementing class. The receiver-binding and
+assignability queries must converge and report the incompatible override instead of panicking.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Generic, Protocol, TypeVar
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+
+class Result(Generic[T_co]): ...
+
+class SupportsMethod(Protocol[T_co]):
+    def method(self: "SupportsMethod[T]") -> Result[T]: ...
+
+class Compatible(SupportsMethod[T_co]):
+    def method(self: "Compatible[T]") -> Result[T]:
+        raise NotImplementedError
+
+class Incompatible(SupportsMethod[T_co]):
+    def method(self: "Incompatible[T]", value: int) -> Result[T]:  # error: [invalid-method-override]
+        raise NotImplementedError
+```
+
 ## Subtyping of protocols with generic method members
 
 Protocol method members can be generic. They can have generic contexts scoped to the class:

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -317,13 +317,23 @@ impl<'db> OwnedConstraintSet<'db> {
         f(&builder, set)
     }
 
+    /// Returns the types in constraints that are still reachable from the decision diagram.
+    ///
+    /// Source ordering also retains quantified-away constraints to preserve binding order, but
+    /// their type variables must not participate in semantic walks or callable freshening.
     pub(crate) fn types(&self) -> impl Iterator<Item = Type<'db>> + '_ {
         self.inner.iter().flat_map(|inner| {
-            inner.constraints.iter().flat_map(|constraint| {
-                std::iter::once(Type::TypeVar(constraint.typevar))
-                    .chain(constraint.bounds.lower)
-                    .chain(constraint.bounds.upper)
-            })
+            inner
+                .nodes
+                .iter()
+                .map(|node| node.constraint)
+                .unique()
+                .map(|constraint| inner.constraints[inner.retained_constraint_index(constraint)])
+                .flat_map(|constraint| {
+                    std::iter::once(Type::TypeVar(constraint.typevar))
+                        .chain(constraint.bounds.lower)
+                        .chain(constraint.bounds.upper)
+                })
         })
     }
 }
@@ -8938,6 +8948,38 @@ mod tests {
         );
         assert_eq!(inner.typevars.len(), 3);
         assert!(owned.node.index() >= inner.nodes.len());
+    }
+
+    #[test]
+    fn owned_constraint_set_type_walk_excludes_quantified_constraints() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let u = create_typevar(db, "U");
+
+        let owned = ConstraintSetBuilder::new().into_owned(|builder| {
+            let t_int = create_constraint(db, builder, t, KnownClass::Int);
+            let u_str = create_constraint(db, builder, u, KnownClass::Str);
+            t_int.and(db, builder, || u_str).reduce_inferable(
+                db,
+                &env,
+                builder,
+                TypeVarSet::from_typevars(db, [t]),
+            )
+        });
+
+        assert_eq!(
+            owned
+                .types()
+                .filter_map(Type::as_typevar)
+                .collect::<Vec<_>>(),
+            vec![u],
+        );
+        assert_eq!(
+            owned.inner.as_ref().map(|inner| inner.source_orders.len()),
+            Some(3),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

An owned constraint set retains both its live decision diagram and source-order metadata. Existential quantification can remove a constraint from the diagram while keeping it in the ordering metadata so inferred solutions retain their original order.

```text
exists T. (T = int and U = str)
live constraint: U = str
source ordering: T, U
```

Previously, `OwnedConstraintSet::types()` walked every retained constraint, including ordering-only entries. When checking a covariant generic protocol with an explicitly typed receiver, stale method-local type variables were repeatedly freshened (`T`, `T₁`, `T₂`, ...), preventing Salsa from reaching a fixed point and causing a `too many cycle iterations` panic.

We now walk only unique constraints reachable from decision-diagram nodes while preserving the complete source-order metadata. Existing quantified-solution ordering stays intact, and incompatible protocol overrides produce the expected diagnostic instead of crashing.

Closes https://github.com/astral-sh/ty/issues/4222.
