### PR TITLE
[ty] Preserve constrained TypeVars when slicing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/subscript/typevar.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/typevar.md
@@ -1,13 +1,13 @@
 # Subscripts involving type variables
 
-## TypeVar bound/constrained to a tuple/int-literal/bool-literal
-
-The upper bounds of type variables are considered when analysing subscripts.
-
 ```toml
 [environment]
 python-version = "3.12"
 ```
+
+## TypeVar bound/constrained to a tuple/int-literal/bool-literal
+
+The upper bounds of type variables are considered when analysing subscripts.
 
 ```py
 from typing_extensions import TypeAlias, Literal
@@ -41,20 +41,113 @@ def f[
     # but it's hard to do that without introducing false positives elsewhere
     reveal_type(tuple_1[some_integer])  # revealed: str | int | bytes
 
-    # TODO: would ideally be `tuple[str, int] | tuple[int, bytes]`
-    reveal_type(tuple_2[:2])  # revealed: tuple[str | int | bytes, ...]
+    reveal_type(tuple_2[:2])  # revealed: tuple[str, int] | tuple[int, bytes]
     reveal_type(tuple_2[zero])  # revealed: str | int
     reveal_type(tuple_2[some_integer])  # revealed: str | int | bytes
 
 # fmt: on
 ```
 
-## TypeVars
+## Slicing overlapping constrained sequence types
+
+A value-constrained type variable selects one declared constraint for the entire function call.
+Slicing a `list` or a `Sequence` preserves the selected constraint, even though `list` is also a
+subtype of `Sequence`.
+
+```py
+from collections.abc import Sequence
+
+def slice_sequence[T: (list[int], Sequence[int])](value: T) -> T:
+    reveal_type(value[:2])  # revealed: T@slice_sequence
+    return value[:2]
+```
+
+## Slicing constrained types with distinct implementations
+
+Each constraint's `__getitem__` method must be called with its own receiver. When both methods
+return their corresponding constraint, the result preserves the original type variable.
+
+```py
+class First:
+    def __getitem__(self, index: slice) -> "First":
+        return self
+
+class Second:
+    def __getitem__(self, index: slice) -> "Second":
+        return self
+
+def slice_value[T: (First, Second)](value: T) -> T:
+    return value[:2]
+```
+
+## Slicing a legacy constrained type variable
+
+Legacy `TypeVar` declarations preserve the selected constraint in the same way as PEP 695 type
+parameters.
 
 ```toml
 [environment]
-python-version = "3.12"
+python-version = "3.10"
 ```
+
+```py
+from collections.abc import Sequence
+from typing import TypeVar
+
+T = TypeVar("T", list[int], Sequence[int])
+
+def slice_sequence(value: T) -> T:
+    return value[:2]
+```
+
+## Slicing a constrained type can change its type
+
+A result cannot retain the constrained type variable when one constraint's slice returns a different
+type.
+
+```py
+class First:
+    def __getitem__(self, index: slice) -> "First":
+        return self
+
+class ChangesType:
+    def __getitem__(self, index: slice) -> First:
+        return First()
+
+def slice_value[T: (First, ChangesType)](value: T) -> T:
+    reveal_type(value[:2])  # revealed: First
+    # error: [invalid-return-type]
+    return value[:2]
+```
+
+## Slicing an upper-bounded type variable
+
+An upper-bounded type variable can specialize to a `Sequence` subclass whose slice returns a
+different sequence type, so the slice is not guaranteed to preserve the type variable.
+
+```py
+from collections.abc import Sequence
+
+def slice_sequence[T: Sequence[int]](value: T) -> T:
+    # error: [invalid-return-type]
+    return value[:2]
+```
+
+## Subscripting an unsupported constrained type
+
+A subscript remains invalid when any declared constraint does not support it.
+
+```py
+class Sliceable:
+    def __getitem__(self, index: slice) -> "Sliceable":
+        return self
+
+def slice_value[T: (Sliceable, int)](value: T) -> None:
+    # error: [not-subscriptable]
+    value[:2]
+```
+
+## TypeVars
 
 ```py
 from typing import Protocol
@@ -67,11 +160,6 @@ def f[K: SupportsLessThan](dictionary: dict[K, int], key: K):
 ```
 
 ## ParamSpecs
