### PR TITLE
[ty] Refresh PEP 723 script environments in watch mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4822,6 +4822,7 @@ dependencies = [
  "shellexpand",
  "strum",
  "strum_macros",
+ "tempfile",
  "thiserror 2.0.19",
  "toml 1.1.4+spec-1.1.0",
  "tracing",

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -27,7 +27,7 @@ use ruff_diagnostics::Applicability;
 use salsa::Database;
 use ty_project::metadata::settings::TerminalSettings;
 use ty_project::watch::ProjectWatcher;
-use ty_project::{CollectReporter, Db, ScriptSyncProgress, watch};
+use ty_project::{CollectReporter, Db, ScriptEnvironmentAvailability, ScriptSyncProgress, watch};
 use ty_project::{ProjectDatabase, ProjectMetadata};
 use ty_python_semantic::{fix_all_diagnostics, suppress_all_diagnostics};
 use ty_static::EnvVars;
@@ -277,12 +277,11 @@ struct MainLoop {
     /// Receiver for the messages sent **to** the main loop.
     receiver: crossbeam_channel::Receiver<MainLoopMessage>,
 
-    /// Capacity-one channel used to coalesce pending workspace checks.
-    check_sender: crossbeam_channel::Sender<()>,
-    check_receiver: crossbeam_channel::Receiver<()>,
-
     /// The file system watcher, if running in watch mode.
     watcher: Option<ProjectWatcher>,
+
+    /// Progress bars shared by project checks and background script synchronization.
+    progress: ProgressDisplay,
 
     /// Interface for displaying information to the user.
     printer: Printer,
@@ -296,19 +295,19 @@ struct MainLoop {
 impl MainLoop {
     fn new(mode: MainLoopMode, printer: Printer) -> (Self, MainLoopCancellationToken) {
         let (sender, receiver) = crossbeam_channel::bounded(10);
-        let (check_sender, check_receiver) = crossbeam_channel::bounded(1);
 
         let cancellation_token_source = CancellationTokenSource::new();
         let cancellation_token = cancellation_token_source.token();
+        let progress = ProgressDisplay::new();
+        progress.bars.set_draw_target(printer.progress_target());
 
         (
             Self {
                 mode,
                 sender: sender.clone(),
                 receiver,
-                check_sender,
-                check_receiver,
                 watcher: None,
+                progress,
                 printer,
                 cancellation_token,
             },
@@ -331,8 +330,6 @@ impl MainLoop {
     }
 
     fn run(self, db: &mut ProjectDatabase) -> Result<ExitStatus> {
-        self.request_check();
-
         let result = self.main_loop(db);
 
         tracing::debug!("Exiting main loop");
@@ -340,32 +337,39 @@ impl MainLoop {
         result
     }
 
-    fn request_check(&self) {
-        // A pending request already represents a check of the latest database revision.
-        let _ = self.check_sender.try_send(());
-    }
-
     fn main_loop(mut self, db: &mut ProjectDatabase) -> Result<ExitStatus> {
         tracing::debug!("Starting main loop");
 
         let mut revision = 0u64;
+        let script_sync_wakeups = db.script_environments().sync_wakeups();
+        let (check_sender, check_receiver) = crossbeam_channel::bounded(1);
+        request_check(db, &check_sender);
 
         // Apply all queued changes before starting a pending check because every applied change
         // cancels the running check.
         while let Ok(message) = crossbeam_channel::select_biased! {
+            recv(script_sync_wakeups) -> wakeup => {
+                wakeup.map(|()| MainLoopMessage::PollScriptEnvironments)
+            }
             recv(self.receiver) -> message => message,
-            recv(self.check_receiver) -> request => request.map(|()| MainLoopMessage::CheckWorkspace),
+            recv(check_receiver) -> request => request.map(|()| MainLoopMessage::CheckWorkspace),
         } {
             match message {
                 MainLoopMessage::CheckWorkspace => {
+                    // Synchronization may have started after this request was queued.
+                    if db.script_environments().has_pending_synchronizations() {
+                        tracing::debug!("Deferring check until script synchronization completes");
+                        continue;
+                    }
                     let db = db.clone();
                     let sender = self.sender.clone();
+                    let progress = self.progress.clone();
 
                     // Spawn a new task that checks the project. This needs to be done in a separate thread
                     // to prevent blocking the main loop here.
                     rayon::spawn(move || {
                         match salsa::Cancelled::catch(|| {
-                            let mut reporter = IndicatifReporter::from(self.printer);
+                            let mut reporter = IndicatifReporter::new(progress);
                             db.check_with_reporter(&mut reporter);
                             reporter.into_sorted_diagnostics(&db)
                         }) {
@@ -380,8 +384,9 @@ impl MainLoop {
                             }
                         }
                     });
+                    tracing::debug!("Waiting for next main loop message.");
+                    continue;
                 }
-
                 MainLoopMessage::CheckCompleted {
                     result,
                     revision: check_revision,
@@ -482,21 +487,43 @@ impl MainLoop {
                     return Ok(exit_status);
                 }
 
+                MainLoopMessage::PollScriptEnvironments => {
+                    let environments = db.script_environments().clone();
+                    if !environments.poll_sync(db).is_empty() {
+                        revision += 1;
+                    }
+                    request_check(db, &check_sender);
+                }
+
                 MainLoopMessage::ApplyChanges(changes) => {
-                    Printer::clear_screen()?;
+                    // Another filesystem event can arrive while a script is still synchronizing.
+                    // Keep its progress visible after clearing the previous check's output.
+                    self.progress.bars.suspend(Printer::clear_screen)?;
 
                     revision += 1;
                     // Automatically cancels any pending queries and waits for them to complete.
                     db.apply_changes(&changes);
+
+                    let environments = db.script_environments().clone();
+                    for file in environments.files() {
+                        environments.request_sync(
+                            db,
+                            file,
+                            ScriptEnvironmentAvailability::Pending,
+                            &|db, file| self.progress.for_script(db, file),
+                        );
+                    }
+
                     if let Some(watcher) = self.watcher.as_mut() {
                         watcher.update(db);
                     }
 
-                    self.request_check();
+                    request_check(db, &check_sender);
                 }
                 MainLoopMessage::Exit => {
                     // Cancel any pending queries and wait for them to complete.
                     db.trigger_cancellation();
+                    self.progress.clear();
                     return Ok(ExitStatus::Interrupted);
                 }
             }
@@ -630,27 +657,21 @@ struct IndicatifReporter {
     /// do not initialize the bar too early as it may take a while to collect the number of files to
     /// process and we don't want to display an empty "0/0" bar.
     checking_bar: indicatif::ProgressBar,
-
-    printer: Printer,
 }
 
 impl IndicatifReporter {
-    fn into_sorted_diagnostics(mut self, db: &dyn Db) -> Vec<Diagnostic> {
-        std::mem::take(&mut self.collector).into_sorted(db)
-    }
-}
-
-impl From<Printer> for IndicatifReporter {
-    fn from(printer: Printer) -> Self {
-        let progress = ProgressDisplay::new();
+    fn new(progress: ProgressDisplay) -> Self {
         let checking_bar = progress.bars.add(indicatif::ProgressBar::hidden());
 
         Self {
             progress,
             checking_bar,
             collector: CollectReporter::default(),
-            printer,
         }
+    }
+
+    fn into_sorted_diagnostics(mut self, db: &dyn Db) -> Vec<Diagnostic> {
+        std::mem::take(&mut self.collector).into_sorted(db)
     }
 }
 
@@ -667,9 +688,6 @@ impl ty_project::ProgressReporter for IndicatifReporter {
             .unwrap()
             .progress_chars("--"),
         );
-        self.progress
-            .bars
-            .set_draw_target(self.printer.progress_target());
         self.checking_bar.tick();
     }
 
@@ -767,8 +785,19 @@ enum MainLoopMessage {
         result: Vec<Diagnostic>,
         revision: u64,
     },
+    PollScriptEnvironments,
     ApplyChanges(Vec<watch::ChangeEvent>),
     Exit,
+}
+
+fn request_check(db: &dyn Db, sender: &crossbeam_channel::Sender<()>) {
+    if db.script_environments().has_pending_synchronizations() {
+        return;
+    }
+
+    // A full channel means that a check has already been requested. Keeping one pending request
+    // coalesces bursts of file changes while the main loop drains higher-priority work.
+    let _ = sender.try_send(());
 }
 
 fn current_directory() -> Result<SystemPathBuf> {

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -395,6 +395,14 @@ fn setup<F>(setup_files: F) -> anyhow::Result<TestCase>
 where
     F: Setup,
 {
+    setup_with_system(setup_files, |_| {})
+}
+
+fn setup_with_system<F, C>(setup_files: F, configure_system: C) -> anyhow::Result<TestCase>
+where
+    F: Setup,
+    C: FnOnce(&TestSystem),
+{
     let temp_dir = tempfile::tempdir()?;
 
     let root_path = SystemPath::from_std_path(temp_dir.path()).ok_or_else(|| {
@@ -423,6 +431,7 @@ where
     let user_config_directory_override = os_system.with_user_config_directory(None);
     let system = TestSystem::new(os_system.clone());
     isolate_environment(&system);
+    configure_system(&system);
 
     let mut setup_context = SetupContext {
         system: &os_system,
@@ -2481,4 +2490,173 @@ fn submodule_cache_invalidation_after_pyproject_created() -> anyhow::Result<()> 
     );
 
     Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+mod uv_metadata {
+    use std::process::Command;
+    use std::time::Duration;
+
+    use anyhow::Context;
+    use ruff_db::diagnostic::DiagnosticId;
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::{OsSystem, System as _};
+    use ty_project::{Db, ScriptEnvironmentAvailability};
+    use ty_static::EnvVars;
+
+    use super::{Setup, TestCase, event_for_file, setup_with_system, update_file};
+
+    #[test]
+    fn unchanged_script_environment_is_reused_after_source_edits() -> anyhow::Result<()> {
+        assert_uv_supports_script_metadata()?;
+
+        let mut case = setup_script_uv([(
+            "script.py",
+            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+        )])?;
+
+        assert!(case.db().check().is_empty());
+
+        assert!(!update_and_synchronize_script(
+            &mut case,
+            "\n# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\nvalue = 2\n",
+        )?);
+
+        assert!(case.db().check().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_changes_resynchronize_the_script_environment() -> anyhow::Result<()> {
+        assert_uv_supports_script_metadata()?;
+
+        let mut case = setup_script_uv([(
+            "script.py",
+            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+        )])?;
+
+        assert!(case.db().check().is_empty());
+
+        let synchronized = update_and_synchronize_script(
+            &mut case,
+            "# /// script\n# requires-python = '>=3.11'\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+        )?;
+        assert!(synchronized);
+
+        assert!(case.db().check().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn ordinary_files_becoming_scripts_initialize_their_environments() -> anyhow::Result<()> {
+        assert_uv_supports_script_metadata()?;
+
+        let mut case = setup_script_uv([("script.py", "from attrs import define\n")])?;
+
+        let ordinary = case.db().check();
+        assert!(
+            ordinary
+                .iter()
+                .any(|diagnostic| diagnostic.id().as_str() == "unresolved-import")
+        );
+
+        let synchronized = update_and_synchronize_script(
+            &mut case,
+            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+        )?;
+        assert!(!synchronized);
+
+        assert!(case.db().check().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn corrected_script_dependencies_replace_initialization_errors() -> anyhow::Result<()> {
+        assert_uv_supports_script_metadata()?;
+
+        let mut case = setup_script_uv([(
+            "script.py",
+            "# /// script\n# dependencies = ['not a valid requirement ???']\n# ///\nvalue = 1\n",
+        )])?;
+
+        let initial = case.db().check();
+        assert!(
+            initial
+                .iter()
+                .any(|diagnostic| diagnostic.id() == DiagnosticId::UvMetadata)
+        );
+
+        let synchronized = update_and_synchronize_script(
+            &mut case,
+            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+        )?;
+        assert!(synchronized);
+
+        let corrected = case.db().check();
+        assert!(
+            corrected.is_empty(),
+            "unexpected diagnostics: {corrected:?}"
+        );
+
+        Ok(())
+    }
+
+    fn assert_uv_supports_script_metadata() -> anyhow::Result<()> {
+        let output = Command::new("uv")
+            .args(["workspace", "metadata", "--help"])
+            .output()
+            .context("failed to inspect uv workspace metadata support")?;
+
+        assert!(
+            output.status.success() && String::from_utf8_lossy(&output.stdout).contains("--script"),
+            "installed uv does not support script metadata"
+        );
+
+        Ok(())
+    }
+
+    fn setup_script_uv<F>(setup_files: F) -> anyhow::Result<TestCase>
+    where
+        F: Setup,
+    {
+        let uv = OsSystem::default().which("uv")?;
+        setup_with_system(setup_files, move |system| {
+            system.set_env_var(EnvVars::TY_UV, "scripts");
+            system.set_env_var(EnvVars::UV, uv.as_str());
+        })
+    }
+
+    fn update_and_synchronize_script(case: &mut TestCase, source: &str) -> anyhow::Result<bool> {
+        update_file(case.project_path("script.py"), source)?;
+        let changes = case.take_watch_changes(event_for_file("script.py"));
+        case.apply_changes(&changes);
+
+        let file = system_path_to_file(case.db(), case.project_path("script.py"))?;
+        let environments = case.db().script_environments().clone();
+        if !environments.files().contains(&file) {
+            return Ok(false);
+        }
+        let wakeups = environments.sync_wakeups();
+        environments.request_sync(
+            &mut case.db,
+            file,
+            ScriptEnvironmentAvailability::Pending,
+            &|_, _| None,
+        );
+        if !environments.has_pending_synchronizations() {
+            return Ok(false);
+        }
+        let mut changed = Vec::new();
+        while environments.has_pending_synchronizations() {
+            wakeups
+                .recv_timeout(Duration::from_secs(30))
+                .context("script synchronization did not finish")?;
+            changed.extend(environments.poll_sync(&mut case.db));
+        }
+
+        Ok(!changed.is_empty())
+    }
 }

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -63,6 +63,7 @@ tracing = { workspace = true }
 ruff_db = { workspace = true, features = ["os", "testing"] }
 
 insta = { workspace = true, features = ["redactions", "ron"] }
+tempfile = { workspace = true }
 
 [features]
 default = ["zstd"]
@@ -78,6 +79,7 @@ schemars = [
 zstd = ["ty_vendored/zstd"]
 junit = ["ruff_db/junit"]
 format = ["ruff_python_formatter"]
+test-uv = []
 testing = []
 
 [lints]

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -23,7 +23,7 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use rustc_hash::FxHashSet;
 use salsa::{Database, Durability, Setter};
-pub use script::ScriptEnvironments;
+pub use script::{ScriptEnvironmentAvailability, ScriptEnvironments};
 use std::backtrace::BacktraceStatus;
 use std::collections::{BTreeSet, hash_set};
 use std::iter::FusedIterator;
@@ -404,8 +404,17 @@ impl Project {
                 let check_file_span =
                     tracing::debug_span!(parent: &project_span, "check_file", ?file);
                 let _entered = check_file_span.entered();
-                db.script_environments()
+                let initialization = db
+                    .script_environments()
                     .initialize_blocking(db, file, reporter);
+                if initialization.is_pending() {
+                    // The CLI watch loop or language server already scheduled this script's first
+                    // synchronization in the background. Until it completes, there is no
+                    // environment that can produce correct diagnostics. Applying the result
+                    // causes the diagnostics to be recomputed.
+                    reporter.report_checked_file(db, file, &[]);
+                    return;
+                }
                 let program_file = db.program_file(file);
 
                 match check_file_impl(db, program_file) {
@@ -686,10 +695,18 @@ fn check_file(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 /// Returns whether semantic checking and semantic diagnostics should run for `file`.
 ///
 /// Scripts with invalid configuration still produce configuration diagnostics and retain a program
-/// for editor operations, but their semantic diagnostics must not be reported.
+/// for editor operations, but their semantic diagnostics must not be reported. Semantic checks are
+/// also skipped until a script's first environment synchronization completes.
 pub fn should_check_semantics(db: &dyn Db, file: File) -> bool {
-    db.should_check_file(file)
-        && Script::for_file(db, file).is_none_or(|script| script.has_valid_settings(db))
+    if !db.should_check_file(file) {
+        return false;
+    }
+
+    let Some(script) = Script::for_file(db, file) else {
+        return true;
+    };
+
+    script.has_valid_settings(db) && !db.script_environments().is_initialization_pending(db, file)
 }
 
 /// Returns `true` if the file should be checked.

--- a/crates/ty_project/src/script.rs
+++ b/crates/ty_project/src/script.rs
@@ -23,8 +23,8 @@ use crate::{Db, ProjectMetadata};
 mod environment;
 
 pub(crate) use environment::ScriptEnvironmentCacheKey;
-pub use environment::ScriptEnvironments;
 use environment::script_environment;
+pub use environment::{ScriptEnvironmentAvailability, ScriptEnvironments};
 
 /// A standalone PEP 723 script and its resolved settings.
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]

--- a/crates/ty_project/src/script/environment.rs
+++ b/crates/ty_project/src/script/environment.rs
@@ -310,6 +310,9 @@ impl ScriptEnvironments {
     ///
     /// Returns the files whose environments were updated so callers can recheck them.
     pub fn poll_sync(&self, db: &mut dyn Db) -> Vec<File> {
+        // Updating a Salsa input waits for outstanding snapshots to be dropped. Cancel
+        // them before taking an entry lock, which their queries may need to finish.
+        db.trigger_cancellation();
         let mut changed_files = Vec::new();
 
         while let Ok(result) = self.inner.sync_results.try_recv() {
@@ -854,7 +857,8 @@ mod tests {
     #[cfg(feature = "test-uv")]
     mod uv {
         use std::process::Command;
-        use std::time::Duration;
+        use std::thread;
+        use std::time::{Duration, Instant};
 
         use anyhow::Context;
         use ruff_db::files::{File, system_path_to_file};
@@ -862,6 +866,7 @@ mod tests {
             DbWithTestSystem, DbWithWritableSystem, OsSystem, System as _, SystemPath,
             SystemPathBuf,
         };
+        use salsa::Database as _;
         use ty_static::EnvVars;
 
         use super::super::{ScriptEnvironmentAvailability, script_environment};
@@ -962,6 +967,48 @@ mod tests {
             assert_eq!(changed, vec![case.file]);
             case.assert_can_import("attrs")?;
 
+            Ok(())
+        }
+
+        #[test]
+        fn background_result_cancels_snapshots_before_locking_entry() -> anyhow::Result<()> {
+            let mut case = UvTestCase::new("# /// script\n# dependencies = []\n# ///\n")?;
+            let environments = case.db.script_environments().clone();
+            environments.request_sync(
+                &mut case.db,
+                case.file,
+                ScriptEnvironmentAvailability::Pending,
+                &|_, _| None,
+            );
+            environments
+                .sync_wakeups()
+                .recv_timeout(Duration::from_secs(30))
+                .context("script synchronization did not finish")?;
+
+            let entry = environments
+                .existing_entry(case.file)
+                .context("expected a script environment entry")?;
+            let snapshot = case.db.clone();
+            let reader = thread::spawn(move || {
+                let deadline = Instant::now() + Duration::from_secs(5);
+                while salsa::Cancelled::catch(|| snapshot.unwind_if_revision_cancelled()).is_ok() {
+                    assert!(Instant::now() < deadline, "snapshot was not cancelled");
+                    thread::sleep(Duration::from_millis(1));
+                }
+
+                // A cancelled query may need this lock before it can drop its snapshot. Use a
+                // timeout so a regression fails instead of deadlocking the test itself.
+                assert!(
+                    entry.state.try_lock_for(Duration::from_secs(1)).is_some(),
+                    "the entry lock was held while waiting for a cancelled snapshot"
+                );
+                drop(snapshot);
+            });
+
+            assert_eq!(environments.poll_sync(&mut case.db), vec![case.file]);
+            reader
+                .join()
+                .map_err(|_| anyhow::anyhow!("reader panicked"))?;
             Ok(())
         }
 

--- a/crates/ty_project/src/script/environment.rs
+++ b/crates/ty_project/src/script/environment.rs
@@ -13,6 +13,11 @@
 //! Waiting is necessary because the script's dependencies and Python version must be known to
 //! produce accurate diagnostics.
 //!
+//! CLI watch mode also schedules synchronization in the background after filesystem changes, but
+//! delays the next check until those synchronizations have completed. Scripts discovered during
+//! the subsequent check are initialized lazily. Repeated changes to a script are combined so only
+//! the latest requested synchronization runs after the current one.
+//!
 //! Each script's virtual environment is represented by a stable [`ScriptEnvironment`] Salsa input.
 //! Updating that input invalidates semantic queries that depend on the script's Python version or
 //! module search paths, ensuring that checks are rerun after synchronization.
@@ -21,23 +26,30 @@ use std::hash::Hasher;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crossbeam::channel::Receiver;
 use parking_lot::{Condvar, Mutex, MutexGuard};
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_db::FxDashMap;
-use ruff_db::files::File;
+use ruff_db::files::{File, Files};
 use ruff_db::system::SystemPathBuf;
+use salsa::Setter;
 
 use super::script_tag;
-use crate::uv::{ScriptSyncTask, Uv, UvMetadata, UvSyncService};
-use crate::{Db, ProgressReporter, UseUv};
+use crate::uv::{
+    ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, Uv, UvMetadata, UvSyncService,
+};
+use crate::{Db, ProgressReporter, ScriptSyncProgress, UseUv};
 
 const CANCELLATION_CHECK_INTERVAL: Duration = Duration::from_millis(1);
 
+type ProgressFactory<'factory> =
+    dyn Fn(&dyn Db, File) -> Option<Box<dyn ScriptSyncProgress>> + 'factory;
+
 /// Returns the Salsa input representing `file`'s script environment.
 ///
-/// Project checks normally synchronize the script's virtual environment before it is needed. This
-/// function never invokes uv; it returns the [`ScriptEnvironment`] input so semantic queries can
-/// depend on it.
+/// The CLI and language server normally synchronize the script's virtual environment before it
+/// is needed. This function never invokes uv; it returns the [`ScriptEnvironment`] input so
+/// semantic queries can depend on it.
 ///
 /// If no [`ScriptEnvironment`] exists, creates one without uv metadata. Its identity
 /// remains the same when synchronization later provides that metadata, just as a [`File`]
@@ -68,28 +80,54 @@ impl ScriptEnvironments {
         }
     }
 
+    /// Returns a receiver for background synchronization wakeups.
+    ///
+    /// A wakeup indicates that synchronization results may be ready to process with
+    /// [`poll_sync`](Self::poll_sync). Wakeups are coalesced, so one signal can represent
+    /// multiple completed synchronizations.
+    ///
+    /// The CLI and language-server main loops wait on this receiver alongside their other events.
+    /// When signaled, they call [`poll_sync`](Self::poll_sync) to update script environments and
+    /// recheck the affected files.
+    pub fn sync_wakeups(&self) -> Receiver<()> {
+        self.inner.sync_wakeups.clone()
+    }
+
     /// Initializes `file`'s environment before checking it.
     ///
     /// Discovering scripts requires reading file contents, so initializing every environment before
-    /// a project check would require eagerly inspecting every candidate file.
+    /// a project check would require eagerly inspecting every candidate file. After a directory
+    /// change, it could also require traversing the directory and reading each file before applying
+    /// the change, increasing CLI and language-server latency.
     ///
     /// Instead, project checks initialize virtual environments lazily as they encounter scripts.
     /// If no [`ScriptEnvironment`] exists, this method synchronizes the virtual environment and
     /// waits for uv before creating the input. An existing [`ScriptEnvironment`] is reused.
     ///
-    /// Concurrent callers wait for the initial environment creation to finish.
+    /// Background synchronization works differently: it creates the [`ScriptEnvironment`] input
+    /// before invoking uv so other operations can use it while synchronization runs. Applying the
+    /// result must therefore update an existing Salsa input. Before allowing that update, Salsa
+    /// cancels active checks and waits for them to finish. This method cannot wait for the update
+    /// because the current check must finish before the update can proceed.
+    ///
+    /// Returns [`Pending`] if no usable environment exists yet, allowing callers to decide whether
+    /// to proceed. For example, a caller can skip diagnostics that would be incorrect without the
+    /// script's dependencies. Applying the synchronization result schedules another check once the
+    /// environment becomes available.
+    ///
+    /// [`Pending`]: ScriptEnvironmentAvailability::Pending
     pub(crate) fn initialize_blocking(
         &self,
         db: &dyn Db,
         file: File,
         reporter: &dyn ProgressReporter,
-    ) {
+    ) -> ScriptEnvironmentAvailability {
         if !self.is_enabled() {
-            return;
+            return ScriptEnvironmentAvailability::Available;
         }
 
         let Some(task) = script_sync_task(db, file) else {
-            return;
+            return ScriptEnvironmentAvailability::Available;
         };
         let entry = self.entry(file);
 
@@ -97,18 +135,17 @@ impl ScriptEnvironments {
         loop {
             match &*state {
                 ScriptEnvironmentState::Current { .. } => {
-                    return;
+                    return ScriptEnvironmentAvailability::Available;
+                }
+
+                ScriptEnvironmentState::SynchronizingInBackground { availability, .. } => {
+                    return *availability;
                 }
 
                 // Another caller is synchronizing the virtual environment and will create its
                 // `ScriptEnvironment` input when uv finishes.
                 // Wait for that caller instead of starting a second synchronization.
-                ScriptEnvironmentState::InitializingBlocking { cache_key } => {
-                    debug_assert_eq!(
-                        *cache_key,
-                        task.request.cache_key(),
-                        "concurrent initializations must use the same script environment cache key"
-                    );
+                ScriptEnvironmentState::InitializingBlocking { .. } => {
                     // If the other caller is cancelled, it restores the entry to `Vacant`. Check the
                     // state again after waiting so this caller can initialize the environment instead.
                     state = entry.wait_until_initialized(db, state);
@@ -126,7 +163,7 @@ impl ScriptEnvironments {
 
                     // Run uv and show progress until the synchronization finishes.
                     let output = {
-                        let _progress = reporter.for_script(db, task.file);
+                        let _progress = reporter.for_script(db, file);
                         self.inner.sync_service.run_blocking(db, task)
                     };
 
@@ -143,10 +180,225 @@ impl ScriptEnvironments {
                     // Store the `ScriptEnvironment` input and wake waiting callers. Dropping the
                     // claim without completing it would instead restore the entry to `Vacant`.
                     claim.complete(environment);
-                    return;
+                    return ScriptEnvironmentAvailability::Available;
                 }
             }
         }
+    }
+
+    /// Returns whether `file`'s environment is [`Pending`](ScriptEnvironmentAvailability::Pending).
+    pub fn is_initialization_pending(&self, db: &dyn Db, file: File) -> bool {
+        if !self.is_enabled() || script_tag(db, file).is_none() {
+            return false;
+        }
+
+        self.existing_entry(file)
+            .is_some_and(|entry| entry.state.lock().availability().is_pending())
+    }
+
+    /// Requests background synchronization for `file`'s environment.
+    ///
+    /// If this call creates the script's first `ScriptEnvironment`, `availability` determines
+    /// whether it can be used while synchronization runs. An existing `ScriptEnvironment`
+    /// remains available, even if its virtual environment has not previously been synchronized.
+    ///
+    /// If another synchronization is already running, records the latest request to run afterward
+    /// and reuses the existing progress indicator. Otherwise, creates a new progress indicator and
+    /// submits the synchronization.
+    ///
+    /// Blocks while the worker queue is full, applying backpressure to the caller.
+    pub fn request_sync(
+        &self,
+        db: &mut dyn Db,
+        file: File,
+        availability: ScriptEnvironmentAvailability,
+        make_progress: &ProgressFactory<'_>,
+    ) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let Some(task) = script_sync_task(db, file) else {
+            return;
+        };
+        let entry: Arc<ScriptEnvironmentEntry> = self.entry(file);
+        let mut state = entry.state.lock();
+
+        let (environment, availability) = match &mut *state {
+            ScriptEnvironmentState::InitializingBlocking { cache_key: running } => {
+                // Both requests must observe the same script metadata and Python override. Changing
+                // either requires a Salsa update, which first cancels the blocking initialization
+                // and waits for it to finish. A different cache key therefore cannot be observed
+                // while the blocking initialization is still running.
+                assert_eq!(
+                    *running,
+                    task.request.cache_key(),
+                    "concurrent initializations must use the same script environment cache key"
+                );
+                tracing::trace!(
+                    "Script environment synchronization for `{}` is already running",
+                    task.request.path()
+                );
+                return;
+            }
+            ScriptEnvironmentState::Vacant => {
+                (ScriptEnvironment::new(db, None, None, None), availability)
+            }
+            ScriptEnvironmentState::Current { environment } => {
+                let synchronized_cache_key = environment.synchronized_cache_key(db);
+                let already_synchronized = synchronized_cache_key == Some(task.request.cache_key());
+
+                if already_synchronized {
+                    tracing::trace!(
+                        "Script environment for `{}` is already synchronized",
+                        task.request.path()
+                    );
+                    return;
+                }
+
+                (*environment, ScriptEnvironmentAvailability::Available)
+            }
+            ScriptEnvironmentState::SynchronizingInBackground { sync, .. } => {
+                if !sync.update_next_request(task.request.clone()) {
+                    tracing::trace!(
+                        "Script environment synchronization for `{}` is already requested",
+                        task.request.path()
+                    );
+                } else {
+                    tracing::debug!(
+                        "Updated pending script environment synchronization for `{}`",
+                        task.request.path()
+                    );
+                }
+
+                return;
+            }
+        };
+
+        let progress = make_progress(db, file);
+        *state = ScriptEnvironmentState::SynchronizingInBackground {
+            environment,
+            availability,
+            sync: InFlightSync {
+                active_cache_key: task.request.cache_key(),
+                next_request: None,
+            },
+        };
+
+        tracing::debug!(
+            "Requested script environment synchronization for `{}`",
+            task.request.path()
+        );
+
+        // Scheduling can block while the worker queue is full; release the entry lock first.
+        drop(state);
+
+        self.inner
+            .sync_service
+            .schedule_one(db.system(), task, progress);
+    }
+
+    /// Processes completed background synchronizations and updates their script environments.
+    ///
+    /// Background workers cannot apply their results because updating an existing Salsa input
+    /// requires mutable access to the database. The CLI and language-server main loops call this
+    /// method after receiving a [`sync_wakeups`](Self::sync_wakeups) notification.
+    ///
+    /// If a newer synchronization was requested while the current one was running, discards the
+    /// outdated result and schedules the newer request instead, transferring the existing progress
+    /// indicator. Scheduling can block while the worker queue is full.
+    ///
+    /// Returns the files whose environments were updated so callers can recheck them.
+    pub fn poll_sync(&self, db: &mut dyn Db) -> Vec<File> {
+        let mut changed_files = Vec::new();
+
+        while let Ok(result) = self.inner.sync_results.try_recv() {
+            let ScriptSyncResult {
+                task,
+                output,
+                progress,
+            } = result;
+            let file = task.file;
+            let request = task.request;
+            let Some(entry) = self.existing_entry(file) else {
+                panic!(
+                    "received a synchronization result for unknown script `{}`",
+                    request.path(),
+                );
+            };
+
+            let mut state = entry.state.lock();
+            let ScriptEnvironmentState::SynchronizingInBackground {
+                environment, sync, ..
+            } = &mut *state
+            else {
+                panic!(
+                    "synchronization result for `{}` does not match any task currently in flight",
+                    request.path(),
+                );
+            };
+            assert_eq!(
+                sync.active_cache_key,
+                request.cache_key(),
+                "synchronization result for `{}` does not match the task currently in flight",
+                request.path()
+            );
+
+            if let Some(next) = sync.next_request.take() {
+                // uv updates the same environment on disk for every version of this script. If the
+                // metadata changes A -> B -> A, the B synchronization may already have modified the
+                // environment. Run A again even though its cache key matches the last completed
+                // synchronization.
+                sync.active_cache_key = next.cache_key();
+
+                tracing::debug!(
+                    "Discarded superseded script environment synchronization result for `{}`",
+                    request.path()
+                );
+
+                // Scheduling can block while the worker queue is full; release the entry lock first.
+                drop(state);
+
+                self.inner.sync_service.schedule_one(
+                    db.system(),
+                    ScriptSyncTask {
+                        file,
+                        request: next,
+                    },
+                    progress,
+                );
+                continue;
+            }
+
+            let environment = *environment;
+            apply_sync_result(db, environment, &request, output);
+            *state = ScriptEnvironmentState::Current { environment };
+            changed_files.push(file);
+        }
+
+        changed_files
+    }
+
+    /// Returns whether any script environment is being initialized or synchronized.
+    ///
+    /// Can be used to delay checking until all requested synchronizations have completed.
+    pub fn has_pending_synchronizations(&self) -> bool {
+        self.inner.by_file.iter().any(|entry| {
+            matches!(
+                *entry.state.lock(),
+                ScriptEnvironmentState::InitializingBlocking { .. }
+                    | ScriptEnvironmentState::SynchronizingInBackground { .. }
+            )
+        })
+    }
+
+    /// Returns every file for which a `ScriptEnvironment` input has been created.
+    pub fn files(&self) -> Vec<File> {
+        self.inner
+            .by_file
+            .iter()
+            .filter_map(|entry| entry.state.lock().environment().map(|_| *entry.key()))
+            .collect()
     }
 
     fn environment(&self, db: &dyn Db, file: File) -> Option<ScriptEnvironment> {
@@ -167,7 +419,8 @@ impl ScriptEnvironments {
                 ScriptEnvironmentState::InitializingBlocking { .. } => {
                     state = entry.wait_until_initialized(db, state);
                 }
-                ScriptEnvironmentState::Current { environment } => {
+                ScriptEnvironmentState::Current { environment }
+                | ScriptEnvironmentState::SynchronizingInBackground { environment, .. } => {
                     return Some(environment);
                 }
             }
@@ -178,6 +431,11 @@ impl ScriptEnvironments {
         self.inner.use_uv.script_environments_enabled()
     }
 
+    fn existing_entry(&self, file: File) -> Option<Arc<ScriptEnvironmentEntry>> {
+        let entry = self.inner.by_file.get(&file)?;
+        Some(Arc::clone(entry.value()))
+    }
+
     fn entry(&self, file: File) -> Arc<ScriptEnvironmentEntry> {
         // Return an owned entry so the map's shard lock is released before the caller waits
         // for synchronization. Otherwise, unrelated scripts in the same shard would also be blocked.
@@ -186,6 +444,30 @@ impl ScriptEnvironments {
 }
 
 impl std::panic::RefUnwindSafe for ScriptEnvironments {}
+
+/// Whether a script environment is suitable for operations that depend on its dependencies.
+///
+/// When opening a script, the initial environment lacks its declared dependencies and can produce
+/// incorrect results. Operations affected by those dependencies, such as semantic diagnostics,
+/// should be deferred. Operations such as semantic tokens can continue.
+///
+/// During a resync, the previous environment remains a reasonable approximation. If an unsaved edit
+/// turns an ordinary file into a script, its default environment is also used: it already reflects
+/// the script's settings, and synchronization is deferred until the file is saved.
+#[derive(Clone, Copy)]
+pub enum ScriptEnvironmentAvailability {
+    /// Operations that require the script's dependencies should be deferred.
+    Pending,
+
+    /// The default or previously synchronized environment can be used.
+    Available,
+}
+
+impl ScriptEnvironmentAvailability {
+    pub(crate) const fn is_pending(self) -> bool {
+        matches!(self, Self::Pending)
+    }
+}
 
 /// Identifies when a script's environment needs to be synchronized.
 ///
@@ -200,8 +482,8 @@ pub(crate) type ScriptEnvironmentCacheKey = u64;
 /// semantic analysis reaches a script before synchronization, [`script_environment`] creates
 /// this input without invoking uv.
 ///
-/// Later synchronization updates the same input. Keeping its identity stable ensures that Salsa
-/// invalidates queries which observed the earlier
+/// The CLI or language server later synchronizes the script and updates the same input. Keeping
+/// its identity stable ensures that Salsa invalidates queries which observed the earlier
 /// environment when its Python version, module search paths, or initialization error changes.
 #[salsa::input(heap_size=ruff_memory_usage::heap_size)]
 #[derive(Debug)]
@@ -228,11 +510,26 @@ pub(super) struct ScriptEnvironment {
     pub(super) initialization_error: Option<Box<str>>,
 }
 
-#[derive(Default)]
 struct ScriptEnvironmentsInner {
     use_uv: UseUv,
     by_file: FxDashMap<File, Arc<ScriptEnvironmentEntry>>,
     sync_service: UvSyncService,
+    sync_results: Receiver<ScriptSyncResult>,
+    sync_wakeups: Receiver<()>,
+}
+
+impl Default for ScriptEnvironmentsInner {
+    fn default() -> Self {
+        let (results_sender, sync_results) = crossbeam::channel::unbounded();
+        let (wake_sender, sync_wakeups) = crossbeam::channel::bounded(1);
+        Self {
+            use_uv: UseUv::default(),
+            by_file: FxDashMap::default(),
+            sync_service: UvSyncService::new(results_sender, wake_sender),
+            sync_results,
+            sync_wakeups,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -275,7 +572,9 @@ impl ScriptEnvironmentEntry {
 
 /// The synchronization state of one script environment.
 ///
-/// Ensures that at most one blocking synchronization runs for a script at a time.
+/// Distinguishes blocking initialization from background synchronization because they create
+/// and update Salsa inputs differently. Also ensures that at most one synchronization runs for
+/// a script at a time.
 #[derive(Default)]
 enum ScriptEnvironmentState {
     /// No [`ScriptEnvironment`] exists and no synchronization is running.
@@ -287,8 +586,9 @@ enum ScriptEnvironmentState {
 
     /// A caller is waiting for uv to initialize the script's environment.
     ///
-    /// The caller waits for uv, creates the [`ScriptEnvironment`] input from its result, and wakes
-    /// any other callers waiting for the same script.
+    /// Unlike background synchronization, this does not create a [`ScriptEnvironment`] in advance.
+    /// The caller waits for uv, creates the input from its result, and wakes any other callers
+    /// waiting for the same script.
     InitializingBlocking {
         /// Identifies the script metadata and Python override passed to uv.
         cache_key: ScriptEnvironmentCacheKey,
@@ -300,8 +600,84 @@ enum ScriptEnvironmentState {
     /// [`ScriptEnvironment`] input. If semantic analysis reaches a script before synchronization
     /// has been requested, [`script_environment`] creates an input without uv metadata instead.
     ///
-    /// The environment does not necessarily match the latest script metadata.
+    /// For example, when an unsaved edit adds script metadata to a file, synchronization is
+    /// deferred until the file is saved. Checking continues with the default environment so
+    /// existing diagnostics do not disappear in the meantime.
+    ///
+    /// The environment does not necessarily match the latest script metadata. The CLI or language
+    /// server is responsible for requesting synchronization when an updated environment is needed.
     Current { environment: ScriptEnvironment },
+
+    /// A background synchronization is initializing or updating the script's virtual environment.
+    ///
+    /// Unlike blocking initialization, a [`ScriptEnvironment`] input already exists while uv runs.
+    /// If no input exists yet, one is created before synchronization starts so semantic queries
+    /// have a stable Salsa identity to depend on.
+    ///
+    /// The background worker cannot update the [`ScriptEnvironment`] because modifying a Salsa
+    /// input requires mutable access to the database. Instead, the CLI or language-server main loop
+    /// updates it when synchronization finishes.
+    SynchronizingInBackground {
+        /// The [`ScriptEnvironment`] input that will receive the synchronization result.
+        environment: ScriptEnvironment,
+
+        availability: ScriptEnvironmentAvailability,
+
+        /// The active synchronization and the next request, if any.
+        sync: InFlightSync,
+    },
+}
+
+impl ScriptEnvironmentState {
+    fn availability(&self) -> ScriptEnvironmentAvailability {
+        match self {
+            Self::InitializingBlocking { .. } => ScriptEnvironmentAvailability::Pending,
+            Self::Vacant | Self::Current { .. } => ScriptEnvironmentAvailability::Available,
+            Self::SynchronizingInBackground { availability, .. } => *availability,
+        }
+    }
+
+    fn environment(&self) -> Option<ScriptEnvironment> {
+        match self {
+            Self::Current { environment, .. }
+            | Self::SynchronizingInBackground { environment, .. } => Some(*environment),
+            Self::Vacant | Self::InitializingBlocking { .. } => None,
+        }
+    }
+}
+
+/// An active synchronization and the latest request to run after it.
+///
+/// At most one additional request is retained. If the script changes repeatedly while uv is
+/// running, newer requests replace the pending request instead of accumulating in a queue.
+struct InFlightSync {
+    active_cache_key: ScriptEnvironmentCacheKey,
+    next_request: Option<ScriptSyncRequest>,
+}
+
+impl InFlightSync {
+    /// Updates the synchronization to run after the active request.
+    ///
+    /// If `request` matches the active synchronization, removes any previously requested follow-up.
+    /// Otherwise, replaces the follow-up with `request`.
+    ///
+    /// Returns whether the requested synchronization changed.
+    fn update_next_request(&mut self, request: ScriptSyncRequest) -> bool {
+        let desired = self
+            .next_request
+            .as_ref()
+            .map_or(self.active_cache_key, ScriptSyncRequest::cache_key);
+        if desired == request.cache_key() {
+            return false;
+        }
+
+        self.next_request = if self.active_cache_key == request.cache_key() {
+            None
+        } else {
+            Some(request)
+        };
+        true
+    }
 }
 
 /// Ensures a blocking synchronization always releases its claim on the script.
@@ -348,6 +724,62 @@ impl Drop for InitializationClaim<'_> {
     }
 }
 
+/// Applies a completed synchronization to the existing [`ScriptEnvironment`] input.
+///
+/// Stores the returned metadata or initialization error and records the synchronized cache key.
+/// Updating the input invalidates semantic queries that depend on the script's virtual
+/// environment.
+fn apply_sync_result(
+    db: &mut dyn Db,
+    environment: ScriptEnvironment,
+    request: &ScriptSyncRequest,
+    output: std::io::Result<std::process::Output>,
+) {
+    let previous_root = environment
+        .uv_metadata(db)
+        .and_then(UvMetadata::environment)
+        .map(ToOwned::to_owned);
+    let recovering_from_error = environment.initialization_error(db).is_some();
+    let (uv_metadata, initialization_error) = parse_metadata_output(db, output);
+    let current_root = uv_metadata.as_ref().and_then(UvMetadata::environment);
+
+    if let Some(root) = previous_root
+        .as_deref()
+        .or_else(|| current_root.filter(|_| recovering_from_error))
+    {
+        // uv can install, update, or remove packages without changing the virtual-environment path.
+        // Refresh files under that path so semantic queries see the updated package contents.
+        // After a failed synchronization, recover the path from the new metadata because the
+        // previous metadata was cleared along with its virtual-environment path.
+        //
+        // FIXME: This is overbroad. A file watcher can tell us precisely what changed.
+        // Changes inside virtual environments should instead be watched and processed through `ProjectDatabase::apply_changes`.
+        // Using a file watcher also ensures that virtual environment changes in
+        // scripts without using uv are detected.
+        Files::sync_all_recursive(db, [root]);
+    }
+
+    if environment.uv_metadata(db) != uv_metadata.as_ref() {
+        environment.set_uv_metadata(db).to(uv_metadata);
+    }
+
+    if environment.initialization_error(db) != initialization_error.as_deref() {
+        environment
+            .set_initialization_error(db)
+            .to(initialization_error);
+    }
+
+    let cache_key = Some(request.cache_key());
+    if environment.synchronized_cache_key(db) != cache_key {
+        environment.set_synchronized_cache_key(db).to(cache_key);
+    }
+
+    tracing::debug!(
+        "Applied script environment synchronization result for `{}`",
+        request.path()
+    );
+}
+
 fn parse_metadata_output(
     db: &dyn Db,
     output: std::io::Result<std::process::Output>,
@@ -385,4 +817,240 @@ fn script_python(db: &dyn Db) -> Option<SystemPathBuf> {
         .and_then(|options| options.environment.as_ref())
         .and_then(|environment| environment.python.as_ref())
         .map(|python| python.absolute(metadata.root(), db.system()))
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::{DbWithWritableSystem, SystemPath};
+
+    use super::script_environment;
+    use crate::db::testing::TestDb;
+    use crate::{Db as _, ProjectMetadata, UseUv};
+
+    #[test]
+    fn semantic_lookup_creates_a_stable_default_environment() -> anyhow::Result<()> {
+        let root = SystemPath::new("/project").to_path_buf();
+        let path = root.join("script.py");
+        let metadata = ProjectMetadata::new("test", root).with_use_uv(UseUv::Scripts);
+        let mut db = TestDb::new(metadata);
+        db.write_file(&path, "# /// script\n# dependencies = []\n# ///\n")?;
+        let file = system_path_to_file(&db, &path)?;
+        let environments = db.script_environments().clone();
+
+        // Semantic queries can reach a script before its environment has been synchronized. They
+        // create one stable Salsa input with no uv metadata or initialization error.
+        let environment = script_environment(&db, file).context("expected a script environment")?;
+        assert_eq!(script_environment(&db, file), Some(environment));
+        assert_eq!(environment.synchronized_cache_key(&db), None);
+        assert_eq!(environment.uv_metadata(&db), None);
+        assert_eq!(environment.initialization_error(&db), None);
+        assert!(!environments.is_initialization_pending(&db, file));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "test-uv")]
+    mod uv {
+        use std::process::Command;
+        use std::time::Duration;
+
+        use anyhow::Context;
+        use ruff_db::files::{File, system_path_to_file};
+        use ruff_db::system::{
+            DbWithTestSystem, DbWithWritableSystem, OsSystem, System as _, SystemPath,
+            SystemPathBuf,
+        };
+        use ty_static::EnvVars;
+
+        use super::super::{ScriptEnvironmentAvailability, script_environment};
+        use crate::db::testing::TestDb;
+        use crate::{Db as _, ProjectMetadata, UseUv};
+
+        #[test]
+        fn initial_background_synchronization_is_pending_until_completion() -> anyhow::Result<()> {
+            let mut case = UvTestCase::new(
+                "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+            )?;
+            let environments = case.db.script_environments().clone();
+
+            environments.request_sync(
+                &mut case.db,
+                case.file,
+                ScriptEnvironmentAvailability::Pending,
+                &|_, _| None,
+            );
+            assert!(environments.is_initialization_pending(&case.db, case.file));
+
+            assert_eq!(case.wait_for_synchronizations()?, vec![case.file]);
+            assert!(!environments.is_initialization_pending(&case.db, case.file));
+            case.assert_can_import("attrs")?;
+
+            Ok(())
+        }
+
+        #[test]
+        fn existing_environment_remains_available_during_background_synchronization()
+        -> anyhow::Result<()> {
+            let mut case = UvTestCase::new(
+                "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+            )?;
+            let environments = case.db.script_environments().clone();
+            let environment = script_environment(&case.db, case.file)
+                .context("expected a default script environment")?;
+
+            environments.request_sync(
+                &mut case.db,
+                case.file,
+                ScriptEnvironmentAvailability::Pending,
+                &|_, _| None,
+            );
+            assert_eq!(script_environment(&case.db, case.file), Some(environment));
+            assert!(!environments.is_initialization_pending(&case.db, case.file));
+
+            assert_eq!(case.wait_for_synchronizations()?, vec![case.file]);
+            assert_eq!(script_environment(&case.db, case.file), Some(environment));
+            case.assert_can_import("attrs")?;
+
+            Ok(())
+        }
+
+        #[test]
+        fn returning_to_previous_metadata_resynchronizes_the_environment() -> anyhow::Result<()> {
+            let initial = "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n";
+            let mut case = UvTestCase::new(initial)?;
+            let environments = case.db.script_environments().clone();
+            environments.request_sync(
+                &mut case.db,
+                case.file,
+                ScriptEnvironmentAvailability::Pending,
+                &|_, _| None,
+            );
+            assert_eq!(case.wait_for_synchronizations()?, vec![case.file]);
+            case.assert_can_import("attrs")?;
+
+            case.db.write_file(
+                &case.path,
+                "# /// script\n# dependencies = ['anyio']\n# ///\nfrom attrs import define\n",
+            )?;
+            let wakeups = environments.sync_wakeups();
+            environments.request_sync(
+                &mut case.db,
+                case.file,
+                ScriptEnvironmentAvailability::Pending,
+                &|_, _| None,
+            );
+
+            // Wait until uv has changed the virtual environment, but leave its result unapplied.
+            wakeups
+                .recv_timeout(Duration::from_secs(30))
+                .context("intermediate script synchronization did not finish")?;
+
+            // Restoring the original metadata must reinstall its dependencies, even though its
+            // cache key matches the last synchronization whose result was applied.
+            case.db.write_file(&case.path, initial)?;
+            environments.request_sync(
+                &mut case.db,
+                case.file,
+                ScriptEnvironmentAvailability::Pending,
+                &|_, _| None,
+            );
+
+            let mut changed = environments.poll_sync(&mut case.db);
+            changed.extend(case.wait_for_synchronizations()?);
+            assert_eq!(changed, vec![case.file]);
+            case.assert_can_import("attrs")?;
+
+            Ok(())
+        }
+
+        struct UvTestCase {
+            _temp_dir: tempfile::TempDir,
+            db: TestDb,
+            file: File,
+            path: SystemPathBuf,
+        }
+
+        impl UvTestCase {
+            fn new(source: &str) -> anyhow::Result<Self> {
+                let temp_dir = tempfile::tempdir()?;
+                let root = SystemPath::from_std_path(temp_dir.path())
+                    .context("temporary directory is not a valid UTF-8 path")?
+                    .to_path_buf();
+                let metadata =
+                    ProjectMetadata::new("test", root.clone()).with_use_uv(UseUv::Scripts);
+                let mut db = TestDb::new(metadata);
+                db.use_system(OsSystem::new(&root));
+
+                let uv = OsSystem::default().which("uv")?;
+                db.test_system().set_env_var(EnvVars::UV, uv.as_str());
+                for name in [
+                    EnvVars::VIRTUAL_ENV,
+                    EnvVars::CONDA_PREFIX,
+                    EnvVars::CONDA_DEFAULT_ENV,
+                    EnvVars::CONDA_ROOT,
+                    EnvVars::PYTHONPATH,
+                ] {
+                    db.test_system().remove_env_var(name);
+                }
+
+                let path = root.join("script.py");
+                db.write_file(&path, source)?;
+                let file = system_path_to_file(&db, &path)?;
+
+                Ok(Self {
+                    _temp_dir: temp_dir,
+                    db,
+                    file,
+                    path,
+                })
+            }
+
+            fn wait_for_synchronizations(&mut self) -> anyhow::Result<Vec<File>> {
+                let environments = self.db.script_environments().clone();
+                let wakeups = environments.sync_wakeups();
+                let mut changed = Vec::new();
+
+                while environments.has_pending_synchronizations() {
+                    wakeups
+                        .recv_timeout(Duration::from_secs(30))
+                        .context("script synchronization did not finish")?;
+                    changed.extend(environments.poll_sync(&mut self.db));
+                }
+
+                Ok(changed)
+            }
+
+            fn assert_can_import(&self, module: &str) -> anyhow::Result<()> {
+                let environment = script_environment(&self.db, self.file)
+                    .context("expected a script environment")?;
+                let metadata = environment.uv_metadata(&self.db).with_context(|| {
+                    format!(
+                        "script synchronization did not produce uv metadata: {:?}",
+                        environment.initialization_error(&self.db)
+                    )
+                })?;
+                let root = metadata
+                    .environment()
+                    .context("uv metadata did not include a virtual environment")?;
+                let python = if cfg!(windows) {
+                    root.join("Scripts/python.exe")
+                } else {
+                    root.join("bin/python")
+                };
+                let output = Command::new(python.as_std_path())
+                    .args(["-c", &format!("import {module}")])
+                    .output()?;
+
+                anyhow::ensure!(
+                    output.status.success(),
+                    "failed to import `{module}` from the synchronized environment: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+
+                Ok(())
+            }
+        }
+    }
 }

--- a/crates/ty_project/src/uv.rs
+++ b/crates/ty_project/src/uv.rs
@@ -7,7 +7,7 @@ use ty_combine::Combine;
 use ty_static::EnvVars;
 
 pub(crate) use metadata::{UvMetadata, UvMetadataError};
-pub(crate) use sync::{ScriptSyncTask, UvSyncService};
+pub(crate) use sync::{ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, UvSyncService};
 
 mod metadata;
 mod sync;

--- a/crates/ty_project/src/uv/sync.rs
+++ b/crates/ty_project/src/uv/sync.rs
@@ -136,6 +136,7 @@ impl UvSyncService {
                 script = %path,
             ),
         };
+        tracing::debug!("Queuing script synchronization for `{path}`");
         match workers.jobs.send(job) {
             Ok(()) => tracing::debug!("Queued script synchronization for `{path}`"),
             Err(error) => {

--- a/crates/ty_project/src/uv/sync.rs
+++ b/crates/ty_project/src/uv/sync.rs
@@ -2,13 +2,13 @@ use std::process::Output;
 use std::sync::{Arc, OnceLock, Weak};
 use std::time::Duration;
 
-use crossbeam::channel::{Receiver, RecvTimeoutError, SendTimeoutError, Sender};
+use crossbeam::channel::{Receiver, RecvTimeoutError, SendTimeoutError, Sender, TrySendError};
 use ruff_db::files::File;
 use ruff_db::system::{CommandExecutor, System, SystemPathBuf};
 
 use super::{MetadataTarget, Uv, unsupported_command_execution, uv_executable_error};
-use crate::Db;
 use crate::script::ScriptEnvironmentCacheKey;
+use crate::{Db, ScriptSyncProgress};
 
 /// Synchronizes standalone script environments with uv.
 ///
@@ -24,12 +24,29 @@ use crate::script::ScriptEnvironmentCacheKey;
 /// The service only owns scheduling of `uv metadata` calls.
 /// [`ScriptEnvironments`](crate::ScriptEnvironments) is the higher level abstraction that
 /// application code should use.
-#[derive(Default)]
 pub(crate) struct UvSyncService {
     workers: OnceLock<std::io::Result<UvWorkerPool>>,
+
+    /// Channel, where to send the background results to.
+    results_sender: Sender<ScriptSyncResult>,
+
+    /// Signals when new background results are available.
+    ///
+    /// This overlaps with `results_sender`, but the main difference is that it doesn't expose the
+    /// sync result. The LSP and CLI use it as a wake up signal for when to call
+    /// [`ScriptEnvironments::poll_sync`](crate::ScriptEnvironments::poll_sync).
+    wake_sender: Sender<()>,
 }
 
 impl UvSyncService {
+    pub(crate) fn new(results_sender: Sender<ScriptSyncResult>, wake_sender: Sender<()>) -> Self {
+        Self {
+            workers: OnceLock::new(),
+            results_sender,
+            wake_sender,
+        }
+    }
+
     /// Synchronizes one script and waits for its result.
     ///
     /// Blocks the calling thread, periodically checking for Salsa cancellation.
@@ -80,6 +97,74 @@ impl UvSyncService {
                     db.unwind_if_revision_cancelled();
                 }
                 Err(RecvTimeoutError::Disconnected) => return Err(worker_disconnected()),
+            }
+        }
+    }
+
+    /// Submits one background synchronization.
+    ///
+    /// This blocks while the bounded worker queue is full, applying backpressure until a worker
+    /// accepts another job.
+    pub(crate) fn schedule_one(
+        &self,
+        system: &dyn System,
+        task: ScriptSyncTask,
+        progress: Option<Box<dyn ScriptSyncProgress>>,
+    ) {
+        let workers = match self.worker_pool(system) {
+            Ok(workers) => workers,
+            Err(error) => {
+                self.publish_result(ScriptSyncResult {
+                    task,
+                    output: Err(error),
+                    progress,
+                });
+                return;
+            }
+        };
+
+        let path = task.request.path().to_path_buf();
+        let job = UvJob {
+            task,
+            mode: UvJobMode::Background {
+                result_sender: self.results_sender.clone(),
+                wake_sender: self.wake_sender.clone(),
+                progress,
+            },
+            span: tracing::debug_span!(
+                "script_environment_sync",
+                script = %path,
+            ),
+        };
+        match workers.jobs.send(job) {
+            Ok(()) => tracing::debug!("Queued script synchronization for `{path}`"),
+            Err(error) => {
+                let UvJob { task, mode, .. } = error.into_inner();
+                match mode {
+                    UvJobMode::Blocking { result_sender, .. } => {
+                        let _ = result_sender.send(Err(worker_disconnected()));
+                    }
+                    UvJobMode::Background { progress, .. } => {
+                        self.publish_result(ScriptSyncResult {
+                            task,
+                            output: Err(worker_disconnected()),
+                            progress,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    fn publish_result(&self, result: ScriptSyncResult) {
+        self.results_sender
+            .send(result)
+            .expect("the uv synchronization result receiver must remain connected");
+
+        match self.wake_sender.try_send(()) {
+            Ok(()) | Err(TrySendError::Full(())) => {}
+            Err(TrySendError::Disconnected(())) => {
+                panic!("the uv synchronization wakeup receiver must remain connected");
             }
         }
     }
@@ -153,6 +238,15 @@ struct ScriptSyncRequestData {
     path: SystemPathBuf,
     python: Option<SystemPathBuf>,
     cache_key: ScriptEnvironmentCacheKey,
+}
+
+/// The result of synchronizing a standalone script environment.
+///
+/// This owns the progress guard so progress remains active until the result is consumed.
+pub(crate) struct ScriptSyncResult {
+    pub(crate) task: ScriptSyncTask,
+    pub(crate) output: std::io::Result<Output>,
+    pub(crate) progress: Option<Box<dyn ScriptSyncProgress>>,
 }
 
 const MAX_UV_WORKERS: usize = 2;
@@ -237,8 +331,9 @@ impl UvWorker {
             };
 
             // Don't schedule jobs that have been cancelled in the meantime (salsa cancellation).
-            let UvJobMode::Blocking { cancellation, .. } = &job.mode;
-            if cancellation.is_cancelled() {
+            if let UvJobMode::Blocking { cancellation, .. } = &job.mode
+                && cancellation.is_cancelled()
+            {
                 tracing::debug!(
                     "Discarded cancelled script synchronization for `{}`",
                     job.task.request.path()
@@ -260,11 +355,29 @@ impl UvWorker {
             };
 
             // Send the result
-            let UvJob { mode, .. } = job;
+            let UvJob { task, mode, .. } = job;
             match mode {
                 UvJobMode::Blocking { result_sender, .. } => {
                     // The receiver disappears when the blocking caller is cancelled.
                     let _ = result_sender.send(output);
+                }
+                UvJobMode::Background {
+                    result_sender,
+                    wake_sender,
+                    progress,
+                } => {
+                    // The receiver disappears when the owning project is dropped.
+                    if result_sender
+                        .send(ScriptSyncResult {
+                            task,
+                            output,
+                            progress,
+                        })
+                        .is_ok()
+                    {
+                        // Signal that there's a new result.
+                        let _ = wake_sender.try_send(());
+                    }
                 }
             }
         }
@@ -283,6 +396,17 @@ enum UvJobMode {
         result_sender: Sender<std::io::Result<Output>>,
         /// Lets a worker discard a queued job after its blocking Salsa operation is cancelled.
         cancellation: UvJobCancellation,
+    },
+
+    /// The job runs as a background task.
+    ///
+    Background {
+        /// The sender end of the channel communicating with the sync service.
+        result_sender: Sender<ScriptSyncResult>,
+
+        /// The wake signal that notifies that there's a new result to process.
+        wake_sender: Sender<()>,
+        progress: Option<Box<dyn ScriptSyncProgress>>,
     },
 }
 


### PR DESCRIPTION
## Summary

This PR adds `uv metadata` support to `ty check --watch`. The main complexity introduced by this PR is that we can't synchronous scripts on ty's main loop, because that would make `Ctrl + C` unresponsive, ty would also stop responding to other incoming file changes (which can fill the file watcher queue, which ultimately results in dropped events, requiring rescanning). 


This is why this PR introduces an API to start a background synchronization, that notifies the main loop when a new completed sync result is ready to be applied. 

The CLI waits before scheduling a new check until all synchronization have completed, to avoid running on a partial virtual environment.

Part of https://github.com/astral-sh/ty/issues/4183

## Test plan


https://github.com/user-attachments/assets/16034a0f-fc0f-4833-9747-eed5b5120c76

