### PR TITLE
[ty] Avoid treating augmented assignments as attribute definitions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
@@ -426,23 +426,24 @@ def update(counter: Counter | None) -> None:
     counter.count += 1
 ```
 
-An augmented assignment should not define an otherwise missing instance attribute, because it must
-read an existing value before writing its result. We currently treat it like an ordinary
-self-referential assignment instead.
+An augmented assignment cannot define an otherwise missing instance attribute, because it must read
+an existing value before writing its result.
 
 ```py
 class UninitializedCounter:
     def increment(self) -> None:
-        # TODO: Report an unresolved-attribute error instead of implicitly defining the attribute.
+        # error: [unresolved-attribute]
         self.value += 1
 
-reveal_type(UninitializedCounter().value)  # revealed: Divergent
+# error: [unresolved-attribute]
+reveal_type(UninitializedCounter().value)  # revealed: Unknown
 ```
 
 ## Dynamically provided attributes
 
-A dynamic attribute hook can provide the initial value read by an augmented assignment. The
-assignment currently infers a divergent attribute type instead of preserving the hook's return type.
+A dynamic attribute hook can provide the initial value read by an augmented assignment. Ordinary
+attribute lookup preserves the hook's return type, but the resulting assignment is not yet
+recognized as establishing instance storage.
 
 ```py
 class DynamicCounter:
@@ -450,10 +451,11 @@ class DynamicCounter:
         return 0
 
     def increment(self) -> None:
+        # TODO: Recognize the instance attribute established after reading from a dynamic hook.
+        # error: [unresolved-attribute]
         self.value += 1
 
-# TODO: Infer `int` from the dynamic attribute hook.
-reveal_type(DynamicCounter().value)  # revealed: Divergent
+reveal_type(DynamicCounter().value)  # revealed: int
 ```
 
 The same behavior applies when the attribute is provided by `__getattribute__`.
@@ -464,9 +466,11 @@ class InterceptedCounter:
         return 0
 
     def increment(self) -> None:
+        # TODO: Recognize the instance attribute established after reading from a dynamic hook.
+        # error: [unresolved-attribute]
         self.value += 1
 
-reveal_type(InterceptedCounter().value)  # revealed: Divergent
+reveal_type(InterceptedCounter().value)  # revealed: int
 ```
 
 ## Class-level defaults in diamond inheritance

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -276,6 +276,74 @@ class C:
 reveal_type(C().w)  # revealed: Weird | str
 ```
 
+#### Augmented assignments to unannotated class-level defaults
+
+An unannotated class-level default can supply the initial value read by an augmented assignment. The
+instance attribute can then contain either the original value or the result of the operation.
+
+```py
+class After:
+    def __iadd__(self, other: int) -> "After":
+        return self
+
+class Before:
+    def __iadd__(self, other: int) -> After:
+        return After()
+
+class C:
+    value = Before()
+
+    def update(self) -> None:
+        self.value += 1
+
+reveal_type(C().value)  # revealed: Before | After
+```
+
+#### Augmented assignments to inherited instance attributes
+
+An instance attribute established by a superclass can supply the initial value read by an augmented
+assignment in a subclass.
+
+```py
+class After:
+    def __iadd__(self, other: int) -> "After":
+        return self
+
+class Before:
+    def __iadd__(self, other: int) -> After:
+        return After()
+
+class Base:
+    def __init__(self) -> None:
+        self.value = Before()
+
+class Child(Base):
+    def update(self) -> None:
+        self.value += 1
+
+reveal_type(Child().value)  # revealed: Before | After
+```
+
+#### Augmented assignments with gradual operands
+
+An augmented assignment with an `Any` or untyped operand contributes its gradual result to the
+inferred instance attribute.
+
+```py
+from typing import Any
+
+class C:
+    def __init__(self, any_value: Any, unknown_value) -> None:
+        self.from_any = 0.0
+        self.from_any += any_value
+
+        self.from_unknown = 0
+        self.from_unknown += unknown_value
+
+reveal_type(C(0, 0).from_any)  # revealed: float | Any
+reveal_type(C(0, 0).from_unknown)  # revealed: int | Unknown
+```
+
 #### Augmented assignments cannot define missing attributes
 
 An augmented assignment must read an existing attribute before writing its result, so it cannot
@@ -907,6 +975,19 @@ class Child(First, Second):
         self.value |= 2
 
 reveal_type(Child().value)  # revealed: int
+```
+
+An overriding class-level default also shadows the inherited instance declaration when it has no
+explicit annotation.
+
+```py
+class UnannotatedChild(First, Second):
+    value = 1
+
+    def update(self) -> None:
+        self.value |= 2
+
+reveal_type(UnannotatedChild().value)  # revealed: int
 ```
 
 #### Descriptor attributes as class variables

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -326,6 +326,36 @@ class Counter:
 reveal_type(Counter().value)  # revealed: int
 ```
 
+#### Augmented assignments to narrowed optional attributes
+
+Once an optional attribute has been narrowed to its non-`None` value, augmented assignments must not
+introduce `Unknown` into its instance attribute type.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+class Counter:
+    def __init__(self, value: int | None) -> None:
+        self.value = value
+
+    def update(self, decrement: bool) -> None:
+        if self.value is None:
+            return
+
+        if decrement:
+            self.value -= 1
+        else:
+            self.value += 1
+
+    def current(self) -> int | None:
+        return self.value
+
+reveal_type(Counter(0).value)  # revealed: int | None
+```
+
 #### Augmented assignments to unannotated class-level defaults
 
 An unannotated class-level default can supply the initial value read by an augmented assignment. The

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -294,9 +294,48 @@ class C:
     value = Before()
 
     def update(self) -> None:
-        self.value += 1
+        self.value += 1  # error: [invalid-assignment]
 
 reveal_type(C().value)  # revealed: Before | After
+```
+
+#### Augmented assignments to conditionally defined class-level defaults
+
+A conditional class default must not hide the dynamic fallback used when that default is absent.
+
+```py
+class After:
+    def __iadd__(self, other: int) -> "After":
+        return self
+
+class Before:
+    def __iadd__(self, other: int) -> After:
+        return After()
+
+class FallbackAfter:
+    def __iadd__(self, other: int) -> "FallbackAfter":
+        return self
+
+class Fallback:
+    def __iadd__(self, other: int) -> FallbackAfter:
+        return FallbackAfter()
+
+def flag() -> bool:
+    return True
+
+class C:
+    if flag():
+        value = Before()
+
+    def __getattr__(self, name: str) -> Fallback:
+        return Fallback()
+
+    def update(self) -> None:
+        # error: [invalid-assignment]
+        # error: [possibly-missing-attribute]
+        self.value += 1
+
+reveal_type(C().value)  # revealed: Before | After | FallbackAfter | Fallback
 ```
 
 #### Augmented assignments with expanding generic results
@@ -319,9 +358,38 @@ class Counter:
     value = Grow[int]()
 
     def update(self) -> None:
-        self.value += 1
+        self.value += 1  # error: [invalid-assignment]
 
-reveal_type(Counter().value)  # revealed: Grow[int] | Unknown
+reveal_type(Counter().value)  # revealed: Grow[int] | Grow[list[int]]
+```
+
+An independently initialized attribute must use the same bounded cycle recovery.
+
+```py
+class InitializedCounter:
+    def __init__(self) -> None:
+        self.value = Grow[int]()
+
+    def update(self) -> None:
+        self.value += 1  # error: [invalid-assignment]
+
+reveal_type(InitializedCounter().value)  # revealed: Grow[int] | Grow[list[int]]
+```
+
+#### Augmented assignments with expanding tuple results
+
+Repeatedly nesting an independently initialized tuple must converge instead of exhausting Salsa's
+cycle-iteration limit.
+
+```py
+class C:
+    def __init__(self) -> None:
+        self.value = (1,)
+
+    def update(self) -> None:
+        self.value += (self.value,)
+
+reveal_type(C().value)  # revealed: tuple[int] | tuple[Divergent, ...]
 ```
 
 #### Augmented assignments to inherited instance attributes
@@ -347,6 +415,41 @@ class Child(Base):
         self.value += 1
 
 reveal_type(Child().value)  # revealed: Before | After
+```
+
+#### Augmented assignments preserve inherited instance bindings beneath class defaults
+
+A superclass initializer writes instance storage even when a subclass defines a class-level default
+with the same name. Both initial values and their augmented-assignment results remain possible.
+
+```py
+class AfterA:
+    def __iadd__(self, other: int) -> "AfterA":
+        return self
+
+class AfterB:
+    def __iadd__(self, other: int) -> "AfterB":
+        return self
+
+class BeforeA:
+    def __iadd__(self, other: int) -> AfterA:
+        return AfterA()
+
+class BeforeB:
+    def __iadd__(self, other: int) -> AfterB:
+        return AfterB()
+
+class Base:
+    def __init__(self) -> None:
+        self.value = BeforeA()
+
+class Child(Base):
+    value = BeforeB()
+
+    def update(self) -> None:
+        self.value += 1  # error: [invalid-assignment]
+
+reveal_type(Child().value)  # revealed: BeforeB | AfterB | AfterA | BeforeA
 ```
 
 #### Augmented assignments preserve subclass attribute bindings
@@ -431,6 +534,50 @@ class Counter:
 
 # error: [unresolved-attribute]
 reveal_type(Counter().value)  # revealed: Unknown
+```
+
+#### Augmented assignments to possible data descriptors
+
+An augmented assignment to a data descriptor passes its result to `__set__` rather than creating
+instance storage. When a class default might be a descriptor, preserve the existing attribute types
+without exposing the descriptor's write-only result.
+
+```py
+class After:
+    def __iadd__(self, other: int) -> "After":
+        return self
+
+class Before:
+    def __iadd__(self, other: int) -> After:
+        return After()
+
+class DescriptorAfter:
+    def __iadd__(self, other: int) -> "DescriptorAfter":
+        return self
+
+class DescriptorValue:
+    def __iadd__(self, other: int) -> DescriptorAfter:
+        return DescriptorAfter()
+
+class Descriptor:
+    def __get__(self, instance: object, owner: type[object]) -> DescriptorValue:
+        return DescriptorValue()
+
+    def __set__(self, instance: object, value: DescriptorAfter) -> None: ...
+
+def flag() -> bool:
+    return True
+
+class C:
+    value = Descriptor() if flag() else Before()
+
+    def update(self) -> None:
+        # error: [invalid-assignment]
+        # error: [invalid-assignment]
+        self.value += 1
+
+# TODO: Include `After` from the non-descriptor branch without including `DescriptorAfter`.
+reveal_type(C().value)  # revealed: DescriptorValue | Before
 ```
 
 #### Nested augmented assignments after narrowing
@@ -1784,6 +1931,25 @@ class UsesAugmentedDescriptor(metaclass=AugmentedDescriptorMeta): ...
 
 # error: [unresolved-attribute]
 reveal_type(UsesAugmentedDescriptor().descriptor_value)  # revealed: Unknown
+```
+
+A metaclass default that might be a data descriptor likewise must not expose a class attribute on
+constructed instances.
+
+```py
+def choose_descriptor() -> bool:
+    return True
+
+class MaybeAugmentedDescriptorMeta(type):
+    descriptor_value = AugmentedDescriptor() if choose_descriptor() else 1
+
+    def update(cls) -> None:
+        cls.descriptor_value += 1  # error: [invalid-assignment]
+
+class UsesMaybeAugmentedDescriptor(metaclass=MaybeAugmentedDescriptorMeta): ...
+
+# error: [unresolved-attribute]
+reveal_type(UsesMaybeAugmentedDescriptor().descriptor_value)  # revealed: Unknown
 ```
 
 When a metaclass declaration uses a union, only the data descriptors in that union take precedence

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -259,8 +259,8 @@ reveal_type(c_instance.b)  # revealed: int
 
 #### Augmented assignments
 
-An augmented assignment contributes its result to the inferred type of an unannotated instance
-attribute.
+An augmented assignment contributes its result to an instance attribute that already has an
+independent binding.
 
 ```py
 class Weird:
@@ -274,6 +274,21 @@ class C:
 
 # TODO: Infer only `str`, since the initial `Weird` value has been overwritten.
 reveal_type(C().w)  # revealed: Weird | str
