### PR TITLE
[ty] Reduce Stmt size to 80 bytes

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -53,14 +53,14 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 is_async,
                 name,
                 decorator_list,
-                returns,
-                parameters,
+                signature,
                 body,
-                type_params: _,
                 range: _,
                 node_index: _,
             },
         ) => {
+            let parameters = &signature.parameters;
+            let returns = &signature.returns;
             if checker.is_rule_enabled(Rule::DjangoNonLeadingReceiverDecorator) {
                 flake8_django::rules::non_leading_receiver_decorator(checker, decorator_list);
             }
@@ -381,14 +381,16 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
         Stmt::ClassDef(
             class_def @ ast::StmtClassDef {
                 name,
-                arguments,
-                type_params: _,
+                signature,
                 decorator_list,
                 body,
                 range: _,
                 node_index: _,
             },
         ) => {
+            let arguments = signature
+                .as_ref()
+                .and_then(|signature| signature.arguments.as_ref());
             if checker.is_rule_enabled(Rule::NoClassmethodDecorator) {
                 pylint::rules::no_classmethod_decorator(checker, stmt);
             }
@@ -460,7 +462,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pep8_naming::rules::error_suffix_on_exception_name(
                     checker,
                     stmt,
-                    arguments.as_deref(),
+                    arguments,
                     name,
                     &checker.settings().pep8_naming.ignore_names,
                 );
@@ -471,11 +473,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     Rule::EmptyMethodWithoutAbstractDecorator,
                 ]) {
                     flake8_bugbear::rules::abstract_base_class(
-                        checker,
-                        stmt,
-                        name,
-                        arguments.as_deref(),
-                        body,
+                        checker, stmt, name, arguments, body,
                     );
                 }
             }
