### PR TITLE
[ty] Add diagnostic baseline support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,6 +4811,7 @@ dependencies = [
  "ruff_ranged_value",
  "ruff_text_size",
  "rustc-hash",
+ "rustc-stable-hash",
  "salsa",
  "schemars",
  "serde",

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -273,6 +273,11 @@ impl Diagnostic {
         self.inner.severity
     }
 
+    /// Sets the severity of this diagnostic.
+    pub fn set_severity(&mut self, severity: Severity) {
+        Arc::make_mut(&mut self.inner).severity = severity;
+    }
+
     /// Returns a shared borrow of the "primary" annotation of this diagnostic
     /// if one exists.
     ///
@@ -1088,6 +1093,9 @@ pub enum DiagnosticId {
     /// Use of an invalid command-line option.
     InvalidCliOption,
 
+    /// The configured diagnostic baseline is invalid.
+    InvalidBaseline,
+
     /// Experimental feature requires preview mode.
     PreviewFeature,
 
@@ -1144,6 +1152,7 @@ impl DiagnosticId {
             DiagnosticId::UnsupportedPythonVersion => "unsupported-python-version",
             DiagnosticId::Unformatted => "unformatted",
             DiagnosticId::InvalidCliOption => "invalid-cli-option",
+            DiagnosticId::InvalidBaseline => "invalid-baseline",
             DiagnosticId::PreviewFeature => "preview-feature",
             DiagnosticId::InternalError => "internal-error",
         }

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1315,6 +1315,7 @@ impl From<crate::files::FileRange> for Span {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum Severity {
+    Hint,
     Info,
     Warning,
     Error,
@@ -1324,7 +1325,7 @@ pub enum Severity {
 impl Severity {
     fn to_annotate(self) -> AnnotateLevel<'static> {
         match self {
-            Severity::Info => AnnotateLevel::INFO,
+            Severity::Hint | Severity::Info => AnnotateLevel::INFO,
             Severity::Warning => AnnotateLevel::WARNING,
             Severity::Error => AnnotateLevel::ERROR,
             // NOTE: Should we really collapse this to "error"?

--- a/crates/ruff_db/src/diagnostic/render/azure.rs
+++ b/crates/ruff_db/src/diagnostic/render/azure.rs
@@ -23,7 +23,7 @@ impl AzureRenderer<'_> {
     ) -> std::fmt::Result {
         for diag in diagnostics {
             let severity = match diag.severity() {
-                Severity::Info | Severity::Warning => "warning",
+                Severity::Hint | Severity::Info | Severity::Warning => "warning",
                 Severity::Error | Severity::Fatal => "error",
             };
             write!(f, "##vso[task.logissue type={severity};")?;

--- a/crates/ruff_db/src/diagnostic/render/concise.rs
+++ b/crates/ruff_db/src/diagnostic/render/concise.rs
@@ -94,6 +94,7 @@ impl<'a> ConciseRenderer<'a> {
                 }
             } else {
                 let (severity, severity_style) = match diag.severity() {
+                    Severity::Hint => ("hint", stylesheet.info),
                     Severity::Info => ("info", stylesheet.info),
                     Severity::Warning => ("warning", stylesheet.warning),
                     Severity::Error => ("error", stylesheet.error),

--- a/crates/ruff_db/src/diagnostic/render/github.rs
+++ b/crates/ruff_db/src/diagnostic/render/github.rs
@@ -22,7 +22,7 @@ impl<'a> GithubRenderer<'a> {
     ) -> std::fmt::Result {
         for diagnostic in diagnostics {
             let severity = match diagnostic.severity() {
-                Severity::Info => "notice",
+                Severity::Hint | Severity::Info => "notice",
                 Severity::Warning => "warning",
                 Severity::Error | Severity::Fatal => "error",
             };

--- a/crates/ruff_db/src/diagnostic/render/gitlab.rs
+++ b/crates/ruff_db/src/diagnostic/render/gitlab.rs
@@ -108,7 +108,7 @@ impl Serialize for SerializedMessages<'_> {
                 diagnostic.secondary_code_or_id()
             };
             let severity = match diagnostic.severity() {
-                Severity::Info => "info",
+                Severity::Hint | Severity::Info => "info",
                 Severity::Warning => "minor",
                 Severity::Error => "major",
                 // Another option here is `blocker`

--- a/crates/ruff_db/src/diagnostic/render/junit.rs
+++ b/crates/ruff_db/src/diagnostic/render/junit.rs
@@ -109,6 +109,7 @@ impl<'a> JunitRenderer<'a> {
 
 const fn severity_name(severity: Severity) -> &'static str {
     match severity {
+        Severity::Hint => "hint",
         Severity::Info => "info",
         Severity::Warning => "warning",
         Severity::Error => "error",

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -309,7 +309,7 @@ enum SarifLevel {
 impl From<Severity> for SarifLevel {
     fn from(value: Severity) -> Self {
         match value {
-            Severity::Info => SarifLevel::Note,
+            Severity::Hint | Severity::Info => SarifLevel::Note,
             Severity::Warning => SarifLevel::Warning,
             Severity::Error | Severity::Fatal => SarifLevel::Error,
         }

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -387,6 +387,7 @@ fn to_lsp_diagnostic(
     } else {
         (
             match diagnostic.severity() {
+                ruff_db::diagnostic::Severity::Hint => lsp_types::DiagnosticSeverity::Hint,
                 ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::Information,
                 ruff_db::diagnostic::Severity::Warning => lsp_types::DiagnosticSeverity::Warning,
                 ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::Error,

--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -39,6 +39,7 @@ ty check [OPTIONS] [PATH]...
 <h3 class="cli-reference">Options</h3>
 
 <dl class="cli-reference"><dt id="ty-check--add-ignore"><a href="#ty-check--add-ignore"><code>--add-ignore</code></a></dt><dd><p>Adds <code>ty: ignore</code> comments to suppress all rule diagnostics</p>
+</dd><dt id="ty-check--baseline"><a href="#ty-check--baseline"><code>--baseline</code></a> <i>path</i></dt><dd><p>Path to a JSON diagnostic baseline</p>
 </dd><dt id="ty-check--color"><a href="#ty-check--color"><code>--color</code></a> <i>when</i></dt><dd><p>Control when colored output is used</p>
 <p>Possible values:</p>
 <ul>
@@ -107,6 +108,7 @@ over all configuration files.</p>
 </ul></dd><dt id="ty-check--quiet"><a href="#ty-check--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output (or <code>-qq</code> for silent output)</p>
 </dd><dt id="ty-check--respect-ignore-files"><a href="#ty-check--respect-ignore-files"><code>--respect-ignore-files</code></a></dt><dd><p>Respect file exclusions via <code>.gitignore</code> and other standard ignore files. Use <code>--no-respect-ignore-files</code> to disable</p>
 </dd><dt id="ty-check--typeshed"><a href="#ty-check--typeshed"><code>--typeshed</code></a>, <code>--custom-typeshed-dir</code> <i>path</i></dt><dd><p>Custom directory to use for stdlib typeshed stubs</p>
+</dd><dt id="ty-check--update-baseline"><a href="#ty-check--update-baseline"><code>--update-baseline</code></a></dt><dd><p>Regenerate the configured diagnostic baseline</p>
 </dd><dt id="ty-check--verbose"><a href="#ty-check--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output (or <code>-vv</code> and <code>-vvv</code> for more verbose output)</p>
 </dd><dt id="ty-check--warn"><a href="#ty-check--warn"><code>--warn</code></a> <i>rule</i></dt><dd><p>Treat the given rule as having severity 'warn'. Can be specified multiple times. Use 'all' to apply to all rules.</p>
 </dd><dt id="ty-check--watch"><a href="#ty-check--watch"><code>--watch</code></a>, <code>-W</code></dt><dd><p>Watch files for changes and recheck files related to the changed files</p>

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -1,6 +1,33 @@
 <!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the 'Options' struct in 'crates/ty_project/src/metadata/options.rs' if you want to change anything here. -->
 
 # Configuration
+## `baseline`
+
+Path to a JSON file containing diagnostics that should be treated as baselined.
+
+Relative paths are resolved relative to the project root.
+
+**Default value**: `null`
+
+**Type**: `str`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty]
+    baseline = "ty-baseline.json"
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    baseline = "ty-baseline.json"
+    ```
+
+---
+
 ## `rules`
 
 Configures the enabled rules and their severity.

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -77,6 +77,14 @@ pub(crate) struct CheckCommand {
     #[arg(long, conflicts_with("fix"))]
     pub(crate) add_ignore: bool,
 
+    /// Path to a JSON diagnostic baseline.
+    #[arg(long, value_name = "PATH")]
+    baseline: Option<SystemPathBuf>,
+
+    /// Regenerate the configured diagnostic baseline.
+    #[arg(long, conflicts_with_all = ["watch", "fix", "add_ignore"])]
+    pub(crate) update_baseline: bool,
+
     /// Run the command within the given project directory.
     ///
     /// All `pyproject.toml` files will be discovered by walking up the directory tree from the given project directory,
@@ -273,6 +281,7 @@ impl CheckCommand {
             .then_some(false)
             .or(self.error_on_warning);
         let options = Options {
+            baseline: self.baseline.map(RelativePathBuf::cli),
             environment: Some(EnvironmentOptions {
                 python_version: self.python_version.map(Into::into).map(RangedValue::cli),
                 python_platform: self

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -138,6 +138,8 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         MainLoopMode::Fix(FixMode::ApplyFixes)
     } else if args.add_ignore {
         MainLoopMode::Fix(FixMode::AddIgnore)
+    } else if args.update_baseline {
+        MainLoopMode::UpdateBaseline
     } else {
         MainLoopMode::Check
     };
@@ -176,6 +178,12 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
 
     let mut db = ProjectDatabase::fallible(project_metadata, system)?;
     let project = db.project();
+
+    if matches!(mode, MainLoopMode::UpdateBaseline) && project.settings(&db).baseline().is_none() {
+        return Err(anyhow!(
+            "`--update-baseline` requires a baseline path from `--baseline` or configuration"
+        ));
+    }
 
     project.set_verbose(&mut db, verbosity >= VerbosityLevel::Verbose);
     project.set_force_exclude(&mut db, force_exclude);
@@ -411,6 +419,11 @@ impl MainLoop {
                         tracing::warn!("No python files found under the given path(s)");
                     }
 
+                    let mut result = result;
+                    if !matches!(self.mode, MainLoopMode::UpdateBaseline) {
+                        retain_visible_diagnostics(&mut result);
+                    }
+
                     let result = match self.mode {
                         MainLoopMode::Check => {
                             // TODO: We should have an official flag to silence workspace diagnostics.
@@ -440,6 +453,8 @@ impl MainLoop {
                             };
 
                             if let Ok(result) = result {
+                                let mut result = result;
+                                retain_visible_diagnostics(&mut result.diagnostics);
                                 let fixed_diagnostics = match mode {
                                     FixMode::AddIgnore => None,
                                     FixMode::ApplyFixes => Some(result.count),
@@ -468,6 +483,32 @@ impl MainLoop {
                             } else {
                                 Err(Canceled)
                             }
+                        }
+                        MainLoopMode::UpdateBaseline => {
+                            let settings = db.project().settings(db);
+                            let Some(baseline_path) = settings.baseline() else {
+                                return Err(anyhow!(
+                                    "`--update-baseline` requires a baseline path from `--baseline` or configuration"
+                                ));
+                            };
+                            let count = ty_project::baseline::write(db, baseline_path, &result)?;
+
+                            result.retain(|diagnostic| {
+                                diagnostic.id() != DiagnosticId::InvalidBaseline
+                                    && !ty_project::baseline::diagnostic_is_eligible(db, diagnostic)
+                            });
+                            if !result.is_empty() {
+                                self.write_diagnostics(db, &result, None)?;
+                            }
+
+                            if settings.terminal().output_format.is_human_readable() {
+                                writeln!(
+                                    self.printer.stream_for_requested_summary(),
+                                    "Updated baseline `{baseline_path}` with {count} diagnostic{}.",
+                                    if count == 1 { "" } else { "s" }
+                                )?;
+                            }
+                            Ok(result)
                         }
                     };
 
@@ -589,12 +630,19 @@ impl MainLoop {
 enum MainLoopMode {
     Check,
     Fix(FixMode),
+    UpdateBaseline,
 }
 
 #[derive(Copy, Clone, Debug)]
 enum FixMode {
     AddIgnore,
     ApplyFixes,
+}
+
+fn retain_visible_diagnostics(diagnostics: &mut Vec<Diagnostic>) {
+    diagnostics.retain(|diagnostic| {
+        !(diagnostic.severity() == Severity::Hint && diagnostic.id().is_lint())
+    });
 }
 
 fn exit_status_from_diagnostics(

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -618,7 +618,7 @@ fn exit_status_from_diagnostics(
     }
 
     match max_severity {
-        Severity::Info => ExitStatus::Success,
+        Severity::Hint | Severity::Info => ExitStatus::Success,
         Severity::Warning => {
             if terminal_settings.error_on_warning {
                 ExitStatus::Failure

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -452,8 +452,7 @@ impl MainLoop {
                                 ),
                             };
 
-                            if let Ok(result) = result {
-                                let mut result = result;
+                            if let Ok(mut result) = result {
                                 retain_visible_diagnostics(&mut result.diagnostics);
                                 let fixed_diagnostics = match mode {
                                     FixMode::AddIgnore => None,

--- a/crates/ty/tests/cli/baseline.rs
+++ b/crates/ty/tests/cli/baseline.rs
@@ -39,7 +39,7 @@ fn update_and_use_configured_baseline() -> anyhow::Result<()> {
     let serialized = fs::read_to_string(case.root().join("baseline.json"))?;
     assert!(serialized.ends_with('\n'));
     let value: serde_json::Value = serde_json::from_str(&serialized)?;
-    assert_eq!(value["version"], 1);
+    assert_eq!(value["version"], 0);
     assert_eq!(value["files"]["test.py"].as_array().unwrap().len(), 1);
     assert_eq!(value["files"]["test.py"][0]["rule"], "invalid-assignment");
     assert!(value["files"]["test.py"][0].get("message").is_none());
@@ -248,7 +248,7 @@ fn baseline_json_is_path_keyed() -> anyhow::Result<()> {
     let baseline = fs::read_to_string(case.root().join("baseline.json"))?;
     assert_snapshot!(baseline.lines().take(6).collect::<Vec<_>>().join("\n"), @r#"
     {
-      "version": 1,
+      "version": 0,
       "files": {
         "a.py": [
           {

--- a/crates/ty/tests/cli/baseline.rs
+++ b/crates/ty/tests/cli/baseline.rs
@@ -1,0 +1,258 @@
+use std::fs;
+
+use insta::assert_snapshot;
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::CliTest;
+
+#[test]
+fn update_and_use_configured_baseline() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("pyproject.toml", "[tool.ty]\nbaseline = 'baseline.json'\n"),
+        (
+            "test.py",
+            r#"
+            from typing_extensions import reveal_type
+
+            x: int = "wrong"
+            reveal_type(x)
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command().arg("--update-baseline"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    info[revealed-type]: Revealed type
+     --> test.py:5:13
+      |
+    5 | reveal_type(x)
+      |             ^ `int`
+
+    Found 1 diagnostic
+    Updated baseline `<temp_dir>/baseline.json` with 1 diagnostic.
+
+    ----- stderr -----
+    ");
+
+    let serialized = fs::read_to_string(case.root().join("baseline.json"))?;
+    assert!(serialized.ends_with('\n'));
+    let value: serde_json::Value = serde_json::from_str(&serialized)?;
+    assert_eq!(value["version"], 1);
+    assert_eq!(value["files"]["test.py"].as_array().unwrap().len(), 1);
+    assert_eq!(value["files"]["test.py"][0]["rule"], "invalid-assignment");
+    assert!(value["files"]["test.py"][0].get("message").is_none());
+
+    assert_cmd_snapshot!(case.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    info[revealed-type]: Revealed type
+     --> test.py:5:13
+      |
+    5 | reveal_type(x)
+      |             ^ `int`
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    case.write_file(
+        "test.py",
+        r#"
+        from typing_extensions import reveal_type
+
+        x: int = "wrong"
+        y: int = "new"
+        reveal_type(x)
+        "#,
+    )?;
+    assert_cmd_snapshot!(case.command().arg("--output-format=concise"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    test.py:5:10: error[invalid-assignment] Object of type `Literal["new"]` is not assignable to `int`
+    test.py:6:13: info[revealed-type] Revealed type: `int`
+    Found 2 diagnostics
+
+    ----- stderr -----
+    "#);
+
+    assert_cmd_snapshot!(case.command().arg("--update-baseline"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    info[revealed-type]: Revealed type
+     --> test.py:6:13
+      |
+    6 | reveal_type(x)
+      |             ^ `int`
+
+    Found 1 diagnostic
+    Updated baseline `<temp_dir>/baseline.json` with 2 diagnostics.
+
+    ----- stderr -----
+    ");
+    let updated = fs::read_to_string(case.root().join("baseline.json"))?;
+    assert_cmd_snapshot!(case.command().arg("--update-baseline"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    info[revealed-type]: Revealed type
+     --> test.py:6:13
+      |
+    6 | reveal_type(x)
+      |             ^ `int`
+
+    Found 1 diagnostic
+    Updated baseline `<temp_dir>/baseline.json` with 2 diagnostics.
+
+    ----- stderr -----
+    ");
+    assert_eq!(
+        fs::read_to_string(case.root().join("baseline.json"))?,
+        updated
+    );
+    Ok(())
+}
+
+#[test]
+fn cli_baseline_path() -> anyhow::Result<()> {
+    let case = CliTest::with_file("test.py", "x: int = 'wrong'\n")?;
+
+    assert_cmd_snapshot!(case.command().args(["--baseline", "state/baseline.json", "--update-baseline"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Updated baseline `<temp_dir>/state/baseline.json` with 1 diagnostic.
+
+    ----- stderr -----
+    ");
+    assert!(case.root().join("state/baseline.json").is_file());
+
+    assert_cmd_snapshot!(case.command().args(["--baseline", "state/baseline.json"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
+fn update_requires_path_and_rejects_conflicts() -> anyhow::Result<()> {
+    let case = CliTest::with_file("test.py", "x: int = 'wrong'\n")?;
+    assert_cmd_snapshot!(case.command().arg("--update-baseline"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    ty failed
+      Cause: `--update-baseline` requires a baseline path from `--baseline` or configuration
+    ");
+
+    assert_cmd_snapshot!(case.command().args(["--baseline", "baseline.json", "--update-baseline", "--fix"]), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--update-baseline' cannot be used with '--fix'
+
+    Usage: ty check --baseline <PATH> --update-baseline [PATH]...
+
+    For more information, try '--help'.
+    ");
+    Ok(())
+}
+
+#[test]
+fn update_fails_when_non_baselineable_diagnostics_remain() -> anyhow::Result<()> {
+    let case = CliTest::with_file("test.py", "if:\n")?;
+    assert_cmd_snapshot!(case.command().args(["--baseline", "baseline.json", "--update-baseline"]), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[invalid-syntax]: Expected an expression
+     --> test.py:1:3
+      |
+    1 | if:
+      |   ^
+
+    error[invalid-syntax]: Expected an indented block after `if` statement
+     --> test.py:1:4
+      |
+    1 | if:
+      |    ^
+
+    Found 2 diagnostics
+    Updated baseline `<temp_dir>/baseline.json` with 0 diagnostics.
+
+    ----- stderr -----
+    ");
+
+    let baseline: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(case.root().join("baseline.json"))?)?;
+    assert_eq!(baseline["files"], serde_json::json!({}));
+    Ok(())
+}
+
+#[test]
+fn invalid_baseline_is_reported_once() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("pyproject.toml", "[tool.ty]\nbaseline = 'baseline.json'\n"),
+        ("baseline.json", "{ not json"),
+        ("test.py", "x: int = 'wrong'\n"),
+    ])?;
+
+    assert_cmd_snapshot!(case.command().arg("--output-format=concise"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    baseline.json:1:1: error[invalid-baseline] Failed to parse baseline `<temp_dir>/baseline.json`
+    test.py:1:10: error[invalid-assignment] Object of type `Literal["wrong"]` is not assignable to `int`
+    Found 2 diagnostics
+
+    ----- stderr -----
+    "#);
+
+    // Update mode intentionally ignores the invalid old baseline and replaces it.
+    assert_cmd_snapshot!(case.command().arg("--update-baseline"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Updated baseline `<temp_dir>/baseline.json` with 1 diagnostic.
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
+#[test]
+fn baseline_json_is_path_keyed() -> anyhow::Result<()> {
+    let case = CliTest::with_files([("b.py", "b: int = 'b'\n"), ("a.py", "a: int = 'a'\n")])?;
+    assert_cmd_snapshot!(case.command().args(["--baseline", "baseline.json", "--update-baseline"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Updated baseline `<temp_dir>/baseline.json` with 2 diagnostics.
+
+    ----- stderr -----
+    ");
+
+    let baseline = fs::read_to_string(case.root().join("baseline.json"))?;
+    assert_snapshot!(baseline.lines().take(6).collect::<Vec<_>>().join("\n"), @r#"
+    {
+      "version": 1,
+      "files": {
+        "a.py": [
+          {
+            "rule": "invalid-assignment",
+    "#);
+    Ok(())
+}

--- a/crates/ty/tests/cli/config_option.rs
+++ b/crates/ty/tests/cli/config_option.rs
@@ -123,7 +123,7 @@ fn cli_config_args_invalid_option() -> anyhow::Result<()> {
       |
     1 | bad-option=true
       | ^^^^^^^^^^
-    unknown field `bad-option`, expected one of `environment`, `src`, `rules`, `terminal`, `analysis`, `overrides`
+    unknown field `bad-option`, expected one of `baseline`, `environment`, `src`, `rules`, `terminal`, `analysis`, `overrides`
 
 
     Usage: ty <COMMAND>

--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -263,3 +263,72 @@ fn fix_clean_file() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn fix_skips_baselined_diagnostics() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("pyproject.toml", "[tool.ty]\nbaseline = 'baseline.json'\n"),
+        (
+            "unused_ignore.py",
+            "x = 1  # ty: ignore[unresolved-reference]\n",
+        ),
+    ])?;
+    assert_cmd_snapshot!(case.command().args(["--warn", "unused-ignore-comment", "--update-baseline"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Updated baseline `<temp_dir>/baseline.json` with 1 diagnostic.
+
+    ----- stderr -----
+    ");
+
+    case.write_file(
+        "unused_ignore.py",
+        "x = 1  # ty: ignore[unresolved-reference]\ny = 2  # ty: ignore[unresolved-reference]\n",
+    )?;
+    assert_cmd_snapshot!(case.command().args(["--warn", "unused-ignore-comment", "--fix"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Found 1 diagnostic (1 fixed, 0 remaining).
+
+    ----- stderr -----
+    ");
+    assert_snapshot!(fs::read_to_string(case.root().join("unused_ignore.py"))?, @"
+    x = 1  # ty: ignore[unresolved-reference]
+    y = 2
+    ");
+    Ok(())
+}
+
+#[test]
+fn add_ignore_skips_baselined_diagnostics() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("pyproject.toml", "[tool.ty]\nbaseline = 'baseline.json'\n"),
+        ("errors.py", "x: int = 'wrong'\n"),
+    ])?;
+    assert_cmd_snapshot!(case.command().arg("--update-baseline"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Updated baseline `<temp_dir>/baseline.json` with 1 diagnostic.
+
+    ----- stderr -----
+    ");
+
+    case.write_file("errors.py", "x: int = 'wrong'\nprint(missing)\n")?;
+    assert_cmd_snapshot!(case.command().arg("--add-ignore"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+    Added 1 ignore comment
+
+    ----- stderr -----
+    ");
+    assert_snapshot!(fs::read_to_string(case.root().join("errors.py"))?, @r#"
+    x: int = 'wrong'
+    print(missing)  # ty: ignore[unresolved-reference]
+    "#);
+    Ok(())
+}

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -1,4 +1,5 @@
 mod analysis_options;
+mod baseline;
 mod config_option;
 mod exit_code;
 mod file_selection;

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -48,9 +48,10 @@ rayon = { workspace = true }
 regex = { workspace = true }
 regex-automata = { workspace = true }
 rustc-hash = { workspace = true }
+rustc-stable-hash = { workspace = true }
 salsa = { workspace = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }
 strum = { workspace = true }

--- a/crates/ty_project/src/baseline.rs
+++ b/crates/ty_project/src/baseline.rs
@@ -1,4 +1,25 @@
 //! Diagnostic baseline loading, matching, and serialization.
+//!
+//! Source offsets are poor persistent identifiers: inserting or removing unrelated code can move a
+//! diagnostic without changing the underlying problem. ty therefore adapts the hash-based matching
+//! approach from [*Tracking Static Analysis Violations Over Time to Capture Developer
+//! Characteristics*][paper] (section III-C), which identifies a violation using source context on
+//! both sides of its start position.
+//!
+//! A baseline fingerprint consists of the lint rule and two hashes. The hashes cover up to 100
+//! non-whitespace characters immediately before and starting at the diagnostic's primary range.
+//! They act as independent anchors: an edit on one side can change one hash while the other still
+//! identifies the diagnostic. Removing whitespace also keeps the anchors stable across formatting
+//! and indentation changes. A current diagnostic matches an entry for the same project-relative
+//! file when the rule and at least one of the two hashes match.
+//!
+//! Matching is one-to-one and order-preserving. Baseline entries and current diagnostics are
+//! compared in deterministic source order, and a baseline entry is consumed after it matches.
+//! This preserves duplicate diagnostics without allowing one baseline entry to hide more than one
+//! current diagnostic. A match changes the diagnostic's severity to [`Severity::Hint`]; consumers
+//! decide whether hints should be displayed.
+//!
+//! [paper]: https://codeql.github.com/publications/tracking-analysis-violations.pdf
 
 use std::collections::BTreeMap;
 use std::hash::Hasher;
@@ -30,6 +51,7 @@ struct Baseline {
 )]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct BaselineEntry {
+    /// Used to sort generated entries; baseline files preserve their serialized array order.
     #[serde(skip)]
     offset: TextSize,
     rule: String,

--- a/crates/ty_project/src/baseline.rs
+++ b/crates/ty_project/src/baseline.rs
@@ -39,12 +39,15 @@ use crate::Db;
 const BASELINE_VERSION: u32 = 1;
 const CONTEXT_SIZE: usize = 100;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, get_size2::GetSize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct Baseline {
+struct BaselineFile {
     version: u32,
     files: BTreeMap<String, Vec<BaselineEntry>>,
 }
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, get_size2::GetSize)]
+struct Baseline(FxHashMap<String, Box<[BaselineEntry]>>);
 
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, get_size2::GetSize,
@@ -87,10 +90,10 @@ impl BaselineError {
 ///
 /// Reading through `source_text` makes this query dependent on the baseline file's contents.
 #[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
-fn load(db: &dyn Db) -> Result<FxHashMap<String, Box<[BaselineEntry]>>, BaselineError> {
+fn load(db: &dyn Db) -> Result<Baseline, BaselineError> {
     let project = db.project();
     let Some(path) = project.settings(db).baseline() else {
-        return Ok(FxHashMap::default());
+        return Ok(Baseline::default());
     };
 
     let file = match system_path_to_file(db, path) {
@@ -113,7 +116,7 @@ fn load(db: &dyn Db) -> Result<FxHashMap<String, Box<[BaselineEntry]>>, Baseline
         });
     }
 
-    let baseline: Baseline = match serde_json::from_str(source.as_str()) {
+    let baseline: BaselineFile = match serde_json::from_str(source.as_str()) {
         Ok(baseline) => baseline,
         Err(error) => {
             return Err(BaselineError {
@@ -132,11 +135,7 @@ fn load(db: &dyn Db) -> Result<FxHashMap<String, Box<[BaselineEntry]>>, Baseline
         });
     }
 
-    Ok(baseline
-        .files
-        .into_iter()
-        .map(|(path, entries)| (path, entries.into_boxed_slice()))
-        .collect())
+    Ok(Baseline::from_file(baseline))
 }
 
 pub(crate) fn settings_diagnostic(db: &dyn Db) -> Option<Diagnostic> {
@@ -149,32 +148,10 @@ pub(crate) fn demote_diagnostics(db: &dyn Db, file: File, diagnostics: &mut [Dia
     if db.project().settings(db).baseline().is_none() {
         return;
     }
-    let Ok(files) = load(db) else {
+    let Ok(baseline) = load(db) else {
         return;
     };
-    let Some(path) = project_relative_path(db, file) else {
-        return;
-    };
-    let Some(baseline_entries) = files.get(&path) else {
-        return;
-    };
-
-    let source = source_text(db, file);
-
-    let mut entries: Vec<_> = diagnostics
-        .iter()
-        .enumerate()
-        .filter_map(|(index, diagnostic)| {
-            let diagnostic = BaselineDiagnostic::from_diagnostic(diagnostic)?;
-            Some((index, diagnostic.entry(source.as_str())))
-        })
-        .collect();
-    entries.sort_by(|(_, left), (_, right)| left.cmp(right));
-    let (diagnostic_indices, entries): (Vec<_>, Vec<_>) = entries.into_iter().unzip();
-
-    for matched_index in matched_indices(baseline_entries, &entries) {
-        diagnostics[diagnostic_indices[matched_index]].set_severity(Severity::Hint);
-    }
+    baseline.demote_diagnostics(db, file, diagnostics);
 }
 
 /// Returns `true` for lint diagnostics that can be written to a baseline.
@@ -186,29 +163,81 @@ pub fn diagnostic_is_eligible(db: &dyn Db, diagnostic: &Diagnostic) -> bool {
 
 /// Writes a new baseline containing all eligible diagnostics.
 pub fn write(db: &dyn Db, path: &SystemPath, diagnostics: &[Diagnostic]) -> anyhow::Result<usize> {
-    let baseline = Baseline::from_diagnostics(db, diagnostics);
-    let count = baseline.files.values().map(Vec::len).sum();
-    let mut serialized = serde_json::to_string_pretty(&baseline)?;
-    serialized.push('\n');
-
-    let writable = db
-        .system()
-        .as_writable()
-        .context("The active file system is read-only")?;
-    if let Some(parent) = path.parent() {
-        writable
-            .create_directory_all(parent)
-            .with_context(|| format!("Failed to create baseline directory `{parent}`"))?;
-    }
-    writable
-        .write_file(path, &serialized)
-        .with_context(|| format!("Failed to write baseline `{path}`"))?;
-    Ok(count)
+    Baseline::from_diagnostics(db, diagnostics).write(db, path)
 }
 
 impl Baseline {
+    fn from_file(file: BaselineFile) -> Self {
+        Self(
+            file.files
+                .into_iter()
+                .map(|(path, entries)| (path, entries.into_boxed_slice()))
+                .collect(),
+        )
+    }
+
+    fn into_file(self) -> BaselineFile {
+        BaselineFile {
+            version: BASELINE_VERSION,
+            files: self
+                .0
+                .into_iter()
+                .map(|(path, entries)| (path, entries.into_vec()))
+                .collect(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.0.values().map(|entries| entries.len()).sum()
+    }
+
+    fn write(self, db: &dyn Db, path: &SystemPath) -> anyhow::Result<usize> {
+        let count = self.len();
+        let mut serialized = serde_json::to_string_pretty(&self.into_file())?;
+        serialized.push('\n');
+
+        let writable = db
+            .system()
+            .as_writable()
+            .context("The active file system is read-only")?;
+        if let Some(parent) = path.parent() {
+            writable
+                .create_directory_all(parent)
+                .with_context(|| format!("Failed to create baseline directory `{parent}`"))?;
+        }
+        writable
+            .write_file(path, &serialized)
+            .with_context(|| format!("Failed to write baseline `{path}`"))?;
+        Ok(count)
+    }
+
+    fn demote_diagnostics(&self, db: &dyn Db, file: File, diagnostics: &mut [Diagnostic]) {
+        let Some(path) = project_relative_path(db, file) else {
+            return;
+        };
+        let Some(baseline_entries) = self.0.get(&path) else {
+            return;
+        };
+
+        let source = source_text(db, file);
+        let mut entries: Vec<_> = diagnostics
+            .iter()
+            .enumerate()
+            .filter_map(|(index, diagnostic)| {
+                let diagnostic = BaselineDiagnostic::from_diagnostic(diagnostic)?;
+                Some((index, diagnostic.entry(source.as_str())))
+            })
+            .collect();
+        entries.sort_by(|(_, left), (_, right)| left.cmp(right));
+        let (diagnostic_indices, entries): (Vec<_>, Vec<_>) = entries.into_iter().unzip();
+
+        for matched_index in matched_indices(baseline_entries, &entries) {
+            diagnostics[diagnostic_indices[matched_index]].set_severity(Severity::Hint);
+        }
+    }
+
     fn from_diagnostics(db: &dyn Db, diagnostics: &[Diagnostic]) -> Self {
-        let mut grouped: BTreeMap<String, Vec<BaselineDiagnostic>> = BTreeMap::new();
+        let mut grouped: FxHashMap<String, Vec<BaselineDiagnostic>> = FxHashMap::default();
         for diagnostic in diagnostics {
             let Some(diagnostic) = BaselineDiagnostic::from_diagnostic(diagnostic) else {
                 continue;
@@ -219,7 +248,11 @@ impl Baseline {
             grouped.entry(path).or_default().push(diagnostic);
         }
 
-        let mut files = BTreeMap::new();
+        let mut files = FxHashMap::default();
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "each file is processed independently and its entries are sorted"
+        )]
         for (path, diagnostics) in grouped {
             let file = diagnostics[0].file;
             let source = source_text(db, file);
@@ -228,13 +261,10 @@ impl Baseline {
                 .map(|diagnostic| diagnostic.entry(source.as_str()))
                 .collect();
             entries.sort();
-            files.insert(path, entries);
+            files.insert(path, entries.into_boxed_slice());
         }
 
-        Self {
-            version: BASELINE_VERSION,
-            files,
-        }
+        Self(files)
     }
 }
 
@@ -335,8 +365,8 @@ mod tests {
     use ty_python_semantic::Db as _;
 
     use super::{
-        Baseline, BaselineEntry, context_hashes, demote_diagnostics, load, matched_indices,
-        two_hash_matches, write,
+        Baseline, BaselineEntry, BaselineFile, context_hashes, demote_diagnostics, load,
+        matched_indices, two_hash_matches, write,
     };
 
     fn entry(rule: &str, preceding: &str, following: &str) -> BaselineEntry {
@@ -380,7 +410,7 @@ mod tests {
     #[test]
     fn schema_validation() {
         let unknown_top_level = r#"{"version":1,"files":{},"unknown":true}"#;
-        assert!(serde_json::from_str::<Baseline>(unknown_top_level).is_err());
+        assert!(serde_json::from_str::<BaselineFile>(unknown_top_level).is_err());
 
         let valid = r#"{
             "version": 1,
@@ -392,7 +422,7 @@ mod tests {
                 }]
             }
         }"#;
-        assert!(serde_json::from_str::<Baseline>(valid).is_ok());
+        assert!(serde_json::from_str::<BaselineFile>(valid).is_ok());
 
         let message = r#"{
             "version": 1,
@@ -405,7 +435,7 @@ mod tests {
                 }]
             }
         }"#;
-        assert!(serde_json::from_str::<Baseline>(message).is_err());
+        assert!(serde_json::from_str::<BaselineFile>(message).is_err());
     }
 
     #[test]
@@ -447,7 +477,10 @@ mod tests {
         let initial = Baseline::from_diagnostics(&db, &[warning.clone(), error.clone()]);
 
         let baseline_path = SystemPath::new("/project/baseline.json");
-        db.write_file(baseline_path, serde_json::to_string(&initial)?)?;
+        db.write_file(
+            baseline_path,
+            serde_json::to_string(&initial.clone().into_file())?,
+        )?;
         let mut diagnostics = vec![warning.clone(), error.clone()];
         demote_diagnostics(&db, source_file, &mut diagnostics);
         assert!(

--- a/crates/ty_project/src/baseline.rs
+++ b/crates/ty_project/src/baseline.rs
@@ -1,0 +1,495 @@
+//! Diagnostic baseline loading, matching, and serialization.
+
+use std::collections::BTreeMap;
+use std::hash::Hasher;
+
+use anyhow::Context;
+use ruff_cache::CacheKeyHasher;
+use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, LintName, Severity, Span};
+use ruff_db::files::{File, FilePath, system_path_to_file};
+use ruff_db::source::source_text;
+use ruff_db::system::SystemPath;
+use ruff_text_size::{TextRange, TextSize};
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+
+use crate::Db;
+
+const BASELINE_VERSION: u32 = 1;
+const CONTEXT_SIZE: usize = 100;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, get_size2::GetSize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Baseline {
+    version: u32,
+    files: BTreeMap<String, Vec<BaselineEntry>>,
+}
+
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, get_size2::GetSize,
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct BaselineEntry {
+    #[serde(skip)]
+    offset: TextSize,
+    rule: String,
+    preceding_hash: String,
+    following_hash: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize)]
+struct BaselineError {
+    file: Option<File>,
+    message: String,
+    detail: String,
+}
+
+impl BaselineError {
+    fn to_diagnostic(&self) -> Diagnostic {
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidBaseline,
+            Severity::Error,
+            self.message.clone(),
+        );
+        if let Some(file) = self.file {
+            diagnostic.annotate(Annotation::primary(
+                Span::from(file).with_range(TextRange::default()),
+            ));
+        }
+        diagnostic.info(self.detail.clone());
+        diagnostic
+    }
+}
+
+/// Loads and validates the configured baseline.
+///
+/// Reading through `source_text` makes this query dependent on the baseline file's contents.
+#[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
+fn load(db: &dyn Db) -> Result<FxHashMap<String, Box<[BaselineEntry]>>, BaselineError> {
+    let project = db.project();
+    let Some(path) = project.settings(db).baseline() else {
+        return Ok(FxHashMap::default());
+    };
+
+    let file = match system_path_to_file(db, path) {
+        Ok(file) => file,
+        Err(error) => {
+            return Err(BaselineError {
+                file: None,
+                message: format!("Failed to read baseline `{path}`"),
+                detail: error.to_string(),
+            });
+        }
+    };
+
+    let source = source_text(db, file);
+    if let Some(error) = source.read_error() {
+        return Err(BaselineError {
+            file: Some(file),
+            message: format!("Failed to read baseline `{path}`"),
+            detail: error.to_string(),
+        });
+    }
+
+    let baseline: Baseline = match serde_json::from_str(source.as_str()) {
+        Ok(baseline) => baseline,
+        Err(error) => {
+            return Err(BaselineError {
+                file: Some(file),
+                message: format!("Failed to parse baseline `{path}`"),
+                detail: error.to_string(),
+            });
+        }
+    };
+
+    if baseline.version != BASELINE_VERSION {
+        return Err(BaselineError {
+            file: Some(file),
+            message: format!("Unsupported baseline version `{}`", baseline.version),
+            detail: format!("ty supports baseline version `{BASELINE_VERSION}`"),
+        });
+    }
+
+    Ok(baseline
+        .files
+        .into_iter()
+        .map(|(path, entries)| (path, entries.into_boxed_slice()))
+        .collect())
+}
+
+pub(crate) fn settings_diagnostic(db: &dyn Db) -> Option<Diagnostic> {
+    db.project().settings(db).baseline()?;
+    load(db).as_ref().err().map(BaselineError::to_diagnostic)
+}
+
+/// Demotes diagnostics matched by the configured baseline to hint severity.
+pub(crate) fn demote_diagnostics(db: &dyn Db, file: File, diagnostics: &mut [Diagnostic]) {
+    if db.project().settings(db).baseline().is_none() {
+        return;
+    }
+    let Ok(files) = load(db) else {
+        return;
+    };
+    let Some(path) = project_relative_path(db, file) else {
+        return;
+    };
+    let Some(baseline_entries) = files.get(&path) else {
+        return;
+    };
+
+    let source = source_text(db, file);
+
+    let mut entries: Vec<_> = diagnostics
+        .iter()
+        .enumerate()
+        .filter_map(|(index, diagnostic)| {
+            let diagnostic = BaselineDiagnostic::from_diagnostic(diagnostic)?;
+            Some((index, diagnostic.entry(source.as_str())))
+        })
+        .collect();
+    entries.sort_by(|(_, left), (_, right)| left.cmp(right));
+    let (diagnostic_indices, entries): (Vec<_>, Vec<_>) = entries.into_iter().unzip();
+
+    for matched_index in matched_indices(baseline_entries, &entries) {
+        diagnostics[diagnostic_indices[matched_index]].set_severity(Severity::Hint);
+    }
+}
+
+/// Returns `true` for lint diagnostics that can be written to a baseline.
+pub fn diagnostic_is_eligible(db: &dyn Db, diagnostic: &Diagnostic) -> bool {
+    BaselineDiagnostic::from_diagnostic(diagnostic)
+        .and_then(|diagnostic| project_relative_path(db, diagnostic.file))
+        .is_some()
+}
+
+/// Writes a new baseline containing all eligible diagnostics.
+pub fn write(db: &dyn Db, path: &SystemPath, diagnostics: &[Diagnostic]) -> anyhow::Result<usize> {
+    let baseline = Baseline::from_diagnostics(db, diagnostics);
+    let count = baseline.files.values().map(Vec::len).sum();
+    let mut serialized = serde_json::to_string_pretty(&baseline)?;
+    serialized.push('\n');
+
+    let writable = db
+        .system()
+        .as_writable()
+        .context("The active file system is read-only")?;
+    if let Some(parent) = path.parent() {
+        writable
+            .create_directory_all(parent)
+            .with_context(|| format!("Failed to create baseline directory `{parent}`"))?;
+    }
+    writable
+        .write_file(path, &serialized)
+        .with_context(|| format!("Failed to write baseline `{path}`"))?;
+    Ok(count)
+}
+
+impl Baseline {
+    fn from_diagnostics(db: &dyn Db, diagnostics: &[Diagnostic]) -> Self {
+        let mut grouped: BTreeMap<String, Vec<BaselineDiagnostic>> = BTreeMap::new();
+        for diagnostic in diagnostics {
+            let Some(diagnostic) = BaselineDiagnostic::from_diagnostic(diagnostic) else {
+                continue;
+            };
+            let Some(path) = project_relative_path(db, diagnostic.file) else {
+                continue;
+            };
+            grouped.entry(path).or_default().push(diagnostic);
+        }
+
+        let mut files = BTreeMap::new();
+        for (path, diagnostics) in grouped {
+            let file = diagnostics[0].file;
+            let source = source_text(db, file);
+            let mut entries: Vec<_> = diagnostics
+                .into_iter()
+                .map(|diagnostic| diagnostic.entry(source.as_str()))
+                .collect();
+            entries.sort();
+            files.insert(path, entries);
+        }
+
+        Self {
+            version: BASELINE_VERSION,
+            files,
+        }
+    }
+}
+
+fn project_relative_path(db: &dyn Db, file: File) -> Option<String> {
+    let FilePath::System(path) = file.path(db) else {
+        return None;
+    };
+    let relative = path.strip_prefix(db.project().root(db)).ok()?;
+    Some(relative.as_str().replace('\\', "/"))
+}
+
+struct BaselineDiagnostic {
+    rule: LintName,
+    file: File,
+    range: TextRange,
+}
+
+impl BaselineDiagnostic {
+    fn from_diagnostic(diagnostic: &Diagnostic) -> Option<Self> {
+        let rule = diagnostic.id().as_lint()?;
+        let span = diagnostic.expect_primary_span();
+        Some(Self {
+            rule,
+            file: span.expect_ty_file(),
+            range: span.range().expect("lint diagnostics always have a range"),
+        })
+    }
+
+    fn entry(&self, source: &str) -> BaselineEntry {
+        let (preceding_hash, following_hash) = context_hashes(source, self.range.start());
+        BaselineEntry {
+            offset: self.range.start(),
+            rule: self.rule.as_str().to_owned(),
+            preceding_hash,
+            following_hash,
+        }
+    }
+}
+
+fn context_hashes(source: &str, offset: TextSize) -> (String, String) {
+    let offset = usize::from(offset);
+    let mut preceding: Vec<_> = source[..offset]
+        .chars()
+        .rev()
+        .filter(|character| !character.is_whitespace())
+        .take(CONTEXT_SIZE)
+        .collect();
+    preceding.reverse();
+    let preceding: String = preceding.into_iter().collect();
+    let following: String = source[offset..]
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .take(CONTEXT_SIZE)
+        .collect();
+    (stable_hash(&preceding), stable_hash(&following))
+}
+
+fn stable_hash(context: &str) -> String {
+    let mut hasher = CacheKeyHasher::new();
+    hasher.write(context.as_bytes());
+    format!("{:x}", hasher.finish())
+}
+
+fn matched_indices(baseline: &[BaselineEntry], current: &[BaselineEntry]) -> Vec<usize> {
+    let mut matched = Vec::new();
+    let mut baseline_start = 0;
+    for (current_index, current_entry) in current.iter().enumerate() {
+        let Some(relative_index) = baseline[baseline_start..]
+            .iter()
+            .position(|baseline_entry| two_hash_matches(baseline_entry, current_entry))
+        else {
+            continue;
+        };
+        matched.push(current_index);
+        baseline_start += relative_index + 1;
+    }
+    matched
+}
+
+fn two_hash_matches(baseline: &BaselineEntry, current: &BaselineEntry) -> bool {
+    baseline.rule == current.rule
+        && (baseline.preceding_hash == current.preceding_hash
+            || baseline.following_hash == current.following_hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::{DbWithWritableSystem as _, SystemPath, SystemPathBuf};
+    use ruff_text_size::TextRange;
+
+    use crate::db::Db as _;
+    use crate::db::testing::TestDb;
+    use crate::metadata::options::Options;
+    use crate::metadata::value::RelativePathBuf;
+    use crate::{ProjectMetadata, check_file_impl};
+    use ty_python_semantic::Db as _;
+
+    use super::{
+        Baseline, BaselineEntry, context_hashes, demote_diagnostics, load, matched_indices,
+        two_hash_matches, write,
+    };
+
+    fn entry(rule: &str, preceding: &str, following: &str) -> BaselineEntry {
+        BaselineEntry {
+            offset: 0.into(),
+            rule: rule.to_owned(),
+            preceding_hash: preceding.to_owned(),
+            following_hash: following.to_owned(),
+        }
+    }
+
+    #[test]
+    fn two_hash_matches_either_context() {
+        assert!(two_hash_matches(
+            &entry("rule", "a", "b"),
+            &entry("rule", "a", "c")
+        ));
+        assert!(two_hash_matches(
+            &entry("rule", "a", "b"),
+            &entry("rule", "c", "b")
+        ));
+        assert!(!two_hash_matches(
+            &entry("rule", "a", "b"),
+            &entry("rule", "c", "d")
+        ));
+
+        assert!(!two_hash_matches(
+            &entry("rule", "a", "b"),
+            &entry("other-rule", "a", "b")
+        ));
+    }
+
+    #[test]
+    fn context_hash_ignores_whitespace() {
+        assert_eq!(
+            context_hashes("a \nç d", 3.into()),
+            context_hashes("açd", 1.into())
+        );
+    }
+
+    #[test]
+    fn schema_validation() {
+        let unknown_top_level = r#"{"version":1,"files":{},"unknown":true}"#;
+        assert!(serde_json::from_str::<Baseline>(unknown_top_level).is_err());
+
+        let valid = r#"{
+            "version": 1,
+            "files": {
+                "test.py": [{
+                    "rule": "invalid-assignment",
+                    "precedingHash": "before",
+                    "followingHash": "after"
+                }]
+            }
+        }"#;
+        assert!(serde_json::from_str::<Baseline>(valid).is_ok());
+
+        let message = r#"{
+            "version": 1,
+            "files": {
+                "test.py": [{
+                    "rule": "invalid-assignment",
+                    "precedingHash": "before",
+                    "followingHash": "after",
+                    "message": "review only"
+                }]
+            }
+        }"#;
+        assert!(serde_json::from_str::<Baseline>(message).is_err());
+    }
+
+    #[test]
+    fn ordered_matching_preserves_duplicate_cardinality() {
+        let duplicate = entry("rule", "before", "after");
+        let baseline = vec![duplicate.clone(), duplicate.clone()];
+        let current = vec![duplicate.clone(), duplicate.clone(), duplicate];
+
+        assert_eq!(matched_indices(&baseline, &current).len(), 2);
+    }
+
+    fn test_db_with_baseline() -> TestDb {
+        let root = SystemPathBuf::from("/project");
+        let mut metadata = ProjectMetadata::new("test", root);
+        metadata.apply_override_options(Options {
+            baseline: Some(RelativePathBuf::cli("/project/baseline.json")),
+            ..Options::default()
+        });
+        TestDb::new(metadata)
+    }
+
+    #[test]
+    fn serialization_order_ignores_input_order_and_severity() -> ruff_db::system::Result<()> {
+        let mut db = test_db_with_baseline();
+        let source_path = SystemPath::new("/project/test.py");
+        db.write_file(source_path, "x\n")?;
+        let source_file = system_path_to_file(&db, source_path).unwrap();
+        let span = Span::from(source_file).with_range(TextRange::new(0.into(), 1.into()));
+
+        let mut warning = Diagnostic::new(
+            DiagnosticId::lint("z-warning"),
+            Severity::Warning,
+            "warning",
+        );
+        warning.annotate(Annotation::primary(span.clone()));
+        let mut error = Diagnostic::new(DiagnosticId::lint("a-error"), Severity::Error, "error");
+        error.annotate(Annotation::primary(span));
+
+        let initial = Baseline::from_diagnostics(&db, &[warning.clone(), error.clone()]);
+
+        let baseline_path = SystemPath::new("/project/baseline.json");
+        db.write_file(baseline_path, serde_json::to_string(&initial)?)?;
+        let mut diagnostics = vec![warning.clone(), error.clone()];
+        demote_diagnostics(&db, source_file, &mut diagnostics);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.severity() == Severity::Hint)
+        );
+
+        warning.set_severity(Severity::Hint);
+        error.set_severity(Severity::Hint);
+        assert_eq!(Baseline::from_diagnostics(&db, &[error, warning]), initial);
+        Ok(())
+    }
+
+    #[test]
+    fn baseline_file_changes_invalidate_matching() -> anyhow::Result<()> {
+        let mut db = test_db_with_baseline();
+        let source_path = SystemPath::new("/project/test.py");
+        let baseline_path = SystemPath::new("/project/baseline.json");
+        db.write_file(source_path, "x: int = 'wrong'\n")?;
+        let source_file = system_path_to_file(&db, source_path).unwrap();
+
+        let initial_result = check_file_impl(&db, db.program_file(source_file));
+        let initial = initial_result.as_ref().unwrap();
+        assert!(initial.iter().any(|diagnostic| {
+            diagnostic.id().is_lint() && diagnostic.severity() != Severity::Hint
+        }));
+
+        assert_eq!(write(&db, baseline_path, initial)?, 1);
+        ruff_db::files::File::sync_path(&mut db, baseline_path);
+
+        let baselined_result = check_file_impl(&db, db.program_file(source_file));
+        let baselined = baselined_result.as_ref().unwrap();
+        assert!(baselined.iter().any(|diagnostic| {
+            diagnostic.id().is_lint() && diagnostic.severity() == Severity::Hint
+        }));
+
+        db.write_file(baseline_path, "{\"version\": 2, \"files\": {}}")?;
+        assert!(
+            db.project()
+                .check_settings(&db)
+                .iter()
+                .any(|diagnostic| diagnostic.id() == DiagnosticId::InvalidBaseline)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_baseline_is_a_settings_diagnostic() -> ruff_db::system::Result<()> {
+        let mut db = test_db_with_baseline();
+        db.write_file(SystemPath::new("/project/baseline.json"), "not json")?;
+        assert!(load(&db).is_err());
+        let diagnostics = db.project().check_settings(&db);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].id(), DiagnosticId::InvalidBaseline);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_baseline_is_a_settings_diagnostic() {
+        let db = test_db_with_baseline();
+        assert!(load(&db).is_err());
+        let diagnostics = db.project().check_settings(&db);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].id(), DiagnosticId::InvalidBaseline);
+    }
+}

--- a/crates/ty_project/src/baseline.rs
+++ b/crates/ty_project/src/baseline.rs
@@ -1,157 +1,83 @@
-//! Diagnostic baseline loading, matching, and serialization.
+//! Loads, matches, and writes diagnostic baselines.
 //!
-//! Source offsets are poor persistent identifiers: inserting or removing unrelated code can move a
-//! diagnostic without changing the underlying problem. ty therefore adapts the hash-based matching
-//! approach from [*Tracking Static Analysis Violations Over Time to Capture Developer
-//! Characteristics*][paper] (section III-C), which identifies a violation using source context on
-//! both sides of its start position.
+//! A diagnostic can move when code is added or removed. Its source offset alone cannot identify
+//! the same diagnostic across revisions. ty instead uses nearby source text, based on section III-C
+//! of [*Tracking Static Analysis Violations Over Time to Capture Developer Characteristics*][paper].
 //!
-//! A baseline fingerprint consists of the lint rule and two hashes. The hashes cover up to 100
-//! non-whitespace characters immediately before and starting at the diagnostic's primary range.
-//! They act as independent anchors: an edit on one side can change one hash while the other still
-//! identifies the diagnostic. Removing whitespace also keeps the anchors stable across formatting
-//! and indentation changes. A current diagnostic matches an entry for the same project-relative
-//! file when the rule and at least one of the two hashes match.
+//! Each baseline entry contains a lint rule and two hashes. Each hash includes up to 100 characters.
+//! Line breaks are kept and normalized to `\n`. Other whitespace is ignored. The first hash reads
+//! backward from the end of the first word in the diagnostic. The second hash reads forward from
+//! the beginning of the same word. Including this word in both hashes ties both hashes to the
+//! diagnostic itself. Either hash can still match when the other changes. Ignoring other whitespace
+//! keeps the hashes stable when formatting or indentation changes.
 //!
-//! Matching is one-to-one and order-preserving. Baseline entries and current diagnostics are
-//! compared in deterministic source order, and a baseline entry is consumed after it matches.
-//! This preserves duplicate diagnostics without allowing one baseline entry to hide more than one
-//! current diagnostic. A match changes the diagnostic's severity to [`Severity::Hint`]; consumers
-//! decide whether hints should be displayed.
+//! A diagnostic matches an entry when the file and rule are the same and either hash matches.
+//! Diagnostics and entries are matched in source order. Each entry matches at most one diagnostic.
+//! A match changes the diagnostic's severity to [`Severity::Hint`]. The caller decides whether to
+//! show hints.
+//!
+//! # Format versions
+//!
+//! The current baseline format is version 0. Version 0 is unstable and does not need to be
+//! compatible with other ty releases.
+//!
+//! Version 1 will be the first stable format. After that, a ty release must be able to read and
+//! compare baseline files written by the previous major ty release. This can include more than one
+//! format version. Updating a baseline may always write the current format version.
 //!
 //! [paper]: https://codeql.github.com/publications/tracking-analysis-violations.pdf
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::hash::Hasher;
+use std::sync::Arc;
 
 use anyhow::Context;
-use ruff_cache::CacheKeyHasher;
+use compact_str::CompactString;
 use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, LintName, Severity, Span};
 use ruff_db::files::{File, FilePath, system_path_to_file};
 use ruff_db::source::source_text;
-use ruff_db::system::SystemPath;
+use ruff_db::system::{SystemPath, SystemPathBuf};
 use ruff_text_size::{TextRange, TextSize};
 use rustc_hash::FxHashMap;
+use rustc_stable_hash::{FromStableHash, SipHasher128Hash, StableSipHasher128};
+use serde::de::{self, Visitor};
 use serde::{Deserialize, Serialize};
 
 use crate::Db;
 
-const BASELINE_VERSION: u32 = 1;
+const BASELINE_VERSION: u32 = 0;
 const CONTEXT_SIZE: usize = 100;
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct BaselineFile {
-    version: u32,
-    files: BTreeMap<String, Vec<BaselineEntry>>,
-}
-
-#[derive(Debug, Clone, Default, Eq, PartialEq, get_size2::GetSize)]
-struct Baseline(FxHashMap<String, Box<[BaselineEntry]>>);
-
-#[derive(
-    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, get_size2::GetSize,
-)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct BaselineEntry {
-    /// Used to sort generated entries; baseline files preserve their serialized array order.
-    #[serde(skip)]
-    offset: TextSize,
-    rule: String,
-    preceding_hash: String,
-    following_hash: String,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize)]
-struct BaselineError {
-    file: Option<File>,
-    message: String,
-    detail: String,
-}
-
-impl BaselineError {
-    fn to_diagnostic(&self) -> Diagnostic {
-        let mut diagnostic = Diagnostic::new(
-            DiagnosticId::InvalidBaseline,
-            Severity::Error,
-            self.message.clone(),
-        );
-        if let Some(file) = self.file {
-            diagnostic.annotate(Annotation::primary(
-                Span::from(file).with_range(TextRange::default()),
-            ));
-        }
-        diagnostic.info(self.detail.clone());
-        diagnostic
-    }
-}
-
-/// Loads and validates the configured baseline.
-///
-/// Reading through `source_text` makes this query dependent on the baseline file's contents.
-#[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
-fn load(db: &dyn Db) -> Result<Baseline, BaselineError> {
-    let project = db.project();
-    let Some(path) = project.settings(db).baseline() else {
-        return Ok(Baseline::default());
-    };
-
-    let file = match system_path_to_file(db, path) {
-        Ok(file) => file,
-        Err(error) => {
-            return Err(BaselineError {
-                file: None,
-                message: format!("Failed to read baseline `{path}`"),
-                detail: error.to_string(),
-            });
-        }
-    };
-
-    let source = source_text(db, file);
-    if let Some(error) = source.read_error() {
-        return Err(BaselineError {
-            file: Some(file),
-            message: format!("Failed to read baseline `{path}`"),
-            detail: error.to_string(),
-        });
-    }
-
-    let baseline: BaselineFile = match serde_json::from_str(source.as_str()) {
-        Ok(baseline) => baseline,
-        Err(error) => {
-            return Err(BaselineError {
-                file: Some(file),
-                message: format!("Failed to parse baseline `{path}`"),
-                detail: error.to_string(),
-            });
-        }
-    };
-
-    if baseline.version != BASELINE_VERSION {
-        return Err(BaselineError {
-            file: Some(file),
-            message: format!("Unsupported baseline version `{}`", baseline.version),
-            detail: format!("ty supports baseline version `{BASELINE_VERSION}`"),
-        });
-    }
-
-    Ok(Baseline::from_file(baseline))
-}
-
+/// Returns a diagnostic if the configured baseline cannot be loaded.
 pub(crate) fn settings_diagnostic(db: &dyn Db) -> Option<Diagnostic> {
     db.project().settings(db).baseline()?;
-    load(db).as_ref().err().map(BaselineError::to_diagnostic)
+    baselines(db).err().map(Error::to_diagnostic)
 }
 
 /// Demotes diagnostics matched by the configured baseline to hint severity.
 pub(crate) fn demote_diagnostics(db: &dyn Db, file: File, diagnostics: &mut [Diagnostic]) {
-    if db.project().settings(db).baseline().is_none() {
-        return;
-    }
-    let Ok(baseline) = load(db) else {
+    let Some(baseline_entries) = baseline(db, file) else {
         return;
     };
-    baseline.demote_diagnostics(db, file, diagnostics);
+
+    let source = source_text(db, file);
+    let mut entries: Vec<_> = diagnostics
+        .iter()
+        .enumerate()
+        .filter_map(|(index, diagnostic)| {
+            let diagnostic = BaselineDiagnostic::from_diagnostic(diagnostic)?;
+            Some((index, diagnostic.entry(source.as_str())))
+        })
+        .collect();
+    entries.sort_by(|(_, left), (_, right)| left.cmp(right));
+
+    let mut remaining = baseline_entries;
+    for (index, entry) in entries {
+        if consume_matching_entry(&mut remaining, &entry) {
+            diagnostics[index].set_severity(Severity::Hint);
+        }
+    }
 }
 
 /// Returns `true` for lint diagnostics that can be written to a baseline.
@@ -163,37 +89,116 @@ pub fn diagnostic_is_eligible(db: &dyn Db, diagnostic: &Diagnostic) -> bool {
 
 /// Writes a new baseline containing all eligible diagnostics.
 pub fn write(db: &dyn Db, path: &SystemPath, diagnostics: &[Diagnostic]) -> anyhow::Result<usize> {
-    Baseline::from_diagnostics(db, diagnostics).write(db, path)
+    BaselineFile::from_diagnostics(db, diagnostics).write(db, path)
 }
 
-impl Baseline {
-    fn from_file(file: BaselineFile) -> Self {
-        Self(
-            file.files
-                .into_iter()
-                .map(|(path, entries)| (path, entries.into_boxed_slice()))
-                .collect(),
-        )
+/// Returns the baseline for `file` without depending on the query when baselines are disabled.
+#[inline]
+fn baseline(db: &dyn Db, file: File) -> Option<&[BaselineEntry]> {
+    #[salsa::tracked(returns(as_deref), heap_size = ruff_memory_usage::heap_size)]
+    fn baseline_impl(db: &dyn Db, file: File) -> Option<Arc<[BaselineEntry]>> {
+        let path = project_relative_path(db, file)?;
+        let baseline = baselines(db).ok()?.as_ref()?;
+        baseline.0.get(path).cloned()
     }
 
-    fn into_file(self) -> BaselineFile {
-        BaselineFile {
-            version: BASELINE_VERSION,
-            files: self
-                .0
+    db.project().settings(db).baseline()?;
+    baseline_impl(db, file)
+}
+
+/// Loads and validates the configured baseline.
+///
+/// Reading through `source_text` makes this query dependent on the baseline file's contents.
+#[salsa::tracked(returns(as_ref), heap_size = ruff_memory_usage::heap_size)]
+fn baselines(db: &dyn Db) -> Result<Option<Baseline>, Error> {
+    let project = db.project();
+    let Some(path) = project.settings(db).baseline() else {
+        return Ok(None);
+    };
+
+    let file = system_path_to_file(db, path).map_err(|error| Error::Read {
+        path: path.to_path_buf(),
+        file: None,
+        detail: error.to_string(),
+    })?;
+
+    let source = source_text(db, file);
+    if let Some(error) = source.read_error() {
+        return Err(Error::Read {
+            path: path.to_path_buf(),
+            file: Some(file),
+            detail: error.to_string(),
+        });
+    }
+
+    let baseline: BaselineFile =
+        serde_json::from_str(source.as_str()).map_err(|error| Error::Parse {
+            path: path.to_path_buf(),
+            file,
+            detail: error.to_string(),
+        })?;
+
+    if baseline.version != BASELINE_VERSION {
+        return Err(Error::UnsupportedVersion {
+            file,
+            version: baseline.version,
+        });
+    }
+
+    Ok(Some(Baseline(baseline.files)))
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize)]
+struct Baseline(BTreeMap<SystemPathBuf, Arc<[BaselineEntry]>>);
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct BaselineFile {
+    version: u32,
+    /// Source-file paths relative to the project root.
+    files: BTreeMap<SystemPathBuf, Arc<[BaselineEntry]>>,
+}
+
+impl BaselineFile {
+    fn from_diagnostics(db: &dyn Db, diagnostics: &[Diagnostic]) -> Self {
+        let mut grouped: FxHashMap<File, Vec<BaselineDiagnostic>> = FxHashMap::default();
+        for diagnostic in diagnostics {
+            let Some(diagnostic) = BaselineDiagnostic::from_diagnostic(diagnostic) else {
+                continue;
+            };
+            grouped.entry(diagnostic.file).or_default().push(diagnostic);
+        }
+
+        let mut files = BTreeMap::new();
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "each file is processed independently and its entries are sorted"
+        )]
+        for (file, diagnostics) in grouped {
+            let Some(path) = project_relative_path(db, file) else {
+                continue;
+            };
+            let source = source_text(db, file);
+            let mut entries: Vec<_> = diagnostics
                 .into_iter()
-                .map(|(path, entries)| (path, entries.into_vec()))
-                .collect(),
+                .map(|diagnostic| diagnostic.entry(source.as_str()))
+                .collect();
+            entries.sort();
+            files.insert(
+                SystemPathBuf::from(path.as_str().replace('\\', "/")),
+                Arc::from(entries),
+            );
+        }
+
+        Self {
+            version: BASELINE_VERSION,
+            files,
         }
     }
 
-    fn len(&self) -> usize {
-        self.0.values().map(|entries| entries.len()).sum()
-    }
-
     fn write(self, db: &dyn Db, path: &SystemPath) -> anyhow::Result<usize> {
-        let count = self.len();
-        let mut serialized = serde_json::to_string_pretty(&self.into_file())?;
+        let count = self.files.values().map(|entries| entries.len()).sum();
+        let mut serialized = serde_json::to_string_pretty(&self)?;
         serialized.push('\n');
 
         let writable = db
@@ -210,70 +215,72 @@ impl Baseline {
             .with_context(|| format!("Failed to write baseline `{path}`"))?;
         Ok(count)
     }
+}
 
-    fn demote_diagnostics(&self, db: &dyn Db, file: File, diagnostics: &mut [Diagnostic]) {
-        let Some(path) = project_relative_path(db, file) else {
-            return;
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, get_size2::GetSize,
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct BaselineEntry {
+    /// Used to sort generated entries; baseline files preserve their serialized array order.
+    #[serde(skip)]
+    offset: TextSize,
+    rule: CompactString,
+    preceding_hash: BaselineHash,
+    following_hash: BaselineHash,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, thiserror::Error, get_size2::GetSize)]
+enum Error {
+    #[error("Failed to read baseline `{path}`")]
+    Read {
+        path: SystemPathBuf,
+        file: Option<File>,
+        detail: String,
+    },
+
+    #[error("Failed to parse baseline `{path}`")]
+    Parse {
+        path: SystemPathBuf,
+        file: File,
+        detail: String,
+    },
+
+    #[error("Unsupported baseline version `{version}`")]
+    UnsupportedVersion { file: File, version: u32 },
+}
+
+impl Error {
+    fn to_diagnostic(&self) -> Diagnostic {
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidBaseline,
+            Severity::Error,
+            self.to_string(),
+        );
+        let (file, detail) = match self {
+            Self::Read { file, detail, .. } => (*file, detail.clone()),
+            Self::Parse { file, detail, .. } => (Some(*file), detail.clone()),
+            Self::UnsupportedVersion { file, .. } => (
+                Some(*file),
+                format!("ty supports baseline version `{BASELINE_VERSION}`"),
+            ),
         };
-        let Some(baseline_entries) = self.0.get(&path) else {
-            return;
-        };
 
-        let source = source_text(db, file);
-        let mut entries: Vec<_> = diagnostics
-            .iter()
-            .enumerate()
-            .filter_map(|(index, diagnostic)| {
-                let diagnostic = BaselineDiagnostic::from_diagnostic(diagnostic)?;
-                Some((index, diagnostic.entry(source.as_str())))
-            })
-            .collect();
-        entries.sort_by(|(_, left), (_, right)| left.cmp(right));
-        let (diagnostic_indices, entries): (Vec<_>, Vec<_>) = entries.into_iter().unzip();
-
-        for matched_index in matched_indices(baseline_entries, &entries) {
-            diagnostics[diagnostic_indices[matched_index]].set_severity(Severity::Hint);
+        if let Some(file) = file {
+            diagnostic.annotate(Annotation::primary(
+                Span::from(file).with_range(TextRange::default()),
+            ));
         }
-    }
-
-    fn from_diagnostics(db: &dyn Db, diagnostics: &[Diagnostic]) -> Self {
-        let mut grouped: FxHashMap<String, Vec<BaselineDiagnostic>> = FxHashMap::default();
-        for diagnostic in diagnostics {
-            let Some(diagnostic) = BaselineDiagnostic::from_diagnostic(diagnostic) else {
-                continue;
-            };
-            let Some(path) = project_relative_path(db, diagnostic.file) else {
-                continue;
-            };
-            grouped.entry(path).or_default().push(diagnostic);
-        }
-
-        let mut files = FxHashMap::default();
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "each file is processed independently and its entries are sorted"
-        )]
-        for (path, diagnostics) in grouped {
-            let file = diagnostics[0].file;
-            let source = source_text(db, file);
-            let mut entries: Vec<_> = diagnostics
-                .into_iter()
-                .map(|diagnostic| diagnostic.entry(source.as_str()))
-                .collect();
-            entries.sort();
-            files.insert(path, entries.into_boxed_slice());
-        }
-
-        Self(files)
+        diagnostic.info(detail);
+        diagnostic
     }
 }
 
-fn project_relative_path(db: &dyn Db, file: File) -> Option<String> {
+fn project_relative_path(db: &dyn Db, file: File) -> Option<&SystemPath> {
     let FilePath::System(path) = file.path(db) else {
         return None;
     };
-    let relative = path.strip_prefix(db.project().root(db)).ok()?;
-    Some(relative.as_str().replace('\\', "/"))
+    path.strip_prefix(db.project().root(db)).ok()
 }
 
 struct BaselineDiagnostic {
@@ -297,51 +304,23 @@ impl BaselineDiagnostic {
         let (preceding_hash, following_hash) = context_hashes(source, self.range.start());
         BaselineEntry {
             offset: self.range.start(),
-            rule: self.rule.as_str().to_owned(),
+            rule: CompactString::const_new(self.rule.as_str()),
             preceding_hash,
             following_hash,
         }
     }
 }
 
-fn context_hashes(source: &str, offset: TextSize) -> (String, String) {
-    let offset = usize::from(offset);
-    let mut preceding: Vec<_> = source[..offset]
-        .chars()
-        .rev()
-        .filter(|character| !character.is_whitespace())
-        .take(CONTEXT_SIZE)
-        .collect();
-    preceding.reverse();
-    let preceding: String = preceding.into_iter().collect();
-    let following: String = source[offset..]
-        .chars()
-        .filter(|character| !character.is_whitespace())
-        .take(CONTEXT_SIZE)
-        .collect();
-    (stable_hash(&preceding), stable_hash(&following))
-}
+fn consume_matching_entry(baseline: &mut &[BaselineEntry], current: &BaselineEntry) -> bool {
+    let Some(index) = baseline
+        .iter()
+        .position(|entry| two_hash_matches(entry, current))
+    else {
+        return false;
+    };
 
-fn stable_hash(context: &str) -> String {
-    let mut hasher = CacheKeyHasher::new();
-    hasher.write(context.as_bytes());
-    format!("{:x}", hasher.finish())
-}
-
-fn matched_indices(baseline: &[BaselineEntry], current: &[BaselineEntry]) -> Vec<usize> {
-    let mut matched = Vec::new();
-    let mut baseline_start = 0;
-    for (current_index, current_entry) in current.iter().enumerate() {
-        let Some(relative_index) = baseline[baseline_start..]
-            .iter()
-            .position(|baseline_entry| two_hash_matches(baseline_entry, current_entry))
-        else {
-            continue;
-        };
-        matched.push(current_index);
-        baseline_start += relative_index + 1;
-    }
-    matched
+    *baseline = &baseline[index + 1..];
+    true
 }
 
 fn two_hash_matches(baseline: &BaselineEntry, current: &BaselineEntry) -> bool {
@@ -350,11 +329,141 @@ fn two_hash_matches(baseline: &BaselineEntry, current: &BaselineEntry) -> bool {
             || baseline.following_hash == current.following_hash)
 }
 
+fn context_hashes(source: &str, offset: TextSize) -> (BaselineHash, BaselineHash) {
+    let offset = usize::from(offset);
+    let (word_start, word_end) = word_bounds(source, offset);
+
+    (
+        stable_hash(&source[..word_end], HashDirection::Backward),
+        stable_hash(&source[word_start..], HashDirection::Forward),
+    )
+}
+
+fn word_bounds(source: &str, offset: usize) -> (usize, usize) {
+    let Some(character) = source[offset..].chars().next() else {
+        return (offset, offset);
+    };
+
+    let is_word_character = |character: char| character == '_' || character.is_alphanumeric();
+    if !is_word_character(character) {
+        return (offset, offset + character.len_utf8());
+    }
+
+    let start = source[..offset]
+        .char_indices()
+        .rev()
+        .take_while(|(_, character)| is_word_character(*character))
+        .last()
+        .map_or(offset, |(index, _)| index);
+    let end = source[offset..]
+        .char_indices()
+        .find(|(_, character)| !is_word_character(*character))
+        .map_or(source.len(), |(index, _)| offset + index);
+
+    (start, end)
+}
+
+#[derive(Clone, Copy)]
+enum HashDirection {
+    Forward,
+    Backward,
+}
+
+fn stable_hash(context: &str, direction: HashDirection) -> BaselineHash {
+    let mut hasher = StableSipHasher128::new();
+    let mut characters = context.char_indices();
+    let mut length = 0_u8;
+
+    while usize::from(length) < CONTEXT_SIZE {
+        let character = match direction {
+            HashDirection::Forward => characters.next(),
+            HashDirection::Backward => characters.next_back(),
+        };
+        let Some((index, character)) = character else {
+            break;
+        };
+        let character = match character {
+            '\r' if context.as_bytes().get(index + 1) == Some(&b'\n') => continue,
+            '\r' | '\n' => '\n',
+            character if character.is_whitespace() => continue,
+            character => character,
+        };
+
+        hasher.write_u32(u32::from(character));
+        length += 1;
+    }
+
+    hasher.write_u8(length);
+    hasher.finish()
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, get_size2::GetSize)]
+struct BaselineHash(u128);
+
+impl FromStableHash for BaselineHash {
+    type Hash = SipHasher128Hash;
+
+    fn from(SipHasher128Hash([first, second]): SipHasher128Hash) -> Self {
+        Self((u128::from(first) << 64) | u128::from(second))
+    }
+}
+
+impl fmt::Display for BaselineHash {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{:032x}", self.0)
+    }
+}
+
+impl Serialize for BaselineHash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for BaselineHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct BaselineHashVisitor;
+
+        impl Visitor<'_> for BaselineHashVisitor {
+            type Value = BaselineHash;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a 32-character hexadecimal hash")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if value.len() != 32 {
+                    return Err(E::invalid_length(value.len(), &self));
+                }
+
+                u128::from_str_radix(value, 16)
+                    .map(BaselineHash)
+                    .map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(BaselineHashVisitor)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
-    use ruff_db::files::system_path_to_file;
+    use ruff_db::files::{File, system_path_to_file};
     use ruff_db::system::{DbWithWritableSystem as _, SystemPath, SystemPathBuf};
+    use ruff_db::testing::{
+        assert_const_function_query_was_not_run, assert_function_query_was_not_run,
+        assert_function_query_was_not_run_by_name, find_will_execute_event_by_name,
+    };
     use ruff_text_size::TextRange;
 
     use crate::db::Db as _;
@@ -365,17 +474,37 @@ mod tests {
     use ty_python_semantic::Db as _;
 
     use super::{
-        Baseline, BaselineEntry, BaselineFile, context_hashes, demote_diagnostics, load,
-        matched_indices, two_hash_matches, write,
+        BaselineEntry, BaselineFile, BaselineHash, Error, HashDirection, baseline, baselines,
+        consume_matching_entry, context_hashes, demote_diagnostics, stable_hash, two_hash_matches,
+        write,
     };
 
     fn entry(rule: &str, preceding: &str, following: &str) -> BaselineEntry {
         BaselineEntry {
             offset: 0.into(),
-            rule: rule.to_owned(),
-            preceding_hash: preceding.to_owned(),
-            following_hash: following.to_owned(),
+            rule: rule.into(),
+            preceding_hash: stable_hash(preceding, HashDirection::Backward),
+            following_hash: stable_hash(following, HashDirection::Forward),
         }
+    }
+
+    #[test]
+    fn baseline_hash_is_inline_and_serializes_as_hexadecimal() -> anyhow::Result<()> {
+        let hash = BaselineHash(0x0123_4567_89ab_cdef_0123_4567_89ab_cdef);
+        let serialized = r#""0123456789abcdef0123456789abcdef""#;
+
+        assert_eq!(std::mem::size_of::<BaselineHash>(), 16);
+        assert_eq!(serde_json::to_string(&hash)?, serialized);
+        assert_eq!(serde_json::from_str::<BaselineHash>(serialized)?, hash);
+        assert_eq!(
+            serde_json::from_str::<BaselineHash>(r#""\u0030123456789abcdef0123456789abcdef""#,)?,
+            hash
+        );
+        assert!(serde_json::from_str::<BaselineHash>(r#""0123456789abcdef""#).is_err());
+        assert!(
+            serde_json::from_str::<BaselineHash>(r#""0123456789abcdef0123456789abcdeg""#).is_err()
+        );
+        Ok(())
     }
 
     #[test]
@@ -400,37 +529,120 @@ mod tests {
     }
 
     #[test]
-    fn context_hash_ignores_whitespace() {
+    fn context_hash_ignores_non_newline_whitespace() {
         assert_eq!(
-            context_hashes("a \nç d", 3.into()),
-            context_hashes("açd", 1.into())
+            context_hashes("a + \tç . d", 5.into()),
+            context_hashes("a+ç.d", 2.into())
         );
     }
 
     #[test]
+    fn context_hashes_preserve_newlines() {
+        let (preceding, following) = context_hashes("before\nword\nafter", 7.into());
+
+        assert_eq!(
+            preceding,
+            stable_hash("before\nword", HashDirection::Backward)
+        );
+        assert_eq!(
+            following,
+            stable_hash("word\nafter", HashDirection::Forward)
+        );
+        assert_ne!(
+            (preceding, following),
+            context_hashes("before word after", 7.into())
+        );
+    }
+
+    #[test]
+    fn context_hashes_normalize_line_endings() {
+        let expected = context_hashes("before\nword\nafter", 7.into());
+
+        assert_eq!(expected, context_hashes("before\rword\rafter", 7.into()));
+        assert_eq!(
+            expected,
+            context_hashes("before\r\nword\r\nafter", 8.into())
+        );
+    }
+
+    #[test]
+    fn context_hashes_limit_each_window() {
+        let source = format!("{}target{}", "ç ".repeat(100), " β".repeat(100));
+        let (preceding, following) = context_hashes(&source, 300.into());
+
+        assert_eq!(
+            preceding,
+            stable_hash(
+                &format!("{}target", "ç".repeat(94)),
+                HashDirection::Backward
+            )
+        );
+        assert_eq!(
+            following,
+            stable_hash(&format!("target{}", "β".repeat(94)), HashDirection::Forward)
+        );
+    }
+
+    #[test]
+    fn context_hashes_overlap_complete_word() {
+        let (preceding, following) = context_hashes("before diagnostic_word.after", 7.into());
+
+        assert_eq!(
+            preceding,
+            stable_hash("beforediagnostic_word", HashDirection::Backward)
+        );
+        assert_eq!(
+            following,
+            stable_hash("diagnostic_word.after", HashDirection::Forward)
+        );
+    }
+
+    #[test]
+    fn context_hashes_overlap_word_containing_diagnostic_start() {
+        let (preceding, following) = context_hashes("before café_word2.after", 9.into());
+
+        assert_eq!(
+            preceding,
+            stable_hash("beforecafé_word2", HashDirection::Backward)
+        );
+        assert_eq!(
+            following,
+            stable_hash("café_word2.after", HashDirection::Forward)
+        );
+    }
+
+    #[test]
+    fn context_hashes_overlap_punctuation() {
+        let (preceding, following) = context_hashes("before + after", 7.into());
+
+        assert_eq!(preceding, stable_hash("before+", HashDirection::Backward));
+        assert_eq!(following, stable_hash("+after", HashDirection::Forward));
+    }
+
+    #[test]
     fn schema_validation() {
-        let unknown_top_level = r#"{"version":1,"files":{},"unknown":true}"#;
+        let unknown_top_level = r#"{"version":0,"files":{},"unknown":true}"#;
         assert!(serde_json::from_str::<BaselineFile>(unknown_top_level).is_err());
 
         let valid = r#"{
-            "version": 1,
+            "version": 0,
             "files": {
                 "test.py": [{
                     "rule": "invalid-assignment",
-                    "precedingHash": "before",
-                    "followingHash": "after"
+                    "precedingHash": "0123456789abcdef0123456789abcdef",
+                    "followingHash": "fedcba9876543210fedcba9876543210"
                 }]
             }
         }"#;
         assert!(serde_json::from_str::<BaselineFile>(valid).is_ok());
 
         let message = r#"{
-            "version": 1,
+            "version": 0,
             "files": {
                 "test.py": [{
                     "rule": "invalid-assignment",
-                    "precedingHash": "before",
-                    "followingHash": "after",
+                    "precedingHash": "0123456789abcdef0123456789abcdef",
+                    "followingHash": "fedcba9876543210fedcba9876543210",
                     "message": "review only"
                 }]
             }
@@ -441,10 +653,23 @@ mod tests {
     #[test]
     fn ordered_matching_preserves_duplicate_cardinality() {
         let duplicate = entry("rule", "before", "after");
-        let baseline = vec![duplicate.clone(), duplicate.clone()];
-        let current = vec![duplicate.clone(), duplicate.clone(), duplicate];
+        let baseline = [duplicate.clone(), duplicate.clone()];
+        let mut remaining = baseline.as_slice();
 
-        assert_eq!(matched_indices(&baseline, &current).len(), 2);
+        assert!(consume_matching_entry(&mut remaining, &duplicate));
+        assert!(consume_matching_entry(&mut remaining, &duplicate));
+        assert!(!consume_matching_entry(&mut remaining, &duplicate));
+    }
+
+    #[test]
+    fn matching_preserves_diagnostic_order() {
+        let first = entry("rule", "first-before", "first-after");
+        let second = entry("rule", "second-before", "second-after");
+        let baseline = [first.clone(), second.clone()];
+        let mut remaining = baseline.as_slice();
+
+        assert!(consume_matching_entry(&mut remaining, &second));
+        assert!(!consume_matching_entry(&mut remaining, &first));
     }
 
     fn test_db_with_baseline() -> TestDb {
@@ -466,7 +691,7 @@ mod tests {
         let span = Span::from(source_file).with_range(TextRange::new(0.into(), 1.into()));
 
         let mut warning = Diagnostic::new(
-            DiagnosticId::lint("z-warning"),
+            DiagnosticId::lint("z-warning-name-longer-than-twenty-four-characters"),
             Severity::Warning,
             "warning",
         );
@@ -474,13 +699,15 @@ mod tests {
         let mut error = Diagnostic::new(DiagnosticId::lint("a-error"), Severity::Error, "error");
         error.annotate(Annotation::primary(span));
 
-        let initial = Baseline::from_diagnostics(&db, &[warning.clone(), error.clone()]);
+        let initial = BaselineFile::from_diagnostics(&db, &[warning.clone(), error.clone()]);
+        assert!(
+            initial.files[SystemPath::new("test.py")]
+                .iter()
+                .all(|entry| !entry.rule.is_heap_allocated())
+        );
 
         let baseline_path = SystemPath::new("/project/baseline.json");
-        db.write_file(
-            baseline_path,
-            serde_json::to_string(&initial.clone().into_file())?,
-        )?;
+        db.write_file(baseline_path, serde_json::to_string(&initial)?)?;
         let mut diagnostics = vec![warning.clone(), error.clone()];
         demote_diagnostics(&db, source_file, &mut diagnostics);
         assert!(
@@ -491,7 +718,60 @@ mod tests {
 
         warning.set_severity(Severity::Hint);
         error.set_severity(Severity::Hint);
-        assert_eq!(Baseline::from_diagnostics(&db, &[error, warning]), initial);
+        assert_eq!(
+            BaselineFile::from_diagnostics(&db, &[error, warning]),
+            initial
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn disabled_baseline_returns_none() {
+        let db = TestDb::new(ProjectMetadata::new(
+            "test",
+            SystemPathBuf::from("/project"),
+        ));
+
+        assert!(baselines(&db).unwrap().is_none());
+    }
+
+    #[test]
+    fn disabled_baseline_does_not_run_baseline_queries() -> ruff_db::system::Result<()> {
+        let mut db = TestDb::new(ProjectMetadata::new(
+            "test",
+            SystemPathBuf::from("/project"),
+        ));
+        let source_path = SystemPath::new("/project/test.py");
+        db.write_file(source_path, "x: int = 'wrong'\n")?;
+        let source_file = system_path_to_file(&db, source_path).unwrap();
+        db.take_salsa_events();
+
+        assert!(baseline(&db, source_file).is_none());
+        let diagnostics = check_file_impl(&db, db.program_file(source_file));
+        assert_eq!(diagnostics.unwrap()[0].severity(), Severity::Error);
+
+        let events = db.take_salsa_events();
+        assert_function_query_was_not_run_by_name(&db, "baseline_impl", None, &events);
+        assert_const_function_query_was_not_run(&db, baselines, &events);
+        Ok(())
+    }
+
+    #[test]
+    fn per_file_baseline_shares_cached_entries() -> ruff_db::system::Result<()> {
+        let mut db = test_db_with_baseline();
+        let source_path = SystemPath::new("/project/nested/test.py");
+        db.write_file(source_path, "x\n")?;
+        db.write_file(
+            SystemPath::new("/project/baseline.json"),
+            r#"{"version":0,"files":{"nested/test.py":[{"rule":"rule","precedingHash":"0123456789abcdef0123456789abcdef","followingHash":"fedcba9876543210fedcba9876543210"}]}}"#,
+        )?;
+        let source_file = system_path_to_file(&db, source_path).unwrap();
+
+        let entries =
+            &baselines(&db).unwrap().as_ref().unwrap().0[SystemPath::new("nested/test.py")];
+        let file_entries = baseline(&db, source_file).unwrap();
+
+        assert!(std::ptr::eq(entries.as_ref(), file_entries));
         Ok(())
     }
 
@@ -518,7 +798,11 @@ mod tests {
             diagnostic.id().is_lint() && diagnostic.severity() == Severity::Hint
         }));
 
-        db.write_file(baseline_path, "{\"version\": 2, \"files\": {}}")?;
+        db.write_file(baseline_path, "{\"version\": 1, \"files\": {}}")?;
+        assert!(matches!(
+            baselines(&db),
+            Err(Error::UnsupportedVersion { version: 1, .. })
+        ));
         assert!(
             db.project()
                 .check_settings(&db)
@@ -529,10 +813,48 @@ mod tests {
     }
 
     #[test]
+    fn unrelated_baseline_changes_preserve_cached_file_checks() -> anyhow::Result<()> {
+        let mut db = test_db_with_baseline();
+        let first_path = SystemPath::new("/project/first.py");
+        let second_path = SystemPath::new("/project/second.py");
+        let baseline_path = SystemPath::new("/project/baseline.json");
+        db.write_file(first_path, "x: int = 'wrong'\n")?;
+        db.write_file(second_path, "y: int = 'wrong'\n")?;
+        let first_file = system_path_to_file(&db, first_path).unwrap();
+        let second_file = system_path_to_file(&db, second_path).unwrap();
+
+        let mut diagnostics = db.check_file(first_file);
+        diagnostics.extend(db.check_file(second_file));
+        assert_eq!(write(&db, baseline_path, &diagnostics)?, 2);
+        File::sync_path(&mut db, baseline_path);
+
+        let initial = check_file_impl(&db, db.program_file(second_file));
+        assert_eq!(initial.unwrap()[0].severity(), Severity::Hint);
+
+        let mut updated = BaselineFile::from_diagnostics(&db, &diagnostics);
+        updated.files.remove(SystemPath::new("first.py"));
+        db.write_file(baseline_path, serde_json::to_string(&updated)?)?;
+        db.take_salsa_events();
+
+        let unchanged = check_file_impl(&db, db.program_file(second_file));
+        assert_eq!(unchanged.unwrap()[0].severity(), Severity::Hint);
+
+        let events = db.take_salsa_events();
+        assert!(find_will_execute_event_by_name(&db, "baseline_impl", None, &events).is_some());
+        assert_function_query_was_not_run(
+            &db,
+            check_file_impl,
+            db.program_file(second_file),
+            &events,
+        );
+        Ok(())
+    }
+
+    #[test]
     fn malformed_baseline_is_a_settings_diagnostic() -> ruff_db::system::Result<()> {
         let mut db = test_db_with_baseline();
         db.write_file(SystemPath::new("/project/baseline.json"), "not json")?;
-        assert!(load(&db).is_err());
+        assert!(matches!(baselines(&db), Err(Error::Parse { .. })));
         let diagnostics = db.project().check_settings(&db);
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].id(), DiagnosticId::InvalidBaseline);
@@ -542,7 +864,7 @@ mod tests {
     #[test]
     fn missing_baseline_is_a_settings_diagnostic() {
         let db = test_db_with_baseline();
-        assert!(load(&db).is_err());
+        assert!(matches!(baselines(&db), Err(Error::Read { .. })));
         let diagnostics = db.project().check_settings(&db);
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].id(), DiagnosticId::InvalidBaseline);

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -33,6 +33,7 @@ use ty_python_core::program::{Program, ProgramSettings};
 pub use ty_python_semantic::Db as SemanticDb;
 use ty_python_semantic::lint::RuleSelection;
 
+pub mod baseline;
 mod db;
 mod files;
 pub mod glob;
@@ -360,11 +361,7 @@ impl Project {
             name = self.name(db)
         );
 
-        let mut diagnostics: Vec<Diagnostic> = self
-            .settings_diagnostics(db)
-            .iter()
-            .map(OptionDiagnostic::to_diagnostic)
-            .collect();
+        let mut diagnostics = self.check_settings(db);
 
         let files = ProjectFiles::new(db, self);
         reporter.set_files(files.len());
@@ -641,10 +638,13 @@ impl Project {
 
     /// Check if the project's settings have any issues
     pub fn check_settings(&self, db: &dyn Db) -> Vec<Diagnostic> {
-        self.settings_diagnostics(db)
+        let mut diagnostics: Vec<_> = self
+            .settings_diagnostics(db)
             .iter()
             .map(OptionDiagnostic::to_diagnostic)
-            .collect()
+            .collect();
+        diagnostics.extend(baseline::settings_diagnostic(db));
+        diagnostics
     }
 }
 
@@ -757,7 +757,10 @@ pub(crate) fn check_file_impl(
             diagnostics.extend(script_diagnostics.iter().cloned());
             Ok(diagnostics.into_boxed_slice())
         }) {
-            Ok(result) => result,
+            Ok(result) => result.map(|mut diagnostics| {
+                baseline::demote_diagnostics(*db, source_file, &mut diagnostics);
+                diagnostics
+            }),
             Err(diagnostic) => Ok(Box::new([diagnostic])),
         }
     }

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -524,7 +524,7 @@ impl Options {
             baseline: self
                 .baseline
                 .as_ref()
-                .map(|path| path.absolute(project_root, db.system())),
+                .map(|path| path.absolute(context.configuration_root(), db.system())),
             rules: Arc::new(rules),
             terminal,
             src,

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -59,6 +59,17 @@ use ty_static::EnvVars;
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
+    /// Path to a JSON file containing diagnostics that should be treated as baselined.
+    ///
+    /// Relative paths are resolved relative to the project root.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = "str",
+        example = r#"baseline = "ty-baseline.json""#
+    )]
+    pub baseline: Option<RelativePathBuf>,
+
     /// Configures the type checking environment.
     #[option_group]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -510,6 +521,10 @@ impl Options {
         let overrides = strategy.fallback(overrides, |_| Vec::new())?;
 
         let settings = Settings {
+            baseline: self
+                .baseline
+                .as_ref()
+                .map(|path| path.absolute(project_root, db.system())),
             rules: Arc::new(rules),
             terminal,
             src,

--- a/crates/ty_project/src/metadata/settings.rs
+++ b/crates/ty_project/src/metadata/settings.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use ruff_db::files::File;
+use ruff_db::system::{SystemPath, SystemPathBuf};
 use ty_combine::Combine;
 use ty_python_semantic::AnalysisSettings;
 use ty_python_semantic::lint::RuleSelection;
@@ -24,6 +25,7 @@ use crate::{Db, glob::IncludeExcludeFilter};
 /// Settings that are part of [`ty_python_core::program::ProgramSettings`] are not included here.
 #[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub struct Settings {
+    pub(super) baseline: Option<SystemPathBuf>,
     pub(super) rules: Arc<RuleSelection>,
     pub(super) terminal: TerminalSettings,
     pub(super) src: SrcSettings,
@@ -38,6 +40,10 @@ pub struct Settings {
 }
 
 impl Settings {
+    pub fn baseline(&self) -> Option<&SystemPath> {
+        self.baseline.as_deref()
+    }
+
     fn rules(&self) -> &RuleSelection {
         &self.rules
     }

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -365,6 +365,10 @@ enum FixMode {
 
 impl FixMode {
     fn is_fixable(self, diagnostic: &Diagnostic) -> bool {
+        if is_hidden_lint(diagnostic) {
+            return false;
+        }
+
         let Some(primary_span) = diagnostic.primary_span() else {
             return false;
         };
@@ -391,6 +395,7 @@ impl FixMode {
             FixMode::Suppress => {
                 let suppressable_diagnostics: Vec<_> = file_diagnostics
                     .iter()
+                    .filter(|diagnostic| !is_hidden_lint(diagnostic))
                     .filter_map(|diagnostic| {
                         let lint_id = diagnostic.id().as_lint()?;
 
@@ -422,6 +427,7 @@ impl FixMode {
             }
             FixMode::ApplyFixes(applicability) => file_diagnostics
                 .iter()
+                .filter(|diagnostic| !is_hidden_lint(diagnostic))
                 .filter(|diagnostic| diagnostic.has_applicable_fix(applicability))
                 .filter_map(|diagnostic| {
                     diagnostic.fix().cloned().map(|fix| ApplicableFix {
@@ -432,6 +438,10 @@ impl FixMode {
                 .collect(),
         }
     }
+}
+
+fn is_hidden_lint(diagnostic: &Diagnostic) -> bool {
+    diagnostic.severity() == Severity::Hint && diagnostic.id().is_lint()
 }
 
 struct ApplicableFix {

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -365,7 +365,7 @@ enum FixMode {
 
 impl FixMode {
     fn is_fixable(self, diagnostic: &Diagnostic) -> bool {
-        if is_hidden_lint(diagnostic) {
+        if diagnostic.severity() == Severity::Hint && diagnostic.id().is_lint() {
             return false;
         }
 
@@ -375,6 +375,7 @@ impl FixMode {
 
         match self {
             FixMode::Suppress => {
+                // Don't suppress unused ignore comments.
                 primary_span.range().is_some()
                     && diagnostic
                         .id()
@@ -391,18 +392,15 @@ impl FixMode {
         file: PythonFile<'_>,
         file_diagnostics: &[Diagnostic],
     ) -> Vec<ApplicableFix> {
+        let fixable_diagnostics = file_diagnostics
+            .iter()
+            .filter(|diagnostic| self.is_fixable(diagnostic));
+
         match self {
             FixMode::Suppress => {
-                let suppressable_diagnostics: Vec<_> = file_diagnostics
-                    .iter()
-                    .filter(|diagnostic| !is_hidden_lint(diagnostic))
+                let suppressable_diagnostics: Vec<_> = fixable_diagnostics
                     .filter_map(|diagnostic| {
                         let lint_id = diagnostic.id().as_lint()?;
-
-                        // Don't suppress unused ignore comments.
-                        if is_unused_ignore_comment_lint(lint_id) {
-                            return None;
-                        }
 
                         // We can't suppress diagnostics without a corresponding file or range.
                         let span = diagnostic.primary_span()?;
@@ -425,10 +423,7 @@ impl FixMode {
                     )
                     .collect()
             }
-            FixMode::ApplyFixes(applicability) => file_diagnostics
-                .iter()
-                .filter(|diagnostic| !is_hidden_lint(diagnostic))
-                .filter(|diagnostic| diagnostic.has_applicable_fix(applicability))
+            FixMode::ApplyFixes(_) => fixable_diagnostics
                 .filter_map(|diagnostic| {
                     diagnostic.fix().cloned().map(|fix| ApplicableFix {
                         fix,
@@ -438,10 +433,6 @@ impl FixMode {
                 .collect(),
         }
     }
-}
-
-fn is_hidden_lint(diagnostic: &Diagnostic) -> bool {
-    diagnostic.severity() == Severity::Hint && diagnostic.id().is_lint()
 }
 
 struct ApplicableFix {

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -479,6 +479,7 @@ pub(super) fn to_lsp_diagnostic(
     };
 
     let severity = match diagnostic.severity() {
+        Severity::Hint => DiagnosticSeverity::Hint,
         Severity::Info => DiagnosticSeverity::Information,
         Severity::Warning => DiagnosticSeverity::Warning,
         Severity::Error | Severity::Fatal => DiagnosticSeverity::Error,

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -778,7 +778,6 @@ impl TestServer {
         self.test_context.root().join(path)
     }
 
-    #[expect(dead_code)]
     pub(crate) fn write_file(
         &self,
         path: impl AsRef<SystemPath>,

--- a/crates/ty_server/tests/e2e/pull_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/pull_diagnostics.rs
@@ -48,12 +48,12 @@ fn baselined_diagnostic_is_a_hint_and_refreshes() -> Result<()> {
     let baseline_path = SystemPath::new("src/baseline.json");
     let foo_content = "def foo() -> str:\n    return 42\n";
     let baseline = r#"{
-        "version": 1,
+        "version": 0,
         "files": {
             "foo.py": [{
                 "rule": "invalid-return-type",
-                "precedingHash": "e99fde1986a53fd7",
-                "followingHash": "7b33129b3c4424a"
+                "precedingHash": "41b4ab2dc0fd3c0697a4f3c3c8e4a048",
+                "followingHash": "7d090b0c134202a4dc847ca723b9a012"
             }]
         }
     }"#;
@@ -70,7 +70,7 @@ fn baselined_diagnostic_is_a_hint_and_refreshes() -> Result<()> {
     let diagnostics = server.document_diagnostic_request(foo, None);
     insta::assert_debug_snapshot!(condensed_document_diagnostic_snapshot(diagnostics), @r#""1:11..1:13[HINT]: Return type does not match returned value: expected `str`, found `Literal[42]`""#);
 
-    server.write_file(baseline_path, "{\"version\": 1, \"files\": {}}")?;
+    server.write_file(baseline_path, "{\"version\": 0, \"files\": {}}")?;
     server.did_change_watched_files(vec![FileEvent {
         uri: server.file_uri(baseline_path),
         kind: FileChangeType::Changed,

--- a/crates/ty_server/tests/e2e/pull_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/pull_diagnostics.rs
@@ -4,9 +4,9 @@ use anyhow::Result;
 use insta::{assert_compact_json_snapshot, assert_debug_snapshot};
 use lsp_server::RequestId;
 use lsp_types::{
-    DocumentDiagnosticReport, PartialResultParams, PreviousResultId, ProgressNotification, Uri,
-    WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressParams, WorkspaceDiagnosticParams,
-    WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult,
+    DocumentDiagnosticReport, FileChangeType, FileEvent, PartialResultParams, PreviousResultId,
+    ProgressNotification, Uri, WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressParams,
+    WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult,
     WorkspaceDocumentDiagnosticReport,
 };
 use lsp_types::{TextDocumentContentChangeWholeDocument, WorkspaceDiagnosticRequest};
@@ -38,6 +38,45 @@ def foo() -> str:
 
     assert_debug_snapshot!(diagnostics);
 
+    Ok(())
+}
+
+#[test]
+fn baselined_diagnostic_is_a_hint_and_refreshes() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let baseline_path = SystemPath::new("src/baseline.json");
+    let foo_content = "def foo() -> str:\n    return 42\n";
+    let baseline = r#"{
+        "version": 1,
+        "files": {
+            "foo.py": [{
+                "rule": "invalid-return-type",
+                "precedingHash": "e99fde1986a53fd7",
+                "followingHash": "7b33129b3c4424a"
+            }]
+        }
+    }"#;
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file("src/ty.toml", "baseline = 'baseline.json'\n")?
+        .with_file(baseline_path, baseline)?
+        .with_file(foo, foo_content)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+    let diagnostics = server.document_diagnostic_request(foo, None);
+    insta::assert_debug_snapshot!(condensed_document_diagnostic_snapshot(diagnostics), @r#""1:11..1:13[HINT]: Return type does not match returned value: expected `str`, found `Literal[42]`""#);
+
+    server.write_file(baseline_path, "{\"version\": 1, \"files\": {}}")?;
+    server.did_change_watched_files(vec![FileEvent {
+        uri: server.file_uri(baseline_path),
+        kind: FileChangeType::Changed,
+    }]);
+    let diagnostics = server.document_diagnostic_request(foo, None);
+    insta::assert_debug_snapshot!(condensed_document_diagnostic_snapshot(diagnostics), @r#""1:11..1:13[ERROR]: Return type does not match returned value: expected `str`, found `Literal[42]`""#);
     Ok(())
 }
 

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -39,6 +39,7 @@ Program:
     vendored://stdlib,
   ]
 Settings: Settings {
+    baseline: None,
     rules: <RULES>,
     terminal: TerminalSettings {
         output_format: Full,

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -1221,11 +1221,13 @@ pub enum Severity {
     Warning,
     Error,
     Fatal,
+    Hint,
 }
 
 impl From<diagnostic::Severity> for Severity {
     fn from(value: diagnostic::Severity) -> Self {
         match value {
+            diagnostic::Severity::Hint => Self::Hint,
             diagnostic::Severity::Info => Self::Info,
             diagnostic::Severity::Warning => Self::Warning,
             diagnostic::Severity::Error => Self::Error,

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -13,6 +13,17 @@
         }
       ]
     },
+    "baseline": {
+      "description": "Path to a JSON file containing diagnostics that should be treated as baselined.\n\nRelative paths are resolved relative to the project root.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RelativePathBuf"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "environment": {
       "description": "Configures the type checking environment.",
       "anyOf": [


### PR DESCRIPTION
## Summary

Adds JSON diagnostic baselines to ty, including CLI support for generating and consuming them. Baselined lint diagnostics are exposed as hints through the LSP and excluded from CLI and fix output.

Closes: https://github.com/astral-sh/ty/issues/1074

## Test Plan

Testing: Added project, CLI, fix, and LSP coverage and ran the relevant test suites.