+```
+
+#### Augmented assignments cannot define missing attributes
+
+An augmented assignment must read an existing attribute before writing its result, so it cannot
+introduce an attribute on its own.
+
+```py
+class Counter:
+    def increment(self) -> None:
+        # error: [unresolved-attribute]
+        self.value += 1
+
+# error: [unresolved-attribute]
+reveal_type(Counter().value)  # revealed: Unknown
 ```
 
 #### Nested augmented assignments after narrowing
@@ -869,6 +884,29 @@ C.variable_with_class_default1 = "overwritten on class"
 
 reveal_type(C.variable_with_class_default1)  # revealed: Literal["overwritten on class"]
 reveal_type(c_instance.variable_with_class_default1)  # revealed: Literal["value set on instance"]
+```
+
+#### Augmented assignments to overriding class-level defaults
+
+A class-level default supplies the initial value for an augmented assignment, even when another
+branch of a diamond declares a wider instance attribute.
+
+```py
+class Base:
+    value: int | None = None
+
+class First(Base): ...
+
+class Second(Base):
+    value: int | None
+
+class Child(First, Second):
+    value: int = 1
+
+    def update(self) -> None:
+        self.value |= 2
+
+reveal_type(Child().value)  # revealed: int
 ```
 
 #### Descriptor attributes as class variables

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -276,6 +276,56 @@ class C:
 reveal_type(C().w)  # revealed: Weird | str
 ```
 
+#### Augmented assignments with stable recursive inference
+
+An independently initialized buffer updated from multiple methods must retain its concrete type,
+even when augmented assignments recursively look up that attribute.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+class Buffer:
+    def __init__(self) -> None:
+        self.reset()
+
+    def append(self, value: bytes) -> None:
+        if value:
+            self.content += b","
+        self.content += value
+
+    def reset(self) -> None:
+        self.content = bytearray()
+
+    def finish(self) -> bytearray:
+        self.content += b"]"
+        return self.content
+
+reveal_type(Buffer().content)  # revealed: bytearray
+```
+
+The same cycle recovery also preserves a concrete integer attribute.
+
+```py
+class Counter:
+    def __init__(self) -> None:
+        self.reset()
+
+    def increment(self, value: int) -> None:
+        self.value += value
+
+    def reset(self) -> None:
+        self.value = 0
+
+    def finish(self) -> int:
+        self.value += 1
+        return self.value
+
+reveal_type(Counter().value)  # revealed: int
+```
+
 #### Augmented assignments to unannotated class-level defaults
 
 An unannotated class-level default can supply the initial value read by an augmented assignment. The
@@ -1121,6 +1171,53 @@ reveal_type(c_instance.pure_class_variable)  # revealed: str
 
 # TODO: should raise an error.
 c_instance.pure_class_variable = "value set on instance"
+```
+
+#### Augmented assignments in class methods
+
+A classmethod can establish an implicit class variable and then augment it with an operation that
+changes its type. Both the initial value and the augmented result remain possible.
+
+```py
+class After: ...
+
+class Before:
+    def __iadd__(self, other: int) -> After:
+        return After()
+
+class Example:
+    @classmethod
+    def update(cls) -> None:
+        cls.value = Before()
+        cls.value += 1
+
+reveal_type(Example.value)  # revealed: Before | After
+```
+
+#### Augmented assignments to inherited class variables
+
+A classmethod can read an inherited class variable before storing its augmented result on the
+subclass. Class-member lookup must preserve the deferred assignment until it finds that inherited
+value.
+
+```py
+class After:
+    def __iadd__(self, other: int) -> "After":
+        return self
+
+class Before:
+    def __iadd__(self, other: int) -> After:
+        return After()
+
+class Parent:
+    value = Before()
+
+class Child(Parent):
+    @classmethod
+    def update(cls) -> None:
+        cls.value += 1
+
+reveal_type(Child.value)  # revealed: Before | After
 ```
 
 ### Instance variables with class-level default values

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -299,6 +299,31 @@ class C:
 reveal_type(C().value)  # revealed: Before | After
 ```
 
+#### Augmented assignments with expanding generic results
+
+An augmented assignment can repeatedly expand a generic attribute's type arguments. Inference must
+still converge when the initial value comes from a class-level default.
+
+```py
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Grow(Generic[T]):
+    def __iadd__(self, other: int) -> Grow[list[T]]:
+        raise NotImplementedError
+
+class Counter:
+    value = Grow[int]()
+
+    def update(self) -> None:
+        self.value += 1
+
+reveal_type(Counter().value)  # revealed: Grow[int] | Unknown
+```
+
 #### Augmented assignments to inherited instance attributes
 
 An instance attribute established by a superclass can supply the initial value read by an augmented
@@ -322,6 +347,55 @@ class Child(Base):
         self.value += 1
 
 reveal_type(Child().value)  # revealed: Before | After
+```
+
+#### Augmented assignments preserve subclass attribute bindings
+
+An augmented assignment inherited from an intermediate class must not discard instance attributes
+that subclasses establish independently.
+
+```py
+from typing import Any
+
+class Base:
+    value = 0
+
+class Middle(Base):
+    def increment(self) -> None:
+        self.value += 1
+
+class Child(Middle):
+    def set(self, value: Any) -> None:
+        self.value = value
+
+reveal_type(Child().value)  # revealed: int | Any
+```
+
+An untyped subclass binding is likewise preserved.
+
+```py
+class UnknownChild(Middle):
+    def set(self, value) -> None:
+        self.value = value
+
+reveal_type(UnknownChild().value)  # revealed: int | Unknown
+```
+
+An explicitly annotated class-level default also preserves subclass bindings.
+
+```py
+class AnnotatedBase:
+    value: int = 0
+
+class AnnotatedMiddle(AnnotatedBase):
+    def increment(self) -> None:
+        self.value += 1
+
+class AnnotatedChild(AnnotatedMiddle):
+    def set(self, value: Any) -> None:
+        self.value = value
+
+reveal_type(AnnotatedChild().value)  # revealed: int | Any
 ```
 
 #### Augmented assignments with gradual operands
@@ -1688,6 +1762,28 @@ class UsesGeneratedDescriptor(metaclass=DescriptorMeta):
         self.generated_descriptor = 1
 
 reveal_type(UsesGeneratedDescriptor().generated_descriptor)  # revealed: Literal["descriptor"]
+```
+
+An augmented assignment to a data descriptor on a metaclass calls the descriptor's `__set__` method.
+It does not store an attribute on the class, so the attribute is unavailable on instances.
+
+```py
+class AugmentedDescriptor:
+    def __get__(self, instance: object, owner: type[object]) -> int:
+        return 1
+
+    def __set__(self, instance: object, value: int) -> None: ...
+
+class AugmentedDescriptorMeta(type):
+    descriptor_value = AugmentedDescriptor()
+
+    def update(cls) -> None:
+        cls.descriptor_value += 1
+
+class UsesAugmentedDescriptor(metaclass=AugmentedDescriptorMeta): ...
+
+# error: [unresolved-attribute]
+reveal_type(UsesAugmentedDescriptor().descriptor_value)  # revealed: Unknown
 ```
 
 When a metaclass declaration uses a union, only the data descriptors in that union take precedence

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -521,21 +521,6 @@ reveal_type(C(0, 0).from_any)  # revealed: float | Any
 reveal_type(C(0, 0).from_unknown)  # revealed: int | Unknown
 ```
 
-#### Augmented assignments cannot define missing attributes
-
-An augmented assignment must read an existing attribute before writing its result, so it cannot
-introduce an attribute on its own.
-
-```py
-class Counter:
-    def increment(self) -> None:
-        # error: [unresolved-attribute]
-        self.value += 1
-
-# error: [unresolved-attribute]
-reveal_type(Counter().value)  # revealed: Unknown
-```
-
 #### Augmented assignments to possible data descriptors
 
 An augmented assignment to a data descriptor passes its result to `__set__` rather than creating
@@ -1177,8 +1162,8 @@ reveal_type(c_instance.variable_with_class_default1)  # revealed: Literal["value
 
 #### Augmented assignments to overriding class-level defaults
 
-A class-level default supplies the initial value for an augmented assignment, even when another
-branch of a diamond declares a wider instance attribute.
+An unannotated class-level default supplies the initial value for an augmented assignment, even when
+another branch of a diamond declares a wider instance attribute.
 
 ```py
 class Base:
@@ -1190,25 +1175,12 @@ class Second(Base):
     value: int | None
 
 class Child(First, Second):
-    value: int = 1
-
-    def update(self) -> None:
-        self.value |= 2
-
-reveal_type(Child().value)  # revealed: int
-```
-
-An overriding class-level default also shadows the inherited instance declaration when it has no
-explicit annotation.
-
-```py
-class UnannotatedChild(First, Second):
     value = 1
 
     def update(self) -> None:
         self.value |= 2
 
-reveal_type(UnannotatedChild().value)  # revealed: int
+reveal_type(Child().value)  # revealed: int
 ```
 
 #### Descriptor attributes as class variables

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1046,7 +1046,8 @@ class AnySelf(Protocol):
 ```
 
 Assignments in a comprehension and augmented assignments are also writes to the instance.
