### PR TITLE
[ty] Preserve literal types during expression inference cycles

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -276,6 +276,36 @@ class C:
 reveal_type(C().w)  # revealed: Weird | str
 ```
 
+#### Augmented assignments to narrowed optional attributes
+
+An optional attribute narrowed by an identity comparison remains narrowed while cyclic inference
+resolves augmented assignments in separate branches.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+class Counter:
+    def __init__(self, value: int | None) -> None:
+        self.value = value
+
+    def update(self, decrement: bool) -> None:
+        if self.value is None:
+            return
+
+        if decrement:
+            self.value -= 1
+        else:
+            self.value += 1
+
+    def current(self) -> int | None:
+        return self.value
+
+reveal_type(Counter(0).value)  # revealed: int | None
+```
+
 #### Nested augmented assignments after narrowing
 
 Augmented assignments to nested attributes (e.g., `self.inner.value += ...`) should work correctly

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -47,6 +47,7 @@ use crate::ProgramEnvironment;
 use itertools::Either;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
+use ruff_python_ast::visitor::{self, Visitor};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashMap;
 use salsa;
@@ -456,8 +457,63 @@ fn expression_cycle_initial<'db>(
     input: InferExpression<'db>,
 ) -> ExpressionInference<'db> {
     let (expression, _) = input.into_inner(db);
-    let cycle_recovery = Type::divergent(id);
-    ExpressionInference::cycle_initial(expression.scope(db), cycle_recovery)
+    let module = parsed_module(db, expression.python_file(db)).load(db);
+    let env = ProgramEnvironment::from_file(expression.program_file(db));
+    let mut literals = ContextIndependentLiteralCollector {
+        db,
+        env: &env,
+        expressions: Vec::new(),
+    };
+    literals.visit_expr(expression.node_ref(db).node(&module));
+
+    ExpressionInference::cycle_initial(
+        expression.scope(db),
+        Type::divergent(id),
+        literals.expressions.into_iter().collect(),
+    )
+}
+
+/// Collect literal types that do not depend on the expression currently being inferred.
+///
+/// In `value is None`, `value` may be cyclic, but `None` remains `None` from the first fixed-point
+/// iteration. Preserving these literals also keeps comparison narrowing stable during that cycle.
+struct ContextIndependentLiteralCollector<'db, 'env> {
+    db: &'db dyn Db,
+    env: &'env ProgramEnvironment<'db>,
+    expressions: Vec<(ExpressionNodeKey, Type<'db>)>,
+}
+
+impl<'ast> Visitor<'ast> for ContextIndependentLiteralCollector<'_, '_> {
+    fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+        let ty = match expression {
+            ast::Expr::NoneLiteral(_) => Some(Type::none(self.db, self.env)),
+            ast::Expr::BooleanLiteral(literal) => Some(Type::bool_literal(literal.value)),
+            ast::Expr::NumberLiteral(literal) => Some(match &literal.value {
+                ast::Number::Int(value) => value
+                    .as_i64()
+                    .map(Type::int_literal)
+                    .unwrap_or_else(|| KnownClass::Int.to_instance(self.db, self.env)),
+                ast::Number::Float(_) => KnownClass::Float.to_instance(self.db, self.env),
+                ast::Number::Complex { .. } => KnownClass::Complex.to_instance(self.db, self.env),
+            }),
+            ast::Expr::EllipsisLiteral(_) => {
+                Some(KnownClass::EllipsisType.to_instance(self.db, self.env))
+            }
+            // Nested function and comprehension bodies belong to separate inference regions.
+            ast::Expr::Lambda(_)
+            | ast::Expr::Generator(_)
+            | ast::Expr::ListComp(_)
+            | ast::Expr::SetComp(_)
+            | ast::Expr::DictComp(_) => return,
+            _ => None,
+        };
+
+        if let Some(ty) = ty {
+            self.expressions.push((expression.into(), ty));
+        } else {
+            visitor::walk_expr(self, expression);
+        }
+    }
 }
 
 /// Infers the type of an `expression` that is guaranteed to be in the same file as the calling query.
