### PR TITLE
[ty] Preserve enum attributes on Self and bounded type variables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -489,6 +489,23 @@ class Child(Parent):
         assert_type(self.create(), Self)
 ```
 
+Truthiness narrowing must also preserve `Self` when an instance accesses a class method.
+
+```py
+from typing import Self, assert_type
+
+class MaybeEmpty:
+    @classmethod
+    def create(cls, other: Self) -> Self:
+        return cls()
+
+    def copy_if_empty(self, other: Self) -> Self:
+        if not self:
+            assert_type(self.create(other), Self)
+            return self.create(other)
+        return self
+```
+
 ## Attributes
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -506,6 +506,19 @@ class MaybeEmpty:
         return self
 ```
 
+A mixin narrowed to an unrelated class can also call that class's class methods.
+
+```py
+class Base:
+    @classmethod
+    def warn(cls) -> None: ...
+
+class Mixin:
+    def method(self) -> None:
+        assert isinstance(self, Base)
+        self.warn()
+```
+
 ## Attributes
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -2206,6 +2206,154 @@ def _(answer: Answer):
     reveal_type(answer.value)  # revealed: Literal["yes", "no"]
 ```
 
+### Special attributes on method receivers
+
+Implicit receivers and receivers annotated with `Self` retain the special attributes of their enum
+bound. Their `Self` type must still preserve the particular member at call sites.
+
+```toml
+[environment]
+python-version = "3.11"
+
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from enum import Enum
+from typing import Self
+
+class Answer(Enum):
+    YES = 1
+    NO = 2
+
+    def implicit(self) -> int:
+        reveal_type(self)  # revealed: Self@implicit
+        reveal_type(self.name)  # revealed: Literal["YES", "NO"]
+        reveal_type(self._name_)  # revealed: Literal["YES", "NO"]
+        reveal_type(self.value)  # revealed: Literal[1, 2]
+        reveal_type(self._value_)  # revealed: Literal[1, 2]
+        return self.value
+
+    def explicit(self: Self) -> int:
+        reveal_type(self.value)  # revealed: Literal[1, 2]
+        return self.value
+
+    def concrete(self: "Answer") -> int:
+        reveal_type(self.value)  # revealed: Literal[1, 2]
+        return self.value
+
+    def identity(self) -> Self:
+        return self
+
+reveal_type(Answer.YES.identity())  # revealed: Literal[Answer.YES]
+```
+
+### Special attributes on bounded type variables
+
+An ordinary type variable bounded by an enum has the same special attributes as the enum itself.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from enum import Enum
+from typing import TypeVar
+
+class Answer(Enum):
+    YES = 1
+    NO = 2
+
+AnswerT = TypeVar("AnswerT", bound=Answer)
+
+def value(answer: AnswerT) -> int:
+    reveal_type(answer.name)  # revealed: Literal["YES", "NO"]
+    reveal_type(answer._name_)  # revealed: Literal["YES", "NO"]
+    reveal_type(answer.value)  # revealed: Literal[1, 2]
+    reveal_type(answer._value_)  # revealed: Literal[1, 2]
+    return answer.value
+```
+
+### Special attributes on constrained type variables
+
+When a type variable can be one of several enum types, its special attributes include the values
+from every possible enum.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from enum import Enum
+from typing import TypeVar
+
+class Number(Enum):
+    ONE = 1
+    TWO = 2
+
+class Word(Enum):
+    LEFT = "left"
+    RIGHT = "right"
+
+EnumT = TypeVar("EnumT", Number, Word)
+
+def value(item: EnumT) -> int | str:
+    reveal_type(item.name)  # revealed: Literal["ONE", "TWO", "LEFT", "RIGHT"]
+    reveal_type(item.value)  # revealed: Literal[1, 2, "left", "right"]
+    return item.value
+```
+
+### Annotated enum values on method receivers
+
+An explicit `_value_` annotation also determines the type of `.value` on an enum-bounded receiver.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from enum import Enum
+
+class Answer(Enum):
+    _value_: int
+    YES = 1
+    NO = 2
+
+    def read_value(self) -> int:
+        reveal_type(self._value_)  # revealed: int
+        reveal_type(self.value)  # revealed: int
+        return self.value
+```
+
+### Overridden special attributes on method receivers
+
+A custom `enum.property` still takes precedence over the generated enum value on an implicit
+receiver.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from enum import Enum, property as enum_property
+
+class Answer(Enum):
+    YES = 1
+
+    @enum_property
+    def value(self) -> str:
+        return "custom"
+
+    def method(self) -> str:
+        reveal_type(self.value)  # revealed: str
+        return self.value
+```
+
 ## Properties of enum types
 
 ### Implicitly final

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -2209,7 +2209,7 @@ def _(answer: Answer):
 ### Special attributes on method receivers
 
 Implicit receivers and receivers annotated with `Self` retain the special attributes of their enum
-bound. Their `Self` type must still preserve the particular member at call sites.
+bound. Their `Self` type preserves the particular member at call sites.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -375,7 +375,8 @@ class Color(Enum):
     PURPLE = []  # error: [invalid-assignment]
 ```
 
