### PR TITLE
[`pylint`] Allow `continue` in `finally` on Python 3.8

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1355,7 +1355,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 flake8_bugbear::rules::jump_statement_in_finally(checker, finalbody);
             }
             if checker.is_rule_enabled(Rule::ContinueInFinally) {
-                if checker.target_version() <= PythonVersion::PY38 {
+                if checker.target_version() < PythonVersion::PY38 {
                     pylint::rules::continue_in_finally(checker, finalbody);
                 }
             }

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -293,6 +293,17 @@ mod tests {
     }
 
     #[test]
+    fn continue_in_finally_python_38() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pylint/continue_in_finally.py"),
+            &LinterSettings::for_rule(Rule::ContinueInFinally)
+                .with_target_version(PythonVersion::PY38),
+        )?;
+        assert!(diagnostics.is_empty());
+        Ok(())
+    }
+
+    #[test]
     fn allow_magic_value_types() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pylint/magic_value_comparison.py"),


### PR DESCRIPTION
## Summary

Python 3.8 allowed `continue` statements in `finally` clauses (https://docs.python.org/3.14/whatsnew/3.8.html#other-language-changes), but PLE0116 treated Python 3.8 as unsupported. Restrict the diagnostic to targets older than Python 3.8. 

## Test plan


Added regression test