@@ -509,7 +507,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 flake8_builtins::rules::builtin_variable_shadowing(checker, name, name.range());
             }
             if checker.is_rule_enabled(Rule::DuplicateBases) {
-                pylint::rules::duplicate_bases(checker, name, arguments.as_deref());
+                pylint::rules::duplicate_bases(checker, name, arguments);
             }
             if checker.is_rule_enabled(Rule::NoSlotsInStrSubclass) {
                 flake8_slots::rules::no_slots_in_str_subclass(checker, stmt, class_def);

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -953,8 +953,8 @@ impl SemanticSyntaxContext for Checker<'_> {
 
     fn is_bound_parameter(&self, name: &str) -> bool {
         match self.semantic.current_scope().kind {
-            ScopeKind::Function(ast::StmtFunctionDef { parameters, .. }) => {
-                parameters.includes(name)
+            ScopeKind::Function(ast::StmtFunctionDef { signature, .. }) => {
+                signature.parameters.includes(name)
             }
             ScopeKind::Class(_)
             | ScopeKind::Lambda(_)
@@ -1250,13 +1250,16 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 function_def @ ast::StmtFunctionDef {
                     name,
                     body,
-                    parameters,
+                    signature,
                     decorator_list,
-                    returns,
-                    type_params,
                     ..
                 },
             ) => {
+                let ast::FunctionSignature {
+                    parameters,
+                    returns,
+                    type_params,
+                } = signature.as_ref();
                 // Visit the decorators and arguments, but avoid the body, which will be
                 // deferred.
                 for decorator in decorator_list {
@@ -1390,12 +1393,17 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 class_def @ ast::StmtClassDef {
                     name,
                     body,
-                    arguments,
+                    signature,
                     decorator_list,
-                    type_params,
                     ..
                 },
             ) => {
+                let type_params = signature
+                    .as_ref()
+                    .and_then(|signature| signature.type_params.as_ref());
+                let arguments = signature
+                    .as_ref()
+                    .and_then(|signature| signature.arguments.as_ref());
                 for decorator in decorator_list {
                     self.visit_decorator(decorator);
                 }
@@ -3109,7 +3117,7 @@ impl<'a> Checker<'a> {
                 let stmt = self.semantic.current_statement();
 
                 let Stmt::FunctionDef(ast::StmtFunctionDef {
-                    body, parameters, ..
+                    body, signature, ..
                 }) = stmt
                 else {
                     unreachable!("Expected Stmt::FunctionDef")
@@ -3117,7 +3125,7 @@ impl<'a> Checker<'a> {
 
                 self.with_semantic_checker(|semantic, context| semantic.visit_stmt(stmt, context));
 
-                self.visit_parameters(parameters);
+                self.visit_parameters(&signature.parameters);
                 // Set the docstring state before visiting the function body.
                 self.docstring_state = DocstringState::Expected(ExpectedDocstringKind::Function);
                 self.visit_body(body);

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -521,11 +521,12 @@ fn is_kwarg_parameter(semantic: &SemanticModel, name: &ExprName) -> bool {
         return false;
     };
     let binding = semantic.binding(binding_id);
-    let Some(Stmt::FunctionDef(StmtFunctionDef { parameters, .. })) = binding.statement(semantic)
+    let Some(Stmt::FunctionDef(StmtFunctionDef { signature, .. })) = binding.statement(semantic)
     else {
         return false;
     };
-    parameters
+    signature
+        .parameters
         .kwarg
         .as_deref()
         .is_some_and(|kwarg| kwarg.name.as_str() == name.id.as_str())

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -644,11 +644,11 @@ pub(crate) fn definition(
         is_async: _,
         decorator_list,
         name,
-        type_params: _,
-        parameters,
-        returns,
+        signature,
         body,
     } = function;
+    let parameters = &signature.parameters;
+    let returns = &signature.returns;
 
     let is_method = definition.is_method();
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -87,8 +87,9 @@ impl<'a> Visitor<'a> for SuspiciousVariablesVisitor<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::FunctionDef(ast::StmtFunctionDef {
-                parameters, body, ..
+                signature, body, ..
             }) => {
+                let parameters = &signature.parameters;
                 // Collect all loaded variable names.
                 let mut visitor = LoadedNamesVisitor::default();
                 visitor.visit_body(body);

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
@@ -129,14 +129,13 @@ pub(crate) fn custom_type_var_instead_of_self(checker: &Checker, binding: &Bindi
 
     let ast::StmtFunctionDef {
         name: function_name,
-        parameters,
-        returns,
+        signature,
         decorator_list,
-        type_params,
         ..
     } = function_def;
-
-    let type_params = type_params.as_deref();
+    let parameters = &signature.parameters;
+    let returns = &signature.returns;
+    let type_params = signature.type_params.as_deref();
 
     // Given, e.g., `def foo(self: _S, arg: bytes)`, extract `_S`.
     let Some(self_or_cls_parameter) = parameters.posonlyargs.iter().chain(&parameters.args).next()

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -136,9 +136,10 @@ pub(crate) fn bad_exit_annotation(checker: &Checker, function: &StmtFunctionDef)
         is_async,
         decorator_list,
         name,
-        parameters,
+        signature,
         ..
     } = function;
+    let parameters = &signature.parameters;
 
     let func_kind = match name.as_str() {
         "__exit__" if !is_async => FuncKind::Sync,
@@ -336,9 +337,10 @@ fn check_positional_args_for_overloaded_method(
     for function_def in &function_overloads {
         let StmtFunctionDef {
             is_async,
-            parameters,
+            signature,
             ..
         } = function_def;
+        let parameters = &signature.parameters;
 
         // If any overloads are an unexpected sync/async colour, don't do any checking
         if *is_async != kind.is_async() {
@@ -354,7 +356,7 @@ fn check_positional_args_for_overloaded_method(
             vararg: None,
             kwonlyargs,
             kwarg: None,
-        } = &**parameters
+        } = parameters
         else {
             return;
         };

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
@@ -102,7 +102,7 @@ impl Violation for GenericNotLastBaseClass {
 
 /// PYI059
 pub(crate) fn generic_not_last_base_class(checker: &Checker, class_def: &ast::StmtClassDef) {
-    let Some(bases) = class_def.arguments.as_deref() else {
+    let Some(bases) = class_def.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -261,8 +261,8 @@ fn replace_with_self_fix(
     let mut others = Vec::with_capacity(2);
 
     let remove_first_argument_type_hint = || -> Option<Edit> {
-        let ast::StmtFunctionDef { parameters, .. } = stmt.as_function_def_stmt()?;
-        let first = parameters.iter().next()?;
+        let ast::StmtFunctionDef { signature, .. } = stmt.as_function_def_stmt()?;
+        let first = signature.parameters.iter().next()?;
         let annotation = first.annotation()?;
 
         is_class_reference(semantic, annotation, &class_def.name)

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
@@ -47,17 +47,17 @@ pub(crate) fn str_or_repr_defined_in_stub(checker: &Checker, stmt: &Stmt) {
     let Stmt::FunctionDef(ast::StmtFunctionDef {
         name,
         decorator_list,
-        returns,
-        parameters,
+        signature,
         ..
     }) = stmt
     else {
         return;
     };
 
-    let Some(returns) = returns else {
+    let Some(returns) = &signature.returns else {
         return;
     };
+    let parameters = &signature.parameters;
 
     if !matches!(name.as_str(), "__str__" | "__repr__") {
         return;

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -454,12 +454,12 @@ fn is_noreturn_func(func: &Expr, semantic: &SemanticModel) -> bool {
         return false;
     };
 
-    let Stmt::FunctionDef(ast::StmtFunctionDef { returns, .. }) = semantic.statement(node_id)
+    let Stmt::FunctionDef(ast::StmtFunctionDef { signature, .. }) = semantic.statement(node_id)
     else {
         return false;
     };
 
-    let Some(returns) = returns.as_ref() else {
+    let Some(returns) = signature.returns.as_ref() else {
         return false;
     };
 
@@ -764,10 +764,11 @@ fn create_stack<'a>(
 pub(crate) fn function(checker: &Checker, function_def: &ast::StmtFunctionDef) {
     let ast::StmtFunctionDef {
         decorator_list,
-        returns,
+        signature,
         body,
         ..
     } = function_def;
+    let returns = &signature.returns;
 
     let Some(stack) = create_stack(checker, function_def) else {
         return;

--- a/crates/ruff_linter/src/rules/flake8_return/visitor.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/visitor.rs
@@ -95,9 +95,8 @@ impl<'a> Visitor<'a> for ReturnVisitor<'_, 'a> {
                 return;
             }
             Stmt::FunctionDef(ast::StmtFunctionDef {
-                parameters,
+                signature,
                 decorator_list,
-                returns,
                 ..
             }) => {
                 // Visit the decorators, etc.
@@ -106,10 +105,10 @@ impl<'a> Visitor<'a> for ReturnVisitor<'_, 'a> {
                 for decorator in decorator_list {
                     visitor::walk_decorator(self, decorator);
                 }
-                if let Some(returns) = returns {
+                if let Some(returns) = &signature.returns {
                     visitor::walk_expr(self, returns);
                 }
-                visitor::walk_parameters(self, parameters);
+                visitor::walk_parameters(self, &signature.parameters);
                 self.parents.pop();
 
                 // But don't recurse into the body.

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
@@ -83,7 +83,7 @@ pub(crate) fn no_slots_in_namedtuple_subclass(
     if checker.source_type.is_stub() {
         return;
     }
-    let Some(Arguments { args: bases, .. }) = class.arguments.as_deref() else {
+    let Some(Arguments { args: bases, .. }) = class.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
@@ -55,7 +55,7 @@ pub(crate) fn no_slots_in_str_subclass(checker: &Checker, stmt: &Stmt, class: &S
     if checker.source_type.is_stub() {
         return;
     }
-    let Some(Arguments { args: bases, .. }) = class.arguments.as_deref() else {
+    let Some(Arguments { args: bases, .. }) = class.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
@@ -56,7 +56,7 @@ pub(crate) fn no_slots_in_tuple_subclass(checker: &Checker, stmt: &Stmt, class: 
     if checker.source_type.is_stub() {
         return;
     }
-    let Some(Arguments { args: bases, .. }) = class.arguments.as_deref() else {
+    let Some(Arguments { args: bases, .. }) = class.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -440,11 +440,12 @@ pub(crate) fn unused_arguments(checker: &Checker, scope: &Scope) {
         ScopeKind::Function(
             function_def @ ast::StmtFunctionDef {
                 name,
-                parameters,
+                signature,
                 decorator_list,
                 ..
             },
         ) => {
+            let parameters = &signature.parameters;
             match function_type::classify(
                 name,
                 decorator_list,

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
@@ -204,13 +204,14 @@ impl FunctionType {
 pub(crate) fn invalid_first_argument_name(checker: &Checker, scope: &Scope) {
     let ScopeKind::Function(ast::StmtFunctionDef {
         name,
-        parameters,
+        signature,
         decorator_list,
         ..
     }) = &scope.kind
     else {
         panic!("Expected ScopeKind::Function")
     };
+    let parameters = &signature.parameters;
 
     let semantic = checker.semantic();
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -235,15 +235,17 @@ fn function(
             let func = Stmt::FunctionDef(ast::StmtFunctionDef {
                 is_async: false,
                 name: Identifier::new(name.to_string(), TextRange::default()),
-                parameters: Box::new(Parameters {
-                    posonlyargs: new_posonlyargs,
-                    args: new_args,
-                    ..parameters
+                signature: Box::new(ast::FunctionSignature {
+                    parameters: Parameters {
+                        posonlyargs: new_posonlyargs,
+                        args: new_args,
+                        ..parameters
+                    },
+                    returns: Some(Box::new(return_type)),
+                    type_params: None,
                 }),
                 body: ast::Suite::from([body]),
                 decorator_list: ast::DecoratorList::new(),
-                returns: Some(Box::new(return_type)),
-                type_params: None,
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             });
@@ -255,11 +257,13 @@ fn function(
     let function = Stmt::FunctionDef(ast::StmtFunctionDef {
         is_async: false,
         name: Identifier::new(name.to_string(), TextRange::default()),
-        parameters: Box::new(parameters),
+        signature: Box::new(ast::FunctionSignature {
+            parameters,
+            returns: None,
+            type_params: None,
+        }),
         body: ast::Suite::from([body]),
         decorator_list: DecoratorList::new(),
-        returns: None,
-        type_params: None,
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     });

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_staticmethod_argument.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_staticmethod_argument.rs
@@ -64,9 +64,10 @@ pub(crate) fn bad_staticmethod_argument(checker: &Checker, scope: &Scope) {
     let ast::StmtFunctionDef {
         name,
         decorator_list,
-        parameters,
+        signature,
         ..
     } = func;
+    let parameters = &signature.parameters;
 
     let Some(parent) = checker.semantic().first_non_type_parent_scope(scope) else {
         return;

--- a/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
@@ -85,10 +85,11 @@ pub(crate) fn no_self_use(checker: &Checker, scope_id: ScopeId, scope: &Scope) {
 
     let ast::StmtFunctionDef {
         name,
-        parameters,
+        signature,
         decorator_list,
         ..
     } = func;
+    let parameters = &signature.parameters;
 
     if !matches!(
         function_type::classify(

--- a/crates/ruff_linter/src/rules/pylint/rules/self_or_cls_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/self_or_cls_assignment.rs
@@ -77,12 +77,13 @@ pub(crate) fn self_or_cls_assignment(checker: &Checker, target: &Expr) {
     let ScopeKind::Function(ast::StmtFunctionDef {
         name,
         decorator_list,
-        parameters,
+        signature,
         ..
     }) = checker.semantic().current_scope().kind
     else {
         return;
     };
+    let parameters = &signature.parameters;
 
     let Some(parent) = &checker
         .semantic()

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -235,14 +235,16 @@ fn create_fields_from_keywords(keywords: &[Keyword]) -> Option<Suite> {
 fn create_class_def_stmt(typename: &str, body: Suite, base_class: &Expr) -> Stmt {
     ast::StmtClassDef {
         name: Identifier::new(typename.to_string(), TextRange::default()),
-        arguments: Some(Box::new(Arguments {
-            args: Box::from([base_class.clone()]),
-            keywords: std::iter::empty().collect(),
-            range: TextRange::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+        signature: Some(Box::new(ast::ClassSignature {
+            arguments: Some(Arguments {
+                args: Box::from([base_class.clone()]),
+                keywords: std::iter::empty().collect(),
+                range: TextRange::default(),
+                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+            }),
+            type_params: None,
         })),
         body,
-        type_params: None,
         decorator_list: DecoratorList::new(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -175,17 +175,19 @@ fn create_class_def_stmt(
 ) -> Stmt {
     ast::StmtClassDef {
         name: Identifier::new(class_name.to_string(), TextRange::default()),
-        arguments: Some(Box::new(Arguments {
-            args: Box::from([base_class.clone()]),
-            keywords: match total_keyword {
-                Some(keyword) => std::iter::once(keyword.clone()).collect(),
-                None => std::iter::empty().collect(),
-            },
-            range: TextRange::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+        signature: Some(Box::new(ast::ClassSignature {
+            arguments: Some(Arguments {
+                args: Box::from([base_class.clone()]),
+                keywords: match total_keyword {
+                    Some(keyword) => std::iter::once(keyword.clone()).collect(),
+                    None => std::iter::empty().collect(),
+                },
+                range: TextRange::default(),
+                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+            }),
+            type_params: None,
         })),
         body,
-        type_params: None,
         decorator_list: ast::DecoratorList::new(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
@@ -163,19 +163,19 @@ pub(crate) fn non_pep695_generic_class(checker: &Checker, class_def: &StmtClassD
     }
 
     let StmtClassDef {
-        name,
-        type_params,
-        arguments,
-        ..
+        name, signature, ..
     } = class_def;
+    let Some(signature) = signature else {
+        return;
+    };
 
     // it's a runtime error to mix type_params and Generic, so bail out early if we see existing
     // type_params
-    if type_params.is_some() {
+    if signature.type_params.is_some() {
         return;
     }
 
-    let Some(arguments) = arguments.as_ref() else {
+    let Some(arguments) = signature.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
@@ -116,11 +116,9 @@ pub(crate) fn non_pep695_generic_function(checker: &Checker, function_def: &Stmt
     }
 
     let StmtFunctionDef {
-        name,
-        type_params,
-        parameters,
-        ..
+        name, signature, ..
     } = function_def;
+    let parameters = &signature.parameters;
 
     // TODO(brent) handle methods, for now return early in a class body. For example, an additional
     // generic parameter on the method needs to be handled separately from one already on the class
@@ -141,7 +139,7 @@ pub(crate) fn non_pep695_generic_function(checker: &Checker, function_def: &Stmt
     }
 
     // invalid to mix old-style and new-style generics
-    if type_params.is_some() {
+    if signature.type_params.is_some() {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_str_enum.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_str_enum.rs
@@ -102,7 +102,7 @@ impl Violation for ReplaceStrEnum {
 
 /// UP042
 pub(crate) fn replace_str_enum(checker: &Checker, class_def: &ast::StmtClassDef) {
-    let Some(arguments) = class_def.arguments.as_deref() else {
+    let Some(arguments) = class_def.arguments.as_ref() else {
         // class does not inherit anything, exit early
         return;
     };

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -99,17 +99,13 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
     // Find the enclosing callable and extract the name of its first parameter.
     let (parent_arg_name, has_local_dunder_class_var_ref) = match &callable_scope.kind {
         ScopeKind::Function(_) => {
-            let Some(
-                func_stmt @ Stmt::FunctionDef(ast::StmtFunctionDef {
-                    parameters: parent_parameters,
-                    ..
-                }),
-            ) = parents.find(|stmt| stmt.is_function_def_stmt())
+            let Some(func_stmt @ Stmt::FunctionDef(ast::StmtFunctionDef { signature, .. })) =
+                parents.find(|stmt| stmt.is_function_def_stmt())
             else {
                 return;
             };
 
-            let Some(parent_arg) = parent_parameters.args.first() else {
+            let Some(parent_arg) = signature.parameters.args.first() else {
                 return;
             };
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
@@ -46,7 +46,7 @@ impl AlwaysFixableViolation for UnnecessaryClassParentheses {
 
 /// UP039
 pub(crate) fn unnecessary_class_parentheses(checker: &Checker, class_def: &ast::StmtClassDef) {
-    let Some(arguments) = class_def.arguments.as_deref() else {
+    let Some(arguments) = class_def.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_class_metaclass_type.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_class_metaclass_type.rs
@@ -50,7 +50,7 @@ impl Violation for UselessClassMetaclassType {
 
 /// UP050
 pub(crate) fn useless_class_metaclass_type(checker: &Checker, class_def: &StmtClassDef) {
-    let Some(arguments) = class_def.arguments.as_deref() else {
+    let Some(arguments) = class_def.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -51,7 +51,7 @@ impl AlwaysFixableViolation for UselessObjectInheritance {
 
 /// UP004
 pub(crate) fn useless_object_inheritance(checker: &Checker, class_def: &ast::StmtClassDef) {
-    let Some(arguments) = class_def.arguments.as_deref() else {
+    let Some(arguments) = class_def.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
@@ -90,7 +90,7 @@ pub(crate) fn subclass_builtin(checker: &Checker, class: &StmtClassDef) {
         return;
     }
 
-    let Some(Arguments { args: bases, .. }) = class.arguments.as_deref() else {
+    let Some(Arguments { args: bases, .. }) = class.arguments.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/class_with_mixed_type_vars.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/class_with_mixed_type_vars.rs
@@ -84,17 +84,13 @@ pub(crate) fn class_with_mixed_type_vars(checker: &Checker, class_def: &StmtClas
         return;
     }
 
-    let StmtClassDef {
-        type_params,
-        arguments,
-        ..
-    } = class_def;
-
-    let Some(type_params) = type_params else {
+    let Some(signature) = &class_def.signature else {
         return;
     };
-
-    let Some(arguments) = arguments else {
+    let Some(type_params) = &signature.type_params else {
+        return;
+    };
+    let Some(arguments) = &signature.arguments else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
@@ -111,10 +111,8 @@ fn function_def_visit_preorder_except_body<'a, V>(
     V: source_order::SourceOrderVisitor<'a>,
 {
     let ast::StmtFunctionDef {
-        parameters,
+        signature,
         decorator_list,
-        returns,
-        type_params,
         ..
     } = function_def;
 
@@ -122,13 +120,13 @@ fn function_def_visit_preorder_except_body<'a, V>(
         visitor.visit_decorator(decorator);
     }
 
-    if let Some(type_params) = type_params {
+    if let Some(type_params) = &signature.type_params {
         visitor.visit_type_params(type_params);
     }
 
-    visitor.visit_parameters(parameters);
+    visitor.visit_parameters(&signature.parameters);
 
-    if let Some(expr) = returns {
+    if let Some(expr) = &signature.returns {
         visitor.visit_annotation(expr);
     }
 }
@@ -140,9 +138,8 @@ where
     V: source_order::SourceOrderVisitor<'a>,
 {
     let ast::StmtClassDef {
-        arguments,
+        signature,
         decorator_list,
-        type_params,
         ..
     } = class_def;
 
@@ -150,12 +147,13 @@ where
         visitor.visit_decorator(decorator);
     }
 
-    if let Some(type_params) = type_params {
-        visitor.visit_type_params(type_params);
-    }
-
-    if let Some(arguments) = arguments {
-        visitor.visit_arguments(arguments);
+    if let Some(signature) = signature {
+        if let Some(type_params) = &signature.type_params {
+            visitor.visit_type_params(type_params);
+        }
+        if let Some(arguments) = &signature.arguments {
+            visitor.visit_arguments(arguments);
+        }
     }
 }
 

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -85,23 +85,24 @@ doc = """See also [FunctionDef](https://docs.python.org/3/library/ast.html#ast.F
 and [AsyncFunctionDef](https://docs.python.org/3/library/ast.html#ast.AsyncFunctionDef).
 
 This type differs from the original Python AST, as it collapses the synchronous and asynchronous variants into a single type."""
+custom_debug = true
+custom_source_order = true
 fields = [
   { name = "is_async", type = "bool" },
   { name = "decorator_list", type = "ThinVec<Decorator>" },
   { name = "name", type = "Identifier" },
-  { name = "type_params", type = "Box<crate::TypeParams>?" },
-  { name = "parameters", type = "Box<crate::Parameters>" },
-  { name = "returns", type = "Expr?", is_annotation = true },
+  { name = "signature", type = "Box<crate::FunctionSignature>", skip_visit = true },
   { name = "body", type = "ThinVec<Stmt>" },
 ]
 
 [Stmt.nodes.StmtClassDef]
 doc = "See also [ClassDef](https://docs.python.org/3/library/ast.html#ast.ClassDef)"
+custom_debug = true
+custom_source_order = true
 fields = [
   { name = "decorator_list", type = "ThinVec<Decorator>" },
   { name = "name", type = "Identifier" },
-  { name = "type_params", type = "Box<crate::TypeParams>?" },
-  { name = "arguments", type = "Box<crate::Arguments>?" },
+  { name = "signature", type = "Box<crate::ClassSignature>?", skip_visit = true },
   { name = "body", type = "ThinVec<Stmt>" },
 ]
 

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -1628,36 +1628,40 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
             ast::Stmt::FunctionDef(ast::StmtFunctionDef {
                 is_async,
                 name,
-                parameters,
+                signature,
                 body,
                 decorator_list,
-                returns,
-                type_params,
                 range: _,
                 node_index: _,
             }) => Self::FunctionDef(StmtFunctionDef {
                 is_async: *is_async,
                 name: name.as_str(),
-                parameters: parameters.into(),
+                parameters: (&signature.parameters).into(),
                 body: body.iter().map(Into::into).collect(),
                 decorator_list: decorator_list.iter().map(Into::into).collect(),
-                returns: returns.as_ref().map(Into::into),
-                type_params: type_params.as_ref().map(Into::into),
+                returns: signature.returns.as_ref().map(Into::into),
+                type_params: signature.type_params.as_ref().map(Into::into),
             }),
             ast::Stmt::ClassDef(ast::StmtClassDef {
                 name,
-                arguments,
+                signature,
                 body,
                 decorator_list,
-                type_params,
                 range: _,
                 node_index: _,
             }) => Self::ClassDef(StmtClassDef {
                 name: name.as_str(),
-                arguments: arguments.as_ref().map(Into::into).unwrap_or_default(),
+                arguments: signature
+                    .as_ref()
+                    .and_then(|signature| signature.arguments.as_ref())
+                    .map(Into::into)
+                    .unwrap_or_default(),
                 body: body.iter().map(Into::into).collect(),
                 decorator_list: decorator_list.iter().map(Into::into).collect(),
-                type_params: type_params.as_ref().map(Into::into),
+                type_params: signature
+                    .as_ref()
+                    .and_then(|signature| signature.type_params.as_ref())
+                    .map(Into::into),
             }),
             ast::Stmt::Return(ast::StmtReturn {
                 value,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -9296,7 +9296,7 @@ pub struct ModExpression {
 /// and [AsyncFunctionDef](https://docs.python.org/3/library/ast.html#ast.AsyncFunctionDef).
 ///
 /// This type differs from the original Python AST, as it collapses the synchronous and asynchronous variants into a single type.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct StmtFunctionDef {
     pub node_index: crate::AtomicNodeIndex,
@@ -9304,22 +9304,19 @@ pub struct StmtFunctionDef {
     pub is_async: bool,
     pub decorator_list: thin_vec::ThinVec<crate::Decorator>,
     pub name: crate::Identifier,
-    pub type_params: Option<Box<crate::TypeParams>>,
-    pub parameters: Box<crate::Parameters>,
-    pub returns: Option<Box<Expr>>,
+    pub signature: Box<crate::FunctionSignature>,
     pub body: thin_vec::ThinVec<Stmt>,
 }
 
 /// See also [ClassDef](https://docs.python.org/3/library/ast.html#ast.ClassDef)
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct StmtClassDef {
     pub node_index: crate::AtomicNodeIndex,
     pub range: ruff_text_size::TextRange,
     pub decorator_list: thin_vec::ThinVec<crate::Decorator>,
     pub name: crate::Identifier,
-    pub type_params: Option<Box<crate::TypeParams>>,
-    pub arguments: Option<Box<crate::Arguments>>,
+    pub signature: Option<Box<crate::ClassSignature>>,
     pub body: thin_vec::ThinVec<Stmt>,
 }
 
@@ -10101,74 +10098,6 @@ impl ModExpression {
             node_index: _,
         } = self;
         visitor.visit_expr(body);
-    }
-}
-
-impl StmtFunctionDef {
-    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
-    where
-        V: SourceOrderVisitor<'a> + ?Sized,
-    {
-        let StmtFunctionDef {
-            is_async: _,
-            decorator_list,
-            name,
-            type_params,
-            parameters,
-            returns,
-            body,
-            range: _,
-            node_index: _,
-        } = self;
-
-        for elm in decorator_list {
-            visitor.visit_decorator(elm);
-        }
-        visitor.visit_identifier(name);
-
-        if let Some(type_params) = type_params {
-            visitor.visit_type_params(type_params);
-        }
-
-        visitor.visit_parameters(parameters);
-
-        if let Some(returns) = returns {
-            visitor.visit_annotation(returns);
-        }
-
-        visitor.visit_body(body);
-    }
-}
-
-impl StmtClassDef {
-    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
-    where
-        V: SourceOrderVisitor<'a> + ?Sized,
-    {
-        let StmtClassDef {
-            decorator_list,
-            name,
-            type_params,
-            arguments,
-            body,
-            range: _,
-            node_index: _,
-        } = self;
-
-        for elm in decorator_list {
-            visitor.visit_decorator(elm);
-        }
-        visitor.visit_identifier(name);
-
-        if let Some(type_params) = type_params {
-            visitor.visit_type_params(type_params);
-        }
-
-        if let Some(arguments) = arguments {
-            visitor.visit_arguments(arguments);
-        }
-
-        visitor.visit_body(body);
     }
 }
 

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -530,13 +530,16 @@ where
     fn inner(stmt: &Stmt, func: &mut dyn FnMut(&Expr) -> bool) -> bool {
         match stmt {
             Stmt::FunctionDef(ast::StmtFunctionDef {
-                parameters,
-                type_params,
+                signature,
                 body,
                 decorator_list,
-                returns,
                 ..
             }) => {
+                let ast::FunctionSignature {
+                    parameters,
+                    type_params,
+                    returns,
+                } = signature.as_ref();
                 parameters.iter().any(|param| {
                     param
                         .default()
@@ -557,28 +560,29 @@ where
                         .is_some_and(|value| any_over_expr(value, func))
             }
             Stmt::ClassDef(ast::StmtClassDef {
-                arguments,
-                type_params,
+                signature,
                 body,
                 decorator_list,
                 ..
             }) => {
+                let arguments = signature
+                    .as_ref()
+                    .and_then(|signature| signature.arguments.as_ref());
+                let type_params = signature
+                    .as_ref()
+                    .and_then(|signature| signature.type_params.as_ref());
                 // Note that e.g. `class A(*args, a=2, *args2, **kwargs): pass` is a valid class
                 // definition
-                arguments
-                    .as_deref()
-                    .is_some_and(|Arguments { args, keywords, .. }| {
-                        args.iter().any(|expr| any_over_expr(expr, &mut *func))
-                            || keywords
-                                .iter()
-                                .any(|keyword| any_over_expr(&keyword.value, &mut *func))
-                    })
-                    || type_params.as_ref().is_some_and(|type_params| {
-                        type_params
+                arguments.is_some_and(|Arguments { args, keywords, .. }| {
+                    args.iter().any(|expr| any_over_expr(expr, &mut *func))
+                        || keywords
                             .iter()
-                            .any(|type_param| any_over_type_param(type_param, &mut *func))
-                    })
-                    || body.iter().any(|stmt| any_over_stmt(stmt, &mut *func))
+                            .any(|keyword| any_over_expr(&keyword.value, &mut *func))
+                }) || type_params.is_some_and(|type_params| {
+                    type_params
+                        .iter()
+                        .any(|type_param| any_over_type_param(type_param, &mut *func))
+                }) || body.iter().any(|stmt| any_over_stmt(stmt, &mut *func))
                     || decorator_list
                         .iter()
                         .any(|decorator| any_over_expr(&decorator.expression, &mut *func))

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -4,6 +4,7 @@ use crate::AtomicNodeIndex;
 use crate::generated::{
     ExprBytesLiteral, ExprCall, ExprDict, ExprFString, ExprList, ExprName, ExprSet,
     ExprStringLiteral, ExprTString, ExprTuple, PatternMatchAs, PatternMatchOr, StmtClassDef,
+    StmtFunctionDef,
 };
 use std::borrow::Cow;
 use std::fmt;
@@ -21,6 +22,7 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use crate::str_prefix::{
     AnyStringPrefix, ByteStringPrefix, FStringPrefix, StringLiteralPrefix, TStringPrefix,
 };
+use crate::visitor::source_order::SourceOrderVisitor;
 use crate::{
     Expr, ExprRef, InterpolatedStringElement, LiteralExpressionRef, OperatorPrecedence, Pattern,
     Stmt, TypeParam, int,
@@ -28,7 +30,126 @@ use crate::{
     str::{Quote, TripleQuotes},
 };
 
+/// The parts of a function definition that share its parameters allocation.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+pub struct FunctionSignature {
+    pub type_params: Option<Box<TypeParams>>,
+    pub parameters: Parameters,
+    pub returns: Option<Box<Expr>>,
+}
+
+impl Deref for StmtFunctionDef {
+    type Target = FunctionSignature;
+
+    fn deref(&self) -> &Self::Target {
+        &self.signature
+    }
+}
+
+impl fmt::Debug for StmtFunctionDef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StmtFunctionDef")
+            .field("node_index", &self.node_index)
+            .field("range", &self.range)
+            .field("is_async", &self.is_async)
+            .field("decorator_list", &self.decorator_list)
+            .field("name", &self.name)
+            .field("type_params", &self.signature.type_params)
+            .field("parameters", &self.signature.parameters)
+            .field("returns", &self.signature.returns)
+            .field("body", &self.body)
+            .finish()
+    }
+}
+
+impl StmtFunctionDef {
+    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
+    where
+        V: SourceOrderVisitor<'a> + ?Sized,
+    {
+        for decorator in &self.decorator_list {
+            visitor.visit_decorator(decorator);
+        }
+        visitor.visit_identifier(&self.name);
+        if let Some(type_params) = &self.type_params {
+            visitor.visit_type_params(type_params);
+        }
+        visitor.visit_parameters(&self.parameters);
+        if let Some(returns) = &self.returns {
+            visitor.visit_annotation(returns);
+        }
+        visitor.visit_body(&self.body);
+    }
+}
+
+/// The optional type parameters and parenthesized arguments of a class definition.
+#[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+pub struct ClassSignature {
+    pub type_params: Option<Box<TypeParams>>,
+    pub arguments: Option<Arguments>,
+}
+
+impl ClassSignature {
+    const EMPTY: Self = Self {
+        type_params: None,
+        arguments: None,
+    };
+}
+
+impl Deref for StmtClassDef {
+    type Target = ClassSignature;
+
+    fn deref(&self) -> &Self::Target {
+        self.signature.as_deref().unwrap_or(&ClassSignature::EMPTY)
+    }
+}
+
+impl fmt::Debug for StmtClassDef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StmtClassDef")
+            .field("node_index", &self.node_index)
+            .field("range", &self.range)
+            .field("decorator_list", &self.decorator_list)
+            .field("name", &self.name)
+            .field(
+                "type_params",
+                &self
+                    .signature
+                    .as_ref()
+                    .and_then(|signature| signature.type_params.as_ref()),
+            )
+            .field(
+                "arguments",
+                &self
+                    .signature
+                    .as_ref()
+                    .and_then(|signature| signature.arguments.as_ref()),
+            )
+            .field("body", &self.body)
+            .finish()
+    }
+}
+
 impl StmtClassDef {
+    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
+    where
+        V: SourceOrderVisitor<'a> + ?Sized,
+    {
+        for decorator in &self.decorator_list {
+            visitor.visit_decorator(decorator);
+        }
+        visitor.visit_identifier(&self.name);
+        if let Some(type_params) = &self.type_params {
+            visitor.visit_type_params(type_params);
+        }
+        if let Some(arguments) = &self.arguments {
+            visitor.visit_arguments(arguments);
+        }
+        visitor.visit_body(&self.body);
+    }
+
     /// Return an iterator over the bases of the class.
     pub fn bases(&self) -> &[Expr] {
         match &self.arguments {
@@ -3933,14 +4054,16 @@ impl From<bool> for Singleton {
 #[cfg(test)]
 mod tests {
     use crate::generated::*;
-    use crate::{Arguments, Mod, Parameters};
+    use crate::{Arguments, ClassSignature, FunctionSignature, Mod, Parameters};
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Stmt>(), 88);
-        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 88);
-        assert_eq!(std::mem::size_of::<StmtClassDef>(), 80);
+        assert_eq!(std::mem::size_of::<Stmt>(), 80);
+        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 72);
+        assert_eq!(std::mem::size_of::<StmtClassDef>(), 72);
+        assert_eq!(std::mem::size_of::<FunctionSignature>(), 72);
+        assert_eq!(std::mem::size_of::<ClassSignature>(), 48);
         assert_eq!(std::mem::size_of::<StmtTry>(), 64);
         assert_eq!(std::mem::size_of::<Mod>(), 32);
         assert_eq!(std::mem::size_of::<Pattern>(), 72);

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -135,13 +135,16 @@ pub fn walk_elif_else_clause<'a, V: Visitor<'a> + ?Sized>(
 pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
     match stmt {
         Stmt::FunctionDef(ast::StmtFunctionDef {
-            parameters,
+            signature,
             body,
             decorator_list,
-            returns,
-            type_params,
             ..
         }) => {
+            let ast::FunctionSignature {
+                parameters,
+                returns,
+                type_params,
+            } = signature.as_ref();
             for decorator in decorator_list {
                 visitor.visit_decorator(decorator);
             }
@@ -155,20 +158,21 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             visitor.visit_body(body);
         }
         Stmt::ClassDef(ast::StmtClassDef {
-            arguments,
+            signature,
             body,
             decorator_list,
-            type_params,
             ..
         }) => {
             for decorator in decorator_list {
                 visitor.visit_decorator(decorator);
             }
-            if let Some(type_params) = type_params {
-                visitor.visit_type_params(type_params);
-            }
-            if let Some(arguments) = arguments {
-                visitor.visit_arguments(arguments);
+            if let Some(signature) = signature {
+                if let Some(type_params) = &signature.type_params {
+                    visitor.visit_type_params(type_params);
+                }
+                if let Some(arguments) = &signature.arguments {
+                    visitor.visit_arguments(arguments);
+                }
             }
             visitor.visit_body(body);
         }

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -122,13 +122,16 @@ pub fn walk_elif_else_clause<V: Transformer + ?Sized>(
 pub fn walk_stmt<V: Transformer + ?Sized>(visitor: &V, stmt: &mut Stmt) {
     match stmt {
         Stmt::FunctionDef(ast::StmtFunctionDef {
-            parameters,
+            signature,
             body,
             decorator_list,
-            returns,
-            type_params,
             ..
         }) => {
+            let ast::FunctionSignature {
+                parameters,
+                returns,
+                type_params,
+            } = signature.as_mut();
             for decorator in decorator_list {
                 visitor.visit_decorator(decorator);
             }
@@ -142,20 +145,21 @@ pub fn walk_stmt<V: Transformer + ?Sized>(visitor: &V, stmt: &mut Stmt) {
             visitor.visit_body(body);
         }
         Stmt::ClassDef(ast::StmtClassDef {
-            arguments,
+            signature,
             body,
             decorator_list,
-            type_params,
             ..
         }) => {
             for decorator in decorator_list {
                 visitor.visit_decorator(decorator);
             }
-            if let Some(type_params) = type_params {
-                visitor.visit_type_params(type_params);
-            }
-            if let Some(arguments) = arguments {
-                visitor.visit_arguments(arguments);
+            if let Some(signature) = signature {
+                if let Some(type_params) = &mut signature.type_params {
+                    visitor.visit_type_params(type_params);
+                }
+                if let Some(arguments) = &mut signature.arguments {
+                    visitor.visit_arguments(arguments);
+                }
             }
             visitor.visit_body(body);
         }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -259,13 +259,16 @@ impl<'a> Generator<'a> {
             Stmt::FunctionDef(ast::StmtFunctionDef {
                 is_async,
                 name,
-                parameters,
+                signature,
                 body,
-                returns,
                 decorator_list,
-                type_params,
                 ..
             }) => {
+                let ast::FunctionSignature {
+                    parameters,
+                    returns,
+                    type_params,
+                } = signature.as_ref();
                 self.newlines(if self.indent_depth == 0 { 2 } else { 1 });
                 for decorator in decorator_list {
                     statement!({
@@ -298,10 +301,9 @@ impl<'a> Generator<'a> {
             }
             Stmt::ClassDef(ast::StmtClassDef {
                 name,
-                arguments,
+                signature,
                 body,
                 decorator_list,
-                type_params,
                 range: _,
                 node_index: _,
             }) => {
@@ -315,10 +317,16 @@ impl<'a> Generator<'a> {
                 statement!({
                     self.p("class ");
                     self.p_id(name);
-                    if let Some(type_params) = type_params {
+                    if let Some(type_params) = signature
+                        .as_ref()
+                        .and_then(|signature| signature.type_params.as_ref())
+                    {
                         self.unparse_type_params(type_params);
                     }
-                    if let Some(arguments) = arguments {
+                    if let Some(arguments) = signature
+                        .as_ref()
+                        .and_then(|signature| signature.arguments.as_ref())
+                    {
                         self.p("(");
                         let mut first = true;
                         for arg_or_keyword in arguments.iter_source_order() {

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -99,7 +99,7 @@ impl NeedsParentheses for ExprSubscript {
                                 AnyNodeRef::ptr_eq(returns.into(), self.into())
                             }) {
                                 if function.parameters.is_empty()
-                                    && !context.comments().has(&*function.parameters)
+                                    && !context.comments().has(&function.parameters)
                                 {
                                     // Apply the `optional_parentheses` layout when the subscript
                                     // is in a return type position of a function without parameters.

--- a/crates/ruff_python_formatter/src/statement/clause.rs
+++ b/crates/ruff_python_formatter/src/statement/clause.rs
@@ -119,39 +119,37 @@ impl<'a> ClauseHeader<'a> {
 
         match self {
             ClauseHeader::Class(StmtClassDef {
-                type_params,
-                arguments,
+                signature,
                 range: _,
                 node_index: _,
                 decorator_list: _,
                 name: _,
                 body: _,
             }) => {
-                if let Some(type_params) = type_params.as_deref() {
-                    visit(type_params, visitor);
-                }
-
-                if let Some(arguments) = arguments {
-                    visit(arguments.as_ref(), visitor);
+                if let Some(signature) = signature {
+                    if let Some(type_params) = signature.type_params.as_deref() {
+                        visit(type_params, visitor);
+                    }
+                    if let Some(arguments) = &signature.arguments {
+                        visit(arguments, visitor);
+                    }
                 }
             }
             ClauseHeader::Function(StmtFunctionDef {
-                type_params,
-                parameters,
+                signature,
                 range: _,
                 node_index: _,
                 is_async: _,
                 decorator_list: _,
                 name: _,
-                returns,
                 body: _,
             }) => {
-                if let Some(type_params) = type_params.as_deref() {
+                if let Some(type_params) = signature.type_params.as_deref() {
                     visit(type_params, visitor);
                 }
-                visit(parameters.as_ref(), visitor);
+                visit(&signature.parameters, visitor);
 
-                if let Some(returns) = returns.as_deref() {
+                if let Some(returns) = signature.returns.as_deref() {
                     visit(returns, visitor);
                 }
             }

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -20,11 +20,16 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
             range: _,
             node_index: _,
             name,
-            arguments,
+            signature,
             body,
-            type_params,
             decorator_list,
         } = item;
+        let type_params = signature
+            .as_ref()
+            .and_then(|signature| signature.type_params.as_ref());
+        let arguments = signature
+            .as_ref()
+            .and_then(|signature| signature.arguments.as_ref());
 
         let comments = f.context().comments().clone();
 
@@ -70,11 +75,11 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
                     &format_with(|f| {
                         write!(f, [token("class"), space(), name.format()])?;
 
-                        if let Some(type_params) = type_params.as_deref() {
+                        if let Some(type_params) = type_params {
                             write!(f, [type_params.format()])?;
                         }
 
-                        if let Some(arguments) = arguments.as_deref() {
+                        if let Some(arguments) = arguments {
                             // Drop empty the arguments node entirely (i.e., remove the parentheses) if it is empty,
                             // e.g., given:
                             // ```python

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -98,11 +98,14 @@ fn format_function_header(f: &mut PyFormatter, item: &StmtFunctionDef) -> Format
         is_async,
         decorator_list: _,
         name,
+        signature,
+        body: _,
+    } = item;
+    let ruff_python_ast::FunctionSignature {
         type_params,
         parameters,
         returns,
-        body: _,
-    } = item;
+    } = signature.as_ref();
 
     let comments = f.context().comments().clone();
 
@@ -163,7 +166,7 @@ fn format_function_header(f: &mut PyFormatter, item: &StmtFunctionDef) -> Format
                     .with_options(Parentheses::Always)
                     .fmt(f)
             } else {
-                let parenthesize = if parameters.is_empty() && !comments.has(parameters.as_ref()) {
+                let parenthesize = if parameters.is_empty() && !comments.has(parameters) {
                     // If the parameters are empty, add parentheses around literal expressions
                     // (any non splitable expression) but avoid parenthesizing subscripts and
                     // other parenthesized expressions unless necessary.

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2108,12 +2108,14 @@ impl<'src> Parser<'src> {
 
         ast::StmtFunctionDef {
             name,
-            type_params: type_params.map(Box::new),
-            parameters: Box::new(parameters),
+            signature: Box::new(ast::FunctionSignature {
+                type_params: type_params.map(Box::new),
+                parameters,
+                returns,
+            }),
             body,
             decorator_list,
             is_async: false,
-            returns,
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }
@@ -2173,7 +2175,7 @@ impl<'src> Parser<'src> {
         // class Foo(base for base in bases): ...
         let arguments = self
             .at(TokenKind::Lpar)
-            .then(|| Box::new(self.parse_arguments(ArgumentsContext::ClassDefinition)));
+            .then(|| self.parse_arguments(ArgumentsContext::ClassDefinition));
 
         self.expect(TokenKind::Colon);
 
@@ -2187,8 +2189,12 @@ impl<'src> Parser<'src> {
             range: self.node_range(start),
             decorator_list,
             name,
-            type_params: type_params.map(Box::new),
-            arguments,
+            signature: (type_params.is_some() || arguments.is_some()).then(|| {
+                Box::new(ast::ClassSignature {
+                    type_params: type_params.map(Box::new),
+                    arguments,
+                })
+            }),
             body,
             node_index: AtomicNodeIndex::NONE,
         }
@@ -3067,12 +3073,14 @@ impl<'src> Parser<'src> {
                         range: self.missing_node_range(),
                         node_index: AtomicNodeIndex::NONE,
                     },
-                    type_params: None,
-                    parameters: Box::new(ast::Parameters {
-                        range: self.missing_node_range(),
-                        ..ast::Parameters::default()
+                    signature: Box::new(ast::FunctionSignature {
+                        type_params: None,
+                        parameters: ast::Parameters {
+                            range: self.missing_node_range(),
+                            ..ast::Parameters::default()
+                        },
+                        returns: None,
                     }),
-                    returns: None,
                     body: Suite::new(),
                 }
                 .into()

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -204,16 +204,12 @@ impl SemanticSyntaxChecker {
                     visitor.visit_pattern(&case.pattern);
                 }
             }
-            Stmt::FunctionDef(ast::StmtFunctionDef {
-                type_params,
-                parameters,
-                ..
-            }) => {
-                if let Some(type_params) = type_params {
+            Stmt::FunctionDef(ast::StmtFunctionDef { signature, .. }) => {
+                if let Some(type_params) = &signature.type_params {
                     Self::duplicate_type_parameter_name(type_params, ctx);
                     Self::type_parameter_default_order(type_params, ctx);
                 }
-                Self::duplicate_parameter_name(parameters, ctx);
+                Self::duplicate_parameter_name(&signature.parameters, ctx);
             }
             Stmt::Global(ast::StmtGlobal { names, .. }) => {
                 for name in names {
@@ -227,10 +223,13 @@ impl SemanticSyntaxChecker {
                 }
             }
             Stmt::ClassDef(ast::StmtClassDef {
-                type_params: Some(type_params),
+                signature: Some(signature),
                 ..
-            })
-            | Stmt::TypeAlias(ast::StmtTypeAlias {
+            }) if let Some(type_params) = &signature.type_params => {
+                Self::duplicate_type_parameter_name(type_params, ctx);
+                Self::type_parameter_default_order(type_params, ctx);
+            }
+            Stmt::TypeAlias(ast::StmtTypeAlias {
                 type_params: Some(type_params),
                 ..
             }) => {
@@ -389,12 +388,12 @@ impl SemanticSyntaxChecker {
                     }
                 }
             }
-            Stmt::FunctionDef(ast::StmtFunctionDef {
-                type_params,
-                parameters,
-                returns,
-                ..
-            }) => {
+            Stmt::FunctionDef(ast::StmtFunctionDef { signature, .. }) => {
+                let ast::FunctionSignature {
+                    type_params,
+                    parameters,
+                    returns,
+                } = signature.as_ref();
                 // test_ok valid_annotation_function_py313
                 // # parse_options: {"target-version": "3.13"}
                 // def f() -> (y := 3): ...
@@ -468,10 +467,10 @@ impl SemanticSyntaxChecker {
                 }
             }
             Stmt::ClassDef(ast::StmtClassDef {
-                type_params: Some(type_params),
-                arguments,
+                signature: Some(signature),
                 ..
-            }) => {
+            }) if let Some(type_params) = &signature.type_params => {
+                let arguments = &signature.arguments;
                 // test_ok valid_annotation_class
                 // class F(y := list): ...
                 // def f():
@@ -577,10 +576,7 @@ impl SemanticSyntaxChecker {
     fn debug_shadowing<Ctx: SemanticSyntaxContext>(stmt: &ast::Stmt, ctx: &Ctx) {
         match stmt {
             Stmt::FunctionDef(ast::StmtFunctionDef {
-                name,
-                type_params,
-                parameters,
-                ..
+                name, signature, ..
             }) => {
                 // test_err debug_shadow_function
                 // def __debug__(): ...  # function name
@@ -588,23 +584,26 @@ impl SemanticSyntaxChecker {
                 // def f(__debug__): ...  # parameter name
                 // lambda __debug__: 0  # lambda parameter name
                 Self::check_identifier(name, ctx);
-                if let Some(type_params) = type_params {
+                if let Some(type_params) = &signature.type_params {
                     for type_param in type_params.iter() {
                         Self::check_identifier(type_param.name(), ctx);
                     }
                 }
-                for parameter in parameters {
+                for parameter in &signature.parameters {
                     Self::check_identifier(parameter.name(), ctx);
                 }
             }
             Stmt::ClassDef(ast::StmtClassDef {
-                name, type_params, ..
+                name, signature, ..
             }) => {
                 // test_err debug_shadow_class
                 // class __debug__: ...  # class name
                 // class C[__debug__]: ...  # type parameter name
                 Self::check_identifier(name, ctx);
-                if let Some(type_params) = type_params {
+                if let Some(type_params) = signature
+                    .as_ref()
+                    .and_then(|signature| signature.type_params.as_ref())
+                {
                     for type_param in type_params.iter() {
                         Self::check_identifier(type_param.name(), ctx);
                     }

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -683,20 +683,21 @@ impl Visitor<'_> for SemanticSyntaxCheckerVisitor<'_> {
         self.with_semantic_checker(|semantic, context| semantic.visit_stmt(stmt, context));
         match stmt {
             ast::Stmt::ClassDef(ast::StmtClassDef {
-                arguments,
+                signature,
                 body,
                 decorator_list,
-                type_params,
                 ..
             }) => {
                 for decorator in decorator_list {
                     self.visit_decorator(decorator);
                 }
-                if let Some(type_params) = type_params {
-                    self.visit_type_params(type_params);
-                }
-                if let Some(arguments) = arguments {
-                    self.visit_arguments(arguments);
+                if let Some(signature) = signature {
+                    if let Some(type_params) = &signature.type_params {
+                        self.visit_type_params(type_params);
+                    }
+                    if let Some(arguments) = &signature.arguments {
+                        self.visit_arguments(arguments);
+                    }
                 }
                 self.scopes.push(Scope::Class);
                 self.visit_body(body);

--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -332,11 +332,12 @@ fn has_metaclass_new_signature(class_def: &ast::StmtClassDef, semantic: &Semanti
     // Look for a __new__ method in the class body
     for stmt in &class_def.body {
         let ast::Stmt::FunctionDef(ast::StmtFunctionDef {
-            name, parameters, ..
+            name, signature, ..
         }) = stmt
         else {
             continue;
         };
+        let parameters = &signature.parameters;
 
         if name != "__new__" {
             continue;

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -707,8 +707,8 @@ pub fn check_type<T: TypeChecker>(binding: &Binding, semantic: &SemanticModel) -
             // ```
             //
             // We trust the annotation and see if the type checker matches the annotation.
-            Some(Stmt::FunctionDef(ast::StmtFunctionDef { parameters, .. })) => {
-                let Some(parameter) = find_parameter(parameters, binding) else {
+            Some(Stmt::FunctionDef(ast::StmtFunctionDef { signature, .. })) => {
+                let Some(parameter) = find_parameter(&signature.parameters, binding) else {
                     return false;
                 };
                 let Some(annotation) = parameter.annotation() else {
@@ -737,7 +737,8 @@ pub fn check_type<T: TypeChecker>(binding: &Binding, semantic: &SemanticModel) -
             // def foo() -> int:
             //   ...
             // ```
-            Some(Stmt::FunctionDef(ast::StmtFunctionDef { returns, .. })) => returns
+            Some(Stmt::FunctionDef(ast::StmtFunctionDef { signature, .. })) => signature
+                .returns
                 .as_ref()
                 .is_some_and(|return_ann| T::match_annotation(return_ann, semantic)),
 
@@ -1056,10 +1057,10 @@ pub fn is_dict(binding: &Binding, semantic: &SemanticModel) -> bool {
     //   ...
     // ```
     if matches!(binding.kind, BindingKind::Argument) {
-        if let Some(Stmt::FunctionDef(ast::StmtFunctionDef { parameters, .. })) =
+        if let Some(Stmt::FunctionDef(ast::StmtFunctionDef { signature, .. })) =
             binding.statement(semantic)
         {
-            if let Some(kwarg_parameter) = parameters.kwarg.as_deref() {
+            if let Some(kwarg_parameter) = signature.parameters.kwarg.as_deref() {
                 if kwarg_parameter.name.range() == binding.range() {
                     return true;
                 }
@@ -1109,10 +1110,10 @@ pub fn is_tuple(binding: &Binding, semantic: &SemanticModel) -> bool {
     //   ...
     // ```
     if matches!(binding.kind, BindingKind::Argument) {
-        if let Some(Stmt::FunctionDef(ast::StmtFunctionDef { parameters, .. })) =
+        if let Some(Stmt::FunctionDef(ast::StmtFunctionDef { signature, .. })) =
             binding.statement(semantic)
         {
-            if let Some(arg_parameter) = parameters.vararg.as_deref() {
+            if let Some(arg_parameter) = signature.parameters.vararg.as_deref() {
                 if arg_parameter.name.range() == binding.range() {
                     return true;
                 }

--- a/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
@@ -82,7 +82,7 @@ pub fn outgoing_calls(db: &dyn Db, file: ProgramFile<'_>, offset: TextSize) -> V
                 finder.walk_class_signature(
                     &class.decorator_list,
                     class.type_params.as_deref(),
-                    class.arguments.as_deref(),
+                    class.arguments.as_ref(),
                 );
                 walk_body(&mut finder, &class.body);
             }
@@ -256,7 +256,7 @@ impl<'a> SourceOrderVisitor<'a> for OutgoingCallsFinder<'a, '_> {
                 self.walk_class_signature(
                     &class.decorator_list,
                     class.type_params.as_deref(),
-                    class.arguments.as_deref(),
+                    class.arguments.as_ref(),
                 );
                 return TraversalSignal::Skip;
             }

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2037,7 +2037,7 @@ fn add_argument_completions<'db>(
                 return;
             }
             ast::AnyNodeRef::StmtClassDef(class_def) => {
-                if let Some(arguments) = class_def.arguments.as_deref()
+                if let Some(arguments) = class_def.arguments.as_ref()
                     && arguments.range().contains_range(cursor.range)
                 {
                     add_class_arg_completions(model, class_def, completions);

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2992,15 +2992,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Stmt::FunctionDef(function_def) => {
                 let ast::StmtFunctionDef {
                     decorator_list,
-                    parameters,
-                    type_params,
+                    signature,
                     name,
-                    returns,
                     body,
                     is_async: _,
                     range: _,
                     node_index: _,
                 } = function_def;
+                let ast::FunctionSignature {
+                    parameters,
+                    type_params,
+                    returns,
+                } = signature.as_ref();
                 for decorator in decorator_list {
                     self.visit_decorator(decorator);
                 }

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -178,9 +178,8 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
             ast::Stmt::ClassDef(ast::StmtClassDef {
                 name,
                 decorator_list,
-                arguments,
-                type_params: _, // We don't want to visit the type params of the class
-                body: _,        // We don't want to visit the body of the class
+                signature,
+                body: _, // We don't want to visit the body of the class
                 range: _,
                 node_index: _,
             }) => {
@@ -188,7 +187,10 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                 for decorator in decorator_list {
                     self.visit_decorator(decorator);
                 }
-                if let Some(arguments) = arguments {
+                if let Some(arguments) = signature
+                    .as_ref()
+                    .and_then(|signature| signature.arguments.as_ref())
+                {
                     self.visit_arguments(arguments);
                 }
             }
@@ -196,10 +198,8 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
             ast::Stmt::FunctionDef(ast::StmtFunctionDef {
                 name,
                 decorator_list,
-                parameters,
-                returns,
-                type_params: _, // We don't want to visit the type params of the function
-                body: _,        // We don't want to visit the body of the function
+                signature,
+                body: _, // We don't want to visit the body of the function
                 range: _,
                 node_index: _,
                 is_async: _,
@@ -208,8 +208,8 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                 for decorator in decorator_list {
                     self.visit_decorator(decorator);
                 }
-                self.visit_parameters(parameters);
-                if let Some(returns) = returns {
+                self.visit_parameters(&signature.parameters);
+                if let Some(returns) = &signature.returns {
                     self.visit_expr(returns);
                 }
             }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -8837,7 +8837,7 @@ impl<'db> BindingError<'db> {
             (Some(ast::ArgOrKeyword::Keyword(expr)), _) => expr.into(),
             (None, ast::AnyNodeRef::StmtClassDef(class_def)) => class_def
                 .arguments
-                .as_deref()
+                .as_ref()
                 .map(ast::AnyNodeRef::Arguments)
                 .unwrap_or(node),
             (None, _) => node,
@@ -8862,7 +8862,7 @@ impl<'db> BindingError<'db> {
             // is the special keyword argument `metaclass`. These need to be excluded from the
             // argument index when looking up the relevant keyword-argument node.
             (ast::AnyNodeRef::StmtClassDef(class_def), Some(argument_index)) => {
-                class_def.arguments.as_deref().and_then(|args| {
+                class_def.arguments.as_ref().and_then(|args| {
                     args.iter_source_order()
                         .filter_map(ArgOrKeyword::as_keyword)
                         .filter(|keyword| {
@@ -9147,7 +9147,7 @@ fn all_arguments_range(node: AnyNodeRef) -> TextRange {
                 class.start(),
                 class
                     .arguments
-                    .as_deref()
+                    .as_ref()
                     .map(Ranged::end)
                     .unwrap_or(class.name.end()),
             )

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -3490,7 +3490,7 @@ impl<'db> StaticClassLiteral<'db> {
             class_name.start(),
             class_node
                 .arguments
-                .as_deref()
+                .as_ref()
                 .map(Ranged::end)
                 .unwrap_or_else(|| class_name.end()),
         )

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10209,7 +10209,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
 
-        let function_parameters = &*current_function.parameters;
+        let function_parameters = &current_function.parameters;
 
         // `self`/`cls` can't be a keyword-only parameter.
         if function_parameters.posonlyargs.is_empty() && function_parameters.args.is_empty() {

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -90,11 +90,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             range: _,
             node_index: _,
             name,
-            type_params,
+            signature,
             decorator_list,
-            arguments: _,
             body: _,
         } = class_node;
+        let type_params = signature
+            .as_ref()
+            .and_then(|signature| signature.type_params.as_ref());
         let db = self.db();
 
         let mut decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator)> =
@@ -132,11 +134,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut total_ordering = false;
         let has_explicit_bases = class_node
             .arguments
-            .as_deref()
+            .as_ref()
             .is_some_and(|arguments| !arguments.args.is_empty());
         let has_explicit_metaclass = class_node
             .arguments
-            .as_deref()
+            .as_ref()
             .is_some_and(|arguments| arguments.find_keyword("metaclass").is_some());
         let infer_original_class_ty = |deprecated,
                                        type_check_only,
@@ -406,7 +408,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .any(|expr| any_over_expr(expr, &ast::Expr::is_string_literal_expr))
                 || class_node
                     .arguments
-                    .as_deref()
+                    .as_ref()
                     .and_then(|args| args.find_keyword("extra_items"))
                     .is_some()
             {
@@ -440,7 +442,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         }
 
-        if let Some(arguments) = class.arguments.as_deref()
+        if let Some(arguments) = class.arguments.as_ref()
             && let Some(extra_items_keyword) = arguments.find_keyword("extra_items")
         {
             if original_class_type(self.db(), definition)

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -406,12 +406,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             node_index: _,
             is_async: _,
             name,
-            type_params,
-            parameters,
-            returns: _,
+            signature,
             body: _,
             decorator_list,
         } = function;
+        let type_params = &signature.type_params;
+        let parameters = &signature.parameters;
 
         let db = self.db();
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -667,7 +667,7 @@ pub(crate) fn check_static_class_definitions<'db>(
 
     // Check that the class arguments matches the arguments of the
     // base class `__init_subclass__` method.
-    if let Some(args) = class_node.arguments.as_deref() {
+    if let Some(args) = class_node.arguments.as_ref() {
         if class_kind == Some(CodeGeneratorKind::TypedDict) {
             let supports_pep_728 = context.in_stub()
                 || class.typed_dict_module(db) == Some(TypedDictModule::TypingExtensions)

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
@@ -158,7 +158,7 @@ fn validate_typed_dict_openness<'db>(
     let child_openness = child.openness(db);
     let child_items = child.items(db);
 
-    if let Some(arguments) = class_node.arguments.as_deref()
+    if let Some(arguments) = class_node.arguments.as_ref()
         && arguments.find_keyword("closed").is_some()
         && arguments.find_keyword("extra_items").is_some()
     {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -789,7 +789,7 @@ impl<'db> Signature<'db> {
         let parameters = Parameters::from_parameters(
             db,
             definition,
-            function_node.parameters.as_ref(),
+            &function_node.parameters,
             has_implicitly_positional_first_parameter,
         );
         let return_ty = function_node


### PR DESCRIPTION
## Summary

Reduces `Stmt` from 88 to 80 bytes by boxing function and class signatures. I'm not sure this is worth doing, but wanted to see the results.
