### PR TITLE
[ty] Benchmark checking PEP 723 scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1321,7 +1321,7 @@ jobs:
           tool: cargo-codspeed
 
       - name: "Build benchmarks"
-        run: cargo codspeed build -m walltime --features "codspeed,ty_walltime" --profile profiling --no-default-features -p ruff_benchmark --bench ty_walltime
+        run: cargo codspeed build -m walltime --features "codspeed,ty_walltime" --profile profiling --no-default-features -p ruff_benchmark --bench ty_walltime --bench ty_script
 
       - name: "Upload benchmark binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1343,6 +1343,8 @@ jobs:
     strategy:
       matrix:
         benchmark:
+          - name: script
+            target: ty_script
           - name: sympy
             target: ty_walltime
             filter: sympy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,10 +3187,12 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "tempfile",
  "tikv-jemallocator",
  "tracing",
  "ty_module_resolver",
  "ty_project",
+ "ty_static",
 ]
 
 [[package]]

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -44,6 +44,8 @@ rayon = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_ranged_value = { workspace = true }
 rustc-hash = { workspace = true }
+tempfile = { workspace = true }
+ty_static = { workspace = true }
 
 [features]
 default = ["module_resolution", "ruff_instrumented", "ty_instrumented", "ty_walltime"]
@@ -99,6 +101,11 @@ required-features = ["ty_instrumented"]
 name = "module_resolution"
 harness = false
 required-features = ["module_resolution"]
+
+[[bench]]
+name = "ty_script"
+harness = false
+required-features = ["ty_walltime"]
 
 [[bench]]
 name = "ty_walltime"

--- a/crates/ruff_benchmark/benches/ty_script.rs
+++ b/crates/ruff_benchmark/benches/ty_script.rs
@@ -1,0 +1,64 @@
+use divan::{Bencher, bench};
+use rayon::ThreadPoolBuilder;
+use ruff_db::system::{OsSystem, SystemPath, TestSystem};
+use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_static::EnvVars;
+
+fn setup_iteration(root: &SystemPath) -> ProjectDatabase {
+    let system = TestSystem::new(OsSystem::new(root));
+    for name in [
+        EnvVars::VIRTUAL_ENV,
+        EnvVars::CONDA_PREFIX,
+        EnvVars::CONDA_DEFAULT_ENV,
+        EnvVars::CONDA_ROOT,
+        EnvVars::PYTHONPATH,
+    ] {
+        system.remove_env_var(name);
+    }
+
+    let metadata = ProjectMetadata::new("script", root.to_path_buf());
+    ProjectDatabase::fallible(metadata, system).unwrap()
+}
+
+#[bench(sample_size = 2, sample_count = 3)]
+fn simple_script(bencher: Bencher) {
+    let directory = tempfile::tempdir().unwrap();
+    let root = SystemPath::from_std_path(directory.path()).unwrap();
+    std::fs::write(
+        root.join("script.py"),
+        r#"# /// script
+# requires-python = ">=3.12"
+# dependencies = ["attrs==25.4.0"]
+# ///
+
+from attrs import define
+
+@define
+class User:
+    name: str
+
+
+def greet(user: User) -> str:
+    return f"Hello, {user.name}!"
+"#,
+    )
+    .unwrap();
+
+    bencher
+        .with_inputs(|| setup_iteration(root))
+        .bench_local_refs(|db| {
+            let diagnostics = db.check();
+            assert_eq!(diagnostics.len(), 1);
+            assert!(diagnostics[0].id().is_lint_named("unresolved-import"));
+        });
+}
+
+fn main() {
+    ThreadPoolBuilder::new()
+        .num_threads(1)
+        .use_current_thread()
+        .build_global()
+        .unwrap();
+
+    divan::main();
+}


### PR DESCRIPTION
## Summary

Add a CodSpeed baseline for checking a PEP 723 script that imports a declared dependency. The following CLI integration PR uses the same benchmark to measure warm-cache uv synchronization overhead and catch regressions.

Testing: Ran the benchmark in the profiling profile and checked the affected benchmark target.