-`__getattr__` provides the read side of `+=` below, so that case tests only the write:
+`__getattr__` provides the read side of `+=` below, although the write is not yet recognized as
+establishing an instance attribute:
 
 ```py
 class AssignmentForms(Protocol):
@@ -1057,14 +1058,15 @@ class AssignmentForms(Protocol):
         [None for self.from_comprehension in [1]]  # error: [ambiguous-protocol-member]
 
     def augmented_assignment(self) -> None:
+        # error: [unresolved-attribute]
         self.augmented += 1  # snapshot: ambiguous-protocol-member
 ```
 
 ```snapshot
 warning[ambiguous-protocol-member]: Cannot assign to an undeclared attribute in a protocol method
-   --> src/mdtest_snippet.py:326:9
+   --> src/mdtest_snippet.py:327:9
     |
-326 |         self.augmented += 1  # snapshot: ambiguous-protocol-member
+327 |         self.augmented += 1  # snapshot: ambiguous-protocol-member
     |         ^^^^^^^^^^^^^^ `augmented` is not declared as a protocol member
 info: Assigning to an undeclared attribute in a protocol method leads to an ambiguous interface
    --> src/mdtest_snippet.py:318:7

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2213,24 +2213,32 @@ impl<'db> ClassType<'db> {
         name: &str,
     ) -> ImplicitAttribute<'db> {
         let member = self.own_instance_member(db, env, name);
-        if !member.is_undefined() {
-            return ImplicitAttribute::Defined(member);
-        }
-
         let Some((class, _)) = self.static_class_literal(db) else {
-            return ImplicitAttribute::Undefined;
+            return ImplicitAttribute {
+                member,
+                read_dependent_bindings: None,
+            };
         };
 
-        match StaticClassLiteral::implicit_attribute_bindings(
+        let implicit = StaticClassLiteral::implicit_attribute_bindings(
             db,
             class.body_scope(db),
             name,
             MethodDecorator::None,
-        ) {
-            deferred @ ImplicitAttribute::Deferred(_) => deferred,
-            ImplicitAttribute::Defined(_) | ImplicitAttribute::Undefined => {
-                ImplicitAttribute::Undefined
-            }
+        );
+
+        // Ordinary member lookup can deliberately suppress implicit assignments, such as those
+        // targeting generated NamedTuple fields. Preserve dependent writes only when both
+        // lookups agree on whether an independent instance attribute exists.
+        let read_dependent_bindings = if member.is_undefined() == implicit.member.is_undefined() {
+            implicit.read_dependent_bindings
+        } else {
+            None
+        };
+
+        ImplicitAttribute {
+            member,
+            read_dependent_bindings,
         }
     }
 
@@ -2764,25 +2772,17 @@ impl<'db> VarianceInferable<'db> for ClassLiteral<'db> {
 #[salsa::tracked(
     returns(copy),
     cycle_initial=|_, id, _, _| Type::divergent(id),
-    cycle_fn=|db, cycle: &salsa::Cycle, previous: &Type<'db>, ty: Type<'db>, _, definition: Definition<'db>| {
-        if cycle.iteration() > crate::TAINTED_CYCLES && ty != *previous {
-            Type::unknown()
-        } else {
-            let env = ProgramEnvironment::from_definition(definition);
-            ty.cycle_normalized(db, &env, *previous, cycle)
-        }
+    cycle_fn=|db, cycle: &salsa::Cycle, previous: &Type<'db>, ty: Type<'db>, definition: Definition<'db>, _| {
+        let env = ProgramEnvironment::from_definition(definition);
+        ty.cycle_normalized(db, &env, *previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
 fn read_dependent_binding_type<'db>(
     db: &'db dyn Db,
-    class: ClassType<'db>,
     definition: Definition<'db>,
+    specialization: Option<Specialization<'db>>,
 ) -> Type<'db> {
-    let specialization = class
-        .static_class_literal(db)
-        .and_then(|(_, specialization)| specialization);
-
     infer_definition_types(db, definition)
         .binding_type(definition)
         .apply_optional_specialization(db, specialization)
@@ -2822,8 +2822,12 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let mut provenance = Provenance::Unknown;
 
         for (class, bindings) in bindings {
+            let specialization = class
+                .static_class_literal(db)
+                .and_then(|(_, specialization)| specialization);
+
             for definition in bindings.definitions(db) {
-                let inferred_ty = read_dependent_binding_type(db, *class, *definition);
+                let inferred_ty = read_dependent_binding_type(db, *definition, specialization);
                 union = union.add(inferred_ty);
                 provenance = provenance.or(Provenance::SingleDefinition(*definition));
             }
@@ -2939,7 +2943,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let db = self.db;
         let mut union = UnionBuilder::new(db, &self.env);
         let mut union_qualifiers = TypeQualifiers::empty();
-        let mut is_definitely_bound = false;
+        let mut definitely_bound_member: Option<PlaceAndQualifiers<'db>> = None;
         let mut provenance = Provenance::Unknown;
         let mut read_dependent_bindings = Vec::new();
 
@@ -2956,7 +2960,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                 }
                 ClassBase::Class(class) => {
                     let implicit = class.own_instance_member_bindings(db, &self.env, name);
-                    if let ImplicitAttribute::Deferred(bindings) = implicit {
+                    if let Some(bindings) = implicit.read_dependent_bindings {
                         read_dependent_bindings.push((class, bindings));
                     }
 
@@ -2970,16 +2974,28 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                                 ..
                             }),
                         qualifiers,
-                    } = implicit.into_member().inner
+                    } = implicit.member.inner
                     {
                         if boundness == Definedness::AlwaysDefined {
                             if origin.is_declared() {
+                                if definitely_bound_member.is_some_and(|member| {
+                                    !member
+                                        .qualifiers
+                                        .contains(TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE)
+                                }) && !qualifiers
+                                    .contains(TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE)
+                                {
+                                    // An overriding class default shadows inherited declarations,
+                                    // but inherited instance assignments must still be collected.
+                                    continue;
+                                }
+
                                 // We found a definitely-declared attribute. Discard possibly collected
                                 // inferred types from subclasses and return the declared type.
                                 return InstanceMemberResult::Done(member);
                             }
 
-                            is_definitely_bound = true;
+                            definitely_bound_member = Some(member);
                         }
 
                         // If the attribute is not definitely declared on this class, keep looking
@@ -3013,6 +3029,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                                         Place::Defined(DefinedPlace {
                                             ty: class_member_ty,
                                             origin,
+                                            definedness: class_member_definedness,
                                             provenance: class_member_provenance,
                                             ..
                                         }),
@@ -3020,7 +3037,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                                 },
                         } = class.own_class_member(db, &self.env, None, name)
                     {
-                        if class_member_ty.is_data_descriptor(db, &self.env) {
+                        if !class_member_ty.is_definitely_non_data_descriptor(db, &self.env) {
                             read_dependent_bindings.clear();
                             continue;
                         }
@@ -3044,8 +3061,10 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                             union_qualifiers |= TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
                         }
 
-                        is_definitely_bound = true;
-                        break;
+                        read_dependent_bindings.clear();
+                        if class_member_definedness == Definedness::AlwaysDefined {
+                            definitely_bound_member = Some(class_member.inner);
+                        }
                     }
                 }
                 ClassBase::TypedDict(_) => {
@@ -3057,7 +3076,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let result = if union.is_empty() {
             Place::Undefined.with_qualifiers(TypeQualifiers::empty())
         } else {
-            let boundness = if is_definitely_bound {
+            let boundness = if definitely_bound_member.is_some() {
                 Definedness::AlwaysDefined
             } else {
                 Definedness::PossiblyUndefined

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2191,29 +2191,46 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    /// Look up an instance member without discarding writes that require an existing attribute.
+    /// Look up an instance member without discarding assignments that require an existing value.
+    ///
+    /// For example, `increment` can only establish an instance attribute because it first reads
+    /// the class-level default:
+    ///
+    /// ```python
+    /// class Counter:
+    ///     value = 0
+    ///
+    ///     def increment(self):
+    ///         self.value += 1
+    /// ```
+    ///
+    /// If an instance member is not already defined, preserve the augmented assignment until MRO
+    /// lookup finds a class-level default or an inherited instance attribute.
     fn own_instance_member_bindings(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         name: &str,
     ) -> ImplicitAttribute<'db> {
-        if let Some((class, specialization)) = self.static_class_literal(db) {
-            return match class.own_instance_member_bindings(db, env, name) {
-                ImplicitAttribute::Defined(member) => ImplicitAttribute::Defined(
-                    member.map_type(|ty| ty.apply_optional_specialization(db, specialization)),
-                ),
-                implicit @ (ImplicitAttribute::Undefined | ImplicitAttribute::Deferred(_)) => {
-                    implicit
-                }
-            };
+        let member = self.own_instance_member(db, env, name);
+        if !member.is_undefined() {
+            return ImplicitAttribute::Defined(member);
         }
 
-        let member = self.own_instance_member(db, env, name);
-        if member.is_undefined() {
-            ImplicitAttribute::Undefined
-        } else {
-            ImplicitAttribute::Defined(member)
+        let Some((class, _)) = self.static_class_literal(db) else {
+            return ImplicitAttribute::Undefined;
+        };
+
+        match StaticClassLiteral::implicit_attribute_bindings(
+            db,
+            class.body_scope(db),
+            name,
+            MethodDecorator::None,
+        ) {
+            deferred @ ImplicitAttribute::Deferred(_) => deferred,
+            ImplicitAttribute::Defined(_) | ImplicitAttribute::Undefined => {
+                ImplicitAttribute::Undefined
+            }
         }
     }
 
@@ -2764,12 +2781,15 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         }
     }
 
-    /// Infer augmented-assignment results after their initial attribute has been located.
+    /// Infer augmented-assignment results after finding the existing attribute they read.
+    ///
+    /// Inferring these bindings earlier would recursively look up the same instance member and
+    /// allow an augmented assignment to incorrectly establish an otherwise missing attribute.
     fn read_dependent_instance_member(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         bindings: &[(ClassType<'db>, ReadDependentBindings<'db>)],
-    ) -> Member<'db> {
+    ) -> DefinedPlace<'db> {
         let mut union = UnionBuilder::new(db, env);
         let mut provenance = Provenance::Unknown;
 
@@ -2787,10 +2807,12 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
             }
         }
 
-        Member {
-            inner: Place::bound(union.build().promote(db, env).promote_singletons(db, env))
-                .with_provenance(provenance)
-                .with_qualifiers(TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE),
+        DefinedPlace {
+            ty: union.build().promote(db, env).promote_singletons(db, env),
+            origin: TypeOrigin::Inferred,
+            definedness: Definedness::AlwaysDefined,
+            public_type_policy: PublicTypePolicy::Raw,
+            provenance,
         }
     }
 
@@ -2911,60 +2933,54 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                     return InstanceMemberResult::Done(PlaceAndQualifiers::unbound());
                 }
                 ClassBase::Class(class) => {
-                    match class.own_instance_member_bindings(db, &self.env, name) {
-                        ImplicitAttribute::Defined(Member {
-                            inner:
-                                member @ PlaceAndQualifiers {
-                                    place:
-                                        Place::Defined(DefinedPlace {
-                                            ty,
-                                            origin,
-                                            definedness: boundness,
-                                            provenance: member_provenance,
-                                            ..
-                                        }),
-                                    qualifiers,
-                                },
-                        }) => {
-                            if boundness == Definedness::AlwaysDefined {
-                                if origin.is_declared() {
-                                    // We found a definitely-declared attribute. Discard possibly
-                                    // collected inferred types and return the declared type.
-                                    return InstanceMemberResult::Done(member);
-                                }
+                    let implicit = class.own_instance_member_bindings(db, &self.env, name);
+                    if let ImplicitAttribute::Deferred(bindings) = implicit {
+                        read_dependent_bindings.push((class, bindings));
+                    }
 
-                                is_definitely_bound = true;
+                    if let member @ PlaceAndQualifiers {
+                        place:
+                            Place::Defined(DefinedPlace {
+                                ty,
+                                origin,
+                                definedness: boundness,
+                                provenance: member_provenance,
+                                ..
+                            }),
+                        qualifiers,
+                    } = implicit.into_member().inner
+                    {
+                        if boundness == Definedness::AlwaysDefined {
+                            if origin.is_declared() {
+                                // We found a definitely-declared attribute. Discard possibly collected
+                                // inferred types from subclasses and return the declared type.
+                                return InstanceMemberResult::Done(member);
                             }
 
-                            // Keep looking higher in the MRO when this attribute is not definitely
-                            // declared, unioning inferred and possibly-declared types.
-                            union = union.add(ty);
-                            provenance = provenance.or(member_provenance);
-                            union_qualifiers |= qualifiers;
+                            is_definitely_bound = true;
+                        }
 
-                            if !read_dependent_bindings.is_empty() {
-                                let read_dependent_member = Self::read_dependent_instance_member(
-                                    db,
-                                    &self.env,
-                                    &read_dependent_bindings,
-                                );
-                                if let Place::Defined(DefinedPlace {
-                                    ty,
-                                    provenance: member_provenance,
-                                    ..
-                                }) = read_dependent_member.inner.place
-                                {
-                                    union = union.add(ty);
-                                    provenance = provenance.or(member_provenance);
-                                    union_qualifiers |= read_dependent_member.inner.qualifiers;
-                                }
-                                read_dependent_bindings.clear();
-                            }
+                        // If the attribute is not definitely declared on this class, keep looking
+                        // higher up in the MRO, and build a union of all inferred types (and
+                        // possibly-declared types):
+                        union = union.add(ty);
+                        provenance = provenance.or(member_provenance);
+
+                        // TODO: We could raise a diagnostic here if there are conflicting type
+                        // qualifiers
+                        union_qualifiers |= qualifiers;
+
+                        if !read_dependent_bindings.is_empty() {
+                            let read_dependent_member = Self::read_dependent_instance_member(
+                                db,
+                                &self.env,
+                                &read_dependent_bindings,
+                            );
+                            union = union.add(read_dependent_member.ty);
+                            provenance = provenance.or(read_dependent_member.provenance);
+                            union_qualifiers |= TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
+                            read_dependent_bindings.clear();
                         }
-                        ImplicitAttribute::Deferred(bindings) => {
-                            read_dependent_bindings.push((class, bindings));
-                        }
-                        ImplicitAttribute::Undefined | ImplicitAttribute::Defined(_) => {}
                     }
 
                     if !read_dependent_bindings.is_empty()
@@ -2981,12 +2997,12 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         }
 
                         return InstanceMemberResult::Done(
-                            Self::read_dependent_instance_member(
+                            Place::Defined(Self::read_dependent_instance_member(
                                 db,
                                 &self.env,
                                 &read_dependent_bindings,
-                            )
-                            .inner,
+                            ))
+                            .with_qualifiers(TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE),
                         );
                     }
                 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2760,6 +2760,34 @@ impl<'db> VarianceInferable<'db> for ClassLiteral<'db> {
     }
 }
 
+/// Infer an augmented assignment without allowing recursive results to expand indefinitely.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial=|_, id, _, _| Type::divergent(id),
+    cycle_fn=|db, cycle: &salsa::Cycle, previous: &Type<'db>, ty: Type<'db>, _, definition: Definition<'db>| {
+        if cycle.iteration() > crate::TAINTED_CYCLES && ty != *previous {
+            Type::unknown()
+        } else {
+            let env = ProgramEnvironment::from_definition(definition);
+            ty.cycle_normalized(db, &env, *previous, cycle)
+        }
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn read_dependent_binding_type<'db>(
+    db: &'db dyn Db,
+    class: ClassType<'db>,
+    definition: Definition<'db>,
+) -> Type<'db> {
+    let specialization = class
+        .static_class_literal(db)
+        .and_then(|(_, specialization)| specialization);
+
+    infer_definition_types(db, definition)
+        .binding_type(definition)
+        .apply_optional_specialization(db, specialization)
+}
+
 /// Performs member lookups over an MRO (Method Resolution Order).
 ///
 /// This struct encapsulates the shared logic for looking up class and instance
