### PR TITLE
[ty] Support Annotated inside type[...]

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
@@ -22,6 +22,45 @@ def _(x: Annotated[tuple[str, int], bytes]):
     reveal_type(x)  # revealed: tuple[str, int]
 ```
 
+## Inside `type[...]`
+
+`Annotated` can wrap a class or specialized generic class inside `type[...]` without changing the
+resulting class object type.
+
+```py
+from typing_extensions import Annotated
+
+def _(
+    simple: type[Annotated[int, "metadata"]],
+    generic: type[Annotated[list[str], "metadata"]],
+):
+    reveal_type(simple)  # revealed: type[int]
+    reveal_type(generic)  # revealed: type[list[str]]
+```
+
+This also works for unions of classes and nested `Annotated` forms.
+
+```py
+def _(
+    union: type[Annotated[int | str, "metadata"]],
+    nested: type[Annotated[Annotated[int, "inner"], "outer"]],
+):
+    reveal_type(union)  # revealed: type[int | str]
+    reveal_type(nested)  # revealed: type[int]
+```
+
+Wrapping a non-class type in `Annotated` does not make it a valid argument to `type[...]`.
+
+```py
+from typing import Callable
+
+def _(
+    # error: [invalid-type-form] "The argument to `type[]` must be a class object type"
+    invalid: type[Annotated[Callable[[], int], "metadata"]],
+):
+    reveal_type(invalid)  # revealed: type[Unknown]
+```
+
 ## Parameterization
 
 It is invalid to parameterize `Annotated` with less than two arguments.

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1378,7 +1378,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         invalid_type_argument(self, slice)
                     }
                     value_ty @ (Type::SpecialForm(
-                        SpecialFormType::Top | SpecialFormType::Bottom,
+                        SpecialFormType::Top | SpecialFormType::Bottom | SpecialFormType::Annotated,
                     )
                     | Type::KnownInstance(KnownInstanceType::TypeAliasType(_))) => {
                         let slice_ty = self.infer_subscript_type_expression(subscript, value_ty);


### PR DESCRIPTION
## Summary

Support `type[Annotated[T, ...]]` by routing `Annotated` through the existing nested `type[...]` special-form handling.

- Preserve the wrapped class type for ordinary classes, specialized generics, unions, and nested `Annotated` forms.
- Continue rejecting annotated values that do not represent class object types.

## Why

The dedicated `type[...]` evaluator bypassed the shared `Annotated` parser and produced `@Todo(unsupported nested subscript in type[X])` instead of inferring the class object type.