-When `_value_` is annotated, `.value` and `._value_` are inferred as the declared type:
+When `_value_` is annotated, `.value` and `._value_` are inferred as the declared type on both enum
+members and method receivers:
 
 ```py
 from enum import Enum
@@ -385,6 +386,11 @@ class Color2(Enum):
     _value_: int
     RED = 1
     GREEN = 2
+
+    def read_value(self) -> int:
+        reveal_type(self._value_)  # revealed: int
+        reveal_type(self.value)  # revealed: int
+        return self.value
 
 reveal_type(Color2.RED.value)  # revealed: int
 reveal_type(Color2.RED._value_)  # revealed: int
@@ -1187,6 +1193,9 @@ class Choices(Enum):
 
     @enum_property
     def value(self) -> Any: ...
+    def read_value(self) -> Any:
+        reveal_type(self.value)  # revealed: Any
+        return self.value
 
 reveal_type(Choices.A.value)  # revealed: Any
 
@@ -1197,6 +1206,10 @@ class BaseChoices(Enum):
 
 class InheritedChoices(BaseChoices):
     A = 1
+
+    def read_value(self) -> str:
+        reveal_type(self.value)  # revealed: str
+        return self.value
 
 reveal_type(InheritedChoices.A.value)  # revealed: str
 ```
@@ -2304,54 +2317,6 @@ def value(item: EnumT) -> int | str:
     reveal_type(item.name)  # revealed: Literal["ONE", "TWO", "LEFT", "RIGHT"]
     reveal_type(item.value)  # revealed: Literal[1, 2, "left", "right"]
     return item.value
-```
-
-### Annotated enum values on method receivers
-
-An explicit `_value_` annotation also determines the type of `.value` on an enum-bounded receiver.
-
-```toml
-[rules]
-unsound-return-statement = "error"
-```
-
-```py
-from enum import Enum
-
-class Answer(Enum):
-    _value_: int
-    YES = 1
-    NO = 2
-
-    def read_value(self) -> int:
-        reveal_type(self._value_)  # revealed: int
-        reveal_type(self.value)  # revealed: int
-        return self.value
-```
-
-### Overridden special attributes on method receivers
-
-A custom `enum.property` still takes precedence over the generated enum value on an implicit
-receiver.
-
-```toml
-[environment]
-python-version = "3.11"
-```
-
-```py
-from enum import Enum, property as enum_property
-
-class Answer(Enum):
-    YES = 1
-
-    @enum_property
-    def value(self) -> str:
-        return "custom"
-
-    def method(self) -> str:
-        reveal_type(self.value)  # revealed: str
-        return self.value
 ```
 
 ## Properties of enum types

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -933,6 +933,30 @@ def union_bound(cls: U) -> None:
     reveal_type(cls.attr)  # revealed: str | int
 ```
 