@@ -2794,14 +2822,8 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let mut provenance = Provenance::Unknown;
 
         for (class, bindings) in bindings {
-            let specialization = class
-                .static_class_literal(db)
-                .and_then(|(_, specialization)| specialization);
-
             for definition in bindings.definitions(db) {
-                let inferred_ty = infer_definition_types(db, *definition)
-                    .binding_type(*definition)
-                    .apply_optional_specialization(db, specialization);
+                let inferred_ty = read_dependent_binding_type(db, *class, *definition);
                 union = union.add(inferred_ty);
                 provenance = provenance.or(Provenance::SingleDefinition(*definition));
             }
@@ -2987,23 +3009,43 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         && let class_member @ Member {
                             inner:
                                 PlaceAndQualifiers {
-                                    place: Place::Defined(DefinedPlace { origin, .. }),
+                                    place:
+                                        Place::Defined(DefinedPlace {
+                                            ty: class_member_ty,
+                                            origin,
+                                            provenance: class_member_provenance,
+                                            ..
+                                        }),
                                     ..
                                 },
                         } = class.own_class_member(db, &self.env, None, name)
                     {
-                        if origin.is_declared() {
-                            return InstanceMemberResult::Done(class_member.inner);
+                        if class_member_ty.is_data_descriptor(db, &self.env) {
+                            read_dependent_bindings.clear();
+                            continue;
                         }
 
-                        return InstanceMemberResult::Done(
-                            Place::Defined(Self::read_dependent_instance_member(
+                        if origin.is_declared() {
+                            if union.is_empty() {
+                                return InstanceMemberResult::Done(class_member.inner);
+                            }
+
+                            union = union.add(class_member_ty);
+                            provenance = provenance.or(class_member_provenance);
+                            union_qualifiers |= class_member.inner.qualifiers;
+                        } else {
+                            let read_dependent_member = Self::read_dependent_instance_member(
                                 db,
                                 &self.env,
                                 &read_dependent_bindings,
-                            ))
-                            .with_qualifiers(TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE),
-                        );
+                            );
+                            union = union.add(read_dependent_member.ty);
+                            provenance = provenance.or(read_dependent_member.provenance);
+                            union_qualifiers |= TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
+                        }
+
+                        is_definitely_bound = true;
+                        break;
                     }
                 }
                 ClassBase::TypedDict(_) => {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -14,6 +14,7 @@ pub(crate) use self::static_literal::{
     ExpandedClassBaseEntry, FrozenDataclassDispatch, StaticClassLiteral,
     expanded_class_base_entries,
 };
+use self::static_literal::{ImplicitAttribute, ReadDependentBindings};
 pub(super) use self::typed_dict::{
     DynamicTypedDictAnchor, DynamicTypedDictLiteral, synthesized_typed_dict_class_member,
 };
@@ -31,6 +32,7 @@ use crate::types::constraints::{
 use crate::types::enums::enum_metadata;
 use crate::types::function::{AbstractMethodKind, DataclassTransformerParams};
 use crate::types::generics::{GenericContext, Specialization, walk_specialization};
+use crate::types::infer::infer_definition_types;
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::member::Member;
 use crate::types::relation::{
@@ -2189,6 +2191,32 @@ impl<'db> ClassType<'db> {
         }
     }
 
+    /// Look up an instance member without discarding writes that require an existing attribute.
+    fn own_instance_member_bindings(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+    ) -> ImplicitAttribute<'db> {
+        if let Some((class, specialization)) = self.static_class_literal(db) {
+            return match class.own_instance_member_bindings(db, env, name) {
+                ImplicitAttribute::Defined(member) => ImplicitAttribute::Defined(
+                    member.map_type(|ty| ty.apply_optional_specialization(db, specialization)),
+                ),
+                implicit @ (ImplicitAttribute::Undefined | ImplicitAttribute::Deferred(_)) => {
+                    implicit
+                }
+            };
+        }
+
+        let member = self.own_instance_member(db, env, name);
+        if member.is_undefined() {
+            ImplicitAttribute::Undefined
+        } else {
+            ImplicitAttribute::Defined(member)
+        }
+    }
+
     /// Return a callable type (or union of callable types) that represents the callable
     /// constructor signature of this class.
     pub(super) fn into_callable(self, db: &'db dyn Db) -> CallableTypes<'db> {
@@ -2736,6 +2764,36 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         }
     }
 
+    /// Infer augmented-assignment results after their initial attribute has been located.
+    fn read_dependent_instance_member(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        bindings: &[(ClassType<'db>, ReadDependentBindings<'db>)],
+    ) -> Member<'db> {
+        let mut union = UnionBuilder::new(db, env);
+        let mut provenance = Provenance::Unknown;
+
+        for (class, bindings) in bindings {
+            let specialization = class
+                .static_class_literal(db)
+                .and_then(|(_, specialization)| specialization);
+
+            for definition in bindings.definitions(db) {
+                let inferred_ty = infer_definition_types(db, *definition)
+                    .binding_type(*definition)
+                    .apply_optional_specialization(db, specialization);
+                union = union.add(inferred_ty);
+                provenance = provenance.or(Provenance::SingleDefinition(*definition));
+            }
+        }
+
+        Member {
+            inner: Place::bound(union.build().promote(db, env).promote_singletons(db, env))
+                .with_provenance(provenance)
+                .with_qualifiers(TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE),
+        }
+    }
+
     /// Look up a class member by iterating through the MRO.
     ///
     /// Parameters:
@@ -2839,6 +2897,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let mut union_qualifiers = TypeQualifiers::empty();
         let mut is_definitely_bound = false;
         let mut provenance = Provenance::Unknown;
+        let mut read_dependent_bindings = Vec::new();
 
         for superclass in self.mro_iter {
             match superclass {
@@ -2852,37 +2911,83 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                     return InstanceMemberResult::Done(PlaceAndQualifiers::unbound());
                 }
                 ClassBase::Class(class) => {
-                    if let member @ PlaceAndQualifiers {
-                        place:
-                            Place::Defined(DefinedPlace {
-                                ty,
-                                origin,
-                                definedness: boundness,
-                                provenance: member_provenance,
-                                ..
-                            }),
-                        qualifiers,
-                    } = class.own_instance_member(db, &self.env, name).inner
-                    {
-                        if boundness == Definedness::AlwaysDefined {
-                            if origin.is_declared() {
-                                // We found a definitely-declared attribute. Discard possibly collected
-                                // inferred types from subclasses and return the declared type.
-                                return InstanceMemberResult::Done(member);
+                    match class.own_instance_member_bindings(db, &self.env, name) {
+                        ImplicitAttribute::Defined(Member {
+                            inner:
+                                member @ PlaceAndQualifiers {
+                                    place:
+                                        Place::Defined(DefinedPlace {
+                                            ty,
+                                            origin,
+                                            definedness: boundness,
+                                            provenance: member_provenance,
+                                            ..
+                                        }),
+                                    qualifiers,
+                                },
+                        }) => {
+                            if boundness == Definedness::AlwaysDefined {
+                                if origin.is_declared() {
+                                    // We found a definitely-declared attribute. Discard possibly
+                                    // collected inferred types and return the declared type.
+                                    return InstanceMemberResult::Done(member);
+                                }
+
+                                is_definitely_bound = true;
                             }
 
-                            is_definitely_bound = true;
+                            // Keep looking higher in the MRO when this attribute is not definitely
+                            // declared, unioning inferred and possibly-declared types.
+                            union = union.add(ty);
+                            provenance = provenance.or(member_provenance);
+                            union_qualifiers |= qualifiers;
+
+                            if !read_dependent_bindings.is_empty() {
+                                let read_dependent_member = Self::read_dependent_instance_member(
+                                    db,
+                                    &self.env,
+                                    &read_dependent_bindings,
+                                );
+                                if let Place::Defined(DefinedPlace {
+                                    ty,
+                                    provenance: member_provenance,
+                                    ..
+                                }) = read_dependent_member.inner.place
+                                {
+                                    union = union.add(ty);
+                                    provenance = provenance.or(member_provenance);
+                                    union_qualifiers |= read_dependent_member.inner.qualifiers;
+                                }
+                                read_dependent_bindings.clear();
+                            }
+                        }
+                        ImplicitAttribute::Deferred(bindings) => {
+                            read_dependent_bindings.push((class, bindings));
+                        }
+                        ImplicitAttribute::Undefined | ImplicitAttribute::Defined(_) => {}
+                    }
+
+                    if !read_dependent_bindings.is_empty()
+                        && let class_member @ Member {
+                            inner:
+                                PlaceAndQualifiers {
+                                    place: Place::Defined(DefinedPlace { origin, .. }),
+                                    ..
+                                },
+                        } = class.own_class_member(db, &self.env, None, name)
+                    {
+                        if origin.is_declared() {
+                            return InstanceMemberResult::Done(class_member.inner);
                         }
 
-                        // If the attribute is not definitely declared on this class, keep looking
-                        // higher up in the MRO, and build a union of all inferred types (and
-                        // possibly-declared types):
-                        union = union.add(ty);
-                        provenance = provenance.or(member_provenance);
-
-                        // TODO: We could raise a diagnostic here if there are conflicting type
-                        // qualifiers
-                        union_qualifiers |= qualifiers;
+                        return InstanceMemberResult::Done(
+                            Self::read_dependent_instance_member(
+                                db,
+                                &self.env,
+                                &read_dependent_bindings,
+                            )
+                            .inner,
+                        );
                     }
                 }
                 ClassBase::TypedDict(_) => {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2191,7 +2191,7 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    /// Look up an instance member without discarding assignments that require an existing value.
+    /// Preserve independent instance attributes and assignments that first read their target.
     ///
     /// For example, `increment` can only establish an instance attribute because it first reads
     /// the class-level default:
@@ -2204,8 +2204,8 @@ impl<'db> ClassType<'db> {
     ///         self.value += 1
     /// ```
     ///
-    /// If an instance member is not already defined, preserve the augmented assignment until MRO
-    /// lookup finds a class-level default or an inherited instance attribute.
+    /// The augmented assignment cannot establish `value` until MRO lookup finds the class default
+    /// or an independently defined instance attribute.
     fn own_instance_member_bindings(
         self,
         db: &'db dyn Db,
@@ -2213,28 +2213,21 @@ impl<'db> ClassType<'db> {
         name: &str,
     ) -> ImplicitAttribute<'db> {
         let member = self.own_instance_member(db, env, name);
-        let Some((class, _)) = self.static_class_literal(db) else {
-            return ImplicitAttribute {
-                member,
-                read_dependent_bindings: None,
-            };
-        };
-
-        let implicit = StaticClassLiteral::implicit_attribute_bindings(
-            db,
-            class.body_scope(db),
-            name,
-            MethodDecorator::None,
-        );
-
         // Ordinary member lookup can deliberately suppress implicit assignments, such as those
         // targeting generated NamedTuple fields. Preserve dependent writes only when both
         // lookups agree on whether an independent instance attribute exists.
-        let read_dependent_bindings = if member.is_undefined() == implicit.member.is_undefined() {
-            implicit.read_dependent_bindings
-        } else {
-            None
-        };
+        let read_dependent_bindings = self
+            .static_class_literal(db)
+            .map(|(class, _)| {
+                StaticClassLiteral::implicit_attribute_bindings(
+                    db,
+                    class.body_scope(db),
+                    name,
+                    MethodDecorator::None,
+                )
+            })
+            .filter(|implicit| member.is_undefined() == implicit.member.is_undefined())
+            .and_then(|implicit| implicit.read_dependent_bindings);
 
         ImplicitAttribute {
             member,
@@ -2768,26 +2761,6 @@ impl<'db> VarianceInferable<'db> for ClassLiteral<'db> {
     }
 }
 
-/// Infer an augmented assignment without allowing recursive results to expand indefinitely.
-#[salsa::tracked(
-    returns(copy),
-    cycle_initial=|_, id, _, _| Type::divergent(id),
-    cycle_fn=|db, cycle: &salsa::Cycle, previous: &Type<'db>, ty: Type<'db>, definition: Definition<'db>, _| {
-        let env = ProgramEnvironment::from_definition(definition);
-        ty.cycle_normalized(db, &env, *previous, cycle)
-    },
-    heap_size=ruff_memory_usage::heap_size
-)]
-fn read_dependent_binding_type<'db>(
-    db: &'db dyn Db,
-    definition: Definition<'db>,
-    specialization: Option<Specialization<'db>>,
-) -> Type<'db> {
-    infer_definition_types(db, definition)
-        .binding_type(definition)
-        .apply_optional_specialization(db, specialization)
-}
-
 /// Performs member lookups over an MRO (Method Resolution Order).
 ///
 /// This struct encapsulates the shared logic for looking up class and instance
@@ -2811,13 +2784,23 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
 
     /// Infer augmented-assignment results after finding the existing attribute they read.
     ///
+    /// ```python
+    /// class Counter:
+    ///     def __init__(self):
+    ///         self.value = (1,)
+    ///
+    ///     def update(self):
+    ///         self.value += (self.value,)
+    /// ```
+    ///
     /// Inferring these bindings earlier would recursively look up the same instance member and
     /// allow an augmented assignment to incorrectly establish an otherwise missing attribute.
-    fn read_dependent_instance_member(
+    /// Existing definition inference also normalizes recursive results such as the tuple above.
+    fn infer_read_dependent_bindings(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         bindings: &[(ClassType<'db>, ReadDependentBindings<'db>)],
-    ) -> DefinedPlace<'db> {
+    ) -> (Type<'db>, Provenance<'db>) {
         let mut union = UnionBuilder::new(db, env);
         let mut provenance = Provenance::Unknown;
 
@@ -2827,19 +2810,18 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                 .and_then(|(_, specialization)| specialization);
 
             for definition in bindings.definitions(db) {
-                let inferred_ty = read_dependent_binding_type(db, *definition, specialization);
+                let inferred_ty = infer_definition_types(db, *definition)
+                    .binding_type(*definition)
+                    .apply_optional_specialization(db, specialization);
                 union = union.add(inferred_ty);
                 provenance = provenance.or(Provenance::SingleDefinition(*definition));
             }
         }
 
-        DefinedPlace {
-            ty: union.build().promote(db, env).promote_singletons(db, env),
-            origin: TypeOrigin::Inferred,
-            definedness: Definedness::AlwaysDefined,
-            public_type_policy: PublicTypePolicy::Raw,
+        (
+            union.build().promote(db, env).promote_singletons(db, env),
             provenance,
-        }
+        )
     }
 
     /// Look up a class member by iterating through the MRO.
@@ -3009,13 +2991,14 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         union_qualifiers |= qualifiers;
 
                         if !read_dependent_bindings.is_empty() {
-                            let read_dependent_member = Self::read_dependent_instance_member(
-                                db,
-                                &self.env,
-                                &read_dependent_bindings,
-                            );
-                            union = union.add(read_dependent_member.ty);
-                            provenance = provenance.or(read_dependent_member.provenance);
+                            let (inferred_ty, inferred_provenance) =
+                                Self::infer_read_dependent_bindings(
+                                    db,
+                                    &self.env,
+                                    &read_dependent_bindings,
+                                );
+                            union = union.add(inferred_ty);
+                            provenance = provenance.or(inferred_provenance);
                             union_qualifiers |= TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
                             read_dependent_bindings.clear();
                         }
@@ -3051,13 +3034,14 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                             provenance = provenance.or(class_member_provenance);
                             union_qualifiers |= class_member.inner.qualifiers;
                         } else {
-                            let read_dependent_member = Self::read_dependent_instance_member(
-                                db,
-                                &self.env,
-                                &read_dependent_bindings,
-                            );
-                            union = union.add(read_dependent_member.ty);
-                            provenance = provenance.or(read_dependent_member.provenance);
+                            let (inferred_ty, inferred_provenance) =
+                                Self::infer_read_dependent_bindings(
+                                    db,
+                                    &self.env,
+                                    &read_dependent_bindings,
+                                );
+                            union = union.add(inferred_ty);
+                            provenance = provenance.or(inferred_provenance);
                             union_qualifiers |= TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
                         }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -10,11 +10,11 @@ use self::named_tuple::synthesize_namedtuple_class_member;
 pub(super) use self::named_tuple::{
     DynamicNamedTupleAnchor, DynamicNamedTupleLiteral, NamedTupleField, NamedTupleSpec,
 };
