### PR TITLE
[ty] Run PEP 723 script synchronization on bounded workers

### DIFF
--- a/crates/ty/tests/cli/scripts.rs
+++ b/crates/ty/tests/cli/scripts.rs
@@ -1591,6 +1591,48 @@ mod uv_metadata {
         "
         );
 
+        // Starting with the script must not run its importer on the same Rayon worker while
+        // initialization is waiting for uv. The importer would wait for that initialization.
+        assert_cmd_snapshot!(
+            command_with_script_uv(&case)
+                .args(["b.py", "a.py"])
+                .env(EnvVars::TY_UV, "scripts")
+                .env(EnvVars::TY_MAX_PARALLELISM, "1"),
+            @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        All checks passed!
+
+        ----- stderr -----
+        "
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn synchronizes_multiple_scripts_with_one_worker() -> anyhow::Result<()> {
+        assert_uv_supports_script_metadata()?;
+
+        let script =
+            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n";
+        let case = CliTest::with_files([("first.py", script), ("second.py", script)])?;
+
+        assert_cmd_snapshot!(
+            command_with_script_uv(&case)
+                .args(["first.py", "second.py"])
+                .env(EnvVars::TY_MAX_PARALLELISM, "1"),
+            @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        All checks passed!
+
+        ----- stderr -----
+        "
+        );
+
         Ok(())
     }
 

--- a/crates/ty/tests/cli/scripts.rs
+++ b/crates/ty/tests/cli/scripts.rs
@@ -1591,6 +1591,27 @@ mod uv_metadata {
         "
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn synchronizes_imported_script_with_one_worker() -> anyhow::Result<()> {
+        assert_uv_supports_script_metadata()?;
+
+        let case = CliTest::with_files([
+            ("a.py", "from b import foo\nprint(foo)\n"),
+            (
+                "b.py",
+                r#"
+                # /// script
+                # requires-python = "==3.12.*"
+                # dependencies = []
+                # ///
+                foo = 1
+                "#,
+            ),
+        ])?;
+
         // Starting with the script must not run its importer on the same Rayon worker while
         // initialization is waiting for uv. The importer would wait for that initialization.
         assert_cmd_snapshot!(

--- a/crates/ty_project/src/script.rs
+++ b/crates/ty_project/src/script.rs
@@ -22,6 +22,7 @@ use crate::{Db, ProjectMetadata};
 
 mod environment;
 
+pub(crate) use environment::ScriptEnvironmentCacheKey;
 pub use environment::ScriptEnvironments;
 use environment::script_environment;
 

--- a/crates/ty_project/src/script/environment.rs
+++ b/crates/ty_project/src/script/environment.rs
@@ -17,15 +17,21 @@
 //! Updating that input invalidates semantic queries that depend on the script's Python version or
 //! module search paths, ensuring that checks are rerun after synchronization.
 
-use std::sync::{Arc, OnceLock};
+use std::hash::Hasher;
+use std::sync::Arc;
+use std::time::Duration;
 
+use parking_lot::{Condvar, Mutex, MutexGuard};
+use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_db::FxDashMap;
 use ruff_db::files::File;
 use ruff_db::system::SystemPathBuf;
 
 use super::script_tag;
-use crate::uv::{MetadataTarget, Uv, UvMetadata, UvMetadataError, uv_executable_error};
+use crate::uv::{ScriptSyncTask, Uv, UvMetadata, UvSyncService};
 use crate::{Db, ProgressReporter, UseUv};
+
+const CANCELLATION_CHECK_INTERVAL: Duration = Duration::from_millis(1);
 
 /// Returns the Salsa input representing `file`'s script environment.
 ///
@@ -33,9 +39,13 @@ use crate::{Db, ProgressReporter, UseUv};
 /// function never invokes uv; it returns the [`ScriptEnvironment`] input so semantic queries can
 /// depend on it.
 ///
-/// If no [`ScriptEnvironment`] exists, creates one without uv metadata. Its identity remains the
-/// same when synchronization later provides that metadata, just as a [`File`] continues to identify
-/// the same path when a previously nonexistent file is created.
+/// If no [`ScriptEnvironment`] exists, creates one without uv metadata. Its identity
+/// remains the same when synchronization later provides that metadata, just as a [`File`]
+/// continues to identify the same path when a previously nonexistent file is created. Updating
+/// the existing input ensures Salsa invalidates queries that read it before initialization.
+///
+/// If a blocking synchronization is already running, waits for it to finish instead of creating
+/// a second [`ScriptEnvironment`] input.
 ///
 /// Returns `None` if script integration is disabled or the script is not an actual file on disk.
 pub(super) fn script_environment(db: &dyn Db, file: File) -> Option<ScriptEnvironment> {
@@ -58,11 +68,14 @@ impl ScriptEnvironments {
         }
     }
 
-    /// Initializes `file`'s environment before a project check analyzes it.
+    /// Initializes `file`'s environment before checking it.
     ///
-    /// Project checks can discover scripts while iterating their files, so they initialize those
-    /// scripts synchronously. This may invoke uv and creates the [`ScriptEnvironment`] input that
-    /// semantic queries depend on.
+    /// Discovering scripts requires reading file contents, so initializing every environment before
+    /// a project check would require eagerly inspecting every candidate file.
+    ///
+    /// Instead, project checks initialize virtual environments lazily as they encounter scripts.
+    /// If no [`ScriptEnvironment`] exists, this method synchronizes the virtual environment and
+    /// waits for uv before creating the input. An existing [`ScriptEnvironment`] is reused.
     ///
     /// Concurrent callers wait for the initial environment creation to finish.
     pub(crate) fn initialize_blocking(
@@ -71,39 +84,69 @@ impl ScriptEnvironments {
         file: File,
         reporter: &dyn ProgressReporter,
     ) {
-        if !self.is_enabled() || script_tag(db, file).is_none() {
+        if !self.is_enabled() {
             return;
         }
 
-        let Some(path) = file.path(db).as_system_path() else {
+        let Some(task) = script_sync_task(db, file) else {
             return;
         };
+        let entry = self.entry(file);
 
-        self.get_or_init_with(file, || {
-            let python = script_python(db);
+        let mut state = entry.state.lock();
+        loop {
+            match &*state {
+                ScriptEnvironmentState::Current { .. } => {
+                    return;
+                }
 
-            let _progress = reporter.for_script(db, file);
+                // Another caller is synchronizing the virtual environment and will create its
+                // `ScriptEnvironment` input when uv finishes.
+                // Wait for that caller instead of starting a second synchronization.
+                ScriptEnvironmentState::InitializingBlocking { cache_key } => {
+                    debug_assert_eq!(
+                        *cache_key,
+                        task.request.cache_key(),
+                        "concurrent initializations must use the same script environment cache key"
+                    );
+                    // If the other caller is cancelled, it restores the entry to `Vacant`. Check the
+                    // state again after waiting so this caller can initialize the environment instead.
+                    state = entry.wait_until_initialized(db, state);
+                }
 
-            let metadata = Uv::new(db.system())
-                .map_err(uv_executable_error)
-                .map_err(UvMetadataError::Invocation)
-                .and_then(|uv| {
-                    uv.metadata(
-                        db.system(),
-                        MetadataTarget::Script {
-                            path,
-                            python: python.as_deref(),
-                        },
-                    )
-                });
+                ScriptEnvironmentState::Vacant => {
+                    let cache_key = task.request.cache_key();
+                    let claim = InitializationClaim::new(&entry, state, cache_key);
 
-            match metadata {
-                Ok(metadata) => ScriptEnvironment::new(db, Some(metadata), None),
-                Err(error) => {
-                    ScriptEnvironment::new(db, None, Some(error.to_string().into_boxed_str()))
+                    db.unwind_if_revision_cancelled();
+                    tracing::debug!(
+                        "Initializing script environment for `{}`",
+                        task.request.path()
+                    );
+
+                    // Run uv and show progress until the synchronization finishes.
+                    let output = {
+                        let _progress = reporter.for_script(db, task.file);
+                        self.inner.sync_service.run_blocking(db, task)
+                    };
+
+                    // Create the `ScriptEnvironment` input from uv's output, retaining its cache key
+                    // and any initialization error.
+                    let (uv_metadata, initialization_error) = parse_metadata_output(db, output);
+                    let environment = ScriptEnvironment::new(
+                        db,
+                        Some(cache_key),
+                        uv_metadata,
+                        initialization_error,
+                    );
+
+                    // Store the `ScriptEnvironment` input and wake waiting callers. Dropping the
+                    // claim without completing it would instead restore the entry to `Vacant`.
+                    claim.complete(environment);
+                    return;
                 }
             }
-        });
+        }
     }
 
     fn environment(&self, db: &dyn Db, file: File) -> Option<ScriptEnvironment> {
@@ -111,26 +154,45 @@ impl ScriptEnvironments {
             return None;
         }
 
-        Some(self.get_or_init_with(file, || ScriptEnvironment::new(db, None, None)))
-    }
+        let entry = self.entry(file);
+        let mut state = entry.state.lock();
 
-    fn get_or_init_with(
-        &self,
-        file: File,
-        initialize: impl FnOnce() -> ScriptEnvironment,
-    ) -> ScriptEnvironment {
-        // Drop the map's shard guard before invoking uv so unrelated scripts sharing that shard
-        // can initialize concurrently.
-        let environment = Arc::clone(self.inner.by_file.entry(file).or_default().value());
-        *environment.get_or_init(initialize)
+        loop {
+            match *state {
+                ScriptEnvironmentState::Vacant => {
+                    let environment = ScriptEnvironment::new(db, None, None, None);
+                    *state = ScriptEnvironmentState::Current { environment };
+                    return Some(environment);
+                }
+                ScriptEnvironmentState::InitializingBlocking { .. } => {
+                    state = entry.wait_until_initialized(db, state);
+                }
+                ScriptEnvironmentState::Current { environment } => {
+                    return Some(environment);
+                }
+            }
+        }
     }
 
     fn is_enabled(&self) -> bool {
         self.inner.use_uv.script_environments_enabled()
     }
+
+    fn entry(&self, file: File) -> Arc<ScriptEnvironmentEntry> {
+        // Return an owned entry so the map's shard lock is released before the caller waits
+        // for synchronization. Otherwise, unrelated scripts in the same shard would also be blocked.
+        Arc::clone(self.inner.by_file.entry(file).or_default().value())
+    }
 }
 
 impl std::panic::RefUnwindSafe for ScriptEnvironments {}
+
+/// Identifies when a script's environment needs to be synchronized.
+///
+/// Matching keys allow an existing environment or synchronization request to be reused without
+/// invoking uv again. The key changes when the script's PEP 723 metadata or configured Python
+/// override changes; edits elsewhere in the script leave it unchanged.
+pub(crate) type ScriptEnvironmentCacheKey = u64;
 
 /// The stable Salsa identity for a script's environment.
 ///
@@ -138,10 +200,20 @@ impl std::panic::RefUnwindSafe for ScriptEnvironments {}
 /// semantic analysis reaches a script before synchronization, [`script_environment`] creates
 /// this input without invoking uv.
 ///
-/// Keeping its identity stable ensures that Salsa invalidates queries when the environment's
-/// Python version, module search paths, or initialization error changes.
+/// Later synchronization updates the same input. Keeping its identity stable ensures that Salsa
+/// invalidates queries which observed the earlier
+/// environment when its Python version, module search paths, or initialization error changes.
 #[salsa::input(heap_size=ruff_memory_usage::heap_size)]
+#[derive(Debug)]
 pub(super) struct ScriptEnvironment {
+    /// The cache key of the most recently completed synchronization.
+    ///
+    /// `None` means the environment has not been synchronized yet. Both successful and failed
+    /// synchronizations store their cache key, preventing repeated uv invocations until the script
+    /// metadata or Python override changes.
+    #[returns(copy)]
+    synchronized_cache_key: Option<ScriptEnvironmentCacheKey>,
+
     /// The environment metadata returned by the most recent successful synchronization.
     ///
     /// `None` means the environment has not been synchronized or synchronization failed.
@@ -159,7 +231,150 @@ pub(super) struct ScriptEnvironment {
 #[derive(Default)]
 struct ScriptEnvironmentsInner {
     use_uv: UseUv,
-    by_file: FxDashMap<File, Arc<OnceLock<ScriptEnvironment>>>,
+    by_file: FxDashMap<File, Arc<ScriptEnvironmentEntry>>,
+    sync_service: UvSyncService,
+}
+
+#[derive(Default)]
+struct ScriptEnvironmentEntry {
+    state: Mutex<ScriptEnvironmentState>,
+
+    /// Wakes callers when a blocking synchronization finishes or is cancelled.
+    ///
+    /// A cancelled synchronization creates no [`ScriptEnvironment`], allowing a waiting caller
+    /// to retry.
+    initialized: Condvar,
+}
+
+impl ScriptEnvironmentEntry {
+    /// Waits for a blocking synchronization to finish or be cancelled.
+    ///
+    /// Database updates cancel running operations and wait for them to finish before modifying
+    /// Salsa inputs. Periodically checking for cancellation allows a waiting caller to unwind;
+    /// otherwise, the update could wait indefinitely for an operation blocked on this condition.
+    ///
+    /// Does not run other Rayon tasks while waiting: a nested task could depend on an
+    /// initialization suspended on the same worker's stack.
+    fn wait_until_initialized<'entry>(
+        &'entry self,
+        db: &dyn Db,
+        mut state: MutexGuard<'entry, ScriptEnvironmentState>,
+    ) -> MutexGuard<'entry, ScriptEnvironmentState> {
+        loop {
+            // A database update cannot proceed until this cancelled operation unwinds.
+            db.unwind_if_revision_cancelled();
+            if !matches!(*state, ScriptEnvironmentState::InitializingBlocking { .. }) {
+                return state;
+            }
+
+            self.initialized
+                .wait_for(&mut state, CANCELLATION_CHECK_INTERVAL);
+        }
+    }
+}
+
+/// The synchronization state of one script environment.
+///
+/// Ensures that at most one blocking synchronization runs for a script at a time.
+#[derive(Default)]
+enum ScriptEnvironmentState {
+    /// No [`ScriptEnvironment`] exists and no synchronization is running.
+    ///
+    /// This is the initial state. A cancelled blocking synchronization also restores this state,
+    /// allowing another caller to initialize the environment.
+    #[default]
+    Vacant,
+
+    /// A caller is waiting for uv to initialize the script's environment.
+    ///
+    /// The caller waits for uv, creates the [`ScriptEnvironment`] input from its result, and wakes
+    /// any other callers waiting for the same script.
+    InitializingBlocking {
+        /// Identifies the script metadata and Python override passed to uv.
+        cache_key: ScriptEnvironmentCacheKey,
+    },
+
+    /// The last synchronized environment, or the default environment before synchronization.
+    ///
+    /// A completed synchronization stores its metadata and any initialization error in the
+    /// [`ScriptEnvironment`] input. If semantic analysis reaches a script before synchronization
+    /// has been requested, [`script_environment`] creates an input without uv metadata instead.
+    ///
+    /// The environment does not necessarily match the latest script metadata.
+    Current { environment: ScriptEnvironment },
+}
+
+/// Ensures a blocking synchronization always releases its claim on the script.
+///
+/// The synchronization runs without holding the entry's state lock. On completion, this guard
+/// stores the new [`ScriptEnvironment`] and wakes waiting callers.
+///
+/// If the caller is cancelled or unwinds before completing synchronization, dropping the guard
+/// restores the entry to `Vacant` and wakes waiting callers so another caller can retry.
+#[must_use]
+struct InitializationClaim<'entry>(Option<&'entry ScriptEnvironmentEntry>);
+
+impl<'entry> InitializationClaim<'entry> {
+    fn new(
+        entry: &'entry ScriptEnvironmentEntry,
+        mut state: MutexGuard<'entry, ScriptEnvironmentState>,
+        cache_key: ScriptEnvironmentCacheKey,
+    ) -> Self {
+        *state = ScriptEnvironmentState::InitializingBlocking { cache_key };
+        Self(Some(entry))
+    }
+
+    fn complete(mut self, environment: ScriptEnvironment) {
+        self.finish(ScriptEnvironmentState::Current { environment });
+    }
+
+    fn finish(&mut self, next: ScriptEnvironmentState) {
+        if let Some(entry) = self.0.take() {
+            let mut state = entry.state.lock();
+            debug_assert!(matches!(
+                *state,
+                ScriptEnvironmentState::InitializingBlocking { .. }
+            ));
+            *state = next;
+            drop(state);
+            entry.initialized.notify_all();
+        }
+    }
+}
+
+impl Drop for InitializationClaim<'_> {
+    fn drop(&mut self) {
+        self.finish(ScriptEnvironmentState::Vacant);
+    }
+}
+
+fn parse_metadata_output(
+    db: &dyn Db,
+    output: std::io::Result<std::process::Output>,
+) -> (Option<UvMetadata>, Option<Box<str>>) {
+    match Uv::parse_metadata_output(db.system(), output) {
+        Ok(metadata) => (Some(metadata), None),
+        Err(error) => (None, Some(error.to_string().into_boxed_str())),
+    }
+}
+
+fn script_sync_task(db: &dyn Db, file: File) -> Option<ScriptSyncTask> {
+    let path = file.path(db).as_system_path()?;
+    let tag = script_tag(db, file)?;
+    let python = script_python(db);
+
+    // Hash the metadata text directly to avoid parsing it solely to compute the cache key.
+    // Formatting-only metadata changes may therefore trigger an unnecessary synchronization.
+    let mut hasher = CacheKeyHasher::new();
+    tag.metadata().cache_key(&mut hasher);
+    python.cache_key(&mut hasher);
+
+    Some(ScriptSyncTask::new(
+        file,
+        path.to_path_buf(),
+        python,
+        hasher.finish(),
+    ))
 }
 
 fn script_python(db: &dyn Db) -> Option<SystemPathBuf> {

--- a/crates/ty_project/src/uv.rs
+++ b/crates/ty_project/src/uv.rs
@@ -1,4 +1,4 @@
-//! Runs uv commands and parses their metadata output.
+//! Runs uv commands and manages background script synchronization.
 
 use std::process::Output;
 
@@ -7,8 +7,10 @@ use ty_combine::Combine;
 use ty_static::EnvVars;
 
 pub(crate) use metadata::{UvMetadata, UvMetadataError};
+pub(crate) use sync::{ScriptSyncTask, UvSyncService};
 
 mod metadata;
+mod sync;
 
 /// Controls which uv integrations ty uses.
 #[derive(
@@ -62,6 +64,7 @@ impl Combine for UseUv {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct Uv {
     executable: String,
 }

--- a/crates/ty_project/src/uv/sync.rs
+++ b/crates/ty_project/src/uv/sync.rs
@@ -1,0 +1,317 @@
+use std::process::Output;
+use std::sync::{Arc, OnceLock, Weak};
+use std::time::Duration;
+
+use crossbeam::channel::{Receiver, RecvTimeoutError, SendTimeoutError, Sender};
+use ruff_db::files::File;
+use ruff_db::system::{CommandExecutor, System, SystemPathBuf};
+
+use super::{MetadataTarget, Uv, unsupported_command_execution, uv_executable_error};
+use crate::Db;
+use crate::script::ScriptEnvironmentCacheKey;
+
+/// Synchronizes standalone script environments with uv.
+///
+/// A project stores one service in its shared `ScriptEnvironments`, so every database snapshot uses
+/// the same bounded request queue and workers. The queue applies backpressure to producers, while
+/// the number of workers limits concurrent uv processes.
+///
+/// The service deliberately owns neither a database nor its `System`. A uv command can outlive the
+/// check that scheduled it, while a database update must wait for all instances to be dropped.
+/// Retaining the scheduling database could therefore prevent that update from completing. Workers
+/// retain only the configured uv executable and a detached command executor.
+///
+/// The service only owns scheduling of `uv metadata` calls.
+/// [`ScriptEnvironments`](crate::ScriptEnvironments) is the higher level abstraction that
+/// application code should use.
+#[derive(Default)]
+pub(crate) struct UvSyncService {
+    workers: OnceLock<std::io::Result<UvWorkerPool>>,
+}
+
+impl UvSyncService {
+    /// Synchronizes one script and waits for its result.
+    ///
+    /// Blocks the calling thread, periodically checking for Salsa cancellation.
+    ///
+    /// This must not yield to Rayon. Another checking task could import this script and wait
+    /// for its initialization, preventing the current task from resuming to finish it.
+    /// The uv workers run on separate threads and can make progress while this thread waits.
+    pub(crate) fn run_blocking(
+        &self,
+        db: &dyn Db,
+        task: ScriptSyncTask,
+    ) -> std::io::Result<Output> {
+        let workers = self.worker_pool(db.system())?;
+
+        // Dropping the guard during Salsa unwinding cancels a job that hasn't started yet.
+        let (_cancellation_guard, cancellation) = UvJobCancellation::new();
+
+        // Each job produces one result. Buffering that result lets the worker publish it without
+        // waiting for this caller to be scheduled again.
+        let (result_sender, result_receiver) = crossbeam::channel::bounded(1);
+
+        let mut job = UvJob {
+            task,
+            mode: UvJobMode::Blocking {
+                result_sender,
+                cancellation,
+            },
+            span: tracing::Span::current(),
+        };
+
+        // Queue the job, checking for Salsa cancellation while waiting for capacity.
+        loop {
+            match workers.jobs.send_timeout(job, POLL_TIMEOUT) {
+                Ok(()) => break,
+                Err(SendTimeoutError::Timeout(pending)) => {
+                    db.unwind_if_revision_cancelled();
+                    job = pending;
+                }
+                Err(SendTimeoutError::Disconnected(_)) => return Err(worker_disconnected()),
+            }
+        }
+
+        // Wait for the result.
+        loop {
+            match result_receiver.recv_timeout(POLL_TIMEOUT) {
+                Ok(output) => return output,
+                Err(RecvTimeoutError::Timeout) => {
+                    db.unwind_if_revision_cancelled();
+                }
+                Err(RecvTimeoutError::Disconnected) => return Err(worker_disconnected()),
+            }
+        }
+    }
+
+    fn worker_pool(&self, system: &dyn System) -> std::io::Result<&UvWorkerPool> {
+        match self.workers.get_or_init(|| {
+            let command_executor = system
+                .command_executor()
+                .ok_or_else(unsupported_command_execution)?;
+            let uv = Uv::new(system).map_err(uv_executable_error)?;
+            UvWorkerPool::new(command_executor, &uv)
+        }) {
+            Ok(workers) => Ok(workers),
+            Err(error) => Err(std::io::Error::new(error.kind(), error.to_string())),
+        }
+    }
+}
+
+impl std::panic::RefUnwindSafe for UvSyncService {}
+
+/// A standalone script environment that should be synchronized by uv.
+#[derive(Debug)]
+pub(crate) struct ScriptSyncTask {
+    /// The script file
+    pub(crate) file: File,
+    pub(crate) request: ScriptSyncRequest,
+}
+
+impl ScriptSyncTask {
+    pub(crate) fn new(
+        file: File,
+        path: SystemPathBuf,
+        python: Option<SystemPathBuf>,
+        cache_key: ScriptEnvironmentCacheKey,
+    ) -> Self {
+        Self {
+            file,
+            request: ScriptSyncRequest(Arc::new(ScriptSyncRequestData {
+                path,
+                python,
+                cache_key,
+            })),
+        }
+    }
+}
+
+/// The immutable inputs to one uv synchronization.
+///
+/// The entry state and worker retain cheap clones because a job can outlive the Salsa snapshot that
+/// scheduled it.
+#[derive(Clone, Debug)]
+pub(crate) struct ScriptSyncRequest(Arc<ScriptSyncRequestData>);
+
+impl ScriptSyncRequest {
+    pub(crate) fn path(&self) -> &ruff_db::system::SystemPath {
+        &self.0.path
+    }
+
+    /// The `--python` argument
+    pub(crate) fn python(&self) -> Option<&ruff_db::system::SystemPath> {
+        self.0.python.as_deref()
+    }
+
+    pub(crate) fn cache_key(&self) -> ScriptEnvironmentCacheKey {
+        self.0.cache_key
+    }
+}
+
+#[derive(Debug)]
+struct ScriptSyncRequestData {
+    path: SystemPathBuf,
+    python: Option<SystemPathBuf>,
+    cache_key: ScriptEnvironmentCacheKey,
+}
+
+const MAX_UV_WORKERS: usize = 2;
+const MAX_QUEUED_UV_TASKS: usize = 8;
+/// Maximum time to block before checking for Salsa cancellation.
+const POLL_TIMEOUT: Duration = Duration::from_millis(1);
+
+/// A bounded worker pool for synchronizing standalone script environments with uv.
+struct UvWorkerPool {
+    /// Disconnects when the pool is dropped so workers abandon buffered jobs.
+    ///
+    /// This field precedes `jobs` so shutdown wins if dropping the pool makes both channels
+    /// ready simultaneously.
+    _shutdown: Sender<()>,
+
+    /// Sender end of the pool <-> worker communication.
+    ///
+    /// Used to submit jobs to the workers.
+    jobs: Sender<UvJob>,
+}
+
+impl UvWorkerPool {
+    /// Creates worker threads using a detached command executor and resolved uv executable.
+    fn new(command_executor: &dyn CommandExecutor, uv: &Uv) -> std::io::Result<Self> {
+        let (jobs, job_receiver) = crossbeam::channel::bounded(MAX_QUEUED_UV_TASKS);
+        let (shutdown, shutdown_receiver) = crossbeam::channel::bounded(0);
+
+        let workers = ruff_db::max_parallelism().get().min(MAX_UV_WORKERS);
+
+        tracing::debug!("Starting {workers} uv synchronization workers");
+
+        for index in 0..workers {
+            let worker = UvWorker {
+                executor: command_executor.dyn_clone(),
+                uv: uv.clone(),
+                jobs: job_receiver.clone(),
+                shutdown: shutdown_receiver.clone(),
+            };
+
+            let _ = std::thread::Builder::new()
+                .name(format!("ty-uv-sync-{index}"))
+                .spawn(move || worker.run())?;
+        }
+
+        Ok(Self {
+            jobs,
+            _shutdown: shutdown,
+        })
+    }
+}
+
+struct UvWorker {
+    executor: Box<dyn CommandExecutor>,
+    uv: Uv,
+
+    /// Receiver end of the pool <-> worker channel.
+    ///
+    /// Used to retrieve jobs.
+    jobs: Receiver<UvJob>,
+
+    /// Channel used as a signal when the [`UvWorkerPool`] disconnects.
+    ///
+    /// When `jobs` disconnects, the receiver still yields all elements
+    /// that are already queued, before returning `Disconnect`. We use this
+    /// always-empty channel to be informed immediately if the worker pool disconnects,
+    /// to avoid processing any unnecessary items.
+    shutdown: Receiver<()>,
+}
+
+impl UvWorker {
+    fn run(self) {
+        loop {
+            let job = crossbeam::channel::select_biased! {
+                // The worker pool disconnected, exit immetiatley
+                recv(self.shutdown) -> _ => return,
+                recv(self.jobs) -> job => {
+                    let Ok(job) = job else {
+                        return;
+                    };
+                    job
+                }
+            };
+
+            // Don't schedule jobs that have been cancelled in the meantime (salsa cancellation).
+            let UvJobMode::Blocking { cancellation, .. } = &job.mode;
+            if cancellation.is_cancelled() {
+                tracing::debug!(
+                    "Discarded cancelled script synchronization for `{}`",
+                    job.task.request.path()
+                );
+                continue;
+            }
+
+            // Run the job
+            let output = {
+                let _span = job.span.enter();
+                tracing::info!("Synchronizing script `{}`", job.task.request.path());
+
+                let target = MetadataTarget::Script {
+                    path: job.task.request.path(),
+                    python: job.task.request.python(),
+                };
+
+                self.uv.execute(&*self.executor, target)
+            };
+
+            // Send the result
+            let UvJob { mode, .. } = job;
+            match mode {
+                UvJobMode::Blocking { result_sender, .. } => {
+                    // The receiver disappears when the blocking caller is cancelled.
+                    let _ = result_sender.send(output);
+                }
+            }
+        }
+    }
+}
+
+struct UvJob {
+    task: ScriptSyncTask,
+    mode: UvJobMode,
+    span: tracing::Span,
+}
+
+enum UvJobMode {
+    Blocking {
+        /// Sender end of the channel that communicates with the thread waiting on this result (blocking).
+        result_sender: Sender<std::io::Result<Output>>,
+        /// Lets a worker discard a queued job after its blocking Salsa operation is cancelled.
+        cancellation: UvJobCancellation,
+    },
+}
+
+/// Cancellation token for a blocking uv operation.
+///
+/// The scheduling operation holds a [`UvJobCancellationGuard`] while the queued job holds this weak
+/// token. Salsa cancellation unwinds the scheduling operation and drops the guard, allowing the
+/// worker to discard the job without retaining the database or explicitly updating shared state.
+/// An already running uv process is not interrupted.
+struct UvJobCancellation(Weak<()>);
+
+impl UvJobCancellation {
+    fn new() -> (UvJobCancellationGuard, Self) {
+        let guard = UvJobCancellationGuard(Arc::new(()));
+        let cancellation = Self(Arc::downgrade(&guard.0));
+        (guard, cancellation)
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.0.upgrade().is_none()
+    }
+}
+
+/// Keeps a blocking uv job active while its scheduling operation is running.
+struct UvJobCancellationGuard(Arc<()>);
+
+fn worker_disconnected() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::BrokenPipe,
+        "uv synchronization worker terminated unexpectedly",
+    )
+}


### PR DESCRIPTION
## Summary

This PR moves the `uv metadata` synchronization for scripts to a background worker in preparation for watch and LSP support. 

Up to now, the metadata synchronization always ran blocking (with some form of polling). This works when checking an entire project, because we can't finish checking until the synchronization finished. However, we'll need an asynchronous (in the background) syncing mechanism for `--watch` and the LSP to avoid blocking the main loops (which would result in rust-analyzer like stalls where everything waits on `cargo check` to complete). 

* CLI: The initial synchronization continues to run in blocking mode (because we need the environment to check the file). Updating the environment after changes will run on the background thread to ensure ty remains responsive to other files changing and `Ctrl + C`
* LSP: I'll talk more about this in the LSP PR but things are more complicated here. Only the `diagnosticMode: Workspace` uses blocking synchronization. All other synchronizations run async in the background when a file is opened or saved to avoid blocking other LSP operations (for other files) or operations that don't necessarily need a fully initialized environment (e.g. semantic tokens, go to def within the file, ...). 


## Concurrency 

I decided to limit concurrent `uv metadata` runs to 2 instances. There's no good reason for 2, and we may want to play with this going forward. It may also be something where uv will take more control because ty really can't know what the ideal parallelism is. It depends on:

* How many venvs are warm vs how many are cold?
* How good is the network connectivity? 

Ultimately, it feels like uv can make the best scheduling decisions. 

## Test plan

https://github.com/user-attachments/assets/ce078f4f-508a-4fe4-a6c3-239bc4312da4