+## Attribute access on TypeVars constrained to instances and class objects
+
+A constrained type variable can contain both ordinary instances and class objects. Accessing a
+shared attribute must inspect each constraint without treating the entire type variable as a class.
+
+```py
+from typing import TypeVar
+
+class Instance:
+    @staticmethod
+    def keys() -> list[str]:
+        return []
+
+class ClassObject:
+    @staticmethod
+    def keys() -> list[str]:
+        return []
+
+T = TypeVar("T", Instance, type[ClassObject])
+
+def read(value: T) -> list[str]:
+    return value.keys()
+```
+
 ## Solving TypeVars with upper bounds in unions
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4986,10 +4986,19 @@ impl<'db> Type<'db> {
                     let bound_or_constraints = typevar.typevar(db).bound_or_constraints(db, env);
                     if let Some(bound) = bound_or_constraints
                         .map(|bound_or_constraints| bound_or_constraints.as_type(db, env))
-                        && bound.to_instance(db, env).is_some()
+                        && (bound.to_instance(db, env).is_some()
+                            || matches!(name_str, "name" | "_name_" | "value" | "_value_")
+                                && match bound {
+                                    Type::Union(union) => union
+                                        .elements(db)
+                                        .iter()
+                                        .any(|element| element.is_enum(db, env)),
+                                    _ => bound.is_enum(db, env),
+                                })
                     {
                         // A TypeVar can be bounded by a class-object type such as `type[A]`, which
-                        // requires the full lookup path rather than instance-member lookup.
+                        // requires the full lookup path rather than instance-member lookup. Enum
+                        // bounds also need full lookup for their metadata-derived attributes.
                         return bound.member_lookup_with_policy_and_receiver(
                             db,
                             env,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4265,15 +4265,15 @@ impl<'db> Type<'db> {
     ) -> MemberLookupResult<'db> {
         let meta_attr_plain = Self::instance_lookup_class_member_with_policy(db, env, key);
         // A TypeVar retains its class identity when lookup is delegated to its bound, including
-        // after narrowing adds other intersection elements. Other intersections still require the
-        // lookup type because their precise meta-type cannot yet be represented.
+        // after narrowing. Narrowing can also add an unrelated class to a mixin's `Self`, in which
+        // case the TypeVar alone is not a valid owner for descriptors from that class.
         let owner = match receiver {
             Type::TypeVar(_) => receiver,
             Type::Intersection(intersection) => intersection
                 .positive(db)
                 .iter()
                 .copied()
-                .find(|element| element.is_type_var())
+                .find(|element| element.is_type_var() && element.is_subtype_of(db, env, key.ty(db)))
                 .unwrap_or(key.ty(db)),
             _ => key.ty(db),
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4264,13 +4264,20 @@ impl<'db> Type<'db> {
         policy: InstanceFallbackShadowsNonDataDescriptor,
     ) -> MemberLookupResult<'db> {
         let meta_attr_plain = Self::instance_lookup_class_member_with_policy(db, env, key);
-        // A bounded TypeVar retains its own class identity even when member lookup is delegated to
-        // its bound. Other lookup types remain necessary for intersections without precise meta-types.
-        let owner = if matches!(receiver, Type::TypeVar(_)) {
-            receiver.to_meta_type(db, env)
-        } else {
-            key.ty(db).to_meta_type(db, env)
-        };
+        // A TypeVar retains its class identity when lookup is delegated to its bound, including
+        // after narrowing adds other intersection elements. Other intersections still require the
+        // lookup type because their precise meta-type cannot yet be represented.
+        let owner = match receiver {
+            Type::TypeVar(_) => receiver,
+            Type::Intersection(intersection) => intersection
+                .positive(db)
+                .iter()
+                .copied()
+                .find(|element| element.is_type_var())
+                .unwrap_or(key.ty(db)),
+            _ => key.ty(db),
+        }
+        .to_meta_type(db, env);
         let (
             PlaceAndQualifiers {
                 place: meta_attr,
@@ -5094,8 +5101,11 @@ impl<'db> Type<'db> {
 
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
                     // A class-object lookup can originate from a TypeVar bound such as `type[A]`.
-                    // Retain that TypeVar as the receiver so `Self` binds to `T'instance`, not `A`.
-                    let receiver = receiver.unwrap_or(this);
+                    // Retain that TypeVar as the receiver so `Self` binds to `T'instance`, not `A`,
+                    // unless its constraints also include non-class-object types.
+                    let receiver = receiver
+                        .filter(|receiver| receiver.to_instance_approximation(db, env).is_some())
+                        .unwrap_or(this);
                     let enum_class = match this {
                         Type::ClassLiteral(literal) => literal.into_enum_class(db),
                         Type::SubclassOf(subclass_of) => subclass_of

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4263,8 +4263,14 @@ impl<'db> Type<'db> {
         fallback: MemberLookupResult<'db>,
         policy: InstanceFallbackShadowsNonDataDescriptor,
     ) -> MemberLookupResult<'db> {
-        let ty = key.ty(db);
         let meta_attr_plain = Self::instance_lookup_class_member_with_policy(db, env, key);
+        // A bounded TypeVar retains its own class identity even when member lookup is delegated to
+        // its bound. Other lookup types remain necessary for intersections without precise meta-types.
+        let owner = if matches!(receiver, Type::TypeVar(_)) {
+            receiver.to_meta_type(db, env)
+        } else {
+            key.ty(db).to_meta_type(db, env)
+        };
         let (
             PlaceAndQualifiers {
                 place: meta_attr,
@@ -4272,13 +4278,7 @@ impl<'db> Type<'db> {
             },
             meta_attr_kind,
             meta_attr_error,
-        ) = Self::try_call_dunder_get_on_attribute(
-            db,
-            env,
-            meta_attr_plain,
-            Some(receiver),
-            ty.to_meta_type(db, env),
-        );
+        ) = Self::try_call_dunder_get_on_attribute(db, env, meta_attr_plain, Some(receiver), owner);
 
         let meta_attr_error = meta_attr_error.map(MemberLookupErrorKind::DescriptorGet);
         let fallback_error = fallback.err().map(|error| error.kind(db));
@@ -4983,32 +4983,23 @@ impl<'db> Type<'db> {
                 }
                 Type::TypeVar(typevar) => {
                     let receiver = receiver.unwrap_or(this);
-                    let bound_or_constraints = typevar.typevar(db).bound_or_constraints(db, env);
-                    if let Some(bound) = bound_or_constraints
-                        .map(|bound_or_constraints| bound_or_constraints.as_type(db, env))
-                        && (bound.to_instance(db, env).is_some()
-                            || matches!(name_str, "name" | "_name_" | "value" | "_value_")
-                                && match bound {
-                                    Type::Union(union) => union
-                                        .elements(db)
-                                        .iter()
-                                        .any(|element| element.is_enum(db, env)),
-                                    _ => bound.is_enum(db, env),
-                                })
+                    if let Some(bound_or_constraints) =
+                        typevar.typevar(db).bound_or_constraints(db, env)
                     {
-                        // A TypeVar can be bounded by a class-object type such as `type[A]`, which
-                        // requires the full lookup path rather than instance-member lookup. Enum
-                        // bounds also need full lookup for their metadata-derived attributes.
-                        return bound.member_lookup_with_policy_and_receiver(
-                            db,
-                            env,
-                            name_str,
-                            policy,
-                            Some(receiver),
-                        );
+                        // Use the bound's complete lookup behavior, but retain the original
+                        // receiver so descriptors and `Self` remain correctly specialized.
+                        bound_or_constraints
+                            .as_type(db, env)
+                            .member_lookup_with_policy_and_receiver(
+                                db,
+                                env,
+                                name_str,
+                                policy,
+                                Some(receiver),
+                            )
+                    } else {
+                        instance_like_member_lookup(db, env, key, receiver)
                     }
-
-                    instance_like_member_lookup(db, env, key, receiver)
                 }
 
                 Type::NominalInstance(instance)


### PR DESCRIPTION
## Summary

- Delegate bounded and constrained type-variable member lookup to the complete lookup behavior of each bound or constraint while preserving the original receiver for descriptors and `Self`.
- Restore enum-derived `name`, `_name_`, `value`, and `_value_` attributes for implicit `self`, explicit `Self`, and enum-bounded or enum-constrained type variables.
- Preserve class-object lookup, mixed instance/class-object constraints, custom enum-property overrides, and classmethod binding for narrowed `Self` and mixin receivers.
- Fixes https://github.com/astral-sh/ty/issues/4229.

## Test plan

- Extend enum mdtests to cover implicit `self`, explicit `Self`, explicitly annotated enum receivers, enum-bounded and enum-constrained type variables, special name/value attributes, explicitly annotated `_value_`, custom `enum.property` overrides, strict return checking, and literal-preserving `Self` return values.
- Add generic mdtest coverage for type variables constrained to both ordinary instances and class objects.
- Extend `Self` mdtests to cover truthiness-narrowed classmethod receivers and mixins narrowed to unrelated classes.