+use self::static_literal::{AugmentedBindings, ImplicitAttribute};
 pub(crate) use self::static_literal::{
     ExpandedClassBaseEntry, FrozenDataclassDispatch, StaticClassLiteral,
     expanded_class_base_entries,
 };
-use self::static_literal::{ImplicitAttribute, ReadDependentBindings};
 pub(super) use self::typed_dict::{
     DynamicTypedDictAnchor, DynamicTypedDictLiteral, synthesized_typed_dict_class_member,
 };
@@ -2097,33 +2097,6 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    /// Preserve class attributes and augmented assignments made by classmethods.
-    ///
-    /// ```python
-    /// class Counter:
-    ///     @classmethod
-    ///     def update(cls):
-    ///         cls.value = 0
-    ///         cls.value += 1
-    /// ```
-    ///
-    /// Class-member MRO lookup resolves the augmented assignment after locating the independently
-    /// established class attribute, just as instance-member lookup resolves writes through `self`.
-    fn own_class_member_bindings(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        inherited_generic_context: Option<GenericContext<'db>>,
-        name: &str,
-    ) -> ImplicitAttribute<'db> {
-        self.member_with_read_dependent_bindings(
-            db,
-            self.own_class_member(db, env, inherited_generic_context, name),
-            name,
-            MethodDecorator::ClassMethod,
-        )
-    }
-
     /// Look up an instance attribute (available in `__dict__`) of the given name.
     ///
     /// See [`Type::instance_member`] for more details.
@@ -2218,10 +2191,7 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    /// Preserve independent instance attributes and assignments that first read their target.
-    ///
-    /// For example, `increment` can only establish an instance attribute because it first reads
-    /// the class-level default:
+    /// Pair an ordinary member lookup with augmented assignments that first read their target.
     ///
     /// ```python
     /// class Counter:
