### PR TITLE
[ty] Fix truthiness inference for subclassable known classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/truthiness.md
@@ -122,6 +122,18 @@ static_assert(is_subtype_of(types.MethodWrapperType, AlwaysTruthy))
 static_assert(is_subtype_of(types.WrapperDescriptorType, AlwaysTruthy))
 ```
 
+### Subclassable special-cased classes
+
+`Path` and `super` cannot be inferred as always truthy because subclasses can override `__bool__`.
+
+```py
+from pathlib import Path
+
+def _(path: Path, superclass: super):
+    reveal_type(bool(path))  # revealed: bool
+    reveal_type(bool(superclass))  # revealed: bool
+```
+
 ### `Callable` types always have ambiguous truthiness
 
 ```py

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -202,7 +202,6 @@ impl KnownClass {
             | Self::TypeVarTuple
             | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
-            | Self::Super
             | Self::WrapperDescriptorType
             | Self::UnionType
             | Self::GeneratorType
@@ -210,8 +209,7 @@ impl KnownClass {
             | Self::MethodWrapperType
             | Self::CoroutineType
             | Self::BuiltinFunctionType
-            | Self::Template
-            | Self::Path => Some(Truthiness::AlwaysTrue),
+            | Self::Template => Some(Truthiness::AlwaysTrue),
 
             Self::NoneType => Some(Truthiness::AlwaysFalse),
 
@@ -273,6 +271,7 @@ impl KnownClass {
             | Self::SupportsKeysAndGetItem
             | Self::Staticmethod
             | Self::Classmethod
+            | Self::Super
             | Self::Awaitable
             | Self::Generator
             | Self::AsyncGenerator
@@ -287,6 +286,7 @@ impl KnownClass {
             | Self::Specialization
             | Self::ProtocolMeta
             | Self::FunctoolsPartial
+            | Self::Path
             | Self::ExtensionTypedDictFallback
             | Self::TypedDictFallback
             | Self::PydanticBaseModel


### PR DESCRIPTION
## Summary

Treat `pathlib.Path` and `super` as having ambiguous truthiness instead of assuming their instances are always truthy.

Both classes can be subclassed, and neither class has a `__bool__` method in typeshed annotated as returning `Literal[True]` or `Literal[False]`, so subclasses can validly override `__bool__` to return `False`.