-
-```toml
-[environment]
-python-version = "3.12"
-```
 
 ```py
 from typing import Callable

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -24,7 +24,7 @@ use super::instance::SliceLiteral;
 use super::special_form::SpecialFormType;
 use super::{
     ClassLiteral, IntersectionBuilder, IntersectionType, KnownInstanceType, Type, TypeAliasType,
-    TypedDictType, UnionBuilder, UnionType, todo_type,
+    TypeVarBoundOrConstraints, TypedDictType, UnionBuilder, todo_type,
 };
 
 /// The kind of subscriptable type that had an out-of-bounds index.
@@ -385,25 +385,27 @@ impl<'db> SubscriptErrorKind<'db> {
     }
 }
 
-fn map_union_subscript<'db, F>(
+/// Preserve a constrained type variable when each alternative's result matches that constraint.
+fn map_subscript_alternatives<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
-    union: UnionType<'db>,
-    mut map_fn: F,
-) -> Result<Type<'db>, SubscriptError<'db>>
-where
-    F: FnMut(Type<'db>) -> Result<Type<'db>, SubscriptError<'db>>,
-{
+    full_object_ty: Type<'db>,
+    alternatives: impl IntoIterator<Item = Type<'db>>,
+    mut map_fn: impl FnMut(Type<'db>) -> Result<Type<'db>, SubscriptError<'db>>,
+) -> Result<Type<'db>, SubscriptError<'db>> {
     let mut builder = UnionBuilder::new(db, env);
     let mut errors = Vec::new();
+    let mut preserves_typevar = matches!(full_object_ty, Type::TypeVar(_));
 
-    for element in union.elements(db) {
-        match map_fn(*element) {
+    for element in alternatives {
+        match map_fn(element) {
             Ok(result) => {
+                if preserves_typevar {
+                    preserves_typevar = result.is_equivalent_to(db, env, element);
+                }
                 builder = builder.add(result);
             }
             Err(error) => {
-                let full_object_ty = Type::Union(union);
                 builder = builder.add(error.result_type());
                 errors.extend(
                     error
@@ -415,12 +417,17 @@ where
         }
     }
 
-    builder = builder.recursively_defined(union.recursively_defined(db));
-    let result_ty = builder.build();
+    if let Type::Union(union) = full_object_ty {
+        builder = builder.recursively_defined(union.recursively_defined(db));
+    }
     if errors.is_empty() {
-        Ok(result_ty)
+        Ok(if preserves_typevar {
+            full_object_ty
+        } else {
+            builder.build()
+        })
     } else {
-        Err(SubscriptError::with_errors(result_ty, errors))
+        Err(SubscriptError::with_errors(builder.build(), errors))
     }
 }
 
@@ -581,13 +588,21 @@ impl<'db> Type<'db> {
                 Some(value_ty.subscript(db, env, alias.value_type(db), expr_context))
             }
 
-            (Type::Union(union), _) => Some(map_union_subscript(db, env, union, |element| {
-                element.subscript(db, env, slice_ty, expr_context)
-            })),
+            (Type::Union(union), _) => Some(map_subscript_alternatives(
+                db,
+                env,
+                value_ty,
+                union.elements(db).iter().copied(),
+                |element| element.subscript(db, env, slice_ty, expr_context),
+            )),
 
-            (_, Type::Union(union)) => Some(map_union_subscript(db, env, union, |element| {
-                value_ty.subscript(db, env, element, expr_context)
-            })),
+            (_, Type::Union(union)) => Some(map_subscript_alternatives(
+                db,
+                env,
+                slice_ty,
+                union.elements(db).iter().copied(),
+                |element| value_ty.subscript(db, env, element, expr_context),
+            )),
 
             (Type::EnumComplement(complement), _) => {
                 Some(complement.remaining_literal_union(db, env).subscript(
@@ -618,6 +633,19 @@ impl<'db> Type<'db> {
                 intersection,
                 |element| value_ty.subscript(db, env, element, expr_context),
             )),
+
+            (Type::TypeVar(typevar), _)
+                if let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
+                    typevar.typevar(db).bound_or_constraints(db, env) =>
+            {
+                Some(map_subscript_alternatives(
+                    db,
+                    env,
+                    value_ty,
+                    constraints.elements(db).iter().copied(),
+                    |constraint| constraint.subscript(db, env, slice_ty, expr_context),
+                ))
+            }
 
             // Ex) Given `person["name"]`, return `str`
             (Type::TypedDict(typed_dict), _) if expr_context != ast::ExprContext::Store => {
@@ -849,7 +877,7 @@ impl<'db> Type<'db> {
                 Some(Ok(todo_type!("Inference of subscript on special form")))
             }
 
-            // TODO: more complex logic required for the `Type::TypeVar(_) branch!
+            // Upper-bounded and unconstrained type variables use ordinary method lookup.
             (
                 Type::FunctionLiteral(_)
                 | Type::WrapperDescriptor(_)


### PR DESCRIPTION
## Summary

- Preserve a constrained type variable when subscripting each declared constraint returns that same constraint.
- Share alternative handling between unions and constrained type variables while retaining existing diagnostics and recursive-union behavior.
- Infer precise unions when slicing constrained tuples.

Mypy handles these constrained typevar situations by actually checking the entire function once per constraint type, I think. We may eventually decide to do the same, but for now we already have precedent for this approach in binary ops inference, and it seems to work well.

Fixes astral-sh/ty#4226.

## Test plan

- Mdtests cover overlapping `list` and `Sequence` constraints, distinct slice-preserving implementations, and legacy constrained `TypeVar` declarations on Python 3.10.
- Mdtests retain errors for type-changing slices, upper-bounded `Sequence` variables, and unsupported constrained alternatives.
- Existing tuple-slicing coverage verifies the newly precise union of slice results.