@@ -2229,36 +2199,23 @@ impl<'db> ClassType<'db> {
     ///
     ///     def increment(self):
     ///         self.value += 1
+    ///
+    ///     @classmethod
+    ///     def increment_class(cls):
+    ///         cls.value += 1
     /// ```
     ///
-    /// The augmented assignment cannot establish `value` until MRO lookup finds the class default
-    /// or an independently defined instance attribute.
-    fn own_instance_member_bindings(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        name: &str,
-    ) -> ImplicitAttribute<'db> {
-        self.member_with_read_dependent_bindings(
-            db,
-            self.own_instance_member(db, env, name),
-            name,
-            MethodDecorator::None,
-        )
-    }
-
-    /// Attach augmented assignments only when ordinary lookup preserves their independent target.
-    fn member_with_read_dependent_bindings(
+    /// MRO lookup can infer either assignment only after locating an existing `value`. If ordinary
+    /// lookup suppressed an implicit attribute, such as a generated `NamedTuple` field, its writes
+    /// must remain suppressed too.
+    fn member_with_augmented_bindings(
         self,
         db: &'db dyn Db,
         member: Member<'db>,
         name: &str,
         target_method_decorator: MethodDecorator,
     ) -> ImplicitAttribute<'db> {
-        // Ordinary member lookup can deliberately suppress implicit assignments, such as those
-        // targeting generated NamedTuple fields. Preserve dependent writes only when both
-        // lookups agree on whether an independently established attribute exists.
-        let read_dependent_bindings = self
+        let augmented_bindings = self
             .static_class_literal(db)
             .map(|(class, _)| {
                 StaticClassLiteral::implicit_attribute_bindings(
@@ -2269,11 +2226,11 @@ impl<'db> ClassType<'db> {
                 )
             })
             .filter(|implicit| member.is_undefined() == implicit.member.is_undefined())
-            .and_then(|implicit| implicit.read_dependent_bindings);
+            .and_then(|implicit| implicit.augmented_bindings);
 
         ImplicitAttribute {
             member,
-            read_dependent_bindings,
+            augmented_bindings,
         }
     }
 
@@ -2835,23 +2792,21 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
     ///         self.value += (self.value,)
     /// ```
     ///
-    /// Inferring these bindings earlier would recursively look up the same instance member and
+    /// Inferring these bindings earlier would recursively look up the same attribute and
     /// allow an augmented assignment to incorrectly establish an otherwise missing attribute.
     /// Once recursive inference produces a concrete result, top-level cycle placeholders do not
     /// represent additional runtime values. Other inferred alternatives remain intact, as do
     /// nested placeholders in genuinely expanding recursive types such as the tuple above.
-    fn infer_read_dependent_bindings(
+    fn infer_augmented_bindings(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        bindings: &[(ClassType<'db>, ReadDependentBindings<'db>)],
+        bindings: &[(ClassType<'db>, AugmentedBindings<'db>)],
     ) -> (Type<'db>, Provenance<'db>) {
         let mut union = UnionBuilder::new(db, env);
         let mut provenance = Provenance::Unknown;
 
         for (class, bindings) in bindings {
-            let specialization = class
-                .static_class_literal(db)
-                .and_then(|(_, specialization)| specialization);
+            let (_, specialization) = class.class_literal_and_specialization(db);
 
             for definition in bindings.definitions(db) {
                 let inferred_ty = infer_definition_types(db, *definition)
@@ -2906,7 +2861,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let mut dynamic_type: Option<Type<'db>> = None;
         let mut lookup_result: LookupResult<'db> =
             Err(LookupError::Undefined(TypeQualifiers::empty()));
-        let mut read_dependent_bindings = Vec::new();
+        let mut pending_augmented_bindings = Vec::new();
 
         for superclass in self.mro_iter {
             match superclass {
@@ -2944,27 +2899,26 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         continue;
                     }
 
-                    let implicit = class.own_class_member_bindings(
+                    let implicit = class.member_with_augmented_bindings(
                         db,
-                        &self.env,
-                        inherited_generic_context,
+                        class.own_class_member(db, &self.env, inherited_generic_context, name),
                         name,
+                        MethodDecorator::ClassMethod,
                     );
-                    if let Some(bindings) = implicit.read_dependent_bindings {
-                        read_dependent_bindings.push((class, bindings));
+                    if let Some(bindings) = implicit.augmented_bindings {
+                        pending_augmented_bindings.push((class, bindings));
                     }
 
                     let mut member = implicit.member.inner;
-                    if let Place::Defined(mut defined) = member.place
-                        && !read_dependent_bindings.is_empty()
+                    if let Place::Defined(defined) = &mut member.place
+                        && !pending_augmented_bindings.is_empty()
                     {
                         if !defined.origin.is_declared() {
-                            let (inferred_ty, inferred_provenance) =
-                                Self::infer_read_dependent_bindings(
-                                    db,
-                                    &self.env,
-                                    &read_dependent_bindings,
-                                );
+                            let (inferred_ty, inferred_provenance) = Self::infer_augmented_bindings(
+                                db,
+                                &self.env,
+                                &pending_augmented_bindings,
+                            );
                             defined.ty = UnionType::from_two_elements(
                                 db,
                                 &self.env,
@@ -2972,10 +2926,9 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                                 inferred_ty,
                             );
                             defined.provenance = defined.provenance.or(inferred_provenance);
-                            member.place = Place::Defined(defined);
                         }
 
-                        read_dependent_bindings.clear();
+                        pending_augmented_bindings.clear();
                     }
 
                     lookup_result = lookup_result.or_else(|lookup_error| {
@@ -3012,7 +2965,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let mut union_qualifiers = TypeQualifiers::empty();
         let mut definitely_bound_member: Option<PlaceAndQualifiers<'db>> = None;
         let mut provenance = Provenance::Unknown;
-        let mut read_dependent_bindings = Vec::new();
+        let mut pending_augmented_bindings = Vec::new();
 
         for superclass in self.mro_iter {
             match superclass {
@@ -3026,9 +2979,14 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                     return InstanceMemberResult::Done(PlaceAndQualifiers::unbound());
                 }
                 ClassBase::Class(class) => {
-                    let implicit = class.own_instance_member_bindings(db, &self.env, name);
-                    if let Some(bindings) = implicit.read_dependent_bindings {
-                        read_dependent_bindings.push((class, bindings));
+                    let implicit = class.member_with_augmented_bindings(
+                        db,
+                        class.own_instance_member(db, &self.env, name),
+                        name,
+                        MethodDecorator::None,
+                    );
+                    if let Some(bindings) = implicit.augmented_bindings {
+                        pending_augmented_bindings.push((class, bindings));
                     }
 
                     if let member @ PlaceAndQualifiers {
@@ -3075,21 +3033,20 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         // qualifiers
                         union_qualifiers |= qualifiers;
 
-                        if !read_dependent_bindings.is_empty() {
-                            let (inferred_ty, inferred_provenance) =
-                                Self::infer_read_dependent_bindings(
-                                    db,
-                                    &self.env,
-                                    &read_dependent_bindings,
-                                );
+                        if !pending_augmented_bindings.is_empty() {
+                            let (inferred_ty, inferred_provenance) = Self::infer_augmented_bindings(
+                                db,
+                                &self.env,
+                                &pending_augmented_bindings,
+                            );
                             union = union.add(inferred_ty);
                             provenance = provenance.or(inferred_provenance);
                             union_qualifiers |= TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
-                            read_dependent_bindings.clear();
+                            pending_augmented_bindings.clear();
                         }
                     }
 
-                    if !read_dependent_bindings.is_empty()
+                    if !pending_augmented_bindings.is_empty()
                         && let class_member @ Member {
                             inner:
                                 PlaceAndQualifiers {
@@ -3106,7 +3063,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         } = class.own_class_member(db, &self.env, None, name)
                     {
                         if !class_member_ty.is_definitely_non_data_descriptor(db, &self.env) {
-                            read_dependent_bindings.clear();
+                            pending_augmented_bindings.clear();
                             continue;
                         }
 
@@ -3119,18 +3076,17 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                             provenance = provenance.or(class_member_provenance);
                             union_qualifiers |= class_member.inner.qualifiers;
                         } else {
-                            let (inferred_ty, inferred_provenance) =
-                                Self::infer_read_dependent_bindings(
-                                    db,
-                                    &self.env,
-                                    &read_dependent_bindings,
-                                );
+                            let (inferred_ty, inferred_provenance) = Self::infer_augmented_bindings(
+                                db,
+                                &self.env,
+                                &pending_augmented_bindings,
+                            );
                             union = union.add(inferred_ty);
                             provenance = provenance.or(inferred_provenance);
                             union_qualifiers |= TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
                         }
 
-                        read_dependent_bindings.clear();
+                        pending_augmented_bindings.clear();
                         if class_member_definedness == Definedness::AlwaysDefined {
                             definitely_bound_member = Some(class_member.inner);
                         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2097,6 +2097,33 @@ impl<'db> ClassType<'db> {
         }
     }
 
+    /// Preserve class attributes and augmented assignments made by classmethods.
+    ///
+    /// ```python
+    /// class Counter:
+    ///     @classmethod
+    ///     def update(cls):
+    ///         cls.value = 0
+    ///         cls.value += 1
+    /// ```
+    ///
+    /// Class-member MRO lookup resolves the augmented assignment after locating the independently
+    /// established class attribute, just as instance-member lookup resolves writes through `self`.
+    fn own_class_member_bindings(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        inherited_generic_context: Option<GenericContext<'db>>,
+        name: &str,
+    ) -> ImplicitAttribute<'db> {
+        self.member_with_read_dependent_bindings(
+            db,
+            self.own_class_member(db, env, inherited_generic_context, name),
+            name,
+            MethodDecorator::ClassMethod,
+        )
+    }
+
     /// Look up an instance attribute (available in `__dict__`) of the given name.
     ///
     /// See [`Type::instance_member`] for more details.
@@ -2212,10 +2239,25 @@ impl<'db> ClassType<'db> {
         env: &ProgramEnvironment<'db>,
         name: &str,
     ) -> ImplicitAttribute<'db> {
-        let member = self.own_instance_member(db, env, name);
+        self.member_with_read_dependent_bindings(
+            db,
+            self.own_instance_member(db, env, name),
+            name,
+            MethodDecorator::None,
+        )
+    }
+
+    /// Attach augmented assignments only when ordinary lookup preserves their independent target.
+    fn member_with_read_dependent_bindings(
+        self,
+        db: &'db dyn Db,
+        member: Member<'db>,
+        name: &str,
+        target_method_decorator: MethodDecorator,
+    ) -> ImplicitAttribute<'db> {
         // Ordinary member lookup can deliberately suppress implicit assignments, such as those
         // targeting generated NamedTuple fields. Preserve dependent writes only when both
-        // lookups agree on whether an independent instance attribute exists.
+        // lookups agree on whether an independently established attribute exists.
         let read_dependent_bindings = self
             .static_class_literal(db)
             .map(|(class, _)| {
@@ -2223,7 +2265,7 @@ impl<'db> ClassType<'db> {
                     db,
                     class.body_scope(db),
                     name,
-                    MethodDecorator::None,
+                    target_method_decorator,
                 )
             })
             .filter(|implicit| member.is_undefined() == implicit.member.is_undefined())
@@ -2795,7 +2837,9 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
     ///
     /// Inferring these bindings earlier would recursively look up the same instance member and
     /// allow an augmented assignment to incorrectly establish an otherwise missing attribute.
-    /// Existing definition inference also normalizes recursive results such as the tuple above.
+    /// Once recursive inference produces a concrete result, top-level cycle placeholders do not
+    /// represent additional runtime values. Other inferred alternatives remain intact, as do
+    /// nested placeholders in genuinely expanding recursive types such as the tuple above.
     fn infer_read_dependent_bindings(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -2818,10 +2862,22 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
             }
         }
 
-        (
-            union.build().promote(db, env).promote_singletons(db, env),
-            provenance,
-        )
+        let inferred_ty = union.build().promote(db, env).promote_singletons(db, env);
+        let inferred_ty = if let Some(elements) =
+            inferred_ty.as_union().map(|union| union.elements(db))
+            && elements.iter().any(Type::is_divergent)
+            && elements.iter().any(|ty| !ty.is_divergent())
+        {
+            UnionType::from_elements(
+                db,
+                env,
+                elements.iter().copied().filter(|ty| !ty.is_divergent()),
+            )
+        } else {
+            inferred_ty
+        };
+
+        (inferred_ty, provenance)
     }
 
     /// Look up a class member by iterating through the MRO.
@@ -2850,6 +2906,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let mut dynamic_type: Option<Type<'db>> = None;
         let mut lookup_result: LookupResult<'db> =
             Err(LookupError::Undefined(TypeQualifiers::empty()));
+        let mut read_dependent_bindings = Vec::new();
 
         for superclass in self.mro_iter {
             match superclass {
@@ -2887,14 +2944,42 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         continue;
                     }
 
+                    let implicit = class.own_class_member_bindings(
+                        db,
+                        &self.env,
+                        inherited_generic_context,
+                        name,
+                    );
+                    if let Some(bindings) = implicit.read_dependent_bindings {
+                        read_dependent_bindings.push((class, bindings));
+                    }
+
+                    let mut member = implicit.member.inner;
+                    if let Place::Defined(mut defined) = member.place
+                        && !read_dependent_bindings.is_empty()
+                    {
+                        if !defined.origin.is_declared() {
+                            let (inferred_ty, inferred_provenance) =
+                                Self::infer_read_dependent_bindings(
+                                    db,
+                                    &self.env,
+                                    &read_dependent_bindings,
+                                );
+                            defined.ty = UnionType::from_two_elements(
+                                db,
+                                &self.env,
+                                defined.ty,
+                                inferred_ty,
+                            );
+                            defined.provenance = defined.provenance.or(inferred_provenance);
+                            member.place = Place::Defined(defined);
+                        }
+
+                        read_dependent_bindings.clear();
+                    }
+
                     lookup_result = lookup_result.or_else(|lookup_error| {
-                        lookup_error.or_fall_back_to(
-                            db,
-                            &self.env,
-                            class
-                                .own_class_member(db, &self.env, inherited_generic_context, name)
-                                .inner,
-                        )
+                        lookup_error.or_fall_back_to(db, &self.env, member)
                     });
                 }
                 ClassBase::TypedDict(module) => {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2787,7 +2787,7 @@ impl<'db> StaticClassLiteral<'db> {
 
     /// Classify an implicit attribute as defined, undefined, or deferred until an existing value
     /// is available.
-    fn implicit_attribute_bindings(
+    pub(super) fn implicit_attribute_bindings(
         db: &'db dyn Db,
         class_body_scope: ScopeId<'db>,
         name: &str,
@@ -3243,17 +3243,13 @@ impl<'db> StaticClassLiteral<'db> {
                     if has_binding {
                         // The attribute is declared and bound in the class body.
 
-                        let implicit = Self::implicit_attribute_bindings(
-                            db,
-                            body_scope,
-                            name,
-                            MethodDecorator::None,
-                        );
+                        let implicit =
+                            Self::implicit_attribute(db, body_scope, name, MethodDecorator::None);
                         if let Place::Defined(DefinedPlace {
                             ty: implicit_ty,
                             provenance: implicit_provenance,
                             ..
-                        }) = implicit.into_member().inner.place
+                        }) = implicit.inner.place
                         {
                             if declaredness == Definedness::AlwaysDefined {
                                 // If a symbol is definitely declared, and we see
@@ -3370,35 +3366,6 @@ impl<'db> StaticClassLiteral<'db> {
             // It could still be implicitly defined in a method.
 
             Self::implicit_attribute(db, body_scope, name, MethodDecorator::None)
-        }
-    }
-
-    /// Preserve augmented assignments that need an existing value while looking up this class.
-    ///
-    /// An ordinary instance member can be returned immediately, but a read-dependent write must
-    /// remain available until MRO lookup finds either a class-level value or an inherited instance
-    /// attribute.
-    pub(super) fn own_instance_member_bindings(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        name: &str,
-    ) -> ImplicitAttribute<'db> {
-        let member = self.own_instance_member(db, env, name);
-        if !member.is_undefined() {
-            return ImplicitAttribute::Defined(member);
-        }
-
-        match Self::implicit_attribute_bindings(
-            db,
-            self.body_scope(db),
-            name,
-            MethodDecorator::None,
-        ) {
-            ImplicitAttribute::Deferred(bindings) => ImplicitAttribute::Deferred(bindings),
-            ImplicitAttribute::Defined(_) | ImplicitAttribute::Undefined => {
-                ImplicitAttribute::Undefined
-            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2781,12 +2781,24 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
         target_method_decorator: MethodDecorator,
     ) -> Member<'db> {
+        Self::implicit_attribute_bindings(db, class_body_scope, name, target_method_decorator)
+            .into_member()
+    }
+
+    /// Classify an implicit attribute as defined, undefined, or deferred until an existing value
+    /// is available.
+    fn implicit_attribute_bindings(
+        db: &'db dyn Db,
+        class_body_scope: ScopeId<'db>,
+        name: &str,
+        target_method_decorator: MethodDecorator,
+    ) -> ImplicitAttribute<'db> {
         // Collect names in a tracked query so unrelated edits can preserve dependent member
         // lookups, and avoid retaining query entries for names that no method can define.
         let names = implicit_attribute_names(db, class_body_scope);
         let Ok(name_index) = names.binary_search_by(|candidate| candidate.as_str().cmp(name))
         else {
-            return Member::unbound();
+            return ImplicitAttribute::Undefined;
         };
 
         Self::implicit_attribute_inner(
@@ -2803,15 +2815,17 @@ impl<'db> StaticClassLiteral<'db> {
     #[salsa::tracked(
         returns(copy),
         cycle_fn=implicit_attribute_cycle_recover,
-        cycle_initial=|_, id, _| Member {
-            inner: Place::bound(Type::divergent(id)).into(),
-        },
+        cycle_initial=|_, id, _| ImplicitAttribute::Defined(
+            Member {
+                inner: Place::bound(Type::divergent(id)).into(),
+            },
+        ),
         heap_size=ruff_memory_usage::heap_size,
     )]
     fn implicit_attribute_inner(
         db: &'db dyn Db,
         attribute: ImplicitAttributeName<'db>,
-    ) -> Member<'db> {
+    ) -> ImplicitAttribute<'db> {
         let class_body_scope = attribute.class_body_scope(db);
         let name = attribute.name(db).as_str();
         let target_method_decorator = attribute.target_method_decorator(db);
@@ -2826,6 +2840,7 @@ impl<'db> StaticClassLiteral<'db> {
         let mut qualifiers = TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
 
         let mut is_attribute_bound = false;
+        let mut read_dependent_bindings = Vec::new();
         let mut provenance = Provenance::Unknown;
 
         let module = parsed_module(db, python_file).load(db);
@@ -2919,11 +2934,11 @@ impl<'db> StaticClassLiteral<'db> {
                             index.expression(value),
                             TypeContext::default(),
                         );
-                        return Member {
+                        return ImplicitAttribute::Defined(Member {
                             inner: Place::bound(inferred_ty)
                                 .with_definition(declaration)
                                 .with_qualifiers(all_qualifiers),
-                        };
+                        });
                     }
 
                     // If there is no right-hand side, just record that we saw a `Final` qualifier
@@ -2931,7 +2946,7 @@ impl<'db> StaticClassLiteral<'db> {
                     continue;
                 }
 
-                return Member { inner: annotation };
+                return ImplicitAttribute::Defined(Member { inner: annotation });
             }
         }
 
@@ -2988,6 +3003,11 @@ impl<'db> StaticClassLiteral<'db> {
                 let DefinitionState::Defined(binding) = attribute_assignment.binding else {
                     continue;
                 };
+
+                if matches!(binding.kind(db), DefinitionKind::AugmentedAssignment(_)) {
+                    read_dependent_bindings.push(binding);
+                    continue;
+                }
 
                 if !is_method_reachable.is_always_false() {
                     is_attribute_bound = true;
@@ -3105,9 +3125,6 @@ impl<'db> StaticClassLiteral<'db> {
                             }
                         }
                     }
-                    DefinitionKind::AugmentedAssignment(_) => {
-                        Some(infer_definition_types(db, binding).binding_type(binding))
-                    }
                     DefinitionKind::NamedExpression(_) => {
                         // A named expression whose target is an attribute is syntactically prohibited
                         None
@@ -3122,19 +3139,27 @@ impl<'db> StaticClassLiteral<'db> {
             }
         }
 
-        Member {
-            inner: if is_attribute_bound {
-                Place::bound(
+        if is_attribute_bound {
+            for binding in read_dependent_bindings {
+                let inferred_ty = infer_definition_types(db, binding).binding_type(binding);
+                provenance = provenance.or(Provenance::SingleDefinition(binding));
+                union_of_inferred_types = union_of_inferred_types.add(inferred_ty);
+            }
+
+            ImplicitAttribute::Defined(Member {
+                inner: Place::bound(
                     union_of_inferred_types
                         .build()
                         .promote(db, env)
                         .promote_singletons(db, env),
                 )
                 .with_provenance(provenance)
-                .with_qualifiers(qualifiers)
-            } else {
-                Place::Undefined.with_qualifiers(qualifiers)
-            },
+                .with_qualifiers(qualifiers),
+            })
+        } else if read_dependent_bindings.is_empty() {
+            ImplicitAttribute::Undefined
+        } else {
+            ImplicitAttribute::Deferred
         }
     }
 
@@ -3215,13 +3240,17 @@ impl<'db> StaticClassLiteral<'db> {
                     if has_binding {
                         // The attribute is declared and bound in the class body.
 
-                        let implicit =
-                            Self::implicit_attribute(db, body_scope, name, MethodDecorator::None);
+                        let implicit = Self::implicit_attribute_bindings(
+                            db,
+                            body_scope,
+                            name,
+                            MethodDecorator::None,
+                        );
                         if let Place::Defined(DefinedPlace {
                             ty: implicit_ty,
                             provenance: implicit_provenance,
                             ..
-                        }) = implicit.inner.place
+                        }) = implicit.into_member().inner.place
                         {
                             if declaredness == Definedness::AlwaysDefined {
                                 // If a symbol is definitely declared, and we see
@@ -3246,6 +3275,13 @@ impl<'db> StaticClassLiteral<'db> {
                                     })
                                     .with_qualifiers(qualifiers),
                                 }
+                            }
+                        } else if matches!(implicit, ImplicitAttribute::Deferred) {
+                            // The class-body binding supplies the initial value. A successful
+                            // augmented assignment then writes an instance attribute, so this
+                            // declaration must continue to shadow inherited instance declarations.
+                            Member {
+                                inner: declared.with_qualifiers(qualifiers),
                             }
                         } else if self.is_own_dataclass_instance_field(db, name)
                             && declared_ty
@@ -3818,6 +3854,30 @@ fn explicit_bases_cycle_fn<'db>(
     }
 }
 
+/// The result of looking for instance attributes established by methods on one class.
+///
+/// An ordinary assignment such as `self.value = 1` establishes an instance attribute. An
+/// augmented assignment such as `self.value += 1` only does so if an existing instance or class
+/// attribute can supply the value it reads first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+enum ImplicitAttribute<'db> {
+    /// An independent assignment or declaration defines the instance attribute.
+    Defined(Member<'db>),
+    /// No assignment defines the instance attribute.
+    Undefined,
+    /// Augmented assignments can define the attribute only if an existing value is available.
+    Deferred,
+}
+
+impl<'db> ImplicitAttribute<'db> {
+    fn into_member(self) -> Member<'db> {
+        match self {
+            Self::Defined(member) => member,
+            Self::Undefined | Self::Deferred => Member::unbound(),
+        }
+    }
+}
+
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct ImplicitAttributeName<'db> {
     #[returns(copy)]
@@ -3853,13 +3913,19 @@ fn implicit_attribute_names<'db>(db: &'db dyn Db, class_body_scope: ScopeId<'db>
 fn implicit_attribute_cycle_recover<'db>(
     db: &'db dyn Db,
     cycle: &salsa::Cycle,
-    previous_member: &Member<'db>,
-    member: Member<'db>,
+    previous: &ImplicitAttribute<'db>,
+    attribute_member: ImplicitAttribute<'db>,
     attribute: ImplicitAttributeName<'db>,
-) -> Member<'db> {
-    let env = ProgramEnvironment::from_scope(attribute.class_body_scope(db));
-    let inner = member
-        .inner
-        .cycle_normalized(db, &env, previous_member.inner, cycle);
-    Member { inner }
+) -> ImplicitAttribute<'db> {
+    if let (ImplicitAttribute::Defined(previous), ImplicitAttribute::Defined(current)) =
+        (previous, attribute_member)
+    {
+        let env = ProgramEnvironment::from_scope(attribute.class_body_scope(db));
+        let inner = current
+            .inner
+            .cycle_normalized(db, &env, previous.inner, cycle);
+        ImplicitAttribute::Defined(Member { inner })
+    } else {
+        attribute_member
+    }
 }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -48,7 +48,7 @@ use crate::{
             is_implicit_staticmethod,
         },
         generics::Specialization,
-        infer::{infer_definition_types, infer_unpack_types},
+        infer::infer_unpack_types,
         infer_expression_type, inferred_declaration,
         known_instance::DeprecatedInstance,
         member::{Member, class_member},
@@ -2782,11 +2782,10 @@ impl<'db> StaticClassLiteral<'db> {
         target_method_decorator: MethodDecorator,
     ) -> Member<'db> {
         Self::implicit_attribute_bindings(db, class_body_scope, name, target_method_decorator)
-            .into_member()
+            .member
     }
 
-    /// Classify an implicit attribute as defined, undefined, or deferred until an existing value
-    /// is available.
+    /// Collect independent attribute bindings and assignments that require an existing value.
     pub(super) fn implicit_attribute_bindings(
         db: &'db dyn Db,
         class_body_scope: ScopeId<'db>,
@@ -2798,7 +2797,10 @@ impl<'db> StaticClassLiteral<'db> {
         let names = implicit_attribute_names(db, class_body_scope);
         let Ok(name_index) = names.binary_search_by(|candidate| candidate.as_str().cmp(name))
         else {
-            return ImplicitAttribute::Undefined;
+            return ImplicitAttribute {
+                member: Member::unbound(),
+                read_dependent_bindings: None,
+            };
         };
 
         Self::implicit_attribute_inner(
@@ -2815,11 +2817,12 @@ impl<'db> StaticClassLiteral<'db> {
     #[salsa::tracked(
         returns(copy),
         cycle_fn=implicit_attribute_cycle_recover,
-        cycle_initial=|_, id, _| ImplicitAttribute::Defined(
-            Member {
+        cycle_initial=|_, id, _| ImplicitAttribute {
+            member: Member {
                 inner: Place::bound(Type::divergent(id)).into(),
             },
-        ),
+            read_dependent_bindings: None,
+        },
         heap_size=ruff_memory_usage::heap_size,
     )]
     fn implicit_attribute_inner(
@@ -2934,11 +2937,14 @@ impl<'db> StaticClassLiteral<'db> {
                             index.expression(value),
                             TypeContext::default(),
                         );
-                        return ImplicitAttribute::Defined(Member {
-                            inner: Place::bound(inferred_ty)
-                                .with_definition(declaration)
-                                .with_qualifiers(all_qualifiers),
-                        });
+                        return ImplicitAttribute {
+                            member: Member {
+                                inner: Place::bound(inferred_ty)
+                                    .with_definition(declaration)
+                                    .with_qualifiers(all_qualifiers),
+                            },
+                            read_dependent_bindings: None,
+                        };
                     }
 
                     // If there is no right-hand side, just record that we saw a `Final` qualifier
@@ -2946,7 +2952,10 @@ impl<'db> StaticClassLiteral<'db> {
                     continue;
                 }
 
-                return ImplicitAttribute::Defined(Member { inner: annotation });
+                return ImplicitAttribute {
+                    member: Member { inner: annotation },
+                    read_dependent_bindings: None,
+                };
             }
         }
 
@@ -3139,14 +3148,8 @@ impl<'db> StaticClassLiteral<'db> {
             }
         }
 
-        if is_attribute_bound {
-            for binding in read_dependent_bindings {
-                let inferred_ty = infer_definition_types(db, binding).binding_type(binding);
-                provenance = provenance.or(Provenance::SingleDefinition(binding));
-                union_of_inferred_types = union_of_inferred_types.add(inferred_ty);
-            }
-
-            ImplicitAttribute::Defined(Member {
+        let member = if is_attribute_bound {
+            Member {
                 inner: Place::bound(
                     union_of_inferred_types
                         .build()
@@ -3155,14 +3158,16 @@ impl<'db> StaticClassLiteral<'db> {
                 )
                 .with_provenance(provenance)
                 .with_qualifiers(qualifiers),
-            })
-        } else if read_dependent_bindings.is_empty() {
-            ImplicitAttribute::Undefined
+            }
         } else {
-            ImplicitAttribute::Deferred(ReadDependentBindings::new(
-                db,
-                read_dependent_bindings.into_boxed_slice(),
-            ))
+            Member::unbound()
+        };
+
+        ImplicitAttribute {
+            member,
+            read_dependent_bindings: (!read_dependent_bindings.is_empty()).then(|| {
+                ReadDependentBindings::new(db, read_dependent_bindings.into_boxed_slice())
+            }),
         }
     }
 
@@ -3846,28 +3851,17 @@ fn explicit_bases_cycle_fn<'db>(
     }
 }
 
-/// The result of looking for instance attributes established by methods on one class.
+/// The instance attribute bindings established by methods on one class.
 ///
 /// An ordinary assignment such as `self.value = 1` establishes an instance attribute. An
 /// augmented assignment such as `self.value += 1` only does so if an existing instance or class
 /// attribute can supply the value it reads first.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
-pub(super) enum ImplicitAttribute<'db> {
-    /// An independent assignment or declaration defines the instance attribute.
-    Defined(Member<'db>),
-    /// No assignment defines the instance attribute.
-    Undefined,
-    /// Augmented assignments can define the attribute only if an existing value is available.
-    Deferred(ReadDependentBindings<'db>),
-}
-
-impl<'db> ImplicitAttribute<'db> {
-    pub(super) fn into_member(self) -> Member<'db> {
-        match self {
-            Self::Defined(member) => member,
-            Self::Undefined | Self::Deferred(_) => Member::unbound(),
-        }
-    }
+pub(super) struct ImplicitAttribute<'db> {
+    /// The attribute established by assignments that do not depend on an existing value.
+    pub(super) member: Member<'db>,
+    /// Augmented assignments that require an existing instance or class attribute.
+    pub(super) read_dependent_bindings: Option<ReadDependentBindings<'db>>,
 }
 
 /// Augmented assignments that must not be inferred until their initial value is known to exist.
@@ -3919,15 +3913,14 @@ fn implicit_attribute_cycle_recover<'db>(
     attribute_member: ImplicitAttribute<'db>,
     attribute: ImplicitAttributeName<'db>,
 ) -> ImplicitAttribute<'db> {
-    if let (ImplicitAttribute::Defined(previous), ImplicitAttribute::Defined(current)) =
-        (previous, attribute_member)
-    {
-        let env = ProgramEnvironment::from_scope(attribute.class_body_scope(db));
-        let inner = current
-            .inner
-            .cycle_normalized(db, &env, previous.inner, cycle);
-        ImplicitAttribute::Defined(Member { inner })
-    } else {
+    let env = ProgramEnvironment::from_scope(attribute.class_body_scope(db));
+    let inner =
         attribute_member
+            .member
+            .inner
+            .cycle_normalized(db, &env, previous.member.inner, cycle);
+    ImplicitAttribute {
+        member: Member { inner },
+        ..attribute_member
     }
 }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2785,7 +2785,16 @@ impl<'db> StaticClassLiteral<'db> {
             .member
     }
 
-    /// Collect independent attribute bindings and assignments that require an existing value.
+    /// Separate independently established attributes from assignments that must first read them.
+    ///
+    /// ```python
+    /// class Counter:
+    ///     def increment(self):
+    ///         self.value += 1
+    /// ```
+    ///
+    /// Here, `value` remains undefined unless a class default or inherited attribute supplies its
+    /// initial value during MRO lookup.
     pub(super) fn implicit_attribute_bindings(
         db: &'db dyn Db,
         class_body_scope: ScopeId<'db>,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2785,7 +2785,7 @@ impl<'db> StaticClassLiteral<'db> {
             .member
     }
 
-    /// Separate independently established attributes from assignments that must first read them.
+    /// Separate assignments that establish an attribute from assignments that must first read it.
     ///
     /// ```python
     /// class Counter:
@@ -2793,8 +2793,8 @@ impl<'db> StaticClassLiteral<'db> {
     ///         self.value += 1
     /// ```
     ///
-    /// Here, `value` remains undefined unless a class default or inherited attribute supplies its
-    /// initial value during MRO lookup.
+    /// Here, `value` remains undefined until MRO lookup finds an independent class or instance
+    /// attribute. The same rule applies to `cls.value` in a classmethod.
     pub(super) fn implicit_attribute_bindings(
         db: &'db dyn Db,
         class_body_scope: ScopeId<'db>,
@@ -2808,7 +2808,7 @@ impl<'db> StaticClassLiteral<'db> {
         else {
             return ImplicitAttribute {
                 member: Member::unbound(),
-                read_dependent_bindings: None,
+                augmented_bindings: None,
             };
         };
 
@@ -2830,7 +2830,7 @@ impl<'db> StaticClassLiteral<'db> {
             member: Member {
                 inner: Place::bound(Type::divergent(id)).into(),
             },
-            read_dependent_bindings: None,
+            augmented_bindings: None,
         },
         heap_size=ruff_memory_usage::heap_size,
     )]
@@ -2852,7 +2852,7 @@ impl<'db> StaticClassLiteral<'db> {
         let mut qualifiers = TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
 
         let mut is_attribute_bound = false;
-        let mut read_dependent_bindings = Vec::new();
+        let mut augmented_bindings = Vec::new();
         let mut provenance = Provenance::Unknown;
 
         let module = parsed_module(db, python_file).load(db);
@@ -2952,7 +2952,7 @@ impl<'db> StaticClassLiteral<'db> {
                                     .with_definition(declaration)
                                     .with_qualifiers(all_qualifiers),
                             },
-                            read_dependent_bindings: None,
+                            augmented_bindings: None,
                         };
                     }
 
@@ -2963,7 +2963,7 @@ impl<'db> StaticClassLiteral<'db> {
 
                 return ImplicitAttribute {
                     member: Member { inner: annotation },
-                    read_dependent_bindings: None,
+                    augmented_bindings: None,
                 };
             }
         }
@@ -3023,7 +3023,7 @@ impl<'db> StaticClassLiteral<'db> {
                 };
 
                 if matches!(binding.kind(db), DefinitionKind::AugmentedAssignment(_)) {
-                    read_dependent_bindings.push(binding);
+                    augmented_bindings.push(binding);
                     continue;
                 }
 
@@ -3174,9 +3174,8 @@ impl<'db> StaticClassLiteral<'db> {
 
         ImplicitAttribute {
             member,
-            read_dependent_bindings: (!read_dependent_bindings.is_empty()).then(|| {
-                ReadDependentBindings::new(db, read_dependent_bindings.into_boxed_slice())
-            }),
+            augmented_bindings: (!augmented_bindings.is_empty())
+                .then(|| AugmentedBindings::new(db, augmented_bindings.into_boxed_slice())),
         }
     }
 
@@ -3860,28 +3859,28 @@ fn explicit_bases_cycle_fn<'db>(
     }
 }
 
