### PR TITLE
[ty] Prepare ecosystem analysis for script-only uv integration

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -134,6 +134,7 @@ jobs:
     timeout-minutes: 10
     env:
       EXCLUDE_NEWER: ${{ github.event.pull_request.updated_at }}
+      # Enable experimental support for installing PEP 723 script dependencies.
       TY_UV: scripts
     steps:
       - name: Install the latest version of uv

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -134,6 +134,7 @@ jobs:
     timeout-minutes: 10
     env:
       EXCLUDE_NEWER: ${{ github.event.pull_request.updated_at }}
+      TY_UV: scripts
     steps:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -26,6 +26,8 @@ jobs:
     name: Create ecosystem report
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 40
+    env:
+      TY_UV: scripts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-22.04-32' || 'ubuntu-latest' }}
     timeout-minutes: 40
     env:
+      # Enable experimental support for installing PEP 723 script dependencies.
       TY_UV: scripts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Enable the new automatic "sync script virtual environment" in ecosystem runs. This ensures that scripts will be checked with their own virtual environment and own dependencies (at least, once PRs later in this stack land). 

I decided to only enable the new scripts behavior because enabling the new automatic uv sync for all projects breaks mypy primer, because uv now tries to install all dependencies of that project which may not succeed. We'll need to find a solution for this, but I prefer to solve this later