@@ -1681,14 +1737,18 @@ struct ExpressionInferenceExtra<'db> {
 }
 
 impl<'db> ExpressionInference<'db> {
-    fn cycle_initial(scope: ScopeId<'db>, cycle_recovery: Type<'db>) -> Self {
+    fn cycle_initial(
+        scope: ScopeId<'db>,
+        cycle_recovery: Type<'db>,
+        expressions: FrozenMap<ExpressionNodeKey, Type<'db>>,
+    ) -> Self {
         let _ = scope;
         Self {
             extra: Some(Box::new(ExpressionInferenceExtra {
                 cycle_recovery: Some(cycle_recovery),
                 ..ExpressionInferenceExtra::default()
             })),
-            expressions: FrozenMap::default(),
+            expressions,
             #[cfg(debug_assertions)]
             scope,
         }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -495,6 +495,60 @@ fn pep695_type_params() {
 }
 
 #[test]
+fn expression_cycle_initial_preserves_context_independent_literals() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "src/a.py",
+        "if (value, None, True, 1, 1.5, 1j, ..., 'text', lambda: None): pass",
+    )?;
+
+    let file = system_path_to_file(&db, "src/a.py").expect("file to exist");
+    let file = program_file(&db, file);
+    let module = parsed_module(&db, file.python_file(&db)).load(&db);
+    let test = &module.syntax().body[0]
+        .as_if_stmt()
+        .expect("if statement")
+        .test;
+    let expression = semantic_index(&db, file).expression(test);
+    let inference = expression_cycle_initial(
+        &db,
+        expression.as_id(),
+        InferExpression::new(&db, expression, TypeContext::default()),
+    );
+    let values = &test.as_tuple_expr().expect("tuple expression").elts;
+    let env = ProgramEnvironment::from_file(file);
+
+    assert!(inference.expression_type(&values[0]).is_divergent());
+    assert_eq!(inference.expression_type(&values[1]), Type::none(&db, &env));
+    assert_eq!(
+        inference.expression_type(&values[2]),
+        Type::bool_literal(true)
+    );
+    assert_eq!(inference.expression_type(&values[3]), Type::int_literal(1));
+    assert_eq!(
+        inference.expression_type(&values[4]),
+        KnownClass::Float.to_instance(&db, &env)
+    );
+    assert_eq!(
+        inference.expression_type(&values[5]),
+        KnownClass::Complex.to_instance(&db, &env)
+    );
+    assert_eq!(
+        inference.expression_type(&values[6]),
+        KnownClass::EllipsisType.to_instance(&db, &env)
+    );
+    assert!(inference.expression_type(&values[7]).is_divergent());
+    assert!(
+        inference
+            .expression_type(&values[8].as_lambda_expr().expect("lambda expression").body)
+            .is_divergent()
+    );
+    assert!(inference.expression_type(test).is_divergent());
+
+    Ok(())
+}
+
+#[test]
 fn simple_assignment_does_not_enter_salsa_cycle() {
     let mut db = setup_db();
     db.write_dedented("src/a.py", "x = 1; y = x + 1").unwrap();


### PR DESCRIPTION
## Summary

Expression-level Salsa cycle recovery currently initializes every subexpression as `Divergent`, including literal values that cannot depend on the cycle:

```python
if self.value is None:
    return
```

When recursive implicit-attribute inference revisits this condition, replacing `None` with `Divergent` can temporarily erase the comparison's narrowing constraint and introduce a spurious `Unknown` into the attribute type.

We now seed expression-cycle recovery with context-independent literal types: `None`, boolean literals, numeric literals, and `...`. Names and other genuinely recursive expressions retain their `Divergent` fallback; context-sensitive string literals and nested inference regions are intentionally excluded.

A focused inference test establishes that these literals keep their real types from the first cycle iteration, and an augmented-assignment regression protects narrowing for optional instance attributes.

This is an independent prerequisite for #27633.