-/// The instance attribute bindings established by methods on one class.
+/// Attributes assigned by instance methods or classmethods on a single class.
 ///
-/// An ordinary assignment such as `self.value = 1` establishes an instance attribute. An
-/// augmented assignment such as `self.value += 1` only does so if an existing instance or class
-/// attribute can supply the value it reads first.
+/// Ordinary assignments such as `self.value = 1` or `cls.value = 1` establish an attribute
+/// directly. Augmented assignments first require an existing instance or class attribute to supply
+/// the value they read.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) struct ImplicitAttribute<'db> {
     /// The attribute established by assignments that do not depend on an existing value.
     pub(super) member: Member<'db>,
     /// Augmented assignments that require an existing instance or class attribute.
-    pub(super) read_dependent_bindings: Option<ReadDependentBindings<'db>>,
+    pub(super) augmented_bindings: Option<AugmentedBindings<'db>>,
 }
 
-/// Augmented assignments that must not be inferred until their initial value is known to exist.
+/// Augmented assignments deferred until MRO lookup finds the attribute they read.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
-pub(super) struct ReadDependentBindings<'db> {
+pub(super) struct AugmentedBindings<'db> {
     #[returns(deref)]
     pub(super) definitions: Box<[Definition<'db>]>,
 }
 
 // The Salsa heap is tracked separately.
