### PR TITLE
[ty] Two equality constraints are usually disjoint

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -460,8 +460,7 @@ def infer_pair(value: Pair[T]) -> T:
 
 def check_pair(value: GradualPair[U]) -> None:
     # TODO: error: [invalid-argument-type] "Argument to function `infer_pair` is incorrect"
-    # TODO: This revealed union is incorrect; the incompatible exact member types should make inference fail.
-    reveal_type(infer_pair(value))  # revealed: tuple[U@check_pair, Any] | tuple[U@check_pair, int]
+    reveal_type(infer_pair(value))  # revealed: Unknown
 ```
 
 ## Prefer specific compatible constraints over gradual constraints

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -436,6 +436,34 @@ def consume_callback(callback: Callable[[Row], None]) -> Row:
 reveal_type(consume_callback(callback))  # revealed: tuple[Any, ...]
 ```
 
+## Incompatible invariant protocol members
+
+When the same inferred type variable appears in multiple invariant protocol members, those members
+must agree on one exact specialization. Gradual consistency between their types is not sufficient.
+
+```py
+from typing import Any, Generic, Protocol, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Pair(Protocol[T]):
+    first: T
+    second: T
+
+class GradualPair(Generic[U]):
+    first: tuple[U, Any]
+    second: tuple[U, int]
+
+def infer_pair(value: Pair[T]) -> T:
+    raise NotImplementedError
+
+def check_pair(value: GradualPair[U]) -> None:
+    # TODO: error: [invalid-argument-type] "Argument to function `infer_pair` is incorrect"
+    # TODO: This revealed union is incorrect; the incompatible exact member types should make inference fail.
+    reveal_type(infer_pair(value))  # revealed: tuple[U@check_pair, Any] | tuple[U@check_pair, int]
+```
+
 ## Prefer specific compatible constraints over gradual constraints
 
 A gradual constraint can be compatible with a concrete argument and a more specific declared

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -370,6 +370,53 @@ def lower_bounds[T]():
     static_assert(union_type == intersection_constraint)
 ```
 
+### Intersection of two equality constraints
+
+A type variable cannot be exactly equal to two non-equivalent types. This is stronger than checking
+whether the types are disjoint: two classes can have a common subclass, which makes their
+upper-bound constraints compatible, but that subclass is not exactly equal to either class.
+
+```py
+from typing import Any
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+class Row: ...
+class RowTuple(Row, tuple[Any, ...]): ...
+
+def _[T, U, V]() -> None:
+    row = ConstraintSet.equality(T, Row)
+    tuple_ = ConstraintSet.equality(T, tuple[Any, ...])
+    static_assert(~(row & tuple_))
+
+    equivalent = row & row
+    static_assert(equivalent == row)
+
+    upper_bounds = ConstraintSet.upper_bound(T, Row) & ConstraintSet.upper_bound(T, tuple[Any, ...])
+    static_assert(not ~upper_bounds)
+
+    row_tuple = ConstraintSet.equality(T, RowTuple)
+    static_assert(row_tuple & upper_bounds == row_tuple)
+
+    gradual_mismatch = ConstraintSet.equality(T, list[Any]) & ConstraintSet.equality(T, list[int])
+    # TODO: This error is undesired; distinct exact equality constraints should be incompatible.
+    # error: [static-assert-error]
+    static_assert(~gradual_mismatch)
+
+    any_mismatch = ConstraintSet.equality(T, Any) & ConstraintSet.equality(T, int)
+    # TODO: This error is undesired; distinct exact equality constraints should be incompatible.
+    # error: [static-assert-error]
+    static_assert(~any_mismatch)
+
+    symbolic_mismatch = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, int])
+    # TODO: This error is undesired; no specialization of `U` makes these exact bounds equivalent.
+    # error: [static-assert-error]
+    static_assert(~symbolic_mismatch)
+
+    symbolic_match = ConstraintSet.equality(T, list[U]) & ConstraintSet.equality(T, list[V])
+    static_assert(not ~symbolic_match)
+```
+
 ### Intersection of a range and a negated range
 
 The bounds of the range constraint provide a range of types that should be included; the bounds of

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -399,18 +399,12 @@ def _[T, U, V]() -> None:
     static_assert(row_tuple & upper_bounds == row_tuple)
 
     gradual_mismatch = ConstraintSet.equality(T, list[Any]) & ConstraintSet.equality(T, list[int])
-    # TODO: This error is undesired; distinct exact equality constraints should be incompatible.
-    # error: [static-assert-error]
     static_assert(~gradual_mismatch)
 
     any_mismatch = ConstraintSet.equality(T, Any) & ConstraintSet.equality(T, int)
-    # TODO: This error is undesired; distinct exact equality constraints should be incompatible.
-    # error: [static-assert-error]
     static_assert(~any_mismatch)
 
     symbolic_mismatch = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, int])
-    # TODO: This error is undesired; no specialization of `U` makes these exact bounds equivalent.
-    # error: [static-assert-error]
     static_assert(~symbolic_mismatch)
 
     symbolic_match = ConstraintSet.equality(T, list[U]) & ConstraintSet.equality(T, list[V])

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1878,6 +1878,12 @@ impl<'db> ConstraintBounds<'db> {
         self.upper.is_some()
     }
 
+    fn as_equality(self) -> Option<Type<'db>> {
+        let lower = self.lower?;
+        let upper = self.upper?;
+        (lower == upper).then_some(lower)
+    }
+
     fn materialized_lower(self) -> Type<'db> {
         self.lower.unwrap_or(Type::Never)
     }
@@ -2497,6 +2503,17 @@ impl ConstraintId {
     ) -> IntersectionResult<'db> {
         let self_constraint = storage.constraint_data(self);
         let other_constraint = storage.constraint_data(other);
+
+        // A typevar cannot be exactly equal to two different types under any specialization. This
+        // is stronger than checking whether the types are disjoint: two classes can have a common
+        // subclass, which makes their upper-bound constraints compatible, but that subclass is not
+        // exactly equal to either class.
+        if let Some(left) = self_constraint.bounds.as_equality()
+            && let Some(right) = other_constraint.bounds.as_equality()
+            && !left.can_be_constraint_set_equivalent_to(db, env, right)
+        {
+            return IntersectionResult::Disjoint;
+        }
 
         // (s₁ ≤ α ≤ t₁) ∧ (s₂ ≤ α ≤ t₂) = (s₁ ∪ s₂) ≤ α ≤ (t₁ ∩ t₂))
         let lower = match (self_constraint.bounds.lower, other_constraint.bounds.lower) {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -765,6 +765,7 @@ impl<'db> Type<'db> {
             other,
             &ConstraintSetBuilder::new(),
             materialization_visitor,
+            TypeVarEvaluation::Eager,
         )
         .is_always_satisfied(db, materialization_visitor.env)
     }
@@ -782,6 +783,44 @@ impl<'db> Type<'db> {
             other,
             constraints,
             &materialization_visitor,
+            TypeVarEvaluation::Eager,
+        )
+    }
+
+    /// Returns whether `self` and `other` can be equivalent under some typevar specialization.
+    pub(super) fn can_be_constraint_set_equivalent_to(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        other: Type<'db>,
+    ) -> bool {
+        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| true, heap_size=ruff_memory_usage::heap_size)]
+        fn can_be_constraint_set_equivalent_to_impl<'db>(
+            db: &'db dyn Db,
+            types: TypePair<'db>,
+        ) -> bool {
+            let env = ProgramEnvironment::from_program(types.program(db));
+            let constraints = ConstraintSetBuilder::new();
+            let materialization_visitor = ApplyTypeMappingVisitor::new(&env);
+            !types
+                .first(db)
+                .when_equivalent_to_with_materialization_visitor(
+                    db,
+                    types.second(db),
+                    &constraints,
+                    &materialization_visitor,
+                    TypeVarEvaluation::Lazy,
+                )
+                .is_never_satisfied(db, &env)
+        }
+
+        if self == other {
+            return true;
+        }
+
+        can_be_constraint_set_equivalent_to_impl(
+            db,
+            TypePair::new(db, env.program(db), self, other),
         )
     }
 
@@ -791,6 +830,7 @@ impl<'db> Type<'db> {
         other: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         materialization_visitor: &ApplyTypeMappingVisitor<'_, 'db>,
+        typevar_evaluation: TypeVarEvaluation,
     ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
@@ -800,6 +840,7 @@ impl<'db> Type<'db> {
             constraints,
             given: ConstraintSet::from_bool(constraints, false),
             perform_expensive_checks: true,
+            typevar_evaluation,
             relation_visitor: &relation_visitor,
             disjointness_visitor: &disjointness_visitor,
             signature_relation_visitor: &signature_relation_visitor,
@@ -2650,6 +2691,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints: self.constraints,
             given: self.given,
             perform_expensive_checks: self.perform_expensive_checks,
+            typevar_evaluation: TypeVarEvaluation::Eager,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
@@ -2704,6 +2746,7 @@ pub(super) struct EquivalenceChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     given: ConstraintSet<'db, 'c>,
     perform_expensive_checks: bool,
+    typevar_evaluation: TypeVarEvaluation,
 
     // N.B. these fields are private to reduce the risk of
     // "double-visiting" a given pair of types. You should
@@ -2725,7 +2768,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         TypeRelationChecker {
             env: self.env,
             relation: TypeRelation::Redundancy { pure: true },
-            typevar_evaluation: TypeVarEvaluation::Eager,
+            typevar_evaluation: self.typevar_evaluation,
             constraints: self.constraints,
             context_tree: None,
             given: self.given,
@@ -2836,6 +2879,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             constraints: self.constraints,
             given: self.given,
             perform_expensive_checks: self.perform_expensive_checks,
+            typevar_evaluation: TypeVarEvaluation::Eager,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,


### PR DESCRIPTION
This fixes a small bug in our intersection of constraints: two _equality_ constraints are disjoint if the types in question are not equivalent.

When consider upper-bound constraints, this is not true: `(T ≤ Foo) ∧ (T ≤ Bar)` is not empty, since you could define a new class that inherits from both `Foo` and `Bar`.

With equality constraints, that doesn't matter: `(T = Foo) ∧ (T = Bar)` is empty. A joint subclass does not satisfy `T = Foo` or `T = Bar` individually, let alone their conjunction.