### PR TITLE
[`pylint`] Fix `PLE1307` false positive with bools

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_string_format_type.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_string_format_type.py
@@ -66,3 +66,6 @@ r'\%03o' % (ord(c),)
 
 # No errors here, will be reported separately by bad-string-format-character.
 "%b" % b"xx"
+
+# bool is acceptable as int/float/character.
+"%d %c %f" % (True, True, True)

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
@@ -63,11 +63,11 @@ impl FormatType {
                 self,
                 FormatType::Unknown | FormatType::String | FormatType::Repr
             ),
-            PythonType::Number(NumberLike::Complex | NumberLike::Bool) => matches!(
+            PythonType::Number(NumberLike::Complex) => matches!(
                 self,
                 FormatType::Unknown | FormatType::String | FormatType::Repr
             ),
-            PythonType::Number(NumberLike::Integer) => matches!(
+            PythonType::Number(NumberLike::Integer | NumberLike::Bool) => matches!(
                 self,
                 FormatType::Unknown
                     | FormatType::String

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1307_bad_string_format_type.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1307_bad_string_format_type.py.snap
@@ -140,3 +140,10 @@ PLE1307 Format type does not match argument type
 17 |
 18 | # False negatives
    |
+
+PLE1307 Format type does not match argument type
+  --> bad_string_format_type.py:71:1
+   |
+70 | # bool is acceptable as int/float/character.
+71 | "%d %c %f" % (True, True, True)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1307_bad_string_format_type.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1307_bad_string_format_type.py.snap
@@ -140,10 +140,3 @@ PLE1307 Format type does not match argument type
 17 |
 18 | # False negatives
    |
-
-PLE1307 Format type does not match argument type
-  --> bad_string_format_type.py:71:1
-   |
-70 | # bool is acceptable as int/float/character.
-71 | "%d %c %f" % (True, True, True)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Was working on a refactor for https://docs.astral.sh/ruff/rules/bad-string-format-type/ and found a bug  - it incorrectly flags any use of bools unless they're used with `%s`, `%r`. See example below, on the runtime it runs without errors and prints `1 \x01 1.000000`.

```python
  |
1 | # PLE1307 Format type does not match argument type
2 | # OK.
3 | print("%d %c %f" % (True, True, True))
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```


## Test Plan

Added new test - note it's producing an error in 03625fe4876402aaf468f9e93856de7e13957cdd and fixed in 6f3e7bf32dce03603affc36627dfd03191136f44
All previous tests also pass.