-impl get_size2::GetSize for ReadDependentBindings<'_> {}
+impl get_size2::GetSize for AugmentedBindings<'_> {}
 
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct ImplicitAttributeName<'db> {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -3159,7 +3159,10 @@ impl<'db> StaticClassLiteral<'db> {
         } else if read_dependent_bindings.is_empty() {
             ImplicitAttribute::Undefined
         } else {
-            ImplicitAttribute::Deferred
+            ImplicitAttribute::Deferred(ReadDependentBindings::new(
+                db,
+                read_dependent_bindings.into_boxed_slice(),
+            ))
         }
     }
 
@@ -3276,13 +3279,6 @@ impl<'db> StaticClassLiteral<'db> {
                                     .with_qualifiers(qualifiers),
                                 }
                             }
-                        } else if matches!(implicit, ImplicitAttribute::Deferred) {
-                            // The class-body binding supplies the initial value. A successful
-                            // augmented assignment then writes an instance attribute, so this
-                            // declaration must continue to shadow inherited instance declarations.
-                            Member {
-                                inner: declared.with_qualifiers(qualifiers),
-                            }
                         } else if self.is_own_dataclass_instance_field(db, name)
                             && declared_ty
                                 .class_member(db, env, "__get__")
@@ -3374,6 +3370,35 @@ impl<'db> StaticClassLiteral<'db> {
             // It could still be implicitly defined in a method.
 
             Self::implicit_attribute(db, body_scope, name, MethodDecorator::None)
+        }
+    }
+
+    /// Preserve augmented assignments that need an existing value while looking up this class.
+    ///
+    /// An ordinary instance member can be returned immediately, but a read-dependent write must
+    /// remain available until MRO lookup finds either a class-level value or an inherited instance
+    /// attribute.
+    pub(super) fn own_instance_member_bindings(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+    ) -> ImplicitAttribute<'db> {
+        let member = self.own_instance_member(db, env, name);
+        if !member.is_undefined() {
+            return ImplicitAttribute::Defined(member);
+        }
+
+        match Self::implicit_attribute_bindings(
+            db,
+            self.body_scope(db),
+            name,
+            MethodDecorator::None,
+        ) {
+            ImplicitAttribute::Deferred(bindings) => ImplicitAttribute::Deferred(bindings),
+            ImplicitAttribute::Defined(_) | ImplicitAttribute::Undefined => {
+                ImplicitAttribute::Undefined
+            }
         }
     }
 
@@ -3860,23 +3885,33 @@ fn explicit_bases_cycle_fn<'db>(
 /// augmented assignment such as `self.value += 1` only does so if an existing instance or class
 /// attribute can supply the value it reads first.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
-enum ImplicitAttribute<'db> {
+pub(super) enum ImplicitAttribute<'db> {
     /// An independent assignment or declaration defines the instance attribute.
     Defined(Member<'db>),
     /// No assignment defines the instance attribute.
     Undefined,
     /// Augmented assignments can define the attribute only if an existing value is available.
-    Deferred,
+    Deferred(ReadDependentBindings<'db>),
 }
 
 impl<'db> ImplicitAttribute<'db> {
-    fn into_member(self) -> Member<'db> {
+    pub(super) fn into_member(self) -> Member<'db> {
         match self {
             Self::Defined(member) => member,
-            Self::Undefined | Self::Deferred => Member::unbound(),
+            Self::Undefined | Self::Deferred(_) => Member::unbound(),
         }
     }
 }
+
+/// Augmented assignments that must not be inferred until their initial value is known to exist.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub(super) struct ReadDependentBindings<'db> {
+    #[returns(deref)]
+    pub(super) definitions: Box<[Definition<'db>]>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for ReadDependentBindings<'_> {}
 
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct ImplicitAttributeName<'db> {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4088,9 +4088,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
         }
 
-        // Expression inference can temporarily substitute a cycle placeholder for every
-        // subexpression. `None` has a stable type regardless of that cycle, so preserve it when
-        // deriving comparison constraints for recursively inferred attributes.
+        // Expression-inference cycles can replace every subexpression's type, including literals,
+        // with a cycle placeholder. This can prevent comparisons against `None` from narrowing
+        // recursively inferred attributes. Other literals can encounter the same issue, but a
+        // general solution would require broader changes to cycle recovery. For now, intentionally
+        // preserve only `None`, whose type can be recovered directly.
         let expression_type = |expr: &ast::Expr, env: &ProgramEnvironment<'db>| {
             if expr.is_none_literal_expr() {
                 Type::none(db, env)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4088,11 +4088,21 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
         }
 
+        // Expression inference can temporarily substitute a cycle placeholder for every
+        // subexpression. `None` has a stable type regardless of that cycle, so preserve it when
+        // deriving comparison constraints for recursively inferred attributes.
+        let expression_type = |expr: &ast::Expr, env: &ProgramEnvironment<'db>| {
+            if expr.is_none_literal_expr() {
+                Type::none(db, env)
+            } else {
+                inference.expression_type(expr)
+            }
+        };
         let mut last_rhs_ty: Option<Type> = None;
 
         for (op, (left, right)) in std::iter::zip(&**ops, comparator_tuples) {
-            let lhs_ty = last_rhs_ty.unwrap_or_else(|| inference.expression_type(left));
-            let rhs_ty = inference.expression_type(right);
+            let lhs_ty = last_rhs_ty.unwrap_or_else(|| expression_type(left, &self.env));
+            let rhs_ty = expression_type(right, &self.env);
             let lhs_narrowing_rhs_ty = if matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn) {
                 self.inline_membership_rhs_type(right, inference)
                     .unwrap_or(rhs_ty)


### PR DESCRIPTION
## Summary

Previously, we treated augmented assignments as ordinary bindings when inferring implicit attributes. However, `self.value += 1` first reads `self.value`, so it cannot establish an otherwise missing attribute:

```python
class Counter:
    def __init__(self) -> None:
        self.value = 0

    def increment(self) -> None:
        self.value += 1


class UninitializedCounter:
    def increment(self) -> None:
        self.value += 1  # error: [unresolved-attribute]
```

We now distinguish assignments that establish an attribute from augmented assignments that require an existing value. Class and instance member lookup collects augmented assignments while traversing the MRO and incorporates their inferred results only after resolving an independent attribute binding.

This preserves missing-attribute diagnostics and allows augmented assignments to contribute to inferred attribute types.
