### PR TITLE
[ty] Clarify incompatible loop declaration regression

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/declaration/error.md
+++ b/crates/ty_python_semantic/resources/mdtest/declaration/error.md
@@ -15,8 +15,8 @@ An incompatible binding that predates the loop must still invalidate a declarati
 values = [1]
 
 while True:
-    values: list[object]  # error: [invalid-declaration]
-    values = [1]
+    values: list[str]  # error: [invalid-declaration]
+    values = ["a"]
 ```
 
 ## Incompatible declarations


### PR DESCRIPTION
## Summary

Use an unambiguously incompatible `list[str]` declaration in the loop-declaration regression. The earlier binding remains `list[int]`, while the loop assignment now matches the declared type, so the test isolates the incompatible pre-loop binding.

The previous `list[object]` declaration could become valid under whole-scope bidirectional inference, making it an ambiguous example for this diagnostic.

Follow-up to [review feedback on #27594](https://github.com/astral-sh/ruff/pull/27594#discussion_r3753906101).
