### PR TITLE
Use Depot runners for release builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,7 +5,6 @@ self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
     - depot-ubuntu-24.04-4
-    - depot-ubuntu-24.04-8
     - depot-ubuntu-latest-8
     - depot-ubuntu-22.04-16
     - depot-ubuntu-22.04-32

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,8 @@ self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
     - depot-ubuntu-24.04-4
+    - depot-ubuntu-24.04-8
+    - depot-ubuntu-latest-4
     - depot-ubuntu-latest-8
     - depot-ubuntu-22.04-16
     - depot-ubuntu-22.04-32

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,7 +6,6 @@ self-hosted-runner:
   labels:
     - depot-ubuntu-24.04-4
     - depot-ubuntu-24.04-8
-    - depot-ubuntu-latest-4
     - depot-ubuntu-latest-8
     - depot-ubuntu-22.04-16
     - depot-ubuntu-22.04-32

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -282,7 +282,7 @@ jobs:
 
   linux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         platform:
@@ -433,7 +433,7 @@ jobs:
 
   musllinux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   sdist:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -224,7 +224,7 @@ jobs:
 
   linux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest-4
     strategy:
       matrix:
         target:
@@ -282,7 +282,7 @@ jobs:
 
   linux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     strategy:
       matrix:
         platform:
@@ -372,7 +372,7 @@ jobs:
 
   musllinux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         target:
@@ -433,7 +433,7 @@ jobs:
 
   musllinux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -224,7 +224,7 @@ jobs:
 
   linux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         target:


### PR DESCRIPTION
## Summary

Move source distributions and Linux release builds onto pinned, four-core Ubuntu 24.04 Depot runners. This preserves the CPU allocation of the GitHub-hosted runners they replace while avoiding GitHub runner queues; recent Ruff releases were limited by native Linux, Docker, or publishing work rather than cross-build CPU capacity.
