### PR TITLE
[ty] Handle bound/constrained typevars by adding to the constraint set

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -349,7 +349,7 @@ expanding `Solutions`:
 
 ## Phase status and dependencies
 
-- [ ] Phase 1: retain bound type-variable instances in constraint-set arenas.
+- [x] Phase 1: retain bound type-variable instances in constraint-set arenas.
 - [ ] Phase 2: replace optional constraint bounds with validity/evidence bounds.
 - [ ] Phase 3: reintroduce support-derived validity-domain construction.
 - [ ] Phase 4: preserve evidence-derived variance and add complete-solution pruning.

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,8 +18,10 @@ Minimal diff churn is an explicit requirement:
 - Do not attempt general correlation-preserving solution combination.
 - Do not change eager existential or universal quantification; it is being replaced in a separate
     workstream.
-- Do not change existing gradual-type assignability, constraint implication, or declaration
-    semantics; this project moves where bounds and constraints are handled, not how they behave.
+- Do not change Python's general gradual-type assignability or declaration semantics. Phase 5 now
+    owns the narrower sequent correction needed by domain activation: concrete logical proofs must
+    use fully static bounds and subtyping, while structurally valid symbolic rules may propagate an
+    existing gradual witness. Do not choose a relation based on validity/evidence provenance.
 
 ## Workflow and handoff requirements
 
@@ -29,8 +31,8 @@ and Jujutsu revisions to verify that completion markers are accurate before cont
 
 Each implementation phase must be its own Jujutsu revision. Before editing for a new phase, create
 a revision with `jj new -A @` and describe it with `jj describe`; descriptions must begin with
-`[π]`. Never edit an existing revision with `jj edit`. Update this document's phase marker in the
-revision that completes that phase.
+`[π]`. Never edit an existing revision with `jj edit`. Update this legacy in-repository plan only
+after the phase passes full validation, using a separate plan-only revision.
 
 Documentation and tests are cross-cutting requirements of every phase, not separate phases.
 Prioritize focused tests of user-visible typing behavior. Existing mdtests using
@@ -48,6 +50,43 @@ Use `jj` for source control and inspect changes with `jj diff --git` or `jj diff
 in this Jujutsu workspace through `/home/dcreager/bin/jpk`. Never modify snapshot files or inline
 snapshot bodies manually: regenerate them with the documented test commands, inspect every
 snapshot change, and check for `.pending-snap` files when inline snapshots are involved.
+
+## Joint Phase 5: domain activation and fully static sequents
+
+Phase 5 and fully static sequent handling are one semantic integration unit. Investigation showed
+that neither has a useful independently passing boundary:
+
+- The sequent map treats gradual assignability as transitive logical implication. Exact validity
+    alternatives such as `T = Any` and `T = int` can therefore become mutually implicative and be
+    collected into one aggregate path.
+- A prototype static-sequent gate on the Phase 5 diagnostic stack preserved the expected `int`
+    result for the typed-dictionary union ordering regression and passed the full constraint-set
+    ordering mdtest after cycle-safe derived-candidate validation.
+- The same prototype exposed a Phase 5 pruning assumption: gradual constrained-TypeVar paths do
+    not always present one exact equality validity bound. The current pruner panics instead of
+    conservatively retaining such paths.
+- Removing gradual closure also exposes independent alternative solutions. In particular,
+    unbounded `Container[T]` inference still selects `object` rather than preserving `Any`; domain
+    pruning cannot repair an unbounded variable.
+
+Do not revive either rejected workaround from the standalone prototype: selectively retaining TDD
+uncertain branches during abstraction, or locally unioning gradual solutions in `generics.rs`.
+Likewise, do not add a provenance-dependent typing relation, an equality-only exception, broad
+witness metadata, or a general correlation-preserving solution representation without another
+approved replan.
+
+The incomplete Phase 5 revision `pvynqtrq` and its pause revision are diagnostic snapshots, not
+part of the implementation path. Restart the joint phase from `sqkowvys` (the completed Phase 4
+stack plus the raw-graph fix), which is the parent of this replanning revision. The detailed static
+sequent requirements remain in
+`~/.pi/memory/plans/ruff/fully-static-sequents/PLAN.md`; this document is authoritative for the
+combined phase order and completion marker.
+
+The intended landing order is:
+
+1. completed domain-solving Phases 1–4 and the raw-graph fix;
+1. the combined Phase 5 domain activation and fully static sequent revision;
+1. `dcreager/remove-remove-noninferable-2`.
 
 ## Current baseline
 
@@ -281,12 +320,25 @@ controls the effective restriction. Preserve witnessed bare-TypeVar relationship
 constraints are accumulated, but do not commit in advance to dedicated relationship metadata;
 first determine what the new provenance-aware lower/upper bounds already make possible.
 
-### Preserve existing gradual behavior without changing implication semantics
+### Preserve existing gradual behavior while restricting concrete sequents
 
 `Constraint::new_node_with_bounds` already accepts gradual bounds despite a stale claim that only
-fully static bounds are supported. Existing implication logic has known questionable behavior for
-exact gradual/static alternatives, but fixing that behavior is out of scope: do not change the
-underlying gradual assignability or implication relation as part of this project.
+fully static bounds are supported. In the joint phase, concrete endpoint containment, overlap,
+contradiction, and pivot proofs must require structurally static endpoints and use constraint-set
+subtyping rather than assignability. Solver TypeVars are opaque symbolic atoms for this eligibility
+check. Use an owned Salsa-tracked relation where cycle recovery is required, and validate and skip
+derived candidates that settle as unsatisfiable after a coinductive cycle.
+
+Structurally universal TypeVar rules may still carry an existing gradual witness through a
+relationship. Keep the existing dedicated same-TypeVar, different-TypeVar, and nested-TypeVar
+constructor paths as that boundary; do not introduce general witness provenance machinery. Keep
+single-range derivation assignability-based initially, with the existing PR #26873 TODO, and stop
+if focused evidence shows that this path itself creates invalid closure.
+
+Domain-conjoined path extraction and solution selection must be developed with this sequent
+boundary active. Preserve distinct gradual/static alternatives and existing gradual evidence
+without a provenance-dependent relation, equality exception, TDD abstraction special case, or
+ad hoc solution-union rule.
 
 Existing generic-function behavior must nevertheless be preserved:
 
@@ -297,9 +349,9 @@ reveal_type(identity("x"))  # Any
 reveal_type(identity(1))  # int
 ```
 
-The analogous `list[Any]`/`list[int]` behavior must also remain unchanged. Restrict sequent changes
-to the validity/evidence provenance rules described above; do not use this refactor to redefine
-relationships between gradual and static types, and do not compensate by expanding declared
+The analogous `list[Any]`/`list[int]` behavior must also remain unchanged. Keep general gradual
+assignability unchanged; restrict sequent changes to the static concrete-proof boundary and the
+validity/evidence propagation rules described above. Do not compensate by expanding declared
 gradual equalities into bottom/top materialization ranges.
 
 ### Prefer narrowly subsumed complete paths
@@ -314,7 +366,8 @@ Compare complete paths conservatively:
 1. Both paths must contain the same type-variable identities.
 1. All type-variable bounds except one must be identical.
 1. The differing bounds must belong to a declared constrained type variable and identify exact
-    declared alternatives through their validity bounds.
+    declared alternatives through their validity bounds. If either bound does not expose one exact
+    declared validity alternative, preserve both complete paths rather than panicking.
 1. Both paths must retain the same inference evidence and compatible evidence-derived variance.
 1. Lower-side evidence prefers the narrower compatible declared alternative.
 1. Upper-side-only evidence prefers the broader compatible declared alternative.
@@ -364,10 +417,14 @@ expanding `Solutions`:
 - [x] Phase 2: replace optional constraint bounds with validity/evidence bounds.
 - [x] Phase 3: reintroduce support-derived validity-domain construction.
 - [x] Phase 4: preserve evidence-derived variance and add complete-path pruning.
-- [ ] Phase 5: solve the domain-conjoined TDD and simplify default solving.
+- [ ] Phase 5: jointly restrict concrete sequents, solve the domain-conjoined TDD, and simplify
+    default solving.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
-revision, relevant documentation/tests, and a passing full test suite.
+revision, relevant documentation/tests, and a passing full test suite. The abandoned Phase 5 and
+standalone fully-static revisions are diagnostic evidence only. Implement the joint phase in a new
+revision based on this replanning revision; do not layer it onto `pvynqtrq` or copy its rejected
+workarounds.
 
 ### Phase 1: retain bound type-variable instances in constraint-set arenas
 
@@ -463,31 +520,48 @@ Suggested revision description: `[π] Preserve evidence variance and compare com
 1. Delay behavior-changing consumer integration until Phase 5.
 1. Run the full suite before marking the phase complete.
 
-### Phase 5: solve the domain-conjoined TDD and simplify default solving
+### Phase 5: jointly activate domains and restrict concrete sequents
 
-Suggested revision description: `[π] Solve declared type-variable domains as constraint-set paths`.
+Suggested revision description: `[π] Solve domains with fully static sequents`.
 
+1. Add focused coverage showing that `int -> Any -> str` assignability cannot become transitive
+    sequent closure. Define structural sequent eligibility locally in `constraints.rs`, treating
+    solver TypeVars as opaque and rejecting actual dynamic concrete components.
+1. Apply the gate per participating endpoint to concrete implication, overlap/intersection, pair
+    impossibility, contradiction, and pivot proofs. Use constraint-set subtyping for eligible
+    concrete proofs and an owned Salsa-tracked query for recursive cycle handling.
+1. Audit symbolic and derived sequent constructors. Preserve structurally universal propagation of
+    an existing gradual witness, but prevent gradual concrete pivots or unrelated TDD branches from
+    manufacturing evidence. Validate provisionally discovered coinductive candidates and skip
+    those that settle as unsatisfiable.
 1. Conjoin the support-derived validity domain with the original root before path extraction in
-    both direct and Salsa-cached entry points.
-1. Preserve source ordering and keep simple concrete-bound conjunctions on the existing fast path
-    whenever possible.
+    both direct and Salsa-cached entry points. Preserve source ordering and the simple concrete-bound
+    fast path whenever possible.
 1. Produce separate valid paths for declared constrained alternatives and reject incompatible
-    declared specializations during domain-aware traversal.
-1. Simplify `PathBounds::default_solve` so it selects from effective path bounds without
-    inspecting `TypeVarBoundOrConstraints` or rebuilding declared alternatives independently.
+    specializations during traversal. Diagnose any aggregated gradual validity path before changing
+    abstraction or solution combination; do not reintroduce unsound closure merely to restore the
+    old shape.
+1. Make complete-path pruning conservative: if a differing constrained-TypeVar bound does not
+    expose an exact declared equality validity bound, retain both paths rather than panicking.
+    Normal domain alternatives should still expose exact validity bounds so existing specificity,
+    static-over-gradual, and declaration-order preferences continue to work.
+1. Simplify `PathBounds::default_solve` so it selects from effective path bounds without inspecting
+    `TypeVarBoundOrConstraints` or rebuilding declared alternatives independently.
 1. Preserve witnessed variance, gradual evidence, bounded lower/upper behavior, absent versus
     explicit bounds, unsolved variables, and relationships between compatible type variables.
+    Preserve current constrained `Any`/`int`, `list[Any]`/`list[int]`, ambiguous gradual evidence,
+    and unbounded `Container[T]` behavior without a local solution-union heuristic.
 1. Explicitly prune subsumed complete paths in affected specialization consumers before extracting
-    solutions and combining bindings individually; leave raw internal solution APIs exhaustive.
+    solutions and combining bindings independently; leave raw internal solution APIs exhaustive.
 1. Recover declaration-specific diagnostics by inspecting unconjoined paths only after a
-    domain-aware solve fails.
-1. Do not apply domains before eager quantification or expand this project into the separate
-    quantifier-replacement workstream.
-1. Favor existing user-visible generic-function, contextual-inference, receiver, narrowing,
-    overload, correlation, ordering, and diagnostic tests. Change implementation-focused internal
-    expectations only when required.
+    domain-aware solve fails. Do not apply domains before eager quantification or expand this phase
+    into the separate quantifier-replacement workstream.
+1. Audit cache growth, path fuel, deterministic ordering, and the
+    `ty_micro[pydantic_core_schema_dict]`-sensitive fast path. Favor existing user-visible tests;
+    change implementation-focused expectations only when semantically required.
 1. Remove superseded TODOs and obsolete declaration-handling code after replacement coverage
-    passes. Run the full suite, review snapshots and diffs, and run prek.
+    passes. Run focused tests, `ty_python_semantic`, the full suite, clippy, snapshot review, and
+    prek before marking the joint phase complete.
 
 ## Focused regression coverage
 
@@ -588,11 +662,11 @@ Run prek from the Jujutsu workspace:
     relationship for compatible constrained variables, including compatible subsets and callbacks
     with redundant bounds, while rejecting incompatible or merely overlapping domains. The
     user-visible behavior is required; a dedicated `PathBound` field is not prescribed.
-- **Gradual alternatives:** store declared gradual alternatives directly as exact validity
-    constraints, without bottom/top materialization. Preserve existing user-visible behavior for
-    `Any`/`int` and `list[Any]`/`list[int]`, including static preference when both match. Known
-    issues in the underlying gradual constraint-implication relation are out of scope and must
-    not be fixed as part of this refactor.
+- **Gradual alternatives and sequents:** store declared gradual alternatives directly as exact
+    validity constraints, without bottom/top materialization. The joint phase must prevent
+    non-transitive gradual assignability from collapsing their paths while preserving existing
+    `Any`/`int` and `list[Any]`/`list[int]` behavior. Do not reinterpret provenance as a typing
+    relation or add equality-specific sequent behavior.
 - **Arena overlays:** retain full type-variable instances while continuing to intern by identity
     and avoiding unstable Salsa-ID-based ordering or unnecessary `db` parameter churn.
 - **Fast-path performance:** preserve `compute_simple_bound_conjunction` and its no-sequent-cache

--- a/PLAN.md
+++ b/PLAN.md
@@ -21,8 +21,9 @@ Minimal diff churn is an explicit requirement:
 - Do not change Python's general gradual-type assignability or declaration semantics. A dedicated
     static-sequent phase before Phase 5 owns the narrower logical correction: concrete proofs must
     use fully static bounds and subtyping, while structurally valid symbolic rules may propagate an
-    existing gradual witness. Phase 5 then activates domains and restores temporary compatibility
-    regressions. Do not choose a relation based on validity/evidence provenance.
+    existing gradual witness. Phase 5 then activates domains and replaces legacy declaration-aware
+    solving; a potential Phase 6 restores accepted compatibility regressions. Do not choose a
+    relation based on validity/evidence provenance.
 
 ## Workflow and handoff requirements
 
@@ -47,11 +48,13 @@ ultimately correct result, do not disable, comment out, or ignore tests. Instead
 assertion or mdtest expectation to the currently observed behavior and add a clear TODO describing
 the expected correct behavior. Prefer sequencing that avoids temporary regressions entirely.
 
-The static-sequent phase is the deliberate exception where temporary user-visible regressions are
-expected. Keep each regression covered at its observed intermediate behavior and add an adjacent
-`XXX` naming the behavior that Phase 5 must restore. The static-sequent revision must still pass the
-full suite, clippy, and prek. It is an implementation checkpoint only and must not be merged or used
-as a landing bookmark target independently of Phase 5.
+The static-sequent phase was initially the only deliberate exception where temporary user-visible
+regressions were expected. Phase 5 may also retain explicitly characterized behavioral regressions
+behind adjacent `XXX` expectations, but it must complete the structural migration: declared domains
+supply the legal paths, pruning compares those paths, and `PathBounds::default_solve` must no longer
+re-read declarations or reconstruct their alternatives. Both revisions must pass the full suite,
+clippy, and prek. A potential Phase 6 may restore or explicitly resolve the accepted compatibility
+and performance debt before selecting a landing tip.
 
 Use `jj` for source control and inspect changes with `jj diff --git` or `jj diff --stat`. Run prek
 in this Jujutsu workspace through `/home/dcreager/bin/jpk`. Never modify snapshot files or inline
@@ -61,9 +64,11 @@ snapshot change, and check for `.pending-snap` files when inline snapshots are i
 ## Staged integration: fully static sequents before Phase 5
 
 Fully static sequent handling and domain activation remain one merge unit, but they are implemented
-as two test-clean project revisions. The first revision establishes the sound logical boundary and
-records temporary compatibility regressions; Phase 5 activates domains and removes those
-regressions before the stack can land.
+as test-clean project revisions. The static revision establishes the sound logical boundary and
+records temporary compatibility regressions. The Phase 5 activation checkpoint activates domains
+and records the still-observed behavior as passing `XXX` expectations. Phase 5 remains incomplete
+until structural path-only solving replaces the legacy declaration-aware solver; a potential Phase
+6 may then remove the accepted behavioral debt before the stack can land.
 
 Investigation established this split:
 
@@ -73,13 +78,14 @@ Investigation established this split:
 - A prototype static-sequent gate on the Phase 5 diagnostic stack preserved the expected `int`
     result for the typed-dictionary union ordering regression and passed the full constraint-set
     ordering mdtest after cycle-safe derived-candidate validation.
-- The same prototype exposed a Phase 5 pruning assumption: gradual constrained-TypeVar paths do
-    not always present one exact equality validity bound. Phase 5 must make pruning conservative
-    rather than panic.
+- The same prototype exposed a provenance bug that could pollute a constrained TypeVar's declared
+    validity equality with derived bounds. Every complete constrained-TypeVar domain path must
+    retain exactly one pure validity equality; derived constraints belong in `Mixed`, and consumers
+    must assert this invariant rather than accepting or skipping an invalid path.
 - Removing gradual closure exposes independent alternative solutions. In particular, unbounded
     `Container[T]` inference selects `object` rather than preserving `Any`. The static phase records
-    that intermediate result with an `XXX`; Phase 5 must restore the existing behavior even though
-    declared-domain pruning alone cannot repair an unbounded variable.
+    that intermediate result with an `XXX`; this accepted behavioral regression may be restored in
+    a potential Phase 6 because declared-domain pruning alone cannot repair an unbounded variable.
 
 Do not revive either rejected workaround from the standalone prototype: selectively retaining TDD
 uncertain branches during abstraction, or locally unioning gradual solutions in `generics.rs`.
@@ -98,7 +104,11 @@ The implementation and landing order is:
 
 1. completed domain-solving Phases 1–4 and the raw-graph fix;
 1. a full-suite-clean but intentionally non-mergeable static-sequent revision;
-1. Phase 5 domain activation and compatibility restoration, which is the first landable tip;
+1. the full-suite-clean Phase 5 domain-activation checkpoint, including enforcement of the
+    validity-equality invariant;
+1. Phase 5 structural completion, replacing legacy declaration-aware default solving;
+1. potential Phase 6 compatibility restoration and performance work, which produces the first
+    landable tip;
 1. `dcreager/remove-remove-noninferable-2`.
 
 ## Current baseline
@@ -293,10 +303,13 @@ add a single-implication sequent across validity/evidence provenance, even when 
 bounds have different strengths: declaration validity must not manufacture inference evidence,
 and evidence must not be silently relabeled as validity. This applies both to direct implications
 and to reverse implications derived from intersections. Pair-implication sequents may combine
-premises with different provenance. For same-side intersections, inherit the provenance of the
-stronger restriction. For transitive derivations, emit evidence only when every contributing
-premise is evidence; any contributing validity premise makes the derived bound validity. Continue
-using the underlying types to detect genuinely incompatible effective restrictions.
+premises with different provenance. Same-subject lattice combinations retain one operand's
+provenance only when the resulting type equals that operand; otherwise they become `Mixed`.
+Only direct declaration-domain bounds are `Validity`: transitive derivations are `Evidence` only
+when every indispensable premise is evidence, and are otherwise `Mixed`. This preserves the one
+pure validity equality contributed by a constrained TypeVar's declared alternative on every
+complete path. Continue using the underlying types to detect genuinely incompatible effective
+restrictions.
 
 Propagate provenance through accumulated `PathBound` values and factored `UpperBound` clauses.
 `default_solve` and custom `choose` callbacks select concrete solutions, so they must be able to
@@ -382,8 +395,9 @@ Compare complete paths conservatively:
 1. Both paths must contain the same type-variable identities.
 1. All type-variable bounds except one must be identical.
 1. The differing bounds must belong to a declared constrained type variable and identify exact
-    declared alternatives through their validity bounds. If either bound does not expose one exact
-    declared validity alternative, preserve both complete paths rather than panicking.
+    declared alternatives through their validity bounds. Every such complete path must expose one
+    exact declared validity equality; assert this invariant rather than accepting or skipping a
+    path whose validity bounds were polluted by a derived constraint.
 1. Both paths must retain the same inference evidence and compatible evidence-derived variance.
 1. Lower-side evidence prefers the narrower compatible declared alternative.
 1. Upper-side-only evidence prefers the broader compatible declared alternative.
@@ -436,14 +450,22 @@ expanding `Solutions`:
 - [x] Static-sequent integration phase: restrict concrete sequents and characterize temporary
     regressions in a non-mergeable intermediate revision. Change `kqntvqkmuuqp`, commit
     `148c3d7cf8cbcce6bdab30fb5b77bd6926b8c42d`.
-- [ ] Phase 5: activate the domain-conjoined TDD, simplify default solving, and restore every
-    temporary static-phase regression.
+- [x] Phase 5 activation checkpoint: activate the domain-conjoined TDD, reserve pure `Validity`
+    bounds for direct declaration domains, classify every transitive derivation with a validity
+    premise as `Mixed`, assert that constrained-TypeVar paths expose one exact validity equality,
+    and preserve accepted compatibility debt behind xfail comments. Change
+    `qtllpywmtvzrnswnvkqptllkykwpqqzp`, commit
+    `2f3d8b49b29b532ca8c629efa9eb785cab1ea20e`.
+- [ ] Phase 5 structural completion: replace legacy declaration-aware default solving with solving
+    from the effective domain-conjoined path bounds. Accepted behavioral regressions may remain as
+    passing `XXX` expectations.
+- [ ] Potential Phase 6: restore relationship preservation and the remaining recorded compatibility
+    and performance regressions, then select a landable tip.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
-revision, relevant documentation/tests, and a passing full test suite. The abandoned Phase 5 and
-standalone fully-static revisions are diagnostic evidence only. Implement Phase 5 in a new revision
-on top of the static checkpoint and this plan-only checkpoint; do not layer it onto `pvynqtrq` or
-copy its rejected workarounds.
+revision, relevant documentation/tests, and a passing full test suite. The earlier abandoned Phase 5
+prototype and standalone fully-static revisions are diagnostic evidence only. Complete Phase 5 from
+its recorded activation checkpoint; do not revive `pvynqtrq` or copy its rejected workarounds.
 
 The static checkpoint passes all 816 `ty_python_semantic` tests, all 8,908 workspace tests, workspace
 clippy, and prek. It records seven `XXX: Phase 5` markers covering gradual range algebra,
@@ -451,8 +473,8 @@ clippy, and prek. It records seven `XXX: Phase 5` markers covering gradual range
 wobble audit found that every non-normal mode already failed on the pre-static Phase 4 baseline. The
 static phase adds one temporary mask-4 mismatch for the mutable `TypedDict` case: normal ordering
 now reports the characterized `object` regression while mask 4 already retains the final `int`
-behavior. Phase 5 must restore the correlation and make those outcomes converge; do not update a
-wobble expectation to preserve the intermediate diagnostic.
+behavior. A potential Phase 6 must restore the correlation and make those outcomes converge; do not
+update a wobble expectation to preserve the intermediate diagnostic.
 
 ### Phase 1: retain bound type-variable instances in constraint-set arenas
 
@@ -488,9 +510,9 @@ Suggested revision description: `[π] Distinguish constraint validity from infer
     implication relation for underlying types.
 1. Intern otherwise-identical validity and evidence bounds separately. Never add a
     single-implication sequent across different provenance, including reverse implications derived
-    from intersections. Allow pair-implication sequents with mixed-provenance premises, preserving
-    the stronger bound's provenance for same-side intersections and deriving validity for
-    transitive bounds whenever any contributing premise is validity.
+    from intersections. Allow pair-implication sequents with mixed-provenance premises, using the
+    operation-aware same-subject rule for intersections and joining every indispensable premise's
+    provenance for transitive bounds.
 1. Keep `ConstraintBound` helpers small and local; avoid mechanical renames or broad API rewrites
     beyond the required representation change.
 1. Add narrow tests only for important bound/provenance invariants not already protected by
@@ -570,16 +592,50 @@ This revision is an implementation checkpoint, not a landable tip.
     compensate in TDD abstraction or solution combination.
 1. Run focused generic-function, constraint-algebra, and ordering tests. For each changed behavior,
     assert the observed intermediate result and add an adjacent `XXX` that states the final behavior
-    Phase 5 must restore or classify. Do not disable tests, weaken unrelated assertions, or accept
-    panics as temporary behavior.
+    the activation checkpoint or potential Phase 6 must restore or classify. Do not disable tests, weaken
+    unrelated assertions, or accept panics as temporary behavior.
 1. Run `ty_python_semantic`, the full suite, clippy, snapshot review, and prek. Record the project
     change and commit IDs as a non-mergeable intermediate checkpoint.
 
-### Phase 5: activate domains and restore compatibility
+### Phase 5: activate domains and complete structural path solving
 
-**Mandatory stop-and-escalate gate:** Start Phase 5 from the validated static checkpoint and run
-focused tests after the smallest implementation step. If any test fails unexpectedly, stop
-implementation immediately and switch to diagnosis-only work. Determine the root cause, using
+**Approved checkpoint scope clarification:** Domain activation may persist while some correlated
+TypeVar relationships and other inference behavior remain behind adjacent `XXX` expectations. That
+permission defers behavioral restoration only; it does not defer replacement of the legacy
+`PathBounds::default_solve` declaration logic. Phase 5 is complete only when solving uses the
+effective domain-conjoined path bounds without re-reading declarations or rebuilding alternatives.
+
+The activation checkpoint:
+
+- Projects non-inferable variables before deriving and conjoining validity domains, then extracts
+    paths using the conjoined support without a second projection.
+- Enables complete-path pruning in specialization consumers while asserting that every complete
+    constrained-TypeVar domain path retains one exact validity equality. Invalid producer state is
+    never accepted or skipped.
+- Preserves declaration-specific diagnostics by inspecting unconjoined paths only after a
+    domain-aware solve is unsatisfiable.
+- Preserves all indispensable premise provenance: transitive derivations remain `Evidence` only
+    when every premise is evidence, and any validity premise makes the result `Mixed`. Pure
+    `Validity` is reserved for direct declaration-domain constraints.
+- Retains the legacy declaration lookup in `PathBounds::default_solve`; removing that lookup and
+    solving structurally from path bounds is the remaining Phase 5 work.
+- Accepts, for now, concrete alternative unions such as `int | str` and `Left | Right` where a bare
+    evidence relationship such as `T := S` should survive. Relationship restoration and
+    ambiguous-`Any` behavior are potential Phase 6 work, not reasons to retain the legacy solver.
+- Records all observed mdtest changes with adjacent TODO/XXX xfail comments stating the intended
+    behavior, including gradual inference, inherited generic constructors, cycles, recursive
+    protocols, quantification, and mutable mapping/TypedDict behavior.
+
+Validation at the checkpoint passed all 820 `ty_python_semantic` tests, all 8,913 workspace tests,
+workspace clippy, snapshot review,
+and `/home/dcreager/bin/jpk`. A local Pydantic ecosystem comparison found six additional
+diagnostics consistent with the recorded inherited-generic and relationship losses. It also
+measured a repeatable median type-check time of about 2.91 seconds versus 0.384 seconds at the
+pre-activation parent; audit and resolve that regression before landing.
+
+**Stop-and-escalate gate for the remaining Phase 5 work:** Run focused tests after each small
+implementation step. If any test fails unexpectedly, stop implementation immediately and switch to
+diagnosis-only work. Determine the root cause, using
 temporary debug instrumentation when useful, and report the exact command, failure, current diff,
 and supporting evidence. Propose potential fixes—ideally multiple alternatives—with their
 tradeoffs, but do not retain production-code or mdtest behavior changes, implement a fix, update an
@@ -588,40 +644,37 @@ applies if a characterized Phase 5 regression does not recover in the expected w
 intended mdtest assertions as xfails, including `# error: [static-assert-error]`, unless the user
 explicitly approves a final expectation change.
 
-Suggested revision description: `[π] Solve declared type-variable domains as constraint-set paths`.
+Phase 5 completion checklist:
 
-1. Inventory every static-phase `XXX`; Phase 5 is incomplete until all are removed and their final
-    expectations are covered.
-1. Conjoin the support-derived validity domain with the original root before path extraction in
-    both direct and Salsa-cached entry points. Preserve source ordering and the simple concrete-bound
-    fast path whenever possible.
-1. Produce separate valid paths for declared constrained alternatives and reject incompatible
-    specializations during traversal. Diagnose any aggregated gradual validity path before changing
-    abstraction or solution combination; do not reintroduce unsound closure merely to restore the
-    old shape.
-1. Make complete-path pruning conservative: if a differing constrained-TypeVar bound does not
-    expose an exact declared equality validity bound, retain both paths rather than panicking.
-    Normal domain alternatives should still expose exact validity bounds so existing specificity,
-    static-over-gradual, and declaration-order preferences continue to work.
-1. Simplify `PathBounds::default_solve` so it selects from effective path bounds without inspecting
-    `TypeVarBoundOrConstraints` or rebuilding declared alternatives independently.
-1. Preserve witnessed variance, gradual evidence, bounded lower/upper behavior, absent versus
-    explicit bounds, unsolved variables, and relationships between compatible type variables.
-    Restore constrained `Any`/`int`, `list[Any]`/`list[int]`, ambiguous gradual evidence, and
-    unbounded `Container[T]` behavior without a local solution-union heuristic.
-1. Explicitly prune subsumed complete paths in affected specialization consumers before extracting
-    solutions and combining bindings independently; leave raw internal solution APIs exhaustive.
-1. Recover declaration-specific diagnostics by inspecting unconjoined paths only after a
-    domain-aware solve fails. Do not apply domains before eager quantification or expand this phase
-    into the separate quantifier-replacement workstream.
-1. Classify temporary constraint-algebra changes and replace each `XXX` with its justified final
-    assertion. User-visible inference regressions must be restored rather than recharacterized.
-1. Audit cache growth, path fuel, deterministic ordering, and the
-    `ty_micro[pydantic_core_schema_dict]`-sensitive fast path. Favor existing user-visible tests;
-    change implementation-focused expectations only when semantically required.
-1. Remove superseded TODOs and obsolete declaration-handling code after replacement coverage
+- [x] Inventory the static-phase `XXX` expectations and update every observed activation result with
+    an adjacent follow-up expectation.
+- [x] Conjoin the support-derived validity domain before path extraction in both direct and
+    Salsa-cached entry points while preserving source ordering and the trivial-domain fast path.
+- [x] Produce separate valid paths for declared constrained alternatives and reject incompatible
+    specializations during traversal without reintroducing gradual sequent closure.
+- [x] Preserve one exact pure validity equality for every constrained-TypeVar domain path, classify
+    derived constraints as `Mixed`, and assert the invariant during complete-path pruning.
+- [ ] Replace `PathBounds::default_solve` with solving from effective structural path bounds without
+    re-reading `TypeVarBoundOrConstraints` or rebuilding declared alternatives. Remove the
+    superseded declaration-specific selection code and helpers that become unused.
+- [ ] Preserve evidence-derived variance, effective lower/upper restrictions, absent versus explicit
+    bounds, and unsolved variables structurally. Compatible TypeVar relationships, constrained
+    `Any`/`int`, `list[Any]`/`list[int]`, ambiguous gradual evidence, and unbounded `Container[T]`
+    may remain as explicitly characterized Phase 6 regressions.
+- [x] Explicitly prune subsumed complete paths in affected specialization consumers before
+    extracting solutions and combining bindings independently; leave raw internal solution APIs
+    exhaustive.
+- [x] Recover declaration-specific diagnostics from unconjoined paths only after a domain-aware
+    solve fails. Do not apply domains before eager quantification or expand this work into the
+    separate quantifier-replacement workstream.
+- [ ] Keep accepted temporary constraint-algebra and user-visible changes covered by adjacent
+    `XXX` expectations; final classification and restoration may occur in Phase 6.
+- [ ] Leave the cache-growth, path-fuel, determinism, and
+    `ty_micro[pydantic_core_schema_dict]` performance audit for Phase 6 unless structural solving
+    introduces a new regression beyond the activation checkpoint.
+- [ ] Remove superseded TODOs and obsolete declaration-handling code after replacement coverage
     passes. Run focused tests, `ty_python_semantic`, the full suite, clippy, snapshot review, and
-    prek before marking Phase 5 complete and selecting its tip for landing.
+    prek before marking Phase 5 complete.
 
 ## Focused regression coverage
 
@@ -714,19 +767,20 @@ Run prek from the Jujutsu workspace:
     size must remain correct; avoid assuming provenance tags change the actual set of legal
     specializations.
 - **Derived constraints:** bound provenance must survive transitive, nested, canonicalized, and
-    intersected sequents without converting declaration-only restrictions into spurious evidence.
-    Start conservatively: transitive derivations with any validity premise produce validity, while
-    all-evidence derivations produce evidence.
+    intersected sequents without converting declaration-only restrictions into spurious evidence
+    or polluting the direct declaration-domain validity equality. Transitive derivations produce
+    evidence only when every indispensable premise is evidence; any validity or mixed premise
+    produces `Mixed`. Pure `Validity` is reserved for direct declaration-domain constraints.
 - **Compatible TypeVars:** conjoining `T`'s declared finite domain with witnessed `T = S`
-    currently turns `T = S` into concrete `T = int`/`T = str` alternatives. Preserve the symbolic
-    relationship for compatible constrained variables, including compatible subsets and callbacks
-    with redundant bounds, while rejecting incompatible or merely overlapping domains. The
-    user-visible behavior is required; a dedicated `PathBound` field is not prescribed.
+    currently turns `T = S` into concrete `T = int`/`T = str` alternatives. A potential Phase 6
+    must preserve the symbolic relationship for compatible constrained variables, including
+    compatible subsets and callbacks with redundant bounds, while rejecting incompatible or merely
+    overlapping domains. A dedicated `PathBound` field is not prescribed.
 - **Gradual alternatives and sequents:** store declared gradual alternatives directly as exact
     validity constraints, without bottom/top materialization. The static-sequent phase prevents
-    non-transitive gradual assignability from collapsing paths; Phase 5 must then restore existing
-    `Any`/`int` and `list[Any]`/`list[int]` behavior. Do not reinterpret provenance as a typing
-    relation or add equality-specific sequent behavior.
+    non-transitive gradual assignability from collapsing paths; a potential Phase 6 must restore
+    existing `Any`/`int` and `list[Any]`/`list[int]` behavior. Do not reinterpret provenance as a
+    typing relation or add equality-specific sequent behavior.
 - **Arena overlays:** retain full type-variable instances while continuing to intern by identity
     and avoiding unstable Salsa-ID-based ordering or unnecessary `db` parameter churn.
 - **Fast-path performance:** preserve `compute_simple_bound_conjunction` and its no-sequent-cache

--- a/PLAN.md
+++ b/PLAN.md
@@ -470,8 +470,10 @@ expanding `Solutions`:
     with adjacent TODO/XXX comments stating the intended behavior. Change
     `smrkruyysnpoyswkpypttlpowomwsmrs`, commit
     `72cbd05ee9b3124bca1b796ac5f41099e975f1b5`.
-- [ ] Phase 6A: make logically contradictory positive/negative assignments impossible across bound
+- [x] Phase 6A: make logically contradictory positive/negative assignments impossible across bound
     provenance without allowing validity restrictions to manufacture positive inference evidence.
+    Change `qynqxkpqotkuzvstnylupmuxmwrkokpm`, commit
+    `c6195be50758b035dc299839995774e0d7d8cfeb`.
 - [ ] Phase 6B: recover one universally valid bare-TypeVar symbolic solution such as `T := S` from
     the complete domain-conjoined path family, using the existing `inferable` set as the
     authoritative partition and a mapped-TDD implication check.
@@ -484,14 +486,13 @@ approved implementation ground truth. In particular, the contradiction-only sequ
 to provenance-suppressed implications; `PathBounds::Constrained` owns `paths` and the single
 optional symbolic default; and no caller-accessible path-local default solver remains. Custom
 chooser fallback receives immutable family context because pruning is complete before read-only
-solution selection. Do not begin implementation without explicit authorization.
+solution selection. Do not begin Phase 6B implementation without explicit authorization.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
 revision, relevant documentation/tests, and a passing full test suite. The earlier abandoned Phase 5
 prototype and standalone fully-static revisions are diagnostic evidence only; do not revive
-`pvynqtrq` or copy its rejected workarounds. Phase 6A starts from the completed Phase 5
-structural-solving revision recorded above and the subsequent approved plan-only revisions;
-Phase 6B starts only after Phase 6A and its full validation are complete.
+`pvynqtrq` or copy its rejected workarounds. Phase 6B starts from the completed Phase 6A revision
+recorded above and the subsequent plan-only checkpoint.
 
 The rewritten activation checkpoint and structural-completion revision each pass all 820
 `ty_python_semantic` tests, all 8,913 workspace tests, workspace clippy, snapshot review, and prek.
@@ -516,6 +517,12 @@ equality when the domain path fixes one specialization, and otherwise solves fro
 evidence. Accepted gradual and relationship regressions remain visible behind adjacent TODO/XXX
 expectations. Validation passed all 820 `ty_python_semantic` tests, all 8,913 workspace tests,
 workspace clippy, snapshot review, and prek.
+
+Phase 6A adds an `ImplicationContradiction` sequent for provenance-suppressed implications. It
+rejects `C and not D` when the underlying `C` implies `D` without propagating positive `D` across
+provenance. Existing pair implications derive their intermediate constraint before the new sequent
+checks the contradiction, so no dedicated pair-conflict form is needed. Validation passed all 823
+`ty_python_semantic` tests, all 8,921 workspace tests, workspace clippy, snapshot review, and prek.
 
 ### Phase 1: retain bound type-variable instances in constraint-set arenas
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -90,9 +90,9 @@ approved replan.
 The incomplete Phase 5 revision `pvynqtrq` and its pause revision are diagnostic snapshots, not
 part of the implementation path. The new static-sequent phase starts after `sqkowvys` (the
 completed Phase 4 stack plus the raw-graph fix) and the approved plan-only revisions. Phase 5 is a
-child of that static revision. The detailed static requirements remain in
-`~/.pi/memory/plans/ruff/fully-static-sequents/PLAN.md`; this document is authoritative for phase
-order and completion markers.
+child of that static revision. The former standalone plan is archived at
+`~/.pi/memory/archive/plans/ruff/fully-static-sequents/PLAN.md` for historical rationale only;
+this document now owns the active static requirements, phase order, and completion markers.
 
 The implementation and landing order is:
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -106,7 +106,8 @@ The implementation and landing order is:
 1. a full-suite-clean but intentionally non-mergeable static-sequent revision;
 1. the full-suite-clean Phase 5 domain-activation checkpoint, including enforcement of the
     validity-equality invariant;
-1. Phase 5 structural completion, replacing legacy declaration-aware default solving;
+1. Phase 5 structural completion, replacing legacy declaration-aware default solving while keeping
+    intended Phase 6 results as adjacent xfail TODOs;
 1. potential Phase 6 compatibility restoration and performance work, which produces the first
     landable tip;
 1. `dcreager/remove-remove-noninferable-2`.
@@ -456,16 +457,27 @@ expanding `Solutions`:
     and preserve accepted compatibility debt behind xfail comments. Change
     `qtllpywmtvzrnswnvkqptllkykwpqqzp`, commit
     `2f3d8b49b29b532ca8c629efa9eb785cab1ea20e`.
-- [ ] Phase 5 structural completion: replace legacy declaration-aware default solving with solving
-    from the effective domain-conjoined path bounds. Accepted behavioral regressions may remain as
-    passing `XXX` expectations.
+- [x] Phase 5 structural completion: replace legacy declaration-aware default solving with solving
+    from the effective domain-conjoined path bounds. Accepted behavioral regressions remain passing
+    with adjacent TODO/XXX comments stating the intended behavior. Change
+    `smrkruyysnpoyswkpypttlpowomwsmrs`, commit
+    `72cbd05ee9b3124bca1b796ac5f41099e975f1b5`.
 - [ ] Potential Phase 6: restore relationship preservation and the remaining recorded compatibility
     and performance regressions, then select a landable tip.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
 revision, relevant documentation/tests, and a passing full test suite. The earlier abandoned Phase 5
-prototype and standalone fully-static revisions are diagnostic evidence only. Complete Phase 5 from
-its recorded activation checkpoint; do not revive `pvynqtrq` or copy its rejected workarounds.
+prototype and standalone fully-static revisions are diagnostic evidence only; do not revive
+`pvynqtrq` or copy its rejected workarounds. Potential Phase 6 work starts from the completed Phase 5
+structural-solving revision recorded above.
+
+The rewritten activation checkpoint and structural-completion revision each pass all 820
+`ty_python_semantic` tests, all 8,913 workspace tests, workspace clippy, snapshot review, and prek.
+Derived constraints with any validity premise are `Mixed`, while constrained TypeVar domain paths
+retain the declared alternative as their sole pure validity equality. The
+`as_equality_validity_bound` assertions protect this invariant. Relationship regressions exposed by
+correct provenance remain explicit behind adjacent TODO xfails in the revision that introduces the
+observed behavior.
 
 The static checkpoint passes all 816 `ty_python_semantic` tests, all 8,908 workspace tests, workspace
 clippy, and prek. It records seven `XXX: Phase 5` markers covering gradual range algebra,
@@ -475,6 +487,13 @@ static phase adds one temporary mask-4 mismatch for the mutable `TypedDict` case
 now reports the characterized `object` regression while mask 4 already retains the final `int`
 behavior. A potential Phase 6 must restore the correlation and make those outcomes converge; do not
 update a wobble expectation to preserve the intermediate diagnostic.
+
+The Phase 5 structural completion removes the declaration lookup and declared-alternative selection
+from `PathBounds::default_solve`. It validates the effective path interval, selects an exact validity
+equality when the domain path fixes one specialization, and otherwise solves from lower or upper
+evidence. Accepted gradual and relationship regressions remain visible behind adjacent TODO/XXX
+expectations. Validation passed all 820 `ty_python_semantic` tests, all 8,913 workspace tests,
+workspace clippy, snapshot review, and prek.
 
 ### Phase 1: retain bound type-variable instances in constraint-set arenas
 
@@ -627,8 +646,7 @@ The activation checkpoint:
     protocols, quantification, and mutable mapping/TypedDict behavior.
 
 Validation at the checkpoint passed all 820 `ty_python_semantic` tests, all 8,913 workspace tests,
-workspace clippy, snapshot review,
-and `/home/dcreager/bin/jpk`. A local Pydantic ecosystem comparison found six additional
+workspace clippy, snapshot review, and `/home/dcreager/bin/jpk`. A local Pydantic ecosystem comparison found six additional
 diagnostics consistent with the recorded inherited-generic and relationship losses. It also
 measured a repeatable median type-check time of about 2.91 seconds versus 0.384 seconds at the
 pre-activation parent; audit and resolve that regression before landing.
@@ -654,10 +672,10 @@ Phase 5 completion checklist:
     specializations during traversal without reintroducing gradual sequent closure.
 - [x] Preserve one exact pure validity equality for every constrained-TypeVar domain path, classify
     derived constraints as `Mixed`, and assert the invariant during complete-path pruning.
-- [ ] Replace `PathBounds::default_solve` with solving from effective structural path bounds without
+- [x] Replace `PathBounds::default_solve` with solving from effective structural path bounds without
     re-reading `TypeVarBoundOrConstraints` or rebuilding declared alternatives. Remove the
     superseded declaration-specific selection code and helpers that become unused.
-- [ ] Preserve evidence-derived variance, effective lower/upper restrictions, absent versus explicit
+- [x] Preserve evidence-derived variance, effective lower/upper restrictions, absent versus explicit
     bounds, and unsolved variables structurally. Compatible TypeVar relationships, constrained
     `Any`/`int`, `list[Any]`/`list[int]`, ambiguous gradual evidence, and unbounded `Container[T]`
     may remain as explicitly characterized Phase 6 regressions.
@@ -667,12 +685,12 @@ Phase 5 completion checklist:
 - [x] Recover declaration-specific diagnostics from unconjoined paths only after a domain-aware
     solve fails. Do not apply domains before eager quantification or expand this work into the
     separate quantifier-replacement workstream.
-- [ ] Keep accepted temporary constraint-algebra and user-visible changes covered by adjacent
+- [x] Keep accepted temporary constraint-algebra and user-visible changes covered by adjacent
     `XXX` expectations; final classification and restoration may occur in Phase 6.
-- [ ] Leave the cache-growth, path-fuel, determinism, and
+- [x] Leave the cache-growth, path-fuel, determinism, and
     `ty_micro[pydantic_core_schema_dict]` performance audit for Phase 6 unless structural solving
     introduces a new regression beyond the activation checkpoint.
-- [ ] Remove superseded TODOs and obsolete declaration-handling code after replacement coverage
+- [x] Remove superseded TODOs and obsolete declaration-handling code after replacement coverage
     passes. Run focused tests, `ty_python_semantic`, the full suite, clippy, snapshot review, and
     prek before marking Phase 5 complete.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -302,25 +302,28 @@ to the validity/evidence provenance rules described above; do not use this refac
 relationships between gradual and static types, and do not compensate by expanding declared
 gradual equalities into bottom/top materialization ranges.
 
-### Prefer narrowly subsumed complete solutions
+### Prefer narrowly subsumed complete paths
 
-Add witness-derived `TypeVarVariance` to `TypeVarSolution`. The variance is already available where
-`PathBounds::solve_with` constructs each binding, so no witness-set or callback-signature expansion
-is required.
+Add an explicit shared pruning operation on `PathBounds`, before solution extraction discards the
+validity bounds and inference evidence needed to compare declared alternatives. Read variance and
+gradual/static argument classification directly from each `PathBound`; do not add variance or
+other path metadata to `TypeVarSolution`.
 
-Add an explicit shared pruning operation on `Solutions`. Compare complete assignments
-conservatively:
+Compare complete paths conservatively:
 
-1. Both solutions must contain the same type-variable identities.
-1. All bindings except one must be identical.
-1. The differing binding must belong to a declared constrained type variable.
-1. Both bindings must have compatible evidence-derived variance.
+1. Both paths must contain the same type-variable identities.
+1. All type-variable bounds except one must be identical.
+1. The differing bounds must belong to a declared constrained type variable and identify exact
+    declared alternatives through their validity bounds.
+1. Both paths must retain the same inference evidence and compatible evidence-derived variance.
 1. Lower-side evidence prefers the narrower compatible declared alternative.
 1. Upper-side-only evidence prefers the broader compatible declared alternative.
 1. Mutually assignable alternatives prefer static over gradual; otherwise retain declaration
     order.
-1. Preserve both solutions if multiple bindings differ, the differing alternatives are
-    incomparable, or the variable is not declared constrained.
+1. Preserve both paths if multiple type-variable bounds differ, their evidence differs, the
+    alternatives are incomparable, or the variable is not declared constrained.
+1. Preserve ambiguous gradual argument evidence rather than arbitrarily choosing one compatible
+    declared alternative.
 
 For example, lower-side evidence prefers the first of:
 
@@ -336,8 +339,9 @@ But neither of these dominates the other:
 {T = str | bytes, U = int}
 ```
 
-Pruning is opt-in for concrete-specialization consumers. Do not prune automatically inside
-`PathBounds::solve_with`: internal `ConstraintSet.solutions()` and `solutions_for()` APIs should
+Pruning is opt-in for concrete-specialization consumers: callers explicitly prune `PathBounds`
+before extracting solutions. Do not prune automatically inside `PathBounds::compute` or
+`PathBounds::solve_with`; internal `ConstraintSet.solutions()` and `solutions_for()` APIs should
 continue returning their raw solution paths unless a specific implementation expectation conflicts
 with required user-visible behavior.
 
@@ -359,7 +363,7 @@ expanding `Solutions`:
 - [x] Phase 1: retain bound type-variable instances in constraint-set arenas.
 - [x] Phase 2: replace optional constraint bounds with validity/evidence bounds.
 - [x] Phase 3: reintroduce support-derived validity-domain construction.
-- [ ] Phase 4: preserve evidence-derived variance and add complete-solution pruning.
+- [x] Phase 4: preserve evidence-derived variance and add complete-path pruning.
 - [ ] Phase 5: solve the domain-conjoined TDD and simplify default solving.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
@@ -431,9 +435,9 @@ Suggested revision description: `[π] Derive type-variable validity domains from
     user-visible bounded/constrained generic behavior.
 1. Run the full suite before marking the phase complete.
 
-### Phase 4: preserve evidence-derived variance and add complete-solution pruning
+### Phase 4: preserve evidence-derived variance and add complete-path pruning
 
-Suggested revision description: `[π] Preserve evidence variance and compare complete solutions`.
+Suggested revision description: `[π] Preserve evidence variance and compare complete paths`.
 
 1. Propagate validity/evidence provenance through `ConstraintBoundsBuilder`, `PathBound`, and
     factored `UpperBound` clauses so both `default_solve` and custom callbacks can inspect it.
@@ -442,19 +446,20 @@ Suggested revision description: `[π] Preserve evidence variance and compare com
 1. Preserve effective lower/upper restrictions while deriving variance and gradual/static
     classification only from evidence.
 1. Update contextual inference, generic specialization, receiver handling, pattern narrowing,
-    diagnostic helpers, and other real `PathBound` consumers to use narrow provenance-aware
-    accessors.
+    diagnostic helpers, and other real `PathBound` consumers to inspect provenance-aware fields
+    directly.
 1. Preserve witnessed relationships between compatible constrained type variables. Prefer using
     the new provenance-aware path bounds directly; introduce specialized relationship metadata only
     if the representation proves insufficient.
 1. Ensure the ordinary visitor and `compute_simple_bound_conjunction` agree, including canonical
     reorientation of constraints involving another type variable.
 1. Leave variables without positive evidence unsolved while preserving valid empty solution paths.
-1. Add variance to `TypeVarSolution` and update the small number of direct initializers.
-1. Implement the explicit whole-`Solution` pruning operation without changing solver callbacks or
+1. Keep `TypeVarSolution` limited to the type variable and its selected solution; derive variance
+    and gradual/static evidence directly from `PathBound` when comparing paths.
+1. Implement explicit whole-path pruning on `PathBounds` without changing solver callbacks or
     automatically pruning raw solver results.
 1. Cover narrow versus broad preference, static versus gradual preference, declaration-order ties,
-    incomparable complete assignments, and correlated assignments where necessary.
+    incomparable or independently evidenced alternatives, and correlated paths where necessary.
 1. Delay behavior-changing consumer integration until Phase 5.
 1. Run the full suite before marking the phase complete.
 
@@ -472,8 +477,8 @@ Suggested revision description: `[π] Solve declared type-variable domains as co
     inspecting `TypeVarBoundOrConstraints` or rebuilding declared alternatives independently.
 1. Preserve witnessed variance, gradual evidence, bounded lower/upper behavior, absent versus
     explicit bounds, unsolved variables, and relationships between compatible type variables.
-1. Explicitly prune subsumed complete solutions in affected specialization consumers before they
-    combine bindings individually; leave raw internal solution APIs exhaustive.
+1. Explicitly prune subsumed complete paths in affected specialization consumers before extracting
+    solutions and combining bindings individually; leave raw internal solution APIs exhaustive.
 1. Recover declaration-specific diagnostics by inspecting unconjoined paths only after a
     domain-aware solve fails.
 1. Do not apply domains before eager quantification or expand this project into the separate
@@ -596,8 +601,9 @@ Run prek from the Jujutsu workspace:
     empty complete solutions; validity bounds alone must not manufacture inferred bindings.
 - **Variance direction:** lower-only evidence maps to `Contravariant`; upper-only evidence maps to
     `Covariant`. Preserve the existing narrower/broader solution preferences.
-- **Complete-solution correlations:** only compare assignments differing in one constrained
-    variable; do not create independently combined assignments or prune raw solver output.
+- **Complete-path correlations:** only compare paths differing in one constrained variable while
+    retaining identical inference evidence; do not create independently combined assignments or
+    prune raw solver output.
 - **Diagnostics:** invalid paths may disappear before callbacks run; reconstruct specific
     declaration errors only on the diagnostic failure path.
 - **Ordering:** merge source-order sidecars consistently and retain declaration-order tie breaks

--- a/PLAN.md
+++ b/PLAN.md
@@ -577,6 +577,17 @@ This revision is an implementation checkpoint, not a landable tip.
 
 ### Phase 5: activate domains and restore compatibility
 
+**Mandatory stop-and-escalate gate:** Start Phase 5 from the validated static checkpoint and run
+focused tests after the smallest implementation step. If any test fails unexpectedly, stop
+implementation immediately and switch to diagnosis-only work. Determine the root cause, using
+temporary debug instrumentation when useful, and report the exact command, failure, current diff,
+and supporting evidence. Propose potential fixes—ideally multiple alternatives—with their
+tradeoffs, but do not retain production-code or mdtest behavior changes, implement a fix, update an
+expectation, or continue to a later Phase 5 step without explicit user approval. The same gate
+applies if a characterized Phase 5 regression does not recover in the expected way. Preserve
+intended mdtest assertions as xfails, including `# error: [static-assert-error]`, unless the user
+explicitly approves a final expectation change.
+
 Suggested revision description: `[π] Solve declared type-variable domains as constraint-set paths`.
 
 1. Inventory every static-phase `XXX`; Phase 5 is incomplete until all are removed and their final

--- a/PLAN.md
+++ b/PLAN.md
@@ -430,16 +430,26 @@ expanding `Solutions`:
 - [x] Phase 2: replace optional constraint bounds with validity/evidence bounds.
 - [x] Phase 3: reintroduce support-derived validity-domain construction.
 - [x] Phase 4: preserve evidence-derived variance and add complete-path pruning.
-- [ ] Static-sequent integration phase: restrict concrete sequents and characterize temporary
-    regressions in a non-mergeable intermediate revision.
+- [x] Static-sequent integration phase: restrict concrete sequents and characterize temporary
+    regressions in a non-mergeable intermediate revision. Change `kqntvqkmuuqp`, commit
+    `f5d21fd5194b720803865f6160fbbb430b0c4eb2`.
 - [ ] Phase 5: activate the domain-conjoined TDD, simplify default solving, and restore every
     temporary static-phase regression.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
 revision, relevant documentation/tests, and a passing full test suite. The abandoned Phase 5 and
-standalone fully-static revisions are diagnostic evidence only. Implement the static phase in a new
-revision based on this replanning revision, then implement Phase 5 as its child; do not layer either
-onto `pvynqtrq` or copy its rejected workarounds.
+standalone fully-static revisions are diagnostic evidence only. Implement Phase 5 in a new revision
+on top of the static checkpoint and this plan-only checkpoint; do not layer it onto `pvynqtrq` or
+copy its rejected workarounds.
+
+The static checkpoint passes all 816 `ty_python_semantic` tests, all 8,908 workspace tests, workspace
+clippy, and prek. It records seven `XXX: Phase 5` markers covering gradual range algebra,
+`Container[T]`, recursive protocol inference, and mutable `TypedDict` correlation. A constraint-order
+wobble audit found that every non-normal mode already failed on the pre-static Phase 4 baseline. The
+static phase adds one temporary mask-4 mismatch for the mutable `TypedDict` case: normal ordering
+now reports the characterized `object` regression while mask 4 already retains the final `int`
+behavior. Phase 5 must restore the correlation and make those outcomes converge; do not update a
+wobble expectation to preserve the intermediate diagnostic.
 
 ### Phase 1: retain bound type-variable instances in constraint-set arenas
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,598 @@
+# Move declared type-variable restrictions into constraint-set domains
+
+## Goal
+
+Move enforcement of declared type-variable upper bounds and value constraints out of
+`PathBounds::default_solve` and into the constraint set traversed to produce solutions. Represent
+declared alternatives as actual TDD paths, distinguish validity restrictions from inference
+evidence independently on each lower and upper bound, and preserve existing user-visible generic
+inference and diagnostics.
+
+Minimal diff churn is an explicit requirement:
+
+- Keep the existing `ConstraintSet::node` field and Boolean operations.
+- Do not add a stored domain field, rename `node`, add witness flags to `InteriorNodeData`, or
+    track witness-constraint sets on solutions.
+- Reuse root support, existing constraint/path representations, source ordering, and existing
+    specialization-error construction.
+- Do not attempt general correlation-preserving solution combination.
+- Do not change eager existential or universal quantification; it is being replaced in a separate
+    workstream.
+- Do not change existing gradual-type assignability, constraint implication, or declaration
+    semantics; this project moves where bounds and constraints are handled, not how they behave.
+
+## Workflow and handoff requirements
+
+This document is the ground truth for phase order, dependencies, agreed decisions, and completion
+status. Complete phases in order. An agent resuming the work must inspect the source code, tests,
+and Jujutsu revisions to verify that completion markers are accurate before continuing.
+
+Each implementation phase must be its own Jujutsu revision. Before editing for a new phase, create
+a revision with `jj new -A @` and describe it with `jj describe`; descriptions must begin with
+`[π]`. Never edit an existing revision with `jj edit`. Update this document's phase marker in the
+revision that completes that phase.
+
+Documentation and tests are cross-cutting requirements of every phase, not separate phases.
+Prioritize focused tests of user-visible typing behavior. Existing mdtests using
+`ty_extensions._internal.ConstraintSet` can describe implementation rather than user requirements;
+change those tests when necessary to obtain the correct user-visible behavior. Do not add large
+batteries of implementation-locking tests when existing coverage or a targeted invariant test
+suffices.
+
+The full test suite must pass at the end of every phase. If a subsequent phase is required for the
+ultimately correct result, do not disable, comment out, or ignore tests. Instead, update the
+assertion or mdtest expectation to the currently observed behavior and add a clear TODO describing
+the expected correct behavior. Prefer sequencing that avoids temporary regressions entirely.
+
+Use `jj` for source control and inspect changes with `jj diff --git` or `jj diff --stat`. Run prek
+in this Jujutsu workspace through `/home/dcreager/bin/jpk`. Never modify snapshot files or inline
+snapshot bodies manually: regenerate them with the documented test commands, inspect every
+snapshot change, and check for `.pending-snap` files when inline snapshots are involved.
+
+## Current baseline
+
+The principal implementation is `crates/ty_python_semantic/src/types/constraints.rs`.
+
+A prerequisite revision has already removed the vestigial `satisfied_by_all_typevars` API and its
+implementation-focused mdtests. Its removal also deleted `valid_specializations` and
+`required_specializations`. Do not restore `satisfied_by_all_typevars` or bend the new
+implementation around its former behavior. Reintroduce only the narrow domain-construction helper
+needed for this project, using its historical implementation as a reference while preserving
+existing user-visible gradual-bound and gradual-constraint behavior.
+
+### Current per-path solving
+
+`PathBounds::default_solve` currently inspects
+`bound_typevar.typevar(db).require_bound_or_constraints(db, env)` for each type variable on each
+TDD path.
+
+For declared upper bounds, it:
+
+- Uses the upper bound's top materialization; unbounded type variables effectively use `object`.
+- Prefers an inferred lower bound after checking the path's upper bounds and the declaration.
+- Otherwise intersects explicitly inferred upper bounds with the declared bound.
+- Leaves a variable unsolved when there is no inference evidence.
+
+For declared value constraints, it:
+
+- Checks each declared alternative against the path's inferred bounds.
+- Uses bottom/top materializations when checking gradual alternatives.
+- Rejects paths that match no alternative.
+- Promotes an inferred subtype to the declared alternative.
+- Prefers the narrowest compatible alternative for lower-bound evidence and the broadest
+    compatible alternative for upper-bound-only evidence.
+- Prefers static over equivalent gradual alternatives, then preserves declaration order.
+- Preserves gradual argument evidence when several alternatives are compatible.
+- Preserves witnessed relationships to other type variables instead of always replacing them with
+    concrete declared alternatives.
+
+Because this logic runs independently on each path, it cannot compare declared alternatives that
+appear on different TDD paths.
+
+### Current support and type-variable arenas
+
+`crates/ty_python_semantic/src/types/constraints/support.rs` records all type variables mentioned
+in an individual constraint, including variables nested in lower or upper bounds. A root node's
+support is the union of the supports reachable through its condition and all three TDD branches.
+
+Support members are stable builder-local `TypeVarId`s. Builder-local and compacted owned arenas
+currently map those IDs to `BoundTypeVarIdentity`, which deliberately omits declared bounds and
+constraints. Domain construction instead needs a `BoundTypeVarInstance`.
+
+Treat identities and retained instances as effectively one-to-one here. Multiple instances can
+share one identity when lazy declarations have been resolved differently; preserve one instance
+per identity and continue using the identity for interning, stable ordering, and membership.
+
+### Current bounds and solutions
+
+`ConstraintBounds` currently stores:
+
+```rust
+pub(crate) lower: Option<Type<'db>>,
+pub(crate) upper: Option<Type<'db>>,
+```
+
+`None` means the relevant side is absent. Logical defaults are `Never` for the lower side and
+`object` for the upper side, but an explicit `Never` or `object` must remain distinguishable from
+an absent bound.
+
+`ConstraintBoundsBuilder` currently accumulates all lower bounds into a union and upper bounds
+into a factored `UpperBound` conjunction. It also classifies every accumulated bound as inference
+evidence. `PathBound::variance` currently infers variance from the presence of accumulated lower
+and upper bounds:
+
+- Evidence on the lower side only: `TypeVarVariance::Contravariant`.
+- Evidence on the upper side only: `TypeVarVariance::Covariant`.
+- Evidence on both sides: `TypeVarVariance::Invariant`.
+- No evidence: `TypeVarVariance::Bivariant`.
+
+`PathBounds::compute` serves both `ConstraintSet::solutions_with` and the Salsa-cached
+`Type::assignable_solutions_with_inferable` query. Its
+`compute_simple_bound_conjunction` fast path avoids `PathAssignments` and sequent-map construction
+for conjunctions of concrete bounds.
+
+`Solutions::Constrained` holds a `Vec<Solution>`, and each `Solution` is a
+`Vec<TypeVarSolution>`. One complete solution represents a correlated assignment. Existing
+consumers, notably `SpecializationBuilder::solve_pending_with` in
+`crates/ty_python_semantic/src/types/generics.rs`, often combine bindings independently; replacing
+that broader behavior is outside this project.
+
+## Agreed design
+
+### Compute domains from root support
+
+Do not store a domain alongside `ConstraintSet::node`. Instead compute it from root support when
+extracting solutions:
+
+```text
+domain(node) = AND(valid_specializations(T) for T in support(node))
+node_to_solve = node AND domain(node)
+```
+
+Reintroduce a narrow helper analogous to the removed `valid_specializations`:
+
+- Unbounded variables and `P.args`/`P.kwargs` contribute `ALWAYS_TRUE`.
+- An upper-bounded variable contributes a validity upper bound.
+- A constrained variable contributes an OR of exact validity constraints, one for each declared
+    alternative.
+- Preserve gradual declared constraints directly instead of replacing them with their bottom/top
+    materializations, either while constructing the domain or while computing effective path
+    bounds.
+
+For example:
+
+```text
+declared constraint: list[Any]
+domain constraint:   list[Any] <= T <= list[Any]
+```
+
+Directly retaining the declared gradual type avoids additional domain-branch metadata and lets
+solution selection recover the original declared alternative naturally. In particular, `T = Any`
+must remain an exact validity equality; do not reinterpret it as `Never <= T <= object`, even
+internally. The removed `satisfied_by_all_typevars` API and its historical `valid_specializations`
+materialization strategy no longer constrain this design.
+
+Include every type variable present in root support, not just inferable variables. Do not add a
+separate recursive/fixed-point expansion: the agreed invariant is that relevant variable closure
+is already represented by support.
+
+Root support already follows existing Boolean operations and their short-circuiting. Keep those
+operations unchanged. Preserve source-order sidecars and the distinction between missing and
+explicit logical-default bounds.
+
+### Track validity and evidence separately on each bound
+
+Replace each `Option<Type>` inside `ConstraintBounds` with a provenance-aware enum:
+
+```rust
+enum ConstraintBound<'db> {
+    None,
+    Validity(Type<'db>),
+    Evidence(Type<'db>),
+}
+```
+
+`None` remains a genuinely absent bound. `Validity` restricts which specializations are legal;
+`Evidence` additionally represents an inference preference supplied by the original relationship.
+Record the distinction independently for the lower and upper sides:
+
+```text
+argument evidence: Evidence(bool) <= T
+validity domain:                      T <= Validity(int)
+combined bounds:   Evidence(bool) <= T <= Validity(int)
+```
+
+The effective solution must satisfy both sides, but variance remains lower-bound-only because the
+upper side contributes validity rather than evidence.
+
+Similarly, an exact declared constraint can provide validity on both sides without manufacturing
+invariant argument evidence:
+
+```text
+argument evidence: Evidence(bool) <= T
+declared domain:   Validity(int) <= T <= Validity(int)
+```
+
+When two bounds on the same side are comparable, preserve the provenance of the stronger
+restriction. The direction depends on the side: a lower bound is stronger when its type is wider,
+while an upper bound is stronger when its type is narrower.
+
+```text
+Evidence(bool) <= T  and  Validity(int) <= T  =>  Validity(int) <= T
+Evidence(int)  <= T  and  Validity(bool) <= T =>  Evidence(int) <= T
+
+T <= Validity(bool)  and  T <= Evidence(int)  =>  T <= Validity(bool)
+T <= Evidence(bool)  and  T <= Validity(int)  =>  T <= Evidence(bool)
+```
+
+This prevents a weaker evidence bound from relabeling a stronger declaration-imposed restriction
+as evidence. Incomparable same-side bounds do not require a merged provenance rule: upper-bound
+intersections and lower-bound unions are represented as separate constraints, preserving each
+bound's original `Validity` or `Evidence` tag independently.
+
+Preserve provenance through bound normalization, type-variable reorientation, intersection,
+sequent derivation, type mapping, owned-set compaction/loading, and path extraction. Validity and
+evidence constraints with identical underlying bounds remain distinct interned constraints. Never
+add a single-implication sequent across validity/evidence provenance, even when the underlying
+bounds have different strengths: declaration validity must not manufacture inference evidence,
+and evidence must not be silently relabeled as validity. This applies both to direct implications
+and to reverse implications derived from intersections. Pair-implication sequents may combine
+premises with different provenance. For same-side intersections, inherit the provenance of the
+stronger restriction. For transitive derivations, emit evidence only when every contributing
+premise is evidence; any contributing validity premise makes the derived bound validity. Continue
+using the underlying types to detect genuinely incompatible effective restrictions.
+
+Propagate provenance through accumulated `PathBound` values and factored `UpperBound` clauses.
+`default_solve` and custom `choose` callbacks select concrete solutions, so they must be able to
+inspect validity versus evidence directly. Do not erase provenance merely to preserve the existing
+`PathBound` field types.
+
+Provide narrow helpers or constructors so callers can extract effective types, inspect provenance,
+check presence, materialize logical defaults, and construct ordinary evidence bounds without
+unnecessary API churn. Keep existing external constructors accepting `Option<Type>` where
+practical, converting those inputs to evidence internally; update actual `PathBound` consumers as
+needed.
+
+Do not add witness flags to `InteriorNodeData`, propagate booleans through `PathAssignments`, or
+introduce separate witness-specific fuel accounting. Bound-side provenance supersedes that earlier
+design.
+
+When collecting paths:
+
+- Preserve validity and evidence in the `PathBound` representation rather than exposing only an
+    unannotated effective type.
+- Accumulate lower bounds into two unions: one containing all evidence lower bounds and one
+    containing all validity lower bounds. Their union is the effective lower restriction.
+- Preserve provenance individually for factored upper-bound clauses.
+- Include both validity and evidence in effective solution restrictions.
+- Derive variance and gradual/static argument classification only from evidence bounds.
+- Do not infer bindings for variables that have no positive evidence.
+- Keep valid empty solutions and genuine alternatives intact.
+
+The two lower unions preserve the original evidence even when a stronger validity lower bound
+controls the effective restriction. Preserve witnessed bare-TypeVar relationships after validity
+constraints are accumulated, but do not commit in advance to dedicated relationship metadata;
+first determine what the new provenance-aware lower/upper bounds already make possible.
+
+### Preserve existing gradual behavior without changing implication semantics
+
+`Constraint::new_node_with_bounds` already accepts gradual bounds despite a stale claim that only
+fully static bounds are supported. Existing implication logic has known questionable behavior for
+exact gradual/static alternatives, but fixing that behavior is out of scope: do not change the
+underlying gradual assignability or implication relation as part of this project.
+
+Existing generic-function behavior must nevertheless be preserved:
+
+```py
+def identity[T: (Any, int)](value: T) -> T: ...
+
+reveal_type(identity("x"))  # Any
+reveal_type(identity(1))  # int
+```
+
+The analogous `list[Any]`/`list[int]` behavior must also remain unchanged. Restrict sequent changes
+to the validity/evidence provenance rules described above; do not use this refactor to redefine
+relationships between gradual and static types, and do not compensate by expanding declared
+gradual equalities into bottom/top materialization ranges.
+
+### Prefer narrowly subsumed complete solutions
+
+Add witness-derived `TypeVarVariance` to `TypeVarSolution`. The variance is already available where
+`PathBounds::solve_with` constructs each binding, so no witness-set or callback-signature expansion
+is required.
+
+Add an explicit shared pruning operation on `Solutions`. Compare complete assignments
+conservatively:
+
+1. Both solutions must contain the same type-variable identities.
+1. All bindings except one must be identical.
+1. The differing binding must belong to a declared constrained type variable.
+1. Both bindings must have compatible evidence-derived variance.
+1. Lower-side evidence prefers the narrower compatible declared alternative.
+1. Upper-side-only evidence prefers the broader compatible declared alternative.
+1. Mutually assignable alternatives prefer static over gradual; otherwise retain declaration
+    order.
+1. Preserve both solutions if multiple bindings differ, the differing alternatives are
+    incomparable, or the variable is not declared constrained.
+
+For example, lower-side evidence prefers the first of:
+
+```text
+{T = str,         U = bytes}
+{T = str | bytes, U = bytes}
+```
+
+But neither of these dominates the other:
+
+```text
+{T = str,         U = bytes}
+{T = str | bytes, U = int}
+```
+
+Pruning is opt-in for concrete-specialization consumers. Do not prune automatically inside
+`PathBounds::solve_with`: internal `ConstraintSet.solutions()` and `solutions_for()` APIs should
+continue returning their raw solution paths unless a specific implementation expectation conflicts
+with required user-visible behavior.
+
+### Recover specific diagnostics only after solving fails
+
+Domain-aware solving can eliminate invalid declarations before `default_solve` or its caller's
+callback runs. Preserve existing `MismatchedBound` and `MismatchedConstraint` diagnostics without
+expanding `Solutions`:
+
+1. Solve the domain-conjoined set normally.
+1. Only if it is unsatisfiable, inspect paths from the original unconjoined constraint set.
+1. Reuse `SpecializationBuilder::specialization_error_from_failed_bounds` to distinguish declared
+    mismatches from unrelated unsatisfiability.
+1. Keep the extra traversal off the successful-solving hot path.
+1. Preserve concise diagnostic output and existing user-visible diagnostic coverage.
+
+## Phase status and dependencies
+
+- [ ] Phase 1: retain bound type-variable instances in constraint-set arenas.
+- [ ] Phase 2: replace optional constraint bounds with validity/evidence bounds.
+- [ ] Phase 3: reintroduce support-derived validity-domain construction.
+- [ ] Phase 4: preserve evidence-derived variance and add complete-solution pruning.
+- [ ] Phase 5: solve the domain-conjoined TDD and simplify default solving.
+
+Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
+revision, relevant documentation/tests, and a passing full test suite.
+
+### Phase 1: retain bound type-variable instances in constraint-set arenas
+
+Suggested revision description: `[π] Retain bound type-variable instances in constraint arenas`.
+
+1. Store `BoundTypeVarInstance` rather than only `BoundTypeVarIdentity` in builder-local and owned
+    type-variable arenas.
+1. Continue using bound identities for `typevar_cache`, support IDs, stable ordering, and
+    occurrence equality.
+1. Preserve the first instance for each identity; do not duplicate entries when eager/lazy
+    evaluation produces another instance for the same occurrence.
+1. Update compacted owned overlays, identity-cache initialization, `typevar_data`, loading, and
+    affected assertions without threading unnecessary APIs through unrelated interners.
+1. Add only the focused coverage needed for retained-instance lookup, identity deduplication, and
+    owned-set round trips.
+1. Run the full suite and verify that inference behavior is unchanged.
+
+### Phase 2: replace optional constraint bounds with validity/evidence bounds
+
+Suggested revision description: `[π] Distinguish constraint validity from inference evidence`.
+
+1. Introduce the `None`/`Validity(Type)`/`Evidence(Type)` bound enum and replace the two optional
+    sides of `ConstraintBounds`.
+1. Convert every existing relationship constraint to evidence bounds so current behavior remains
+    unchanged.
+1. Preserve explicit `Never` and `object`, optional public constructor inputs where practical,
+    logical-default materialization, support collection, source ordering, and type traversal.
+1. Update normalization, bound projection, intersection, sequent derivation, type-variable
+    reorientation, owned-set compaction/loading, and type mapping to preserve or combine per-side
+    provenance correctly. For comparable bounds on the same side, inherit the provenance of the
+    stronger restriction: the wider lower bound or narrower upper bound. Preserve the existing
+    implication relation for underlying types.
+1. Intern otherwise-identical validity and evidence bounds separately. Never add a
+    single-implication sequent across different provenance, including reverse implications derived
+    from intersections. Allow pair-implication sequents with mixed-provenance premises, preserving
+    the stronger bound's provenance for same-side intersections and deriving validity for
+    transitive bounds whenever any contributing premise is validity.
+1. Keep `ConstraintBound` helpers small and local; avoid mechanical renames or broad API rewrites
+    beyond the required representation change.
+1. Add narrow tests only for important bound/provenance invariants not already protected by
+    user-visible tests.
+1. Run the full suite and confirm that all-evidence constraints preserve existing inference.
+
+### Phase 3: reintroduce support-derived validity-domain construction
+
+Suggested revision description: `[π] Derive type-variable validity domains from TDD support`.
+
+1. Reintroduce only the narrow `valid_specializations`-style helper needed to create declared
+    validity restrictions.
+1. Encode declared upper bounds as validity upper bounds and declared constrained alternatives as
+    exact validity bounds on both sides.
+1. Preserve gradual declared bounds and constraints directly. In particular, encode an `Any`
+    constraint as exact validity `T = Any`, not `Never <= T <= object`; do not apply deferred
+    bottom/top materialization when accumulating effective path bounds. Remove stale documentation
+    claiming all constraint bounds must be fully static.
+1. Return `ALWAYS_TRUE` for unbounded variables and `P.args`/`P.kwargs`.
+1. Build the full domain by walking existing root support in stable builder-local order and
+    conjoining every relevant type variable's validity restrictions.
+1. Preserve source-order sidecars, owned-builder overlays, existing Boolean short-circuiting, and
+    the distinction between absent and explicit logical-default bounds.
+1. Keep the new domain inactive in ordinary solution extraction until Phase 5. Do not restore
+    deleted satisfaction APIs or deleted implementation-only mdtests.
+1. Add focused coverage for exact gradual alternatives and the representation needed by
+    user-visible bounded/constrained generic behavior.
+1. Run the full suite before marking the phase complete.
+
+### Phase 4: preserve evidence-derived variance and add complete-solution pruning
+
+Suggested revision description: `[π] Preserve evidence variance and compare complete solutions`.
+
+1. Propagate validity/evidence provenance through `ConstraintBoundsBuilder`, `PathBound`, and
+    factored `UpperBound` clauses so both `default_solve` and custom callbacks can inspect it.
+1. Accumulate lower bounds into separate evidence and validity unions rather than one
+    provenance-erasing union. Preserve provenance individually for factored upper-bound clauses.
+1. Preserve effective lower/upper restrictions while deriving variance and gradual/static
+    classification only from evidence.
+1. Update contextual inference, generic specialization, receiver handling, pattern narrowing,
+    diagnostic helpers, and other real `PathBound` consumers to use narrow provenance-aware
+    accessors.
+1. Preserve witnessed relationships between compatible constrained type variables. Prefer using
+    the new provenance-aware path bounds directly; introduce specialized relationship metadata only
+    if the representation proves insufficient.
+1. Ensure the ordinary visitor and `compute_simple_bound_conjunction` agree, including canonical
+    reorientation of constraints involving another type variable.
+1. Leave variables without positive evidence unsolved while preserving valid empty solution paths.
+1. Add variance to `TypeVarSolution` and update the small number of direct initializers.
+1. Implement the explicit whole-`Solution` pruning operation without changing solver callbacks or
+    automatically pruning raw solver results.
+1. Cover narrow versus broad preference, static versus gradual preference, declaration-order ties,
+    incomparable complete assignments, and correlated assignments where necessary.
+1. Delay behavior-changing consumer integration until Phase 5.
+1. Run the full suite before marking the phase complete.
+
+### Phase 5: solve the domain-conjoined TDD and simplify default solving
+
+Suggested revision description: `[π] Solve declared type-variable domains as constraint-set paths`.
+
+1. Conjoin the support-derived validity domain with the original root before path extraction in
+    both direct and Salsa-cached entry points.
+1. Preserve source ordering and keep simple concrete-bound conjunctions on the existing fast path
+    whenever possible.
+1. Produce separate valid paths for declared constrained alternatives and reject incompatible
+    declared specializations during domain-aware traversal.
+1. Simplify `PathBounds::default_solve` so it selects from effective path bounds without
+    inspecting `TypeVarBoundOrConstraints` or rebuilding declared alternatives independently.
+1. Preserve witnessed variance, gradual evidence, bounded lower/upper behavior, absent versus
+    explicit bounds, unsolved variables, and relationships between compatible type variables.
+1. Explicitly prune subsumed complete solutions in affected specialization consumers before they
+    combine bindings individually; leave raw internal solution APIs exhaustive.
+1. Recover declaration-specific diagnostics by inspecting unconjoined paths only after a
+    domain-aware solve fails.
+1. Do not apply domains before eager quantification or expand this project into the separate
+    quantifier-replacement workstream.
+1. Favor existing user-visible generic-function, contextual-inference, receiver, narrowing,
+    overload, correlation, ordering, and diagnostic tests. Change implementation-focused internal
+    expectations only when required.
+1. Remove superseded TODOs and obsolete declaration-handling code after replacement coverage
+    passes. Run the full suite, review snapshots and diffs, and run prek.
+
+## Focused regression coverage
+
+Prefer extending existing user-visible behavior sections:
+
+- `crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md`
+    - Exact constrained-TypeVar promotion.
+    - Static versus gradual declared alternatives, including arguments that match only the gradual
+        alternative.
+    - Narrowest lower-bound and broadest upper-bound-only preferences.
+    - Ambiguous gradual evidence.
+    - Bounded callable inference and concise mismatch diagnostics.
+    - Forwarding compatible constrained type variables while preserving their relationships.
+- `crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md` for corresponding
+    modern generic syntax.
+- `crates/ty_python_semantic/resources/mdtest/regression/2799_constraint_correlation.md` for
+    correlated generic-protocol solutions.
+- `crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md` for source
+    ordering, genuine alternatives, absent positive evidence, and stable results; update
+    implementation-specific expectations when necessary.
+- `crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md` for narrowly
+    relevant constraint invariants and missing versus explicit bounds, not as an excuse to lock in
+    incorrect implementation details.
+- `crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md` only to confirm
+    this change does not interfere with the separate eager-quantification workstream.
+- Existing sections of `crates/ty_python_semantic/resources/mdtest/call/function.md`,
+    `crates/ty_python_semantic/resources/mdtest/call/overloads.md`, and diagnostic files when
+    corresponding user-visible behavior changes.
+
+Run a focused mdtest, substituting its resource-relative path:
+
+```sh
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off \
+    INSTA_FORCE_PASS=1 INSTA_UPDATE=always \
+    CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 \
+    cargo nextest run -p ty_python_semantic --test mdtest \
+    -- mdtest::generics/legacy/functions.md
+```
+
+Run the crate suite while iterating:
+
+```sh
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off \
+    INSTA_FORCE_PASS=1 INSTA_UPDATE=always \
+    CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 \
+    cargo nextest run -p ty_python_semantic
+```
+
+Run the full suite at the end of each phase:
+
+```sh
+CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off \
+    INSTA_FORCE_PASS=1 INSTA_UPDATE=always \
+    CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 \
+    cargo nextest run
+```
+
+Use the documented `cargo test` fallback if needed. Never run multiple Cargo commands in parallel
+in the same workspace.
+
+After snapshot-generating tests:
+
+```sh
+find crates -name '*.pending-snap' -print
+jj diff --stat
+jj diff --git
+```
+
+Run prek from the Jujutsu workspace:
+
+```sh
+/home/dcreager/bin/jpk
+```
+
+## Risks and remaining open decisions
+
+- **Bound-side provenance merging:** comparable same-side bounds inherit the provenance of the
+    stronger restriction: the wider lower bound or narrower upper bound. Incomparable lower bounds
+    and upper bounds remain separate constraints. Path aggregation retains separate evidence and
+    validity lower unions and individually tagged upper clauses, preserving provenance for
+    `default_solve` and custom callbacks.
+- **Provenance-sensitive sequents:** evidence and validity constraints are separate interned
+    propositions. Never add single-implication sequents across provenance, regardless of the
+    underlying bounds' relative strength, including reverse implications from simplified
+    intersections. Pair-implication sequents can combine mixed-provenance premises: same-side
+    intersections inherit the stronger restriction's provenance, while transitive derivations
+    produce evidence only when all contributing premises are evidence.
+- **Logical identity versus provenance:** provenance-aware bounds can cause otherwise identical
+    ranges to intern separately. Logical implication, sequent equivalence, source order, and TDD
+    size must remain correct; avoid assuming provenance tags change the actual set of legal
+    specializations.
+- **Derived constraints:** bound provenance must survive transitive, nested, canonicalized, and
+    intersected sequents without converting declaration-only restrictions into spurious evidence.
+    Start conservatively: transitive derivations with any validity premise produce validity, while
+    all-evidence derivations produce evidence.
+- **Compatible TypeVars:** conjoining `T`'s declared finite domain with witnessed `T = S`
+    currently turns `T = S` into concrete `T = int`/`T = str` alternatives. Preserve the symbolic
+    relationship for compatible constrained variables, including compatible subsets and callbacks
+    with redundant bounds, while rejecting incompatible or merely overlapping domains. The
+    user-visible behavior is required; a dedicated `PathBound` field is not prescribed.
+- **Gradual alternatives:** store declared gradual alternatives directly as exact validity
+    constraints, without bottom/top materialization. Preserve existing user-visible behavior for
+    `Any`/`int` and `list[Any]`/`list[int]`, including static preference when both match. Known
+    issues in the underlying gradual constraint-implication relation are out of scope and must
+    not be fixed as part of this refactor.
+- **Arena overlays:** retain full type-variable instances while continuing to intern by identity
+    and avoiding unstable Salsa-ID-based ordering or unnecessary `db` parameter churn.
+- **Fast-path performance:** preserve `compute_simple_bound_conjunction` and its no-sequent-cache
+    guarantees. Watch the existing `ty_micro[pydantic_core_schema_dict]` scenario.
+- **Empty evidence paths:** negated alternatives and unrelated disjuncts can legitimately produce
+    empty complete solutions; validity bounds alone must not manufacture inferred bindings.
+- **Variance direction:** lower-only evidence maps to `Contravariant`; upper-only evidence maps to
+    `Covariant`. Preserve the existing narrower/broader solution preferences.
+- **Complete-solution correlations:** only compare assignments differing in one constrained
+    variable; do not create independently combined assignments or prune raw solver output.
+- **Diagnostics:** invalid paths may disappear before callbacks run; reconstruct specific
+    declaration errors only on the diagnostic failure path.
+- **Ordering:** merge source-order sidecars consistently and retain declaration-order tie breaks
+    without depending on Salsa IDs or arbitrary TDD variable ordering.
+- **Quantification:** domains are applied at solution extraction only. Do not expand the scope to
+    eager quantifiers being replaced elsewhere.

--- a/PLAN.md
+++ b/PLAN.md
@@ -186,15 +186,18 @@ Replace each `Option<Type>` inside `ConstraintBounds` with a provenance-aware en
 
 ```rust
 enum ConstraintBound<'db> {
-    None,
     Validity(Type<'db>),
     Evidence(Type<'db>),
 }
 ```
 
-`None` remains a genuinely absent bound. `Validity` restricts which specializations are legal;
-`Evidence` additionally represents an inference preference supplied by the original relationship.
-Record the distinction independently for the lower and upper sides:
+`Validity` restricts which specializations are legal; `Evidence` additionally represents an
+inference preference supplied by the original relationship. A missing lower bound is represented as
+`Validity(Never)`, and a missing upper bound as `Validity(object)`. This preserves the important
+distinction from explicitly inferred logical defaults, which are represented as `Evidence(Never)`
+or `Evidence(object)`. Existing behavior for absent bounds therefore validates the same
+validity/evidence combination rules used for nontrivial declaration restrictions. Record the
+distinction independently for the lower and upper sides:
 
 ```text
 argument evidence: Evidence(bool) <= T
@@ -226,9 +229,10 @@ T <= Evidence(bool)  and  T <= Validity(int)  =>  T <= Evidence(bool)
 ```
 
 This prevents a weaker evidence bound from relabeling a stronger declaration-imposed restriction
-as evidence. Incomparable same-side bounds do not require a merged provenance rule: upper-bound
-intersections and lower-bound unions are represented as separate constraints, preserving each
-bound's original `Validity` or `Evidence` tag independently.
+as evidence. When both restrictions are equivalent, prefer evidence: it retains the restriction
+while also preserving the inference information. Incomparable same-side bounds do not require a
+merged provenance rule: upper-bound intersections and lower-bound unions are represented as
+separate constraints, preserving each bound's original `Validity` or `Evidence` tag independently.
 
 Preserve provenance through bound normalization, type-variable reorientation, intersection,
 sequent derivation, type mapping, owned-set compaction/loading, and path extraction. Validity and
@@ -247,11 +251,14 @@ Propagate provenance through accumulated `PathBound` values and factored `UpperB
 inspect validity versus evidence directly. Do not erase provenance merely to preserve the existing
 `PathBound` field types.
 
-Provide narrow helpers or constructors so callers can extract effective types, inspect provenance,
-check presence, materialize logical defaults, and construct ordinary evidence bounds without
-unnecessary API churn. Keep existing external constructors accepting `Option<Type>` where
-practical, converting those inputs to evidence internally; update actual `PathBound` consumers as
-needed.
+Provide narrow helpers or constructors so callers can extract underlying types, inspect
+provenance, and construct ordinary evidence bounds. Process both bounds directly: logical-default
+validity bounds behave as mathematical identities rather than as a hidden optional-bound variant.
+Update existing constructors and callers to use provenance-aware bounds directly, and update
+actual `PathBound` consumers as needed. The internal `ty_extensions` testing API should offer
+`ConstraintSet.lower_bound(lower, typevar)` and `ConstraintSet.upper_bound(typevar, upper)` for
+one-sided evidence; `ConstraintSet.range(lower, typevar, upper)` continues to record explicit
+evidence on both sides, including `Never` and `object`.
 
 Do not add witness flags to `InteriorNodeData`, propagate booleans through `PathAssignments`, or
 introduce separate witness-specific fuel accounting. Bound-side provenance supersedes that earlier
@@ -350,7 +357,7 @@ expanding `Solutions`:
 ## Phase status and dependencies
 
 - [x] Phase 1: retain bound type-variable instances in constraint-set arenas.
-- [ ] Phase 2: replace optional constraint bounds with validity/evidence bounds.
+- [x] Phase 2: replace optional constraint bounds with validity/evidence bounds.
 - [ ] Phase 3: reintroduce support-derived validity-domain construction.
 - [ ] Phase 4: preserve evidence-derived variance and add complete-solution pruning.
 - [ ] Phase 5: solve the domain-conjoined TDD and simplify default solving.
@@ -378,12 +385,13 @@ Suggested revision description: `[π] Retain bound type-variable instances in co
 
 Suggested revision description: `[π] Distinguish constraint validity from inference evidence`.
 
-1. Introduce the `None`/`Validity(Type)`/`Evidence(Type)` bound enum and replace the two optional
-    sides of `ConstraintBounds`.
+1. Introduce the `Validity(Type)`/`Evidence(Type)` bound enum and replace the two optional sides
+    of `ConstraintBounds`. Represent missing lower and upper bounds as `Validity(Never)` and
+    `Validity(object)`, respectively.
 1. Convert every existing relationship constraint to evidence bounds so current behavior remains
     unchanged.
-1. Preserve explicit `Never` and `object`, optional public constructor inputs where practical,
-    logical-default materialization, support collection, source ordering, and type traversal.
+1. Preserve explicit `Evidence(Never)` and `Evidence(object)`, logical-default materialization,
+    support collection, source ordering, and type traversal.
 1. Update normalization, bound projection, intersection, sequent derivation, type-variable
     reorientation, owned-set compaction/loading, and type mapping to preserve or combine per-side
     provenance correctly. For comparable bounds on the same side, inherit the provenance of the

--- a/PLAN.md
+++ b/PLAN.md
@@ -358,7 +358,7 @@ expanding `Solutions`:
 
 - [x] Phase 1: retain bound type-variable instances in constraint-set arenas.
 - [x] Phase 2: replace optional constraint bounds with validity/evidence bounds.
-- [ ] Phase 3: reintroduce support-derived validity-domain construction.
+- [x] Phase 3: reintroduce support-derived validity-domain construction.
 - [ ] Phase 4: preserve evidence-derived variance and add complete-solution pruning.
 - [ ] Phase 5: solve the domain-conjoined TDD and simplify default solving.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -339,8 +339,11 @@ first determine what the new provenance-aware lower/upper bounds already make po
 fully static bounds are supported. In the static-sequent phase, concrete endpoint containment,
 overlap, contradiction, and pivot proofs must require structurally static endpoints and use
 constraint-set subtyping rather than assignability. Solver TypeVars are opaque symbolic atoms for
-this eligibility check. Use an owned Salsa-tracked relation where cycle recovery is required, and
-validate and skip derived candidates that settle as unsatisfiable after a coinductive cycle.
+this eligibility check. Where recursive cycle handling is required, reuse the existing Salsa-tracked
+owned assignability relation: structural eligibility makes it equivalent to subtyping for concrete
+endpoints while still allowing symbolic TypeVars to carry an existing gradual witness. Preserve the
+single-range constructor invariant that its derived relation is satisfiable rather than treating a
+settled-unsatisfiable range as an expected candidate to skip.
 
 Structurally universal TypeVar rules may still carry an existing gradual witness through a
 relationship. Keep the existing dedicated same-TypeVar, different-TypeVar, and nested-TypeVar
@@ -432,7 +435,7 @@ expanding `Solutions`:
 - [x] Phase 4: preserve evidence-derived variance and add complete-path pruning.
 - [x] Static-sequent integration phase: restrict concrete sequents and characterize temporary
     regressions in a non-mergeable intermediate revision. Change `kqntvqkmuuqp`, commit
-    `f5d21fd5194b720803865f6160fbbb430b0c4eb2`.
+    `148c3d7cf8cbcce6bdab30fb5b77bd6926b8c42d`.
 - [ ] Phase 5: activate the domain-conjoined TDD, simplify default solving, and restore every
     temporary static-phase regression.
 
@@ -555,12 +558,14 @@ This revision is an implementation checkpoint, not a landable tip.
     sequent closure. Define structural sequent eligibility locally in `constraints.rs`, treating
     solver TypeVars as opaque and rejecting actual dynamic concrete components.
 1. Apply the gate per participating endpoint to concrete implication, overlap/intersection, pair
-    impossibility, contradiction, and pivot proofs. Use constraint-set subtyping for eligible
-    concrete proofs and an owned Salsa-tracked query for recursive cycle handling.
+    impossibility, contradiction, and pivot proofs. Use constraint-set subtyping for ordinary
+    eligible concrete proofs. Where recursive cycle handling is required, reuse the existing
+    Salsa-tracked owned assignability query; structural eligibility makes it equivalent to
+    subtyping for concrete endpoints without starting an inconsistent second coinductive query.
 1. Audit symbolic and derived sequent constructors. Preserve structurally universal propagation of
     an existing gradual witness, but prevent gradual concrete pivots or unrelated TDD branches from
-    manufacturing evidence. Validate provisionally discovered coinductive candidates and skip
-    those that settle as unsatisfiable.
+    manufacturing evidence. Preserve the single-range constructor invariant that its derived
+    relation is satisfiable rather than silently accepting or skipping an invalid range.
 1. Keep support-derived validity domains and behavior-changing pruning consumers inactive. Do not
     compensate in TDD abstraction or solution combination.
 1. Run focused generic-function, constraint-algebra, and ordering tests. For each changed behavior,

--- a/PLAN.md
+++ b/PLAN.md
@@ -22,8 +22,9 @@ Minimal diff churn is an explicit requirement:
     static-sequent phase before Phase 5 owns the narrower logical correction: concrete proofs must
     use fully static bounds and subtyping, while structurally valid symbolic rules may propagate an
     existing gradual witness. Phase 5 then activates domains and replaces legacy declaration-aware
-    solving; a potential Phase 6 restores accepted compatibility regressions. Do not choose a
-    relation based on validity/evidence provenance.
+    solving. Phase 6 first recovers universally valid bare-TypeVar symbolic solutions without
+    changing the typing relation; later phases restore or classify the remaining compatibility
+    regressions. Do not choose a relation based on validity/evidence provenance.
 
 ## Workflow and handoff requirements
 
@@ -53,8 +54,9 @@ regressions were expected. Phase 5 may also retain explicitly characterized beha
 behind adjacent `XXX` expectations, but it must complete the structural migration: declared domains
 supply the legal paths, pruning compares those paths, and `PathBounds::default_solve` must no longer
 re-read declarations or reconstruct their alternatives. Both revisions must pass the full suite,
-clippy, and prek. A potential Phase 6 may restore or explicitly resolve the accepted compatibility
-and performance debt before selecting a landing tip.
+clippy, and prek. Phase 6 restores the first approved relationship regression. Potential Phase 7
+and later work must restore or explicitly resolve the remaining compatibility and performance debt
+before selecting a landing tip.
 
 Use `jj` for source control and inspect changes with `jj diff --git` or `jj diff --stat`. Run prek
 in this Jujutsu workspace through `/home/dcreager/bin/jpk`. Never modify snapshot files or inline
@@ -67,8 +69,9 @@ Fully static sequent handling and domain activation remain one merge unit, but t
 as test-clean project revisions. The static revision establishes the sound logical boundary and
 records temporary compatibility regressions. The Phase 5 activation checkpoint activates domains
 and records the still-observed behavior as passing `XXX` expectations. Phase 5 remains incomplete
-until structural path-only solving replaces the legacy declaration-aware solver; a potential Phase
-6 may then remove the accepted behavioral debt before the stack can land.
+until structural path-only solving replaces the legacy declaration-aware solver. Phase 6 then
+recovers universally valid bare-TypeVar symbolic solutions; later phases must remove the remaining
+accepted behavioral debt before the stack can land.
 
 Investigation established this split:
 
@@ -84,8 +87,8 @@ Investigation established this split:
     must assert this invariant rather than accepting or skipping an invalid path.
 - Removing gradual closure exposes independent alternative solutions. In particular, unbounded
     `Container[T]` inference selects `object` rather than preserving `Any`. The static phase records
-    that intermediate result with an `XXX`; this accepted behavioral regression may be restored in
-    a potential Phase 6 because declared-domain pruning alone cannot repair an unbounded variable.
+    that intermediate result with an `XXX`; this accepted behavioral regression remains later
+    compatibility work because declared-domain pruning alone cannot repair an unbounded variable.
 
 Do not revive either rejected workaround from the standalone prototype: selectively retaining TDD
 uncertain branches during abstraction, or locally unioning gradual solutions in `generics.rs`.
@@ -107,9 +110,10 @@ The implementation and landing order is:
 1. the full-suite-clean Phase 5 domain-activation checkpoint, including enforcement of the
     validity-equality invariant;
 1. Phase 5 structural completion, replacing legacy declaration-aware default solving while keeping
-    intended Phase 6 results as adjacent xfail TODOs;
-1. potential Phase 6 compatibility restoration and performance work, which produces the first
-    landable tip;
+    intended later results as adjacent xfail TODOs;
+1. Phase 6 recovery of universally valid bare-TypeVar symbolic solutions;
+1. potential Phase 7 and later compatibility restoration and performance work, which produces the
+    first landable tip;
 1. `dcreager/remove-remove-noninferable-2`.
 
 ## Current baseline
@@ -462,14 +466,18 @@ expanding `Solutions`:
     with adjacent TODO/XXX comments stating the intended behavior. Change
     `smrkruyysnpoyswkpypttlpowomwsmrs`, commit
     `72cbd05ee9b3124bca1b796ac5f41099e975f1b5`.
-- [ ] Potential Phase 6: restore relationship preservation and the remaining recorded compatibility
-    and performance regressions, then select a landable tip.
+- [ ] Phase 6: recover universally valid bare-TypeVar symbolic solutions such as `T := S` from the
+    complete domain-conjoined path family, using the existing `inferable` set as the authoritative
+    quantifier partition and a mapped-TDD universal verification.
+- [ ] Potential Phase 7 and later: support structured symbolic candidates such as `T := list[S]`,
+    restore or classify the remaining compatibility regressions, resolve the recorded performance
+    debt, and select a landable tip.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
 revision, relevant documentation/tests, and a passing full test suite. The earlier abandoned Phase 5
 prototype and standalone fully-static revisions are diagnostic evidence only; do not revive
-`pvynqtrq` or copy its rejected workarounds. Potential Phase 6 work starts from the completed Phase 5
-structural-solving revision recorded above.
+`pvynqtrq` or copy its rejected workarounds. Phase 6 starts from the completed Phase 5
+structural-solving revision recorded above and the subsequent approved plan-only revisions.
 
 The rewritten activation checkpoint and structural-completion revision each pass all 820
 `ty_python_semantic` tests, all 8,913 workspace tests, workspace clippy, snapshot review, and prek.
@@ -485,8 +493,8 @@ clippy, and prek. It records seven `XXX: Phase 5` markers covering gradual range
 wobble audit found that every non-normal mode already failed on the pre-static Phase 4 baseline. The
 static phase adds one temporary mask-4 mismatch for the mutable `TypedDict` case: normal ordering
 now reports the characterized `object` regression while mask 4 already retains the final `int`
-behavior. A potential Phase 6 must restore the correlation and make those outcomes converge; do not
-update a wobble expectation to preserve the intermediate diagnostic.
+behavior. A later compatibility phase must restore the correlation and make those outcomes
+converge; do not update a wobble expectation to preserve the intermediate diagnostic.
 
 The Phase 5 structural completion removes the declaration lookup and declared-alternative selection
 from `PathBounds::default_solve`. It validates the effective path interval, selects an exact validity
@@ -611,7 +619,7 @@ This revision is an implementation checkpoint, not a landable tip.
     compensate in TDD abstraction or solution combination.
 1. Run focused generic-function, constraint-algebra, and ordering tests. For each changed behavior,
     assert the observed intermediate result and add an adjacent `XXX` that states the final behavior
-    the activation checkpoint or potential Phase 6 must restore or classify. Do not disable tests, weaken
+    the activation checkpoint or later phases must restore or classify. Do not disable tests, weaken
     unrelated assertions, or accept panics as temporary behavior.
 1. Run `ty_python_semantic`, the full suite, clippy, snapshot review, and prek. Record the project
     change and commit IDs as a non-mergeable intermediate checkpoint.
@@ -639,8 +647,9 @@ The activation checkpoint:
 - Retains the legacy declaration lookup in `PathBounds::default_solve`; removing that lookup and
     solving structurally from path bounds is the remaining Phase 5 work.
 - Accepts, for now, concrete alternative unions such as `int | str` and `Left | Right` where a bare
-    evidence relationship such as `T := S` should survive. Relationship restoration and
-    ambiguous-`Any` behavior are potential Phase 6 work, not reasons to retain the legacy solver.
+    evidence relationship such as `T := S` should survive. Bare-TypeVar relationship restoration is
+    Phase 6 work; ambiguous-`Any` behavior remains later work and is not a reason to retain the
+    legacy solver.
 - Records all observed mdtest changes with adjacent TODO/XXX xfail comments stating the intended
     behavior, including gradual inference, inherited generic constructors, cycles, recursive
     protocols, quantification, and mutable mapping/TypedDict behavior.
@@ -678,7 +687,7 @@ Phase 5 completion checklist:
 - [x] Preserve evidence-derived variance, effective lower/upper restrictions, absent versus explicit
     bounds, and unsolved variables structurally. Compatible TypeVar relationships, constrained
     `Any`/`int`, `list[Any]`/`list[int]`, ambiguous gradual evidence, and unbounded `Container[T]`
-    may remain as explicitly characterized Phase 6 regressions.
+    may remain as explicitly characterized later regressions.
 - [x] Explicitly prune subsumed complete paths in affected specialization consumers before
     extracting solutions and combining bindings independently; leave raw internal solution APIs
     exhaustive.
@@ -686,13 +695,105 @@ Phase 5 completion checklist:
     solve fails. Do not apply domains before eager quantification or expand this work into the
     separate quantifier-replacement workstream.
 - [x] Keep accepted temporary constraint-algebra and user-visible changes covered by adjacent
-    `XXX` expectations; final classification and restoration may occur in Phase 6.
+    `XXX` expectations; final classification and restoration may occur in later phases.
 - [x] Leave the cache-growth, path-fuel, determinism, and
-    `ty_micro[pydantic_core_schema_dict]` performance audit for Phase 6 unless structural solving
+    `ty_micro[pydantic_core_schema_dict]` performance audit for later work unless structural solving
     introduces a new regression beyond the activation checkpoint.
 - [x] Remove superseded TODOs and obsolete declaration-handling code after replacement coverage
     passes. Run focused tests, `ty_python_semantic`, the full suite, clippy, snapshot review, and
     prek before marking Phase 5 complete.
+
+### Phase 6: recover universally valid bare-TypeVar symbolic solutions
+
+Suggested revision description: `[π] Recover universally valid symbolic TypeVar solutions`.
+
+This phase restores the first compatible-TypeVar regression at
+`crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md`, including the redundant
+callback-bound variants. The domain-conjoined TDD currently produces separate paths such as
+`(S = int, T = int)` and `(S = str, T = str)`. These paths prove that the symbolic solution
+`T := S` works for every valid specialization of non-inferable `S`; solving each path independently
+instead produces the incorrect union `int | str`.
+
+Use the `inferable` parameter already passed to `PathBounds::compute` as the sole authoritative
+partition between existential solution variables and universally checked non-inferable variables.
+Do not reconstruct that partition from `GenericContext`, path contents, support, or any other
+source. For this example the required check is:
+
+```text
+for every S in D(S), there exists T in D(T) such that C(T, S)
+```
+
+The candidate `T := S` is valid when the stronger condition holds:
+
+```text
+D(non-inferable) implies C[T := S]
+```
+
+Here `C` is the same projected, domain-conjoined constraint-set node used for path extraction, and
+`D(non-inferable)` is the validity domain constructed only for type variables not present in the
+existing `inferable` set. Obtain declared bounds and constraint lists through the existing cached
+`BoundTypeVarInstance::bound_or_constraints` accessor used by validity-domain construction; do not
+introduce or retain a duplicate domain descriptor.
+
+Phase 6 implementation requirements:
+
+1. Discover at most one bare-TypeVar symbolic candidate for each inferable type variable from pure
+    `Evidence` retained in the complete path family. A candidate may come from an exact pure lower
+    bound or the single effective pure upper evidence bound. Do not treat branch-specific `Mixed`
+    derivations or `Validity` bounds as candidate evidence.
+1. Restrict this phase to candidates `T := S` where `T` is inferable according to the supplied set,
+    `S` is non-inferable, and substituting the candidate leaves no other inferable variable that
+    would require a new existential abstraction. Decline ambiguous or competing candidates and use
+    ordinary path-local solving.
+1. Verify each unique candidate once at the TDD level, not once per concrete domain path. Apply the
+    existing constraint-set type-mapping operation to the domain-conjoined node with `T` mapped to
+    `S`, then prove that the difference between `D(non-inferable)` and the mapped node is
+    unsatisfiable. This verifies the target validity domain and all other evidence, including
+    redundant `object`, union, and nominal callback bounds. It also rejects incompatible domains
+    such as `(int, bytes)` versus `(int, str)` and merely assignable constraints such as `bool`
+    versus `int`.
+1. Keep the original concrete paths. Do not synthesize a replacement path or add a general
+    correlated-solution representation. Record the successfully verified candidate once as a
+    compact family-level symbolic default associated with the computed `PathBounds`.
+1. During solution extraction, let an explicit caller choice take precedence, then use the verified
+    symbolic default for inferable `T`, and otherwise call path-local `default_solve`. Emitting the
+    same `T := S` binding for each retained concrete path may rely on existing solution combination
+    to deduplicate it. Non-inferable path bounds remain proof context and must not become solution
+    targets.
+1. Preserve raw paths for pruning, diagnostics, and other inferable variables. Perform candidate
+    discovery and verification before pruning can discard paths needed to explain the universal
+    result.
+1. Do not add a general quantifier implementation in this phase. The general check with additional
+    inferable variables would require existentially abstracting those variables after substitution;
+    leave that to the separate quantifier workstream.
+1. Keep symbolic defaults capable of storing a `Type`, but accept only a bare `TypeVar` candidate in
+    this phase. A potential Phase 7 may support structured candidates such as `T := list[S]`; mapping
+    a TypeVar subject to a structured type can create substantially more relation constraints and
+    must be designed and measured separately.
+1. Add a TODO at the family-level recovery explaining that quantifier-aware TDD solution extraction
+    should eventually preserve `T := S` before materializing one path per specialization of `S`, at
+    which point this post-extraction recovery can be removed.
+1. Limit verification to one mapped BDD per unique candidate, reuse the existing node and constraint
+    interning, and inspect TDD/node growth. Candidate mapping visits the source DAG rather than each
+    root-to-terminal path, but it remains a performance risk. Run the existing
+    `ty_micro[pydantic_core_schema_dict]` benchmark and the focused Pydantic ecosystem comparison if
+    the mapped verification affects those paths.
+1. Restore the intended assertions for equal constrained domains, compatible source subsets, and
+    redundant `object`, union, and nominal callback bounds in both legacy and PEP 695 syntax. Keep
+    focused negative coverage for incompatible domains and strict-subtype constraints.
+1. Run focused mdtests after each small step. If mapped candidate verification unexpectedly changes
+    another result, causes material TDD growth, or requires general existential handling, stop and
+    report the evidence and alternatives before broadening the phase.
+1. Run `ty_python_semantic`, the full workspace suite, clippy, snapshot review, and prek before
+    marking Phase 6 complete. Record the implementation change and commit IDs in this plan in a
+    separate plan-only revision.
+
+The family-level symbolic default is deliberately narrower than a general witness or correlated
+solution representation. Do not move declaration-aware alternative selection back into
+`PathBounds::default_solve`, reconstruct inferability from `GenericContext`, union gradual solutions
+locally, or revive the rejected TDD-abstraction workarounds. The old `default_solve` implementation
+is useful only as evidence that a pure TypeVar relationship should be preferred after the new
+universal check proves it valid.
 
 ## Focused regression coverage
 
@@ -790,15 +891,21 @@ Run prek from the Jujutsu workspace:
     evidence only when every indispensable premise is evidence; any validity or mixed premise
     produces `Mixed`. Pure `Validity` is reserved for direct declaration-domain constraints.
 - **Compatible TypeVars:** conjoining `T`'s declared finite domain with witnessed `T = S`
-    currently turns `T = S` into concrete `T = int`/`T = str` alternatives. A potential Phase 6
-    must preserve the symbolic relationship for compatible constrained variables, including
-    compatible subsets and callbacks with redundant bounds, while rejecting incompatible or merely
-    overlapping domains. A dedicated `PathBound` field is not prescribed.
+    currently turns `T = S` into concrete `T = int`/`T = str` alternatives. Phase 6 recovers the
+    symbolic relationship only after mapping `T` to non-inferable `S` in the complete
+    domain-conjoined TDD and proving the mapped node for all of `D(non-inferable)`. This must support
+    compatible subsets and callbacks with redundant bounds while rejecting incompatible or merely
+    assignable domains. Keep the conclusion at path-family scope; no individual concrete path proves
+    it and a dedicated per-`PathBound` witness field is not prescribed.
+- **Mapped-candidate TDD growth:** candidate verification rebuilds the domain-conjoined DAG under a
+    type mapping once per unique candidate. Bare-TypeVar substitution should keep subjects symbolic,
+    but node growth, sequent discovery, and cache retention must be measured. Decline multiple or
+    ambiguous candidates rather than multiplying verification work.
 - **Gradual alternatives and sequents:** store declared gradual alternatives directly as exact
     validity constraints, without bottom/top materialization. The static-sequent phase prevents
-    non-transitive gradual assignability from collapsing paths; a potential Phase 6 must restore
-    existing `Any`/`int` and `list[Any]`/`list[int]` behavior. Do not reinterpret provenance as a
-    typing relation or add equality-specific sequent behavior.
+    non-transitive gradual assignability from collapsing paths; a later compatibility phase must
+    restore existing `Any`/`int` and `list[Any]`/`list[int]` behavior. Do not reinterpret provenance
+    as a typing relation or add equality-specific sequent behavior.
 - **Arena overlays:** retain full type-variable instances while continuing to intern by identity
     and avoiding unstable Salsa-ID-based ordering or unnecessary `db` parameter churn.
 - **Fast-path performance:** preserve `compute_simple_bound_conjunction` and its no-sequent-cache
@@ -814,5 +921,8 @@ Run prek from the Jujutsu workspace:
     declaration errors only on the diagnostic failure path.
 - **Ordering:** merge source-order sidecars consistently and retain declaration-order tie breaks
     without depending on Salsa IDs or arbitrary TDD variable ordering.
-- **Quantification:** domains are applied at solution extraction only. Do not expand the scope to
-    eager quantifiers being replaced elsewhere.
+- **Quantification:** Phase 6 uses the existing `inferable` set as its quantifier partition and
+    proves only candidates that require no remaining existential abstraction after substitution.
+    Do not reconstruct inferability from another source or expand the phase into the eager
+    quantifiers being replaced elsewhere. Future quantifier-aware extraction should subsume the
+    narrow family-level symbolic-default recovery.

--- a/PLAN.md
+++ b/PLAN.md
@@ -22,9 +22,10 @@ Minimal diff churn is an explicit requirement:
     static-sequent phase before Phase 5 owns the narrower logical correction: concrete proofs must
     use fully static bounds and subtyping, while structurally valid symbolic rules may propagate an
     existing gradual witness. Phase 5 then activates domains and replaces legacy declaration-aware
-    solving. Phase 6 first recovers universally valid bare-TypeVar symbolic solutions without
-    changing the typing relation; later phases restore or classify the remaining compatibility
-    regressions. Do not choose a relation based on validity/evidence provenance.
+    solving. Phase 6A first fixes cross-provenance contradiction handling, and Phase 6B then
+    recovers one universally valid bare-TypeVar symbolic solution without changing the typing
+    relation; later phases restore or classify the remaining compatibility regressions. Do not
+    choose a relation based on validity/evidence provenance.
 
 ## Workflow and handoff requirements
 
@@ -54,9 +55,9 @@ regressions were expected. Phase 5 may also retain explicitly characterized beha
 behind adjacent `XXX` expectations, but it must complete the structural migration: declared domains
 supply the legal paths, pruning compares those paths, and `PathBounds::default_solve` must no longer
 re-read declarations or reconstruct their alternatives. Both revisions must pass the full suite,
-clippy, and prek. Phase 6 restores the first approved relationship regression. Potential Phase 7
-and later work must restore or explicitly resolve the remaining compatibility and performance debt
-before selecting a landing tip.
+clippy, and prek. Phase 6A fixes the prerequisite sequent invariant, and Phase 6B restores the first
+approved relationship regression. Potential Phase 7 and later work must restore or explicitly
+resolve the remaining compatibility and performance debt before selecting a landing tip.
 
 Use `jj` for source control and inspect changes with `jj diff --git` or `jj diff --stat`. Run prek
 in this Jujutsu workspace through `/home/dcreager/bin/jpk`. Never modify snapshot files or inline
@@ -69,9 +70,10 @@ Fully static sequent handling and domain activation remain one merge unit, but t
 as test-clean project revisions. The static revision establishes the sound logical boundary and
 records temporary compatibility regressions. The Phase 5 activation checkpoint activates domains
 and records the still-observed behavior as passing `XXX` expectations. Phase 5 remains incomplete
-until structural path-only solving replaces the legacy declaration-aware solver. Phase 6 then
-recovers universally valid bare-TypeVar symbolic solutions; later phases must remove the remaining
-accepted behavioral debt before the stack can land.
+until structural path-only solving replaces the legacy declaration-aware solver. Phase 6A then
+fixes cross-provenance contradictions, and Phase 6B recovers one universally valid bare-TypeVar
+symbolic solution; later phases must remove the remaining accepted behavioral debt before the stack
+can land.
 
 Investigation established this split:
 
@@ -111,7 +113,9 @@ The implementation and landing order is:
     validity-equality invariant;
 1. Phase 5 structural completion, replacing legacy declaration-aware default solving while keeping
     intended later results as adjacent xfail TODOs;
-1. Phase 6 recovery of universally valid bare-TypeVar symbolic solutions;
+1. Phase 6A cross-provenance contradiction handling, without cross-provenance evidence
+    propagation;
+1. Phase 6B recovery of universally valid bare-TypeVar symbolic solutions;
 1. potential Phase 7 and later compatibility restoration and performance work, which produces the
     first landable tip;
 1. `dcreager/remove-remove-noninferable-2`.
@@ -466,18 +470,28 @@ expanding `Solutions`:
     with adjacent TODO/XXX comments stating the intended behavior. Change
     `smrkruyysnpoyswkpypttlpowomwsmrs`, commit
     `72cbd05ee9b3124bca1b796ac5f41099e975f1b5`.
-- [ ] Phase 6: recover universally valid bare-TypeVar symbolic solutions such as `T := S` from the
-    complete domain-conjoined path family, using the existing `inferable` set as the authoritative
-    quantifier partition and a mapped-TDD universal verification.
-- [ ] Potential Phase 7 and later: support structured symbolic candidates such as `T := list[S]`,
-    restore or classify the remaining compatibility regressions, resolve the recorded performance
-    debt, and select a landable tip.
+- [ ] Phase 6A: make logically contradictory positive/negative assignments impossible across bound
+    provenance without allowing validity restrictions to manufacture positive inference evidence.
+- [ ] Phase 6B: recover one universally valid bare-TypeVar symbolic solution such as `T := S` from
+    the complete domain-conjoined path family, using the existing `inferable` set as the
+    authoritative partition and a mapped-TDD implication check.
+- [ ] Potential Phase 7 and later: support structured or multiple symbolic candidates such as
+    `T := list[S]`, restore or classify the remaining compatibility regressions, resolve the
+    recorded performance debt, and select a landable tip.
+
+Phase 6 design grilling is complete, and the Phase 6A and Phase 6B requirements below are the
+approved implementation ground truth. In particular, the contradiction-only sequent remains limited
+to provenance-suppressed implications; `PathBounds::Constrained` owns `paths` and the single
+optional symbolic default; and no caller-accessible path-local default solver remains. Custom
+chooser fallback receives immutable family context because pruning is complete before read-only
+solution selection. Do not begin implementation without explicit authorization.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
 revision, relevant documentation/tests, and a passing full test suite. The earlier abandoned Phase 5
 prototype and standalone fully-static revisions are diagnostic evidence only; do not revive
-`pvynqtrq` or copy its rejected workarounds. Phase 6 starts from the completed Phase 5
-structural-solving revision recorded above and the subsequent approved plan-only revisions.
+`pvynqtrq` or copy its rejected workarounds. Phase 6A starts from the completed Phase 5
+structural-solving revision recorded above and the subsequent approved plan-only revisions;
+Phase 6B starts only after Phase 6A and its full validation are complete.
 
 The rewritten activation checkpoint and structural-completion revision each pass all 820
 `ty_python_semantic` tests, all 8,913 workspace tests, workspace clippy, snapshot review, and prek.
@@ -648,7 +662,7 @@ The activation checkpoint:
     solving structurally from path bounds is the remaining Phase 5 work.
 - Accepts, for now, concrete alternative unions such as `int | str` and `Left | Right` where a bare
     evidence relationship such as `T := S` should survive. Bare-TypeVar relationship restoration is
-    Phase 6 work; ambiguous-`Any` behavior remains later work and is not a reason to retain the
+    Phase 6B work; ambiguous-`Any` behavior remains later work and is not a reason to retain the
     legacy solver.
 - Records all observed mdtest changes with adjacent TODO/XXX xfail comments stating the intended
     behavior, including gradual inference, inherited generic constructors, cycles, recursive
@@ -703,97 +717,144 @@ Phase 5 completion checklist:
     passes. Run focused tests, `ty_python_semantic`, the full suite, clippy, snapshot review, and
     prek before marking Phase 5 complete.
 
-### Phase 6: recover universally valid bare-TypeVar symbolic solutions
+### Phase 6A: preserve cross-provenance contradictions
 
-Suggested revision description: `[π] Recover universally valid symbolic TypeVar solutions`.
+Suggested revision description: `[π] Preserve contradictions across bound provenance`.
+
+This prerequisite fixes a logical bug exposed by the Phase 6B candidate proof. Provenance controls
+whether a positive restriction may be propagated as inference evidence, but it must not make a
+logically contradictory positive/negative assignment possible. For underlying constraints `C` and
+`D` where `C` implies `D`, a path containing `C` and `not D` is impossible even when the bounds use
+different `Validity`, `Evidence`, or `Mixed` provenance.
+
+`ConstraintId::implies` already compares underlying ranges independently of provenance. The current
+`add_single_implication` suppression conflates two effects of `SingleImplication`: propagating a
+positive consequent and rejecting a negative consequent. Separate those effects:
+
+1. Add an explicit contradiction-only sequent representing `C and not D implies false`.
+1. Keep ordinary `SingleImplication` only when propagating positive `D` is provenance-safe.
+1. When underlying implication holds but provenance prohibits propagation, add only the
+    contradiction sequent. Never derive positive `Evidence(D)` from `Validity(C)`.
+1. Audit pair-derived implications. A derived constraint followed by the new single contradiction
+    should provide the same behavior; add a dedicated pair-conflict form only if focused evidence
+    shows that route is insufficient.
+1. Add focused invariant coverage showing both that opposite assignments across provenance are
+    impossible and that positive evidence still is not derived across provenance. Preserve the
+    existing tests that prohibit cross-provenance evidence implication.
+1. Run focused constraint tests after each step. If the correction changes unrelated mdtest results,
+    stop and report the exact differences before updating expectations or expanding the revision.
+1. Run `ty_python_semantic`, the full workspace suite, clippy, snapshot review, and prek. Record the
+    Phase 6A implementation change and commit IDs in this plan in a separate plan-only revision
+    before beginning Phase 6B.
+
+Do not erase provenance in the Phase 6B verifier. Phase 6A must make the ordinary provenance-aware
+TDD reject logically impossible paths while preserving the evidence/validity distinction for
+positive inference.
+
+### Phase 6B: recover one universally valid bare-TypeVar symbolic solution
+
+Suggested revision description: `[π] Recover a universally valid symbolic TypeVar solution`.
 
 This phase restores the first compatible-TypeVar regression at
 `crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md`, including the redundant
 callback-bound variants. The domain-conjoined TDD currently produces separate paths such as
-`(S = int, T = int)` and `(S = str, T = str)`. These paths prove that the symbolic solution
-`T := S` works for every valid specialization of non-inferable `S`; solving each path independently
-instead produces the incorrect union `int | str`.
+`(S = int, T = int)` and `(S = str, T = str)`. These paths suggest the symbolic solution `T := S`,
+which is correct only after one mapped-TDD check proves it for every valid non-inferable assignment.
+Solving each path independently instead produces the incorrect union `int | str`.
 
 Use the `inferable` parameter already passed to `PathBounds::compute` as the sole authoritative
-partition between existential solution variables and universally checked non-inferable variables.
-Do not reconstruct that partition from `GenericContext`, path contents, support, or any other
-source. For this example the required check is:
+partition. Do not reconstruct it from `GenericContext`, path contents, support, or another source.
+Preserve the existing `remove_noninferable` call and continue producing solutions for non-inferable
+type variables exactly as today; bidirectional inference depends on those solutions, and changing
+that behavior belongs to `dcreager/remove-remove-noninferable-2`.
+
+For candidate substitution `sigma = [T := S]`, let `C` be the exact projected,
+domain-conjoined constraint-set node used for path extraction. Build the non-inferable validity
+domain lazily only after candidate discovery, using the cached
+`BoundTypeVarInstance::bound_or_constraints` accessor rather than a duplicate descriptor. Include
+every non-inferable type variable remaining in the mapped node's support. Verify the candidate with
+ordinary Boolean TDD operations:
 
 ```text
-for every S in D(S), there exists T in D(T) such that C(T, S)
+counterexample = D(non-inferable) and not C[sigma]
 ```
 
-The candidate `T := S` is valid when the stronger condition holds:
+Accept the candidate only when `counterexample` is unsatisfiable. This is an implication check, not
+a call to `for_all`, `reduce_inferable`, `exists`, or any other quantification API. If another
+inferable type variable remains after substitution, decline the candidate rather than abstracting
+it.
 
-```text
-D(non-inferable) implies C[T := S]
-```
+Phase 6B implementation requirements:
 
-Here `C` is the same projected, domain-conjoined constraint-set node used for path extraction, and
-`D(non-inferable)` is the validity domain constructed only for type variables not present in the
-existing `inferable` set. Obtain declared bounds and constraint lists through the existing cached
-`BoundTypeVarInstance::bound_or_constraints` accessor used by validity-domain construction; do not
-introduce or retain a duplicate domain descriptor.
-
-Phase 6 implementation requirements:
-
-1. Discover at most one bare-TypeVar symbolic candidate for each inferable type variable from pure
-    `Evidence` retained in the complete path family. A candidate may come from an exact pure lower
-    bound or the single effective pure upper evidence bound. Do not treat branch-specific `Mixed`
-    derivations or `Validity` bounds as candidate evidence.
-1. Restrict this phase to candidates `T := S` where `T` is inferable according to the supplied set,
-    `S` is non-inferable, and substituting the candidate leaves no other inferable variable that
-    would require a new existential abstraction. Decline ambiguous or competing candidates and use
-    ordinary path-local solving.
-1. Verify each unique candidate once at the TDD level, not once per concrete domain path. Apply the
-    existing constraint-set type-mapping operation to the domain-conjoined node with `T` mapped to
-    `S`, then prove that the difference between `D(non-inferable)` and the mapped node is
-    unsatisfiable. This verifies the target validity domain and all other evidence, including
-    redundant `object`, union, and nominal callback bounds. It also rejects incompatible domains
-    such as `(int, bytes)` versus `(int, str)` and merely assignable constraints such as `bool`
-    versus `int`.
-1. Keep the original concrete paths. Do not synthesize a replacement path or add a general
-    correlated-solution representation. Record the successfully verified candidate once as a
-    compact family-level symbolic default associated with the computed `PathBounds`.
-1. During solution extraction, let an explicit caller choice take precedence, then use the verified
-    symbolic default for inferable `T`, and otherwise call path-local `default_solve`. Emitting the
-    same `T := S` binding for each retained concrete path may rely on existing solution combination
-    to deduplicate it. Non-inferable path bounds remain proof context and must not become solution
-    targets.
-1. Preserve raw paths for pruning, diagnostics, and other inferable variables. Perform candidate
-    discovery and verification before pruning can discard paths needed to explain the universal
-    result.
-1. Do not add a general quantifier implementation in this phase. The general check with additional
-    inferable variables would require existentially abstracting those variables after substitution;
-    leave that to the separate quantifier workstream.
-1. Keep symbolic defaults capable of storing a `Type`, but accept only a bare `TypeVar` candidate in
-    this phase. A potential Phase 7 may support structured candidates such as `T := list[S]`; mapping
-    a TypeVar subject to a structured type can create substantially more relation constraints and
-    must be designed and measured separately.
-1. Add a TODO at the family-level recovery explaining that quantifier-aware TDD solution extraction
-    should eventually preserve `T := S` before materializing one path per specialization of `S`, at
-    which point this post-extraction recovery can be removed.
-1. Limit verification to one mapped BDD per unique candidate, reuse the existing node and constraint
-    interning, and inspect TDD/node growth. Candidate mapping visits the source DAG rather than each
-    root-to-terminal path, but it remains a performance risk. Run the existing
-    `ty_micro[pydantic_core_schema_dict]` benchmark and the focused Pydantic ecosystem comparison if
-    the mapped verification affects those paths.
+1. Refactor `PathBounds::compute` orchestration to have access to the
+    `ConstraintSetBuilder`. Construct the final domain-conjoined node and extract paths under a
+    scoped mutable storage borrow; release that borrow before wrapping the node as a temporary
+    `ConstraintSet` and invoking the existing type-mapping API. Complete verification before return;
+    never retain a builder-local `NodeId` in cached `PathBounds`.
+1. Discover hypotheses from complete, unpruned paths. For an inferable target `T`, collect any
+    top-level bare non-inferable TypeVar appearing as an exact pure lower `Evidence` bound or an
+    individual pure upper `Evidence` clause. Do not inspect `Mixed`, `Validity`, nested TypeVars, or
+    perform redundancy checks during discovery. A hypothesis may appear on any path, but all bare
+    candidates found for `T` must identify the same `S`.
+1. Apply the exact-validity gate unconditionally: attempt recovery only when at least one
+    non-bivariant path for `T` has an exact validity equality that would otherwise override the
+    symbolic candidate. Other relationship regressions remain out of scope and keep adjacent
+    TODO/xfail expectations.
+1. Support exactly one inferable symbolic target in the entire `PathBounds` computation. If another
+    inferable remains after substitution, or another target has a candidate, decline recovery.
+    Store the successful result as exactly one family-level
+    `Option<TypeVarSolution<'db>>` by making `PathBounds::Constrained` a structured variant with
+    separate `paths` and `symbolic_default` fields. Keep `Unsatisfiable` and `Unconstrained` as
+    fieldless variants so they cannot carry a meaningless symbolic default. Add a TODO and, if a
+    minimal behavioral example is available, an mdtest xfail for jointly verified multi-target
+    solutions.
+1. Map the exact projected, domain-conjoined `C` with `T` replaced by `S` and preserve bound
+    provenance. Build `D(non-inferable)` lazily and use the existing builder for mapping,
+    counterexample construction, interning, source ordering, and sequent caches. Perform at most one
+    mapped-BDD verification per `PathBounds` computation and inspect retained node/cache growth.
+1. Keep every original concrete path. Do not synthesize a replacement path, deduplicate identical
+    `Solution` values, or add a general correlated-solution representation. Paths without `T` and
+    bivariant `T` paths retain their current behavior; ordinary cross-path combination may use and
+    deduplicate `T := S` emitted by other paths.
+1. Make family-aware default solving a receiver-taking operation on `PathBounds`. It returns the
+    verified symbolic default immediately, before path-local variance, satisfiability, or exact
+    validity logic. An explicit custom chooser retains precedence and remains responsible for
+    invoking family-aware default solving when it wants fallback behavior; do not change the chooser
+    return protocol. Do not expose a caller-accessible path-local solver: keep the concrete-path
+    algorithm private beneath the family-aware method. Give chooser APIs that may request fallback,
+    notably the constraint-set path through `SpecializationBuilder::build_with`, an immutable
+    `&PathBounds` alongside the current `&PathBound` (or equivalent family-aware context). Pruning
+    finishes before solving and default selection is read-only, so no mutable family reference is
+    needed.
+1. Expose unpruned `ConstraintSet::path_bounds` to affected consumers. Callers decide whether and
+    when to invoke `prune_subsumed`, then call `solve_with` while retaining the enclosing
+    `PathBounds` needed by receiver-taking default solving. Remove `pruned_solutions_with` if no
+    callers remain.
+1. Do not invoke or modify eager existential or universal abstraction. Add a TODO explaining that
+    quantifier-aware TDD solution extraction should eventually preserve `T := S` before
+    materializing one path per specialization of `S`, at which point this post-extraction recovery
+    can be removed.
+1. Keep the stored solution type capable of containing any `Type`, but accept only bare
+    `Type::TypeVar(S)` candidates. A potential Phase 7 may support structured candidates such as
+    `T := list[S]`; mapping a TypeVar subject to a structured type can create substantially more
+    relation constraints and must be designed and measured separately.
 1. Restore the intended assertions for equal constrained domains, compatible source subsets, and
     redundant `object`, union, and nominal callback bounds in both legacy and PEP 695 syntax. Keep
     focused negative coverage for incompatible domains and strict-subtype constraints.
-1. Run focused mdtests after each small step. If mapped candidate verification unexpectedly changes
-    another result, causes material TDD growth, or requires general existential handling, stop and
-    report the evidence and alternatives before broadening the phase.
-1. Run `ty_python_semantic`, the full workspace suite, clippy, snapshot review, and prek before
-    marking Phase 6 complete. Record the implementation change and commit IDs in this plan in a
-    separate plan-only revision.
+1. Run focused mdtests after each small step. If verification changes another result, produces
+    material TDD growth, or appears to require quantification or multiple targets, stop and report
+    the evidence before broadening the phase or updating an expectation. Run the existing
+    `ty_micro[pydantic_core_schema_dict]` benchmark and focused Pydantic ecosystem comparison if
+    candidate verification is reached in those scenarios.
+1. Run `ty_python_semantic`, the full workspace suite, clippy, snapshot review, and prek. Record the
+    Phase 6B implementation change and commit IDs in this plan in a separate plan-only revision.
 
 The family-level symbolic default is deliberately narrower than a general witness or correlated
-solution representation. Do not move declaration-aware alternative selection back into
-`PathBounds::default_solve`, reconstruct inferability from `GenericContext`, union gradual solutions
-locally, or revive the rejected TDD-abstraction workarounds. The old `default_solve` implementation
-is useful only as evidence that a pure TypeVar relationship should be preferred after the new
-universal check proves it valid.
+solution representation. Do not move declaration-aware alternative selection back into path-local
+solving, reconstruct inferability from another source, skip existing non-inferable solution
+production, union gradual solutions locally, or revive the rejected TDD-abstraction workarounds.
+The old `default_solve` implementation is useful only as evidence that a pure TypeVar relationship
+should be preferred after the new implication check proves it valid.
 
 ## Focused regression coverage
 
@@ -876,11 +937,13 @@ Run prek from the Jujutsu workspace:
     validity lower unions and individually tagged upper clauses, preserving provenance for
     `default_solve` and custom callbacks.
 - **Provenance-sensitive sequents:** evidence and validity constraints are separate interned
-    propositions. Never add single-implication sequents across provenance, regardless of the
-    underlying bounds' relative strength, including reverse implications from simplified
-    intersections. Pair-implication sequents can combine mixed-provenance premises: same-side
-    intersections inherit the stronger restriction's provenance, while transitive derivations
-    produce evidence only when all contributing premises are evidence.
+    propositions. Never propagate a positive single-implication consequence across provenance,
+    regardless of the underlying bounds' relative strength, including reverse implications from
+    simplified intersections. Phase 6A must nevertheless reject `C and not D` whenever underlying
+    `C` logically implies `D`, independent of provenance. Pair-implication sequents can combine
+    mixed-provenance premises: same-side intersections inherit the stronger restriction's
+    provenance, while transitive derivations produce evidence only when all contributing premises
+    are evidence.
 - **Logical identity versus provenance:** provenance-aware bounds can cause otherwise identical
     ranges to intern separately. Logical implication, sequent equivalence, source order, and TDD
     size must remain correct; avoid assuming provenance tags change the actual set of legal
@@ -891,16 +954,17 @@ Run prek from the Jujutsu workspace:
     evidence only when every indispensable premise is evidence; any validity or mixed premise
     produces `Mixed`. Pure `Validity` is reserved for direct declaration-domain constraints.
 - **Compatible TypeVars:** conjoining `T`'s declared finite domain with witnessed `T = S`
-    currently turns `T = S` into concrete `T = int`/`T = str` alternatives. Phase 6 recovers the
+    currently turns `T = S` into concrete `T = int`/`T = str` alternatives. Phase 6B recovers one
     symbolic relationship only after mapping `T` to non-inferable `S` in the complete
-    domain-conjoined TDD and proving the mapped node for all of `D(non-inferable)`. This must support
-    compatible subsets and callbacks with redundant bounds while rejecting incompatible or merely
-    assignable domains. Keep the conclusion at path-family scope; no individual concrete path proves
-    it and a dedicated per-`PathBound` witness field is not prescribed.
+    domain-conjoined TDD and proving that its non-inferable domain has no counterexample. This must
+    support compatible subsets and callbacks with redundant bounds while rejecting incompatible or
+    merely assignable domains. Keep the conclusion at path-family scope; no individual concrete path
+    proves it and a dedicated per-`PathBound` witness field is not prescribed.
 - **Mapped-candidate TDD growth:** candidate verification rebuilds the domain-conjoined DAG under a
-    type mapping once per unique candidate. Bare-TypeVar substitution should keep subjects symbolic,
-    but node growth, sequent discovery, and cache retention must be measured. Decline multiple or
-    ambiguous candidates rather than multiplying verification work.
+    type mapping only after the exact-validity gate and at most once per `PathBounds` computation.
+    Bare-TypeVar substitution should keep subjects symbolic, but node growth, sequent discovery, and
+    cache retention must be measured. Decline multiple or ambiguous candidates rather than
+    multiplying verification work.
 - **Gradual alternatives and sequents:** store declared gradual alternatives directly as exact
     validity constraints, without bottom/top materialization. The static-sequent phase prevents
     non-transitive gradual assignability from collapsing paths; a later compatibility phase must
@@ -921,8 +985,9 @@ Run prek from the Jujutsu workspace:
     declaration errors only on the diagnostic failure path.
 - **Ordering:** merge source-order sidecars consistently and retain declaration-order tie breaks
     without depending on Salsa IDs or arbitrary TDD variable ordering.
-- **Quantification:** Phase 6 uses the existing `inferable` set as its quantifier partition and
-    proves only candidates that require no remaining existential abstraction after substitution.
-    Do not reconstruct inferability from another source or expand the phase into the eager
-    quantifiers being replaced elsewhere. Future quantifier-aware extraction should subsume the
-    narrow family-level symbolic-default recovery.
+- **Quantification:** Phase 6B uses the existing `inferable` set only to classify candidate targets
+    and build the non-inferable domain. It does not call or modify `for_all`, `reduce_inferable`,
+    `exists`, or another abstraction operation, and it declines candidates that leave another
+    inferable variable after substitution. Do not reconstruct inferability from another source.
+    Future quantifier-aware extraction should subsume the narrow family-level symbolic-default
+    recovery.

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,10 +18,11 @@ Minimal diff churn is an explicit requirement:
 - Do not attempt general correlation-preserving solution combination.
 - Do not change eager existential or universal quantification; it is being replaced in a separate
     workstream.
-- Do not change Python's general gradual-type assignability or declaration semantics. Phase 5 now
-    owns the narrower sequent correction needed by domain activation: concrete logical proofs must
+- Do not change Python's general gradual-type assignability or declaration semantics. A dedicated
+    static-sequent phase before Phase 5 owns the narrower logical correction: concrete proofs must
     use fully static bounds and subtyping, while structurally valid symbolic rules may propagate an
-    existing gradual witness. Do not choose a relation based on validity/evidence provenance.
+    existing gradual witness. Phase 5 then activates domains and restores temporary compatibility
+    regressions. Do not choose a relation based on validity/evidence provenance.
 
 ## Workflow and handoff requirements
 
@@ -46,15 +47,25 @@ ultimately correct result, do not disable, comment out, or ignore tests. Instead
 assertion or mdtest expectation to the currently observed behavior and add a clear TODO describing
 the expected correct behavior. Prefer sequencing that avoids temporary regressions entirely.
 
+The static-sequent phase is the deliberate exception where temporary user-visible regressions are
+expected. Keep each regression covered at its observed intermediate behavior and add an adjacent
+`XXX` naming the behavior that Phase 5 must restore. The static-sequent revision must still pass the
+full suite, clippy, and prek. It is an implementation checkpoint only and must not be merged or used
+as a landing bookmark target independently of Phase 5.
+
 Use `jj` for source control and inspect changes with `jj diff --git` or `jj diff --stat`. Run prek
 in this Jujutsu workspace through `/home/dcreager/bin/jpk`. Never modify snapshot files or inline
 snapshot bodies manually: regenerate them with the documented test commands, inspect every
 snapshot change, and check for `.pending-snap` files when inline snapshots are involved.
 
-## Joint Phase 5: domain activation and fully static sequents
+## Staged integration: fully static sequents before Phase 5
 
-Phase 5 and fully static sequent handling are one semantic integration unit. Investigation showed
-that neither has a useful independently passing boundary:
+Fully static sequent handling and domain activation remain one merge unit, but they are implemented
+as two test-clean project revisions. The first revision establishes the sound logical boundary and
+records temporary compatibility regressions; Phase 5 activates domains and removes those
+regressions before the stack can land.
+
+Investigation established this split:
 
 - The sequent map treats gradual assignability as transitive logical implication. Exact validity
     alternatives such as `T = Any` and `T = int` can therefore become mutually implicative and be
@@ -63,11 +74,12 @@ that neither has a useful independently passing boundary:
     result for the typed-dictionary union ordering regression and passed the full constraint-set
     ordering mdtest after cycle-safe derived-candidate validation.
 - The same prototype exposed a Phase 5 pruning assumption: gradual constrained-TypeVar paths do
-    not always present one exact equality validity bound. The current pruner panics instead of
-    conservatively retaining such paths.
-- Removing gradual closure also exposes independent alternative solutions. In particular,
-    unbounded `Container[T]` inference still selects `object` rather than preserving `Any`; domain
-    pruning cannot repair an unbounded variable.
+    not always present one exact equality validity bound. Phase 5 must make pruning conservative
+    rather than panic.
+- Removing gradual closure exposes independent alternative solutions. In particular, unbounded
+    `Container[T]` inference selects `object` rather than preserving `Any`. The static phase records
+    that intermediate result with an `XXX`; Phase 5 must restore the existing behavior even though
+    declared-domain pruning alone cannot repair an unbounded variable.
 
 Do not revive either rejected workaround from the standalone prototype: selectively retaining TDD
 uncertain branches during abstraction, or locally unioning gradual solutions in `generics.rs`.
@@ -76,16 +88,17 @@ witness metadata, or a general correlation-preserving solution representation wi
 approved replan.
 
 The incomplete Phase 5 revision `pvynqtrq` and its pause revision are diagnostic snapshots, not
-part of the implementation path. Restart the joint phase from `sqkowvys` (the completed Phase 4
-stack plus the raw-graph fix), which is the parent of this replanning revision. The detailed static
-sequent requirements remain in
-`~/.pi/memory/plans/ruff/fully-static-sequents/PLAN.md`; this document is authoritative for the
-combined phase order and completion marker.
+part of the implementation path. The new static-sequent phase starts after `sqkowvys` (the
+completed Phase 4 stack plus the raw-graph fix) and the approved plan-only revisions. Phase 5 is a
+child of that static revision. The detailed static requirements remain in
+`~/.pi/memory/plans/ruff/fully-static-sequents/PLAN.md`; this document is authoritative for phase
+order and completion markers.
 
-The intended landing order is:
+The implementation and landing order is:
 
 1. completed domain-solving Phases 1–4 and the raw-graph fix;
-1. the combined Phase 5 domain activation and fully static sequent revision;
+1. a full-suite-clean but intentionally non-mergeable static-sequent revision;
+1. Phase 5 domain activation and compatibility restoration, which is the first landable tip;
 1. `dcreager/remove-remove-noninferable-2`.
 
 ## Current baseline
@@ -323,11 +336,11 @@ first determine what the new provenance-aware lower/upper bounds already make po
 ### Preserve existing gradual behavior while restricting concrete sequents
 
 `Constraint::new_node_with_bounds` already accepts gradual bounds despite a stale claim that only
-fully static bounds are supported. In the joint phase, concrete endpoint containment, overlap,
-contradiction, and pivot proofs must require structurally static endpoints and use constraint-set
-subtyping rather than assignability. Solver TypeVars are opaque symbolic atoms for this eligibility
-check. Use an owned Salsa-tracked relation where cycle recovery is required, and validate and skip
-derived candidates that settle as unsatisfiable after a coinductive cycle.
+fully static bounds are supported. In the static-sequent phase, concrete endpoint containment,
+overlap, contradiction, and pivot proofs must require structurally static endpoints and use
+constraint-set subtyping rather than assignability. Solver TypeVars are opaque symbolic atoms for
+this eligibility check. Use an owned Salsa-tracked relation where cycle recovery is required, and
+validate and skip derived candidates that settle as unsatisfiable after a coinductive cycle.
 
 Structurally universal TypeVar rules may still carry an existing gradual witness through a
 relationship. Keep the existing dedicated same-TypeVar, different-TypeVar, and nested-TypeVar
@@ -335,10 +348,10 @@ constructor paths as that boundary; do not introduce general witness provenance 
 single-range derivation assignability-based initially, with the existing PR #26873 TODO, and stop
 if focused evidence shows that this path itself creates invalid closure.
 
-Domain-conjoined path extraction and solution selection must be developed with this sequent
-boundary active. Preserve distinct gradual/static alternatives and existing gradual evidence
-without a provenance-dependent relation, equality exception, TDD abstraction special case, or
-ad hoc solution-union rule.
+Keep validity domains inactive during the static-sequent phase. Phase 5 develops domain-conjoined
+path extraction and solution selection with the new boundary active, and must preserve distinct
+gradual/static alternatives and existing gradual evidence without a provenance-dependent relation,
+equality exception, TDD abstraction special case, or ad hoc solution-union rule.
 
 Existing generic-function behavior must nevertheless be preserved:
 
@@ -417,14 +430,16 @@ expanding `Solutions`:
 - [x] Phase 2: replace optional constraint bounds with validity/evidence bounds.
 - [x] Phase 3: reintroduce support-derived validity-domain construction.
 - [x] Phase 4: preserve evidence-derived variance and add complete-path pruning.
-- [ ] Phase 5: jointly restrict concrete sequents, solve the domain-conjoined TDD, and simplify
-    default solving.
+- [ ] Static-sequent integration phase: restrict concrete sequents and characterize temporary
+    regressions in a non-mergeable intermediate revision.
+- [ ] Phase 5: activate the domain-conjoined TDD, simplify default solving, and restore every
+    temporary static-phase regression.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
 revision, relevant documentation/tests, and a passing full test suite. The abandoned Phase 5 and
-standalone fully-static revisions are diagnostic evidence only. Implement the joint phase in a new
-revision based on this replanning revision; do not layer it onto `pvynqtrq` or copy its rejected
-workarounds.
+standalone fully-static revisions are diagnostic evidence only. Implement the static phase in a new
+revision based on this replanning revision, then implement Phase 5 as its child; do not layer either
+onto `pvynqtrq` or copy its rejected workarounds.
 
 ### Phase 1: retain bound type-variable instances in constraint-set arenas
 
@@ -520,9 +535,11 @@ Suggested revision description: `[π] Preserve evidence variance and compare com
 1. Delay behavior-changing consumer integration until Phase 5.
 1. Run the full suite before marking the phase complete.
 
-### Phase 5: jointly activate domains and restrict concrete sequents
+### Static-sequent integration phase
 
-Suggested revision description: `[π] Solve domains with fully static sequents`.
+Suggested revision description: `[π] Restrict concrete sequents to fully static bounds`.
+
+This revision is an implementation checkpoint, not a landable tip.
 
 1. Add focused coverage showing that `int -> Any -> str` assignability cannot become transitive
     sequent closure. Define structural sequent eligibility locally in `constraints.rs`, treating
@@ -534,6 +551,21 @@ Suggested revision description: `[π] Solve domains with fully static sequents`.
     an existing gradual witness, but prevent gradual concrete pivots or unrelated TDD branches from
     manufacturing evidence. Validate provisionally discovered coinductive candidates and skip
     those that settle as unsatisfiable.
+1. Keep support-derived validity domains and behavior-changing pruning consumers inactive. Do not
+    compensate in TDD abstraction or solution combination.
+1. Run focused generic-function, constraint-algebra, and ordering tests. For each changed behavior,
+    assert the observed intermediate result and add an adjacent `XXX` that states the final behavior
+    Phase 5 must restore or classify. Do not disable tests, weaken unrelated assertions, or accept
+    panics as temporary behavior.
+1. Run `ty_python_semantic`, the full suite, clippy, snapshot review, and prek. Record the project
+    change and commit IDs as a non-mergeable intermediate checkpoint.
+
+### Phase 5: activate domains and restore compatibility
+
+Suggested revision description: `[π] Solve declared type-variable domains as constraint-set paths`.
+
+1. Inventory every static-phase `XXX`; Phase 5 is incomplete until all are removed and their final
+    expectations are covered.
 1. Conjoin the support-derived validity domain with the original root before path extraction in
     both direct and Salsa-cached entry points. Preserve source ordering and the simple concrete-bound
     fast path whenever possible.
@@ -549,19 +581,21 @@ Suggested revision description: `[π] Solve domains with fully static sequents`.
     `TypeVarBoundOrConstraints` or rebuilding declared alternatives independently.
 1. Preserve witnessed variance, gradual evidence, bounded lower/upper behavior, absent versus
     explicit bounds, unsolved variables, and relationships between compatible type variables.
-    Preserve current constrained `Any`/`int`, `list[Any]`/`list[int]`, ambiguous gradual evidence,
-    and unbounded `Container[T]` behavior without a local solution-union heuristic.
+    Restore constrained `Any`/`int`, `list[Any]`/`list[int]`, ambiguous gradual evidence, and
+    unbounded `Container[T]` behavior without a local solution-union heuristic.
 1. Explicitly prune subsumed complete paths in affected specialization consumers before extracting
     solutions and combining bindings independently; leave raw internal solution APIs exhaustive.
 1. Recover declaration-specific diagnostics by inspecting unconjoined paths only after a
     domain-aware solve fails. Do not apply domains before eager quantification or expand this phase
     into the separate quantifier-replacement workstream.
+1. Classify temporary constraint-algebra changes and replace each `XXX` with its justified final
+    assertion. User-visible inference regressions must be restored rather than recharacterized.
 1. Audit cache growth, path fuel, deterministic ordering, and the
     `ty_micro[pydantic_core_schema_dict]`-sensitive fast path. Favor existing user-visible tests;
     change implementation-focused expectations only when semantically required.
 1. Remove superseded TODOs and obsolete declaration-handling code after replacement coverage
     passes. Run focused tests, `ty_python_semantic`, the full suite, clippy, snapshot review, and
-    prek before marking the joint phase complete.
+    prek before marking Phase 5 complete and selecting its tip for landing.
 
 ## Focused regression coverage
 
@@ -663,8 +697,8 @@ Run prek from the Jujutsu workspace:
     with redundant bounds, while rejecting incompatible or merely overlapping domains. The
     user-visible behavior is required; a dedicated `PathBound` field is not prescribed.
 - **Gradual alternatives and sequents:** store declared gradual alternatives directly as exact
-    validity constraints, without bottom/top materialization. The joint phase must prevent
-    non-transitive gradual assignability from collapsing their paths while preserving existing
+    validity constraints, without bottom/top materialization. The static-sequent phase prevents
+    non-transitive gradual assignability from collapsing paths; Phase 5 must then restore existing
     `Any`/`int` and `list[Any]`/`list[int]` behavior. Do not reinterpret provenance as a typing
     relation or add equality-specific sequent behavior.
 - **Arena overlays:** retain full type-variable instances while continuing to intern by identity

--- a/PLAN.md
+++ b/PLAN.md
@@ -474,9 +474,11 @@ expanding `Solutions`:
     provenance without allowing validity restrictions to manufacture positive inference evidence.
     Change `qynqxkpqotkuzvstnylupmuxmwrkokpm`, commit
     `c6195be50758b035dc299839995774e0d7d8cfeb`.
-- [ ] Phase 6B: recover one universally valid bare-TypeVar symbolic solution such as `T := S` from
+- [x] Phase 6B: recover one universally valid bare-TypeVar symbolic solution such as `T := S` from
     the complete domain-conjoined path family, using the existing `inferable` set as the
-    authoritative partition and a mapped-TDD implication check.
+    authoritative partition and a mapped-TDD implication check. Change
+    `tnkvtxtqvpvrqxlmxtukkqlzozmxzymk`, commit
+    `0a094f3a8fd935d34183c1ba1c62cfbc2636663c`.
 - [ ] Potential Phase 7 and later: support structured or multiple symbolic candidates such as
     `T := list[S]`, restore or classify the remaining compatibility regressions, resolve the
     recorded performance debt, and select a landable tip.
@@ -486,7 +488,8 @@ approved implementation ground truth. In particular, the contradiction-only sequ
 to provenance-suppressed implications; `PathBounds::Constrained` owns `paths` and the single
 optional symbolic default; and no caller-accessible path-local default solver remains. Custom
 chooser fallback receives immutable family context because pruning is complete before read-only
-solution selection. Do not begin Phase 6B implementation without explicit authorization.
+solution selection. Phase 6B was explicitly authorized and completed without expanding into
+structured candidates, multiple targets, or quantifier changes.
 
 Phases depend on all preceding phases and must execute in order. Every phase has its own `[π]`
 revision, relevant documentation/tests, and a passing full test suite. The earlier abandoned Phase 5
@@ -523,6 +526,19 @@ rejects `C and not D` when the underlying `C` implies `D` without propagating po
 provenance. Existing pair implications derive their intermediate constraint before the new sequent
 checks the contradiction, so no dedicated pair-conflict form is needed. Validation passed all 823
 `ty_python_semantic` tests, all 8,921 workspace tests, workspace clippy, snapshot review, and prek.
+
+Phase 6B discovers one bare non-inferable TypeVar candidate from the complete unpruned path family,
+substitutes it into the exact projected domain-conjoined TDD, and accepts it only when the
+non-inferable validity domain has no counterexample. The verified result is stored once at family
+scope and selected before concrete path defaults. Chooser callbacks receive the family and path as
+one optional pair; legacy exact bounds use a singleton family so the callback API cannot represent
+a path without family context. Validation passed all 823 `ty_python_semantic` tests, all 8,921
+workspace tests, workspace clippy, snapshot review, and prek. Focused successful verifications added
+1–2 constraints, 9–14 nodes, one single-sequent cache entry, and two pair-sequent cache entries per
+builder. `ty_micro[pydantic_core_schema_dict]` measured 11.861 ms at Phase 6B versus 11.814 ms at its
+Phase 6A parent, with Criterion detecting no performance change. That concrete-only benchmark does
+not reach bare-TypeVar candidate verification, so the conditional focused Pydantic ecosystem
+comparison was not required.
 
 ### Phase 1: retain bound type-variable instances in constraint-set arenas
 

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2350,8 +2350,7 @@ class ChildOfParentDataclass[T](ParentDataclass[T]): ...
 def uses_dataclass[T](x: T) -> ChildOfParentDataclass[T]:
     return ChildOfParentDataclass(x)
 
-# TODO: ParentDataclass.__init__ should show generic types, not Unknown
-# revealed: (self: ParentDataclass[Unknown], value: Unknown) -> None
+# revealed: [T](self: ParentDataclass[T], value: T) -> None
 reveal_type(ParentDataclass.__init__)
 
 # revealed: [T](self: ParentDataclass[T], value: T) -> None

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -1203,10 +1203,10 @@ class C:
 C().value
 ```
 
-### Property getters reject invalid receiver specializations
+### Property getters do not infer fixed owner type variables
 
-A property getter checks the same specialized receiver as an ordinary method. A generic alias with
-alternatives that impose different type-variable bounds can produce an invalid property access.
+A property getter treats type variables fixed by the owner specialization as evidence, not as
+inference targets.
 
 ```py
 from collections.abc import Callable
@@ -1229,9 +1229,11 @@ AnyCallback = TypeVar("AnyCallback", bound=Callable[..., str])
 Command = A[AnyCallback] | B[AnyCallback]
 Callback = TypeVar("Callback", bound=Callable[[int], str])
 
+# TODO: `Command[Callback]` produces `B[Callback]`, but `Callback` does not satisfy `BItem`'s
+# upper bound. Report this at `Command[Callback]` once specialization validation can prove that
+# every possible specialization of a symbolic assignment satisfies the destination domain.
 def access(value: Callback | Command[Callback]) -> None:
     if isinstance(value, A | B):
-        # error: [invalid-attribute-access]
         value.callback
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
@@ -180,8 +180,6 @@ T = TypeVar("T", A, B)
 
 def _(x: T, y: int) -> T:
     # error: [invalid-argument-type]
-    # error: [invalid-argument-type]
-    # error: [invalid-argument-type]
     return x.foo(y)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1205,6 +1205,63 @@ def use_stream(stream: Stream) -> Stream:
     return stream.clone()
 ```
 
+## Members of type variables with union upper bounds
+
+Unlike constraints, a union upper bound does not enumerate the possible assignments of a type
+variable. Member lookup can still use the upper bound to prove that a common member is available.
+
+```py
+from typing_extensions import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    @property
+    def value(self) -> T:
+        raise NotImplementedError
+
+class A(Base[int]): ...
+class B(Base[str]): ...
+
+U = TypeVar("U", bound=A | B)
+
+def use_union(value: A | B):
+    # revealed: int | str
+    reveal_type(value.value)
+
+def use_typevar(value: U):
+    # TODO: This should not error once member lookup supports union upper bounds.
+    # error: [invalid-attribute-access] "Invalid access to descriptor attribute `value`"
+    # revealed: int | str
+    reveal_type(value.value)
+```
+
+## Correlated constrained receiver calls
+
+Multiple occurrences of the same constrained type variable have the same assignment. Distributing
+member lookup over the receiver's constraints must preserve that correlation when checking method
+arguments.
+
+```py
+from typing_extensions import TypeVar
+
+class A:
+    def combine(self, other: "A") -> None: ...
+
+class B:
+    def combine(self, other: "B") -> None: ...
+
+T = TypeVar("T", A, B)
+
+def combine(left: T, right: T) -> None:
+    # revealed: (bound method T@combine when A.combine(other: A) -> None) | (bound method T@combine when B.combine(other: B) -> None)
+    reveal_type(left.combine)
+    # TODO: This should not error once callable binding preserves the receiver branch correlation.
+    # error: [invalid-argument-type] "Argument to bound method `A.combine` is incorrect"
+    # error: [invalid-argument-type] "Argument to bound method `B.combine` is incorrect"
+    left.combine(right)
+```
+
 ## Specializations propagate
 
 In a specialized generic alias, the specialization is applied to the attributes and methods of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1166,6 +1166,45 @@ reveal_type(generic_context(c.method))
 reveal_type(generic_context(c.generic_method))
 ```
 
+## Members of constrained type variables
+
+Member lookup distributes over the constraints of a non-inferable type variable. Each member is
+bound to its matching receiver alternative, while `Self` continues to refer to the original type
+variable.
+
+```py
+from typing_extensions import Self, TypeVar
+
+class TextStream:
+    @property
+    def closed(self) -> bool:
+        return False
+
+    def close(self) -> None: ...
+    def clone(self) -> Self:
+        raise NotImplementedError
+
+class BinaryStream:
+    @property
+    def closed(self) -> bool:
+        return False
+
+    def close(self) -> None: ...
+    def clone(self) -> Self:
+        raise NotImplementedError
+
+Stream = TypeVar("Stream", TextStream, BinaryStream)
+
+def use_stream(stream: Stream) -> Stream:
+    # revealed: bool
+    reveal_type(stream.closed)
+    # revealed: (bound method Stream@use_stream when TextStream.close() -> None) | (bound method Stream@use_stream when BinaryStream.close() -> None)
+    reveal_type(stream.close)
+    if not stream.closed:
+        stream.close()
+    return stream.clone()
+```
+
 ## Specializations propagate
 
 In a specialized generic alias, the specialization is applied to the attributes and methods of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -637,8 +637,10 @@ T = TypeVar("T", list[Any], list[int])
 def identity(value: T) -> T:
     return value
 
-reveal_type(identity([1]))  # revealed: list[int]
-reveal_type(identity(["x"]))  # revealed: list[Any]
+# XXX: revealed: list[int]
+reveal_type(identity([1]))  # revealed: list[Any] | list[int]
+# XXX: revealed: list[Any]
+reveal_type(identity(["x"]))  # revealed: list[Any] | list[int]
 ```
 
 ## Typevar inference is a unification problem

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -553,9 +553,9 @@ reveal_type(consume_callback(callback))  # revealed: tuple[Any, ...]
 
 ## Gradual invariant protocol members
 
-When the same inferred type variable appears in multiple invariant protocol members, fully static
-member types must agree on one exact specialization. Gradual members remain conservative
-alternatives because their equality cannot justify a transitive sequent proof.
+When the same inferred type variable appears in multiple invariant protocol members, the member
+types must agree on one exact specialization. Equivalent gradual types still provide a coherent
+solution.
 
 ```py
 from typing import Any, Generic, Protocol, TypeVar
@@ -567,18 +567,30 @@ class Pair(Protocol[T]):
     first: T
     second: T
 
-class GradualPair(Generic[U]):
+class MatchingGradualPair(Generic[U]):
     first: tuple[U, Any]
-    second: tuple[U, int]
+    second: tuple[U, Any]
 
 def infer_pair(value: Pair[T]) -> T:
     raise NotImplementedError
 
-def check_pair(value: GradualPair[U]) -> None:
+def check_matching_pair(value: MatchingGradualPair[U]) -> None:
+    # revealed: tuple[U@check_matching_pair, Any]
+    reveal_type(infer_pair(value))
+```
+
+Member types that are not gradually equivalent can't prove a contradiction, but they also should not
+be unioned: they are simultaneous equality requirements rather than inference alternatives.
+
+```py
+class DifferingGradualPair(Generic[U]):
+    first: tuple[U, Any]
+    second: tuple[U, int]
+
+def check_differing_pair(value: DifferingGradualPair[U]) -> None:
     # TODO: error: [invalid-argument-type] "Argument to function `infer_pair` is incorrect"
-    # XXX: Restore `Unknown` now that domain solving exposes the incompatible exact member types
-    # to the equality-intersection check.
-    reveal_type(infer_pair(value))  # revealed: tuple[U@check_pair, Any] | tuple[U@check_pair, int]
+    # revealed: Unknown
+    reveal_type(infer_pair(value))
 ```
 
 ## Prefer specific compatible constraints over gradual constraints

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1440,7 +1440,9 @@ def value(items: Container[T]) -> T:
     raise NotImplementedError
 
 items: list[str] = []
-reveal_type(value(items))  # revealed: Any
+# XXX: Phase 5 must restore `Any` without reintroducing gradual sequent implication or locally
+# unioning gradual solutions.
+reveal_type(value(items))  # revealed: object
 ```
 
 ## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1309,7 +1309,7 @@ def choose(left: T, right: T) -> T:
 
 def caller(value: Any) -> None:
     reveal_type(identity(value))  # revealed: int | list[int]
-    # XXX: revealed: Any
+    # TODO: revealed: Any
     reveal_type(choose(value, 1))  # revealed: int
 
 def list_caller(value: list[Any]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -618,6 +618,25 @@ specific.asDict()
 
 reveal_type(any_first(1))  # revealed: int
 reveal_type(int_first(1))  # revealed: int
+reveal_type(any_first("x"))  # revealed: Any
+reveal_type(int_first("x"))  # revealed: Any
+```
+
+## Preserve gradual container constraints
+
+A gradual container constraint remains available when the argument does not satisfy a more specific
+constraint. Arguments satisfying both constraints prefer the specific one.
+
+```py
+from typing import Any, TypeVar
+
+T = TypeVar("T", list[Any], list[int])
+
+def identity(value: T) -> T:
+    return value
+
+reveal_type(identity([1]))  # revealed: list[int]
+reveal_type(identity(["x"]))  # revealed: list[Any]
 ```
 
 ## Typevar inference is a unification problem

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1468,9 +1468,8 @@ S = TypeVar("S", int, str)
 def callee(x: T) -> T:
     return x
 
-# XXX: Domain-aware solving currently unions `T`'s alternatives instead of preserving `S`.
 def caller(x: S) -> S:
-    return callee(x)  # error: [invalid-return-type]
+    return callee(x)
 
 reveal_type(caller(1))  # revealed: int
 reveal_type(caller("hello"))  # revealed: str
@@ -1487,9 +1486,8 @@ Narrow = TypeVar("Narrow", int, str)
 def wide(x: Wide) -> Wide:
     return x
 
-# XXX: Preserve `Narrow` instead of unioning its compatible alternatives.
 def narrow(x: Narrow) -> Narrow:
-    return wide(x)  # error: [invalid-return-type]
+    return wide(x)
 
 reveal_type(narrow(1))  # revealed: int
 reveal_type(narrow("hello"))  # revealed: str
@@ -1500,9 +1498,6 @@ reveal_type(narrow("hello"))  # revealed: str
 A contravariant callback can contribute both another constrained type variable and a redundant
 `object` upper bound. The inferred result should retain the other type variable in either callback
 order.
-
-XXX: Domain-aware solving currently loses this relationship and unions the constrained TypeVar's
-alternatives. Restore the `S` result and remove the resulting argument and return diagnostics.
 
 ```py
 from collections.abc import Callable
@@ -1515,20 +1510,14 @@ def select(first: Callable[[T], None], second: Callable[[T], None]) -> T:
     raise NotImplementedError
 
 def forward_object(specific: Callable[[S], None], redundant: Callable[[object], None]) -> S:
-    # TODO: no error
-    result = select(specific, redundant)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_object
-    reveal_type(result)  # revealed: int | str
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select(specific, redundant)
+    reveal_type(result)  # revealed: S@forward_object
+    return result
 
 def forward_object_reversed(specific: Callable[[S], None], redundant: Callable[[object], None]) -> S:
-    # TODO: no error
-    result = select(redundant, specific)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_object_reversed
-    reveal_type(result)  # revealed: int | str
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select(redundant, specific)
+    reveal_type(result)  # revealed: S@forward_object_reversed
+    return result
 ```
 
 A union of the type variable's constraints is also a redundant upper bound, even though it is not
@@ -1536,20 +1525,14 @@ A union of the type variable's constraints is also a redundant upper bound, even
 
 ```py
 def forward_union(specific: Callable[[S], None], redundant: Callable[[int | str], None]) -> S:
-    # TODO: no error
-    result = select(specific, redundant)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_union
-    reveal_type(result)  # revealed: int | str
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select(specific, redundant)
+    reveal_type(result)  # revealed: S@forward_union
+    return result
 
 def forward_union_reversed(specific: Callable[[S], None], redundant: Callable[[int | str], None]) -> S:
-    # TODO: no error
-    result = select(redundant, specific)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_union_reversed
-    reveal_type(result)  # revealed: str | int
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select(redundant, specific)
+    reveal_type(result)  # revealed: S@forward_union_reversed
+    return result
 ```
 
 The same relationship must survive a redundant, non-`object` nominal superclass shared by both
@@ -1567,20 +1550,14 @@ def select_nominal(first: Callable[[TNominal], None], second: Callable[[TNominal
     raise NotImplementedError
 
 def forward_nominal(specific: Callable[[SNominal], None], redundant: Callable[[Base], None]) -> SNominal:
-    # TODO: no error
-    result = select_nominal(specific, redundant)  # error: [invalid-argument-type]
-    # TODO: revealed: SNominal@forward_nominal
-    reveal_type(result)  # revealed: Left | Right
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select_nominal(specific, redundant)
+    reveal_type(result)  # revealed: SNominal@forward_nominal
+    return result
 
 def forward_nominal_reversed(specific: Callable[[SNominal], None], redundant: Callable[[Base], None]) -> SNominal:
-    # TODO: no error
-    result = select_nominal(redundant, specific)  # error: [invalid-argument-type]
-    # TODO: revealed: SNominal@forward_nominal_reversed
-    reveal_type(result)  # revealed: Right | Left
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select_nominal(redundant, specific)
+    reveal_type(result)  # revealed: SNominal@forward_nominal_reversed
+    return result
 ```
 
 ## Incompatible constraint sets

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -576,6 +576,8 @@ def infer_pair(value: Pair[T]) -> T:
 
 def check_pair(value: GradualPair[U]) -> None:
     # TODO: error: [invalid-argument-type] "Argument to function `infer_pair` is incorrect"
+    # XXX: Phase 5 must restore `Unknown` after domain solving exposes the incompatible exact
+    # member types to the equality-intersection check.
     reveal_type(infer_pair(value))  # revealed: tuple[U@check_pair, Any] | tuple[U@check_pair, int]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -576,8 +576,8 @@ def infer_pair(value: Pair[T]) -> T:
 
 def check_pair(value: GradualPair[U]) -> None:
     # TODO: error: [invalid-argument-type] "Argument to function `infer_pair` is incorrect"
-    # XXX: Phase 5 must restore `Unknown` after domain solving exposes the incompatible exact
-    # member types to the equality-intersection check.
+    # XXX: Restore `Unknown` now that domain solving exposes the incompatible exact member types
+    # to the equality-intersection check.
     reveal_type(infer_pair(value))  # revealed: tuple[U@check_pair, Any] | tuple[U@check_pair, int]
 ```
 
@@ -1291,8 +1291,8 @@ reveal_type(broad_first(accepts_object))  # revealed: object
 ## Ambiguous constrained TypeVar inference from `Any`
 
 A gradual argument alone provides no evidence for choosing between multiple compatible constraints.
-We currently fall back to `Unknown` rather than choosing an arbitrary concrete constraint. Ideally,
-we would preserve `Any` instead.
+
+XXX: Domain-aware solving currently unions all compatible alternatives. Preserve `Any` instead.
 
 ```py
 from typing import Any, TypeVar
@@ -1306,8 +1306,8 @@ def choose(left: T, right: T) -> T:
     return left
 
 def caller(value: Any) -> None:
-    reveal_type(identity(value))  # revealed: Any
-    # TODO: revealed: Any
+    reveal_type(identity(value))  # revealed: int | list[int]
+    # XXX: revealed: Any
     reveal_type(choose(value, 1))  # revealed: int
 
 def list_caller(value: list[Any]) -> None:
@@ -1318,8 +1318,8 @@ def list_caller(value: list[Any]) -> None:
 
 ## Ambiguous constrained TypeVar inference from a gradual callable return
 
-Constraint-set-native inference also preserves gradual evidence nested inside a callable. As above,
-we currently fall back to `Unknown` when that evidence matches multiple constraints.
+Constraint-set-native inference should also preserve gradual evidence nested inside a callable.
+Domain-aware solving currently has the same limitation here as for a direct `Any` argument.
 
 ```py
 from typing import Any, Callable, TypeVar
@@ -1332,7 +1332,8 @@ def call(callback: Callable[[], T]) -> T:
 def callback() -> Any:
     return 1
 
-reveal_type(call(callback))  # revealed: Any
+# XXX: This should reveal `Any` rather than unioning the compatible alternatives.
+reveal_type(call(callback))  # revealed: int | list[int]
 ```
 
 ## Bounded TypeVar with callable parameter
@@ -1442,8 +1443,8 @@ def value(items: Container[T]) -> T:
     raise NotImplementedError
 
 items: list[str] = []
-# XXX: Phase 5 must restore `Any` without reintroducing gradual sequent implication or locally
-# unioning gradual solutions.
+# XXX: Restore `Any` without reintroducing gradual sequent implication or locally unioning
+# gradual solutions.
 reveal_type(value(items))  # revealed: object
 ```
 
@@ -1465,8 +1466,9 @@ S = TypeVar("S", int, str)
 def callee(x: T) -> T:
     return x
 
+# XXX: Domain-aware solving currently unions `T`'s alternatives instead of preserving `S`.
 def caller(x: S) -> S:
-    return callee(x)
+    return callee(x)  # error: [invalid-return-type]
 
 reveal_type(caller(1))  # revealed: int
 reveal_type(caller("hello"))  # revealed: str
@@ -1483,8 +1485,9 @@ Narrow = TypeVar("Narrow", int, str)
 def wide(x: Wide) -> Wide:
     return x
 
+# XXX: Preserve `Narrow` instead of unioning its compatible alternatives.
 def narrow(x: Narrow) -> Narrow:
-    return wide(x)
+    return wide(x)  # error: [invalid-return-type]
 
 reveal_type(narrow(1))  # revealed: int
 reveal_type(narrow("hello"))  # revealed: str
@@ -1493,8 +1496,11 @@ reveal_type(narrow("hello"))  # revealed: str
 ## Redundant callback bounds preserve constrained type-variable relationships
 
 A contravariant callback can contribute both another constrained type variable and a redundant
-`object` upper bound. The inferred result must retain the other type variable in either callback
+`object` upper bound. The inferred result should retain the other type variable in either callback
 order.
+
+XXX: Domain-aware solving currently loses this relationship and unions the constrained TypeVar's
+alternatives. Restore the `S` result and remove the resulting argument and return diagnostics.
 
 ```py
 from collections.abc import Callable
@@ -1507,14 +1513,20 @@ def select(first: Callable[[T], None], second: Callable[[T], None]) -> T:
     raise NotImplementedError
 
 def forward_object(specific: Callable[[S], None], redundant: Callable[[object], None]) -> S:
-    result = select(specific, redundant)
-    reveal_type(result)  # revealed: S@forward_object
-    return result
+    # TODO: no error
+    result = select(specific, redundant)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_object
+    reveal_type(result)  # revealed: int | str
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 
 def forward_object_reversed(specific: Callable[[S], None], redundant: Callable[[object], None]) -> S:
-    result = select(redundant, specific)
-    reveal_type(result)  # revealed: S@forward_object_reversed
-    return result
+    # TODO: no error
+    result = select(redundant, specific)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_object_reversed
+    reveal_type(result)  # revealed: int | str
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 ```
 
 A union of the type variable's constraints is also a redundant upper bound, even though it is not
@@ -1522,14 +1534,20 @@ A union of the type variable's constraints is also a redundant upper bound, even
 
 ```py
 def forward_union(specific: Callable[[S], None], redundant: Callable[[int | str], None]) -> S:
-    result = select(specific, redundant)
-    reveal_type(result)  # revealed: S@forward_union
-    return result
+    # TODO: no error
+    result = select(specific, redundant)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_union
+    reveal_type(result)  # revealed: int | str
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 
 def forward_union_reversed(specific: Callable[[S], None], redundant: Callable[[int | str], None]) -> S:
-    result = select(redundant, specific)
-    reveal_type(result)  # revealed: S@forward_union_reversed
-    return result
+    # TODO: no error
+    result = select(redundant, specific)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_union_reversed
+    reveal_type(result)  # revealed: str | int
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 ```
 
 The same relationship must survive a redundant, non-`object` nominal superclass shared by both
@@ -1547,14 +1565,20 @@ def select_nominal(first: Callable[[TNominal], None], second: Callable[[TNominal
     raise NotImplementedError
 
 def forward_nominal(specific: Callable[[SNominal], None], redundant: Callable[[Base], None]) -> SNominal:
-    result = select_nominal(specific, redundant)
-    reveal_type(result)  # revealed: SNominal@forward_nominal
-    return result
+    # TODO: no error
+    result = select_nominal(specific, redundant)  # error: [invalid-argument-type]
+    # TODO: revealed: SNominal@forward_nominal
+    reveal_type(result)  # revealed: Left | Right
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 
 def forward_nominal_reversed(specific: Callable[[SNominal], None], redundant: Callable[[Base], None]) -> SNominal:
-    result = select_nominal(redundant, specific)
-    reveal_type(result)  # revealed: SNominal@forward_nominal_reversed
-    return result
+    # TODO: no error
+    result = select_nominal(redundant, specific)  # error: [invalid-argument-type]
+    # TODO: revealed: SNominal@forward_nominal_reversed
+    reveal_type(result)  # revealed: Right | Left
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 ```
 
 ## Incompatible constraint sets

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -554,8 +554,10 @@ reveal_type(consume_callback(callback))  # revealed: tuple[Any, ...]
 ## Gradual invariant protocol members
 
 When the same inferred type variable appears in multiple invariant protocol members, the member
-types must agree on one exact specialization. Equivalent gradual types still provide a coherent
-solution.
+types must agree on one exact specialization.
+
+Here, `first` and `second` have identical types. Even though that type is gradual, it's an obviously
+correct solution for `T`.
 
 ```py
 from typing import Any, Generic, Protocol, TypeVar
@@ -579,8 +581,10 @@ def check_matching_pair(value: MatchingGradualPair[U]) -> None:
     reveal_type(infer_pair(value))
 ```
 
-Member types that are not gradually equivalent can't prove a contradiction, but they also should not
-be unioned: they are simultaneous equality requirements rather than inference alternatives.
+Here, `first` and `second` do not have identical types, but the fully static type of `second` is one
+of the valid materializations of the type of `first`. We can choose the fully static type as the
+solution for `T`, since there is _some_ materialization that satisfies
+`DifferingGradualPair ≤ Pair`.
 
 ```py
 class DifferingGradualPair(Generic[U]):
@@ -588,8 +592,7 @@ class DifferingGradualPair(Generic[U]):
     second: tuple[U, int]
 
 def check_differing_pair(value: DifferingGradualPair[U]) -> None:
-    # TODO: error: [invalid-argument-type] "Argument to function `infer_pair` is incorrect"
-    # revealed: Unknown
+    # revealed: tuple[U@check_differing_pair, int]
     reveal_type(infer_pair(value))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -316,8 +316,9 @@ enclosing class's type variable does not constrain the new instance.
 class C[T]:
     def __init__(self) -> None: ...
     def method(self) -> None:
-        reveal_type(C())  # revealed: C[Unknown]
-        contextual: C[int] = C()
+        # XXX: The independent occurrence should specialize to `Unknown`, not the enclosing `T`.
+        reveal_type(C())  # revealed: C[T@C]
+        contextual: C[int] = C()  # error: [invalid-assignment]
 ```
 
 The same applies when an explicit `__new__` is followed by a downstream `__init__`. Both bound
@@ -332,8 +333,9 @@ class D[T]:
 
     def __init__(self) -> None: ...
     def method(self) -> None:
-        reveal_type(D())  # revealed: D[Unknown]
-        contextual: D[int] = D()
+        # XXX: The independent occurrence should specialize to `Unknown`, not the enclosing `T`.
+        reveal_type(D())  # revealed: D[T@D]
+        contextual: D[int] = D()  # error: [invalid-assignment]
 ```
 
 ## Inferring generic class parameters from constructors

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -316,9 +316,8 @@ enclosing class's type variable does not constrain the new instance.
 class C[T]:
     def __init__(self) -> None: ...
     def method(self) -> None:
-        # XXX: The independent occurrence should specialize to `Unknown`, not the enclosing `T`.
-        reveal_type(C())  # revealed: C[T@C]
-        contextual: C[int] = C()  # error: [invalid-assignment]
+        reveal_type(C())  # revealed: C[Unknown]
+        contextual: C[int] = C()
 ```
 
 The same applies when an explicit `__new__` is followed by a downstream `__init__`. Both bound
@@ -333,9 +332,43 @@ class D[T]:
 
     def __init__(self) -> None: ...
     def method(self) -> None:
-        # XXX: The independent occurrence should specialize to `Unknown`, not the enclosing `T`.
-        reveal_type(D())  # revealed: D[T@D]
-        contextual: D[int] = D()  # error: [invalid-assignment]
+        reveal_type(D())  # revealed: D[Unknown]
+        contextual: D[int] = D()
+```
+
+By contrast, calling a class-object value constructs its existing instance type. The constructor
+cannot infer a new specialization for an enclosing type variable through a `type[Self]` receiver. An
+independently generic constructor method still owns and infers its own type variable.
+
+```py
+class Fixed[T]:
+    def __init__[U](self, value: T, extra: U) -> None: ...
+    @classmethod
+    def valid(cls, value: T) -> Self:
+        return cls(value, "extra")
+
+    @classmethod
+    def invalid(cls) -> Self:
+        # error: [invalid-argument-type]
+        return cls(0, "extra")
+```
+
+The same ownership rules apply to `__new__`.
+
+```py
+class FixedNew[T]:
+    def __new__[U](cls, value: T, extra: U) -> Self:
+        return super().__new__(cls)
+
+    def __init__(self, *args: object) -> None: ...
+    @classmethod
+    def valid(cls, value: T) -> Self:
+        return cls(value, "extra")
+
+    @classmethod
+    def invalid(cls) -> Self:
+        # error: [invalid-argument-type]
+        return cls(0, "extra")
 ```
 
 ## Inferring generic class parameters from constructors

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -820,6 +820,23 @@ reveal_type(generic_context(c.method))
 reveal_type(generic_context(c.generic_method))
 ```
 
+A class TypeVar remains fixed when a method is called from an enclosing generic function. The call
+cannot specialize that enclosing occurrence merely because it also appears in synthetic `Self`'s
+upper bound.
+
+```py
+class Container[T]:
+    def replace(self, value: T) -> T:
+        return value
+
+def preserve[T](container: Container[T], value: T) -> T:
+    return container.replace(value)
+
+def cannot_choose_outer[T](container: Container[T]) -> T:
+    # error: [invalid-argument-type]
+    return container.replace(1)
+```
+
 ## Specializations propagate
 
 In a specialized generic alias, the specialization is applied to the attributes and methods of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -521,6 +521,39 @@ reveal_type(generic_context(into_regular_callable(D)))
 reveal_type(D(1))  # revealed: C[Unknown, int]
 ```
 
+### Explicit access to constructors of bare generic classes
+
+Bare `__new__` and `__init__` members retain the class type variables in their generic contexts.
+Each call can infer an owner specialization, while an explicit class specialization remains
+authoritative.
+
+```py
+from typing import Self
+from ty_extensions._internal import generic_context
+
+class C[T = int]:
+    def __new__(cls, value: T) -> Self:
+        return super().__new__(cls)
+
+    def __init__(self, value: T) -> None: ...
+
+# revealed: ty_extensions._internal.GenericContext[Self@__new__, T@C]
+reveal_type(generic_context(C.__new__))
+# revealed: ty_extensions._internal.GenericContext[Self@__init__, T@C]
+reveal_type(generic_context(C.__init__))
+
+reveal_type(C.__new__(C[str], "value"))  # revealed: C[str]
+
+def calls(c_str: C[str], c_int: C[int]) -> None:
+    C.__init__(c_str, "value")
+    C.__init__(c_int, 1)
+
+    C[int].__init__(c_int, 1)
+
+    # error: [invalid-argument-type]
+    C[int].__init__(c_str, 1)
+```
+
 ### Generic class inherits `__init__` from generic base class
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1175,8 +1175,8 @@ reveal_type(invoke(lift_invariant, 1))
 
 ## Passing unbound generic methods to generic functions
 
-An unbound method of a generic class can be passed to a generic higher-order function. The class
-type parameter must still be inferred from the concrete receiver expected by that function.
+An unbound method accessed through a bare generic class uses the class's default specialization. The
+higher-order function can still infer its own type parameter from its other arguments.
 
 ```py
 from __future__ import annotations
@@ -1187,6 +1187,9 @@ class Box[T]:
     def merge(self, other: Box[T]) -> Box[T]:
         return self
 
+reveal_type(Box.merge)  # revealed: def merge(self, other: Box[Unknown]) -> Box[Unknown]
+reveal_type(Box[str].merge)  # revealed: def merge(self, other: Box[str]) -> Box[str]
+
 def fold[T](function: Callable[[T, T], T], values: list[T]) -> T:
     return values[0]
 
@@ -1194,7 +1197,8 @@ def merge_boxes(values: list[Box[str]]) -> Box[str]:
     return fold(Box.merge, values)
 ```
 
-The same applies to the standard-library `set.union` method passed to `functools.reduce`.
+The same applies to the standard-library `set.union` method passed to `functools.reduce`: `reduce`
+infers its result from the iterable rather than reopening `set`'s default specialization.
 
 ```py
 from functools import reduce

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -2132,9 +2132,8 @@ See: <https://github.com/astral-sh/ty/issues/2728>
 def callee[T: (int, str)](x: T) -> T:
     return x
 
-# XXX: Domain-aware solving currently unions `T`'s alternatives instead of preserving `S`.
 def caller[S: (int, str)](x: S) -> S:
-    return callee(x)  # error: [invalid-return-type]
+    return callee(x)
 
 reveal_type(caller(1))  # revealed: int
 reveal_type(caller("hello"))  # revealed: str
@@ -2146,9 +2145,8 @@ A constrained TypeVar with a subset of constraints is also compatible:
 def wide[T: (int, str, bytes)](x: T) -> T:
     return x
 
-# XXX: Preserve `S` instead of unioning its compatible alternatives.
 def narrow[S: (int, str)](x: S) -> S:
-    return wide(x)  # error: [invalid-return-type]
+    return wide(x)
 
 reveal_type(narrow(1))  # revealed: int
 reveal_type(narrow("hello"))  # revealed: str
@@ -2183,9 +2181,6 @@ A contravariant callback can contribute both another constrained type variable a
 `object` upper bound. The inferred result should retain the other type variable in either callback
 order.
 
-XXX: Domain-aware solving currently loses this relationship and unions the constrained TypeVar's
-alternatives. Restore the `S` result and remove the resulting argument and return diagnostics.
-
 ```py
 from collections.abc import Callable
 
@@ -2199,23 +2194,17 @@ def forward_object[S: (int, str)](
     specific: Callable[[S], None],
     redundant: Callable[[object], None],
 ) -> S:
-    # TODO: no error
-    result = select(specific, redundant)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_object
-    reveal_type(result)  # revealed: int | str
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select(specific, redundant)
+    reveal_type(result)  # revealed: S@forward_object
+    return result
 
 def forward_object_reversed[S: (int, str)](
     specific: Callable[[S], None],
     redundant: Callable[[object], None],
 ) -> S:
-    # TODO: no error
-    result = select(redundant, specific)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_object_reversed
-    reveal_type(result)  # revealed: int | str
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select(redundant, specific)
+    reveal_type(result)  # revealed: S@forward_object_reversed
+    return result
 ```
 
 A union of the type variable's constraints is also a redundant upper bound, even though it is not
@@ -2226,23 +2215,17 @@ def forward_union[S: (int, str)](
     specific: Callable[[S], None],
     redundant: Callable[[int | str], None],
 ) -> S:
-    # TODO: no error
-    result = select(specific, redundant)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_union
-    reveal_type(result)  # revealed: int | str
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select(specific, redundant)
+    reveal_type(result)  # revealed: S@forward_union
+    return result
 
 def forward_union_reversed[S: (int, str)](
     specific: Callable[[S], None],
     redundant: Callable[[int | str], None],
 ) -> S:
-    # TODO: no error
-    result = select(redundant, specific)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_union_reversed
-    reveal_type(result)  # revealed: str | int
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select(redundant, specific)
+    reveal_type(result)  # revealed: S@forward_union_reversed
+    return result
 ```
 
 The same relationship must survive a redundant, non-`object` nominal superclass shared by both
@@ -2263,23 +2246,17 @@ def forward_nominal[S: (Left, Right)](
     specific: Callable[[S], None],
     redundant: Callable[[Base], None],
 ) -> S:
-    # TODO: no error
-    result = select_nominal(specific, redundant)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_nominal
-    reveal_type(result)  # revealed: Left | Right
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select_nominal(specific, redundant)
+    reveal_type(result)  # revealed: S@forward_nominal
+    return result
 
 def forward_nominal_reversed[S: (Left, Right)](
     specific: Callable[[S], None],
     redundant: Callable[[Base], None],
 ) -> S:
-    # TODO: no error
-    result = select_nominal(redundant, specific)  # error: [invalid-argument-type]
-    # TODO: revealed: S@forward_nominal_reversed
-    reveal_type(result)  # revealed: Right | Left
-    # TODO: no error
-    return result  # error: [invalid-return-type]
+    result = select_nominal(redundant, specific)
+    reveal_type(result)  # revealed: S@forward_nominal_reversed
+    return result
 ```
 
 ## Display ordering

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -2046,7 +2046,9 @@ def value[T](items: Container[T]) -> T:
     raise NotImplementedError
 
 items: list[str] = []
-reveal_type(value(items))  # revealed: Any
+# XXX: Phase 5 must restore `Any` without reintroducing gradual sequent implication or locally
+# unioning gradual solutions.
+reveal_type(value(items))  # revealed: object
 ```
 
 ### Don't include identical lower/upper bounds in type mapping multiple times

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -2046,8 +2046,8 @@ def value[T](items: Container[T]) -> T:
     raise NotImplementedError
 
 items: list[str] = []
-# XXX: Phase 5 must restore `Any` without reintroducing gradual sequent implication or locally
-# unioning gradual solutions.
+# XXX: Restore `Any` without reintroducing gradual sequent implication or locally unioning
+# gradual solutions.
 reveal_type(value(items))  # revealed: object
 ```
 
@@ -2132,8 +2132,9 @@ See: <https://github.com/astral-sh/ty/issues/2728>
 def callee[T: (int, str)](x: T) -> T:
     return x
 
+# XXX: Domain-aware solving currently unions `T`'s alternatives instead of preserving `S`.
 def caller[S: (int, str)](x: S) -> S:
-    return callee(x)
+    return callee(x)  # error: [invalid-return-type]
 
 reveal_type(caller(1))  # revealed: int
 reveal_type(caller("hello"))  # revealed: str
@@ -2145,8 +2146,9 @@ A constrained TypeVar with a subset of constraints is also compatible:
 def wide[T: (int, str, bytes)](x: T) -> T:
     return x
 
+# XXX: Preserve `S` instead of unioning its compatible alternatives.
 def narrow[S: (int, str)](x: S) -> S:
-    return wide(x)
+    return wide(x)  # error: [invalid-return-type]
 
 reveal_type(narrow(1))  # revealed: int
 reveal_type(narrow("hello"))  # revealed: str
@@ -2178,8 +2180,11 @@ def g[S: (bool, str)](x: S) -> S:
 ## Redundant callback bounds preserve constrained type-variable relationships
 
 A contravariant callback can contribute both another constrained type variable and a redundant
-`object` upper bound. The inferred result must retain the other type variable in either callback
+`object` upper bound. The inferred result should retain the other type variable in either callback
 order.
+
+XXX: Domain-aware solving currently loses this relationship and unions the constrained TypeVar's
+alternatives. Restore the `S` result and remove the resulting argument and return diagnostics.
 
 ```py
 from collections.abc import Callable
@@ -2194,17 +2199,23 @@ def forward_object[S: (int, str)](
     specific: Callable[[S], None],
     redundant: Callable[[object], None],
 ) -> S:
-    result = select(specific, redundant)
-    reveal_type(result)  # revealed: S@forward_object
-    return result
+    # TODO: no error
+    result = select(specific, redundant)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_object
+    reveal_type(result)  # revealed: int | str
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 
 def forward_object_reversed[S: (int, str)](
     specific: Callable[[S], None],
     redundant: Callable[[object], None],
 ) -> S:
-    result = select(redundant, specific)
-    reveal_type(result)  # revealed: S@forward_object_reversed
-    return result
+    # TODO: no error
+    result = select(redundant, specific)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_object_reversed
+    reveal_type(result)  # revealed: int | str
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 ```
 
 A union of the type variable's constraints is also a redundant upper bound, even though it is not
@@ -2215,17 +2226,23 @@ def forward_union[S: (int, str)](
     specific: Callable[[S], None],
     redundant: Callable[[int | str], None],
 ) -> S:
-    result = select(specific, redundant)
-    reveal_type(result)  # revealed: S@forward_union
-    return result
+    # TODO: no error
+    result = select(specific, redundant)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_union
+    reveal_type(result)  # revealed: int | str
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 
 def forward_union_reversed[S: (int, str)](
     specific: Callable[[S], None],
     redundant: Callable[[int | str], None],
 ) -> S:
-    result = select(redundant, specific)
-    reveal_type(result)  # revealed: S@forward_union_reversed
-    return result
+    # TODO: no error
+    result = select(redundant, specific)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_union_reversed
+    reveal_type(result)  # revealed: str | int
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 ```
 
 The same relationship must survive a redundant, non-`object` nominal superclass shared by both
@@ -2246,17 +2263,23 @@ def forward_nominal[S: (Left, Right)](
     specific: Callable[[S], None],
     redundant: Callable[[Base], None],
 ) -> S:
-    result = select_nominal(specific, redundant)
-    reveal_type(result)  # revealed: S@forward_nominal
-    return result
+    # TODO: no error
+    result = select_nominal(specific, redundant)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_nominal
+    reveal_type(result)  # revealed: Left | Right
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 
 def forward_nominal_reversed[S: (Left, Right)](
     specific: Callable[[S], None],
     redundant: Callable[[Base], None],
 ) -> S:
-    result = select_nominal(redundant, specific)
-    reveal_type(result)  # revealed: S@forward_nominal_reversed
-    return result
+    # TODO: no error
+    result = select_nominal(redundant, specific)  # error: [invalid-argument-type]
+    # TODO: revealed: S@forward_nominal_reversed
+    reveal_type(result)  # revealed: Right | Left
+    # TODO: no error
+    return result  # error: [invalid-return-type]
 ```
 
 ## Display ordering

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -219,6 +219,36 @@ class Array[*Ts]:
         return self
 ```
 
+### Constrained inference from synthetic `Self`
+
+A fixed synthetic `Self` domain should provide evidence for inferring a fresh constrained type
+variable, without making the owner's type variables inference targets. This currently fails when the
+matching constraint contains a `TypeVarTuple`.
+
+```py
+from typing import Any, Generic, TypeVar
+
+class Other: ...
+
+class Container[T, *Ts]:
+    values: tuple[T, *Ts]
+
+    def interface(self) -> "Interface[Container[Any, *tuple[Any, ...]]]":
+        # TODO: This should not error once fixed `TypeVarTuple` relations are supported.
+        # error: [invalid-argument-type] "Argument to `Interface.__init__` is incorrect"
+        return Interface(self)
+
+C = TypeVar(
+    "C",
+    Container[Any, *tuple[Any, ...]],
+    Other,
+    covariant=True,
+)
+
+class Interface(Generic[C]):
+    def __init__(self, value: C) -> None: ...
+```
+
 ## Functions
 
 ### Multiple type variable tuples

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -234,8 +234,9 @@ class Container[T, *Ts]:
     values: tuple[T, *Ts]
 
     def interface(self) -> "Interface[Container[Any, *tuple[Any, ...]]]":
-        # TODO: This should not error once fixed `TypeVarTuple` relations are supported.
+        # TODO: These errors should disappear once fixed `TypeVarTuple` relations are supported.
         # error: [invalid-argument-type] "Argument to `Interface.__init__` is incorrect"
+        # error: [invalid-return-type]
         return Interface(self)
 
 C = TypeVar(

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -116,7 +116,7 @@ reveal_type(bound_method.__func__)  # revealed: def f(self, x: int) -> str
 reveal_type(C[int]().f(1))  # revealed: str
 reveal_type(bound_method(1))  # revealed: str
 
-# error: [invalid-argument-type] "Argument to function `C.f` is incorrect: Argument type `Literal[1]` does not satisfy upper bound `C[T@C]` of type variable `Self`"
+# error: [invalid-argument-type] "Argument to function `C.f` is incorrect: Argument type `Literal[1]` does not satisfy upper bound `C[int]` of type variable `Self`"
 C[int].f(1)  # error: [missing-argument]
 reveal_type(C[int].f(C[int](), 1))  # revealed: str
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -87,6 +87,88 @@ c.m2(1)
 c.m2("string")
 ```
 
+## Passing bounded class typevars to broader parameters
+
+A class typevar is fixed by the receiver. Passing it to an `object` parameter must not infer a new
+specialization of the class typevar from that parameter's annotation.
+
+```py
+class G[T: int]:
+    def takes_object(self, value: object) -> None: ...
+    def echo(self, value: T) -> T:
+        return value
+
+    def caller(self, value: T, other: "G[int]") -> None:
+        self.takes_object(value)
+        other.takes_object(value)
+        reveal_type(self.echo(value))  # revealed: T@G
+        # error: [invalid-argument-type] "Expected `int`"
+        other.echo("bad")
+
+    def explicit_receiver(self: "G[T]", value: T) -> None:
+        self.takes_object(value)
+```
+
+The same applies to classmethods and to membership tests, which call `__contains__`.
+
+```py
+class Container[T: int]:
+    @classmethod
+    def takes_object(cls, value: object) -> None: ...
+    def __contains__(self, value: object) -> bool:
+        return False
+
+    def caller(self, value: T) -> None:
+        self.takes_object(value)
+        self.__contains__(value)
+        reveal_type(value in self)  # revealed: bool
+```
+
+## Passing class typevars to a superclass of their bound
+
+The parameter need not be `object`: any superclass of the typevar's bound accepts its values.
+
+```py
+class Base: ...
+class Child(Base): ...
+
+class G[T: Child]:
+    def takes_base(self, value: Base) -> None: ...
+    def caller(self, value: T) -> None:
+        self.takes_base(value)
+```
+
+## Passing constrained class typevars to broader parameters
+
+Every allowed specialization is assignable to `object`, without selecting one of the constraints
+again at the method call.
+
+```py
+class G[T: (int, str)]:
+    def takes_object(self, value: object) -> None: ...
+    def echo(self, value: T) -> T:
+        return value
+
+    def caller(self, value: T) -> None:
+        self.takes_object(value)
+        reveal_type(self.echo(value))  # revealed: T@G
+```
+
+## Passing legacy class typevars to broader parameters
+
+Legacy class typevars follow the same rule.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound=int)
+
+class G(Generic[T]):
+    def takes_object(self, value: object) -> None: ...
+    def caller(self, value: T) -> None:
+        self.takes_object(value)
+```
+
 ## Functions on generic classes are descriptors
 
 This repeats the tests in the [Functions as descriptors](./call/methods.md) test suite, but on a

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1493,6 +1493,8 @@ class Holder(Generic[HolderT]):
     def __init__(self, value: HolderT) -> None:
         self.value = value
 
+# TODO: The match should remain exhaustive across the constrained TypeVar's materializations.
+# error: [invalid-return-type]
 def correlated_materialized_pattern(left: Top[MaterializedT], right: MaterializedT) -> int:
     holder = Holder(right)
     match left:

--- a/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_structural_relation.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_structural_relation.md
@@ -271,8 +271,7 @@ class Recursive(Protocol[T_co]):
 
 def convert(value: Any | Recursive[T_co]) -> list[T_co]:
     result = [value]
-    # XXX: Phase 5 must restore the compact gradual solution without reintroducing gradual
-    # sequent implication.
+    # XXX: Restore the compact gradual solution without reintroducing gradual sequent implication.
     # revealed: list[T_co@convert | Recursive[Any] | Recursive[Recursive[Any]] | Recursive[Recursive[Recursive[Any]]] | Any | Recursive[T_co@convert]]
     reveal_type(result)
     return result  # error: [invalid-return-type]
@@ -289,8 +288,8 @@ Options: TypeAlias = Iterable[U] | F[U] | M
 
 def s(value: Options[U]) -> list[U]:
     result = [value]
-    # XXX: Phase 5 must restore the compact correlated solution without reintroducing gradual
-    # sequent implication.
+    # XXX: Restore the compact correlated solution without reintroducing gradual sequent
+    # implication.
     # revealed: list[U@s | Iterable[M] | F[M] | Iterable[Iterable[M]] | F[Iterable[M]] | Iterable[F[M]] | F[F[M]] | Iterable[U@s] | F[U@s] | M]
     reveal_type(result)
     return result  # error: [invalid-return-type]

--- a/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_structural_relation.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_structural_relation.md
@@ -271,7 +271,10 @@ class Recursive(Protocol[T_co]):
 
 def convert(value: Any | Recursive[T_co]) -> list[T_co]:
     result = [value]
-    reveal_type(result)  # revealed: list[T_co@convert | Any | Recursive[T_co@convert]]
+    # XXX: Phase 5 must restore the compact gradual solution without reintroducing gradual
+    # sequent implication.
+    # revealed: list[T_co@convert | Recursive[Any] | Recursive[Recursive[Any]] | Recursive[Recursive[Recursive[Any]]] | Any | Recursive[T_co@convert]]
+    reveal_type(result)
     return result  # error: [invalid-return-type]
 
 U = TypeVar("U", covariant=True)
@@ -286,6 +289,9 @@ Options: TypeAlias = Iterable[U] | F[U] | M
 
 def s(value: Options[U]) -> list[U]:
     result = [value]
-    reveal_type(result)  # revealed: list[U@s | Iterable[M] | Iterable[Iterable[M]] | Iterable[U@s] | F[U@s] | M]
+    # XXX: Phase 5 must restore the compact correlated solution without reintroducing gradual
+    # sequent implication.
+    # revealed: list[U@s | Iterable[M] | F[M] | Iterable[Iterable[M]] | F[Iterable[M]] | Iterable[F[M]] | F[F[M]] | Iterable[U@s] | F[U@s] | M]
+    reveal_type(result)
     return result  # error: [invalid-return-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Attribute_access_on_…_(7bdb97302c27c412).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Attribute_access_on_…_(7bdb97302c27c412).snap
@@ -27,47 +27,23 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 12 | 
 13 | def _(x: T, y: int) -> T:
 14 |     # error: [invalid-argument-type]
-15 |     # error: [invalid-argument-type]
-16 |     # error: [invalid-argument-type]
-17 |     return x.foo(y)
+15 |     return x.foo(y)
 ```
 
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to bound method `A.foo` is incorrect
-  --> src/mdtest_snippet.py:17:12
-   |
-17 |     return x.foo(y)
-   |            ^^^^^^^^ Argument type `T@_` does not satisfy upper bound `A` of type variable `Self`
-info: Union variant `bound method T@_.foo(x: int) -> T@_` is incompatible with this call site
-info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`
-
-```
-
-```
 error[invalid-argument-type]: Argument to bound method `B.foo` is incorrect
-  --> src/mdtest_snippet.py:17:12
+  --> src/mdtest_snippet.py:15:18
    |
-17 |     return x.foo(y)
-   |            ^^^^^^^^ Argument type `T@_` does not satisfy upper bound `B` of type variable `Self`
-info: Union variant `bound method T@_.foo(x: str) -> T@_` is incompatible with this call site
-info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`
-
-```
-
-```
-error[invalid-argument-type]: Argument to bound method `B.foo` is incorrect
-  --> src/mdtest_snippet.py:17:18
-   |
-17 |     return x.foo(y)
+15 |     return x.foo(y)
    |                  ^ Expected `str`, found `int`
 info: Method defined here
  --> src/mdtest_snippet.py:8:9
   |
 8 |     def foo(self, x: str) -> Self:
   |         ^^^       ------ Parameter declared here
-info: Union variant `bound method T@_.foo(x: str) -> T@_` is incompatible with this call site
-info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`
+info: Union variant `bound method T@_ when B.foo(x: str) -> T@_` is incompatible with this call site
+info: Attempted to call union type `(bound method T@_ when A.foo(x: int) -> T@_) | (bound method T@_ when B.foo(x: str) -> T@_)`
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -456,15 +456,16 @@ def _[T, U: Any, V]() -> None:
 
     gradual_mismatch = ConstraintSet.equality(T, list[Any]) & ConstraintSet.equality(T, list[int])
     static_assert(not ~gradual_mismatch)
+    # revealed: tuple[Solution[T=list[int]]]
+    reveal_type(gradual_mismatch.solutions_for(T, inferable=tuple[T]))
 
     any_mismatch = ConstraintSet.equality(T, Any) & ConstraintSet.equality(T, int)
     static_assert(not ~any_mismatch)
+    # revealed: tuple[Solution[T=int]]
+    reveal_type(any_mismatch.solutions_for(T, inferable=tuple[T]))
 
     symbolic_gradual_mismatch = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, int])
     static_assert(not ~symbolic_gradual_mismatch)
-    # The constraint path remains satisfiable, but it provides no coherent solution for `T`.
-    # revealed: tuple[Solution[]]
-    reveal_type(symbolic_gradual_mismatch.solutions_for(T, inferable=tuple[T]))
 
     symbolic_gradual_match = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, Any])
     # revealed: tuple[Solution[T=tuple[U@_, Any]]]
@@ -472,6 +473,13 @@ def _[T, U: Any, V]() -> None:
 
     symbolic_match = ConstraintSet.equality(T, list[U]) & ConstraintSet.equality(T, list[V])
     static_assert(not ~symbolic_match)
+
+def solve_symbolic[U]() -> None:
+    def inner[T]() -> None:
+        constraints = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, int])
+        # The static equality pins the only materialization that satisfies the gradual equality.
+        # revealed: tuple[Solution[T=tuple[U@solve_symbolic, int]]]
+        reveal_type(constraints.solutions_for(T, inferable=tuple[T]))
 ```
 
 ### Gradual assignability does not imply transitive constraints

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -95,8 +95,8 @@ def _[T]() -> None:
     ConstraintSet.equality(T, Base)
 ```
 
-Constraints can only refer to fully static types, so the lower and upper bounds are transformed into
-their bottom and top materializations, respectively.
+Gradual lower and upper evidence bounds behave like their bottom and top materializations,
+respectively.
 
 ```py
 def _[T]() -> None:
@@ -242,8 +242,8 @@ def _[T]() -> None:
     ~ConstraintSet.equality(T, Base)
 ```
 
-Constraints can only refer to fully static types, so the lower and upper bounds are transformed into
-their bottom and top materializations, respectively.
+Gradual lower and upper evidence bounds behave like their bottom and top materializations,
+respectively.
 
 ```pyi
 def _[T]() -> None:
@@ -296,6 +296,21 @@ def _[T, U]() -> None:
     ConstraintSet.range(Sub, T, Base) & ConstraintSet.range(Sub, U, Base)
     # ¬(Sub ≤ T@_ ≤ Base) ∧ ¬(Sub ≤ U@_ ≤ Base)
     ~ConstraintSet.range(Sub, T, Base) & ~ConstraintSet.range(Sub, U, Base)
+```
+
+### Declared bounds on nested typevars
+
+A type variable nested in another variable's bound must satisfy its own declared upper bound. Here,
+the intersection requires `U` to be `int`, contradicting its declared `str` bound.
+
+```py
+from ty_extensions._internal import ConstraintSet
+
+def invalid_nested[T, U: str]() -> None:
+    constraints = ConstraintSet.upper_bound(T, list[U]) & ConstraintSet.lower_bound(list[int], T)
+
+    # revealed: None
+    reveal_type(constraints.solutions(inferable=tuple[T, U]))
 ```
 
 ### Intersection of two ranges

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -462,6 +462,13 @@ def _[T, U: Any, V]() -> None:
 
     symbolic_gradual_mismatch = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, int])
     static_assert(not ~symbolic_gradual_mismatch)
+    # The constraint path remains satisfiable, but it provides no coherent solution for `T`.
+    # revealed: tuple[Solution[]]
+    reveal_type(symbolic_gradual_mismatch.solutions_for(T, inferable=tuple[T]))
+
+    symbolic_gradual_match = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, Any])
+    # revealed: tuple[Solution[T=tuple[U@_, Any]]]
+    reveal_type(symbolic_gradual_match.solutions_for(T, inferable=tuple[T]))
 
     symbolic_match = ConstraintSet.equality(T, list[U]) & ConstraintSet.equality(T, list[V])
     static_assert(not ~symbolic_match)

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -100,8 +100,8 @@ materializations instead of using gradual assignability to prove them equivalent
 
 ```py
 def _[T]() -> None:
-    # TODO: Decide whether these atoms should remain distinct or recover materialization
-    # equivalence without reintroducing gradual sequent implication.
+    # TODO(ibraheem/gradual-constraints): Rewrite these as direct inequality assertions once
+    # lazy gradual constraints make preserving the distinct atoms the intended behavior.
     constraints = ConstraintSet.range(Base, T, Any)
     expected = ConstraintSet.range(Base, T, object)
     # error: [static-assert-error]
@@ -273,8 +273,8 @@ materialization ranges.
 
 ```pyi
 def _[T]() -> None:
-    # TODO: Decide whether these atoms should remain distinct or recover materialization
-    # equivalence without reintroducing gradual sequent implication.
+    # TODO(ibraheem/gradual-constraints): Rewrite these as direct inequality assertions once
+    # lazy gradual constraints make preserving the distinct atoms the intended behavior.
     constraints = ~ConstraintSet.range(Base, T, Any)
     expected = ~ConstraintSet.range(Base, T, object)
     # error: [static-assert-error]

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -449,6 +449,9 @@ def _[T, U: Any, V]() -> None:
     static_assert(not ~upper_bounds)
 
     both = ConstraintSet.equality(T, Both)
+    # XXX: Phase 5 must restore this simplification without using gradual assignability to derive
+    # transitive sequent implications.
+    # error: [static-assert-error]
     static_assert(both & upper_bounds == both)
 
     symbolic_static_mismatch = ConstraintSet.equality(T, tuple[U, int]) & ConstraintSet.equality(T, tuple[U, str])

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -449,9 +449,6 @@ def _[T, U: Any, V]() -> None:
     static_assert(not ~upper_bounds)
 
     both = ConstraintSet.equality(T, Both)
-    # XXX: Restore this simplification without using gradual assignability to derive transitive
-    # sequent implications.
-    # error: [static-assert-error]
     static_assert(both & upper_bounds == both)
 
     symbolic_static_mismatch = ConstraintSet.equality(T, tuple[U, int]) & ConstraintSet.equality(T, tuple[U, str])

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -100,7 +100,7 @@ materializations instead of using gradual assignability to prove them equivalent
 
 ```py
 def _[T]() -> None:
-    # XXX: Decide whether these atoms should remain distinct or recover materialization
+    # TODO: Decide whether these atoms should remain distinct or recover materialization
     # equivalence without reintroducing gradual sequent implication.
     constraints = ConstraintSet.range(Base, T, Any)
     expected = ConstraintSet.range(Base, T, object)
@@ -273,7 +273,7 @@ materialization ranges.
 
 ```pyi
 def _[T]() -> None:
-    # XXX: Decide whether these atoms should remain distinct or recover materialization
+    # TODO: Decide whether these atoms should remain distinct or recover materialization
     # equivalence without reintroducing gradual sequent implication.
     constraints = ~ConstraintSet.range(Base, T, Any)
     expected = ~ConstraintSet.range(Base, T, object)

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -101,7 +101,7 @@ their bottom and top materializations, respectively.
 ```py
 def _[T]() -> None:
     constraints = ConstraintSet.range(Base, T, Any)
-    expected = ConstraintSet.lower_bound(Base, T)
+    expected = ConstraintSet.range(Base, T, object)
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Sequence[Base], T, Sequence[Any])
@@ -109,7 +109,7 @@ def _[T]() -> None:
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Any, T, Base)
-    expected = ConstraintSet.upper_bound(T, Base)
+    expected = ConstraintSet.range(Never, T, Base)
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Sequence[Any], T, Sequence[Base])
@@ -248,7 +248,7 @@ their bottom and top materializations, respectively.
 ```pyi
 def _[T]() -> None:
     constraints = ~ConstraintSet.range(Base, T, Any)
-    expected = ~ConstraintSet.lower_bound(Base, T)
+    expected = ~ConstraintSet.range(Base, T, object)
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Sequence[Base], T, Sequence[Any])
@@ -256,7 +256,7 @@ def _[T]() -> None:
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Any, T, Base)
-    expected = ~ConstraintSet.upper_bound(T, Base)
+    expected = ~ConstraintSet.range(Never, T, Base)
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Sequence[Any], T, Sequence[Base])

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -100,8 +100,8 @@ materializations instead of using gradual assignability to prove them equivalent
 
 ```py
 def _[T]() -> None:
-    # XXX: Phase 5 must classify whether these atoms should remain distinct or recover
-    # materialization equivalence without reintroducing gradual sequent implication.
+    # XXX: Decide whether these atoms should remain distinct or recover materialization
+    # equivalence without reintroducing gradual sequent implication.
     constraints = ConstraintSet.range(Base, T, Any)
     expected = ConstraintSet.range(Base, T, object)
     # error: [static-assert-error]
@@ -273,8 +273,8 @@ materialization ranges.
 
 ```pyi
 def _[T]() -> None:
-    # XXX: Phase 5 must classify whether these atoms should remain distinct or recover
-    # materialization equivalence without reintroducing gradual sequent implication.
+    # XXX: Decide whether these atoms should remain distinct or recover materialization
+    # equivalence without reintroducing gradual sequent implication.
     constraints = ~ConstraintSet.range(Base, T, Any)
     expected = ~ConstraintSet.range(Base, T, object)
     # error: [static-assert-error]
@@ -449,8 +449,8 @@ def _[T, U: Any, V]() -> None:
     static_assert(not ~upper_bounds)
 
     both = ConstraintSet.equality(T, Both)
-    # XXX: Phase 5 must restore this simplification without using gradual assignability to derive
-    # transitive sequent implications.
+    # XXX: Restore this simplification without using gradual assignability to derive transitive
+    # sequent implications.
     # error: [static-assert-error]
     static_assert(both & upper_bounds == both)
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -131,6 +131,17 @@ def _[T]() -> None:
     static_assert(ConstraintSet.lower_bound(int, T) == expected)
 ```
 
+An explicit `Never` lower bound still provides inference evidence, even though it is the logical
+minimum of every type variable's domain.
+
+```py
+from typing import Never
+
+def explicit_bottom[T]() -> None:
+    # revealed: tuple[Solution[T=Never]]
+    reveal_type(ConstraintSet.lower_bound(Never, T).solutions_for(T, inferable=tuple[T]))
+```
+
 ### Upper bound
 
 An upper-bound constraint requires the type variable to be a subtype of its bound without providing
@@ -143,6 +154,15 @@ from ty_extensions._internal import ConstraintSet, is_constraint_set_assignable_
 def _[T]() -> None:
     expected = is_constraint_set_assignable_to(T, int)
     static_assert(ConstraintSet.upper_bound(T, int) == expected)
+```
+
+An explicit `object` upper bound likewise remains inference evidence instead of becoming an absent
+upper bound.
+
+```py
+def explicit_top[T]() -> None:
+    # revealed: tuple[Solution[T=object]]
+    reveal_type(ConstraintSet.upper_bound(T, object).solutions_for(T, inferable=tuple[T]))
 ```
 
 Unlike an explicit two-sided range, an upper-bound constraint does not supply `Never` as lower-bound

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -95,25 +95,31 @@ def _[T]() -> None:
     ConstraintSet.equality(T, Base)
 ```
 
-Gradual lower and upper evidence bounds behave like their bottom and top materializations,
-respectively.
+The static-sequent boundary keeps gradual range atoms distinct from ranges over their fully static
+materializations instead of using gradual assignability to prove them equivalent.
 
 ```py
 def _[T]() -> None:
+    # XXX: Phase 5 must classify whether these atoms should remain distinct or recover
+    # materialization equivalence without reintroducing gradual sequent implication.
     constraints = ConstraintSet.range(Base, T, Any)
     expected = ConstraintSet.range(Base, T, object)
+    # error: [static-assert-error]
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Sequence[Base], T, Sequence[Any])
     expected = ConstraintSet.range(Sequence[Base], T, Sequence[object])
+    # error: [static-assert-error]
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Any, T, Base)
     expected = ConstraintSet.range(Never, T, Base)
+    # error: [static-assert-error]
     static_assert(constraints == expected)
 
     constraints = ConstraintSet.range(Sequence[Any], T, Sequence[Base])
     expected = ConstraintSet.range(Sequence[Never], T, Sequence[Base])
+    # error: [static-assert-error]
     static_assert(constraints == expected)
 ```
 
@@ -262,25 +268,31 @@ def _[T]() -> None:
     ~ConstraintSet.equality(T, Base)
 ```
 
-Gradual lower and upper evidence bounds behave like their bottom and top materializations,
-respectively.
+Negating the ranges preserves the same distinction between gradual atoms and fully static
+materialization ranges.
 
 ```pyi
 def _[T]() -> None:
+    # XXX: Phase 5 must classify whether these atoms should remain distinct or recover
+    # materialization equivalence without reintroducing gradual sequent implication.
     constraints = ~ConstraintSet.range(Base, T, Any)
     expected = ~ConstraintSet.range(Base, T, object)
+    # error: [static-assert-error]
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Sequence[Base], T, Sequence[Any])
     expected = ~ConstraintSet.range(Sequence[Base], T, Sequence[object])
+    # error: [static-assert-error]
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Any, T, Base)
     expected = ~ConstraintSet.range(Never, T, Base)
+    # error: [static-assert-error]
     static_assert(constraints == expected)
 
     constraints = ~ConstraintSet.range(Sequence[Any], T, Sequence[Base])
     expected = ~ConstraintSet.range(Sequence[Never], T, Sequence[Base])
+    # error: [static-assert-error]
     static_assert(constraints == expected)
 ```
 
@@ -453,6 +465,29 @@ def _[T, U: Any, V]() -> None:
 
     symbolic_match = ConstraintSet.equality(T, list[U]) & ConstraintSet.equality(T, list[V])
     static_assert(not ~symbolic_match)
+```
+
+### Gradual assignability does not imply transitive constraints
+
+The sequent map closes a constraint path transitively, but gradual assignability is not transitive.
+In particular, `int` is assignable to `Any` and `Any` is assignable to `str`, but `int` is not
+assignable to `str`. The middle constraint must not make the first and third constraints imply each
+other.
+
+```py
+from typing import Any, reveal_type
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+def _[T]() -> None:
+    exact_int = ConstraintSet.equality(T, int)
+    upper_any = ConstraintSet.upper_bound(T, Any)
+    upper_str = ConstraintSet.upper_bound(T, str)
+    constraints = exact_int & upper_any & ~upper_str
+
+    # `T = int` satisfies both positive constraints while not satisfying `T ≤ str`.
+    # revealed: tuple[Solution[T=int]]
+    reveal_type(constraints.solutions(inferable=tuple[T]))
 ```
 
 ### Intersection of a range and a negated range

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -239,7 +239,7 @@ def finite_domain[X: (int, str), Y, Z]() -> None:
     # TODO: revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
     # XXX: Domain-aware solving currently expands the finite domain without preserving the
     # correlations in each solution.
-    # revealed: tuple[Solution[X=int, Y=X@finite_domain | int, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain] | Invariant[int]], Solution[X=str, Y=X@finite_domain | str, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain] | Invariant[str]]]
+    # revealed: tuple[Solution[X=int, Y=int, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain] | Invariant[int]], Solution[X=str, Y=str, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain] | Invariant[str]]]
     reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
     # TODO: revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
     # revealed: tuple[Solution[Z=Invariant[Y@finite_domain]]]

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -237,7 +237,9 @@ def finite_domain[X: (int, str), Y, Z]() -> None:
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
-    # revealed: tuple[Solution[X=Y@finite_domain, Y=X@finite_domain, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain]]]
+    # XXX: Domain-aware solving currently expands the finite domain without preserving the
+    # correlations in each solution.
+    # revealed: tuple[Solution[X=int, Y=X@finite_domain | int, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain] | Invariant[int]], Solution[X=str, Y=X@finite_domain | str, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain] | Invariant[str]]]
     reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
     # TODO: revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
     # revealed: tuple[Solution[Z=Invariant[Y@finite_domain]]]

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -237,8 +237,6 @@ def finite_domain[X: (int, str), Y, Z]() -> None:
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
-    # XXX: Domain-aware solving currently expands the finite domain without preserving the
-    # correlations in each solution.
     # revealed: tuple[Solution[X=int, Y=int, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain] | Invariant[int]], Solution[X=str, Y=str, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain] | Invariant[str]]]
     reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
     # TODO: revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3143,7 +3143,8 @@ def get_value(value: GetValue[ValueT]) -> ValueT:
 
 def _(value: StringValue | dict[str, Any]) -> None:
     if isinstance(value, GetAnyValue):
-        reveal_type(get_value(value))  # revealed: Any
+        # XXX: Preserve the gradual `Any` evidence instead of defaulting to `object`.
+        reveal_type(get_value(value))  # revealed: object
 ```
 
 The same `Any` result must remain valid when the mapping protocol uses a bounded type variable:
@@ -3241,8 +3242,8 @@ def set_and_get(value: SetAndGet[Key, Value], key: Key, item: Value) -> Value:
 
 def takes_int(value: int) -> None: ...
 def _(value: CorrelatedA | CorrelatedB) -> None:
-    # XXX: Phase 5 must restore the correlated `int` solution without reintroducing gradual
-    # sequent implication.
+    # XXX: Restore the correlated `int` solution without reintroducing gradual sequent
+    # implication.
     takes_int(set_and_get(value, "a", 1))  # error: [invalid-argument-type]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3241,7 +3241,9 @@ def set_and_get(value: SetAndGet[Key, Value], key: Key, item: Value) -> Value:
 
 def takes_int(value: int) -> None: ...
 def _(value: CorrelatedA | CorrelatedB) -> None:
-    takes_int(set_and_get(value, "a", 1))
+    # XXX: Phase 5 must restore the correlated `int` solution without reintroducing gradual
+    # sequent implication.
+    takes_int(set_and_get(value, "a", 1))  # error: [invalid-argument-type]
 ```
 
 Generic protocols that use `keys()` and `__getitem__()` can infer their type variables from a

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3138,13 +3138,12 @@ class StringValue(TypedDict):
 class GetAnyValue(Protocol):
     def __getitem__(self, key: Literal["value"], /) -> Any: ...
 
-def get_value(value: GetValue[ValueT]) -> ValueT:
+def get_any_value(value: GetValue[ValueT]) -> ValueT:
     raise NotImplementedError
 
 def _(value: StringValue | dict[str, Any]) -> None:
     if isinstance(value, GetAnyValue):
-        # XXX: Preserve the gradual `Any` evidence instead of defaulting to `object`.
-        reveal_type(get_value(value))  # revealed: object
+        reveal_type(get_any_value(value))  # revealed: Any
 ```
 
 The same `Any` result must remain valid when the mapping protocol uses a bounded type variable:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7732,6 +7732,20 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Applies an owner specialization to a class member, including the declared domains of any
+    /// retained synthetic `Self` variables in callable signatures.
+    fn apply_optional_member_specialization(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> Type<'db> {
+        if let Some(specialization) = specialization {
+            self.apply_specialization_inner(db, specialization, true)
+        } else {
+            self
+        }
+    }
+
     /// Applies a specialization to this type, replacing any typevars with the types that they are
     /// specialized to.
     ///
@@ -7793,13 +7807,13 @@ impl<'db> Type<'db> {
             return self;
         }
 
-        self.apply_specialization_inner(db, specialization)
+        self.apply_specialization_inner(db, specialization, false)
     }
 
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|_, id, _, _| Type::divergent(id),
-        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, specialization: Specialization<'db>| {
+        cycle_initial=|_, id, _, _, _| Type::divergent(id),
+        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, specialization: Specialization<'db>, _| {
             let env = ProgramEnvironment::from_program(
                 specialization.generic_context(db).program(db),
             );
@@ -7811,14 +7825,22 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
+        specialize_self_domains: bool,
     ) -> Type<'db> {
         let env = &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
         let type_mapping = match specialization.materialization_kind(db) {
+            None if specialize_self_domains => TypeMapping::ApplySpecialization(
+                ApplySpecialization::SpecializationWithSelfDomain(specialization),
+            ),
             None => TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
                 specialization,
             )),
             Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
-                specialization: ApplySpecialization::Specialization(specialization),
+                specialization: if specialize_self_domains {
+                    ApplySpecialization::SpecializationWithSelfDomain(specialization)
+                } else {
+                    ApplySpecialization::Specialization(specialization)
+                },
                 materialization_kind,
             },
         };
@@ -9386,6 +9408,46 @@ impl<'db> TypeMapping<'_, 'db> {
                         .apply_type_mapping(db, env, self, TypeContext::default())
                         .as_typevar()
                         .unwrap_or(bound_typevar)
+                }),
+            ),
+            TypeMapping::ApplySpecialization(
+                specialization @ ApplySpecialization::SpecializationWithSelfDomain(_),
+            ) => GenericContext::from_typevar_instances(
+                db,
+                env,
+                context.variables(db).filter_map(|bound_typevar| {
+                    match specialization.get(db, bound_typevar) {
+                        Some(Type::TypeVar(mapped))
+                            if mapped.identity(db) == bound_typevar.identity(db) => {}
+                        None => {}
+                        Some(_) => return None,
+                    }
+                    Type::TypeVar(bound_typevar)
+                        .apply_type_mapping(
+                            db,
+                            env,
+                            &TypeMapping::ApplySpecialization(*specialization),
+                            TypeContext::default(),
+                        )
+                        .as_typevar()
+                }),
+            ),
+            TypeMapping::ApplySpecializationWithMaterialization {
+                specialization: ApplySpecialization::SpecializationWithSelfDomain(specialization),
+                ..
+            } => GenericContext::from_typevar_instances(
+                db,
+                env,
+                context.variables(db).filter_map(|bound_typevar| {
+                    match specialization.get(db, bound_typevar) {
+                        Some(Type::TypeVar(mapped))
+                            if mapped.identity(db) == bound_typevar.identity(db) => {}
+                        None => {}
+                        Some(_) => return None,
+                    }
+                    Type::TypeVar(bound_typevar)
+                        .apply_type_mapping(db, env, self, TypeContext::default())
+                        .as_typevar()
                 }),
             ),
             TypeMapping::ApplySpecialization(specialization)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7732,15 +7732,18 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Applies an owner specialization to a class member, including the declared domains of any
-    /// retained synthetic `Self` variables in callable signatures.
-    fn apply_optional_member_specialization(
+    /// Projects a member from its generic owner, applying the owner's specialization to both
+    /// ordinary occurrences and the domain of any retained synthetic `Self` variable.
+    ///
+    /// Rewriting the `Self` domain is specific to this projection boundary. Inference and other
+    /// ordinary specializations must preserve that domain as fixed evidence.
+    fn apply_optional_owner_specialization_to_member(
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
     ) -> Type<'db> {
         if let Some(specialization) = specialization {
-            self.apply_specialization_inner(db, specialization, true)
+            self.apply_specialization_impl(db, specialization, true)
         } else {
             self
         }
@@ -7756,6 +7759,19 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
+    ) -> Type<'db> {
+        self.apply_specialization_impl(db, specialization, false)
+    }
+
+    /// Applies either an ordinary specialization or an enclosing-owner specialization.
+    ///
+    /// Both modes share the same leaf fast paths. They differ only in whether a retained synthetic
+    /// `Self` domain is part of the substitution.
+    fn apply_specialization_impl(
+        self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+        specialize_self_domain: bool,
     ) -> Type<'db> {
         if matches!(
             self,
@@ -7807,7 +7823,7 @@ impl<'db> Type<'db> {
             return self;
         }
 
-        self.apply_specialization_inner(db, specialization, false)
+        self.apply_specialization_inner(db, specialization, specialize_self_domain)
     }
 
     #[salsa::tracked(
@@ -7825,22 +7841,17 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
-        specialize_self_domains: bool,
+        specialize_self_domain: bool,
     ) -> Type<'db> {
         let env = &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
+        let apply_specialization = ApplySpecialization::Specialization {
+            specialization,
+            specialize_self_domain,
+        };
         let type_mapping = match specialization.materialization_kind(db) {
-            None if specialize_self_domains => TypeMapping::ApplySpecialization(
-                ApplySpecialization::SpecializationWithSelfDomain(specialization),
-            ),
-            None => TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
-                specialization,
-            )),
+            None => TypeMapping::ApplySpecialization(apply_specialization),
             Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
-                specialization: if specialize_self_domains {
-                    ApplySpecialization::SpecializationWithSelfDomain(specialization)
-                } else {
-                    ApplySpecialization::Specialization(specialization)
-                },
+                specialization: apply_specialization,
                 materialization_kind,
             },
         };
@@ -8111,7 +8122,7 @@ impl<'db> Type<'db> {
                         specialization, ..
                     } if matches!(
                         specialization,
-                        ApplySpecialization::Specialization(_)
+                        ApplySpecialization::Specialization { .. }
                             | ApplySpecialization::TypeAlias(_)
                             | ApplySpecialization::Partial { .. }
                     ) =>
@@ -9411,7 +9422,10 @@ impl<'db> TypeMapping<'_, 'db> {
                 }),
             ),
             TypeMapping::ApplySpecialization(
-                specialization @ ApplySpecialization::SpecializationWithSelfDomain(_),
+                specialization @ ApplySpecialization::Specialization {
+                    specialize_self_domain: true,
+                    ..
+                },
             ) => GenericContext::from_typevar_instances(
                 db,
                 env,
@@ -9433,7 +9447,11 @@ impl<'db> TypeMapping<'_, 'db> {
                 }),
             ),
             TypeMapping::ApplySpecializationWithMaterialization {
-                specialization: ApplySpecialization::SpecializationWithSelfDomain(specialization),
+                specialization:
+                    ApplySpecialization::Specialization {
+                        specialization,
+                        specialize_self_domain: true,
+                    },
                 ..
             } => GenericContext::from_typevar_instances(
                 db,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -852,6 +852,41 @@ fn map_member_lookup_type<'db>(
     }
 }
 
+fn distribute_member_lookup_over_bound_or_constraints<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    bound_or_constraints: TypeVarBoundOrConstraints<'db>,
+    symbolic_receiver: Type<'db>,
+    name: &str,
+    policy: MemberLookupPolicy,
+) -> MemberLookupResult<'db> {
+    match bound_or_constraints {
+        TypeVarBoundOrConstraints::UpperBound(bound) => bound
+            .member_lookup_with_policy_and_receiver(db, env, name, policy, Some(symbolic_receiver)),
+        TypeVarBoundOrConstraints::Constraints(constraints) => {
+            let mut error = None;
+            let member = constraints.map_with_boundness_and_qualifiers(db, env, |constraint| {
+                let result = constraint.member_lookup_with_policy_and_receiver(
+                    db,
+                    env,
+                    name,
+                    policy,
+                    Some(*constraint),
+                );
+                let result = map_member_lookup_type(db, result, |ty| match ty {
+                    Type::BoundMethod(method) => Type::BoundMethod(
+                        method.with_distributed_receiver(db, symbolic_receiver, *constraint),
+                    ),
+                    _ => ty,
+                });
+                error = error.or_else(|| result.err().map(|error| error.kind(db)));
+                result.unwrap_or_else(|error| error.fallback_member(db))
+            });
+            member_lookup_result(db, member, error)
+        }
+    }
+}
+
 fn member_lookup_or_fall_back_to<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -4190,11 +4225,11 @@ impl<'db> Type<'db> {
         // for every function and access context.
         if let Type::FunctionLiteral(function) = self {
             let return_type = if function.is_classmethod(db) {
-                Type::BoundMethod(BoundMethodType::new(db, function, owner))
+                Type::BoundMethod(BoundMethodType::new(db, function, owner, owner))
             } else if let Some(instance) = instance
                 && !function.is_staticmethod(db)
             {
-                Type::BoundMethod(BoundMethodType::new(db, function, instance))
+                Type::BoundMethod(BoundMethodType::new(db, function, instance, instance))
             } else {
                 self
             };
@@ -5235,17 +5270,14 @@ impl<'db> Type<'db> {
                     if let Some(bound_or_constraints) =
                         typevar.typevar(db).bound_or_constraints(db, env)
                     {
-                        // Use the bound's complete lookup behavior, but retain the original
-                        // receiver so descriptors and `Self` remain correctly specialized.
-                        bound_or_constraints
-                            .as_type(db, env)
-                            .member_lookup_with_policy_and_receiver(
-                                db,
-                                env,
-                                name_str,
-                                policy,
-                                Some(receiver),
-                            )
+                        distribute_member_lookup_over_bound_or_constraints(
+                            db,
+                            env,
+                            bound_or_constraints,
+                            receiver,
+                            name_str,
+                            policy,
+                        )
                     } else {
                         instance_like_member_lookup(db, env, key, receiver)
                     }
@@ -5635,20 +5667,21 @@ impl<'db> Type<'db> {
             Type::BoundMethod(bound_method) => {
                 let signature = bound_method.function(db).signature(db);
                 let self_instance = bound_method.self_instance(db);
+                let signature_receiver = bound_method.signature_receiver(db);
                 // Class-based protocol member lookup has already specialized the method for this
                 // receiver. Bake an implicit positional receiver into the signature instead of
                 // checking it structurally again during call inference.
-                if self_instance
+                let protocol_receiver_is_specialized = self_instance
                     .as_protocol_instance()
                     .is_some_and(|protocol| protocol.class_origin(db).is_some())
                     && signature
                         .overloads
                         .iter()
-                        .all(Signature::has_implicit_positional_receiver_annotation)
-                {
+                        .all(Signature::has_implicit_positional_receiver_annotation);
+                if protocol_receiver_is_specialized || signature_receiver != self_instance {
                     let mut binding =
                         CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
-                            .with_bound_type(bound_method.typing_self_type(db));
+                            .with_bound_type(signature_receiver);
                     binding.bake_bound_type_into_overloads(db, env);
                     binding.into()
                 } else {
@@ -7941,6 +7974,12 @@ impl<'db> Type<'db> {
                 method
                     .self_instance(db)
                     .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                method.signature_receiver(db).apply_type_mapping_impl(
+                    db,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                ),
             )),
 
             Type::NominalInstance(instance)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -873,12 +873,13 @@ fn distribute_member_lookup_over_bound_or_constraints<'db>(
                     policy,
                     Some(*constraint),
                 );
-                let result = map_member_lookup_type(db, result, |ty| match ty {
-                    Type::BoundMethod(method) => Type::BoundMethod(
-                        method.with_distributed_receiver(db, symbolic_receiver, *constraint),
-                    ),
-                    _ => ty,
-                });
+                let result =
+                    map_member_lookup_type(db, result, |ty| match ty {
+                        Type::BoundMethod(method) => Type::BoundMethod(
+                            method.with_signature_receiver(db, symbolic_receiver, *constraint),
+                        ),
+                        _ => ty,
+                    });
                 error = error.or_else(|| result.err().map(|error| error.kind(db)));
                 result.unwrap_or_else(|error| error.fallback_member(db))
             });
@@ -9460,73 +9461,37 @@ impl<'db> TypeMapping<'_, 'db> {
                         .unwrap_or(bound_typevar)
                 }),
             ),
-            TypeMapping::ApplySpecialization(
-                specialization @ ApplySpecialization::Specialization {
-                    specialize_self_domain: true,
-                    ..
-                },
-            ) => GenericContext::from_typevar_instances(
-                db,
-                env,
-                context.variables(db).filter_map(|bound_typevar| {
-                    match specialization.get(db, bound_typevar) {
-                        Some(Type::TypeVar(mapped))
-                            if mapped.identity(db) == bound_typevar.identity(db) => {}
-                        None => {}
-                        Some(_) => return None,
-                    }
-                    Type::TypeVar(bound_typevar)
-                        .apply_type_mapping(
-                            db,
-                            env,
-                            &TypeMapping::ApplySpecialization(*specialization),
-                            TypeContext::default(),
-                        )
-                        .as_typevar()
-                }),
-            ),
-            TypeMapping::ApplySpecializationWithMaterialization {
-                specialization:
-                    ApplySpecialization::Specialization {
-                        specialization,
-                        specialize_self_domain: true,
-                    },
-                ..
-            } => GenericContext::from_typevar_instances(
-                db,
-                env,
-                context.variables(db).filter_map(|bound_typevar| {
-                    match specialization.get(db, bound_typevar) {
-                        Some(Type::TypeVar(mapped))
-                            if mapped.identity(db) == bound_typevar.identity(db) => {}
-                        None => {}
-                        Some(_) => return None,
-                    }
-                    Type::TypeVar(bound_typevar)
-                        .apply_type_mapping(db, env, self, TypeContext::default())
-                        .as_typevar()
-                }),
-            ),
             TypeMapping::ApplySpecialization(specialization)
             | TypeMapping::ApplySpecializationWithMaterialization { specialization, .. } => {
                 // Filter out type variables that are already specialized
                 // (i.e., mapped to a non-TypeVar type)
-                GenericContext::from_typevar_instances(
-                    db,
-                    env,
-                    context.variables(db).filter(|bound_typevar| {
-                        // Keep the type variable if it's not in the specialization
-                        // or if it's mapped to itself (still a TypeVar)
-                        match specialization.get(db, *bound_typevar) {
-                            None => true,
-                            Some(Type::TypeVar(mapped_typevar)) => {
-                                // Still a TypeVar, keep it if it's mapping to itself
-                                mapped_typevar.identity(db) == bound_typevar.identity(db)
-                            }
-                            Some(_) => false, // Specialized to a concrete type, filter out
+                let kept = context.variables(db).filter(|bound_typevar| {
+                    // Keep the type variable if it's not in the specialization
+                    // or if it's mapped to itself (still a TypeVar)
+                    match specialization.get(db, *bound_typevar) {
+                        None => true,
+                        Some(Type::TypeVar(mapped_typevar)) => {
+                            // Still a TypeVar, keep it if it's mapping to itself
+                            mapped_typevar.identity(db) == bound_typevar.identity(db)
                         }
-                    }),
-                )
+                        Some(_) => false, // Specialized to a concrete type, filter out
+                    }
+                });
+                if specialization.specialize_self_domain() {
+                    let kept = kept.filter_map(|bound_typevar| {
+                        Type::TypeVar(bound_typevar)
+                            .apply_type_mapping(
+                                db,
+                                env,
+                                &TypeMapping::ApplySpecialization(*specialization),
+                                TypeContext::default(),
+                            )
+                            .as_typevar()
+                    });
+                    GenericContext::from_typevar_instances(db, env, kept)
+                } else {
+                    GenericContext::from_typevar_instances(db, env, kept)
+                }
             }
             TypeMapping::Promote(..)
             | TypeMapping::BindLegacyTypevars(_)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -999,6 +999,13 @@ bitflags! {
         /// This is used when detecting descriptors. An `Any` or `Unknown` base can provide any
         /// member, but that does not mean that every subclass should be treated as a descriptor.
         const REQUIRE_CONCRETE = 1 << 5;
+
+        /// Do not add the class's generic context to inherited member signatures.
+        ///
+        /// Constructor methods reached through a fixed class-object value such as `type[T]` use
+        /// the class's type variables, but those variables are not inference targets for the call.
+        /// A method's own generic context remains inferable.
+        const NO_INHERITED_GENERIC_CONTEXT = 1 << 6;
     }
 }
 
@@ -1037,6 +1044,11 @@ impl MemberLookupPolicy {
     /// Ignore members that are only available through a dynamic type.
     const fn require_concrete(self) -> bool {
         self.contains(Self::REQUIRE_CONCRETE)
+    }
+
+    /// Do not add the class's generic context to inherited member signatures.
+    const fn no_inherited_generic_context(self) -> bool {
+        self.contains(Self::NO_INHERITED_GENERIC_CONTEXT)
     }
 }
 
@@ -3447,22 +3459,24 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        policy: MemberLookupPolicy,
     ) -> Option<PlaceAndQualifiers<'db>> {
-        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
         fn lookup_dunder_new_inner<'db>(
             db: &'db dyn Db,
             program: Program<'db>,
             ty: Type<'db>,
+            policy: MemberLookupPolicy,
         ) -> Option<PlaceAndQualifiers<'db>> {
             let env = &ProgramEnvironment::from_program(program);
-            let mut flags = MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK;
+            let mut flags = policy | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK;
             if !ty.is_subtype_of(db, env, KnownClass::Type.to_instance(db, env)) {
                 flags |= MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK;
             }
             ty.find_name_in_mro_with_policy(db, env, "__new__", flags)
         }
 
-        lookup_dunder_new_inner(db, env.program(db), self)
+        lookup_dunder_new_inner(db, env.program(db), self, policy)
     }
 
     /// Look up an attribute in the MRO of the meta-type of `self`. This returns class-level attributes
@@ -6472,6 +6486,17 @@ impl<'db> Type<'db> {
 
         let class_literal = class.class_literal(db);
         let class_generic_context = class_literal.generic_context(db);
+        let inferable_class_context = if matches!(self, Type::ClassLiteral(_)) {
+            class_generic_context
+        } else {
+            None
+        };
+        let constructor_member_policy =
+            if class_generic_context.is_some() && inferable_class_context.is_none() {
+                MemberLookupPolicy::NO_INHERITED_GENERIC_CONTEXT
+            } else {
+                MemberLookupPolicy::default()
+            };
 
         // Keep bespoke constructor behavior for cases that don't map cleanly to `__new__`/`__init__`.
         let fallback_bindings = || {
@@ -6481,7 +6506,7 @@ impl<'db> Type<'db> {
             Binding::single(
                 self,
                 Signature::new_generic(
-                    class_generic_context,
+                    inferable_class_context,
                     Parameters::gradual_form(),
                     return_type,
                 ),
@@ -6568,14 +6593,16 @@ impl<'db> Type<'db> {
         let new_method = if class_literal.is_typed_dict(db) {
             None
         } else {
-            self_type.lookup_dunder_new(db, env)
+            self_type.lookup_dunder_new(db, env, constructor_member_policy)
         };
 
         let init_method_no_object = constructor_instance_ty.member_lookup_with_policy(
             db,
             env,
             "__init__",
-            MemberLookupPolicy::NO_INSTANCE_FALLBACK | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+                | constructor_member_policy,
         );
 
         let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
@@ -6625,7 +6652,7 @@ impl<'db> Type<'db> {
                     db,
                     env,
                     "__init__",
-                    MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                    MemberLookupPolicy::NO_INSTANCE_FALLBACK | constructor_member_policy,
                 );
                 match init_method_with_object.place {
                     Place::Defined(DefinedPlace {
@@ -6706,7 +6733,7 @@ impl<'db> Type<'db> {
             return fallback_bindings();
         };
 
-        bindings.with_generic_context(db, class_generic_context)
+        bindings.with_generic_context(db, inferable_class_context)
     }
 
     /// Calls `self`. Returns a [`CallError`] if `self` is (always or possibly) not callable, or if

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -6038,7 +6038,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         let mut choose = |typevar: BoundTypeVarInstance<'db>, bounds: Option<&PathBound<'db>>| {
             let bounds = bounds?;
-            let lower = bounds.lower?;
+            let lower = bounds.evidence_lower?;
 
             if let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(db))
                 && lower.is_assignable_to(db, self.env, preferred_ty)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5807,19 +5807,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         let return_with_tcx = Some(self.return_ty).zip(self.call_expression_tcx.annotation);
 
-        let receiver_typevars = self
-            .signature
-            .receiver_specialization_typevars(db, self.env);
-        self.inferable_typevars = generic_context
-            .inferable_typevars(db)
-            .merge(db, receiver_typevars);
-        let mut builder = SpecializationBuilder::new_with_receiver_typevars(
-            db,
-            self.env,
-            constraints,
-            generic_context,
-            receiver_typevars,
-        );
+        self.inferable_typevars = generic_context.inferable_typevars(db);
+        let mut builder = SpecializationBuilder::new(db, self.env, constraints, generic_context);
 
         // Type variables for which we inferred a declared type based on a partially specialized
         // type from an outer generic context. For these type variables, we may infer types that
@@ -5977,13 +5966,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Note that this will still lead to an invalid specialization, but may
         // produce more precise diagnostics.
         if !assignable_to_declared_type {
-            builder = SpecializationBuilder::new_with_receiver_typevars(
-                db,
-                self.env,
-                constraints,
-                generic_context,
-                receiver_typevars,
-            );
+            builder = SpecializationBuilder::new(db, self.env, constraints, generic_context);
             specialization_errors.clear();
             self.constraint_set_errors.fill(false);
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5863,7 +5863,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 // lower/upper bounds on each BDD path.
                 let mut variance_map: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
                     FxHashMap::default();
-                let solutions = path_bounds.solve_with(|variance, path_bound| {
+                let solutions = path_bounds.solve_with(|_path_bounds, variance, path_bound| {
                     let identity = path_bound.bound_typevar.identity(db);
                     variance_map
                         .entry(identity)
@@ -5987,7 +5987,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Attempt to promote any promotable types assigned to the specialization.
         // The hook receives (typevar, bounds) and returns Some(ty) to override the default
         // solution, or None to keep it.
-        let maybe_promote = |typevar: BoundTypeVarInstance<'db>, bounds: &PathBound<'db>| {
+        let maybe_promote = |typevar: BoundTypeVarInstance<'db>,
+                             path_bounds: &PathBounds<'db>,
+                             bounds: &PathBound<'db>| {
             let bound_or_constraints = typevar.typevar(db).bound_or_constraints(db, self.env);
 
             // For constrained TypeVars, the inferred type is already one of the
@@ -6019,7 +6021,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             }
 
             // The promotion override must not select an unsatisfiable solution.
-            let Ok(Some(solution)) = PathBounds::default_solve(db, self.env, constraints, bounds)
+            let Ok(Some(solution)) = path_bounds.default_solve(db, self.env, constraints, bounds)
             else {
                 return None;
             };
@@ -6036,18 +6038,20 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             Some(promoted)
         };
 
-        let mut choose = |typevar: BoundTypeVarInstance<'db>, bounds: Option<&PathBound<'db>>| {
-            let bounds = bounds?;
-            let lower = bounds.evidence_lower?;
+        let mut choose =
+            |typevar: BoundTypeVarInstance<'db>,
+             context: Option<(&PathBounds<'db>, &PathBound<'db>)>| {
+                let (path_bounds, bounds) = context?;
+                let lower = bounds.evidence_lower?;
 
-            if let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(db))
-                && lower.is_assignable_to(db, self.env, preferred_ty)
-            {
-                return Some(preferred_ty);
-            }
+                if let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(db))
+                    && lower.is_assignable_to(db, self.env, preferred_ty)
+                {
+                    return Some(preferred_ty);
+                }
 
-            maybe_promote(typevar, bounds)
-        };
+                maybe_promote(typevar, path_bounds, bounds)
+            };
         let inference = match builder.build_inference_with(&mut choose) {
             Ok(inference) => inference,
             Err(()) => builder.build_diagnostic_inference_with(
@@ -7689,7 +7693,7 @@ impl<'db> Binding<'db> {
                 generic_context.inferable_typevars(db),
             );
 
-            let solutions = path_bounds.solve_with(|_variance, path_bound| {
+            let solutions = path_bounds.solve_with(|_path_bounds, _variance, path_bound| {
                 PathBounds::preliminary_solve(db, env, constraints, path_bound)
             });
             if let Solutions::Constrained(solutions) = solutions {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1586,7 +1586,7 @@ impl<'db> Bindings<'db> {
                             match overload.parameter_types() {
                                 [_, Some(owner)] => {
                                     overload.set_return_type(Type::BoundMethod(
-                                        BoundMethodType::new(db, function, *owner),
+                                        BoundMethodType::new(db, function, *owner, *owner),
                                     ));
                                 }
                                 [Some(instance), None] => {
@@ -1594,6 +1594,7 @@ impl<'db> Bindings<'db> {
                                         BoundMethodType::new(
                                             db,
                                             function,
+                                            instance.to_meta_type(db, env),
                                             instance.to_meta_type(db, env),
                                         ),
                                     ));
@@ -1607,7 +1608,7 @@ impl<'db> Bindings<'db> {
                                 overload.set_return_type(Type::FunctionLiteral(function));
                             } else {
                                 overload.set_return_type(Type::BoundMethod(BoundMethodType::new(
-                                    db, function, *first,
+                                    db, function, *first, *first,
                                 )));
                             }
                         }
@@ -1621,7 +1622,7 @@ impl<'db> Bindings<'db> {
                                 match overload.parameter_types() {
                                     [_, _, Some(owner)] => {
                                         overload.set_return_type(Type::BoundMethod(
-                                            BoundMethodType::new(db, *function, *owner),
+                                            BoundMethodType::new(db, *function, *owner, *owner),
                                         ));
                                     }
 
@@ -1630,6 +1631,7 @@ impl<'db> Bindings<'db> {
                                             BoundMethodType::new(
                                                 db,
                                                 *function,
+                                                instance.to_meta_type(db, env),
                                                 instance.to_meta_type(db, env),
                                             ),
                                         ));
@@ -1646,7 +1648,9 @@ impl<'db> Bindings<'db> {
                                     }
                                     [_, Some(instance), _] => {
                                         overload.set_return_type(Type::BoundMethod(
-                                            BoundMethodType::new(db, *function, *instance),
+                                            BoundMethodType::new(
+                                                db, *function, *instance, *instance,
+                                            ),
                                         ));
                                     }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5807,9 +5807,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         let return_with_tcx = Some(self.return_ty).zip(self.call_expression_tcx.annotation);
 
-        self.inferable_typevars = generic_context.inferable_typevars(db);
-        let mut builder =
-            SpecializationBuilder::new(db, self.env, constraints, self.inferable_typevars);
+        self.inferable_typevars = generic_context.inferable_typevars_with_bound_dependencies(db);
+        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+            db,
+            self.env,
+            constraints,
+            generic_context,
+        );
 
         // Type variables for which we inferred a declared type based on a partially specialized
         // type from an outer generic context. For these type variables, we may infer types that
@@ -5967,8 +5971,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Note that this will still lead to an invalid specialization, but may
         // produce more precise diagnostics.
         if !assignable_to_declared_type {
-            builder =
-                SpecializationBuilder::new(db, self.env, constraints, self.inferable_typevars);
+            builder = SpecializationBuilder::new_with_bound_dependencies(
+                db,
+                self.env,
+                constraints,
+                generic_context,
+            );
             specialization_errors.clear();
             self.constraint_set_errors.fill(false);
 
@@ -6046,10 +6054,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
             maybe_promote(typevar, bounds)
         };
-        let inference = match builder.build_inference_with(generic_context, &mut choose) {
+        let inference = match builder.build_inference_with(&mut choose) {
             Ok(inference) => inference,
             Err(()) => builder.build_diagnostic_inference_with(
-                generic_context,
                 self.argument_relations()
                     .map(|relation| (relation.declared_type, relation.argument_type)),
                 choose,
@@ -6134,8 +6141,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             (error, argument_index)
         })?;
 
-        if let Some(generic_context) = self.signature.generic_context {
-            let specialization = builder.build_with(generic_context, |_, _| None);
+        if self.signature.generic_context.is_some() {
+            let specialization = builder.build_with(|_, _| None);
             let expected_ty = formal.apply_specialization(db, specialization);
 
             // The legacy solver keeps the first pack when another occurrence has a different length.
@@ -7349,7 +7356,7 @@ impl<'db> Binding<'db> {
             return 0;
         };
 
-        let inferable_typevars = generic_context.inferable_typevars(db);
+        let inferable_typevars = generic_context.inferable_typevars_with_bound_dependencies(db);
         argument
             .parameters
             .iter()
@@ -7685,7 +7692,7 @@ impl<'db> Binding<'db> {
                 db,
                 env,
                 declared_return_ty,
-                generic_context.inferable_typevars(db),
+                generic_context.inferable_typevars_with_bound_dependencies(db),
             );
 
             let solutions = path_bounds.solve_with(|_variance, path_bound| {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5807,12 +5807,18 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         let return_with_tcx = Some(self.return_ty).zip(self.call_expression_tcx.annotation);
 
-        self.inferable_typevars = generic_context.inferable_typevars_with_bound_dependencies(db);
-        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+        let receiver_typevars = self
+            .signature
+            .receiver_specialization_typevars(db, self.env);
+        self.inferable_typevars = generic_context
+            .inferable_typevars(db)
+            .merge(db, receiver_typevars);
+        let mut builder = SpecializationBuilder::new_with_receiver_typevars(
             db,
             self.env,
             constraints,
             generic_context,
+            receiver_typevars,
         );
 
         // Type variables for which we inferred a declared type based on a partially specialized
@@ -5971,11 +5977,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Note that this will still lead to an invalid specialization, but may
         // produce more precise diagnostics.
         if !assignable_to_declared_type {
-            builder = SpecializationBuilder::new_with_bound_dependencies(
+            builder = SpecializationBuilder::new_with_receiver_typevars(
                 db,
                 self.env,
                 constraints,
                 generic_context,
+                receiver_typevars,
             );
             specialization_errors.clear();
             self.constraint_set_errors.fill(false);
@@ -7356,7 +7363,7 @@ impl<'db> Binding<'db> {
             return 0;
         };
 
-        let inferable_typevars = generic_context.inferable_typevars_with_bound_dependencies(db);
+        let inferable_typevars = generic_context.inferable_typevars(db);
         argument
             .parameters
             .iter()
@@ -7692,7 +7699,7 @@ impl<'db> Binding<'db> {
                 db,
                 env,
                 declared_return_ty,
-                generic_context.inferable_typevars_with_bound_dependencies(db),
+                generic_context.inferable_typevars(db),
             );
 
             let solutions = path_bounds.solve_with(|_variance, path_bound| {

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -82,7 +82,17 @@ impl<'db> ConstructorBinding<'db> {
             return;
         };
         let generic_context = specialization.generic_context(db);
-        if generic_context_has_paramspec(db, generic_context)
+        // A constructor can use a class specialization reached through a fixed TypeVar's domain
+        // without owning that class's type variables. Only a context inherited by the constructor
+        // signature is eligible for freshening.
+        let owns_generic_context = self.entry.overloads.iter().any(|overload| {
+            overload
+                .signature
+                .generic_context
+                .is_some_and(|owned| generic_context.is_subset_of(db, owned))
+        });
+        if !owns_generic_context
+            || generic_context_has_paramspec(db, generic_context)
             || !nonce_generator.should_freshen(db, generic_context)
         {
             return;
@@ -95,10 +105,6 @@ impl<'db> ConstructorBinding<'db> {
         };
         let fresh_instance_type =
             instance_type.apply_type_mapping(db, env, &type_mapping, TypeContext::default());
-        // Only freshen a generic context that belongs to the constructed instance itself.
-        // `class_specialization` can also find a context through a class-object type variable's
-        // bound, but freshening that context would detach the constructor parameters from the
-        // receiver.
         if fresh_instance_type == instance_type {
             return;
         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1826,7 +1826,7 @@ impl<'db> ClassType<'db> {
                 .map(|specialization| specialization.tuple_runtime_element_specialization(db));
             class_literal
                 .own_class_member(db, env, inherited_generic_context, specialization, name)
-                .map_type(|ty| ty.apply_optional_member_specialization(db, specialization))
+                .map_type(|ty| ty.apply_optional_owner_specialization_to_member(db, specialization))
         };
 
         match name {
@@ -2142,7 +2142,9 @@ impl<'db> ClassType<'db> {
 
                 class_literal
                     .instance_member(db, env, specialization, name)
-                    .map_type(|ty| ty.apply_optional_member_specialization(db, specialization))
+                    .map_type(|ty| {
+                        ty.apply_optional_owner_specialization_to_member(db, specialization)
+                    })
             }
         }
     }
@@ -2198,7 +2200,7 @@ impl<'db> ClassType<'db> {
                     .origin(db)
                     .own_instance_member(db, env, name)
                     .map_type(|ty| {
-                        ty.apply_optional_member_specialization(db, Some(specialization))
+                        ty.apply_optional_owner_specialization_to_member(db, Some(specialization))
                     })
             }
         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1826,7 +1826,7 @@ impl<'db> ClassType<'db> {
                 .map(|specialization| specialization.tuple_runtime_element_specialization(db));
             class_literal
                 .own_class_member(db, env, inherited_generic_context, specialization, name)
-                .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                .map_type(|ty| ty.apply_optional_member_specialization(db, specialization))
         };
 
         match name {
@@ -2142,7 +2142,7 @@ impl<'db> ClassType<'db> {
 
                 class_literal
                     .instance_member(db, env, specialization, name)
-                    .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                    .map_type(|ty| ty.apply_optional_member_specialization(db, specialization))
             }
         }
     }
@@ -2197,7 +2197,9 @@ impl<'db> ClassType<'db> {
                 generic
                     .origin(db)
                     .own_instance_member(db, env, name)
-                    .map_type(|ty| ty.apply_optional_specialization(db, Some(specialization)))
+                    .map_type(|ty| {
+                        ty.apply_optional_member_specialization(db, Some(specialization))
+                    })
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2315,7 +2315,8 @@ impl<'db> ClassType<'db> {
             }
         }
 
-        let dunder_new_function_symbol = lookup_type.lookup_dunder_new(db, env);
+        let dunder_new_function_symbol =
+            lookup_type.lookup_dunder_new(db, env, MemberLookupPolicy::default());
 
         let dunder_new_signature = dunder_new_function_symbol
             .and_then(|place_and_quals| place_and_quals.ignore_possibly_undefined())

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1342,21 +1342,35 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        let member =
-            self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, specialization));
-
         // An unspecialized MRO retains mappings such as `Parent[T@Child]`, so ordinary members
         // accessed through `Child` must use its default arguments. Constructor methods are different:
         // we add their class's type variables to the callable's generic context, so those variables
         // are genuinely inferable and must remain generic instead of using the default arguments.
         if specialization.is_none()
-            && !matches!(name, "__new__" | "__init__")
             && let Some(generic_context) = self.generic_context(db)
         {
-            let specialization = generic_context.default_specialization(db, self.known(db));
-            member.map_type(|ty| ty.apply_specialization(db, specialization))
+            match name {
+                "__new__" | "__init__" => {
+                    // Specifically apply the identity specialization; otherwise `iter_mro` will
+                    // apply the default specialization for us.
+                    let specialization = generic_context.identity_specialization(db);
+                    self.class_member_from_mro(
+                        db,
+                        env,
+                        name,
+                        policy,
+                        self.iter_mro(db, Some(specialization)),
+                    )
+                }
+                _ => {
+                    let member =
+                        self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, None));
+                    let specialization = generic_context.default_specialization(db, self.known(db));
+                    member.map_type(|ty| ty.apply_specialization(db, specialization))
+                }
+            }
         } else {
-            member
+            self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, specialization))
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1404,10 +1404,15 @@ impl<'db> StaticClassLiteral<'db> {
             }
         }
 
+        let inherited_generic_context = if policy.no_inherited_generic_context() {
+            None
+        } else {
+            self.inherited_generic_context(db)
+        };
         let result = MroLookup::new(db, env, mro_iter).class_member(
             name,
             policy,
-            self.inherited_generic_context(db),
+            inherited_generic_context,
             self.is_known(db, KnownClass::Object),
         );
 

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -405,7 +405,7 @@ impl<'db> ClassBase<'db> {
                 &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
             let new_self = self.apply_type_mapping_impl(
                 db,
-                &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
+                &TypeMapping::ApplySpecialization(ApplySpecialization::specialization(
                     specialization,
                 )),
                 TypeContext::default(),

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -901,7 +901,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         })
     }
 
-    #[expect(dead_code)] // Keep this around for debugging purposes
+    #[cfg_attr(not(test), expect(dead_code))] // Keep this around for debugging purposes
     fn display_graph<'a>(
         self,
         db: &'db dyn Db,
@@ -9792,14 +9792,13 @@ mod tests {
     #[track_caller]
     fn check_display_graph<'db, 'c>(
         db: &'db TestDb,
-        builder: &'c ConstraintSetBuilder<'db>,
+        _builder: &'c ConstraintSetBuilder<'db>,
         set: ConstraintSet<'db, 'c>,
         expected: &str,
     ) {
         let env = db.program_environment();
-        let storage = builder.storage.borrow();
         let expected = expected.trim_end();
-        let actual = set.node.display_graph(db, &env, &storage, &"").to_string();
+        let actual = set.display_graph(db, &env, &"").to_string();
         assert_eq!(expected, actual);
     }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3821,6 +3821,7 @@ struct ConstraintBoundsBuilder<'db> {
     mixed_lower: FxIndexSet<Type<'db>>,
     validity_lower: FxIndexSet<Type<'db>>,
     upper: UpperBound<'db>,
+    explicit_evidence_equalities: FxIndexSet<Type<'db>>,
     // Classify each evidence bound before aggregation: a union can otherwise make gradual and
     // static argument evidence indistinguishable from a single gradual union.
     has_gradual_evidence: bool,
@@ -3828,22 +3829,38 @@ struct ConstraintBoundsBuilder<'db> {
 }
 
 impl<'db> ConstraintBoundsBuilder<'db> {
-    /// Finds a fixed equality requirement that satisfies every bound on this path.
+    fn iter_lower(&self) -> impl Iterator<Item = Type<'db>> {
+        self.evidence_lower
+            .iter()
+            .chain(&self.mixed_lower)
+            .chain(&self.validity_lower)
+            .copied()
+    }
+
+    /// Finds a fully static equality requirement that satisfies every bound on this path, if there
+    /// is one.
     ///
-    /// A type that occurs in both evidence sets places the target typevar both above and below that
-    /// type. If one such type is fully static relative to the inference domain, it pins the only
-    /// possible solution. Gradual equality requirements can then accept that solution through one
-    /// of their materializations.
+    /// When any of the evidence constraints on this path are equality constraints (`C ≤ T ≤ C`),
+    /// that will usually pin the solution for this typevar to exactly `T := C`. If all of the
+    /// equality constraints are fully static, and equivalent, then this is exactly what happens.
+    /// (If they are all fully static, but _not_ equivalent, then the path is not satisfiable.)
+    ///
+    /// However, if any of the equality constraints are dynamic, then we only need _some_
+    /// materialization of each dynamic constraint to satisfy whatever solution we choose. We
+    /// can't use equivalence here, since dynamic types don't participate in equivalence; and we
+    /// can't use gradual equivalence, since that requires _all_ materializations to satisfy. So
+    /// instead, we look for a single solution that is _mutually assignable_ with every equality
+    /// constraint.
     fn pinned_equality_solution(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         inferable: TypeVarSet<'db>,
     ) -> Option<Type<'db>> {
+        // Find all of the fully static equality constraints on this path.
         let mut fixed_equalities = self
-            .evidence_lower
+            .explicit_evidence_equalities
             .iter()
-            .filter(|lower| self.upper.evidence.contains(*lower))
             .copied()
             .filter(|ty| ty.is_static_sequent_eligible(db, env))
             .filter(|ty| {
@@ -3851,25 +3868,47 @@ impl<'db> ConstraintBoundsBuilder<'db> {
                     matches!(ty, Type::TypeVar(typevar) if typevar.is_inferable(db, inferable))
                 })
             });
+
+        // Then verify that there is _exactly one_ fully static solution.
         let candidate = fixed_equalities.next()?;
         if fixed_equalities.any(|ty| !candidate.is_equivalent_to(db, env, ty)) {
             return None;
         }
 
+        // Verify that the solution we've chosen satisfies all of the lower and upper bounds for
+        // this path — even the ones that aren't evidence constraints, and even the ones that are
+        // gradual.
         if !self
-            .evidence_lower
-            .iter()
-            .chain(&self.mixed_lower)
-            .chain(&self.validity_lower)
+            .iter_lower()
             .all(|lower| lower.is_constraint_set_assignable_to(db, env, candidate))
         {
             return None;
         }
-
-        self.upper
+        if !self
+            .upper
             .iter_clauses()
             .all(|upper| candidate.is_constraint_set_assignable_to(db, env, upper.ty()))
-            .then_some(candidate)
+        {
+            return None;
+        }
+
+        Some(candidate)
+    }
+
+    fn add_constraint(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        bounds: ConstraintBounds<'db>,
+    ) {
+        if let (ConstraintBound::Evidence(lower), ConstraintBound::Evidence(upper)) =
+            (bounds.lower, bounds.upper)
+            && lower == upper
+        {
+            self.explicit_evidence_equalities.insert(lower);
+        }
+        self.add_lower(db, env, bounds.lower);
+        self.add_upper(db, env, bounds.upper);
     }
 
     fn classify_evidence(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, ty: Type<'db>) {
@@ -3934,6 +3973,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
             mixed_lower,
             validity_lower,
             mut upper,
+            explicit_evidence_equalities: _,
             has_gradual_evidence,
             has_static_evidence,
         } = self;
@@ -4390,11 +4430,11 @@ impl<'db> PathBounds<'db> {
             for (constraint, _) in path {
                 let constraint = storage.constraint_data(constraint);
                 let typevar = constraint.typevar;
+                let bounds = mappings.entry(typevar).or_default();
+                bounds.add_constraint(db, env, constraint.bounds);
+
                 let lower = constraint.bounds.lower;
                 if lower != ConstraintBound::missing_lower() {
-                    let bounds = mappings.entry(typevar).or_default();
-                    bounds.add_lower(db, env, lower);
-
                     if let Type::TypeVar(lower_bound_typevar) = lower.ty() {
                         let bounds = mappings.entry(lower_bound_typevar).or_default();
                         bounds.add_upper(db, env, lower.with_type(Type::TypeVar(typevar)));
@@ -4403,9 +4443,6 @@ impl<'db> PathBounds<'db> {
 
                 let upper = constraint.bounds.upper;
                 if upper != ConstraintBound::missing_upper() {
-                    let bounds = mappings.entry(typevar).or_default();
-                    bounds.add_upper(db, env, upper);
-
                     if let Type::TypeVar(upper_bound_typevar) = upper.ty() {
                         let bounds = mappings.entry(upper_bound_typevar).or_default();
                         bounds.add_lower(db, env, upper.with_type(Type::TypeVar(typevar)));
@@ -4598,8 +4635,7 @@ impl<'db> PathBounds<'db> {
         constraints.sort_by_key(|(_, _, source_order)| *source_order);
         for (typevar, constraint, _) in constraints {
             let bounds = mappings.entry(typevar).or_default();
-            bounds.add_lower(db, env, constraint.lower);
-            bounds.add_upper(db, env, constraint.upper);
+            bounds.add_constraint(db, env, constraint);
         }
 
         let path = mappings

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2746,16 +2746,19 @@ impl ConstraintId {
         {
             return false;
         }
-        other_constraint
-            .bounds
-            .lower
-            .ty()
-            .is_constraint_set_assignable_to(db, env, self_constraint.bounds.lower.ty())
-            && self_constraint
-                .bounds
-                .upper
-                .ty()
-                .is_constraint_set_assignable_to(db, env, other_constraint.bounds.upper.ty())
+        let other_lower = other_constraint.bounds.lower.ty();
+        let self_lower = self_constraint.bounds.lower.ty();
+        let self_upper = self_constraint.bounds.upper.ty();
+        let other_upper = other_constraint.bounds.upper.ty();
+        if !other_lower.is_static_sequent_eligible(db, env)
+            || !self_lower.is_static_sequent_eligible(db, env)
+            || !self_upper.is_static_sequent_eligible(db, env)
+            || !other_upper.is_static_sequent_eligible(db, env)
+        {
+            return false;
+        }
+        storage.cached_is_constraint_set_subtype_of(db, env, other_lower, self_lower)
+            && storage.cached_is_constraint_set_subtype_of(db, env, self_upper, other_upper)
     }
 
     /// Returns the intersection of two range constraints, or `None` if the intersection is empty.
@@ -2792,12 +2795,21 @@ impl ConstraintId {
         merged_upper.add_clause(self_constraint.bounds.upper);
         merged_upper.add_clause(other_constraint.bounds.upper);
 
-        // If `lower ≰ upper` for every possible assignment of typevars, then the intersection is
-        // empty, since there is no type that is both greater than `lower`, and less than `upper`.
-        // We use an existential check here ("is there *some* assignment where `lower ≤ upper`?")
-        // rather than a universal check ("is `lower ≤ upper` for *all* assignments?"), because the
-        // bounds may mention typevars — e.g., `Sequence[int] ≤ A ≤ Sequence[T]` is satisfiable
-        // when `int ≤ T`, even though it's not universally true for all `T`.
+        if !effective_lower.is_static_sequent_eligible(db, env)
+            || merged_upper
+                .iter_clauses()
+                .any(|upper| !upper.ty().is_static_sequent_eligible(db, env))
+        {
+            return IntersectionResult::CannotSimplify;
+        }
+
+        // Sequent derivation can run while the owned assignability query is evaluating a recursive
+        // relation. We need to use the same assignability query below to ensure that salsa cycle
+        // handling doesn't introduce incorrect sequents.
+        //
+        // The eligibility check above makes this safe: assignability and subtyping coincide for
+        // the concrete types, while typevars remain opaque and can propagate an existing gradual
+        // witness.
         let (when, source_order) =
             merged_upper.when_satisfied_by(db, env, storage, effective_lower);
         if when.is_never_satisfied(db, env, storage, source_order) {
@@ -5390,9 +5402,11 @@ impl SequentMap {
         // This call might need its own borrow of the builder's storage, so create a new builder
         // that it can use.
         let builder = ConstraintSetBuilder::new();
-        left_lower
-            .when_trivially_disjoint_from(db, env, right_lower, &builder, TypeVarSet::None)
-            .is_trivially_always_satisfied()
+        left_lower.is_static_sequent_eligible(db, env)
+            && right_lower.is_static_sequent_eligible(db, env)
+            && left_lower
+                .when_trivially_disjoint_from(db, env, right_lower, &builder, TypeVarSet::None)
+                .is_trivially_always_satisfied()
     }
 
     fn add_single_tautology(&mut self, ante: ConstraintId) {
@@ -5413,20 +5427,27 @@ impl SequentMap {
         ante2: ConstraintId,
         post: ConstraintId,
     ) {
-        // If the post constraint is unsatisfiable, then the antecedents contradict each other.
+        // If the post constraint is statically unsatisfiable, then the antecedents contradict
+        // each other. Gradual bounds cannot prove a contradiction.
         let post_data = storage.constraint_data(post);
-        let (when, source_order) = storage.load(
-            db,
-            env,
-            &post_data
-                .bounds
-                .lower
-                .ty()
-                .when_constraint_set_assignable_to_owned(db, env, post_data.bounds.upper.ty()),
-        );
-        if when.is_never_satisfied(db, env, storage, source_order) {
-            self.add_pair_impossibility(ante1, ante2);
-            return;
+        let post_lower = post_data.bounds.lower.ty();
+        let post_upper = post_data.bounds.upper.ty();
+        if post_lower.is_static_sequent_eligible(db, env)
+            && post_upper.is_static_sequent_eligible(db, env)
+        {
+            // Reuse the owned assignability query so recursive sequent derivation stays within the
+            // same coinductive Salsa computation. A separate owned subtyping query can produce an
+            // inconsistent provisional answer. The eligibility checks make this safe for concrete
+            // components, while symbolic typevars can still propagate existing gradual witnesses.
+            let (when, source_order) = storage.load(
+                db,
+                env,
+                &post_lower.when_constraint_set_assignable_to_owned(db, env, post_upper),
+            );
+            if when.is_never_satisfied(db, env, storage, source_order) {
+                self.add_pair_impossibility(ante1, ante2);
+                return;
+            }
         }
 
         // If either antecedent implies the consequent on its own, this new sequent is redundant,
@@ -5525,6 +5546,10 @@ impl SequentMap {
         // when `L ≤ U`. This gives us a constraint set, which should be the rhs of the sequent
         // implication. (That is, this check directly encodes `(L ≤ T ≤ U) → (L ≤ U)` as an
         // implication.)
+        //
+        // TODO: Use the fully static sequent boundary here once lazy subtyping can preserve an
+        // existing gradual witness instead of materializing it away (see PR #26873). Until then,
+        // keep this dedicated single-range symbolic derivation assignability-based.
 
         // Skip trivial cases where the assignability check won't produce useful results.
         if lower.is_never() || upper.is_object() {
@@ -5776,11 +5801,13 @@ impl SequentMap {
             (_, constrained_upper, bound_lower, _)
                 if !constrained_upper.is_never()
                     && !constrained_upper.is_object()
+                    && constrained_upper.is_static_sequent_eligible(db, env)
+                    && bound_lower.is_static_sequent_eligible(db, env)
                     && storage.cached_is_constraint_set_subtype_of(
                         db,
                         env,
-                        constrained_upper.top_materialization(db, env),
-                        bound_lower.bottom_materialization(db, env),
+                        constrained_upper,
+                        bound_lower,
                     ) =>
             {
                 (
@@ -5797,11 +5824,13 @@ impl SequentMap {
             (constrained_lower, _, _, bound_upper)
                 if !constrained_lower.is_never()
                     && !constrained_lower.is_object()
+                    && bound_upper.is_static_sequent_eligible(db, env)
+                    && constrained_lower.is_static_sequent_eligible(db, env)
                     && storage.cached_is_constraint_set_subtype_of(
                         db,
                         env,
-                        bound_upper.top_materialization(db, env),
-                        constrained_lower.bottom_materialization(db, env),
+                        bound_upper,
+                        constrained_lower,
                     ) =>
             {
                 (

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1938,12 +1938,17 @@ pub(crate) struct Constraint<'db> {
 /// Importantly, we don't want to choose a validity bound as a solution unless we have no other
 /// choice. There is often an evidence bound that is a better choice.
 ///
+/// A bound derived from both evidence and validity is _mixed_. Mixed bounds remain
+/// evidence-bearing, but are kept separate from pure validity so that they do not obscure exact
+/// declared-domain bounds.
+///
 /// Every type is a supertype of `Never` and a subtype of `object`, so `Validity(Never)` represents
 /// an absent lower bound and `Validity(object)` represents an absent upper bound.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) enum ConstraintBound<'db> {
     Validity(Type<'db>),
     Evidence(Type<'db>),
+    Mixed(Type<'db>),
 }
 
 impl<'db> ConstraintBound<'db> {
@@ -1957,7 +1962,7 @@ impl<'db> ConstraintBound<'db> {
 
     pub(crate) fn ty(self) -> Type<'db> {
         match self {
-            Self::Validity(ty) | Self::Evidence(ty) => ty,
+            Self::Validity(ty) | Self::Evidence(ty) | Self::Mixed(ty) => ty,
         }
     }
 
@@ -1965,6 +1970,7 @@ impl<'db> ConstraintBound<'db> {
         match self {
             Self::Validity(ty) => Self::Validity(f(ty)),
             Self::Evidence(ty) => Self::Evidence(f(ty)),
+            Self::Mixed(ty) => Self::Mixed(f(ty)),
         }
     }
 
@@ -1972,20 +1978,40 @@ impl<'db> ConstraintBound<'db> {
         self.map(|_| ty)
     }
 
-    /// Retains this bound's type while combining its provenance with another contributing bound.
+    /// Creates a bound produced by mathematically combining `lhs` and `rhs`.
     ///
-    /// The result is evidence only when every contributing bound is evidence.
-    fn with_combined_provenance(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Validity(ty), _) | (Self::Evidence(ty), Self::Validity(_)) => Self::Validity(ty),
-            (Self::Evidence(ty), Self::Evidence(_)) => Self::Evidence(ty),
+    /// If one operand already equals the result, that operand alone establishes the combined
+    /// bound, so its provenance is retained. `Mixed` is only needed when operands with different
+    /// provenance both contribute to a new result.
+    fn from_combination(combined: Type<'db>, lhs: Self, rhs: Self) -> Self {
+        match (combined == lhs.ty(), combined == rhs.ty()) {
+            (true, false) => lhs.with_type(combined),
+            (false, true) => rhs.with_type(combined),
+            (true, true) => match (lhs, rhs) {
+                (Self::Evidence(_), _) | (_, Self::Evidence(_)) => Self::Evidence(combined),
+                (Self::Mixed(_), _) | (_, Self::Mixed(_)) => Self::Mixed(combined),
+                (Self::Validity(_), Self::Validity(_)) => Self::Validity(combined),
+            },
+            (false, false) if lhs.has_same_provenance(rhs) => lhs.with_type(combined),
+            (false, false) => Self::Mixed(combined),
+        }
+    }
+
+    /// Applies the source range's provenance to an evidence bound derived by comparing that range.
+    /// Bounds not produced by the comparison retain their existing provenance.
+    fn with_source_provenance(self, source: ConstraintBounds<'db>) -> Self {
+        match self {
+            Self::Evidence(ty) => Self::from_combination(ty, source.lower, source.upper),
+            Self::Validity(_) | Self::Mixed(_) => self,
         }
     }
 
     fn has_same_provenance(self, other: Self) -> bool {
         matches!(
             (self, other),
-            (Self::Validity(_), Self::Validity(_)) | (Self::Evidence(_), Self::Evidence(_))
+            (Self::Validity(_), Self::Validity(_))
+                | (Self::Evidence(_), Self::Evidence(_))
+                | (Self::Mixed(_), Self::Mixed(_))
         )
     }
 }
@@ -2076,9 +2102,9 @@ impl<'db> ConstraintBounds<'db> {
 
 /// A factored conjunction of upper-bound clauses accumulated for one typevar.
 ///
-/// Validity and evidence clauses are stored separately. Clauses may be unions, keeping bounds such
-/// as `(A | B) & (C | D)` factored rather than distributing them into the DNF representation used
-/// by [`Type`].
+/// Validity, evidence, and mixed clauses are stored separately. Clauses may be unions, keeping
+/// bounds such as `(A | B) & (C | D)` factored rather than distributing them into the DNF
+/// representation used by [`Type`].
 ///
 /// Every `UpperBound` contains at least one validity clause. An unconstrained validity upper bound
 /// is represented explicitly by `object`. An explicit evidence bound of `object` remains meaningful
@@ -2090,6 +2116,7 @@ impl<'db> ConstraintBounds<'db> {
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct UpperBound<'db> {
     evidence: FxOrderSet<Type<'db>>,
+    mixed: FxOrderSet<Type<'db>>,
     validity: FxOrderSet<Type<'db>>,
 }
 
@@ -2097,6 +2124,7 @@ impl Default for UpperBound<'_> {
     fn default() -> Self {
         Self {
             evidence: FxOrderSet::default(),
+            mixed: FxOrderSet::default(),
             validity: FxOrderSet::from_iter([Type::object()]),
         }
     }
@@ -2118,20 +2146,28 @@ impl<'db> UpperBound<'db> {
         self.evidence.iter().copied().map(ConstraintBound::Evidence)
     }
 
+    fn iter_mixed(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
+        self.mixed.iter().copied().map(ConstraintBound::Mixed)
+    }
+
+    fn iter_inference(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
+        std::iter::chain(self.iter_evidence(), self.iter_mixed())
+    }
+
     fn iter_validity(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
         self.validity.iter().copied().map(ConstraintBound::Validity)
     }
 
     pub(crate) fn iter_clauses(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
-        std::iter::chain(self.iter_evidence(), self.iter_validity())
+        std::iter::chain(self.iter_inference(), self.iter_validity())
     }
 
     fn has_evidence(&self) -> bool {
-        !self.evidence.is_empty()
+        !self.evidence.is_empty() || !self.mixed.is_empty()
     }
 
     fn has_same_evidence(&self, other: &Self) -> bool {
-        self.evidence.set_eq(&other.evidence)
+        self.evidence.set_eq(&other.evidence) && self.mixed.set_eq(&other.mixed)
     }
 
     /// Returns an existing upper-bound clause if every other clause is redundant with it.
@@ -2154,7 +2190,7 @@ impl<'db> UpperBound<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Type<'db>> {
-        Self::single_bound_from_iterator(db, env, self.iter_evidence())
+        Self::single_bound_from_iterator(db, env, self.iter_inference())
     }
 
     fn as_single_validity_bound(
@@ -2199,12 +2235,21 @@ impl<'db> UpperBound<'db> {
                 self.evidence.clear();
                 self.evidence.insert(Type::Never);
             }
+            ConstraintBound::Mixed(Type::Never) => {
+                self.mixed.clear();
+                self.mixed.insert(Type::Never);
+            }
             ConstraintBound::Validity(Type::Never) => {
                 self.validity.clear();
                 self.validity.insert(Type::Never);
             }
             ConstraintBound::Evidence(ty) => {
                 self.evidence.insert(ty);
+            }
+            ConstraintBound::Mixed(ty) => {
+                if !self.mixed.contains(&Type::Never) {
+                    self.mixed.insert(ty);
+                }
             }
             ConstraintBound::Validity(ty) => {
                 if !self.validity.contains(&Type::Never) {
@@ -2219,6 +2264,7 @@ impl<'db> UpperBound<'db> {
 
     fn shrink_to_fit(&mut self) {
         self.evidence.shrink_to_fit();
+        self.mixed.shrink_to_fit();
         self.validity.shrink_to_fit();
     }
 
@@ -2824,44 +2870,22 @@ impl ConstraintId {
             return IntersectionResult::CannotSimplify;
         }
 
-        let lower = match (self_constraint.bounds.lower, other_constraint.bounds.lower) {
-            (ConstraintBound::Validity(_), ConstraintBound::Validity(_)) => {
-                ConstraintBound::Validity(effective_lower)
-            }
-            (ConstraintBound::Evidence(_), ConstraintBound::Evidence(_)) => {
-                ConstraintBound::Evidence(effective_lower)
-            }
-            (ConstraintBound::Evidence(evidence), ConstraintBound::Validity(_))
-            | (ConstraintBound::Validity(_), ConstraintBound::Evidence(evidence)) => {
-                if effective_lower.is_equivalent_to(db, env, evidence) {
-                    ConstraintBound::Evidence(effective_lower)
-                } else {
-                    ConstraintBound::Validity(effective_lower)
-                }
-            }
-        };
+        let lower = ConstraintBound::from_combination(
+            effective_lower,
+            self_constraint.bounds.lower,
+            other_constraint.bounds.lower,
+        );
 
         let effective_upper = merged_upper.materialize_exact(db, env);
         if effective_upper.is_nontrivial_intersection(db) {
             return IntersectionResult::CannotSimplify;
         }
 
-        let upper = match (self_constraint.bounds.upper, other_constraint.bounds.upper) {
-            (ConstraintBound::Validity(_), ConstraintBound::Validity(_)) => {
-                ConstraintBound::Validity(effective_upper)
-            }
-            (ConstraintBound::Evidence(_), ConstraintBound::Evidence(_)) => {
-                ConstraintBound::Evidence(effective_upper)
-            }
-            (ConstraintBound::Evidence(evidence), ConstraintBound::Validity(_))
-            | (ConstraintBound::Validity(_), ConstraintBound::Evidence(evidence)) => {
-                if effective_upper.is_equivalent_to(db, env, evidence) {
-                    ConstraintBound::Evidence(effective_upper)
-                } else {
-                    ConstraintBound::Validity(effective_upper)
-                }
-            }
-        };
+        let upper = ConstraintBound::from_combination(
+            effective_upper,
+            self_constraint.bounds.upper,
+            other_constraint.bounds.upper,
+        );
 
         IntersectionResult::Simplified(Constraint {
             typevar: self_constraint.typevar,
@@ -3744,6 +3768,7 @@ struct InteriorNodeData {
 #[derive(Default)]
 struct ConstraintBoundsBuilder<'db> {
     evidence_lower: FxIndexSet<Type<'db>>,
+    mixed_lower: FxIndexSet<Type<'db>>,
     validity_lower: FxIndexSet<Type<'db>>,
     upper: UpperBound<'db>,
     // Classify each evidence bound before aggregation: a union can otherwise make gradual and
@@ -3779,6 +3804,10 @@ impl<'db> ConstraintBoundsBuilder<'db> {
                 self.classify_evidence(db, env, ty);
                 self.evidence_lower.insert(ty);
             }
+            ConstraintBound::Mixed(ty) => {
+                self.classify_evidence(db, env, ty);
+                self.mixed_lower.insert(ty);
+            }
             ConstraintBound::Validity(ty) if bound != ConstraintBound::missing_lower() => {
                 self.validity_lower.insert(ty);
             }
@@ -3792,7 +3821,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
         env: &ProgramEnvironment<'db>,
         bound: ConstraintBound<'db>,
     ) {
-        if let ConstraintBound::Evidence(ty) = bound {
+        if let ConstraintBound::Evidence(ty) | ConstraintBound::Mixed(ty) = bound {
             self.classify_evidence(db, env, ty);
         }
         self.upper.add_clause(bound);
@@ -3806,6 +3835,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
     ) -> PathBound<'db> {
         let Self {
             evidence_lower,
+            mixed_lower,
             validity_lower,
             mut upper,
             has_gradual_evidence,
@@ -3813,6 +3843,8 @@ impl<'db> ConstraintBoundsBuilder<'db> {
         } = self;
         let evidence_lower =
             (!evidence_lower.is_empty()).then(|| UnionType::from_elements(db, env, evidence_lower));
+        let mixed_lower =
+            (!mixed_lower.is_empty()).then(|| UnionType::from_elements(db, env, mixed_lower));
         let validity_lower = if validity_lower.is_empty() {
             Type::Never
         } else {
@@ -3822,6 +3854,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
         PathBound {
             bound_typevar,
             evidence_lower,
+            mixed_lower,
             validity_lower,
             upper,
             has_only_gradual_evidence: has_gradual_evidence && !has_static_evidence,
@@ -3834,6 +3867,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
 pub(crate) struct PathBound<'db> {
     pub(crate) bound_typevar: BoundTypeVarInstance<'db>,
     pub(crate) evidence_lower: Option<Type<'db>>,
+    mixed_lower: Option<Type<'db>>,
     pub(crate) validity_lower: Type<'db>,
     pub(crate) upper: UpperBound<'db>,
     /// Whether the path contains gradual evidence and no static evidence.
@@ -3845,6 +3879,7 @@ impl<'db> PathBound<'db> {
         Self {
             bound_typevar,
             evidence_lower: Some(ty),
+            mixed_lower: None,
             validity_lower: Type::Never,
             upper: UpperBound::from_clause(ty),
             has_only_gradual_evidence: false,
@@ -3856,19 +3891,40 @@ impl<'db> PathBound<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
-        if let Some(evidence) = self.evidence_lower {
-            UnionType::from_two_elements(db, env, evidence, self.validity_lower)
-        } else {
-            self.validity_lower
-        }
+        UnionType::from_elements(
+            db,
+            env,
+            self.evidence_lower
+                .into_iter()
+                .chain(self.mixed_lower)
+                .chain([self.validity_lower]),
+        )
+    }
+
+    pub(crate) fn inference_lower(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Type<'db>> {
+        let mut lower = self.evidence_lower.into_iter().chain(self.mixed_lower);
+        let first = lower.next()?;
+        Some(UnionType::from_elements(
+            db,
+            env,
+            std::iter::once(first).chain(lower),
+        ))
+    }
+
+    fn has_lower_evidence(&self) -> bool {
+        self.evidence_lower.is_some() || self.mixed_lower.is_some()
     }
 
     fn variance(&self) -> TypeVarVariance {
-        match (self.evidence_lower, self.has_upper_evidence()) {
-            (None, true) => TypeVarVariance::Covariant,
-            (Some(_), false) => TypeVarVariance::Contravariant,
-            (Some(_), true) => TypeVarVariance::Invariant,
-            (None, false) => TypeVarVariance::Bivariant,
+        match (self.has_lower_evidence(), self.has_upper_evidence()) {
+            (false, true) => TypeVarVariance::Covariant,
+            (true, false) => TypeVarVariance::Contravariant,
+            (true, true) => TypeVarVariance::Invariant,
+            (false, false) => TypeVarVariance::Bivariant,
         }
     }
 
@@ -4338,7 +4394,9 @@ impl<'db> PathBounds<'db> {
             // A differing bound is comparable only when both paths have the same inference
             // evidence. Otherwise, the paths represent separate inference alternatives rather
             // than different declared constraints for the same alternative.
-            if lhs_bound.evidence_lower != rhs_bound.evidence_lower {
+            if lhs_bound.evidence_lower != rhs_bound.evidence_lower
+                || lhs_bound.mixed_lower != rhs_bound.mixed_lower
+            {
                 return false;
             }
             if !lhs_bound.upper.has_same_evidence(&rhs_bound.upper) {
@@ -4520,7 +4578,7 @@ impl<'db> PathBounds<'db> {
                 // Prefer the lower bound (often the concrete actual type seen) over the
                 // upper bound (which may include TypeVar bounds/constraints). The upper bound
                 // should only be used as a fallback when no concrete type was inferred.
-                if path_bound.evidence_lower.is_some() {
+                if path_bound.has_lower_evidence() {
                     if !path_bound.upper.is_satisfied_by(db, env, lower) {
                         let mut storage = builder.storage.borrow_mut();
                         let (when_upper, source_order) =
@@ -4605,7 +4663,7 @@ impl<'db> PathBounds<'db> {
                         current_best.is_assignable_to(db, env, candidate);
 
                     if candidate_assignable_to_best != best_assignable_to_candidate {
-                        if path_bound.evidence_lower.is_some() {
+                        if path_bound.has_lower_evidence() {
                             candidate_assignable_to_best
                         } else {
                             best_assignable_to_candidate
@@ -4660,7 +4718,7 @@ impl<'db> PathBounds<'db> {
                 };
 
                 if let (Some(ty @ Type::TypeVar(_)), _) | (_, Some(ty @ Type::TypeVar(_))) = (
-                    path_bound.evidence_lower,
+                    path_bound.inference_lower(db, env),
                     path_bound.upper.as_single_evidence_bound(db, env),
                 ) {
                     // This path relates two TypeVars, such as passing `S` to a parameter typed as
@@ -4680,7 +4738,7 @@ impl<'db> PathBounds<'db> {
                 // `T = Any`) If the path solution is fully static, we choose the "tightest"
                 // constraint. (Checking `int` against `T: (int, int | str)` selects `T = int`.)
                 if multiple_compatible_constraints && path_bound.has_only_gradual_evidence {
-                    if path_bound.evidence_lower.is_some() {
+                    if path_bound.has_lower_evidence() {
                         Ok(Some(lower))
                     } else if path_bound.has_upper_evidence() {
                         Ok(IntersectionType::bounded_from_elements(
@@ -4897,8 +4955,12 @@ impl InteriorNode {
         source_order: Option<SourceOrderId>,
     ) -> (NodeId, Option<SourceOrderId>) {
         let is_bare_inferable_typevar = |bound: ConstraintBound<'_>| {
-            matches!(bound, ConstraintBound::Evidence(Type::TypeVar(bound_typevar))
-                if bound_typevar.is_inferable(db, inferable))
+            matches!(
+                bound,
+                ConstraintBound::Evidence(Type::TypeVar(bound_typevar))
+                    | ConstraintBound::Mixed(Type::TypeVar(bound_typevar))
+                    if bound_typevar.is_inferable(db, inferable)
+            )
         };
         self.abstract_inner(
             db,
@@ -5629,13 +5691,11 @@ impl SequentMap {
                         derived
                             .bounds
                             .lower
-                            .with_combined_provenance(constraint_data.bounds.lower)
-                            .with_combined_provenance(constraint_data.bounds.upper),
+                            .with_source_provenance(constraint_data.bounds),
                         derived
                             .bounds
                             .upper
-                            .with_combined_provenance(constraint_data.bounds.lower)
-                            .with_combined_provenance(constraint_data.bounds.upper),
+                            .with_source_provenance(constraint_data.bounds),
                     );
                     if interior.if_true != ALWAYS_FALSE {
                         self.add_single_implication(db, storage, constraint, derived);
@@ -5760,14 +5820,8 @@ impl SequentMap {
                     && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
-                    bound_constraint_data
-                        .bounds
-                        .lower
-                        .with_combined_provenance(constrained_constraint_data.bounds.lower),
-                    bound_constraint_data
-                        .bounds
-                        .upper
-                        .with_combined_provenance(constrained_constraint_data.bounds.upper),
+                    bound_constraint_data.bounds.lower,
+                    bound_constraint_data.bounds.upper,
                 )
             }
 
@@ -5777,10 +5831,7 @@ impl SequentMap {
             {
                 (
                     constrained_constraint_data.bounds.lower,
-                    bound_constraint_data
-                        .bounds
-                        .upper
-                        .with_combined_provenance(constrained_constraint_data.bounds.upper),
+                    bound_constraint_data.bounds.upper,
                 )
             }
 
@@ -5789,10 +5840,7 @@ impl SequentMap {
                 if constrained_lower.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
-                    bound_constraint_data
-                        .bounds
-                        .lower
-                        .with_combined_provenance(constrained_constraint_data.bounds.lower),
+                    bound_constraint_data.bounds.lower,
                     constrained_constraint_data.bounds.upper,
                 )
             }
@@ -5812,11 +5860,11 @@ impl SequentMap {
             {
                 (
                     constrained_constraint_data.bounds.lower,
-                    constrained_constraint_data
-                        .bounds
-                        .upper
-                        .with_combined_provenance(bound_constraint_data.bounds.lower)
-                        .with_type(Type::TypeVar(bound_typevar)),
+                    ConstraintBound::from_combination(
+                        Type::TypeVar(bound_typevar),
+                        constrained_constraint_data.bounds.upper,
+                        bound_constraint_data.bounds.lower,
+                    ),
                 )
             }
 
@@ -5834,11 +5882,11 @@ impl SequentMap {
                     ) =>
             {
                 (
-                    constrained_constraint_data
-                        .bounds
-                        .lower
-                        .with_combined_provenance(bound_constraint_data.bounds.upper)
-                        .with_type(Type::TypeVar(bound_typevar)),
+                    ConstraintBound::from_combination(
+                        Type::TypeVar(bound_typevar),
+                        constrained_constraint_data.bounds.lower,
+                        bound_constraint_data.bounds.upper,
+                    ),
                     constrained_constraint_data.bounds.upper,
                 )
             }
@@ -6015,12 +6063,11 @@ impl SequentMap {
                     (TypeVarVariance::Invariant, bound_lower, bound_upper)
                         if bound_lower == bound_upper && !bound_lower.is_never() =>
                     {
-                        Some(
-                            bound_data
-                                .bounds
-                                .lower
-                                .with_combined_provenance(bound_data.bounds.upper),
-                        )
+                        Some(ConstraintBound::from_combination(
+                            bound_lower,
+                            bound_data.bounds.lower,
+                            bound_data.bounds.upper,
+                        ))
                     }
                     _ => None,
                 };
@@ -6048,11 +6095,11 @@ impl SequentMap {
                             storage,
                             constrained_typevar,
                             constrained_data.bounds.lower,
-                            constrained_data
-                                .bounds
-                                .upper
-                                .with_combined_provenance(replacement)
-                                .with_type(new_upper),
+                            ConstraintBound::from_combination(
+                                new_upper,
+                                constrained_data.bounds.upper,
+                                replacement,
+                            ),
                         );
                         self.add_pair_implication(
                             db,
@@ -6089,12 +6136,11 @@ impl SequentMap {
                     (TypeVarVariance::Invariant, bound_lower, bound_upper)
                         if bound_lower == bound_upper && !bound_lower.is_never() =>
                     {
-                        Some(
-                            bound_data
-                                .bounds
-                                .lower
-                                .with_combined_provenance(bound_data.bounds.upper),
-                        )
+                        Some(ConstraintBound::from_combination(
+                            bound_lower,
+                            bound_data.bounds.lower,
+                            bound_data.bounds.upper,
+                        ))
                     }
                     _ => None,
                 };
@@ -6121,11 +6167,11 @@ impl SequentMap {
                             env,
                             storage,
                             constrained_typevar,
-                            constrained_data
-                                .bounds
-                                .lower
-                                .with_combined_provenance(replacement)
-                                .with_type(new_lower),
+                            ConstraintBound::from_combination(
+                                new_lower,
+                                constrained_data.bounds.lower,
+                                replacement,
+                            ),
                             constrained_data.bounds.upper,
                         );
                         self.add_pair_implication(
@@ -6223,11 +6269,11 @@ impl SequentMap {
                                 storage,
                                 constrained_typevar,
                                 constrained_data.bounds.lower,
-                                constrained_data
-                                    .bounds
-                                    .upper
-                                    .with_combined_provenance(bound)
-                                    .with_type(new_upper),
+                                ConstraintBound::from_combination(
+                                    new_upper,
+                                    constrained_data.bounds.upper,
+                                    bound,
+                                ),
                             );
                             self.add_pair_implication(
                                 db,
@@ -6268,11 +6314,11 @@ impl SequentMap {
                                 env,
                                 storage,
                                 constrained_typevar,
-                                constrained_data
-                                    .bounds
-                                    .lower
-                                    .with_combined_provenance(bound)
-                                    .with_type(new_lower),
+                                ConstraintBound::from_combination(
+                                    new_lower,
+                                    constrained_data.bounds.lower,
+                                    bound,
+                                ),
                                 constrained_data.bounds.upper,
                             );
                             self.add_pair_implication(
@@ -6397,20 +6443,16 @@ impl SequentMap {
                     (Type::TypeVar(bound_typevar), Type::TypeVar(other_bound_typevar))
                         if bound_typevar.is_same_typevar_as(db, other_bound_typevar) =>
                     {
-                        new_constraints(
-                            bound_typevar,
-                            right_lower.with_combined_provenance(left_upper),
-                            right_upper.with_combined_provenance(left_lower),
-                        )
+                        new_constraints(bound_typevar, right_lower, right_upper)
                     }
                     (Type::TypeVar(bound_typevar), _) => new_constraints(
                         bound_typevar,
                         ConstraintBound::missing_lower(),
-                        right_upper.with_combined_provenance(left_lower),
+                        right_upper,
                     ),
                     (_, Type::TypeVar(bound_typevar)) => new_constraints(
                         bound_typevar,
-                        right_lower.with_combined_provenance(left_upper),
+                        right_lower,
                         ConstraintBound::missing_upper(),
                     ),
                     _ => return,
@@ -7742,6 +7784,7 @@ mod tests {
         PathBound {
             bound_typevar,
             evidence_lower,
+            mixed_lower: None,
             validity_lower: alternative,
             upper,
             has_only_gradual_evidence: false,
@@ -7986,6 +8029,55 @@ mod tests {
     }
 
     #[test]
+    fn combined_bound_provenance_tracks_contributing_operands() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let int = known_instance(db, KnownClass::Int);
+        let bool = known_instance(db, KnownClass::Bool);
+        let str = known_instance(db, KnownClass::Str);
+        let int_or_str = UnionType::from_two_elements(db, &env, int, str);
+
+        let cases = [
+            (
+                ConstraintBound::Evidence(bool),
+                ConstraintBound::Validity(int),
+                int,
+                ConstraintBound::Validity(int),
+            ),
+            (
+                ConstraintBound::Evidence(int),
+                ConstraintBound::Validity(bool),
+                int,
+                ConstraintBound::Evidence(int),
+            ),
+            (
+                ConstraintBound::Evidence(int),
+                ConstraintBound::Validity(int),
+                int,
+                ConstraintBound::Evidence(int),
+            ),
+            (
+                ConstraintBound::Evidence(int),
+                ConstraintBound::Validity(str),
+                int_or_str,
+                ConstraintBound::Mixed(int_or_str),
+            ),
+        ];
+
+        for (lhs, rhs, combined, expected) in cases {
+            assert_eq!(
+                ConstraintBound::from_combination(combined, lhs, rhs),
+                expected
+            );
+            assert_eq!(
+                ConstraintBound::from_combination(combined, rhs, lhs),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn constraint_intersection_preserves_stronger_bound_provenance() {
         let db = setup_db();
         let db = &db;
@@ -8188,7 +8280,7 @@ mod tests {
     }
 
     #[test]
-    fn transitive_constraints_inherit_validity_from_either_premise() {
+    fn transitive_constraints_retain_result_bound_provenance() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -8227,7 +8319,7 @@ mod tests {
                 ConstraintBound::missing_lower(),
                 upper,
             );
-            let expected = if relationship_validity || upper_validity {
+            let expected = if upper_validity {
                 ConstraintBound::Validity(int)
             } else {
                 ConstraintBound::Evidence(int)
@@ -8512,6 +8604,27 @@ mod tests {
         assert!(upper.has_evidence());
         assert_eq!(upper.materialize_exact(db, &env), Type::Never);
         assert_eq!(upper.as_single_evidence_bound(db, &env), Some(int));
+    }
+
+    #[test]
+    fn mixed_bounds_do_not_obscure_exact_validity() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let s = Type::TypeVar(create_typevar(db, "S"));
+        let int = known_instance(db, KnownClass::Int);
+        let mut bounds = ConstraintBoundsBuilder::default();
+
+        bounds.add_lower(db, &env, ConstraintBound::Validity(int));
+        bounds.add_lower(db, &env, ConstraintBound::Mixed(s));
+        bounds.add_upper(db, &env, ConstraintBound::Validity(int));
+        bounds.add_upper(db, &env, ConstraintBound::Mixed(s));
+
+        let bounds = bounds.finish(db, &env, t);
+        assert_eq!(bounds.as_equality_validity_bound(db, &env), Some(int));
+        assert_eq!(bounds.inference_lower(db, &env), Some(s));
+        assert_eq!(bounds.upper.as_single_evidence_bound(db, &env), Some(s));
     }
 
     #[test]
@@ -9136,6 +9249,7 @@ mod tests {
         let path_bound = PathBound {
             bound_typevar: t,
             evidence_lower: None,
+            mixed_lower: None,
             validity_lower: Type::Never,
             upper: UpperBound::unconstrained(),
             has_only_gradual_evidence: false,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -4119,6 +4119,15 @@ pub(crate) enum PathBounds<'db> {
     Unconstrained,
     Constrained {
         paths: Vec<Box<[PathBound<'db>]>>,
+        /// A family-wide `TypeVar` relationship that is lost when the validity domain is expanded
+        /// into concrete paths.
+        ///
+        /// For example, when `callee(x: T) -> T` is called from `caller(x: S) -> S`, with both
+        /// `TypeVar`s constrained to `int` and `str`, the paths fix `T` to `int` and `str`
+        /// respectively. Solving either path in isolation therefore produces a concrete type, even
+        /// though the important fact is that the callee's `T` is whichever specialization the
+        /// caller's `S` has. This relationship belongs to the path family because no individual
+        /// path can distinguish `T := S` from its current concrete specialization.
         symbolic_default: Option<TypeVarSolution<'db>>,
     },
 }
@@ -4371,8 +4380,18 @@ impl<'db> PathBounds<'db> {
         )
     }
 
-    /// Recovers one bare `T := S` relationship only when `S`'s complete validity domain implies
-    /// the domain-conjoined constraint set after substituting `T` with `S`.
+    /// Preserves a bare `T := S` relationship that path extraction would otherwise erase.
+    ///
+    /// Validity domains are expanded before solving so that each path can be checked using ordinary
+    /// concrete bounds. That is useful for choosing constrained-TypeVar alternatives, but it loses
+    /// correlations between an inferable `TypeVar` and a `TypeVar` supplied by the caller: each
+    /// path remembers only the concrete alternative selected on that path. Without this recovery,
+    /// an identity-like call through two compatible `TypeVar`s returns the union of their
+    /// alternatives instead of retaining the caller's `TypeVar`.
+    ///
+    /// Agreement on one concrete path is not enough: seeing `T = int` alongside `S = int` does not
+    /// justify `T := S` if `S` can also be `str` but `T` cannot. The relationship is useful only if
+    /// it holds for every valid specialization of the caller's `TypeVar`.
     fn recover_symbolic_default(
         &self,
         db: &'db dyn Db,
@@ -4744,6 +4763,10 @@ impl<'db> PathBounds<'db> {
     }
 
     /// Selects the default solution for a typevar using the complete path family.
+    ///
+    /// A family-wide symbolic relationship takes precedence because an exact validity equality on
+    /// one path describes only that path's concrete alternative. Selecting the equality first
+    /// would discard the correlation that the family establishes.
     pub(crate) fn default_solve(
         &self,
         db: &'db dyn Db,
@@ -7969,135 +7992,6 @@ mod tests {
         PathBounds::Constrained {
             paths: paths.into_iter().map(Vec::into_boxed_slice).collect(),
             symbolic_default: None,
-        }
-    }
-
-    // XXX: Remove once solution extraction exercises validity domains.
-    #[test]
-    fn validity_domain_uses_supported_typevars_in_builder_order() {
-        let db = setup_db();
-        let db = &db;
-        let env = db.program_environment();
-        let int = known_instance(db, KnownClass::Int);
-        let str = known_instance(db, KnownClass::Str);
-        let bytes = known_instance(db, KnownClass::Bytes);
-        let gradual_upper = KnownClass::List.to_specialized_instance(db, &env, &[Type::any()]);
-        let bounded = create_typevar(db, "Bounded").map_bound_or_constraints(db, |_| {
-            Some(TypeVarBoundOrConstraints::UpperBound(gradual_upper))
-        });
-        let nested = create_typevar(db, "Nested")
-            .map_bound_or_constraints(db, |_| Some(TypeVarBoundOrConstraints::UpperBound(str)));
-        let unbounded = create_typevar(db, "Unbounded");
-        let unused = create_typevar(db, "Unused")
-            .map_bound_or_constraints(db, |_| Some(TypeVarBoundOrConstraints::UpperBound(bytes)));
-        let nested_upper =
-            KnownClass::List.to_specialized_instance(db, &env, &[Type::TypeVar(nested)]);
-
-        let owned = ConstraintSetBuilder::new().into_owned(|builder| {
-            let root = ConstraintSet::constrain_typevar_upper_bound(
-                db,
-                &env,
-                builder,
-                bounded,
-                nested_upper,
-            )
-            .and(db, builder, || {
-                ConstraintSet::constrain_typevar_lower_bound(db, &env, builder, unbounded, int)
-            });
-            builder.storage.borrow_mut().intern_typevar(db, unused);
-            root
-        });
-
-        owned.query(|builder, root| {
-            let mut storage = builder.storage.borrow_mut();
-            let (domain, source_order) = storage.validity_domain(db, &env, root.node);
-            let constraints: Vec<_> = storage
-                .calculate_source_orders(source_order)
-                .into_iter()
-                .map(|constraint| storage.constraint_data(constraint))
-                .collect();
-
-            assert_eq!(
-                constraints,
-                vec![
-                    Constraint {
-                        typevar: bounded,
-                        bounds: ConstraintBounds::new(
-                            ConstraintBound::missing_lower(),
-                            ConstraintBound::Validity(gradual_upper),
-                        ),
-                    },
-                    Constraint {
-                        typevar: nested,
-                        bounds: ConstraintBounds::new(
-                            ConstraintBound::missing_lower(),
-                            ConstraintBound::Validity(str),
-                        ),
-                    },
-                ]
-            );
-
-            let support: Vec<_> = storage
-                .node_support(domain)
-                .into_iter()
-                .flat_map(Support::iter)
-                .map(|typevar| storage.typevar_data(typevar))
-                .collect();
-            assert_eq!(support, vec![bounded, nested]);
-            assert_eq!(
-                storage.validity_domain(db, &env, ALWAYS_TRUE),
-                (ALWAYS_TRUE, None)
-            );
-            assert_eq!(
-                storage.validity_domain(db, &env, ALWAYS_FALSE),
-                (ALWAYS_TRUE, None)
-            );
-        });
-    }
-
-    // XXX: Remove once solution extraction exercises validity domains.
-    #[test]
-    fn validity_domain_preserves_exact_gradual_declared_constraints() {
-        let db = setup_db();
-        let db = &db;
-        let env = db.program_environment();
-        let int = known_instance(db, KnownClass::Int);
-        let list_any = KnownClass::List.to_specialized_instance(db, &env, &[Type::any()]);
-        let list_int = KnownClass::List.to_specialized_instance(db, &env, &[int]);
-
-        for alternatives in [[Type::any(), int], [list_any, list_int]] {
-            let typevar = create_typevar(db, "T").map_bound_or_constraints(db, |_| {
-                Some(TypeVarBoundOrConstraints::Constraints(
-                    TypeVarConstraints::new(db, alternatives.as_slice()),
-                ))
-            });
-            let builder = ConstraintSetBuilder::new();
-            let root = ConstraintSet::constrain_typevar_lower_bound(
-                db,
-                &env,
-                &builder,
-                typevar,
-                alternatives[1],
-            );
-            let mut storage = builder.storage.borrow_mut();
-            let (_, source_order) = storage.validity_domain(db, &env, root.node);
-            let actual: Vec<_> = storage
-                .calculate_source_orders(source_order)
-                .into_iter()
-                .map(|constraint| storage.constraint_data(constraint))
-                .collect();
-            let expected: Vec<_> = alternatives
-                .into_iter()
-                .map(|alternative| Constraint {
-                    typevar,
-                    bounds: ConstraintBounds::new(
-                        ConstraintBound::Validity(alternative),
-                        ConstraintBound::Validity(alternative),
-                    ),
-                })
-                .collect();
-
-            assert_eq!(actual, expected);
         }
     }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3828,33 +3828,48 @@ struct ConstraintBoundsBuilder<'db> {
 }
 
 impl<'db> ConstraintBoundsBuilder<'db> {
-    /// Returns whether mirrored lower and upper evidence require multiple exact types.
+    /// Finds a fixed equality requirement that satisfies every bound on this path.
     ///
     /// A type that occurs in both evidence sets places the target typevar both above and below that
-    /// type. Multiple non-equivalent mirrored types are simultaneous equality requirements, not
-    /// lower-bound alternatives that can be unioned.
-    fn has_incoherent_equality_evidence(
+    /// type. If one such type is fully static relative to the inference domain, it pins the only
+    /// possible solution. Gradual equality requirements can then accept that solution through one
+    /// of their materializations.
+    fn pinned_equality_solution(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         inferable: TypeVarSet<'db>,
-    ) -> bool {
+    ) -> Option<Type<'db>> {
         let mut fixed_equalities = self
             .evidence_lower
             .iter()
             .filter(|lower| self.upper.evidence.contains(*lower))
             .copied()
+            .filter(|ty| ty.is_static_sequent_eligible(db, env))
             .filter(|ty| {
-                // Equality types containing inferable typevars can become equivalent once the rest
-                // of the path is solved. Fixed typevars are opaque and can be compared immediately.
                 !any_over_type(db, env, *ty, false, |ty| {
                     matches!(ty, Type::TypeVar(typevar) if typevar.is_inferable(db, inferable))
                 })
             });
-        let Some(first) = fixed_equalities.next() else {
-            return false;
-        };
-        fixed_equalities.any(|ty| !first.is_equivalent_to(db, env, ty))
+        let candidate = fixed_equalities.next()?;
+        if fixed_equalities.any(|ty| !candidate.is_equivalent_to(db, env, ty)) {
+            return None;
+        }
+
+        if !self
+            .evidence_lower
+            .iter()
+            .chain(&self.mixed_lower)
+            .chain(&self.validity_lower)
+            .all(|lower| lower.is_constraint_set_assignable_to(db, env, candidate))
+        {
+            return None;
+        }
+
+        self.upper
+            .iter_clauses()
+            .all(|upper| candidate.is_constraint_set_assignable_to(db, env, upper.ty()))
+            .then_some(candidate)
     }
 
     fn classify_evidence(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, ty: Type<'db>) {
@@ -3913,8 +3928,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
         bound_typevar: BoundTypeVarInstance<'db>,
         inferable: TypeVarSet<'db>,
     ) -> PathBound<'db> {
-        let has_incoherent_equality_evidence =
-            self.has_incoherent_equality_evidence(db, env, inferable);
+        let pinned_equality_solution = self.pinned_equality_solution(db, env, inferable);
         let Self {
             evidence_lower,
             mixed_lower,
@@ -3939,7 +3953,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
             mixed_lower,
             validity_lower,
             upper,
-            has_incoherent_equality_evidence,
+            pinned_equality_solution,
             has_only_gradual_evidence: has_gradual_evidence && !has_static_evidence,
         }
     }
@@ -3953,8 +3967,8 @@ pub(crate) struct PathBound<'db> {
     mixed_lower: Option<Type<'db>>,
     pub(crate) validity_lower: Type<'db>,
     pub(crate) upper: UpperBound<'db>,
-    /// Whether this path requires the typevar to equal multiple non-equivalent fixed types.
-    has_incoherent_equality_evidence: bool,
+    /// A fixed equality requirement that satisfies every bound on this path.
+    pinned_equality_solution: Option<Type<'db>>,
     /// Whether the path contains gradual evidence and no static evidence.
     has_only_gradual_evidence: bool,
 }
@@ -3967,7 +3981,7 @@ impl<'db> PathBound<'db> {
             mixed_lower: None,
             validity_lower: Type::Never,
             upper: UpperBound::from_clause(ty),
-            has_incoherent_equality_evidence: false,
+            pinned_equality_solution: None,
             has_only_gradual_evidence: false,
         }
     }
@@ -4878,10 +4892,10 @@ impl<'db> PathBounds<'db> {
             return Ok(Some(validity));
         }
 
-        // Assignability can keep non-equivalent gradual equality requirements satisfiable, but
-        // their lower bounds are simultaneous obligations rather than alternatives to union.
-        if path_bound.has_incoherent_equality_evidence {
-            return Ok(None);
+        // A fixed exact requirement pins the solution when every gradual equality requirement can
+        // materialize to that type. Prefer it to unioning the simultaneous lower-bound evidence.
+        if let Some(solution) = path_bound.pinned_equality_solution {
+            return Ok(Some(solution));
         }
 
         if has_lower_evidence {
@@ -8027,7 +8041,7 @@ mod tests {
             mixed_lower: None,
             validity_lower: alternative,
             upper,
-            has_incoherent_equality_evidence: false,
+            pinned_equality_solution: None,
             has_only_gradual_evidence: false,
         }
     }
@@ -9522,7 +9536,7 @@ mod tests {
             mixed_lower: None,
             validity_lower: Type::Never,
             upper: UpperBound::unconstrained(),
-            has_incoherent_equality_evidence: false,
+            pinned_equality_solution: None,
             has_only_gradual_evidence: false,
         };
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1955,7 +1955,7 @@ impl<'db> ConstraintBound<'db> {
         Self::Validity(Type::object())
     }
 
-    fn ty(self) -> Type<'db> {
+    pub(crate) fn ty(self) -> Type<'db> {
         match self {
             Self::Validity(ty) | Self::Evidence(ty) => ty,
         }
@@ -2076,42 +2076,62 @@ impl<'db> ConstraintBounds<'db> {
 
 /// A factored conjunction of upper-bound clauses accumulated for one typevar.
 ///
-/// Each stored type is one clause in the conjunction that forms the upper bound. Importantly, each
-/// clause may be a union. This keeps bounds such as `(A | B) & (C | D)` factored in a CNF-like
-/// form instead of immediately converting them to the DNF representation that [`Type`] uses.
+/// Validity and evidence clauses are stored separately. Clauses may be unions, keeping bounds such
+/// as `(A | B) & (C | D)` factored rather than distributing them into the DNF representation used
+/// by [`Type`].
 ///
-/// An empty `UpperBound` represents a _missing_ upper bound, which (in the absence of other
-/// constraints) we solve to `Unknown`. An upper bound of `object` is treated as an explicit
-/// request for "any type" as a solution, so we solve it to `object`.
+/// Every `UpperBound` contains at least one validity clause. An unconstrained validity upper bound
+/// is represented explicitly by `object`. An explicit evidence bound of `object` remains meaningful
+/// because evidence and validity clauses are stored separately.
 ///
-/// Redundant clauses are retained while accumulating the bound, avoiding repeated relation checks
-/// for every newly discovered clause. Consumers that require one effective bound can recover it
-/// with [`UpperBound::as_single_bound`] without eagerly expanding large intersections of unions.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+/// Redundant clauses are retained to preserve evidence even when a validity restriction is
+/// stronger. Consumers that require one effective bound can recover it with
+/// [`UpperBound::as_single_bound`] without eagerly expanding intersections of unions.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct UpperBound<'db> {
-    clauses: FxOrderSet<Type<'db>>,
+    evidence: FxOrderSet<Type<'db>>,
+    validity: FxOrderSet<Type<'db>>,
+}
+
+impl Default for UpperBound<'_> {
+    fn default() -> Self {
+        Self {
+            evidence: FxOrderSet::default(),
+            validity: FxOrderSet::from_iter([Type::object()]),
+        }
+    }
 }
 
 impl<'db> UpperBound<'db> {
-    fn none() -> Self {
+    fn unconstrained() -> Self {
         Self::default()
     }
 
-    /// Creates an upper bound from one explicit clause.
-    ///
-    /// This preserves an explicit `object` clause so callers can distinguish `T <= object` from a
-    /// missing upper bound. Use [`UpperBound::add_clause`] when accumulating multiple clauses.
+    /// Creates an upper bound from one explicit evidence clause.
     fn from_clause(clause: Type<'db>) -> Self {
-        let clauses = FxOrderSet::from_iter([clause]);
-        Self { clauses }
+        let mut upper = Self::default();
+        upper.evidence.insert(clause);
+        upper
     }
 
-    fn is_empty(&self) -> bool {
-        self.clauses.is_empty()
+    fn iter_evidence(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
+        self.evidence.iter().copied().map(ConstraintBound::Evidence)
     }
 
-    fn has_explicit_bound(&self) -> bool {
-        !self.is_empty()
+    fn iter_validity(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
+        self.validity.iter().copied().map(ConstraintBound::Validity)
+    }
+
+    pub(crate) fn iter_clauses(&self) -> impl Iterator<Item = ConstraintBound<'db>> + Clone + '_ {
+        std::iter::chain(self.iter_evidence(), self.iter_validity())
+    }
+
+    fn has_evidence(&self) -> bool {
+        !self.evidence.is_empty()
+    }
+
+    fn has_same_evidence(&self, other: &Self) -> bool {
+        self.evidence.set_eq(&other.evidence)
     }
 
     /// Returns an existing upper-bound clause if every other clause is redundant with it.
@@ -2119,48 +2139,87 @@ impl<'db> UpperBound<'db> {
     /// This preserves constrained type variables without distributing unions: expanding
     /// `S & (int | str)` into `(S & int) | (S & str)` would otherwise lose `S` as the single
     /// effective bound. Returns `None` instead of materializing intersections when no existing
-    /// clause dominates the others. A missing bound remains distinct from an explicit `object`.
+    /// clause dominates the others. An unconstrained validity bound remains distinct from an
+    /// explicit evidence bound of `object`.
     pub(crate) fn as_single_bound(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Type<'db>> {
-        let mut clauses = self.clauses.iter().copied();
-        let first = clauses.next()?;
-        let candidate = clauses.fold(first, |candidate, clause| {
-            if candidate.is_redundant_with(db, env, clause) {
-                candidate
-            } else {
-                clause
-            }
-        });
+        Self::single_bound_from_iterator(db, env, self.iter_clauses())
+    }
 
-        self.clauses
-            .iter()
-            .all(|clause| candidate.is_redundant_with(db, env, *clause))
+    pub(crate) fn as_single_evidence_bound(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Type<'db>> {
+        Self::single_bound_from_iterator(db, env, self.iter_evidence())
+    }
+
+    fn as_single_validity_bound(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Type<'db>> {
+        Self::single_bound_from_iterator(db, env, self.iter_validity())
+    }
+
+    fn single_bound_from_iterator(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        mut clauses: impl Iterator<Item = ConstraintBound<'db>> + Clone,
+    ) -> Option<Type<'db>> {
+        let candidate = clauses
+            .clone()
+            .map(ConstraintBound::ty)
+            .reduce(|candidate, clause| {
+                if candidate.is_redundant_with(db, env, clause) {
+                    candidate
+                } else {
+                    clause
+                }
+            })?;
+
+        clauses
+            .all(|clause| candidate.is_redundant_with(db, env, clause.ty()))
             .then_some(candidate)
     }
 
-    fn is_never(&self) -> bool {
-        self.clauses.len() == 1 && self.clauses.contains(&Type::Never)
-    }
-
-    fn add_clause(&mut self, clause: Type<'db>) {
-        if self.is_never() {
+    fn add_clause(&mut self, clause: ConstraintBound<'db>) {
+        if clause == ConstraintBound::missing_upper()
+            || (matches!(clause, ConstraintBound::Evidence(_))
+                && self.evidence.contains(&Type::Never))
+        {
             return;
         }
 
-        if clause.is_never() {
-            self.clauses.clear();
-            self.clauses.insert(Type::Never);
-            return;
+        match clause {
+            ConstraintBound::Evidence(Type::Never) => {
+                self.evidence.clear();
+                self.evidence.insert(Type::Never);
+            }
+            ConstraintBound::Validity(Type::Never) => {
+                self.validity.clear();
+                self.validity.insert(Type::Never);
+            }
+            ConstraintBound::Evidence(ty) => {
+                self.evidence.insert(ty);
+            }
+            ConstraintBound::Validity(ty) => {
+                if !self.validity.contains(&Type::Never) {
+                    if self.validity.len() == 1 && self.validity.contains(&Type::object()) {
+                        self.validity.clear();
+                    }
+                    self.validity.insert(ty);
+                }
+            }
         }
-
-        self.clauses.insert(clause);
     }
 
     fn shrink_to_fit(&mut self) {
-        self.clauses.shrink_to_fit();
+        self.evidence.shrink_to_fit();
+        self.validity.shrink_to_fit();
     }
 
     /// Exact conversion to an ordinary [`Type`]. This may be expensive: if any stored clause is a
@@ -2171,11 +2230,11 @@ impl<'db> UpperBound<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
-        IntersectionType::from_elements(db, env, self.clauses.iter().copied())
+        IntersectionType::from_elements(db, env, self.iter_clauses().map(ConstraintBound::ty))
     }
 
     fn has_visible_union_clause(&self) -> bool {
-        self.clauses.iter().copied().any(Type::is_union)
+        self.iter_clauses().any(|clause| clause.ty().is_union())
     }
 
     fn is_satisfied_by(
@@ -2184,9 +2243,8 @@ impl<'db> UpperBound<'db> {
         env: &ProgramEnvironment<'db>,
         ty: Type<'db>,
     ) -> bool {
-        self.clauses
-            .iter()
-            .all(|clause| ty.is_constraint_set_assignable_to(db, env, *clause))
+        self.iter_clauses()
+            .all(|clause| ty.is_constraint_set_assignable_to(db, env, clause.ty()))
     }
 
     /// Returns the constraints under which `lower` is assignable to every stored upper clause.
@@ -2199,8 +2257,8 @@ impl<'db> UpperBound<'db> {
     ) -> (NodeId, Option<SourceOrderId>) {
         let mut node = ALWAYS_TRUE;
         let mut source_order = None;
-        for clause in &self.clauses {
-            let when_clause = lower.when_constraint_set_assignable_to_owned(db, env, *clause);
+        for clause in self.iter_clauses() {
+            let when_clause = lower.when_constraint_set_assignable_to_owned(db, env, clause.ty());
             let (clause_node, clause_source_order) = storage.load(db, env, &when_clause);
             node = node.and(storage, clause_node);
             source_order = storage.ordered_source_order(source_order, clause_source_order);
@@ -2730,9 +2788,9 @@ impl ConstraintId {
             self_constraint.bounds.lower.ty(),
             other_constraint.bounds.lower.ty(),
         );
-        let mut merged_upper = UpperBound::none();
-        merged_upper.add_clause(self_constraint.bounds.upper.ty());
-        merged_upper.add_clause(other_constraint.bounds.upper.ty());
+        let mut merged_upper = UpperBound::unconstrained();
+        merged_upper.add_clause(self_constraint.bounds.upper);
+        merged_upper.add_clause(other_constraint.bounds.upper);
 
         // If `lower ≰ upper` for every possible assignment of typevars, then the intersection is
         // empty, since there is no type that is both greater than `lower`, and less than `upper`.
@@ -3666,18 +3724,18 @@ struct InteriorNodeData {
     if_false: NodeId,
 }
 
-/// Accumulates lower and upper bounds for a single typevar on a single BDD path.
+/// Accumulates validity and evidence bounds for a single typevar on one TDD path.
 ///
-/// Lower bounds are collected into a union (they are alternatives for the minimum type the
-/// typevar can specialize to). Upper bounds are kept as a factored intersection (the typevar
-/// must satisfy all of them simultaneously). Once the path has been fully traversed, the
-/// accumulated bounds are stored in a [`PathBound`].
+/// Separate lower-bound unions preserve inference evidence even when a wider validity restriction
+/// determines the effective minimum. Upper clauses retain their individual provenance and stay
+/// factored to avoid distributing intersections over unions.
 #[derive(Default)]
 struct ConstraintBoundsBuilder<'db> {
-    lower: FxIndexSet<Type<'db>>,
+    evidence_lower: FxIndexSet<Type<'db>>,
+    validity_lower: FxIndexSet<Type<'db>>,
     upper: UpperBound<'db>,
-    // Classify each bound before aggregation: unioning lower bounds can otherwise make separate
-    // gradual and static evidence indistinguishable from a single gradual union.
+    // Classify each evidence bound before aggregation: a union can otherwise make gradual and
+    // static argument evidence indistinguishable from a single gradual union.
     has_gradual_evidence: bool,
     has_static_evidence: bool,
 }
@@ -3694,18 +3752,38 @@ impl<'db> ConstraintBoundsBuilder<'db> {
         }
     }
 
-    fn add_lower(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, ty: Type<'db>) {
+    fn add_lower(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        bound: ConstraintBound<'db>,
+    ) {
         // Lower bounds are unioned. Our type representation is in DNF, so unioning a new
         // element is typically cheap (in that it does not involve a combinatorial
         // explosion from distributing the clause through an existing disjunction). So we
         // don't need to be as clever here as in `add_upper`.
-        self.classify_evidence(db, env, ty);
-        self.lower.insert(ty);
+        match bound {
+            ConstraintBound::Evidence(ty) => {
+                self.classify_evidence(db, env, ty);
+                self.evidence_lower.insert(ty);
+            }
+            ConstraintBound::Validity(ty) if bound != ConstraintBound::missing_lower() => {
+                self.validity_lower.insert(ty);
+            }
+            ConstraintBound::Validity(_) => {}
+        }
     }
 
-    fn add_upper(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, ty: Type<'db>) {
-        self.classify_evidence(db, env, ty);
-        self.upper.add_clause(ty);
+    fn add_upper(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        bound: ConstraintBound<'db>,
+    ) {
+        if let ConstraintBound::Evidence(ty) = bound {
+            self.classify_evidence(db, env, ty);
+        }
+        self.upper.add_clause(bound);
     }
 
     fn finish(
@@ -3715,27 +3793,36 @@ impl<'db> ConstraintBoundsBuilder<'db> {
         bound_typevar: BoundTypeVarInstance<'db>,
     ) -> PathBound<'db> {
         let Self {
-            lower,
+            evidence_lower,
+            validity_lower,
             mut upper,
             has_gradual_evidence,
             has_static_evidence,
         } = self;
-        let lower = (!lower.is_empty()).then(|| UnionType::from_elements(db, env, lower));
+        let evidence_lower =
+            (!evidence_lower.is_empty()).then(|| UnionType::from_elements(db, env, evidence_lower));
+        let validity_lower = if validity_lower.is_empty() {
+            Type::Never
+        } else {
+            UnionType::from_elements(db, env, validity_lower)
+        };
         upper.shrink_to_fit();
         PathBound {
             bound_typevar,
-            lower,
+            evidence_lower,
+            validity_lower,
             upper,
             has_only_gradual_evidence: has_gradual_evidence && !has_static_evidence,
         }
     }
 }
 
-/// The explicit lower and upper bounds inferred for one typevar on one BDD path.
+/// The validity restrictions and inference evidence for one typevar on one TDD path.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct PathBound<'db> {
     pub(crate) bound_typevar: BoundTypeVarInstance<'db>,
-    pub(crate) lower: Option<Type<'db>>,
+    pub(crate) evidence_lower: Option<Type<'db>>,
+    pub(crate) validity_lower: Type<'db>,
     pub(crate) upper: UpperBound<'db>,
     /// Whether the path contains gradual evidence and no static evidence.
     has_only_gradual_evidence: bool,
@@ -3745,14 +3832,27 @@ impl<'db> PathBound<'db> {
     pub(crate) fn exact(bound_typevar: BoundTypeVarInstance<'db>, ty: Type<'db>) -> Self {
         Self {
             bound_typevar,
-            lower: Some(ty),
+            evidence_lower: Some(ty),
+            validity_lower: Type::Never,
             upper: UpperBound::from_clause(ty),
             has_only_gradual_evidence: false,
         }
     }
 
+    pub(crate) fn effective_lower(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Type<'db> {
+        if let Some(evidence) = self.evidence_lower {
+            UnionType::from_two_elements(db, env, evidence, self.validity_lower)
+        } else {
+            self.validity_lower
+        }
+    }
+
     fn variance(&self) -> TypeVarVariance {
-        match (self.lower, self.has_upper()) {
+        match (self.evidence_lower, self.has_upper_evidence()) {
             (None, true) => TypeVarVariance::Covariant,
             (Some(_), false) => TypeVarVariance::Contravariant,
             (Some(_), true) => TypeVarVariance::Invariant,
@@ -3760,16 +3860,17 @@ impl<'db> PathBound<'db> {
         }
     }
 
-    fn lower_or_never(&self) -> Type<'db> {
-        self.lower.unwrap_or(Type::Never)
+    pub(crate) fn has_upper_evidence(&self) -> bool {
+        self.upper.has_evidence()
     }
 
-    pub(crate) fn has_upper(&self) -> bool {
-        self.upper.has_explicit_bound()
-    }
-
-    fn has_only_gradual_evidence(&self) -> bool {
-        self.has_only_gradual_evidence
+    fn as_equality_validity_bound(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Type<'db>> {
+        let validity_upper = self.upper.as_single_validity_bound(db, env)?;
+        (self.validity_lower == validity_upper).then_some(self.validity_lower)
     }
 
     /// Restricts the range of a gradual solution by the upper bounds inferred for this constraint.
@@ -3779,8 +3880,9 @@ impl<'db> PathBound<'db> {
         env: &ProgramEnvironment<'db>,
         solution: Type<'db>,
     ) -> Type<'db> {
-        if self.lower != Some(solution)
-            || !self.has_upper()
+        if self.evidence_lower.is_none()
+            || self.effective_lower(db, env) != solution
+            || !self.has_upper_evidence()
             || solution.bottom_materialization(db, env) == solution.top_materialization(db, env)
         {
             return solution;
@@ -3792,7 +3894,7 @@ impl<'db> PathBound<'db> {
         }
 
         // `Divergent` is not safely reflexive, so we cannot intersect identical bounds.
-        if self.upper.clauses.len() == 1 && self.upper.clauses.contains(&solution) {
+        if self.upper.as_single_evidence_bound(db, env) == Some(solution) {
             return solution;
         }
 
@@ -3812,9 +3914,8 @@ impl<'db> PathBound<'db> {
 
         let mut upper_bounds = self
             .upper
-            .clauses
-            .iter()
-            .copied()
+            .iter_evidence()
+            .map(ConstraintBound::ty)
             .filter_map(materialize_upper);
         let Some(first_upper) = upper_bounds.next() else {
             return solution;
@@ -3910,7 +4011,7 @@ fn is_possibly_constraint_set_assignable<'db>(db: &'db dyn Db, types: TypePair<'
 pub(crate) enum PathBounds<'db> {
     Unsatisfiable,
     Unconstrained,
-    Constrained(Box<[Box<[PathBound<'db>]>]>),
+    Constrained(Vec<Box<[PathBound<'db>]>>),
 }
 
 impl<'db> PathBounds<'db> {
@@ -4037,23 +4138,25 @@ impl<'db> PathBounds<'db> {
             for (constraint, _) in path {
                 let constraint = storage.constraint_data(constraint);
                 let typevar = constraint.typevar;
-                if let ConstraintBound::Evidence(lower) = constraint.bounds.lower {
+                let lower = constraint.bounds.lower;
+                if lower != ConstraintBound::missing_lower() {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_lower(db, env, lower);
 
-                    if let Type::TypeVar(lower_bound_typevar) = lower {
+                    if let Type::TypeVar(lower_bound_typevar) = lower.ty() {
                         let bounds = mappings.entry(lower_bound_typevar).or_default();
-                        bounds.add_upper(db, env, Type::TypeVar(typevar));
+                        bounds.add_upper(db, env, lower.with_type(Type::TypeVar(typevar)));
                     }
                 }
 
-                if let ConstraintBound::Evidence(upper) = constraint.bounds.upper {
+                let upper = constraint.bounds.upper;
+                if upper != ConstraintBound::missing_upper() {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_upper(db, env, upper);
 
-                    if let Type::TypeVar(upper_bound_typevar) = upper {
+                    if let Type::TypeVar(upper_bound_typevar) = upper.ty() {
                         let bounds = mappings.entry(upper_bound_typevar).or_default();
-                        bounds.add_lower(db, env, Type::TypeVar(typevar));
+                        bounds.add_lower(db, env, upper.with_type(Type::TypeVar(typevar)));
                     }
                 }
             }
@@ -4065,7 +4168,8 @@ impl<'db> PathBounds<'db> {
             result.push(path_bounds);
         }
 
-        PathBounds::Constrained(result.into_boxed_slice())
+        result.shrink_to_fit();
+        PathBounds::Constrained(result)
     }
 
     /// Accumulates a conjunction of concrete bound constraints without constructing a
@@ -4131,19 +4235,162 @@ impl<'db> PathBounds<'db> {
         constraints.sort_by_key(|(_, _, source_order)| *source_order);
         for (typevar, constraint, _) in constraints {
             let bounds = mappings.entry(typevar).or_default();
-            if let ConstraintBound::Evidence(lower) = constraint.lower {
-                bounds.add_lower(db, env, lower);
-            }
-            if let ConstraintBound::Evidence(upper) = constraint.upper {
-                bounds.add_upper(db, env, upper);
-            }
+            bounds.add_lower(db, env, constraint.lower);
+            bounds.add_upper(db, env, constraint.upper);
         }
 
         let path = mappings
             .drain(..)
             .map(|(bound_typevar, bounds)| bounds.finish(db, env, bound_typevar))
             .collect();
-        Some(PathBounds::Constrained(Box::new([path])))
+        Some(PathBounds::Constrained(vec![path]))
+    }
+
+    /// Removes less-preferred declared alternatives without combining separate paths.
+    ///
+    /// Paths are comparable only when they have the same inference evidence, bind the same
+    /// typevars, and differ in one declared constrained alternative. Callers explicitly opt into
+    /// pruning; ordinary solution extraction preserves every path.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "concrete-specialization consumers opt into pruning in a later phase"
+        )
+    )]
+    pub(crate) fn prune_subsumed(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) {
+        let Self::Constrained(paths) = self else {
+            return;
+        };
+
+        // TODO: Avoid comparing every pair of paths if pruning becomes a hot path. Grouping
+        // paths by their shared bounds could narrow the candidate comparisons.
+        let dominated: Vec<_> = paths
+            .iter()
+            .enumerate()
+            .map(|(index, candidate)| {
+                paths.iter().enumerate().any(|(other_index, other)| {
+                    index != other_index && Self::path_subsumes(db, env, other, candidate)
+                })
+            })
+            .collect();
+        let mut dominated = dominated.into_iter();
+        paths.retain(|_| dominated.next() == Some(false));
+    }
+
+    /// Returns whether `lhs` subsumes `rhs`. If so, `rhs` can be removed from a set containing
+    /// both paths without losing a distinct inference alternative.
+    fn path_subsumes(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        lhs: &[PathBound<'db>],
+        rhs: &[PathBound<'db>],
+    ) -> bool {
+        // We only remove a path when another one includes exactly the same typevars and has
+        // identical bounds for all but one of them. Different path lengths cannot contain the
+        // same set of typevars.
+        if lhs.len() != rhs.len() {
+            return false;
+        }
+
+        // Verify that both paths contain the same typevars and differ in exactly one bound.
+        let mut differing = None;
+        for lhs_bound in lhs {
+            // TODO: Index bounds by typevar identity if paths contain many typevars; repeatedly
+            // scanning the other path makes each comparison quadratic.
+            let Some(rhs_bound) = rhs.iter().find(|rhs_bound| {
+                lhs_bound
+                    .bound_typevar
+                    .is_same_typevar_as(db, rhs_bound.bound_typevar)
+            }) else {
+                // This typevar does not appear in both paths.
+                return false;
+            };
+
+            if lhs_bound == rhs_bound {
+                // The bounds for this typevar match.
+                continue;
+            }
+
+            // Gradual-only evidence does not distinguish between all of the declared constraints
+            // that it is compatible with, so preserve each alternative.
+            if lhs_bound.has_only_gradual_evidence || rhs_bound.has_only_gradual_evidence {
+                return false;
+            }
+
+            // The differing bounds must represent different declared constraint branches.
+            if lhs_bound.validity_lower == rhs_bound.validity_lower {
+                return false;
+            }
+
+            // A differing bound is comparable only when both paths have the same inference
+            // evidence. Otherwise, the paths represent separate inference alternatives rather
+            // than different declared constraints for the same alternative.
+            if lhs_bound.evidence_lower != rhs_bound.evidence_lower {
+                return false;
+            }
+            if !lhs_bound.upper.has_same_evidence(&rhs_bound.upper) {
+                return false;
+            }
+
+            // If the differing typevar does not have any declared constraints, this heuristic does
+            // not apply.
+            let bound_typevar = lhs_bound.bound_typevar;
+            let Some(TypeVarBoundOrConstraints::Constraints(_)) =
+                bound_typevar.typevar(db).bound_or_constraints(db, env)
+            else {
+                return false;
+            };
+
+            // Each declared constraint contributes an equality bound to the validity domain, which
+            // cannot be weakened by other constraints on this path. We can therefore assume that
+            // the validity lower and upper bounds are always present for this typevar, and that
+            // they are equal.
+            let lhs_validity = lhs_bound
+                .as_equality_validity_bound(db, env)
+                .expect("constrained typevar should have an equality validity bound");
+            let rhs_validity = rhs_bound
+                .as_equality_validity_bound(db, env)
+                .expect("constrained typevar should have an equality validity bound");
+
+            if differing
+                .replace((lhs_bound.variance(), lhs_validity, rhs_validity))
+                .is_some()
+            {
+                // A second typevar has different bounds.
+                return false;
+            }
+        }
+
+        let Some((lhs_variance, lhs_validity, rhs_validity)) = differing else {
+            // There were no typevars with different bounds.
+            return false;
+        };
+
+        // Check whether either validity bound is assignable to the other.
+        let lhs_assignable_to_rhs = lhs_validity.is_assignable_to(db, env, rhs_validity);
+        let rhs_assignable_to_lhs = rhs_validity.is_assignable_to(db, env, lhs_validity);
+
+        // If the bounds are mutually unassignable, neither one subsumes the other.
+        if !lhs_assignable_to_rhs && !rhs_assignable_to_lhs {
+            return false;
+        }
+
+        // Gradual alternatives can be assignable in both directions. Prefer a fully static
+        // alternative in that case, but preserve both if they are equally static or gradual.
+        if lhs_assignable_to_rhs == rhs_assignable_to_lhs {
+            let lhs_is_static = lhs_validity.bottom_materialization(db, env)
+                == lhs_validity.top_materialization(db, env);
+            let rhs_is_static = rhs_validity.bottom_materialization(db, env)
+                == rhs_validity.top_materialization(db, env);
+            return lhs_is_static && !rhs_is_static;
+        }
+
+        match lhs_variance {
+            TypeVarVariance::Contravariant | TypeVarVariance::Invariant => lhs_assignable_to_rhs,
+            TypeVarVariance::Covariant => rhs_assignable_to_lhs,
+            TypeVarVariance::Bivariant => false,
+        }
     }
 
     pub(crate) fn solve(
@@ -4178,6 +4425,9 @@ impl<'db> PathBounds<'db> {
             let mut solution = Vec::with_capacity(path.len());
             for path_bound in path {
                 let variance = path_bound.variance();
+                if variance == TypeVarVariance::Bivariant {
+                    continue;
+                }
 
                 match choose(variance, path_bound) {
                     Ok(Some(ty)) => solution.push(TypeVarSolution {
@@ -4241,8 +4491,12 @@ impl<'db> PathBounds<'db> {
         // TODO: Handle the upper bound/constraints by conjoining them with the constraint set
         // before solving.
 
+        if path_bound.variance() == TypeVarVariance::Bivariant {
+            return Ok(None);
+        }
+
         let bound_typevar = path_bound.bound_typevar;
-        let lower = path_bound.lower_or_never();
+        let lower = path_bound.effective_lower(db, env);
 
         match bound_typevar
             .typevar(db)
@@ -4254,7 +4508,7 @@ impl<'db> PathBounds<'db> {
                 // Prefer the lower bound (often the concrete actual type seen) over the
                 // upper bound (which may include TypeVar bounds/constraints). The upper bound
                 // should only be used as a fallback when no concrete type was inferred.
-                if let Some(lower) = path_bound.lower {
+                if path_bound.evidence_lower.is_some() {
                     if !path_bound.upper.is_satisfied_by(db, env, lower) {
                         let mut storage = builder.storage.borrow_mut();
                         let (when_upper, source_order) =
@@ -4280,15 +4534,14 @@ impl<'db> PathBounds<'db> {
                     return Ok(Some(lower));
                 }
 
-                if path_bound.has_upper() {
+                if path_bound.has_upper_evidence() {
                     return Ok(IntersectionType::bounded_from_elements(
                         db,
                         env,
                         path_bound
                             .upper
-                            .clauses
-                            .iter()
-                            .copied()
+                            .iter_clauses()
+                            .map(ConstraintBound::ty)
                             .chain([declared_upper]),
                     ));
                 }
@@ -4340,7 +4593,7 @@ impl<'db> PathBounds<'db> {
                         current_best.is_assignable_to(db, env, candidate);
 
                     if candidate_assignable_to_best != best_assignable_to_candidate {
-                        if path_bound.lower.is_some() {
+                        if path_bound.evidence_lower.is_some() {
                             candidate_assignable_to_best
                         } else {
                             best_assignable_to_candidate
@@ -4394,9 +4647,10 @@ impl<'db> PathBounds<'db> {
                     return Err(());
                 };
 
-                if let (Some(ty @ Type::TypeVar(_)), _) | (_, Some(ty @ Type::TypeVar(_))) =
-                    (path_bound.lower, path_bound.upper.as_single_bound(db, env))
-                {
+                if let (Some(ty @ Type::TypeVar(_)), _) | (_, Some(ty @ Type::TypeVar(_))) = (
+                    path_bound.evidence_lower,
+                    path_bound.upper.as_single_evidence_bound(db, env),
+                ) {
                     // This path relates two TypeVars, such as passing `S` to a parameter typed as
                     // `T: (int, str)`. The compatibility check above has verified that at least
                     // one of `T`'s declared constraints can satisfy the path, but choosing a
@@ -4413,14 +4667,14 @@ impl<'db> PathBounds<'db> {
                 // as the result if it's gradual. (Checking `Any` against `T: (int, str)` selects
                 // `T = Any`) If the path solution is fully static, we choose the "tightest"
                 // constraint. (Checking `int` against `T: (int, int | str)` selects `T = int`.)
-                if multiple_compatible_constraints && path_bound.has_only_gradual_evidence() {
-                    if let Some(lower) = path_bound.lower {
+                if multiple_compatible_constraints && path_bound.has_only_gradual_evidence {
+                    if path_bound.evidence_lower.is_some() {
                         Ok(Some(lower))
-                    } else if path_bound.has_upper() {
+                    } else if path_bound.has_upper_evidence() {
                         Ok(IntersectionType::bounded_from_elements(
                             db,
                             env,
-                            path_bound.upper.clauses.iter().copied(),
+                            path_bound.upper.iter_clauses().map(ConstraintBound::ty),
                         ))
                     } else {
                         Ok(None)
@@ -7438,6 +7692,37 @@ mod tests {
         class.to_instance(db, &db.program_environment())
     }
 
+    fn declared_path_bound<'db>(
+        bound_typevar: BoundTypeVarInstance<'db>,
+        alternative: Type<'db>,
+        variance: TypeVarVariance,
+    ) -> PathBound<'db> {
+        let evidence_lower = matches!(
+            variance,
+            TypeVarVariance::Contravariant | TypeVarVariance::Invariant
+        )
+        .then_some(Type::Never);
+        let mut upper = UpperBound::unconstrained();
+        upper.add_clause(ConstraintBound::Validity(alternative));
+        if matches!(
+            variance,
+            TypeVarVariance::Covariant | TypeVarVariance::Invariant
+        ) {
+            upper.add_clause(ConstraintBound::Evidence(Type::object()));
+        }
+        PathBound {
+            bound_typevar,
+            evidence_lower,
+            validity_lower: alternative,
+            upper,
+            has_only_gradual_evidence: false,
+        }
+    }
+
+    fn path_bounds(paths: Vec<Vec<PathBound<'_>>>) -> PathBounds<'_> {
+        PathBounds::Constrained(paths.into_iter().map(Vec::into_boxed_slice).collect())
+    }
+
     // XXX: Remove once solution extraction exercises validity domains.
     #[test]
     fn validity_domain_uses_supported_typevars_in_builder_order() {
@@ -8166,6 +8451,41 @@ mod tests {
     }
 
     #[test]
+    fn upper_bound_retains_evidence_under_stronger_validity() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let int = known_instance(db, KnownClass::Int);
+        let bool = known_instance(db, KnownClass::Bool);
+
+        for clauses in [
+            [
+                ConstraintBound::Evidence(int),
+                ConstraintBound::Validity(bool),
+            ],
+            [
+                ConstraintBound::Validity(bool),
+                ConstraintBound::Evidence(int),
+            ],
+        ] {
+            let mut upper = UpperBound::unconstrained();
+            for clause in clauses {
+                upper.add_clause(clause);
+            }
+
+            assert!(upper.has_evidence());
+            assert_eq!(upper.as_single_bound(db, &env), Some(bool));
+            assert_eq!(upper.as_single_evidence_bound(db, &env), Some(int));
+        }
+
+        let mut upper = UpperBound::from_clause(int);
+        upper.add_clause(ConstraintBound::Validity(Type::Never));
+        assert!(upper.has_evidence());
+        assert_eq!(upper.materialize_exact(db, &env), Type::Never);
+        assert_eq!(upper.as_single_evidence_bound(db, &env), Some(int));
+    }
+
+    #[test]
     fn upper_bound_collapses_never() {
         let db = setup_db();
         let db = &db;
@@ -8173,12 +8493,17 @@ mod tests {
         let int = known_instance(db, KnownClass::Int);
 
         let mut upper = UpperBound::from_clause(int);
-        upper.add_clause(Type::Never);
-        assert_eq!(upper.clauses, FxOrderSet::from_iter([Type::Never]));
+        upper.add_clause(ConstraintBound::Evidence(Type::Never));
+        assert_eq!(upper.evidence, FxOrderSet::from_iter([Type::Never]));
+        assert_eq!(upper.validity, FxOrderSet::from_iter([Type::object()]));
         assert_eq!(upper.materialize_exact(db, &env), Type::Never);
 
-        upper.add_clause(int);
-        assert_eq!(upper.clauses, FxOrderSet::from_iter([Type::Never]));
+        upper.add_clause(ConstraintBound::Validity(int));
+        assert_eq!(upper.validity, FxOrderSet::from_iter([int]));
+
+        upper.add_clause(ConstraintBound::Evidence(int));
+        assert_eq!(upper.evidence, FxOrderSet::from_iter([Type::Never]));
+        assert_eq!(upper.validity, FxOrderSet::from_iter([int]));
     }
 
     #[test]
@@ -8203,25 +8528,36 @@ mod tests {
             ([int_or_str, u], u),
             ([u, int_or_str], u),
         ] {
-            let mut upper = UpperBound::none();
+            let mut upper = UpperBound::unconstrained();
             for clause in clauses {
-                upper.add_clause(clause);
+                upper.add_clause(ConstraintBound::Evidence(clause));
             }
 
-            assert_eq!(upper.clauses.len(), 2);
+            assert_eq!(upper.evidence.len(), 2);
             assert_eq!(upper.as_single_bound(db, &env), Some(expected));
         }
     }
 
     #[test]
-    fn upper_bound_distinguishes_missing_bound_from_explicit_object() {
+    fn upper_bound_distinguishes_default_validity_from_explicit_object_evidence() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
 
-        assert_eq!(UpperBound::none().as_single_bound(db, &env), None);
+        let validity_only = UpperBound::unconstrained();
         assert_eq!(
-            UpperBound::from_clause(Type::object()).as_single_bound(db, &env),
+            validity_only.as_single_bound(db, &env),
+            Some(Type::object())
+        );
+        assert_eq!(validity_only.as_single_evidence_bound(db, &env), None);
+
+        let explicit_evidence = UpperBound::from_clause(Type::object());
+        assert_eq!(
+            explicit_evidence.as_single_bound(db, &env),
+            Some(Type::object())
+        );
+        assert_eq!(
+            explicit_evidence.as_single_evidence_bound(db, &env),
             Some(Type::object())
         );
     }
@@ -8238,9 +8574,9 @@ mod tests {
         let int_or_bytes = UnionType::from_two_elements(db, &env, int, bytes);
 
         for clauses in [[int_or_str, int_or_bytes], [int_or_bytes, int_or_str]] {
-            let mut upper = UpperBound::none();
+            let mut upper = UpperBound::unconstrained();
             for clause in clauses {
-                upper.add_clause(clause);
+                upper.add_clause(ConstraintBound::Evidence(clause));
             }
 
             assert_eq!(upper.materialize_exact(db, &env), int);
@@ -8256,7 +8592,7 @@ mod tests {
         let int = known_instance(db, KnownClass::Int);
         let u = Type::TypeVar(create_typevar(db, "U"));
         let mut upper = UpperBound::from_clause(u);
-        upper.add_clause(int);
+        upper.add_clause(ConstraintBound::Evidence(int));
 
         assert!(
             upper
@@ -8384,6 +8720,272 @@ mod tests {
     }
 
     #[test]
+    fn path_bounds_preserve_validity_without_manufacturing_evidence() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let int = known_instance(db, KnownClass::Int);
+        let bool = known_instance(db, KnownClass::Bool);
+        let str = known_instance(db, KnownClass::Str);
+        let typevar = create_typevar(db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let evidence =
+            ConstraintSet::constrain_typevar_lower_bound(db, &env, &builder, typevar, bool);
+        let (validity_node, validity_source_order) = Constraint::new_node_with_bounds(
+            db,
+            &env,
+            &mut builder.storage.borrow_mut(),
+            typevar,
+            ConstraintBound::Validity(int),
+            ConstraintBound::Validity(int),
+        );
+        let validity = ConstraintSet::from_node(&builder, validity_node, validity_source_order);
+        let inferable = TypeVarSet::from_typevars(db, [typevar]);
+        let combined = evidence.and(db, &builder, || validity);
+
+        let solutions =
+            combined.solutions_with(db, &env, &builder, inferable, |variance, path_bound| {
+                assert_eq!(variance, TypeVarVariance::Contravariant);
+                assert_eq!(path_bound.evidence_lower, Some(bool));
+                assert_eq!(path_bound.validity_lower, int);
+                assert_eq!(path_bound.effective_lower(db, &env), int);
+                assert!(!path_bound.has_upper_evidence());
+                assert_eq!(path_bound.upper.as_single_bound(db, &env), Some(int));
+                PathBounds::default_solve(db, &env, &builder, path_bound)
+            });
+        let expected = Solutions::Constrained(vec![vec![TypeVarSolution {
+            bound_typevar: typevar,
+            solution: int,
+        }]]);
+        assert_eq!(solutions, expected);
+
+        let (other_node, other_source_order) = Constraint::new_node_with_bounds(
+            db,
+            &env,
+            &mut builder.storage.borrow_mut(),
+            typevar,
+            ConstraintBound::Validity(str),
+            ConstraintBound::Validity(str),
+        );
+        let other = ConstraintSet::from_node(&builder, other_node, other_source_order);
+        let alternatives = validity.or(db, &builder, || other);
+        let ordinary_path = evidence.and(db, &builder, || alternatives);
+        let solutions =
+            ordinary_path.solutions_with(db, &env, &builder, inferable, |variance, path_bound| {
+                assert_eq!(variance, TypeVarVariance::Contravariant);
+                assert_eq!(path_bound.evidence_lower, Some(bool));
+                assert_eq!(path_bound.validity_lower, int);
+                assert_eq!(path_bound.effective_lower(db, &env), int);
+                PathBounds::default_solve(db, &env, &builder, path_bound)
+            });
+        assert_eq!(solutions, expected);
+
+        let mut callback_invoked = false;
+        let solutions =
+            validity.solutions_with(db, &env, &builder, inferable, |_variance, _path_bound| {
+                callback_invoked = true;
+                Ok(Some(int))
+            });
+        assert!(!callback_invoked);
+        assert_eq!(solutions, Solutions::Constrained(vec![Vec::new()]));
+    }
+
+    // XXX: Remove once domain-aware solution extraction invokes `prune_subsumed`; constrained
+    // TypeVar mdtests should cover this pipeline through production callers.
+    #[test]
+    fn path_pruning_selects_declared_domain_alternatives_before_solving() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let bool = known_instance(db, KnownClass::Bool);
+        let int = known_instance(db, KnownClass::Int);
+
+        for lower_evidence in [true, false] {
+            let typevar = create_typevar(db, "T").map_bound_or_constraints(db, |_| {
+                Some(TypeVarBoundOrConstraints::Constraints(
+                    TypeVarConstraints::new(db, [bool, int].as_slice()),
+                ))
+            });
+            let builder = ConstraintSetBuilder::new();
+            let evidence = if lower_evidence {
+                ConstraintSet::constrain_typevar_lower_bound(db, &env, &builder, typevar, bool)
+            } else {
+                ConstraintSet::constrain_typevar_upper_bound(db, &env, &builder, typevar, int)
+            };
+            let (domain, source_order) =
+                builder
+                    .storage
+                    .borrow_mut()
+                    .validity_domain(db, &env, evidence.node);
+            let domain = ConstraintSet::from_node(&builder, domain, source_order);
+            let combined = evidence.and(db, &builder, || domain);
+            let inferable = TypeVarSet::from_typevars(db, [typevar]);
+            let mut paths = PathBounds::compute(
+                db,
+                &env,
+                &mut builder.storage.borrow_mut(),
+                combined.node,
+                inferable,
+                combined.source_order,
+            );
+
+            assert!(matches!(&paths, PathBounds::Constrained(paths) if paths.len() == 2));
+            paths.prune_subsumed(db, &env);
+            let expected = if lower_evidence { bool } else { int };
+            assert_eq!(
+                paths.solve(db, &env, &builder),
+                Solutions::Constrained(vec![vec![TypeVarSolution {
+                    bound_typevar: typevar,
+                    solution: expected,
+                }]])
+            );
+        }
+    }
+
+    #[test]
+    fn path_pruning_ranks_declared_validity_bounds() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let int = known_instance(db, KnownClass::Int);
+        let str = known_instance(db, KnownClass::Str);
+        let any = Type::any();
+        let object = Type::object();
+        let int_or_str = UnionType::from_two_elements(db, &env, int, str);
+        let cases = [
+            (
+                [Type::Never, int],
+                Type::Never,
+                int,
+                TypeVarVariance::Contravariant,
+            ),
+            (
+                [int, int_or_str],
+                int,
+                int_or_str,
+                TypeVarVariance::Contravariant,
+            ),
+            (
+                [int, int_or_str],
+                int_or_str,
+                int,
+                TypeVarVariance::Covariant,
+            ),
+            ([int, object], object, int, TypeVarVariance::Covariant),
+            ([any, int], int, any, TypeVarVariance::Contravariant),
+        ];
+
+        for (alternatives, preferred, discarded, variance) in cases {
+            let typevar = create_typevar(db, "T").map_bound_or_constraints(db, |_| {
+                Some(TypeVarBoundOrConstraints::Constraints(
+                    TypeVarConstraints::new(db, alternatives.as_slice()),
+                ))
+            });
+            let preferred = declared_path_bound(typevar, preferred, variance);
+            let discarded = declared_path_bound(typevar, discarded, variance);
+
+            for paths in [
+                vec![vec![preferred.clone()], vec![discarded.clone()]],
+                vec![vec![discarded.clone()], vec![preferred.clone()]],
+            ] {
+                let mut actual = path_bounds(paths);
+                actual.prune_subsumed(db, &env);
+                assert_eq!(actual, path_bounds(vec![vec![preferred.clone()]]));
+            }
+        }
+    }
+
+    #[test]
+    fn path_pruning_preserves_correlated_and_independent_alternatives() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let bool = known_instance(db, KnownClass::Bool);
+        let int = known_instance(db, KnownClass::Int);
+        let str = known_instance(db, KnownClass::Str);
+        let typevar = create_typevar(db, "T").map_bound_or_constraints(db, |_| {
+            Some(TypeVarBoundOrConstraints::Constraints(
+                TypeVarConstraints::new(db, [bool, int, str].as_slice()),
+            ))
+        });
+        let other = create_typevar(db, "U");
+        let lower = TypeVarVariance::Contravariant;
+        let upper = TypeVarVariance::Covariant;
+        let declared = |alternative, variance| declared_path_bound(typevar, alternative, variance);
+        let unrelated = |alternative| PathBound::exact(other, alternative);
+        let mut different_evidence = declared(int, lower);
+        different_evidence.evidence_lower = Some(bool);
+        let cases = [
+            vec![
+                vec![declared(bool, lower), unrelated(int)],
+                vec![declared(int, lower), unrelated(str)],
+            ],
+            vec![vec![declared(int, lower)], vec![declared(str, lower)]],
+            vec![vec![declared(bool, lower)], vec![declared(int, upper)]],
+            vec![vec![unrelated(bool)], vec![unrelated(int)]],
+            vec![vec![declared(bool, lower)], vec![different_evidence]],
+        ];
+
+        for paths in cases {
+            let mut actual = path_bounds(paths);
+            let expected = actual.clone();
+            actual.prune_subsumed(db, &env);
+            assert_eq!(actual, expected);
+        }
+
+        let narrow = vec![declared(bool, lower), unrelated(int)];
+        let broad = vec![unrelated(int), declared(int, lower)];
+        let mut actual = path_bounds(vec![broad, narrow.clone()]);
+        actual.prune_subsumed(db, &env);
+        assert_eq!(actual, path_bounds(vec![narrow]));
+
+        for mut paths in [
+            path_bounds(vec![Vec::new()]),
+            PathBounds::Unsatisfiable,
+            PathBounds::Unconstrained,
+        ] {
+            let expected = paths.clone();
+            paths.prune_subsumed(db, &env);
+            assert_eq!(paths, expected);
+        }
+    }
+
+    #[test]
+    fn path_pruning_preserves_ambiguous_gradual_alternatives() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let bool = known_instance(db, KnownClass::Bool);
+        let int = known_instance(db, KnownClass::Int);
+        let any = Type::any();
+        let list_any = KnownClass::List.to_specialized_instance(db, &env, &[any]);
+        let typevar = create_typevar(db, "T").map_bound_or_constraints(db, |_| {
+            Some(TypeVarBoundOrConstraints::Constraints(
+                TypeVarConstraints::new(db, [bool, int, any, list_any].as_slice()),
+            ))
+        });
+        let declared =
+            |alternative| declared_path_bound(typevar, alternative, TypeVarVariance::Contravariant);
+
+        let mut gradual_bool = declared(bool);
+        gradual_bool.evidence_lower = Some(any);
+        gradual_bool.has_only_gradual_evidence = true;
+        let mut gradual_int = declared(int);
+        gradual_int.evidence_lower = Some(any);
+        gradual_int.has_only_gradual_evidence = true;
+
+        for paths in [
+            vec![vec![declared(any)], vec![declared(list_any)]],
+            vec![vec![gradual_bool], vec![gradual_int]],
+        ] {
+            let mut actual = path_bounds(paths);
+            let expected = actual.clone();
+            actual.prune_subsumed(db, &env);
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
     fn simple_lower_bound_conjunction_skips_sequent_analysis() {
         let db = setup_db();
         let db = &db;
@@ -8504,8 +9106,9 @@ mod tests {
         let builder = ConstraintSetBuilder::new();
         let path_bound = PathBound {
             bound_typevar: t,
-            lower: None,
-            upper: UpperBound::none(),
+            evidence_lower: None,
+            validity_lower: Type::Never,
+            upper: UpperBound::unconstrained(),
             has_only_gradual_evidence: false,
         };
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5277,6 +5277,21 @@ enum Sequent {
         post: ConstraintId,
     },
 
+    /// Sequent of the form `C ∧ ¬D → false`
+    ///
+    /// In theory, this is equivalent to a `SingleImplication`. However, the two handle provenance
+    /// differently. A `SingleImplication` is used to add new positive facts, and we only allow
+    /// that to happen for certain combinations of provenance. (For example, we don't let an
+    /// `Evidence` constraint imply a `Validity` constraint.)
+    ///
+    /// Contradictions, on the other hand, apply no matter the provenance. So there are situations
+    /// where, given `C`, we don't want to add `D` (for provenance reasons), but we _do_ want to
+    /// verify that we haven't already proven `¬D`.
+    ImplicationContradiction {
+        ante: ConstraintId,
+        post: ConstraintId,
+    },
+
     /// Sequent of the form `C₁ ∧ C₂ → D`
     ///
     /// This indicates that if `C₁` and `C₂` are both true, then `D` is guaranteed to be true as
@@ -5448,18 +5463,23 @@ impl SequentMap {
         ante: ConstraintId,
         post: ConstraintId,
     ) {
+        if ante == post {
+            return;
+        }
+
         let antecedent = storage.constraint_data(ante);
         let consequent = storage.constraint_data(post);
         // Consequences on another type variable already inherit the provenance of their
         // contributing bounds; comparing their unrelated bound positions would discard valid
         // implications.
-        if ante == post
-            || (antecedent
-                .typevar
-                .is_same_typevar_as(db, consequent.typevar)
-                && !antecedent.bounds.has_same_provenance(consequent.bounds)
-                && !consequent.is_bound_projection_of(db, antecedent))
+        if antecedent
+            .typevar
+            .is_same_typevar_as(db, consequent.typevar)
+            && !antecedent.bounds.has_same_provenance(consequent.bounds)
+            && !consequent.is_bound_projection_of(db, antecedent)
         {
+            self.sequents
+                .push(Sequent::ImplicationContradiction { ante, post });
             return;
         }
 
@@ -6544,6 +6564,16 @@ impl SequentMap {
                             post.display(db, env, storage)
                         )?;
                     }
+
+                    Sequent::ImplicationContradiction { ante, post } => {
+                        maybe_write_prefix(f)?;
+                        write!(
+                            f,
+                            "{} ∧ ¬{} → false",
+                            ante.display(db, env, storage),
+                            post.display(db, env, storage),
+                        )?;
+                    }
                 }
             }
 
@@ -7462,6 +7492,9 @@ impl PathAssignments {
                 self.check_single_implication(db, env, storage, ante, post);
                 Ok(())
             }
+            Sequent::ImplicationContradiction { ante, post } => {
+                self.check_implication_contradiction(db, env, storage, ante, post)
+            }
         }
     }
 
@@ -7575,6 +7608,33 @@ impl PathAssignments {
                 AssignmentFuel::derived(fuel_cost, post_fuel),
             );
         }
+    }
+
+    fn check_implication_contradiction<'db>(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        storage: &ConstraintSetStorage<'db>,
+        ante: ConstraintId,
+        post: ConstraintId,
+    ) -> Result<(), PathAssignmentConflict> {
+        if self.assignment_holds(ante.when_true()) && self.assignment_holds(post.when_false()) {
+            tracing::trace!(
+                target: "ty_python_semantic::types::constraints::PathAssignment",
+                ante = %ante.display(db, env, storage),
+                post = %post.display(db, env, storage),
+                facts = %format_args!(
+                    "[{}]",
+                    self.assignments.iter().map(|(assignment, _)| {
+                        assignment.display(db, env, storage)
+                    }).format(", "),
+                ),
+                "found contradiction",
+            );
+            return Err(PathAssignmentConflict);
+        }
+
+        Ok(())
     }
 }
 
@@ -8172,57 +8232,149 @@ mod tests {
         let bool = known_instance(db, KnownClass::Bool);
         let mut storage = ConstraintSetStorage::default();
 
-        for (evidence, validity) in [(int, int), (int, bool), (bool, int)] {
+        for (first_ty, second_ty) in [(int, int), (int, bool), (bool, int)] {
+            let first_bounds = [
+                ConstraintBound::Evidence(first_ty),
+                ConstraintBound::Validity(first_ty),
+                ConstraintBound::Mixed(first_ty),
+            ];
+            let second_bounds = [
+                ConstraintBound::Evidence(second_ty),
+                ConstraintBound::Validity(second_ty),
+                ConstraintBound::Mixed(second_ty),
+            ];
             for lower in [false, true] {
-                let evidence_bounds = if lower {
-                    ConstraintBounds::new(
-                        ConstraintBound::Evidence(evidence),
-                        ConstraintBound::missing_upper(),
-                    )
-                } else {
-                    ConstraintBounds::new(
-                        ConstraintBound::missing_lower(),
-                        ConstraintBound::Evidence(evidence),
-                    )
-                };
-                let validity_bounds = if lower {
-                    ConstraintBounds::new(
-                        ConstraintBound::Validity(validity),
-                        ConstraintBound::missing_upper(),
-                    )
-                } else {
-                    ConstraintBounds::new(
-                        ConstraintBound::missing_lower(),
-                        ConstraintBound::Validity(validity),
-                    )
-                };
-                let evidence = ConstraintId::new_with_bounds(
-                    db,
-                    &env,
-                    &mut storage,
-                    t,
-                    evidence_bounds.lower,
-                    evidence_bounds.upper,
-                );
-                let validity = ConstraintId::new_with_bounds(
-                    db,
-                    &env,
-                    &mut storage,
-                    t,
-                    validity_bounds.lower,
-                    validity_bounds.upper,
-                );
-                for (first, second) in [(evidence, validity), (validity, evidence)] {
-                    let sequents =
-                        SequentMap::for_constraint_pair(db, &env, &mut storage, first, second);
-                    assert!(sequents.sequents.iter().all(|sequent| {
-                        !matches!(sequent, Sequent::SingleImplication { ante, post }
-                            if (*ante == evidence && *post == validity)
-                                || (*ante == validity && *post == evidence))
-                    }));
+                for first_bound in first_bounds {
+                    for second_bound in second_bounds {
+                        if first_bound.has_same_provenance(second_bound) {
+                            continue;
+                        }
+                        let bounds = |bound| {
+                            if lower {
+                                ConstraintBounds::new(bound, ConstraintBound::missing_upper())
+                            } else {
+                                ConstraintBounds::new(ConstraintBound::missing_lower(), bound)
+                            }
+                        };
+                        let first_bounds = bounds(first_bound);
+                        let first = ConstraintId::new_with_bounds(
+                            db,
+                            &env,
+                            &mut storage,
+                            t,
+                            first_bounds.lower,
+                            first_bounds.upper,
+                        );
+                        let second_bounds = bounds(second_bound);
+                        let second = ConstraintId::new_with_bounds(
+                            db,
+                            &env,
+                            &mut storage,
+                            t,
+                            second_bounds.lower,
+                            second_bounds.upper,
+                        );
+                        let first_implies_second =
+                            storage.cached_constraint_implies(db, &env, first, second);
+                        let second_implies_first =
+                            storage.cached_constraint_implies(db, &env, second, first);
+                        let sequents =
+                            SequentMap::for_constraint_pair(db, &env, &mut storage, first, second);
+                        assert!(sequents.sequents.iter().all(|sequent| {
+                            !matches!(sequent, Sequent::SingleImplication { ante, post }
+                                if (*ante == first && *post == second)
+                                    || (*ante == second && *post == first))
+                        }));
+                        for (ante, post, expected) in [
+                            (first, second, first_implies_second),
+                            (second, first, second_implies_first),
+                        ] {
+                            assert_eq!(
+                                sequents.sequents.iter().any(|sequent| {
+                                    matches!(sequent,
+                                        Sequent::ImplicationContradiction {
+                                            ante: actual_ante,
+                                            post: actual_post,
+                                        } if *actual_ante == ante && *actual_post == post)
+                                }),
+                                expected,
+                            );
+                        }
+                    }
                 }
             }
         }
+    }
+
+    #[test]
+    fn cross_provenance_implication_rejects_a_negative_consequence() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let int = known_instance(db, KnownClass::Int);
+        let bool = known_instance(db, KnownClass::Bool);
+        let builder = ConstraintSetBuilder::new();
+        let evidence = ConstraintSet::constrain_typevar_with_bounds(
+            db,
+            &env,
+            &builder,
+            t,
+            ConstraintBound::missing_lower(),
+            ConstraintBound::Evidence(bool),
+        );
+        let validity = ConstraintSet::constrain_typevar_with_bounds(
+            db,
+            &env,
+            &builder,
+            t,
+            ConstraintBound::missing_lower(),
+            ConstraintBound::Validity(int),
+        );
+
+        let contradictory = evidence.and(db, &builder, || validity.negate(db, &builder));
+        assert!(contradictory.is_never_satisfied(db, &env));
+
+        let satisfiable = validity.and(db, &builder, || evidence.negate(db, &builder));
+        assert!(!satisfiable.is_never_satisfied(db, &env));
+    }
+
+    #[test]
+    fn pair_derived_implication_preserves_cross_provenance_contradictions() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let u = create_typevar(db, "U");
+        let int = known_instance(db, KnownClass::Int);
+        let str = known_instance(db, KnownClass::Str);
+        let int_or_str = UnionType::from_elements(db, &env, [int, str]);
+        let builder = ConstraintSetBuilder::new();
+        let relationship =
+            ConstraintSet::constrain_typevar_upper_bound(db, &env, &builder, t, Type::TypeVar(u));
+        let validity = ConstraintSet::constrain_typevar_with_bounds(
+            db,
+            &env,
+            &builder,
+            u,
+            ConstraintBound::missing_lower(),
+            ConstraintBound::Validity(int),
+        );
+        let evidence =
+            ConstraintSet::constrain_typevar_upper_bound(db, &env, &builder, t, int_or_str);
+        let not_evidence = evidence.negate(db, &builder);
+
+        assert!(
+            relationship
+                .and(db, &builder, || validity)
+                .and(db, &builder, || not_evidence)
+                .is_never_satisfied(db, &env)
+        );
+        assert!(
+            !relationship
+                .and(db, &builder, || not_evidence)
+                .is_never_satisfied(db, &env)
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -876,18 +876,59 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         inferable: TypeVarSet<'db>,
         choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
+        self.path_bounds(db, env, builder, inferable)
+            .solve_with(choose)
+    }
+
+    pub(crate) fn pruned_solutions_with(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &'c ConstraintSetBuilder<'db>,
+        inferable: TypeVarSet<'db>,
+        choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
+    ) -> Solutions<'db> {
+        let mut path_bounds = self.path_bounds(db, env, builder, inferable);
+        path_bounds.prune_subsumed(db, env);
+        path_bounds.solve_with(choose)
+    }
+
+    fn path_bounds(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &'c ConstraintSetBuilder<'db>,
+        inferable: TypeVarSet<'db>,
+    ) -> PathBounds<'db> {
         self.verify_builder(builder);
-        let mut storage = builder.storage.borrow_mut();
-        let path_bounds = PathBounds::compute(
+        PathBounds::compute(
             db,
             env,
-            &mut storage,
+            &mut builder.storage.borrow_mut(),
             self.node,
             inferable,
             self.source_order,
-        );
-        drop(storage);
-        path_bounds.solve_with(choose)
+            true,
+        )
+    }
+
+    pub(crate) fn unconjoined_path_bounds(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &'c ConstraintSetBuilder<'db>,
+        inferable: TypeVarSet<'db>,
+    ) -> PathBounds<'db> {
+        self.verify_builder(builder);
+        PathBounds::compute(
+            db,
+            env,
+            &mut builder.storage.borrow_mut(),
+            self.node,
+            inferable,
+            self.source_order,
+            false,
+        )
     }
 
     pub(crate) fn display(
@@ -1656,18 +1697,26 @@ impl<'db> ConstraintSetStorage<'db> {
             .map(|support| self.support_data(support))
     }
 
+    fn has_trivial_validity_domain(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        node: NodeId,
+    ) -> bool {
+        self.node_support(node).is_none_or(|support| {
+            support.iter().all(|typevar| {
+                let typevar = self.typevar_data(typevar);
+                typevar.paramspec_attr(db).is_some()
+                    || typevar.typevar(db).bound_or_constraints(db, env).is_none()
+            })
+        })
+    }
+
     /// Returns a constraint set encoding the declared upper bound or constraints of every typevar
     /// in this node's support. This constraint set defines the _domain_ (or, the set of valid
     /// solutions) of the node. Any constraints in the constraint set will use
     /// [`Validity`][ConstraintBound::Validity] bounds, since they constrain which solutions are
     /// valid, but do not provide direct evidence of the particular solution we should choose.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "validity domains are applied during solution extraction in a later phase"
-        )
-    )]
     fn validity_domain(
         &mut self,
         db: &'db dyn Db,
@@ -2003,9 +2052,13 @@ impl<'db> ConstraintBound<'db> {
     /// the result has the same type as one of them. For example, deriving `int ≤ S` from
     /// `int ≤ T` and `T ≤ S` requires both premises even though the resulting bound type is still
     /// `int`.
+    ///
+    /// Only direct declaration-domain constraints are validity bounds. A derived bound with any
+    /// validity premise is mixed so that it cannot obscure a constrained typevar's exact validity
+    /// equality on a complete path.
     fn from_transitive_derivation(combined: Type<'db>, lhs: Self, rhs: Self) -> Self {
-        if lhs.has_same_provenance(rhs) {
-            lhs.with_type(combined)
+        if matches!((lhs, rhs), (Self::Evidence(_), Self::Evidence(_))) {
+            Self::Evidence(combined)
         } else {
             Self::Mixed(combined)
         }
@@ -4057,14 +4110,14 @@ impl<'db> Type<'db> {
             let env = &ProgramEnvironment::from_program(program);
             let when = source.when_constraint_set_assignable_to_owned(db, env, target);
             when.query(|builder, when| {
-                let mut storage = builder.storage.borrow_mut();
                 PathBounds::compute(
                     db,
                     env,
-                    &mut storage,
+                    &mut builder.storage.borrow_mut(),
                     when.node,
                     inferable,
                     when.source_order,
+                    true,
                 )
             })
         }
@@ -4108,6 +4161,7 @@ impl<'db> PathBounds<'db> {
         node: NodeId,
         inferable: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
+        include_validity_domain: bool,
     ) -> Self {
         struct CollectVisitor<'a> {
             source_orders: &'a FxIndexSet<ConstraintId>,
@@ -4170,20 +4224,53 @@ impl<'db> PathBounds<'db> {
         }
 
         let mut source_orders = storage.calculate_source_orders(source_order);
-        if let Some(path_bounds) = Self::compute_simple_bound_conjunction(
-            db,
-            env,
-            storage,
-            &source_orders,
-            node,
-            inferable,
-        ) {
+        if (!include_validity_domain || storage.has_trivial_validity_domain(db, env, node))
+            && let Some(path_bounds) = Self::compute_simple_bound_conjunction(
+                db,
+                env,
+                storage,
+                &source_orders,
+                node,
+                inferable,
+            )
+        {
             return path_bounds;
         }
 
-        let (node, derived_source_order) =
+        let (mut node, derived_source_order) =
             node.remove_noninferable(db, env, storage, inferable, source_order);
         source_orders.extend(storage.calculate_source_orders(derived_source_order));
+        let mut path_source_order =
+            storage.ordered_source_order(source_order, derived_source_order);
+
+        if include_validity_domain {
+            let (domain, domain_source_order) = storage.validity_domain(db, env, node);
+            source_orders.extend(storage.calculate_source_orders(domain_source_order));
+            if domain != ALWAYS_TRUE {
+                node = node.and(storage, domain);
+                let all_supported = TypeVarSet::from_typevars(
+                    db,
+                    storage
+                        .node_support(node)
+                        .into_iter()
+                        .flat_map(Support::iter)
+                        .map(|typevar| storage.typevar_data(typevar)),
+                );
+                if let Some(path_bounds) = Self::compute_simple_bound_conjunction(
+                    db,
+                    env,
+                    storage,
+                    &source_orders,
+                    node,
+                    all_supported,
+                ) {
+                    return path_bounds;
+                }
+            }
+            path_source_order =
+                storage.ordered_source_order(path_source_order, domain_source_order);
+        }
+
         let interior = match node.node() {
             Node::AlwaysTrue => return PathBounds::Unconstrained,
             Node::AlwaysFalse => return PathBounds::Unsatisfiable,
@@ -4202,7 +4289,6 @@ impl<'db> PathBounds<'db> {
         // Sequent discovery must also happen in source order. Sorting the collected paths below
         // is too late: sequent pairs are not commutative, and TDD traversal order can otherwise
         // discard gradual evidence before solution extraction.
-        let path_source_order = storage.ordered_source_order(source_order, derived_source_order);
         let mut path = interior.path_assignments(db, env, storage, path_source_order);
         let _ = path.visit(db, env, storage, node, &mut collect_visitor);
         collect_visitor.sorted_paths.sort_by(|path1, path2| {
@@ -4333,13 +4419,6 @@ impl<'db> PathBounds<'db> {
     /// Paths are comparable only when they have the same inference evidence, bind the same
     /// typevars, and differ in one declared constrained alternative. Callers explicitly opt into
     /// pruning; ordinary solution extraction preserves every path.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "concrete-specialization consumers opt into pruning in a later phase"
-        )
-    )]
     pub(crate) fn prune_subsumed(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) {
         let Self::Constrained(paths) = self else {
             return;
@@ -4426,10 +4505,9 @@ impl<'db> PathBounds<'db> {
                 return false;
             };
 
-            // Each declared constraint contributes an equality bound to the validity domain, which
-            // cannot be weakened by other constraints on this path. We can therefore assume that
-            // the validity lower and upper bounds are always present for this typevar, and that
-            // they are equal.
+            // Each declared constraint contributes an equality bound to the validity domain that
+            // cannot be weakened by derived constraints on this path. The validity lower and
+            // upper bounds must therefore both be present and equal.
             let lhs_validity = lhs_bound
                 .as_equality_validity_bound(db, env)
                 .expect("constrained typevar should have an equality validity bound");
@@ -4570,10 +4648,9 @@ impl<'db> PathBounds<'db> {
         builder: &ConstraintSetBuilder<'db>,
         path_bound: &PathBound<'db>,
     ) -> Result<Option<Type<'db>>, ()> {
-        // Choose a solution type that satisfies the constraints on this path, as well as any upper
-        // bound or constraints of the typevar itself.
-        // TODO: Handle the upper bound/constraints by conjoining them with the constraint set
-        // before solving.
+        // XXX: Declared domains are now conjoined before path extraction, but this compatibility
+        // logic still re-reads the declaration. A follow-up should solve entirely from the
+        // provenance-aware path bounds while restoring the temporarily accepted regressions.
 
         if path_bound.variance() == TypeVarVariance::Bivariant {
             return Ok(None);
@@ -8410,10 +8487,10 @@ mod tests {
                             ConstraintBound::missing_upper()
                         },
                     );
-                    let expected = match (relationship_validity, concrete_validity) {
-                        (true, true) => ConstraintBound::Validity(int),
-                        (false, false) => ConstraintBound::Evidence(int),
-                        _ => ConstraintBound::Mixed(int),
+                    let expected = if relationship_validity || concrete_validity {
+                        ConstraintBound::Mixed(int)
+                    } else {
+                        ConstraintBound::Evidence(int)
                     };
                     let sequents = SequentMap::for_constraint_pair(
                         db,
@@ -9036,8 +9113,6 @@ mod tests {
         assert_eq!(solutions, Solutions::Constrained(vec![Vec::new()]));
     }
 
-    // XXX: Remove once domain-aware solution extraction invokes `prune_subsumed`; constrained
-    // TypeVar mdtests should cover this pipeline through production callers.
     #[test]
     fn path_pruning_selects_declared_domain_alternatives_before_solving() {
         let db = setup_db();
@@ -9073,6 +9148,7 @@ mod tests {
                 combined.node,
                 inferable,
                 combined.source_order,
+                false,
             );
 
             assert!(matches!(&paths, PathBounds::Constrained(paths) if paths.len() == 2));

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -114,7 +114,7 @@ use crate::types::visitor::{
 };
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, IntersectionType, Type, TypeContext,
-    TypeMapping, TypePair, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
+    TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
 };
 use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet, ProgramEnvironment};
 
@@ -2252,14 +2252,6 @@ impl<'db> UpperBound<'db> {
         Self::single_bound_from_iterator(db, env, self.iter_clauses())
     }
 
-    pub(crate) fn as_single_evidence_bound(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Option<Type<'db>> {
-        Self::single_bound_from_iterator(db, env, self.iter_inference())
-    }
-
     fn as_single_validity_bound(
         &self,
         db: &'db dyn Db,
@@ -4029,7 +4021,9 @@ impl<'db> PathBound<'db> {
         }
 
         // `Divergent` is not safely reflexive, so we cannot intersect identical bounds.
-        if self.upper.as_single_evidence_bound(db, env) == Some(solution) {
+        if UpperBound::single_bound_from_iterator(db, env, self.upper.iter_inference())
+            == Some(solution)
+        {
             return solution;
         }
 
@@ -4049,7 +4043,7 @@ impl<'db> PathBound<'db> {
 
         let mut upper_bounds = self
             .upper
-            .iter_evidence()
+            .iter_inference()
             .map(ConstraintBound::ty)
             .filter_map(materialize_upper);
         let Some(first_upper) = upper_bounds.next() else {
@@ -4125,20 +4119,6 @@ impl<'db> Type<'db> {
         let program = env.program(db);
         assignable_solutions_impl(db, program, self, target, inferable)
     }
-}
-
-#[salsa::tracked(
-    returns(copy),
-    cycle_initial = |_, _, _| true,
-    heap_size = get_size2::GetSize::get_heap_size
-)]
-fn is_possibly_constraint_set_assignable<'db>(db: &'db dyn Db, types: TypePair<'db>) -> bool {
-    let program = types.program(db);
-    let env = &ProgramEnvironment::from_program(program);
-    types
-        .first(db)
-        .when_constraint_set_assignable_to_owned(db, env, types.second(db))
-        .query(|_storage, when| !when.is_never_satisfied(db, env))
 }
 
 /// Per-path bounds for all typevars. Each element is the set of typevar bounds for one BDD path.
@@ -4611,13 +4591,13 @@ impl<'db> PathBounds<'db> {
 
     /// The default solution selection logic for a single typevar on a single BDD path.
     ///
-    /// Given the explicit lower and upper bounds for a typevar, selects the solution type.
-    /// Missing bounds are materialized to their logical defaults only for satisfiability checks;
-    /// they are not selected as inferred solutions.
+    /// Given the validity and evidence bounds for a typevar, selects the solution type.
+    /// Logical-default validity bounds participate in satisfiability checks but are not selected as
+    /// inferred solutions.
     /// Returns:
     /// - `Ok(Some(solution))` if the typevar is solved on this path
     /// - `Ok(None)` if the typevar is unsolved (no solution added)
-    /// - `Err(())` if the path is invalid (bounds violate the typevar's declared constraints)
+    /// - `Err(())` if the effective lower bound cannot satisfy the effective upper bound
     pub(crate) fn default_solve(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -4648,203 +4628,42 @@ impl<'db> PathBounds<'db> {
         builder: &ConstraintSetBuilder<'db>,
         path_bound: &PathBound<'db>,
     ) -> Result<Option<Type<'db>>, ()> {
-        // XXX: Declared domains are now conjoined before path extraction, but this compatibility
-        // logic still re-reads the declaration. A follow-up should solve entirely from the
-        // provenance-aware path bounds while restoring the temporarily accepted regressions.
-
         if path_bound.variance() == TypeVarVariance::Bivariant {
             return Ok(None);
         }
 
-        let bound_typevar = path_bound.bound_typevar;
         let lower = path_bound.effective_lower(db, env);
-
-        match bound_typevar
-            .typevar(db)
-            .require_bound_or_constraints(db, env)
-        {
-            TypeVarBoundOrConstraints::UpperBound(bound) => {
-                let declared_upper = bound.top_materialization(db, env);
-
-                // Prefer the lower bound (often the concrete actual type seen) over the
-                // upper bound (which may include TypeVar bounds/constraints). The upper bound
-                // should only be used as a fallback when no concrete type was inferred.
-                if path_bound.has_lower_evidence() {
-                    if !path_bound.upper.is_satisfied_by(db, env, lower) {
-                        let mut storage = builder.storage.borrow_mut();
-                        let (when_upper, source_order) =
-                            path_bound
-                                .upper
-                                .when_satisfied_by(db, env, &mut storage, lower);
-                        if when_upper.is_never_satisfied(db, env, &mut storage, source_order) {
-                            // This path does not satisfy the accumulated upper bound, and is
-                            // therefore not a valid specialization.
-                            return Err(());
-                        }
-                    }
-
-                    if !is_possibly_constraint_set_assignable(
-                        db,
-                        TypePair::new(db, env.program(db), lower, declared_upper),
-                    ) {
-                        // This path does not satisfy the typevar's declared upper bound, and is
-                        // therefore not a valid specialization.
-                        return Err(());
-                    }
-
-                    return Ok(Some(lower));
-                }
-
-                if path_bound.has_upper_evidence() {
-                    return Ok(IntersectionType::bounded_from_elements(
-                        db,
-                        env,
-                        path_bound
-                            .upper
-                            .iter_clauses()
-                            .map(ConstraintBound::ty)
-                            .chain([declared_upper]),
-                    ));
-                }
-
-                Ok(None)
-            }
-
-            TypeVarBoundOrConstraints::Constraints(constraints) => {
-                // For a constrained typevar, the solution for this path must satisfy at least one
-                // of the constraints. If it doesn't, then this path isn't a valid solution. If it
-                // satisfies exactly one constraint, that constraint is the solution.
-                //
-                // If the path satisfies more than one constraint, we behave differently depending
-                // on whether the path solution is gradual or not. If it's gradual, then the path
-                // solution has _materializations_ that satisfy more than one constraint, and we
-                // use the (gradual) path solution as our result, so that we aren't arbitrarily
-                // preferring one materialization over the others.
-                //
-                // If the path solution is fully static, and satisfies more than one constraint, we
-                // choose the "tightest" constraint as the solution.
-                //
-                // TODO: The way we are handling constrained typevars here breaks our assumption
-                // that each solution is represented by a single path in the BDD. Moreover, the
-                // logic here for disambiguating multiple solutions is different than the logic up
-                // in `SpecializationBuilder` that disambiguates solutions that come from multiple
-                // BDD paths. Ideally we would handle multiple solutions the same way in both
-                // places. The best way to do that is addressed by the TODO comment at the top of
-                // this method: we should handle typevar constraints by conjoining them into the
-                // constraint set before solving. Because typevar constraints would be modeled by
-                // an OR across the constraints, that would "break apart" this BDD path into
-                // separate paths, one for each satisfied typevar constraint. And then we would
-                // have to move this disambiguation logic up to the code that combines/chooses
-                // between solutions from multiple paths.
-
-                // Filter out the typevar constraints that aren't satisfied by this path. If
-                // multiple constraints are satisfied, track which one is "tightest".
-                let mut compatible_constraint = None;
-                let mut multiple_compatible_constraints = false;
-                let is_tighter_solution = |candidate: Type<'db>, current_best: Type<'db>| {
-                    // Lower-bound evidence asks for the narrowest compatible declared constraint
-                    // above the lower bound. With only upper-bound evidence, ask for the widest
-                    // compatible declared constraint below the upper bound. If the candidates are
-                    // assignable in both directions, prefer a fully static constraint over a
-                    // gradual one. Otherwise, keep the current best to preserve the TypeVar's
-                    // declared constraint order.
-                    let candidate_assignable_to_best =
-                        candidate.is_assignable_to(db, env, current_best);
-                    let best_assignable_to_candidate =
-                        current_best.is_assignable_to(db, env, candidate);
-
-                    if candidate_assignable_to_best != best_assignable_to_candidate {
-                        if path_bound.has_lower_evidence() {
-                            candidate_assignable_to_best
-                        } else {
-                            best_assignable_to_candidate
-                        }
-                    } else if candidate_assignable_to_best {
-                        let candidate_is_static = candidate.bottom_materialization(db, env)
-                            == candidate.top_materialization(db, env);
-                        let best_is_static = current_best.bottom_materialization(db, env)
-                            == current_best.top_materialization(db, env);
-                        candidate_is_static && !best_is_static
-                    } else {
-                        false
-                    }
-                };
-
-                for constraint in constraints.elements(db).iter().copied() {
-                    let constraint_lower = constraint.bottom_materialization(db, env);
-                    let constraint_upper = constraint.top_materialization(db, env);
-                    // A gradual constraint can choose any materialization that satisfies this
-                    // path. Its top materialization is the most permissive target for lower-bound
-                    // evidence, while its bottom materialization is the most permissive source
-                    // for upper-bound evidence.
-                    let when_lower =
-                        lower.when_constraint_set_assignable_to_owned(db, env, constraint_upper);
-                    let mut storage = builder.storage.borrow_mut();
-                    let (when_upper, upper_source_order) =
-                        path_bound
-                            .upper
-                            .when_satisfied_by(db, env, &mut storage, constraint_lower);
-                    let (when_lower, lower_source_order) = storage.load(db, env, &when_lower);
-                    let when = when_lower.and(&mut storage, when_upper);
-                    let source_order =
-                        storage.ordered_source_order(lower_source_order, upper_source_order);
-                    if when.is_never_satisfied(db, env, &mut storage, source_order) {
-                        continue;
-                    }
-
-                    if compatible_constraint.is_some() {
-                        multiple_compatible_constraints = true;
-                    }
-                    if compatible_constraint
-                        .is_none_or(|best| is_tighter_solution(constraint, best))
-                    {
-                        compatible_constraint = Some(constraint);
-                    }
-                }
-
-                let Some(compatible_constraint) = compatible_constraint else {
-                    // This path does not satisfy any of the constraints, and is therefore not a
-                    // valid specialization.
-                    return Err(());
-                };
-
-                if let (Some(ty @ Type::TypeVar(_)), _) | (_, Some(ty @ Type::TypeVar(_))) = (
-                    path_bound.inference_lower(db, env),
-                    path_bound.upper.as_single_evidence_bound(db, env),
-                ) {
-                    // This path relates two TypeVars, such as passing `S` to a parameter typed as
-                    // `T: (int, str)`. The compatibility check above has verified that at least
-                    // one of `T`'s declared constraints can satisfy the path, but choosing a
-                    // concrete constraint here would break the relationship between `T` and `S`.
-                    // Keep that relationship as the solution instead.
-                    return Ok(Some(ty));
-                }
-
-                // See above: If the path solution satisfies exactly one constraint, use that
-                // constraint as our solution. (Even if the path solution is gradual: if we are
-                // checking `list[Any]` against `T: (int, list[int])`, we select `T = list[int]`.)
-                //
-                // If the path solution satisfies multiple constraints, then we use path solution
-                // as the result if it's gradual. (Checking `Any` against `T: (int, str)` selects
-                // `T = Any`) If the path solution is fully static, we choose the "tightest"
-                // constraint. (Checking `int` against `T: (int, int | str)` selects `T = int`.)
-                if multiple_compatible_constraints && path_bound.has_only_gradual_evidence {
-                    if path_bound.has_lower_evidence() {
-                        Ok(Some(lower))
-                    } else if path_bound.has_upper_evidence() {
-                        Ok(IntersectionType::bounded_from_elements(
-                            db,
-                            env,
-                            path_bound.upper.iter_clauses().map(ConstraintBound::ty),
-                        ))
-                    } else {
-                        Ok(None)
-                    }
-                } else {
-                    Ok(Some(compatible_constraint))
-                }
+        let has_lower_evidence = path_bound.has_lower_evidence();
+        if !path_bound.upper.is_satisfied_by(db, env, lower) {
+            let mut storage = builder.storage.borrow_mut();
+            let (when_upper, source_order) =
+                path_bound
+                    .upper
+                    .when_satisfied_by(db, env, &mut storage, lower);
+            if when_upper.is_never_satisfied(db, env, &mut storage, source_order) {
+                return Err(());
             }
         }
+
+        // An exact validity equality fixes the specialization represented by this domain path.
+        // Evidence determines whether the path is valid, but does not widen that specialization.
+        if let Some(validity) = path_bound.as_equality_validity_bound(db, env) {
+            return Ok(Some(validity));
+        }
+
+        if has_lower_evidence {
+            return Ok(Some(lower));
+        }
+
+        if path_bound.has_upper_evidence() {
+            return Ok(IntersectionType::bounded_from_elements(
+                db,
+                env,
+                path_bound.upper.iter_clauses().map(ConstraintBound::ty),
+            ));
+        }
+
+        Ok(None)
     }
 }
 
@@ -8777,14 +8596,12 @@ mod tests {
 
             assert!(upper.has_evidence());
             assert_eq!(upper.as_single_bound(db, &env), Some(bool));
-            assert_eq!(upper.as_single_evidence_bound(db, &env), Some(int));
         }
 
         let mut upper = UpperBound::from_clause(int);
         upper.add_clause(ConstraintBound::Validity(Type::Never));
         assert!(upper.has_evidence());
         assert_eq!(upper.materialize_exact(db, &env), Type::Never);
-        assert_eq!(upper.as_single_evidence_bound(db, &env), Some(int));
     }
 
     #[test]
@@ -8805,7 +8622,7 @@ mod tests {
         let bounds = bounds.finish(db, &env, t);
         assert_eq!(bounds.as_equality_validity_bound(db, &env), Some(int));
         assert_eq!(bounds.inference_lower(db, &env), Some(s));
-        assert_eq!(bounds.upper.as_single_evidence_bound(db, &env), Some(s));
+        assert!(bounds.upper.has_evidence());
     }
 
     #[test]
@@ -8872,17 +8689,14 @@ mod tests {
             validity_only.as_single_bound(db, &env),
             Some(Type::object())
         );
-        assert_eq!(validity_only.as_single_evidence_bound(db, &env), None);
+        assert!(!validity_only.has_evidence());
 
         let explicit_evidence = UpperBound::from_clause(Type::object());
         assert_eq!(
             explicit_evidence.as_single_bound(db, &env),
             Some(Type::object())
         );
-        assert_eq!(
-            explicit_evidence.as_single_evidence_bound(db, &env),
-            Some(Type::object())
-        );
+        assert!(explicit_evidence.has_evidence());
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -91,7 +91,6 @@ use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::fmt::{Debug, Display};
-use std::iter;
 use std::marker::PhantomData;
 use std::ops::{ControlFlow, Range};
 use std::sync::{Arc, LazyLock};
@@ -330,9 +329,11 @@ impl<'db> OwnedConstraintSet<'db> {
                 .unique()
                 .map(|constraint| inner.constraints[inner.retained_constraint_index(constraint)])
                 .flat_map(|constraint| {
-                    std::iter::once(Type::TypeVar(constraint.typevar))
-                        .chain(constraint.bounds.lower)
-                        .chain(constraint.bounds.upper)
+                    [
+                        Type::TypeVar(constraint.typevar),
+                        constraint.bounds.lower.ty(),
+                        constraint.bounds.upper.ty(),
+                    ]
                 })
         })
     }
@@ -435,17 +436,24 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         lower: Type<'db>,
         upper: Type<'db>,
     ) -> Self {
-        Self::constrain_typevar_with_bounds(db, env, builder, typevar, Some(lower), Some(upper))
+        Self::constrain_typevar_with_bounds(
+            db,
+            env,
+            builder,
+            typevar,
+            ConstraintBound::Evidence(lower),
+            ConstraintBound::Evidence(upper),
+        )
     }
 
-    /// Returns a constraint set that constrains a typevar with explicit lower and/or upper bounds.
+    /// Returns a constraint set that constrains a typevar with provenance-aware bounds.
     pub(crate) fn constrain_typevar_with_bounds(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         builder: &'c ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
-        lower: Option<Type<'db>>,
-        upper: Option<Type<'db>>,
+        lower: ConstraintBound<'db>,
+        upper: ConstraintBound<'db>,
     ) -> Self {
         let mut storage = builder.storage.borrow_mut();
         let (node, source_order) =
@@ -461,7 +469,14 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
     ) -> Self {
-        Self::constrain_typevar_with_bounds(db, env, builder, typevar, Some(lower), None)
+        Self::constrain_typevar_with_bounds(
+            db,
+            env,
+            builder,
+            typevar,
+            ConstraintBound::Evidence(lower),
+            ConstraintBound::missing_upper(),
+        )
     }
 
     /// Returns a constraint set that constrains a typevar to be a subtype of `upper`.
@@ -472,7 +487,14 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         typevar: BoundTypeVarInstance<'db>,
         upper: Type<'db>,
     ) -> Self {
-        Self::constrain_typevar_with_bounds(db, env, builder, typevar, None, Some(upper))
+        Self::constrain_typevar_with_bounds(
+            db,
+            env,
+            builder,
+            typevar,
+            ConstraintBound::missing_lower(),
+            ConstraintBound::Evidence(upper),
+        )
     }
 
     /// Verifies that this constraint set was created by `builder`
@@ -750,22 +772,18 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
             let mapped = if let Type::TypeVar(typevar) = subject {
                 Constraint::new_node_with_bounds(db, env, &mut storage, typevar, lower, upper)
             } else {
-                let (lower_holds, lower_holds_source_order) = match lower {
-                    Some(lower) => storage.load(
-                        db,
-                        env,
-                        &lower.when_constraint_set_assignable_to_owned(db, env, subject),
-                    ),
-                    None => (ALWAYS_TRUE, None),
-                };
-                let (upper_holds, upper_holds_source_order) = match upper {
-                    Some(upper) => storage.load(
-                        db,
-                        env,
-                        &subject.when_constraint_set_assignable_to_owned(db, env, upper),
-                    ),
-                    None => (ALWAYS_TRUE, None),
-                };
+                let (lower_holds, lower_holds_source_order) = storage.load(
+                    db,
+                    env,
+                    &lower
+                        .ty()
+                        .when_constraint_set_assignable_to_owned(db, env, subject),
+                );
+                let (upper_holds, upper_holds_source_order) = storage.load(
+                    db,
+                    env,
+                    &subject.when_constraint_set_assignable_to_owned(db, env, upper.ty()),
+                );
                 (
                     lower_holds.and(&mut storage, upper_holds),
                     storage
@@ -1343,12 +1361,8 @@ impl<'db> ConstraintSetStorage<'db> {
     ) -> Support {
         let mut support = Support::default();
         support.insert(self.intern_typevar(db, typevar));
-        if let Some(lower) = bounds.lower {
-            self.intern_mentioned_typevars_in_type(db, env, lower, &mut support);
-        }
-        if let Some(upper) = bounds.upper {
-            self.intern_mentioned_typevars_in_type(db, env, upper, &mut support);
-        }
+        self.intern_mentioned_typevars_in_type(db, env, bounds.lower.ty(), &mut support);
+        self.intern_mentioned_typevars_in_type(db, env, bounds.upper.ty(), &mut support);
         support
     }
 
@@ -1830,15 +1844,77 @@ pub(crate) struct Constraint<'db> {
     bounds: ConstraintBounds<'db>,
 }
 
-/// The explicit lower and upper bounds inferred for a typevar on one constraint path.
+/// The lower or upper bound of a constraint, along with its _provenance_
 ///
-/// Missing bounds are represented as `None`; callers can materialize them to the logical defaults
-/// (`Never` for lower bounds, `object` for upper bounds) when they need to reason about
-/// satisfiability.
+/// Most bounds come from specific relationships found at the call site — for instance, the
+/// relationship between the argument type and parameter annotation when invoking a generic
+/// function. These bounds express actual user intent, and are called _evidence_ bounds.
+///
+/// Other bounds are background limitations on which specializations are valid — for instance, the
+/// declared upper bound or constraints of a typevar. These are called _validity_ bounds.
+/// Importantly, we don't want to choose a validity bound as a solution unless we have no other
+/// choice. There is often an evidence bound that is a better choice.
+///
+/// Every type is a supertype of `Never` and a subtype of `object`, so `Validity(Never)` represents
+/// an absent lower bound and `Validity(object)` represents an absent upper bound.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub(crate) enum ConstraintBound<'db> {
+    Validity(Type<'db>),
+    Evidence(Type<'db>),
+}
+
+impl<'db> ConstraintBound<'db> {
+    pub(crate) const fn missing_lower() -> Self {
+        Self::Validity(Type::Never)
+    }
+
+    pub(crate) const fn missing_upper() -> Self {
+        Self::Validity(Type::object())
+    }
+
+    fn ty(self) -> Type<'db> {
+        match self {
+            Self::Validity(ty) | Self::Evidence(ty) => ty,
+        }
+    }
+
+    fn map(self, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Self {
+        match self {
+            Self::Validity(ty) => Self::Validity(f(ty)),
+            Self::Evidence(ty) => Self::Evidence(f(ty)),
+        }
+    }
+
+    fn with_type(self, ty: Type<'db>) -> Self {
+        self.map(|_| ty)
+    }
+
+    /// Retains this bound's type while combining its provenance with another contributing bound.
+    ///
+    /// The result is evidence only when every contributing bound is evidence.
+    fn with_combined_provenance(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Validity(ty), _) | (Self::Evidence(ty), Self::Validity(_)) => Self::Validity(ty),
+            (Self::Evidence(ty), Self::Evidence(_)) => Self::Evidence(ty),
+        }
+    }
+
+    fn has_same_provenance(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Validity(_), Self::Validity(_)) | (Self::Evidence(_), Self::Evidence(_))
+        )
+    }
+}
+
+/// The lower and upper bounds for a typevar on one constraint path.
+///
+/// Logical-default validity bounds represent absent restrictions, while evidence bounds preserve
+/// explicitly inferred `Never` and `object`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct ConstraintBounds<'db> {
-    pub(crate) lower: Option<Type<'db>>,
-    pub(crate) upper: Option<Type<'db>>,
+    pub(crate) lower: ConstraintBound<'db>,
+    pub(crate) upper: ConstraintBound<'db>,
 }
 
 impl<'db> Type<'db> {
@@ -1888,42 +1964,30 @@ impl<'db> Type<'db> {
 }
 
 impl<'db> ConstraintBounds<'db> {
-    pub(crate) fn new(lower: Option<Type<'db>>, upper: Option<Type<'db>>) -> Self {
+    pub(crate) fn new(lower: ConstraintBound<'db>, upper: ConstraintBound<'db>) -> Self {
         Self { lower, upper }
     }
 
     pub(crate) fn exact(ty: Type<'db>) -> Self {
-        Self::new(Some(ty), Some(ty))
-    }
-
-    fn has_lower(self) -> bool {
-        self.lower.is_some()
-    }
-
-    fn has_upper(self) -> bool {
-        self.upper.is_some()
+        Self::new(ConstraintBound::Evidence(ty), ConstraintBound::Evidence(ty))
     }
 
     fn as_equality(self) -> Option<Type<'db>> {
-        let lower = self.lower?;
-        let upper = self.upper?;
+        let lower = self.lower.ty();
+        let upper = self.upper.ty();
         (lower == upper).then_some(lower)
     }
 
     fn is_concrete(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
-        iter::chain(self.lower, self.upper).all(|bound| {
+        [self.lower.ty(), self.upper.ty()].into_iter().all(|bound| {
             !bound.has_typevar(db, env)
                 && !bound.has_unspecialized_type_var(db, env)
                 && bound.bottom_materialization(db, env) == bound.top_materialization(db, env)
         })
     }
 
-    fn materialized_lower(self) -> Type<'db> {
-        self.lower.unwrap_or(Type::Never)
-    }
-
-    fn materialized_upper(self) -> Type<'db> {
-        self.upper.unwrap_or(Type::object())
+    fn has_same_provenance(self, other: Self) -> bool {
+        self.lower.has_same_provenance(other.lower) && self.upper.has_same_provenance(other.upper)
     }
 }
 
@@ -2074,7 +2138,14 @@ impl ConstraintId {
         lower: Type<'db>,
         upper: Type<'db>,
     ) -> ConstraintId {
-        Self::new_with_bounds(db, env, storage, typevar, Some(lower), Some(upper))
+        Self::new_with_bounds(
+            db,
+            env,
+            storage,
+            typevar,
+            ConstraintBound::Evidence(lower),
+            ConstraintBound::Evidence(upper),
+        )
     }
 
     fn new_with_bounds<'db>(
@@ -2082,8 +2153,8 @@ impl ConstraintId {
         env: &ProgramEnvironment<'db>,
         storage: &mut ConstraintSetStorage<'db>,
         typevar: BoundTypeVarInstance<'db>,
-        lower: Option<Type<'db>>,
-        upper: Option<Type<'db>>,
+        lower: ConstraintBound<'db>,
+        upper: ConstraintBound<'db>,
     ) -> ConstraintId {
         storage.intern_constraint(
             db,
@@ -2173,15 +2244,16 @@ fn max_constructor_and_typevar_depth<'db>(
 
 impl<'db> Constraint<'db> {
     fn bound_depth(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> (u16, u16) {
-        let both_bounds = iter::chain(self.bounds.lower, self.bounds.upper);
-        both_bounds.fold((0, 0), |(constructor_depth, typevar_depth), bound| {
-            let (bound_constructor_depth, bound_typevar_depth) =
-                max_constructor_and_typevar_depth(db, env, bound);
-            (
-                constructor_depth.max(bound_constructor_depth),
-                typevar_depth.max(bound_typevar_depth),
-            )
-        })
+        [self.bounds.lower.ty(), self.bounds.upper.ty()]
+            .into_iter()
+            .fold((0, 0), |(constructor_depth, typevar_depth), bound| {
+                let (bound_constructor_depth, bound_typevar_depth) =
+                    max_constructor_and_typevar_depth(db, env, bound);
+                (
+                    constructor_depth.max(bound_constructor_depth),
+                    typevar_depth.max(bound_typevar_depth),
+                )
+            })
     }
 
     /// Returns whether this constraint is produced by dropping exactly one bound from
@@ -2191,29 +2263,25 @@ impl<'db> Constraint<'db> {
             return false;
         }
 
-        let keeps_lower = self.bounds.lower.is_some()
-            && self.bounds.lower == antecedent.bounds.lower
-            && self.bounds.upper.is_none()
-            && antecedent.bounds.upper.is_some();
-        let keeps_upper = self.bounds.upper.is_some()
-            && self.bounds.upper == antecedent.bounds.upper
-            && self.bounds.lower.is_none()
-            && antecedent.bounds.lower.is_some();
+        let keeps_lower = self.bounds.lower == antecedent.bounds.lower
+            && self.bounds.upper == ConstraintBound::missing_upper()
+            && antecedent.bounds.upper != ConstraintBound::missing_upper();
+        let keeps_upper = self.bounds.upper == antecedent.bounds.upper
+            && self.bounds.lower == ConstraintBound::missing_lower()
+            && antecedent.bounds.lower != ConstraintBound::missing_lower();
         keeps_lower || keeps_upper
     }
 
-    /// Returns a new range constraint, preserving whether each bound was present explicitly.
-    ///
-    /// Panics if present `lower` and `upper` bounds are not fully static.
+    /// Returns a new range constraint, preserving the presence and provenance of both bounds.
     fn new_node_with_bounds(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         storage: &mut ConstraintSetStorage<'db>,
         typevar: BoundTypeVarInstance<'db>,
-        mut lower: Option<Type<'db>>,
-        mut upper: Option<Type<'db>>,
+        mut lower: ConstraintBound<'db>,
+        mut upper: ConstraintBound<'db>,
     ) -> (NodeId, Option<SourceOrderId>) {
-        if lower.is_none() && upper.is_none() {
+        if lower == ConstraintBound::missing_lower() && upper == ConstraintBound::missing_upper() {
             return (ALWAYS_TRUE, None);
         }
 
@@ -2225,7 +2293,7 @@ impl<'db> Constraint<'db> {
         //   T ≤ (α & β)   ⇔ (T ≤ α) ∧ (T ≤ β)
         //   T ≤ (¬α & ¬β) ⇔ (T ≤ ¬α) ∧ (T ≤ ¬β)
         //   (α | β) ≤ T   ⇔ (α ≤ T) ∧ (β ≤ T)
-        if let Some(Type::Union(lower_union)) = lower {
+        if let Type::Union(lower_union) = lower.ty() {
             let mut result = ALWAYS_TRUE;
             let mut source_order = None;
             for lower_element in lower_union.elements(db) {
@@ -2234,7 +2302,7 @@ impl<'db> Constraint<'db> {
                     env,
                     storage,
                     typevar,
-                    Some(*lower_element),
+                    lower.with_type(*lower_element),
                     upper,
                 );
                 result = result.and(storage, element_node);
@@ -2245,7 +2313,7 @@ impl<'db> Constraint<'db> {
         // A negated type ¬α is represented as an intersection with no positive elements, and a
         // single negative element. We _don't_ want to treat that an "intersection" for the
         // purposes of simplifying upper bounds.
-        if let Some(Type::Intersection(upper_intersection)) = upper
+        if let Type::Intersection(upper_intersection) = upper.ty()
             && !upper_intersection.is_simple_negation(db)
         {
             let mut result = ALWAYS_TRUE;
@@ -2257,7 +2325,7 @@ impl<'db> Constraint<'db> {
                     storage,
                     typevar,
                     lower,
-                    Some(upper_element),
+                    upper.with_type(upper_element),
                 );
                 result = result.and(storage, element_node);
                 source_order = storage.ordered_source_order(source_order, element_source_order);
@@ -2269,7 +2337,7 @@ impl<'db> Constraint<'db> {
                     storage,
                     typevar,
                     lower,
-                    Some(upper_element.negate(db, env)),
+                    upper.with_type(upper_element.negate(db, env)),
                 );
                 result = result.and(storage, element_node);
                 source_order = storage.ordered_source_order(source_order, element_source_order);
@@ -2279,22 +2347,22 @@ impl<'db> Constraint<'db> {
 
         // Two identical typevars must always solve to the same type, so it is not useful to have
         // an upper or lower bound that is the typevar being constrained.
-        match lower {
-            Some(Type::TypeVar(lower_bound_typevar))
+        match lower.ty() {
+            Type::TypeVar(lower_bound_typevar)
                 if typevar.is_same_typevar_as(db, lower_bound_typevar) =>
             {
-                lower = None;
+                lower = ConstraintBound::missing_lower();
             }
-            Some(Type::Intersection(intersection))
+            Type::Intersection(intersection)
                 if intersection.positive(db).iter().any(|element| {
                     element.as_typevar().is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
                     })
                 }) =>
             {
-                lower = None;
+                lower = ConstraintBound::missing_lower();
             }
-            Some(Type::Intersection(intersection))
+            Type::Intersection(intersection)
                 if intersection.negative(db).iter().any(|element| {
                     element.as_typevar().is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
@@ -2309,20 +2377,20 @@ impl<'db> Constraint<'db> {
             }
             _ => {}
         }
-        match upper {
-            Some(Type::TypeVar(upper_bound_typevar))
+        match upper.ty() {
+            Type::TypeVar(upper_bound_typevar)
                 if typevar.is_same_typevar_as(db, upper_bound_typevar) =>
             {
-                upper = None;
+                upper = ConstraintBound::missing_upper();
             }
-            Some(Type::Union(union))
+            Type::Union(union)
                 if union.elements(db).iter().any(|element| {
                     element.as_typevar().is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
                     })
                 }) =>
             {
-                upper = None;
+                upper = ConstraintBound::missing_upper();
             }
             _ => {}
         }
@@ -2334,8 +2402,8 @@ impl<'db> Constraint<'db> {
         // `upper`. We use an existential check here ("is there *some* assignment where
         // `lower ≤ upper`?") rather than a universal check, because the bounds may mention
         // typevars — e.g., `Sequence[int] ≤ A ≤ Sequence[T]` is satisfiable when `int ≤ T`.
-        let effective_lower = lower.unwrap_or(Type::Never);
-        let effective_upper = upper.unwrap_or(Type::object());
+        let effective_lower = lower.ty();
+        let effective_upper = upper.ty();
         let when =
             effective_lower.when_constraint_set_assignable_to_owned(db, env, effective_upper);
         let is_never_satisfied = when.query(|_storage, when| when.is_never_satisfied(db, env));
@@ -2351,35 +2419,39 @@ impl<'db> Constraint<'db> {
         // therefore the typevar that the constraint applies to.
         match (effective_lower, effective_upper) {
             // L ≤ T ≤ L == (T ≤ [L] ≤ T)
-            (Type::TypeVar(lower), Type::TypeVar(upper)) if lower.is_same_typevar_as(db, upper) => {
-                let (bound, typevar) = if lower.can_be_bound_for(db, storage, typevar) {
-                    (lower, typevar)
-                } else {
-                    (typevar, lower)
-                };
-                let constraint = ConstraintId::new(
+            (Type::TypeVar(lower_typevar), Type::TypeVar(upper_typevar))
+                if lower_typevar.is_same_typevar_as(db, upper_typevar) =>
+            {
+                let (bound, subject, lower, upper) =
+                    if lower_typevar.can_be_bound_for(db, storage, typevar) {
+                        (lower_typevar, typevar, lower, upper)
+                    } else {
+                        (typevar, lower_typevar, upper, lower)
+                    };
+                let bound = Type::TypeVar(bound);
+                let constraint = ConstraintId::new_with_bounds(
                     db,
                     env,
                     storage,
-                    typevar,
-                    Type::TypeVar(bound),
-                    Type::TypeVar(bound),
+                    subject,
+                    lower.with_type(bound),
+                    upper.with_type(bound),
                 );
                 Node::new_constraint(storage, constraint)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
-            (Type::TypeVar(lower), Type::TypeVar(upper))
-                if typevar.can_be_bound_for(db, storage, lower)
-                    && typevar.can_be_bound_for(db, storage, upper) =>
+            (Type::TypeVar(lower_typevar), Type::TypeVar(upper_typevar))
+                if typevar.can_be_bound_for(db, storage, lower_typevar)
+                    && typevar.can_be_bound_for(db, storage, upper_typevar) =>
             {
                 let lower_constraint = ConstraintId::new_with_bounds(
                     db,
                     env,
                     storage,
-                    lower,
-                    None,
-                    Some(Type::TypeVar(typevar)),
+                    lower_typevar,
+                    ConstraintBound::missing_lower(),
+                    lower.with_type(Type::TypeVar(typevar)),
                 );
                 let (lower_node, lower_source_order) =
                     Node::new_constraint(storage, lower_constraint);
@@ -2387,9 +2459,9 @@ impl<'db> Constraint<'db> {
                     db,
                     env,
                     storage,
-                    upper,
-                    Some(Type::TypeVar(typevar)),
-                    None,
+                    upper_typevar,
+                    upper.with_type(Type::TypeVar(typevar)),
+                    ConstraintBound::missing_upper(),
                 );
                 let (upper_node, upper_source_order) =
                     Node::new_constraint(storage, upper_constraint);
@@ -2400,21 +2472,31 @@ impl<'db> Constraint<'db> {
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && ([T] ≤ U)
-            (Type::TypeVar(lower), _) if typevar.can_be_bound_for(db, storage, lower) => {
+            (Type::TypeVar(lower_typevar), _)
+                if typevar.can_be_bound_for(db, storage, lower_typevar) =>
+            {
                 let lower_constraint = ConstraintId::new_with_bounds(
                     db,
                     env,
                     storage,
-                    lower,
-                    None,
-                    Some(Type::TypeVar(typevar)),
+                    lower_typevar,
+                    ConstraintBound::missing_lower(),
+                    lower.with_type(Type::TypeVar(typevar)),
                 );
                 let (lower_node, lower_source_order) =
                     Node::new_constraint(storage, lower_constraint);
-                let (upper_node, upper_source_order) = if upper.is_none() {
+                let (upper_node, upper_source_order) = if upper == ConstraintBound::missing_upper()
+                {
                     (ALWAYS_TRUE, None)
                 } else {
-                    Constraint::new_node_with_bounds(db, env, storage, typevar, None, upper)
+                    Constraint::new_node_with_bounds(
+                        db,
+                        env,
+                        storage,
+                        typevar,
+                        ConstraintBound::missing_lower(),
+                        upper,
+                    )
                 };
                 let node = lower_node.and(storage, upper_node);
                 let source_order =
@@ -2423,19 +2505,29 @@ impl<'db> Constraint<'db> {
             }
 
             // L ≤ T ≤ U == (L ≤ [T]) && (T ≤ [U])
-            (_, Type::TypeVar(upper)) if typevar.can_be_bound_for(db, storage, upper) => {
-                let (lower_node, lower_source_order) = if lower.is_none() {
+            (_, Type::TypeVar(upper_typevar))
+                if typevar.can_be_bound_for(db, storage, upper_typevar) =>
+            {
+                let (lower_node, lower_source_order) = if lower == ConstraintBound::missing_lower()
+                {
                     (ALWAYS_TRUE, None)
                 } else {
-                    Constraint::new_node_with_bounds(db, env, storage, typevar, lower, None)
+                    Constraint::new_node_with_bounds(
+                        db,
+                        env,
+                        storage,
+                        typevar,
+                        lower,
+                        ConstraintBound::missing_upper(),
+                    )
                 };
                 let upper_constraint = ConstraintId::new_with_bounds(
                     db,
                     env,
                     storage,
-                    upper,
-                    Some(Type::TypeVar(typevar)),
-                    None,
+                    upper_typevar,
+                    upper.with_type(Type::TypeVar(typevar)),
+                    ConstraintBound::missing_upper(),
                 );
                 let (upper_node, upper_source_order) =
                     Node::new_constraint(storage, upper_constraint);
@@ -2515,16 +2607,14 @@ impl ConstraintId {
         }
         other_constraint
             .bounds
-            .materialized_lower()
-            .is_constraint_set_assignable_to(db, env, self_constraint.bounds.materialized_lower())
+            .lower
+            .ty()
+            .is_constraint_set_assignable_to(db, env, self_constraint.bounds.lower.ty())
             && self_constraint
                 .bounds
-                .materialized_upper()
-                .is_constraint_set_assignable_to(
-                    db,
-                    env,
-                    other_constraint.bounds.materialized_upper(),
-                )
+                .upper
+                .ty()
+                .is_constraint_set_assignable_to(db, env, other_constraint.bounds.upper.ty())
     }
 
     /// Returns the intersection of two range constraints, or `None` if the intersection is empty.
@@ -2551,19 +2641,15 @@ impl ConstraintId {
         }
 
         // (s₁ ≤ α ≤ t₁) ∧ (s₂ ≤ α ≤ t₂) = (s₁ ∪ s₂) ≤ α ≤ (t₁ ∩ t₂))
-        let lower = match (self_constraint.bounds.lower, other_constraint.bounds.lower) {
-            (Some(left), Some(right)) => Some(UnionType::from_two_elements(db, env, left, right)),
-            (Some(lower), None) | (None, Some(lower)) => Some(lower),
-            (None, None) => None,
-        };
+        let effective_lower = UnionType::from_two_elements(
+            db,
+            env,
+            self_constraint.bounds.lower.ty(),
+            other_constraint.bounds.lower.ty(),
+        );
         let mut merged_upper = UpperBound::none();
-        if let Some(upper) = self_constraint.bounds.upper {
-            merged_upper.add_clause(upper);
-        }
-        if let Some(upper) = other_constraint.bounds.upper {
-            merged_upper.add_clause(upper);
-        }
-        let effective_lower = lower.unwrap_or(Type::Never);
+        merged_upper.add_clause(self_constraint.bounds.upper.ty());
+        merged_upper.add_clause(other_constraint.bounds.upper.ty());
 
         // If `lower ≰ upper` for every possible assignment of typevars, then the intersection is
         // empty, since there is no type that is both greater than `lower`, and less than `upper`.
@@ -2581,15 +2667,48 @@ impl ConstraintId {
         // intersections, since those can be broken apart into BDDs over simpler constraints. If the
         // merged upper contains a union clause, keep any useful disjointness result from above but
         // do not try to derive a factored upper-bound constraint.
-        if lower.is_some_and(Type::is_union) || merged_upper.has_visible_union_clause() {
+        if effective_lower.is_union() || merged_upper.has_visible_union_clause() {
             return IntersectionResult::CannotSimplify;
         }
 
-        let upper = (!merged_upper.is_empty()).then(|| merged_upper.materialize_exact(db, env));
+        let lower = match (self_constraint.bounds.lower, other_constraint.bounds.lower) {
+            (ConstraintBound::Validity(_), ConstraintBound::Validity(_)) => {
+                ConstraintBound::Validity(effective_lower)
+            }
+            (ConstraintBound::Evidence(_), ConstraintBound::Evidence(_)) => {
+                ConstraintBound::Evidence(effective_lower)
+            }
+            (ConstraintBound::Evidence(evidence), ConstraintBound::Validity(_))
+            | (ConstraintBound::Validity(_), ConstraintBound::Evidence(evidence)) => {
+                if effective_lower.is_equivalent_to(db, env, evidence) {
+                    ConstraintBound::Evidence(effective_lower)
+                } else {
+                    ConstraintBound::Validity(effective_lower)
+                }
+            }
+        };
 
-        if upper.is_some_and(|upper| upper.is_nontrivial_intersection(db)) {
+        let effective_upper = merged_upper.materialize_exact(db, env);
+        if effective_upper.is_nontrivial_intersection(db) {
             return IntersectionResult::CannotSimplify;
         }
+
+        let upper = match (self_constraint.bounds.upper, other_constraint.bounds.upper) {
+            (ConstraintBound::Validity(_), ConstraintBound::Validity(_)) => {
+                ConstraintBound::Validity(effective_upper)
+            }
+            (ConstraintBound::Evidence(_), ConstraintBound::Evidence(_)) => {
+                ConstraintBound::Evidence(effective_upper)
+            }
+            (ConstraintBound::Evidence(evidence), ConstraintBound::Validity(_))
+            | (ConstraintBound::Validity(_), ConstraintBound::Evidence(evidence)) => {
+                if effective_upper.is_equivalent_to(db, env, evidence) {
+                    ConstraintBound::Evidence(effective_upper)
+                } else {
+                    ConstraintBound::Validity(effective_upper)
+                }
+            }
+        };
 
         IntersectionResult::Simplified(Constraint {
             typevar: self_constraint.typevar,
@@ -2899,8 +3018,8 @@ impl NodeId {
                         }
 
                         let constraint = storage.constraint_data(interior.constraint);
-                        found_lower |= constraint.bounds.lower.is_some();
-                        found_upper |= constraint.bounds.upper.is_some();
+                        found_lower |= constraint.bounds.lower != ConstraintBound::missing_lower();
+                        found_upper |= constraint.bounds.upper != ConstraintBound::missing_upper();
                         if found_lower && found_upper {
                             // Might be a single conjunction, but doesn't contain _only_
                             // lower-bound-only or upper-bound-only constraints
@@ -3173,16 +3292,16 @@ impl NodeId {
                 env,
                 storage,
                 bound_typevar,
-                None,
-                Some(rhs.bottom_materialization(db, env)),
+                ConstraintBound::missing_lower(),
+                ConstraintBound::Evidence(rhs.bottom_materialization(db, env)),
             ),
             (_, Type::TypeVar(bound_typevar)) => Constraint::new_node_with_bounds(
                 db,
                 env,
                 storage,
                 bound_typevar,
-                Some(lhs.top_materialization(db, env)),
-                None,
+                ConstraintBound::Evidence(lhs.top_materialization(db, env)),
+                ConstraintBound::missing_upper(),
             ),
             _ => panic!("at least one type should be a typevar"),
         };
@@ -3621,7 +3740,7 @@ impl<'db> PathBound<'db> {
         let Some(upper_bound) = IntersectionType::bounded_from_elements(
             db,
             env,
-            iter::once(first_upper)
+            std::iter::once(first_upper)
                 .chain(upper_bounds)
                 .chain(declared_upper),
         ) else {
@@ -3835,7 +3954,7 @@ impl<'db> PathBounds<'db> {
             for (constraint, _) in path {
                 let constraint = storage.constraint_data(constraint);
                 let typevar = constraint.typevar;
-                if let Some(lower) = constraint.bounds.lower {
+                if let ConstraintBound::Evidence(lower) = constraint.bounds.lower {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_lower(db, env, lower);
 
@@ -3845,7 +3964,7 @@ impl<'db> PathBounds<'db> {
                     }
                 }
 
-                if let Some(upper) = constraint.bounds.upper {
+                if let ConstraintBound::Evidence(upper) = constraint.bounds.upper {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_upper(db, env, upper);
 
@@ -3903,9 +4022,12 @@ impl<'db> PathBounds<'db> {
                         return None;
                     }
 
-                    if iter::chain(constraint.bounds.lower, constraint.bounds.upper).any(|bound| {
-                        bound.has_typevar(db, env) || bound.has_unspecialized_type_var(db, env)
-                    }) {
+                    if [constraint.bounds.lower.ty(), constraint.bounds.upper.ty()]
+                        .into_iter()
+                        .any(|bound| {
+                            bound.has_typevar(db, env) || bound.has_unspecialized_type_var(db, env)
+                        })
+                    {
                         return None;
                     }
 
@@ -3926,10 +4048,10 @@ impl<'db> PathBounds<'db> {
         constraints.sort_by_key(|(_, _, source_order)| *source_order);
         for (typevar, constraint, _) in constraints {
             let bounds = mappings.entry(typevar).or_default();
-            if let Some(lower) = constraint.lower {
+            if let ConstraintBound::Evidence(lower) = constraint.lower {
                 bounds.add_lower(db, env, lower);
             }
-            if let Some(upper) = constraint.upper {
+            if let ConstraintBound::Evidence(upper) = constraint.upper {
                 bounds.add_upper(db, env, upper);
             }
         }
@@ -4425,9 +4547,9 @@ impl InteriorNode {
         inferable: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
     ) -> (NodeId, Option<SourceOrderId>) {
-        let is_bare_inferable_typevar = |ty: Type<'_>| {
-            ty.as_typevar()
-                .is_some_and(|bound_typevar| bound_typevar.is_inferable(db, inferable))
+        let is_bare_inferable_typevar = |bound: ConstraintBound<'_>| {
+            matches!(bound, ConstraintBound::Evidence(Type::TypeVar(bound_typevar))
+                if bound_typevar.is_inferable(db, inferable))
         };
         self.abstract_inner(
             db,
@@ -4436,8 +4558,8 @@ impl InteriorNode {
             source_order,
             // We only want to keep constraints on inferable typevars. If the constraint's typevar
             // is itself inferable, we keep it. We also need to keep some constraints in
-            // non-inferable typevars, if their lower or upper bound is a bare inferable typevar.
-            // This ensure that our quantification logic does not depend on typevar ordering.
+            // non-inferable typevars, if an evidence bound is a bare inferable typevar. This
+            // ensures that our quantification logic does not depend on typevar ordering.
             //
             // For example, `I ≤ N` (where I is inferable and N is non-inferable) could be encoded
             // either as `Never ≤ I ≤ N` or `I ≤ N ≤ object`, depending on typevar ordering. If we
@@ -4446,14 +4568,8 @@ impl InteriorNode {
             &mut |storage: &ConstraintSetStorage<'_>, constraint| {
                 let constraint = storage.constraint_data(constraint);
                 !constraint.typevar.is_inferable(db, inferable)
-                    && !constraint
-                        .bounds
-                        .lower
-                        .is_some_and(is_bare_inferable_typevar)
-                    && !constraint
-                        .bounds
-                        .upper
-                        .is_some_and(is_bare_inferable_typevar)
+                    && !is_bare_inferable_typevar(constraint.bounds.lower)
+                    && !is_bare_inferable_typevar(constraint.bounds.upper)
             },
         )
     }
@@ -4739,8 +4855,8 @@ impl ConstraintAssignment {
 
         std::fmt::from_fn(move |f| {
             let constraint_data = storage.constraint_data(self.constraint());
-            let lower = constraint_data.bounds.materialized_lower();
-            let upper = constraint_data.bounds.materialized_upper();
+            let lower = constraint_data.bounds.lower.ty();
+            let upper = constraint_data.bounds.upper.ty();
             let typevar = constraint_data.typevar;
             if lower.is_equivalent_to(db, env, upper) {
                 // If this typevar is equivalent to another, output the constraint in a
@@ -4926,19 +5042,13 @@ impl SequentMap {
             return false;
         }
 
-        let (
-            ConstraintBounds {
-                lower: Some(left_lower),
-                upper: None,
-            },
-            ConstraintBounds {
-                lower: Some(right_lower),
-                upper: None,
-            },
-        ) = (left.bounds, right.bounds)
-        else {
+        if left.bounds.upper != ConstraintBound::missing_upper()
+            || right.bounds.upper != ConstraintBound::missing_upper()
+        {
             return false;
-        };
+        }
+        let left_lower = left.bounds.lower.ty();
+        let right_lower = right.bounds.lower.ty();
 
         // This call might need its own borrow of the builder's storage, so create a new builder
         // that it can use.
@@ -4973,20 +5083,27 @@ impl SequentMap {
             env,
             &post_data
                 .bounds
-                .materialized_lower()
-                .when_constraint_set_assignable_to_owned(
-                    db,
-                    env,
-                    post_data.bounds.materialized_upper(),
-                ),
+                .lower
+                .ty()
+                .when_constraint_set_assignable_to_owned(db, env, post_data.bounds.upper.ty()),
         );
         if when.is_never_satisfied(db, env, storage, source_order) {
             self.add_pair_impossibility(ante1, ante2);
             return;
         }
 
-        // If either antecedent implies the consequent on its own, this new sequent is redundant.
-        if ante1.implies(db, env, storage, post) || ante2.implies(db, env, storage, post) {
+        // If either antecedent implies the consequent on its own, this new sequent is redundant,
+        // as long as it doesn't discard or manufacture evidence.
+        let post_data = storage.constraint_data(post);
+        let ante1_data = storage.constraint_data(ante1);
+        let ante2_data = storage.constraint_data(ante2);
+        if ((ante1_data.bounds.has_same_provenance(post_data.bounds)
+            || post_data.is_bound_projection_of(db, ante1_data))
+            && ante1.implies(db, env, storage, post))
+            || ((ante2_data.bounds.has_same_provenance(post_data.bounds)
+                || post_data.is_bound_projection_of(db, ante2_data))
+                && ante2.implies(db, env, storage, post))
+        {
             return;
         }
 
@@ -4994,8 +5111,25 @@ impl SequentMap {
             .push(Sequent::PairImplication { ante1, ante2, post });
     }
 
-    fn add_single_implication(&mut self, ante: ConstraintId, post: ConstraintId) {
-        if ante == post {
+    fn add_single_implication<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        storage: &ConstraintSetStorage<'db>,
+        ante: ConstraintId,
+        post: ConstraintId,
+    ) {
+        let antecedent = storage.constraint_data(ante);
+        let consequent = storage.constraint_data(post);
+        // Consequences on another type variable already inherit the provenance of their
+        // contributing bounds; comparing their unrelated bound positions would discard valid
+        // implications.
+        if ante == post
+            || (antecedent
+                .typevar
+                .is_same_typevar_as(db, consequent.typevar)
+                && !antecedent.bounds.has_same_provenance(consequent.bounds)
+                && !consequent.is_bound_projection_of(db, antecedent))
+        {
             return;
         }
 
@@ -5013,8 +5147,8 @@ impl SequentMap {
         // If this constraint binds its typevar to `Never ≤ T ≤ object`, then the typevar can take
         // on any type, and the constraint is always satisfied.
         let constraint_data = storage.constraint_data(constraint);
-        let lower = constraint_data.bounds.materialized_lower();
-        let upper = constraint_data.bounds.materialized_upper();
+        let lower = constraint_data.bounds.lower.ty();
+        let upper = constraint_data.bounds.upper.ty();
         if lower.is_never() && upper.is_object() {
             self.add_single_tautology(constraint);
             return;
@@ -5056,11 +5190,7 @@ impl SequentMap {
         // implication.)
 
         // Skip trivial cases where the assignability check won't produce useful results.
-        if !constraint_data.bounds.has_lower()
-            || !constraint_data.bounds.has_upper()
-            || lower.is_never()
-            || upper.is_object()
-        {
+        if lower.is_never() || upper.is_object() {
             return;
         }
 
@@ -5128,11 +5258,28 @@ impl SequentMap {
                 Node::AlwaysTrue | Node::AlwaysFalse => break,
                 Node::Interior(interior) => {
                     let interior = storage.interior_node_data(interior.node());
+                    let derived = storage.constraint_data(interior.constraint);
+                    let derived = ConstraintId::new_with_bounds(
+                        db,
+                        env,
+                        storage,
+                        derived.typevar,
+                        derived
+                            .bounds
+                            .lower
+                            .with_combined_provenance(constraint_data.bounds.lower)
+                            .with_combined_provenance(constraint_data.bounds.upper),
+                        derived
+                            .bounds
+                            .upper
+                            .with_combined_provenance(constraint_data.bounds.lower)
+                            .with_combined_provenance(constraint_data.bounds.upper),
+                    );
                     if interior.if_true != ALWAYS_FALSE {
-                        self.add_single_implication(constraint, interior.constraint);
+                        self.add_single_implication(db, storage, constraint, derived);
                         node = interior.if_true;
                     } else {
-                        self.add_pair_impossibility(constraint, interior.constraint);
+                        self.add_pair_impossibility(constraint, derived);
                         node = interior.if_false;
                     }
                 }
@@ -5183,22 +5330,14 @@ impl SequentMap {
                 right_constraint,
             );
             self.add_nested_typevar_sequents(db, env, storage, left_constraint, right_constraint);
-        } else if left_constraint_data
-            .bounds
-            .lower
-            .is_some_and(Type::is_type_var)
-            || left_constraint_data
-                .bounds
-                .upper
-                .is_some_and(Type::is_type_var)
-            || right_constraint_data
-                .bounds
-                .lower
-                .is_some_and(Type::is_type_var)
-            || right_constraint_data
-                .bounds
-                .upper
-                .is_some_and(Type::is_type_var)
+        } else if [
+            left_constraint_data.bounds.lower,
+            left_constraint_data.bounds.upper,
+            right_constraint_data.bounds.lower,
+            right_constraint_data.bounds.upper,
+        ]
+        .into_iter()
+        .any(|bound| bound.ty().is_type_var())
         {
             self.add_mutual_sequents_for_same_typevars(
                 db,
@@ -5248,42 +5387,56 @@ impl SequentMap {
         // Transitive pivots require subtyping; classes with dynamic bases can be assignable to
         // unrelated types without being subtypes.
         let (new_lower, new_upper) = match (
-            constrained_constraint_data.bounds.lower,
-            constrained_constraint_data.bounds.upper,
-            bound_constraint_data.bounds.lower,
-            bound_constraint_data.bounds.upper,
+            constrained_constraint_data.bounds.lower.ty(),
+            constrained_constraint_data.bounds.upper.ty(),
+            bound_constraint_data.bounds.lower.ty(),
+            bound_constraint_data.bounds.upper.ty(),
         ) {
             // (B ≤ C ≤ B) ∧ (BL ≤ B ≤ BU) → (BL ≤ C ≤ BU)
-            (
-                Some(Type::TypeVar(constrained_lower)),
-                Some(Type::TypeVar(constrained_upper)),
-                _,
-                _,
-            ) if constrained_lower.is_same_typevar_as(db, bound_typevar)
-                && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
+            (Type::TypeVar(constrained_lower), Type::TypeVar(constrained_upper), _, _)
+                if constrained_lower.is_same_typevar_as(db, bound_typevar)
+                    && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
-                    bound_constraint_data.bounds.lower,
-                    bound_constraint_data.bounds.upper,
+                    bound_constraint_data
+                        .bounds
+                        .lower
+                        .with_combined_provenance(constrained_constraint_data.bounds.lower),
+                    bound_constraint_data
+                        .bounds
+                        .upper
+                        .with_combined_provenance(constrained_constraint_data.bounds.upper),
                 )
             }
 
             // (CL ≤ C ≤ B) ∧ (BL ≤ B ≤ BU) → (CL ≤ C ≤ BU)
-            (constrained_lower, Some(Type::TypeVar(constrained_upper)), _, _)
+            (_, Type::TypeVar(constrained_upper), _, _)
                 if constrained_upper.is_same_typevar_as(db, bound_typevar) =>
             {
-                (constrained_lower, bound_constraint_data.bounds.upper)
+                (
+                    constrained_constraint_data.bounds.lower,
+                    bound_constraint_data
+                        .bounds
+                        .upper
+                        .with_combined_provenance(constrained_constraint_data.bounds.upper),
+                )
             }
 
             // (B ≤ C ≤ CU) ∧ (BL ≤ B ≤ BU) → (BL ≤ C ≤ CU)
-            (Some(Type::TypeVar(constrained_lower)), constrained_upper, _, _)
+            (Type::TypeVar(constrained_lower), _, _, _)
                 if constrained_lower.is_same_typevar_as(db, bound_typevar) =>
             {
-                (bound_constraint_data.bounds.lower, constrained_upper)
+                (
+                    bound_constraint_data
+                        .bounds
+                        .lower
+                        .with_combined_provenance(constrained_constraint_data.bounds.lower),
+                    constrained_constraint_data.bounds.upper,
+                )
             }
 
             // (CL ≤ C ≤ pivot) ∧ (pivot ≤ B ≤ BU) → (CL ≤ C ≤ B)
-            (constrained_lower, Some(constrained_upper), Some(bound_lower), _)
+            (_, constrained_upper, bound_lower, _)
                 if !constrained_upper.is_never()
                     && !constrained_upper.is_object()
                     && storage.cached_is_constraint_set_subtype_of(
@@ -5293,11 +5446,18 @@ impl SequentMap {
                         bound_lower.bottom_materialization(db, env),
                     ) =>
             {
-                (constrained_lower, Some(Type::TypeVar(bound_typevar)))
+                (
+                    constrained_constraint_data.bounds.lower,
+                    constrained_constraint_data
+                        .bounds
+                        .upper
+                        .with_combined_provenance(bound_constraint_data.bounds.lower)
+                        .with_type(Type::TypeVar(bound_typevar)),
+                )
             }
 
             // (pivot ≤ C ≤ CU) ∧ (BL ≤ B ≤ pivot) → (B ≤ C ≤ CU)
-            (Some(constrained_lower), constrained_upper, _, Some(bound_upper))
+            (constrained_lower, _, _, bound_upper)
                 if !constrained_lower.is_never()
                     && !constrained_lower.is_object()
                     && storage.cached_is_constraint_set_subtype_of(
@@ -5307,7 +5467,14 @@ impl SequentMap {
                         constrained_lower.bottom_materialization(db, env),
                     ) =>
             {
-                (Some(Type::TypeVar(bound_typevar)), constrained_upper)
+                (
+                    constrained_constraint_data
+                        .bounds
+                        .lower
+                        .with_combined_provenance(bound_constraint_data.bounds.upper)
+                        .with_type(Type::TypeVar(bound_typevar)),
+                    constrained_constraint_data.bounds.upper,
+                )
             }
 
             _ => return,
@@ -5318,8 +5485,16 @@ impl SequentMap {
         // explicit bounds that are equivalent to missing lower/upper bounds, so a derived
         // `T ≤ U ≤ object` can satisfy a later query for `T ≤ U` without requiring a separate
         // materialized-default implication.
-        let mut constrained_lower = new_lower.filter(|lower| !lower.is_never());
-        let mut constrained_upper = new_upper.filter(|upper| !upper.is_object());
+        let mut constrained_lower = if new_lower.ty().is_never() {
+            ConstraintBound::missing_lower()
+        } else {
+            new_lower
+        };
+        let mut constrained_upper = if new_upper.ty().is_object() {
+            ConstraintBound::missing_upper()
+        } else {
+            new_upper
+        };
 
         // The transitive rule above gives us an intended post-condition
         // `new_lower ≤ [constrained] ≤ new_upper`.
@@ -5336,7 +5511,7 @@ impl SequentMap {
         // `T` in this ordering, we emit two pair implications:
         //   `(Never ≤ [A] ≤ T)` and `(T ≤ [B] ≤ object)`.
         // This preserves the relationship while keeping all derived constraints canonical.
-        if let Some(Type::TypeVar(lower_bound_typevar)) = new_lower
+        if let Type::TypeVar(lower_bound_typevar) = new_lower.ty()
             && !lower_bound_typevar.can_be_bound_for(db, storage, constrained_typevar)
         {
             post_constraints.push(ConstraintId::new_with_bounds(
@@ -5344,13 +5519,13 @@ impl SequentMap {
                 env,
                 storage,
                 lower_bound_typevar,
-                None,
-                Some(Type::TypeVar(constrained_typevar)),
+                ConstraintBound::missing_lower(),
+                new_lower.with_type(Type::TypeVar(constrained_typevar)),
             ));
-            constrained_lower = None;
+            constrained_lower = ConstraintBound::missing_lower();
         }
 
-        if let Some(Type::TypeVar(upper_bound_typevar)) = new_upper
+        if let Type::TypeVar(upper_bound_typevar) = new_upper.ty()
             && !upper_bound_typevar.can_be_bound_for(db, storage, constrained_typevar)
         {
             post_constraints.push(ConstraintId::new_with_bounds(
@@ -5358,15 +5533,13 @@ impl SequentMap {
                 env,
                 storage,
                 upper_bound_typevar,
-                Some(Type::TypeVar(constrained_typevar)),
-                None,
+                new_upper.with_type(Type::TypeVar(constrained_typevar)),
+                ConstraintBound::missing_upper(),
             ));
-            constrained_upper = None;
+            constrained_upper = ConstraintBound::missing_upper();
         }
 
-        if !(constrained_lower.is_none_or(|ty| ty.is_never())
-            && constrained_upper.is_none_or(|ty| ty.is_object()))
-        {
+        if !(constrained_lower.ty().is_never() && constrained_upper.ty().is_object()) {
             post_constraints.push(ConstraintId::new_with_bounds(
                 db,
                 env,
@@ -5408,12 +5581,9 @@ impl SequentMap {
     ) {
         // Keep this precheck aligned with `variance_of`, which visits lazy types.
         let has_typevar_bound = |bounds: ConstraintBounds<'db>| {
-            bounds
-                .lower
-                .is_some_and(|bound| any_over_type(db, env, bound, true, Type::is_type_var))
-                || bounds
-                    .upper
-                    .is_some_and(|bound| any_over_type(db, env, bound, true, Type::is_type_var))
+            [bounds.lower, bounds.upper]
+                .into_iter()
+                .any(|bound| any_over_type(db, env, bound.ty(), true, Type::is_type_var))
         };
         if !has_typevar_bound(storage.constraint_data(left_constraint).bounds)
             && !has_typevar_bound(storage.constraint_data(right_constraint).bounds)
@@ -5429,8 +5599,8 @@ impl SequentMap {
                 let constrained_data = storage.constraint_data(constrained_constraint);
                 let constrained_typevar = constrained_data.typevar;
                 let constrained_identity = constrained_typevar.identity(db);
-                let constrained_lower = constrained_data.bounds.materialized_lower();
-                let constrained_upper = constrained_data.bounds.materialized_upper();
+                let constrained_lower = constrained_data.bounds.lower.ty();
+                let constrained_upper = constrained_data.bounds.upper.ty();
 
                 // If the replacement contains the bound typevar itself (e.g., the bound
                 // constraint is `_V ≤ G[_V]`), or the constrained typevar (e.g., the bound
@@ -5458,8 +5628,8 @@ impl SequentMap {
                 // (e.g., `Option<TypeVarVariance>`).
                 let upper_replacement = match (
                     constrained_upper.variance_of(db, env, bound_identity),
-                    bound_data.bounds.lower,
-                    bound_data.bounds.upper,
+                    bound_data.bounds.lower.ty(),
+                    bound_data.bounds.upper.ty(),
                 ) {
                     (TypeVarVariance::Bivariant, _, _) => None,
                     // Skip bare typevars — those are handled by
@@ -5467,23 +5637,24 @@ impl SequentMap {
                     _ if constrained_upper.is_type_var() => None,
                     // Covariance preserves direction: upper bound on T substitutes into upper
                     // bound. A ≤ B → G[A] ≤ G[B], so (T ≤ u_B) gives G[T] ≤ G[u_B].
-                    (TypeVarVariance::Covariant, _, Some(bound_upper))
-                        if !bound_upper.is_object() =>
-                    {
-                        bound_data.bounds.upper
+                    (TypeVarVariance::Covariant, _, bound_upper) if !bound_upper.is_object() => {
+                        Some(bound_data.bounds.upper)
                     }
                     // Contravariance flips direction: lower bound on T substitutes into upper
                     // bound. A ≤ B → G[B] ≤ G[A], so (l_B ≤ T) gives G[T] ≤ G[l_B].
-                    (TypeVarVariance::Contravariant, Some(bound_lower), _)
-                        if !bound_lower.is_never() =>
-                    {
-                        bound_data.bounds.lower
+                    (TypeVarVariance::Contravariant, bound_lower, _) if !bound_lower.is_never() => {
+                        Some(bound_data.bounds.lower)
                     }
                     // Invariance requires equality: only substitute if l_B = u_B.
-                    (TypeVarVariance::Invariant, Some(bound_lower), Some(bound_upper))
+                    (TypeVarVariance::Invariant, bound_lower, bound_upper)
                         if bound_lower == bound_upper && !bound_lower.is_never() =>
                     {
-                        bound_data.bounds.lower
+                        Some(
+                            bound_data
+                                .bounds
+                                .lower
+                                .with_combined_provenance(bound_data.bounds.upper),
+                        )
                     }
                     _ => None,
                 };
@@ -5492,17 +5663,17 @@ impl SequentMap {
                     // very-weak derived constraints and cause severe performance regressions.
                     // Keep the common/non-union case enabled; skip union upper bounds for this
                     // specific typevar-to-typevar replacement shape.
-                    if replacement.is_type_var() && constrained_upper.is_union() {
+                    if replacement.ty().is_type_var() && constrained_upper.is_union() {
                         return false;
                     }
-                    !replacement_mentions_bound_or_constrained(*replacement)
+                    !replacement_mentions_bound_or_constrained(replacement.ty())
                 });
                 if let Some(replacement) = upper_replacement {
                     let new_upper = constrained_upper.substitute_one_typevar(
                         db,
                         env,
                         bound_typevar,
-                        replacement,
+                        replacement.ty(),
                     );
                     if new_upper != constrained_upper {
                         let post = ConstraintId::new_with_bounds(
@@ -5511,7 +5682,11 @@ impl SequentMap {
                             storage,
                             constrained_typevar,
                             constrained_data.bounds.lower,
-                            Some(new_upper),
+                            constrained_data
+                                .bounds
+                                .upper
+                                .with_combined_provenance(replacement)
+                                .with_type(new_upper),
                         );
                         self.add_pair_implication(
                             db,
@@ -5527,30 +5702,33 @@ impl SequentMap {
                 // Check the lower bound of the constrained constraint for nested occurrences.
                 let lower_replacement = match (
                     constrained_lower.variance_of(db, env, bound_identity),
-                    bound_data.bounds.lower,
-                    bound_data.bounds.upper,
+                    bound_data.bounds.lower.ty(),
+                    bound_data.bounds.upper.ty(),
                 ) {
                     (TypeVarVariance::Bivariant, _, _) => None,
                     _ if constrained_lower.is_type_var() => None,
                     // Covariance preserves direction: lower bound on T substitutes into lower
                     // bound. A ≤ B → G[A] ≤ G[B], so (l_B ≤ T) gives G[l_B] ≤ G[T].
-                    (TypeVarVariance::Covariant, Some(bound_lower), _)
-                        if !bound_lower.is_never() =>
-                    {
-                        bound_data.bounds.lower
+                    (TypeVarVariance::Covariant, bound_lower, _) if !bound_lower.is_never() => {
+                        Some(bound_data.bounds.lower)
                     }
                     // Contravariance flips direction: upper bound on T substitutes into lower
                     // bound. A ≤ B → G[B] ≤ G[A], so (T ≤ u_B) gives G[u_B] ≤ G[T].
-                    (TypeVarVariance::Contravariant, _, Some(bound_upper))
+                    (TypeVarVariance::Contravariant, _, bound_upper)
                         if !bound_upper.is_object() =>
                     {
-                        bound_data.bounds.upper
+                        Some(bound_data.bounds.upper)
                     }
                     // Invariance requires equality: only substitute if l_B = u_B.
-                    (TypeVarVariance::Invariant, Some(bound_lower), Some(bound_upper))
+                    (TypeVarVariance::Invariant, bound_lower, bound_upper)
                         if bound_lower == bound_upper && !bound_lower.is_never() =>
                     {
-                        bound_data.bounds.lower
+                        Some(
+                            bound_data
+                                .bounds
+                                .lower
+                                .with_combined_provenance(bound_data.bounds.upper),
+                        )
                     }
                     _ => None,
                 };
@@ -5559,17 +5737,17 @@ impl SequentMap {
                     // many very-weak derived constraints and cause severe performance regressions.
                     // Keep the common/non-intersection case enabled; skip intersection lower
                     // bounds for this specific typevar-to-typevar replacement shape.
-                    if replacement.is_type_var() && constrained_lower.is_intersection() {
+                    if replacement.ty().is_type_var() && constrained_lower.is_intersection() {
                         return false;
                     }
-                    !replacement_mentions_bound_or_constrained(*replacement)
+                    !replacement_mentions_bound_or_constrained(replacement.ty())
                 });
                 if let Some(replacement) = lower_replacement {
                     let new_lower = constrained_lower.substitute_one_typevar(
                         db,
                         env,
                         bound_typevar,
-                        replacement,
+                        replacement.ty(),
                     );
                     if new_lower != constrained_lower {
                         let post = ConstraintId::new_with_bounds(
@@ -5577,7 +5755,11 @@ impl SequentMap {
                             env,
                             storage,
                             constrained_typevar,
-                            Some(new_lower),
+                            constrained_data
+                                .bounds
+                                .lower
+                                .with_combined_provenance(replacement)
+                                .with_type(new_lower),
                             constrained_data.bounds.upper,
                         );
                         self.add_pair_implication(
@@ -5620,14 +5802,14 @@ impl SequentMap {
             |bound_constraint: ConstraintId, constrained_constraint: ConstraintId| {
                 let bound_data = storage.constraint_data(bound_constraint);
                 let bound_typevar = bound_data.typevar;
-                let bound_lower = bound_data.bounds.materialized_lower();
+                let bound_lower = bound_data.bounds.lower.ty();
                 let constrained_data = storage.constraint_data(constrained_constraint);
                 let constrained_typevar = constrained_data.typevar;
-                let constrained_lower = constrained_data.bounds.materialized_lower();
-                let constrained_upper = constrained_data.bounds.materialized_upper();
+                let constrained_lower = constrained_data.bounds.lower.ty();
+                let constrained_upper = constrained_data.bounds.upper.ty();
 
-                let mut try_one_bound = |bound: Type<'db>, is_upper_bound: bool| {
-                    let Some(nested_typevar) = bound.as_typevar() else {
+                let mut try_one_bound = |bound: ConstraintBound<'db>, is_upper_bound: bool| {
+                    let Some(nested_typevar) = bound.ty().as_typevar() else {
                         return;
                     };
 
@@ -5657,7 +5839,7 @@ impl SequentMap {
                             TypeVarVariance::Covariant => !is_upper_bound,
                             TypeVarVariance::Contravariant => is_upper_bound,
                             TypeVarVariance::Invariant => {
-                                bound_data.bounds.lower == bound_data.bounds.upper
+                                bound_data.bounds.lower.ty() == bound_data.bounds.upper.ty()
                                     && !bound_lower.is_never()
                             }
                         };
@@ -5675,7 +5857,11 @@ impl SequentMap {
                                 storage,
                                 constrained_typevar,
                                 constrained_data.bounds.lower,
-                                Some(new_upper),
+                                constrained_data
+                                    .bounds
+                                    .upper
+                                    .with_combined_provenance(bound)
+                                    .with_type(new_upper),
                             );
                             self.add_pair_implication(
                                 db,
@@ -5699,7 +5885,7 @@ impl SequentMap {
                             TypeVarVariance::Covariant => is_upper_bound,
                             TypeVarVariance::Contravariant => !is_upper_bound,
                             TypeVarVariance::Invariant => {
-                                bound_data.bounds.lower == bound_data.bounds.upper
+                                bound_data.bounds.lower.ty() == bound_data.bounds.upper.ty()
                                     && !bound_lower.is_never()
                             }
                         };
@@ -5716,7 +5902,11 @@ impl SequentMap {
                                 env,
                                 storage,
                                 constrained_typevar,
-                                Some(new_lower),
+                                constrained_data
+                                    .bounds
+                                    .lower
+                                    .with_combined_provenance(bound)
+                                    .with_type(new_lower),
                                 constrained_data.bounds.upper,
                             );
                             self.add_pair_implication(
@@ -5735,12 +5925,8 @@ impl SequentMap {
                 // nested in the constrained constraint's bounds. If so, we can substitute B
                 // (the bound constraint's typevar) for S, producing a weaker but useful
                 // constraint.
-                if let Some(upper) = bound_data.bounds.upper {
-                    try_one_bound(upper, true);
-                }
-                if let Some(lower) = bound_data.bounds.lower {
-                    try_one_bound(lower, false);
-                }
+                try_one_bound(bound_data.bounds.upper, true);
+                try_one_bound(bound_data.bounds.lower, false);
             };
 
         try_weakening(left_constraint, right_constraint);
@@ -5765,17 +5951,17 @@ impl SequentMap {
                 let right_upper = right_constraint_data.bounds.upper;
                 let mut new_constraints =
                     |bound_typevar: BoundTypeVarInstance<'db>,
-                     mut right_lower: Option<Type<'db>>,
-                     mut right_upper: Option<Type<'db>>| {
-                        if let Some(Type::TypeVar(other_bound_typevar)) = right_lower
+                     mut right_lower: ConstraintBound<'db>,
+                     mut right_upper: ConstraintBound<'db>| {
+                        if let Type::TypeVar(other_bound_typevar) = right_lower.ty()
                             && bound_typevar.is_same_typevar_as(db, other_bound_typevar)
                         {
-                            right_lower = None;
+                            right_lower = ConstraintBound::missing_lower();
                         }
-                        if let Some(Type::TypeVar(other_bound_typevar)) = right_upper
+                        if let Type::TypeVar(other_bound_typevar) = right_upper.ty()
                             && bound_typevar.is_same_typevar_as(db, other_bound_typevar)
                         {
-                            right_upper = None;
+                            right_upper = ConstraintBound::missing_upper();
                         }
 
                         // Same idea as `add_mutual_sequents_for_different_typevars`: if a derived
@@ -5787,10 +5973,18 @@ impl SequentMap {
                         // Avoid preserving explicit bounds that are equivalent to missing
                         // lower/upper bounds; direct constraints still retain their explicit
                         // bound presence.
-                        let mut constrained_lower = right_lower.filter(|lower| !lower.is_never());
-                        let mut constrained_upper = right_upper.filter(|upper| !upper.is_object());
+                        let mut constrained_lower = if right_lower.ty().is_never() {
+                            ConstraintBound::missing_lower()
+                        } else {
+                            right_lower
+                        };
+                        let mut constrained_upper = if right_upper.ty().is_object() {
+                            ConstraintBound::missing_upper()
+                        } else {
+                            right_upper
+                        };
 
-                        if let Some(Type::TypeVar(lower_bound_typevar)) = right_lower
+                        if let Type::TypeVar(lower_bound_typevar) = right_lower.ty()
                             && !lower_bound_typevar.can_be_bound_for(db, storage, bound_typevar)
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
@@ -5798,13 +5992,13 @@ impl SequentMap {
                                 env,
                                 storage,
                                 lower_bound_typevar,
-                                None,
-                                Some(Type::TypeVar(bound_typevar)),
+                                ConstraintBound::missing_lower(),
+                                right_lower.with_type(Type::TypeVar(bound_typevar)),
                             ));
-                            constrained_lower = None;
+                            constrained_lower = ConstraintBound::missing_lower();
                         }
 
-                        if let Some(Type::TypeVar(upper_bound_typevar)) = right_upper
+                        if let Type::TypeVar(upper_bound_typevar) = right_upper.ty()
                             && !upper_bound_typevar.can_be_bound_for(db, storage, bound_typevar)
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
@@ -5812,14 +6006,14 @@ impl SequentMap {
                                 env,
                                 storage,
                                 upper_bound_typevar,
-                                Some(Type::TypeVar(bound_typevar)),
-                                None,
+                                right_upper.with_type(Type::TypeVar(bound_typevar)),
+                                ConstraintBound::missing_upper(),
                             ));
-                            constrained_upper = None;
+                            constrained_upper = ConstraintBound::missing_upper();
                         }
 
-                        if !(constrained_lower.unwrap_or(Type::Never).is_never()
-                            && constrained_upper.unwrap_or(Type::object()).is_object())
+                        if !(constrained_lower.ty().is_never()
+                            && constrained_upper.ty().is_object())
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
                                 db,
@@ -5833,19 +6027,26 @@ impl SequentMap {
 
                         post_constraints
                     };
-                let post_constraints = match (left_lower, left_upper) {
-                    (
-                        Some(Type::TypeVar(bound_typevar)),
-                        Some(Type::TypeVar(other_bound_typevar)),
-                    ) if bound_typevar.is_same_typevar_as(db, other_bound_typevar) => {
-                        new_constraints(bound_typevar, right_lower, right_upper)
+                let post_constraints = match (left_lower.ty(), left_upper.ty()) {
+                    (Type::TypeVar(bound_typevar), Type::TypeVar(other_bound_typevar))
+                        if bound_typevar.is_same_typevar_as(db, other_bound_typevar) =>
+                    {
+                        new_constraints(
+                            bound_typevar,
+                            right_lower.with_combined_provenance(left_upper),
+                            right_upper.with_combined_provenance(left_lower),
+                        )
                     }
-                    (Some(Type::TypeVar(bound_typevar)), _) => {
-                        new_constraints(bound_typevar, None, right_upper)
-                    }
-                    (_, Some(Type::TypeVar(bound_typevar))) => {
-                        new_constraints(bound_typevar, right_lower, None)
-                    }
+                    (Type::TypeVar(bound_typevar), _) => new_constraints(
+                        bound_typevar,
+                        ConstraintBound::missing_lower(),
+                        right_upper.with_combined_provenance(left_lower),
+                    ),
+                    (_, Type::TypeVar(bound_typevar)) => new_constraints(
+                        bound_typevar,
+                        right_lower.with_combined_provenance(left_upper),
+                        ConstraintBound::missing_upper(),
+                    ),
                     _ => return,
                 };
                 for post_constraint in post_constraints {
@@ -5884,7 +6085,7 @@ impl SequentMap {
                 right = %right_constraint.display(db, env, storage),
                 "left implies right",
             );
-            self.add_single_implication(left_constraint, right_constraint);
+            self.add_single_implication(db, storage, left_constraint, right_constraint);
         }
         if storage.cached_constraint_implies(db, env, right_constraint, left_constraint) {
             tracing::trace!(
@@ -5893,7 +6094,7 @@ impl SequentMap {
                 right = %right_constraint.display(db, env, storage),
                 "right implies left",
             );
-            self.add_single_implication(right_constraint, left_constraint);
+            self.add_single_implication(db, storage, right_constraint, left_constraint);
         }
 
         match left_constraint.intersect(db, env, storage, right_constraint) {
@@ -5915,8 +6116,8 @@ impl SequentMap {
                     right_constraint,
                     intersection_constraint,
                 );
-                self.add_single_implication(intersection_constraint, left_constraint);
-                self.add_single_implication(intersection_constraint, right_constraint);
+                self.add_single_implication(db, storage, intersection_constraint, left_constraint);
+                self.add_single_implication(db, storage, intersection_constraint, right_constraint);
             }
 
             // The sequent map only needs to include constraints that might appear in a BDD. If the
@@ -7153,6 +7354,431 @@ mod tests {
     }
 
     #[test]
+    fn constraint_bounds_distinguish_provenance_and_logical_defaults() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let int = known_instance(db, KnownClass::Int);
+        let mut storage = ConstraintSetStorage::default();
+
+        let evidence = ConstraintId::new_with_bounds(
+            db,
+            &env,
+            &mut storage,
+            t,
+            ConstraintBound::Evidence(int),
+            ConstraintBound::missing_upper(),
+        );
+        let validity = ConstraintId::new_with_bounds(
+            db,
+            &env,
+            &mut storage,
+            t,
+            ConstraintBound::Validity(int),
+            ConstraintBound::missing_upper(),
+        );
+
+        assert_ne!(evidence, validity);
+        let explicit_defaults = ConstraintBounds::new(
+            ConstraintBound::Evidence(Type::Never),
+            ConstraintBound::Evidence(Type::object()),
+        );
+        let default_validity = ConstraintBounds::new(
+            ConstraintBound::missing_lower(),
+            ConstraintBound::missing_upper(),
+        );
+        assert_ne!(explicit_defaults, default_validity);
+        assert_eq!(explicit_defaults.lower.ty(), default_validity.lower.ty());
+        assert_eq!(explicit_defaults.upper.ty(), default_validity.upper.ty());
+        assert!(!explicit_defaults.has_same_provenance(default_validity));
+        assert!(!default_validity.has_same_provenance(explicit_defaults));
+
+        let lower_evidence = ConstraintBounds::new(
+            ConstraintBound::Evidence(Type::Never),
+            ConstraintBound::missing_upper(),
+        );
+        let upper_evidence = ConstraintBounds::new(
+            ConstraintBound::missing_lower(),
+            ConstraintBound::Evidence(Type::object()),
+        );
+        assert!(!default_validity.has_same_provenance(lower_evidence));
+        assert!(!default_validity.has_same_provenance(upper_evidence));
+
+        let u = create_typevar(db, "U");
+        let (relationship, _) = Constraint::new_node_with_bounds(
+            db,
+            &env,
+            &mut storage,
+            t,
+            ConstraintBound::Validity(Type::TypeVar(u)),
+            ConstraintBound::Evidence(Type::TypeVar(u)),
+        );
+        let relationship = relationship
+            .root_constraint(&storage)
+            .map(|constraint| storage.constraint_data(constraint));
+        assert_eq!(
+            relationship,
+            Some(Constraint {
+                typevar: u,
+                bounds: ConstraintBounds::new(
+                    ConstraintBound::Evidence(Type::TypeVar(t)),
+                    ConstraintBound::Validity(Type::TypeVar(t)),
+                ),
+            })
+        );
+    }
+
+    #[test]
+    fn bound_projections_can_retain_identity_bounds() {
+        let db = setup_db();
+        let db = &db;
+        let t = create_typevar(db, "T");
+        let int = known_instance(db, KnownClass::Int);
+        let unrestricted = Constraint {
+            typevar: t,
+            bounds: ConstraintBounds::new(
+                ConstraintBound::missing_lower(),
+                ConstraintBound::missing_upper(),
+            ),
+        };
+
+        for bounds in [
+            ConstraintBounds::new(
+                ConstraintBound::Evidence(int),
+                ConstraintBound::missing_upper(),
+            ),
+            ConstraintBounds::new(
+                ConstraintBound::missing_lower(),
+                ConstraintBound::Evidence(int),
+            ),
+        ] {
+            assert!(unrestricted.is_bound_projection_of(db, Constraint { typevar: t, bounds }));
+        }
+    }
+
+    #[test]
+    fn constraint_intersection_preserves_stronger_bound_provenance() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let int = known_instance(db, KnownClass::Int);
+        let bool = known_instance(db, KnownClass::Bool);
+        let mut storage = ConstraintSetStorage::default();
+
+        let cases = [
+            (
+                ConstraintBounds::new(
+                    ConstraintBound::Evidence(bool),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::Validity(int),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::Validity(int),
+                    ConstraintBound::missing_upper(),
+                ),
+            ),
+            (
+                ConstraintBounds::new(
+                    ConstraintBound::Evidence(int),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::Validity(bool),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::Evidence(int),
+                    ConstraintBound::missing_upper(),
+                ),
+            ),
+            (
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Validity(bool),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Evidence(int),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Validity(bool),
+                ),
+            ),
+            (
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Evidence(bool),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Validity(int),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Evidence(bool),
+                ),
+            ),
+            (
+                ConstraintBounds::new(
+                    ConstraintBound::Evidence(int),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::Validity(int),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::Evidence(int),
+                    ConstraintBound::missing_upper(),
+                ),
+            ),
+            (
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Evidence(int),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Validity(int),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Evidence(int),
+                ),
+            ),
+            (
+                ConstraintBounds::new(
+                    ConstraintBound::Evidence(Type::Never),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::Evidence(Type::Never),
+                    ConstraintBound::missing_upper(),
+                ),
+            ),
+            (
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Evidence(Type::object()),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::missing_upper(),
+                ),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Evidence(Type::object()),
+                ),
+            ),
+        ];
+
+        for (left, right, expected) in cases {
+            let left =
+                ConstraintId::new_with_bounds(db, &env, &mut storage, t, left.lower, left.upper);
+            let right =
+                ConstraintId::new_with_bounds(db, &env, &mut storage, t, right.lower, right.upper);
+            for (first, second) in [(left, right), (right, left)] {
+                assert!(matches!(
+                    first.intersect(db, &env, &mut storage, second),
+                    IntersectionResult::Simplified(intersection) if intersection.bounds == expected
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn single_implications_do_not_cross_bound_provenance() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let int = known_instance(db, KnownClass::Int);
+        let bool = known_instance(db, KnownClass::Bool);
+        let mut storage = ConstraintSetStorage::default();
+
+        for (evidence, validity) in [(int, int), (int, bool), (bool, int)] {
+            for lower in [false, true] {
+                let evidence_bounds = if lower {
+                    ConstraintBounds::new(
+                        ConstraintBound::Evidence(evidence),
+                        ConstraintBound::missing_upper(),
+                    )
+                } else {
+                    ConstraintBounds::new(
+                        ConstraintBound::missing_lower(),
+                        ConstraintBound::Evidence(evidence),
+                    )
+                };
+                let validity_bounds = if lower {
+                    ConstraintBounds::new(
+                        ConstraintBound::Validity(validity),
+                        ConstraintBound::missing_upper(),
+                    )
+                } else {
+                    ConstraintBounds::new(
+                        ConstraintBound::missing_lower(),
+                        ConstraintBound::Validity(validity),
+                    )
+                };
+                let evidence = ConstraintId::new_with_bounds(
+                    db,
+                    &env,
+                    &mut storage,
+                    t,
+                    evidence_bounds.lower,
+                    evidence_bounds.upper,
+                );
+                let validity = ConstraintId::new_with_bounds(
+                    db,
+                    &env,
+                    &mut storage,
+                    t,
+                    validity_bounds.lower,
+                    validity_bounds.upper,
+                );
+                for (first, second) in [(evidence, validity), (validity, evidence)] {
+                    let sequents =
+                        SequentMap::for_constraint_pair(db, &env, &mut storage, first, second);
+                    assert!(sequents.sequents.iter().all(|sequent| {
+                        !matches!(sequent, Sequent::SingleImplication { ante, post }
+                            if (*ante == evidence && *post == validity)
+                                || (*ante == validity && *post == evidence))
+                    }));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn transitive_constraints_inherit_validity_from_either_premise() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let int = known_instance(db, KnownClass::Int);
+
+        for (relationship_validity, upper_validity) in
+            [(false, false), (false, true), (true, false), (true, true)]
+        {
+            let t = create_typevar(db, "T");
+            let u = create_typevar(db, "U");
+            let mut storage = ConstraintSetStorage::default();
+            let relationship = if relationship_validity {
+                ConstraintBound::Validity(Type::TypeVar(u))
+            } else {
+                ConstraintBound::Evidence(Type::TypeVar(u))
+            };
+            let (relationship_node, _) = Constraint::new_node_with_bounds(
+                db,
+                &env,
+                &mut storage,
+                t,
+                ConstraintBound::missing_lower(),
+                relationship,
+            );
+            let relationship = relationship_node.root_constraint(&storage);
+            let upper = if upper_validity {
+                ConstraintBound::Validity(int)
+            } else {
+                ConstraintBound::Evidence(int)
+            };
+            let upper = ConstraintId::new_with_bounds(
+                db,
+                &env,
+                &mut storage,
+                u,
+                ConstraintBound::missing_lower(),
+                upper,
+            );
+            let expected = if relationship_validity || upper_validity {
+                ConstraintBound::Validity(int)
+            } else {
+                ConstraintBound::Evidence(int)
+            };
+            assert!(relationship.is_some_and(|relationship| {
+                let sequents =
+                    SequentMap::for_constraint_pair(db, &env, &mut storage, relationship, upper);
+                let posts: Vec<_> = sequents
+                    .sequents
+                    .iter()
+                    .filter_map(|sequent| match sequent {
+                        Sequent::PairImplication { post, .. } => Some(*post),
+                        _ => None,
+                    })
+                    .collect();
+                posts.iter().any(|post| {
+                    let post = storage.constraint_data(*post);
+                    post.typevar.is_same_typevar_as(db, t) && post.bounds.upper == expected
+                })
+            }));
+        }
+    }
+
+    #[test]
+    fn constraint_provenance_survives_type_mapping_and_owned_round_trip() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let u = create_typevar(db, "U");
+        let int = known_instance(db, KnownClass::Int);
+        let list_of_u = KnownClass::List.to_specialized_instance(db, &env, &[Type::TypeVar(u)]);
+
+        let owned = ConstraintSetBuilder::new().into_owned(|builder| {
+            let (node, source_order) = {
+                let mut storage = builder.storage.borrow_mut();
+                Constraint::new_node_with_bounds(
+                    db,
+                    &env,
+                    &mut storage,
+                    t,
+                    ConstraintBound::Validity(list_of_u),
+                    ConstraintBound::Evidence(Type::object()),
+                )
+            };
+            let set = ConstraintSet::from_node(builder, node, source_order);
+            set.apply_type_mapping_impl(
+                db,
+                &TypeMapping::ApplySpecialization(ApplySpecialization::Single(u, int)),
+                TypeContext::default(),
+                &ApplyTypeMappingVisitor::new(&env),
+            )
+        });
+        let list_of_int = KnownClass::List.to_specialized_instance(db, &env, &[int]);
+        let expected = ConstraintBounds::new(
+            ConstraintBound::Validity(list_of_int),
+            ConstraintBound::Evidence(Type::object()),
+        );
+
+        owned.query(|builder, set| {
+            let storage = builder.storage.borrow();
+            let bounds = set
+                .node
+                .root_constraint(&storage)
+                .map(|constraint| storage.constraint_data(constraint).bounds);
+            assert_eq!(bounds, Some(expected));
+        });
+
+        let builder = ConstraintSetBuilder::new();
+        let loaded = builder.load(db, &env, &owned);
+        let storage = builder.storage.borrow();
+        let bounds = loaded
+            .node
+            .root_constraint(&storage)
+            .map(|constraint| storage.constraint_data(constraint).bounds);
+        assert_eq!(bounds, Some(expected));
+    }
+
+    #[test]
     fn type_mapping_updates_constraint_bounds() {
         // (list[U] ≤ T ≤ list[U])[U ↦ int] = (list[int] ≤ T ≤ list[int])
         let db = setup_db();
@@ -7210,7 +7836,10 @@ mod tests {
             db,
             &env,
             t,
-            ConstraintBounds::new(None, Some(actual_bound)),
+            ConstraintBounds::new(
+                ConstraintBound::missing_lower(),
+                ConstraintBound::Evidence(actual_bound),
+            ),
         );
         let mentioned = support
             .iter()
@@ -7258,7 +7887,10 @@ mod tests {
                 db,
                 &env,
                 t,
-                ConstraintBounds::new(None, Some(Type::TypeVar(u))),
+                ConstraintBounds::new(
+                    ConstraintBound::missing_lower(),
+                    ConstraintBound::Evidence(Type::TypeVar(u)),
+                ),
             );
             let mentioned = support
                 .iter()
@@ -7501,9 +8133,22 @@ mod tests {
         let type_of_u = SubclassOfType::from(db, &env, u);
         let bool_class = KnownClass::Bool.to_class_literal(db, &env);
         let mut storage = builder.storage.borrow_mut();
-        let left = ConstraintId::new_with_bounds(db, &env, &mut storage, t, Some(type_of_u), None);
-        let right =
-            ConstraintId::new_with_bounds(db, &env, &mut storage, t, Some(bool_class), None);
+        let left = ConstraintId::new_with_bounds(
+            db,
+            &env,
+            &mut storage,
+            t,
+            ConstraintBound::Evidence(type_of_u),
+            ConstraintBound::missing_upper(),
+        );
+        let right = ConstraintId::new_with_bounds(
+            db,
+            &env,
+            &mut storage,
+            t,
+            ConstraintBound::Evidence(bool_class),
+            ConstraintBound::missing_upper(),
+        );
 
         for (left, right) in [(left, right), (right, left)] {
             let sequents = SequentMap::for_constraint_pair(db, &env, &mut storage, left, right);
@@ -7670,15 +8315,21 @@ mod tests {
         let int_or_str = UnionType::from_two_elements(db, &env, int, str);
         let bytes_or_bytearray = UnionType::from_two_elements(db, &env, bytes, bytearray);
         let mut storage = builder.storage.borrow_mut();
-        let left =
-            ConstraintId::new_with_bounds(db, &env, &mut storage, t, Some(int), Some(int_or_str));
+        let left = ConstraintId::new_with_bounds(
+            db,
+            &env,
+            &mut storage,
+            t,
+            ConstraintBound::Evidence(int),
+            ConstraintBound::Evidence(int_or_str),
+        );
         let right = ConstraintId::new_with_bounds(
             db,
             &env,
             &mut storage,
             t,
-            None,
-            Some(bytes_or_bytearray),
+            ConstraintBound::missing_lower(),
+            ConstraintBound::Evidence(bytes_or_bytearray),
         );
 
         // Check satisfiability against each upper clause before punting on the union-bearing
@@ -7943,7 +8594,15 @@ mod tests {
             storage: &mut ConstraintSetStorage<'db>,
         ) -> NodeId {
             let PermutedConstraint(typevar, lower, upper) = self;
-            Constraint::new_node_with_bounds(db, env, storage, typevar, lower, upper).0
+            Constraint::new_node_with_bounds(
+                db,
+                env,
+                storage,
+                typevar,
+                lower.map_or(ConstraintBound::missing_lower(), ConstraintBound::Evidence),
+                upper.map_or(ConstraintBound::missing_upper(), ConstraintBound::Evidence),
+            )
+            .0
         }
     }
 
@@ -7980,7 +8639,16 @@ mod tests {
                     &env,
                     Constraint {
                         typevar,
-                        bounds: ConstraintBounds::new(lower, upper),
+                        bounds: ConstraintBounds::new(
+                            lower.map_or(
+                                ConstraintBound::missing_lower(),
+                                ConstraintBound::Evidence,
+                            ),
+                            upper.map_or(
+                                ConstraintBound::missing_upper(),
+                                ConstraintBound::Evidence,
+                            ),
+                        ),
                     },
                 );
             }
@@ -7993,7 +8661,16 @@ mod tests {
                     &env,
                     Constraint {
                         typevar,
-                        bounds: ConstraintBounds::new(lower, upper),
+                        bounds: ConstraintBounds::new(
+                            lower.map_or(
+                                ConstraintBound::missing_lower(),
+                                ConstraintBound::Evidence,
+                            ),
+                            upper.map_or(
+                                ConstraintBound::missing_upper(),
+                                ConstraintBound::Evidence,
+                            ),
+                        ),
                     },
                 );
                 let constraint_source_order = storage.constraint_source_order(constraint);
@@ -8933,8 +9610,8 @@ mod tests {
                 &env,
                 builder,
                 u,
-                None,
-                Some(Type::TypeVar(t)),
+                ConstraintBound::missing_lower(),
+                ConstraintBound::Evidence(Type::TypeVar(t)),
             );
             let t_v = ConstraintSet::constrain_typevar(
                 db,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1656,6 +1656,44 @@ impl<'db> ConstraintSetStorage<'db> {
             .map(|support| self.support_data(support))
     }
 
+    /// Returns a constraint set encoding the declared upper bound or constraints of every typevar
+    /// in this node's support. This constraint set defines the _domain_ (or, the set of valid
+    /// solutions) of the node. Any constraints in the constraint set will use
+    /// [`Validity`][ConstraintBound::Validity] bounds, since they constrain which solutions are
+    /// valid, but do not provide direct evidence of the particular solution we should choose.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "validity domains are applied during solution extraction in a later phase"
+        )
+    )]
+    fn validity_domain(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        node: NodeId,
+    ) -> (NodeId, Option<SourceOrderId>) {
+        let Some(support) = self.node_support(node).cloned() else {
+            return (ALWAYS_TRUE, None);
+        };
+
+        let mut domain = ALWAYS_TRUE;
+        let mut source_order = None;
+        for typevar in support.iter() {
+            let typevar = self.typevar_data(typevar);
+            let (valid_specializations, validity_source_order) =
+                typevar.valid_specializations(db, env, self);
+            domain = domain.and(self, valid_specializations);
+            source_order = self.ordered_source_order(source_order, validity_source_order);
+            if domain == ALWAYS_FALSE {
+                break;
+            }
+        }
+
+        (domain, source_order)
+    }
+
     /// Loads an [`OwnedConstraintSet`] into this storage.
     fn load(
         &mut self,
@@ -1751,6 +1789,51 @@ impl<'db> ConstraintSetStorage<'db> {
 }
 
 impl<'db> BoundTypeVarInstance<'db> {
+    /// Returns a constraint set encoding this type variable's declared upper bound or constraints.
+    /// Any constraints in the constraint set will use [`Validity`][ConstraintBound::Validity]
+    /// bounds, since they constrain which solutions are valid, but do not provide direct evidence
+    /// of the particular solution we should choose.
+    fn valid_specializations(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
+    ) -> (NodeId, Option<SourceOrderId>) {
+        // TODO: Support ParamSpecs in constraint sets
+        if self.paramspec_attr(db).is_some() {
+            return (ALWAYS_TRUE, None);
+        }
+
+        match self.typevar(db).bound_or_constraints(db, env) {
+            None => (ALWAYS_TRUE, None),
+            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => Constraint::new_node_with_bounds(
+                db,
+                env,
+                storage,
+                self,
+                ConstraintBound::missing_lower(),
+                ConstraintBound::Validity(bound),
+            ),
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                let mut specializations = ALWAYS_FALSE;
+                let mut source_order = None;
+                for constraint in constraints.elements(db) {
+                    let validity = ConstraintBound::Validity(*constraint);
+                    let (constraint, constraint_source_order) = Constraint::new_node_with_bounds(
+                        db, env, storage, self, validity, validity,
+                    );
+                    specializations = specializations.or(storage, constraint);
+                    source_order =
+                        storage.ordered_source_order(source_order, constraint_source_order);
+                    if specializations == ALWAYS_TRUE {
+                        break;
+                    }
+                }
+                (specializations, source_order)
+            }
+        }
+    }
+
     /// Returns whether this typevar can be the lower or upper bound of another typevar in a
     /// constraint set.
     ///
@@ -7325,7 +7408,9 @@ mod tests {
 
     use crate::db::tests::{TestDb, setup_db};
     use crate::types::generics::ApplySpecialization;
-    use crate::types::typevar::{TypeVarBoundOrConstraintsEvaluation, TypeVarDefaultEvaluation};
+    use crate::types::typevar::{
+        TypeVarBoundOrConstraintsEvaluation, TypeVarConstraints, TypeVarDefaultEvaluation,
+    };
     use crate::types::{BoundTypeVarInstance, KnownClass, SubclassOfType, TypeVarVariance};
     use ruff_python_ast::name::Name;
 
@@ -7351,6 +7436,135 @@ mod tests {
 
     fn known_instance(db: &TestDb, class: KnownClass) -> Type<'_> {
         class.to_instance(db, &db.program_environment())
+    }
+
+    // XXX: Remove once solution extraction exercises validity domains.
+    #[test]
+    fn validity_domain_uses_supported_typevars_in_builder_order() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let int = known_instance(db, KnownClass::Int);
+        let str = known_instance(db, KnownClass::Str);
+        let bytes = known_instance(db, KnownClass::Bytes);
+        let gradual_upper = KnownClass::List.to_specialized_instance(db, &env, &[Type::any()]);
+        let bounded = create_typevar(db, "Bounded").map_bound_or_constraints(db, |_| {
+            Some(TypeVarBoundOrConstraints::UpperBound(gradual_upper))
+        });
+        let nested = create_typevar(db, "Nested")
+            .map_bound_or_constraints(db, |_| Some(TypeVarBoundOrConstraints::UpperBound(str)));
+        let unbounded = create_typevar(db, "Unbounded");
+        let unused = create_typevar(db, "Unused")
+            .map_bound_or_constraints(db, |_| Some(TypeVarBoundOrConstraints::UpperBound(bytes)));
+        let nested_upper =
+            KnownClass::List.to_specialized_instance(db, &env, &[Type::TypeVar(nested)]);
+
+        let owned = ConstraintSetBuilder::new().into_owned(|builder| {
+            let root = ConstraintSet::constrain_typevar_upper_bound(
+                db,
+                &env,
+                builder,
+                bounded,
+                nested_upper,
+            )
+            .and(db, builder, || {
+                ConstraintSet::constrain_typevar_lower_bound(db, &env, builder, unbounded, int)
+            });
+            builder.storage.borrow_mut().intern_typevar(db, unused);
+            root
+        });
+
+        owned.query(|builder, root| {
+            let mut storage = builder.storage.borrow_mut();
+            let (domain, source_order) = storage.validity_domain(db, &env, root.node);
+            let constraints: Vec<_> = storage
+                .calculate_source_orders(source_order)
+                .into_iter()
+                .map(|constraint| storage.constraint_data(constraint))
+                .collect();
+
+            assert_eq!(
+                constraints,
+                vec![
+                    Constraint {
+                        typevar: bounded,
+                        bounds: ConstraintBounds::new(
+                            ConstraintBound::missing_lower(),
+                            ConstraintBound::Validity(gradual_upper),
+                        ),
+                    },
+                    Constraint {
+                        typevar: nested,
+                        bounds: ConstraintBounds::new(
+                            ConstraintBound::missing_lower(),
+                            ConstraintBound::Validity(str),
+                        ),
+                    },
+                ]
+            );
+
+            let support: Vec<_> = storage
+                .node_support(domain)
+                .into_iter()
+                .flat_map(Support::iter)
+                .map(|typevar| storage.typevar_data(typevar))
+                .collect();
+            assert_eq!(support, vec![bounded, nested]);
+            assert_eq!(
+                storage.validity_domain(db, &env, ALWAYS_TRUE),
+                (ALWAYS_TRUE, None)
+            );
+            assert_eq!(
+                storage.validity_domain(db, &env, ALWAYS_FALSE),
+                (ALWAYS_TRUE, None)
+            );
+        });
+    }
+
+    // XXX: Remove once solution extraction exercises validity domains.
+    #[test]
+    fn validity_domain_preserves_exact_gradual_declared_constraints() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let int = known_instance(db, KnownClass::Int);
+        let list_any = KnownClass::List.to_specialized_instance(db, &env, &[Type::any()]);
+        let list_int = KnownClass::List.to_specialized_instance(db, &env, &[int]);
+
+        for alternatives in [[Type::any(), int], [list_any, list_int]] {
+            let typevar = create_typevar(db, "T").map_bound_or_constraints(db, |_| {
+                Some(TypeVarBoundOrConstraints::Constraints(
+                    TypeVarConstraints::new(db, alternatives.as_slice()),
+                ))
+            });
+            let builder = ConstraintSetBuilder::new();
+            let root = ConstraintSet::constrain_typevar_lower_bound(
+                db,
+                &env,
+                &builder,
+                typevar,
+                alternatives[1],
+            );
+            let mut storage = builder.storage.borrow_mut();
+            let (_, source_order) = storage.validity_domain(db, &env, root.node);
+            let actual: Vec<_> = storage
+                .calculate_source_orders(source_order)
+                .into_iter()
+                .map(|constraint| storage.constraint_data(constraint))
+                .collect();
+            let expected: Vec<_> = alternatives
+                .into_iter()
+                .map(|alternative| Constraint {
+                    typevar,
+                    bounds: ConstraintBounds::new(
+                        ConstraintBound::Validity(alternative),
+                        ConstraintBound::Validity(alternative),
+                    ),
+                })
+                .collect();
+
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5730,9 +5730,10 @@ impl SequentMap {
         // implication. (That is, this check directly encodes `(L ≤ T ≤ U) → (L ≤ U)` as an
         // implication.)
         //
-        // TODO: Use the fully static sequent boundary here once lazy subtyping can preserve an
-        // existing gradual witness instead of materializing it away (see PR #26873). Until then,
-        // keep this dedicated single-range symbolic derivation assignability-based.
+        // TODO(ibraheem/gradual-constraints): Use the fully static sequent boundary here once
+        // lazy subtyping can preserve an existing gradual witness instead of materializing it away
+        // (see PR #26873). Until then, keep this dedicated single-range symbolic derivation
+        // assignability-based.
 
         // Skip trivial cases where the assignability check won't produce useful results.
         if lower.is_never() || upper.is_object() {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3828,6 +3828,35 @@ struct ConstraintBoundsBuilder<'db> {
 }
 
 impl<'db> ConstraintBoundsBuilder<'db> {
+    /// Returns whether mirrored lower and upper evidence require multiple exact types.
+    ///
+    /// A type that occurs in both evidence sets places the target typevar both above and below that
+    /// type. Multiple non-equivalent mirrored types are simultaneous equality requirements, not
+    /// lower-bound alternatives that can be unioned.
+    fn has_incoherent_equality_evidence(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        inferable: TypeVarSet<'db>,
+    ) -> bool {
+        let mut fixed_equalities = self
+            .evidence_lower
+            .iter()
+            .filter(|lower| self.upper.evidence.contains(*lower))
+            .copied()
+            .filter(|ty| {
+                // Equality types containing inferable typevars can become equivalent once the rest
+                // of the path is solved. Fixed typevars are opaque and can be compared immediately.
+                !any_over_type(db, env, *ty, false, |ty| {
+                    matches!(ty, Type::TypeVar(typevar) if typevar.is_inferable(db, inferable))
+                })
+            });
+        let Some(first) = fixed_equalities.next() else {
+            return false;
+        };
+        fixed_equalities.any(|ty| !first.is_equivalent_to(db, env, ty))
+    }
+
     fn classify_evidence(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, ty: Type<'db>) {
         if ty.has_unspecialized_type_var(db, env) {
             return;
@@ -3882,7 +3911,10 @@ impl<'db> ConstraintBoundsBuilder<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         bound_typevar: BoundTypeVarInstance<'db>,
+        inferable: TypeVarSet<'db>,
     ) -> PathBound<'db> {
+        let has_incoherent_equality_evidence =
+            self.has_incoherent_equality_evidence(db, env, inferable);
         let Self {
             evidence_lower,
             mixed_lower,
@@ -3907,6 +3939,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
             mixed_lower,
             validity_lower,
             upper,
+            has_incoherent_equality_evidence,
             has_only_gradual_evidence: has_gradual_evidence && !has_static_evidence,
         }
     }
@@ -3920,6 +3953,8 @@ pub(crate) struct PathBound<'db> {
     mixed_lower: Option<Type<'db>>,
     pub(crate) validity_lower: Type<'db>,
     pub(crate) upper: UpperBound<'db>,
+    /// Whether this path requires the typevar to equal multiple non-equivalent fixed types.
+    has_incoherent_equality_evidence: bool,
     /// Whether the path contains gradual evidence and no static evidence.
     has_only_gradual_evidence: bool,
 }
@@ -3932,6 +3967,7 @@ impl<'db> PathBound<'db> {
             mixed_lower: None,
             validity_lower: Type::Never,
             upper: UpperBound::from_clause(ty),
+            has_incoherent_equality_evidence: false,
             has_only_gradual_evidence: false,
         }
     }
@@ -4365,7 +4401,7 @@ impl<'db> PathBounds<'db> {
 
             let path_bounds = mappings
                 .drain(..)
-                .map(|(bound_typevar, bounds)| bounds.finish(db, env, bound_typevar))
+                .map(|(bound_typevar, bounds)| bounds.finish(db, env, bound_typevar, inferable))
                 .collect();
             result.push(path_bounds);
         }
@@ -4554,7 +4590,7 @@ impl<'db> PathBounds<'db> {
 
         let path = mappings
             .drain(..)
-            .map(|(bound_typevar, bounds)| bounds.finish(db, env, bound_typevar))
+            .map(|(bound_typevar, bounds)| bounds.finish(db, env, bound_typevar, inferable))
             .collect();
         Some(PathBounds::Constrained {
             paths: vec![path],
@@ -4840,6 +4876,12 @@ impl<'db> PathBounds<'db> {
         // Evidence determines whether the path is valid, but does not widen that specialization.
         if let Some(validity) = path_bound.as_equality_validity_bound(db, env) {
             return Ok(Some(validity));
+        }
+
+        // Assignability can keep non-equivalent gradual equality requirements satisfiable, but
+        // their lower bounds are simultaneous obligations rather than alternatives to union.
+        if path_bound.has_incoherent_equality_evidence {
+            return Ok(None);
         }
 
         if has_lower_evidence {
@@ -7985,6 +8027,7 @@ mod tests {
             mixed_lower: None,
             validity_lower: alternative,
             upper,
+            has_incoherent_equality_evidence: false,
             has_only_gradual_evidence: false,
         }
     }
@@ -8837,7 +8880,7 @@ mod tests {
         bounds.add_upper(db, &env, ConstraintBound::Validity(int));
         bounds.add_upper(db, &env, ConstraintBound::Mixed(s));
 
-        let bounds = bounds.finish(db, &env, t);
+        let bounds = bounds.finish(db, &env, t, TypeVarSet::from_typevars(db, [t]));
         assert_eq!(bounds.as_equality_validity_bound(db, &env), Some(int));
         assert_eq!(bounds.inference_lower(db, &env), Some(s));
         assert!(bounds.upper.has_evidence());
@@ -9479,6 +9522,7 @@ mod tests {
             mixed_lower: None,
             validity_lower: Type::Never,
             upper: UpperBound::unconstrained(),
+            has_incoherent_equality_evidence: false,
             has_only_gradual_evidence: false,
         };
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1997,6 +1997,20 @@ impl<'db> ConstraintBound<'db> {
         }
     }
 
+    /// Creates a bound derived by transitivity from two constraint bounds.
+    ///
+    /// Unlike a union or intersection on one typevar, neither premise is redundant merely because
+    /// the result has the same type as one of them. For example, deriving `int ≤ S` from
+    /// `int ≤ T` and `T ≤ S` requires both premises even though the resulting bound type is still
+    /// `int`.
+    fn from_transitive_derivation(combined: Type<'db>, lhs: Self, rhs: Self) -> Self {
+        if lhs.has_same_provenance(rhs) {
+            lhs.with_type(combined)
+        } else {
+            Self::Mixed(combined)
+        }
+    }
+
     /// Applies the source range's provenance to an evidence bound derived by comparing that range.
     /// Bounds not produced by the comparison retain their existing provenance.
     fn with_source_provenance(self, source: ConstraintBounds<'db>) -> Self {
@@ -5820,8 +5834,16 @@ impl SequentMap {
                     && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
-                    bound_constraint_data.bounds.lower,
-                    bound_constraint_data.bounds.upper,
+                    ConstraintBound::from_transitive_derivation(
+                        bound_constraint_data.bounds.lower.ty(),
+                        constrained_constraint_data.bounds.lower,
+                        bound_constraint_data.bounds.lower,
+                    ),
+                    ConstraintBound::from_transitive_derivation(
+                        bound_constraint_data.bounds.upper.ty(),
+                        constrained_constraint_data.bounds.upper,
+                        bound_constraint_data.bounds.upper,
+                    ),
                 )
             }
 
@@ -5831,7 +5853,11 @@ impl SequentMap {
             {
                 (
                     constrained_constraint_data.bounds.lower,
-                    bound_constraint_data.bounds.upper,
+                    ConstraintBound::from_transitive_derivation(
+                        bound_constraint_data.bounds.upper.ty(),
+                        constrained_constraint_data.bounds.upper,
+                        bound_constraint_data.bounds.upper,
+                    ),
                 )
             }
 
@@ -5840,7 +5866,11 @@ impl SequentMap {
                 if constrained_lower.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
-                    bound_constraint_data.bounds.lower,
+                    ConstraintBound::from_transitive_derivation(
+                        bound_constraint_data.bounds.lower.ty(),
+                        constrained_constraint_data.bounds.lower,
+                        bound_constraint_data.bounds.lower,
+                    ),
                     constrained_constraint_data.bounds.upper,
                 )
             }
@@ -5860,7 +5890,7 @@ impl SequentMap {
             {
                 (
                     constrained_constraint_data.bounds.lower,
-                    ConstraintBound::from_combination(
+                    ConstraintBound::from_transitive_derivation(
                         Type::TypeVar(bound_typevar),
                         constrained_constraint_data.bounds.upper,
                         bound_constraint_data.bounds.lower,
@@ -5882,7 +5912,7 @@ impl SequentMap {
                     ) =>
             {
                 (
-                    ConstraintBound::from_combination(
+                    ConstraintBound::from_transitive_derivation(
                         Type::TypeVar(bound_typevar),
                         constrained_constraint_data.bounds.lower,
                         bound_constraint_data.bounds.upper,
@@ -6095,7 +6125,7 @@ impl SequentMap {
                             storage,
                             constrained_typevar,
                             constrained_data.bounds.lower,
-                            ConstraintBound::from_combination(
+                            ConstraintBound::from_transitive_derivation(
                                 new_upper,
                                 constrained_data.bounds.upper,
                                 replacement,
@@ -6167,7 +6197,7 @@ impl SequentMap {
                             env,
                             storage,
                             constrained_typevar,
-                            ConstraintBound::from_combination(
+                            ConstraintBound::from_transitive_derivation(
                                 new_lower,
                                 constrained_data.bounds.lower,
                                 replacement,
@@ -6269,7 +6299,7 @@ impl SequentMap {
                                 storage,
                                 constrained_typevar,
                                 constrained_data.bounds.lower,
-                                ConstraintBound::from_combination(
+                                ConstraintBound::from_transitive_derivation(
                                     new_upper,
                                     constrained_data.bounds.upper,
                                     bound,
@@ -6314,7 +6344,7 @@ impl SequentMap {
                                 env,
                                 storage,
                                 constrained_typevar,
-                                ConstraintBound::from_combination(
+                                ConstraintBound::from_transitive_derivation(
                                     new_lower,
                                     constrained_data.bounds.lower,
                                     bound,
@@ -6443,16 +6473,36 @@ impl SequentMap {
                     (Type::TypeVar(bound_typevar), Type::TypeVar(other_bound_typevar))
                         if bound_typevar.is_same_typevar_as(db, other_bound_typevar) =>
                     {
-                        new_constraints(bound_typevar, right_lower, right_upper)
+                        new_constraints(
+                            bound_typevar,
+                            ConstraintBound::from_transitive_derivation(
+                                right_lower.ty(),
+                                left_lower,
+                                right_lower,
+                            ),
+                            ConstraintBound::from_transitive_derivation(
+                                right_upper.ty(),
+                                left_upper,
+                                right_upper,
+                            ),
+                        )
                     }
                     (Type::TypeVar(bound_typevar), _) => new_constraints(
                         bound_typevar,
                         ConstraintBound::missing_lower(),
-                        right_upper,
+                        ConstraintBound::from_transitive_derivation(
+                            right_upper.ty(),
+                            left_lower,
+                            right_upper,
+                        ),
                     ),
                     (_, Type::TypeVar(bound_typevar)) => new_constraints(
                         bound_typevar,
-                        right_lower,
+                        ConstraintBound::from_transitive_derivation(
+                            right_lower.ty(),
+                            left_upper,
+                            right_lower,
+                        ),
                         ConstraintBound::missing_upper(),
                     ),
                     _ => return,
@@ -8280,66 +8330,120 @@ mod tests {
     }
 
     #[test]
-    fn transitive_constraints_retain_result_bound_provenance() {
+    fn transitive_constraints_combine_premise_provenance() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
         let int = known_instance(db, KnownClass::Int);
 
-        for (relationship_validity, upper_validity) in
-            [(false, false), (false, true), (true, false), (true, true)]
-        {
-            let t = create_typevar(db, "T");
-            let u = create_typevar(db, "U");
-            let mut storage = ConstraintSetStorage::default();
-            let relationship = if relationship_validity {
-                ConstraintBound::Validity(Type::TypeVar(u))
-            } else {
-                ConstraintBound::Evidence(Type::TypeVar(u))
-            };
-            let (relationship_node, _) = Constraint::new_node_with_bounds(
-                db,
-                &env,
-                &mut storage,
-                t,
-                ConstraintBound::missing_lower(),
-                relationship,
-            );
-            let relationship = relationship_node.root_constraint(&storage);
-            let upper = if upper_validity {
-                ConstraintBound::Validity(int)
-            } else {
-                ConstraintBound::Evidence(int)
-            };
-            let upper = ConstraintId::new_with_bounds(
-                db,
-                &env,
-                &mut storage,
-                u,
-                ConstraintBound::missing_lower(),
-                upper,
-            );
-            let expected = if upper_validity {
-                ConstraintBound::Validity(int)
-            } else {
-                ConstraintBound::Evidence(int)
-            };
-            assert!(relationship.is_some_and(|relationship| {
-                let sequents =
-                    SequentMap::for_constraint_pair(db, &env, &mut storage, relationship, upper);
-                let posts: Vec<_> = sequents
-                    .sequents
-                    .iter()
-                    .filter_map(|sequent| match sequent {
-                        Sequent::PairImplication { post, .. } => Some(*post),
-                        _ => None,
-                    })
-                    .collect();
-                posts.iter().any(|post| {
-                    let post = storage.constraint_data(*post);
-                    post.typevar.is_same_typevar_as(db, t) && post.bounds.upper == expected
-                })
-            }));
+        for same_constrained_typevar in [false, true] {
+            for upper in [false, true] {
+                for (relationship_validity, concrete_validity) in
+                    [(false, false), (false, true), (true, false), (true, true)]
+                {
+                    let t = create_typevar(db, "T");
+                    let u = create_typevar(db, "U");
+                    let mut storage = ConstraintSetStorage::default();
+                    let relationship = if relationship_validity {
+                        ConstraintBound::Validity(Type::TypeVar(if same_constrained_typevar {
+                            t
+                        } else {
+                            u
+                        }))
+                    } else {
+                        ConstraintBound::Evidence(Type::TypeVar(if same_constrained_typevar {
+                            t
+                        } else {
+                            u
+                        }))
+                    };
+                    let relationship_is_lower = same_constrained_typevar == upper;
+                    let relationship_lower = if relationship_is_lower {
+                        relationship
+                    } else {
+                        ConstraintBound::missing_lower()
+                    };
+                    let relationship_upper = if relationship_is_lower {
+                        ConstraintBound::missing_upper()
+                    } else {
+                        relationship
+                    };
+                    let relationship = if same_constrained_typevar {
+                        ConstraintId::new_with_bounds(
+                            db,
+                            &env,
+                            &mut storage,
+                            u,
+                            relationship_lower,
+                            relationship_upper,
+                        )
+                    } else {
+                        let (node, _) = Constraint::new_node_with_bounds(
+                            db,
+                            &env,
+                            &mut storage,
+                            t,
+                            relationship_lower,
+                            relationship_upper,
+                        );
+                        node.root_constraint(&storage)
+                            .expect("a typevar relationship should produce one constraint")
+                    };
+                    let concrete = if concrete_validity {
+                        ConstraintBound::Validity(int)
+                    } else {
+                        ConstraintBound::Evidence(int)
+                    };
+                    let concrete = ConstraintId::new_with_bounds(
+                        db,
+                        &env,
+                        &mut storage,
+                        u,
+                        if upper {
+                            ConstraintBound::missing_lower()
+                        } else {
+                            concrete
+                        },
+                        if upper {
+                            concrete
+                        } else {
+                            ConstraintBound::missing_upper()
+                        },
+                    );
+                    let expected = match (relationship_validity, concrete_validity) {
+                        (true, true) => ConstraintBound::Validity(int),
+                        (false, false) => ConstraintBound::Evidence(int),
+                        _ => ConstraintBound::Mixed(int),
+                    };
+                    let sequents = SequentMap::for_constraint_pair(
+                        db,
+                        &env,
+                        &mut storage,
+                        relationship,
+                        concrete,
+                    );
+                    let posts: Vec<_> = sequents
+                        .sequents
+                        .iter()
+                        .filter_map(|sequent| match sequent {
+                            Sequent::PairImplication { post, .. } => Some(*post),
+                            _ => None,
+                        })
+                        .collect();
+                    assert!(
+                        posts.iter().any(|post| {
+                            let post = storage.constraint_data(*post);
+                            post.typevar.is_same_typevar_as(db, t)
+                                && if upper {
+                                    post.bounds.upper == expected
+                                } else {
+                                    post.bounds.lower == expected
+                                }
+                        }),
+                        "same_constrained_typevar={same_constrained_typevar}, upper={upper}, relationship_validity={relationship_validity}, concrete_validity={concrete_validity}",
+                    );
+                }
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -257,7 +257,7 @@ struct OwnedConstraintSetInner<'db> {
     constraints: Box<[Constraint<'db>]>,
     constraint_supports: Box<[SupportId]>,
     constraint_indices: RankBitBox,
-    typevars: IndexVec<TypeVarId, BoundTypeVarIdentity<'db>>,
+    typevars: IndexVec<TypeVarId, BoundTypeVarInstance<'db>>,
     nodes: Box<[InteriorNodeData]>,
     node_supports: Box<[SupportId]>,
     node_indices: RankBitBox,
@@ -959,7 +959,7 @@ struct ConstraintSetStorage<'db> {
     ///
     /// The ordering of typevars within this arena defines which typevars can be the lower/upper
     /// bounds of another (e.g., whether we encode `T ≤ U` as `Never ≤ T ≤ U` or `T ≤ U ≤ object`).
-    typevars: IndexVec<TypeVarId, BoundTypeVarIdentity<'db>>,
+    typevars: IndexVec<TypeVarId, BoundTypeVarInstance<'db>>,
 
     /// The BDD nodes that appear in any of the constraint sets constructed in this builder.
     nodes: IndexVec<NodeId, InteriorNodeData>,
@@ -1003,7 +1003,7 @@ struct ConstraintSetStorage<'db> {
     constraint_set_subtype_cache: FxHashMap<(Type<'db>, Type<'db>), bool>,
 }
 
-impl ConstraintSetStorage<'_> {
+impl<'db> ConstraintSetStorage<'db> {
     fn ensure_overlay_identity_caches(&mut self) {
         let Some(compacted) = &self.compacted else {
             return;
@@ -1012,12 +1012,6 @@ impl ConstraintSetStorage<'_> {
             return;
         }
 
-        self.typevar_cache.extend(
-            compacted
-                .typevars
-                .iter_enumerated()
-                .map(|(id, typevar)| (*typevar, id)),
-        );
         self.constraint_cache.extend(
             compacted
                 .constraint_indices
@@ -1039,6 +1033,23 @@ impl ConstraintSetStorage<'_> {
                 .copied()
                 .enumerate()
                 .map(|(index, source_order)| (source_order, SourceOrderId::from_usize(index))),
+        );
+    }
+
+    // This is a separate method from `ensure_overlay_identity_caches` because it requires a `db`.
+    fn ensure_overlay_typevar_identity_cache(&mut self, db: &'db dyn Db) {
+        let Some(compacted) = &self.compacted else {
+            return;
+        };
+        if !self.typevar_cache.is_empty() {
+            return;
+        }
+
+        self.typevar_cache.extend(
+            compacted
+                .typevars
+                .iter_enumerated()
+                .map(|(id, typevar)| (typevar.identity(db), id)),
         );
     }
 
@@ -1253,10 +1264,11 @@ impl<'db> ConstraintSetStorage<'db> {
     fn intern_typevar(&mut self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
         let identity = typevar.identity(db);
         self.ensure_overlay_identity_caches();
+        self.ensure_overlay_typevar_identity_cache(db);
         if let Some(id) = self.typevar_cache.get(&identity) {
             return *id;
         }
-        let id = self.typevars.push(identity);
+        let id = self.typevars.push(typevar);
         let id = self.adjusted_typevar_id(id);
         self.typevar_cache.insert(identity, id);
         id
@@ -1383,6 +1395,7 @@ impl<'db> ConstraintSetStorage<'db> {
     fn typevar_id(&mut self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
         let identity = typevar.identity(db);
         self.ensure_overlay_identity_caches();
+        self.ensure_overlay_typevar_identity_cache(db);
         self.typevar_cache
             .get(&identity)
             .copied()
@@ -1566,7 +1579,7 @@ impl<'db> ConstraintSetStorage<'db> {
         self.adjusted_support_id(id)
     }
 
-    fn typevar_data(&self, typevar: TypeVarId) -> BoundTypeVarIdentity<'db> {
+    fn typevar_data(&self, typevar: TypeVarId) -> BoundTypeVarInstance<'db> {
         if let Some(compacted) = &self.compacted {
             let index = typevar.index();
             let split = compacted.typevars.len();
@@ -7204,7 +7217,7 @@ mod tests {
             .map(|typevar| storage.typevar_data(typevar))
             .collect::<Vec<_>>();
 
-        assert_eq!(mentioned, vec![t.identity(db), u.identity(db)]);
+        assert_eq!(mentioned, vec![t, u]);
         assert!(support.is_complete());
     }
 
@@ -7252,7 +7265,7 @@ mod tests {
                 .map(|typevar| storage.typevar_data(typevar))
                 .collect::<Vec<_>>();
 
-            assert_eq!(mentioned, vec![t.identity(db), u.identity(db)]);
+            assert_eq!(mentioned, vec![t, u]);
             assert!(support.is_complete());
         }
     }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -113,8 +113,8 @@ use crate::types::visitor::{
     walk_type_with_recursion_guard,
 };
 use crate::types::{
-    ApplyTypeMappingVisitor, BoundTypeVarInstance, IntersectionType, Type, TypeContext,
-    TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
+    ApplySpecialization, ApplyTypeMappingVisitor, BoundTypeVarInstance, IntersectionType, Type,
+    TypeContext, TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
 };
 use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet, ProgramEnvironment};
 
@@ -863,37 +863,28 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         builder: &'c ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
     ) -> Solutions<'db> {
-        self.solutions_with(db, env, builder, inferable, |_variance, path_bound| {
-            PathBounds::default_solve(db, env, builder, path_bound)
-        })
+        self.path_bounds(db, env, builder, inferable)
+            .solve(db, env, builder)
     }
 
+    #[cfg(test)]
     pub(crate) fn solutions_with(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         builder: &'c ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
-        choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
+        choose: impl FnMut(
+            &PathBounds<'db>,
+            TypeVarVariance,
+            &PathBound<'db>,
+        ) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
         self.path_bounds(db, env, builder, inferable)
             .solve_with(choose)
     }
 
-    pub(crate) fn pruned_solutions_with(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        builder: &'c ConstraintSetBuilder<'db>,
-        inferable: TypeVarSet<'db>,
-        choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
-    ) -> Solutions<'db> {
-        let mut path_bounds = self.path_bounds(db, env, builder, inferable);
-        path_bounds.prune_subsumed(db, env);
-        path_bounds.solve_with(choose)
-    }
-
-    fn path_bounds(
+    pub(crate) fn path_bounds(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -904,7 +895,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         PathBounds::compute(
             db,
             env,
-            &mut builder.storage.borrow_mut(),
+            builder,
             self.node,
             inferable,
             self.source_order,
@@ -923,7 +914,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         PathBounds::compute(
             db,
             env,
-            &mut builder.storage.borrow_mut(),
+            builder,
             self.node,
             inferable,
             self.source_order,
@@ -4107,7 +4098,7 @@ impl<'db> Type<'db> {
                 PathBounds::compute(
                     db,
                     env,
-                    &mut builder.storage.borrow_mut(),
+                    builder,
                     when.node,
                     inferable,
                     when.source_order,
@@ -4126,10 +4117,21 @@ impl<'db> Type<'db> {
 pub(crate) enum PathBounds<'db> {
     Unsatisfiable,
     Unconstrained,
-    Constrained(Vec<Box<[PathBound<'db>]>>),
+    Constrained {
+        paths: Vec<Box<[PathBound<'db>]>>,
+        symbolic_default: Option<TypeVarSolution<'db>>,
+    },
 }
 
 impl<'db> PathBounds<'db> {
+    /// Wraps a legacy exact bound so chooser callbacks never receive a path without its family.
+    pub(crate) fn from_legacy_path_bound(path_bound: PathBound<'db>) -> Self {
+        Self::Constrained {
+            paths: vec![vec![path_bound].into_boxed_slice()],
+            symbolic_default: None,
+        }
+    }
+
     /// Computes sorted BDD paths and accumulates per-typevar lower/upper bounds for each path.
     ///
     /// Returns a list of paths, where each path contains the explicit lower/upper bounds for each
@@ -4137,12 +4139,55 @@ impl<'db> PathBounds<'db> {
     fn compute(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        storage: &mut ConstraintSetStorage<'db>,
+        builder: &ConstraintSetBuilder<'db>,
         node: NodeId,
         inferable: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
         include_validity_domain: bool,
     ) -> Self {
+        let (mut path_bounds, node_to_solve) = {
+            let mut storage = builder.storage.borrow_mut();
+            Self::compute_with_storage(
+                db,
+                env,
+                &mut storage,
+                node,
+                inferable,
+                source_order,
+                include_validity_domain,
+            )
+        };
+
+        if include_validity_domain
+            && let Some((node, source_order)) = node_to_solve
+            && let Some(symbolic_default) = path_bounds.recover_symbolic_default(
+                db,
+                env,
+                builder,
+                node,
+                inferable,
+                source_order,
+            )
+            && let Self::Constrained {
+                symbolic_default: current,
+                ..
+            } = &mut path_bounds
+        {
+            *current = Some(symbolic_default);
+        }
+
+        path_bounds
+    }
+
+    fn compute_with_storage(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
+        node: NodeId,
+        inferable: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
+        include_validity_domain: bool,
+    ) -> (Self, Option<(NodeId, Option<SourceOrderId>)>) {
         struct CollectVisitor<'a> {
             source_orders: &'a FxIndexSet<ConstraintId>,
             sorted_paths: Vec<Vec<(ConstraintId, usize)>>,
@@ -4214,7 +4259,7 @@ impl<'db> PathBounds<'db> {
                 inferable,
             )
         {
-            return path_bounds;
+            return (path_bounds, None);
         }
 
         let (mut node, derived_source_order) =
@@ -4244,7 +4289,7 @@ impl<'db> PathBounds<'db> {
                     node,
                     all_supported,
                 ) {
-                    return path_bounds;
+                    return (path_bounds, None);
                 }
             }
             path_source_order =
@@ -4252,8 +4297,8 @@ impl<'db> PathBounds<'db> {
         }
 
         let interior = match node.node() {
-            Node::AlwaysTrue => return PathBounds::Unconstrained,
-            Node::AlwaysFalse => return PathBounds::Unsatisfiable,
+            Node::AlwaysTrue => return (PathBounds::Unconstrained, None),
+            Node::AlwaysFalse => return (PathBounds::Unsatisfiable, None),
             Node::Interior(interior) => interior,
         };
 
@@ -4317,7 +4362,108 @@ impl<'db> PathBounds<'db> {
         }
 
         result.shrink_to_fit();
-        PathBounds::Constrained(result)
+        (
+            PathBounds::Constrained {
+                paths: result,
+                symbolic_default: None,
+            },
+            Some((node, path_source_order)),
+        )
+    }
+
+    /// Recovers one bare `T := S` relationship only when `S`'s complete validity domain implies
+    /// the domain-conjoined constraint set after substituting `T` with `S`.
+    fn recover_symbolic_default(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &ConstraintSetBuilder<'db>,
+        node: NodeId,
+        inferable: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
+    ) -> Option<TypeVarSolution<'db>> {
+        let Self::Constrained { paths, .. } = self else {
+            return None;
+        };
+
+        let mut hypothesis = None;
+        for path_bound in paths.iter().flatten() {
+            let target = path_bound.bound_typevar;
+            if !target.is_inferable(db, inferable) {
+                continue;
+            }
+
+            let lower = path_bound.evidence_lower.and_then(Type::as_typevar);
+            let upper = path_bound
+                .upper
+                .iter_evidence()
+                .filter_map(|bound| bound.ty().as_typevar());
+            for source in lower.into_iter().chain(upper) {
+                if source.is_inferable(db, inferable) {
+                    continue;
+                }
+                if let Some((current_target, current_source)) = hypothesis {
+                    if !target.is_same_typevar_as(db, current_target) {
+                        // TODO: Verify multiple symbolic targets together rather than declining
+                        // the entire family when more than one target has a candidate.
+                        return None;
+                    }
+                    if !source.is_same_typevar_as(db, current_source) {
+                        return None;
+                    }
+                } else {
+                    hypothesis = Some((target, source));
+                }
+            }
+        }
+
+        let (target, source) = hypothesis?;
+        if !paths.iter().flatten().any(|path_bound| {
+            path_bound.bound_typevar.is_same_typevar_as(db, target)
+                && path_bound.variance() != TypeVarVariance::Bivariant
+                && path_bound.as_equality_validity_bound(db, env).is_some()
+        }) {
+            return None;
+        }
+
+        let mapped = ConstraintSet::from_node(builder, node, source_order).apply_type_mapping_impl(
+            db,
+            &TypeMapping::ApplySpecialization(ApplySpecialization::Single(
+                target,
+                Type::TypeVar(source),
+            )),
+            TypeContext::default(),
+            &ApplyTypeMappingVisitor::new(env),
+        );
+
+        let has_inferable = {
+            let storage = builder.storage.borrow();
+            storage.node_support(mapped.node).is_some_and(|support| {
+                support
+                    .iter()
+                    .any(|typevar| storage.typevar_data(typevar).is_inferable(db, inferable))
+            })
+        };
+        if has_inferable {
+            return None;
+        }
+
+        let domain = {
+            let mut storage = builder.storage.borrow_mut();
+            let (domain, domain_source_order) = storage.validity_domain(db, env, mapped.node);
+            ConstraintSet::from_node(builder, domain, domain_source_order)
+        };
+        let counterexample = domain.and(db, builder, || mapped.negate(db, builder));
+        if !counterexample.is_never_satisfied(db, env) {
+            return None;
+        }
+
+        // TODO: Remove this post-extraction recovery once quantifier-aware TDD solution extraction
+        // can preserve symbolic relationships before materializing non-inferable specializations.
+        Some(TypeVarSolution {
+            bound_typevar: target,
+            solution: Type::TypeVar(source),
+        })
     }
 
     /// Accumulates a conjunction of concrete bound constraints without constructing a
@@ -4391,7 +4537,10 @@ impl<'db> PathBounds<'db> {
             .drain(..)
             .map(|(bound_typevar, bounds)| bounds.finish(db, env, bound_typevar))
             .collect();
-        Some(PathBounds::Constrained(vec![path]))
+        Some(PathBounds::Constrained {
+            paths: vec![path],
+            symbolic_default: None,
+        })
     }
 
     /// Removes less-preferred declared alternatives without combining separate paths.
@@ -4400,7 +4549,7 @@ impl<'db> PathBounds<'db> {
     /// typevars, and differ in one declared constrained alternative. Callers explicitly opt into
     /// pruning; ordinary solution extraction preserves every path.
     pub(crate) fn prune_subsumed(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) {
-        let Self::Constrained(paths) = self else {
+        let Self::Constrained { paths, .. } = self else {
             return;
         };
 
@@ -4541,25 +4690,30 @@ impl<'db> PathBounds<'db> {
         env: &ProgramEnvironment<'db>,
         builder: &ConstraintSetBuilder<'db>,
     ) -> Solutions<'db> {
-        self.solve_with(|_variance, path_bound| {
-            PathBounds::default_solve(db, env, builder, path_bound)
+        self.solve_with(|path_bounds, _variance, path_bound| {
+            path_bounds.default_solve(db, env, builder, path_bound)
         })
     }
 
     /// Solves each path by applying a per-typevar solver function, collecting valid solutions.
     ///
-    /// The solver receives the path's explicit lower/upper bounds and their variance, and returns:
+    /// The solver receives the complete path family, the path's explicit lower/upper bounds, and
+    /// their variance. It returns:
     /// - `Ok(Some(solution))` to add a solution for this typevar on this path
     /// - `Ok(None)` to leave this typevar unsolved on this path
     /// - `Err(())` to invalidate the entire path
     pub(crate) fn solve_with(
         &self,
-        mut choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
+        mut choose: impl FnMut(
+            &PathBounds<'db>,
+            TypeVarVariance,
+            &PathBound<'db>,
+        ) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
         let paths = match self {
             PathBounds::Unsatisfiable => return Solutions::Unsatisfiable,
             PathBounds::Unconstrained => return Solutions::Unconstrained,
-            PathBounds::Constrained(paths) => paths,
+            PathBounds::Constrained { paths, .. } => paths,
         };
 
         let mut solutions = Vec::with_capacity(paths.len());
@@ -4571,7 +4725,7 @@ impl<'db> PathBounds<'db> {
                     continue;
                 }
 
-                match choose(variance, path_bound) {
+                match choose(self, variance, path_bound) {
                     Ok(Some(ty)) => solution.push(TypeVarSolution {
                         bound_typevar: path_bound.bound_typevar,
                         solution: ty,
@@ -4589,16 +4743,30 @@ impl<'db> PathBounds<'db> {
         Solutions::Constrained(solutions)
     }
 
-    /// The default solution selection logic for a single typevar on a single BDD path.
-    ///
-    /// Given the validity and evidence bounds for a typevar, selects the solution type.
-    /// Logical-default validity bounds participate in satisfiability checks but are not selected as
-    /// inferred solutions.
-    /// Returns:
-    /// - `Ok(Some(solution))` if the typevar is solved on this path
-    /// - `Ok(None)` if the typevar is unsolved (no solution added)
-    /// - `Err(())` if the effective lower bound cannot satisfy the effective upper bound
+    /// Selects the default solution for a typevar using the complete path family.
     pub(crate) fn default_solve(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &ConstraintSetBuilder<'db>,
+        path_bound: &PathBound<'db>,
+    ) -> Result<Option<Type<'db>>, ()> {
+        if let Self::Constrained {
+            symbolic_default: Some(symbolic_default),
+            ..
+        } = self
+            && symbolic_default
+                .bound_typevar
+                .is_same_typevar_as(db, path_bound.bound_typevar)
+        {
+            return Ok(Some(symbolic_default.solution));
+        }
+
+        Self::solve_path(db, env, builder, path_bound)
+    }
+
+    /// The concrete default solution selection logic for one BDD path.
+    fn solve_path(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         builder: &ConstraintSetBuilder<'db>,
@@ -7798,7 +7966,10 @@ mod tests {
     }
 
     fn path_bounds(paths: Vec<Vec<PathBound<'_>>>) -> PathBounds<'_> {
-        PathBounds::Constrained(paths.into_iter().map(Vec::into_boxed_slice).collect())
+        PathBounds::Constrained {
+            paths: paths.into_iter().map(Vec::into_boxed_slice).collect(),
+            symbolic_default: None,
+        }
     }
 
     // XXX: Remove once solution extraction exercises validity domains.
@@ -9032,16 +9203,21 @@ mod tests {
         let inferable = TypeVarSet::from_typevars(db, [typevar]);
         let combined = evidence.and(db, &builder, || validity);
 
-        let solutions =
-            combined.solutions_with(db, &env, &builder, inferable, |variance, path_bound| {
+        let solutions = combined.solutions_with(
+            db,
+            &env,
+            &builder,
+            inferable,
+            |path_bounds, variance, path_bound| {
                 assert_eq!(variance, TypeVarVariance::Contravariant);
                 assert_eq!(path_bound.evidence_lower, Some(bool));
                 assert_eq!(path_bound.validity_lower, int);
                 assert_eq!(path_bound.effective_lower(db, &env), int);
                 assert!(!path_bound.has_upper_evidence());
                 assert_eq!(path_bound.upper.as_single_bound(db, &env), Some(int));
-                PathBounds::default_solve(db, &env, &builder, path_bound)
-            });
+                path_bounds.default_solve(db, &env, &builder, path_bound)
+            },
+        );
         let expected = Solutions::Constrained(vec![vec![TypeVarSolution {
             bound_typevar: typevar,
             solution: int,
@@ -9059,22 +9235,32 @@ mod tests {
         let other = ConstraintSet::from_node(&builder, other_node, other_source_order);
         let alternatives = validity.or(db, &builder, || other);
         let ordinary_path = evidence.and(db, &builder, || alternatives);
-        let solutions =
-            ordinary_path.solutions_with(db, &env, &builder, inferable, |variance, path_bound| {
+        let solutions = ordinary_path.solutions_with(
+            db,
+            &env,
+            &builder,
+            inferable,
+            |path_bounds, variance, path_bound| {
                 assert_eq!(variance, TypeVarVariance::Contravariant);
                 assert_eq!(path_bound.evidence_lower, Some(bool));
                 assert_eq!(path_bound.validity_lower, int);
                 assert_eq!(path_bound.effective_lower(db, &env), int);
-                PathBounds::default_solve(db, &env, &builder, path_bound)
-            });
+                path_bounds.default_solve(db, &env, &builder, path_bound)
+            },
+        );
         assert_eq!(solutions, expected);
 
         let mut callback_invoked = false;
-        let solutions =
-            validity.solutions_with(db, &env, &builder, inferable, |_variance, _path_bound| {
+        let solutions = validity.solutions_with(
+            db,
+            &env,
+            &builder,
+            inferable,
+            |_path_bounds, _variance, _path_bound| {
                 callback_invoked = true;
                 Ok(Some(int))
-            });
+            },
+        );
         assert!(!callback_invoked);
         assert_eq!(solutions, Solutions::Constrained(vec![Vec::new()]));
     }
@@ -9110,14 +9296,14 @@ mod tests {
             let mut paths = PathBounds::compute(
                 db,
                 &env,
-                &mut builder.storage.borrow_mut(),
+                &builder,
                 combined.node,
                 inferable,
                 combined.source_order,
                 false,
             );
 
-            assert!(matches!(&paths, PathBounds::Constrained(paths) if paths.len() == 2));
+            assert!(matches!(&paths, PathBounds::Constrained { paths, .. } if paths.len() == 2));
             paths.prune_subsumed(db, &env);
             let expected = if lower_evidence { bool } else { int };
             assert_eq!(
@@ -9402,7 +9588,12 @@ mod tests {
         };
 
         assert_eq!(
-            PathBounds::default_solve(db, &env, &builder, &path_bound),
+            path_bounds(vec![vec![path_bound.clone()]]).default_solve(
+                db,
+                &env,
+                &builder,
+                &path_bound,
+            ),
             Ok(None)
         );
     }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1232,6 +1232,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
             Type::BoundMethod(bound_method) => {
                 let function = bound_method.function(db);
                 let self_ty = bound_method.self_instance(db);
+                let receiver_ty = bound_method.signature_receiver(db);
                 let bound_signatures = bound_method.bound_signatures(db);
 
                 match bound_signatures.overloads.as_slice() {
@@ -1252,6 +1253,16 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                             settings: self.settings.singleline(),
                         }
                         .fmt_detailed(f)?;
+                        if self_ty != receiver_ty {
+                            f.write_str(" when ")?;
+                            DisplayMaybeParenthesizedType {
+                                ty: receiver_ty,
+                                db,
+                                env: self.env,
+                                settings: self.settings.singleline(),
+                            }
+                            .fmt_detailed(f)?;
+                        }
                         f.write_char('.')?;
                         f.with_type(self.ty).write_str(function.name(db))?;
                         type_parameters.fmt_detailed(f)?;

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1853,14 +1853,16 @@ impl KnownComparisonSemantics {
             (KnownClass::Tuple, Self::Tuple),
             (KnownClass::Dict, Self::Dict),
         ] {
-            if dunder
-                == lookup_dunder(
+            if same_member_implementation(
+                db,
+                dunder,
+                lookup_dunder(
                     db,
                     env,
                     known_class.to_class_literal(db, env),
                     operator.dunder(),
-                )
-            {
+                ),
+            ) {
                 return Some(semantics);
             }
         }
@@ -1900,6 +1902,28 @@ fn has_known_identity_comparison_semantics<'db>(
                 && KnownComparisonSemantics::of_type(db, env, ty, operator)
                     == Some(KnownComparisonSemantics::Object)
         }
+    }
+}
+
+/// Return whether two looked-up members originate from the same implementation.
+fn same_member_implementation(
+    db: &dyn Db,
+    left: PlaceAndQualifiers<'_>,
+    right: PlaceAndQualifiers<'_>,
+) -> bool {
+    if left.qualifiers != right.qualifiers {
+        return false;
+    }
+
+    match (
+        left.ignore_possibly_undefined()
+            .and_then(Type::as_function_literal),
+        right
+            .ignore_possibly_undefined()
+            .and_then(Type::as_function_literal),
+    ) {
+        (Some(left), Some(right)) => left.literal(db) == right.literal(db),
+        _ => left == right,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1665,7 +1665,7 @@ impl<'db> FunctionType<'db> {
         db: &'db dyn Db,
         self_instance: Type<'db>,
     ) -> BoundMethodType<'db> {
-        BoundMethodType::new(db, self, self_instance)
+        BoundMethodType::new(db, self, self_instance, self_instance)
     }
 
     pub(crate) fn find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3054,8 +3054,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     ) -> Option<ConstraintFailure<'db>> {
         let db = self.db;
         let bound_typevar = path_bound.bound_typevar;
-        let argument = path_bound.lower?;
-        let variance = if path_bound.has_upper() {
+        let argument = path_bound.evidence_lower?;
+        let variance = if path_bound.has_upper_evidence() {
             ConstraintFailureVariance::Invariant
         } else {
             ConstraintFailureVariance::Contravariant
@@ -3071,12 +3071,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 bound_typevar,
                 argument,
             }),
-            TypeVarBoundOrConstraints::Constraints(_) => {
-                (!path_bound.has_upper()).then_some(SpecializationError::MismatchedConstraint {
+            TypeVarBoundOrConstraints::Constraints(_) => (!path_bound.has_upper_evidence())
+                .then_some(SpecializationError::MismatchedConstraint {
                     bound_typevar,
                     argument,
-                })
-            }
+                }),
         }?;
         Some(ConstraintFailure { error, variance })
     }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3054,7 +3054,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     ) -> Option<ConstraintFailure<'db>> {
         let db = self.db;
         let bound_typevar = path_bound.bound_typevar;
-        let argument = path_bound.evidence_lower?;
+        let argument = path_bound.inference_lower(db, self.env)?;
         let variance = if path_bound.has_upper_evidence() {
             ConstraintFailureVariance::Invariant
         } else {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -502,9 +502,17 @@ impl<'db> GenericContext<'db> {
         remove_self_inner(db, self, binding_context)
     }
 
-    /// Returns the typevars that are inferable in this generic context. This set might include
-    /// more typevars than the ones directly bound by the generic context. For instance, consider a
-    /// method of a generic class:
+    /// Returns the typevars directly bound by this generic context.
+    pub(crate) fn inferable_typevars(self, db: &'db dyn Db) -> TypeVarSet<'db> {
+        TypeVarSet::from_typevars(db, self.variables(db))
+    }
+
+    /// Returns the typevars directly bound by this generic context and any typevars reachable from
+    /// their declared bounds or constraints.
+    ///
+    /// This is a transitional compatibility scope for callers that have not yet separated
+    /// receiver specialization from ordinary inference. For instance, consider a method of a
+    /// generic class:
     ///
     /// ```py
     /// class C[A]:
@@ -514,7 +522,10 @@ impl<'db> GenericContext<'db> {
     /// In this example, `method`'s generic context binds `Self` and `T`, but its inferable set
     /// also includes `A@C`. This is needed because at each call site, we need to infer the
     /// specialized class instance type whose method is being invoked.
-    pub(crate) fn inferable_typevars(self, db: &'db dyn Db) -> TypeVarSet<'db> {
+    pub(crate) fn inferable_typevars_with_bound_dependencies(
+        self,
+        db: &'db dyn Db,
+    ) -> TypeVarSet<'db> {
         struct CollectTypeVars<'a, 'db> {
             env: &'a ProgramEnvironment<'db>,
             typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,
@@ -2367,6 +2378,7 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     db: &'db dyn Db,
     env: &'c ProgramEnvironment<'db>,
     constraints: &'c ConstraintSetBuilder<'db>,
+    generic_context: GenericContext<'db>,
     inferable: TypeVarSet<'db>,
     pending: ConstraintSet<'db, 'c>,
     types: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>>,
@@ -2552,21 +2564,35 @@ fn relation_directions<T: Copy>(
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
+    /// Creates a builder that infers only the typevars directly owned by `generic_context`.
     pub(crate) fn new(
         db: &'db dyn Db,
         env: &'c ProgramEnvironment<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
-        inferable: TypeVarSet<'db>,
+        generic_context: GenericContext<'db>,
     ) -> Self {
         Self {
             db,
             env,
             constraints,
-            inferable,
+            generic_context,
+            inferable: generic_context.inferable_typevars(db),
             pending: ConstraintSet::from_bool(constraints, true),
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
         }
+    }
+
+    /// Creates a transitional builder that also infers typevars reachable through bounds.
+    pub(crate) fn new_with_bound_dependencies(
+        db: &'db dyn Db,
+        env: &'c ProgramEnvironment<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        generic_context: GenericContext<'db>,
+    ) -> Self {
+        let mut builder = Self::new(db, env, constraints, generic_context);
+        builder.inferable = generic_context.inferable_typevars_with_bound_dependencies(db);
+        builder
     }
 
     /// Adds a constraint set to the pending specialization and projects its valid solutions into
@@ -2590,10 +2616,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// `None` to use the inferred type unchanged.
     pub(crate) fn build_with(
         &mut self,
-        generic_context: GenericContext<'db>,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> Specialization<'db> {
         let db = self.db;
+        let generic_context = self.generic_context;
         let types = self
             .solve_pending_with(generic_context, &mut choose)
             .unwrap_or_else(|()| self.solve_hash_map_with(generic_context, &mut choose));
@@ -2616,11 +2642,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// Returns an error if the call-wide pending constraints are unsatisfiable.
     pub(crate) fn build_inference_with(
         &mut self,
-        generic_context: GenericContext<'db>,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> Result<TypeVarInference<'db>, ()> {
-        let types = self.solve_pending_with(generic_context, &mut choose)?;
-        Ok(self.typevar_inference(generic_context, &types))
+        let types = self.solve_pending_with(self.generic_context, &mut choose)?;
+        Ok(self.typevar_inference(self.generic_context, &types))
     }
 
     /// Build a diagnostic specialization after the call-wide constraints were unsatisfiable.
@@ -2630,7 +2655,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// even when a migrated inference path only populated `pending`.
     pub(crate) fn build_diagnostic_inference_with(
         &mut self,
-        generic_context: GenericContext<'db>,
         argument_relations: impl IntoIterator<Item = (Type<'db>, Type<'db>)>,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> TypeVarInference<'db> {
@@ -2642,8 +2666,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             self.project_for_legacy_fallback(&analysis);
         }
 
-        let types = self.solve_hash_map_with(generic_context, &mut choose);
-        self.typevar_inference(generic_context, &types)
+        let types = self.solve_hash_map_with(self.generic_context, &mut choose);
+        self.typevar_inference(self.generic_context, &types)
     }
 
     fn typevar_inference(
@@ -4249,7 +4273,7 @@ mod tests {
         });
         let context = GenericContext::from_typevar_instances(db, &env, [t]);
 
-        let inferable = context.inferable_typevars(db);
+        let inferable = context.inferable_typevars_with_bound_dependencies(db);
         assert_eq!(inferable.iter(db).collect::<Vec<_>>(), [t, u]);
         assert!(t.is_inferable(db, inferable));
         assert!(u.is_inferable(db, inferable));
@@ -4268,8 +4292,7 @@ mod tests {
         );
         let context = GenericContext::from_typevar_instances(db, &env, [typevar]);
         let constraints = ConstraintSetBuilder::new();
-        let mut builder =
-            SpecializationBuilder::new(db, &env, &constraints, context.inferable_typevars(db));
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
         let int = KnownClass::Int.to_instance(db, &env);
         let set = ConstraintSet::constrain_typevar(db, &env, &constraints, typevar, int, int);
 
@@ -4301,8 +4324,7 @@ mod tests {
         .map_bound_or_constraints(db, |_| Some(TypeVarBoundOrConstraints::UpperBound(int)));
         let context = GenericContext::from_typevar_instances(db, &env, [typevar]);
         let constraints = ConstraintSetBuilder::new();
-        let mut builder =
-            SpecializationBuilder::new(db, &env, &constraints, context.inferable_typevars(db));
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
         let lower_only =
             ConstraintSet::constrain_typevar_lower_bound(db, &env, &constraints, typevar, str);
         let rejected = ConstraintSet::constrain_typevar(db, &env, &constraints, typevar, str, str);

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -12,8 +12,8 @@ use crate::types::callable::walk_callable_type;
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
-    ConstraintBounds, ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, PathBound,
-    PathBounds, Solution, Solutions,
+    ConstraintBound, ConstraintBounds, ConstraintSet, ConstraintSetBuilder,
+    IteratorConstraintsExtension, PathBound, PathBounds, Solution, Solutions,
 };
 use crate::types::infer::original_class_type;
 use crate::types::relation::{
@@ -2979,8 +2979,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         variance: TypeVarVariance,
     ) {
         let bounds = match variance {
-            TypeVarVariance::Covariant => ConstraintBounds::new(Some(ty), None),
-            TypeVarVariance::Contravariant => ConstraintBounds::new(None, Some(ty)),
+            TypeVarVariance::Covariant => ConstraintBounds::new(
+                ConstraintBound::Evidence(ty),
+                ConstraintBound::missing_upper(),
+            ),
+            TypeVarVariance::Contravariant => ConstraintBounds::new(
+                ConstraintBound::missing_lower(),
+                ConstraintBound::Evidence(ty),
+            ),
             TypeVarVariance::Invariant => ConstraintBounds::exact(ty),
             TypeVarVariance::Bivariant => return,
         };

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -25,9 +25,7 @@ use crate::types::tuple::{
     TupleSpec, TupleSpecBuilder, TupleType, VariableSegment, walk_tuple_type,
 };
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
-use crate::types::typevar::{
-    BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, TypeVarSet, walk_type_var_bounds,
-};
+use crate::types::typevar::{BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, TypeVarSet};
 use crate::types::visitor::{
     TypeCollector, TypeVisitor, any_over_type, walk_type_with_recursion_guard,
 };
@@ -505,86 +503,6 @@ impl<'db> GenericContext<'db> {
     /// Returns the typevars directly bound by this generic context.
     pub(crate) fn inferable_typevars(self, db: &'db dyn Db) -> TypeVarSet<'db> {
         TypeVarSet::from_typevars(db, self.variables(db))
-    }
-
-    /// Returns the typevars directly bound by this generic context and any typevars reachable from
-    /// their declared bounds or constraints.
-    ///
-    /// This is a transitional compatibility scope for callers that have not yet separated
-    /// receiver specialization from ordinary inference. For instance, consider a method of a
-    /// generic class:
-    ///
-    /// ```py
-    /// class C[A]:
-    ///     def method[T](self, t: T):
-    /// ```
-    ///
-    /// In this example, `method`'s generic context binds `Self` and `T`, but its inferable set
-    /// also includes `A@C`. This is needed because at each call site, we need to infer the
-    /// specialized class instance type whose method is being invoked.
-    pub(crate) fn inferable_typevars_with_bound_dependencies(
-        self,
-        db: &'db dyn Db,
-    ) -> TypeVarSet<'db> {
-        struct CollectTypeVars<'a, 'db> {
-            env: &'a ProgramEnvironment<'db>,
-            typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,
-            recursion_guard: TypeCollector<'db>,
-        }
-
-        impl<'db> TypeVisitor<'db> for CollectTypeVars<'_, 'db> {
-            fn program_environment(&self) -> &ProgramEnvironment<'db> {
-                self.env
-            }
-
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
-            }
-
-            fn visit_bound_type_var_type(
-                &self,
-                db: &'db dyn Db,
-                bound_typevar: BoundTypeVarInstance<'db>,
-            ) {
-                self.typevars
-                    .borrow_mut()
-                    .entry(bound_typevar.identity(db))
-                    .or_insert(bound_typevar);
-                let typevar = bound_typevar.typevar(db);
-                if let Some(bound_or_constraints) =
-                    typevar.bound_or_constraints(db, self.program_environment())
-                {
-                    walk_type_var_bounds(db, bound_or_constraints, self);
-                }
-            }
-
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
-            }
-        }
-
-        #[salsa::tracked(
-            returns(copy),
-            cycle_initial=|_, _, _| TypeVarSet::None,
-            heap_size=ruff_memory_usage::heap_size,
-        )]
-        fn inferable_typevars_inner<'db>(
-            db: &'db dyn Db,
-            generic_context: GenericContext<'db>,
-        ) -> TypeVarSet<'db> {
-            let env = ProgramEnvironment::from_program(generic_context.program(db));
-            let visitor = CollectTypeVars {
-                env: &env,
-                typevars: RefCell::default(),
-                recursion_guard: TypeCollector::default(),
-            };
-            for bound_typevar in generic_context.variables(db) {
-                visitor.visit_bound_type_var_type(db, bound_typevar);
-            }
-            TypeVarSet::from_typevars(db, visitor.typevars.into_inner().into_values())
-        }
-
-        inferable_typevars_inner(db, self)
     }
 
     pub(crate) fn variables(
@@ -2583,15 +2501,16 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
-    /// Creates a transitional builder that also infers typevars reachable through bounds.
-    pub(crate) fn new_with_bound_dependencies(
+    /// Creates a context-owned builder that can also solve explicit receiver dependencies.
+    pub(crate) fn new_with_receiver_typevars(
         db: &'db dyn Db,
         env: &'c ProgramEnvironment<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         generic_context: GenericContext<'db>,
+        receiver_typevars: TypeVarSet<'db>,
     ) -> Self {
         let mut builder = Self::new(db, env, constraints, generic_context);
-        builder.inferable = generic_context.inferable_typevars_with_bound_dependencies(db);
+        builder.inferable = builder.inferable.merge(db, receiver_typevars);
         builder
     }
 
@@ -4250,34 +4169,6 @@ mod tests {
     use ruff_python_ast::name::Name;
 
     use crate::db::tests::setup_db;
-
-    #[test]
-    fn generic_context_inferable_typevars_retain_instances_from_bounds() {
-        let db = setup_db();
-        let db = &db;
-        let env = db.program_environment();
-        let u = BoundTypeVarInstance::synthetic(
-            db,
-            &env,
-            Name::new_static("U"),
-            TypeVarVariance::Invariant,
-        );
-        let t = BoundTypeVarInstance::synthetic(
-            db,
-            &env,
-            Name::new_static("T"),
-            TypeVarVariance::Invariant,
-        )
-        .map_bound_or_constraints(db, |_| {
-            Some(TypeVarBoundOrConstraints::UpperBound(Type::TypeVar(u)))
-        });
-        let context = GenericContext::from_typevar_instances(db, &env, [t]);
-
-        let inferable = context.inferable_typevars_with_bound_dependencies(db);
-        assert_eq!(inferable.iter(db).collect::<Vec<_>>(), [t, u]);
-        assert!(t.is_inferable(db, inferable));
-        assert!(u.is_inferable(db, inferable));
-    }
 
     #[test]
     fn recording_constraints_does_not_project_legacy_mappings() {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2642,7 +2642,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // was not enough: `solutions_with` still performed the expensive path traversal, and the
         // skipped projection changed precision in LiteralString tests. See the
         // `ty_micro[pydantic_core_schema_dict]` benchmark for a minimized reproducer.
-        let solutions = match self.pending.solutions_with(
+        let solutions = match self.pending.pruned_solutions_with(
             db,
             self.env,
             self.constraints,
@@ -2997,7 +2997,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     fn analyze_constraint_set(&self, set: ConstraintSet<'db, 'c>) -> ConstraintSetAnalysis<'db> {
         let db = self.db;
         let mut failures = SmallVec::new();
-        let solutions = set.solutions_with(
+        let solutions = set.pruned_solutions_with(
             db,
             self.env,
             self.constraints,
@@ -3015,7 +3015,21 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         );
 
         match solutions {
-            Solutions::Unsatisfiable => ConstraintSetAnalysis::Unsatisfiable(failures),
+            Solutions::Unsatisfiable => {
+                if failures.is_empty()
+                    && let PathBounds::Constrained(paths) = set.unconjoined_path_bounds(
+                        db,
+                        self.env,
+                        self.constraints,
+                        self.inferable,
+                    )
+                {
+                    failures.extend(paths.iter().flatten().filter_map(|path_bound| {
+                        self.constraint_failure_from_failed_bounds(path_bound)
+                    }));
+                }
+                ConstraintSetAnalysis::Unsatisfiable(failures)
+            }
             Solutions::Unconstrained => ConstraintSetAnalysis::Unconstrained,
             Solutions::Constrained(solutions) => ConstraintSetAnalysis::Constrained(solutions),
         }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2183,6 +2183,9 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub enum ApplySpecialization<'a, 'db> {
     Specialization(Specialization<'db>),
+    /// Assignments from a specialization that also apply to the declared domains of retained
+    /// synthetic `Self` variables.
+    SpecializationWithSelfDomain(Specialization<'db>),
     TypeAlias(Specialization<'db>),
     Partial {
         generic_context: GenericContext<'db>,
@@ -2207,6 +2210,7 @@ impl<'db> ApplySpecialization<'_, 'db> {
     ) -> Option<Type<'db>> {
         match self {
             ApplySpecialization::Specialization(specialization)
+            | ApplySpecialization::SpecializationWithSelfDomain(specialization)
             | ApplySpecialization::TypeAlias(specialization) => {
                 specialization.get(db, bound_typevar)
             }
@@ -2241,6 +2245,7 @@ impl<'db> ApplySpecialization<'_, 'db> {
     pub(crate) fn as_specialization(self, db: &'db dyn Db) -> Option<Specialization<'db>> {
         match self {
             ApplySpecialization::Specialization(specialization)
+            | ApplySpecialization::SpecializationWithSelfDomain(specialization)
             | ApplySpecialization::TypeAlias(specialization) => Some(specialization),
             ApplySpecialization::Partial {
                 generic_context,
@@ -2499,19 +2504,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
         }
-    }
-
-    /// Creates a context-owned builder that can also solve explicit receiver dependencies.
-    pub(crate) fn new_with_receiver_typevars(
-        db: &'db dyn Db,
-        env: &'c ProgramEnvironment<'db>,
-        constraints: &'c ConstraintSetBuilder<'db>,
-        generic_context: GenericContext<'db>,
-        receiver_typevars: TypeVarSet<'db>,
-    ) -> Self {
-        let mut builder = Self::new(db, env, constraints, generic_context);
-        builder.inferable = builder.inferable.merge(db, receiver_typevars);
-        builder
     }
 
     /// Adds a constraint set to the pending specialization and projects its valid solutions into

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2213,6 +2213,16 @@ impl<'db> ApplySpecialization<'_, 'db> {
         }
     }
 
+    pub(crate) fn specialize_self_domain(self) -> bool {
+        match self {
+            Self::Specialization {
+                specialize_self_domain,
+                ..
+            } => specialize_self_domain,
+            _ => false,
+        }
+    }
+
     /// Returns the type that a typevar is mapped to, or None if the typevar isn't part of this
     /// mapping.
     pub(crate) fn get(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2487,7 +2487,6 @@ fn relation_directions<T: Copy>(
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
-    /// Creates a builder that infers only the typevars directly owned by `generic_context`.
     pub(crate) fn new(
         db: &'db dyn Db,
         env: &'c ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1342,7 +1342,7 @@ impl<'db> Specialization<'db> {
         let new_specialization = self.apply_type_mapping(
             db,
             env,
-            &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(other)),
+            &TypeMapping::ApplySpecialization(ApplySpecialization::specialization(other)),
         );
         match other.materialization_kind(db) {
             None => new_specialization,
@@ -2182,10 +2182,15 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 /// substitute types for type variables before we have fully constructed a [`Specialization`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub enum ApplySpecialization<'a, 'db> {
-    Specialization(Specialization<'db>),
-    /// Assignments from a specialization that also apply to the declared domains of retained
-    /// synthetic `Self` variables.
-    SpecializationWithSelfDomain(Specialization<'db>),
+    Specialization {
+        specialization: Specialization<'db>,
+        /// Whether to substitute free owner variables in the declared domain of a retained
+        /// synthetic `Self`.
+        ///
+        /// This is only set when projecting a member from its enclosing generic owner. Ordinary
+        /// specialization preserves that domain as fixed evidence.
+        specialize_self_domain: bool,
+    },
     TypeAlias(Specialization<'db>),
     Partial {
         generic_context: GenericContext<'db>,
@@ -2201,6 +2206,13 @@ pub enum ApplySpecialization<'a, 'db> {
 }
 
 impl<'db> ApplySpecialization<'_, 'db> {
+    pub(crate) fn specialization(specialization: Specialization<'db>) -> Self {
+        Self::Specialization {
+            specialization,
+            specialize_self_domain: false,
+        }
+    }
+
     /// Returns the type that a typevar is mapped to, or None if the typevar isn't part of this
     /// mapping.
     pub(crate) fn get(
@@ -2209,8 +2221,7 @@ impl<'db> ApplySpecialization<'_, 'db> {
         bound_typevar: BoundTypeVarInstance<'db>,
     ) -> Option<Type<'db>> {
         match self {
-            ApplySpecialization::Specialization(specialization)
-            | ApplySpecialization::SpecializationWithSelfDomain(specialization)
+            ApplySpecialization::Specialization { specialization, .. }
             | ApplySpecialization::TypeAlias(specialization) => {
                 specialization.get(db, bound_typevar)
             }
@@ -2244,8 +2255,7 @@ impl<'db> ApplySpecialization<'_, 'db> {
     /// context, preserving skipped type variables in partial specializations as identity mappings.
     pub(crate) fn as_specialization(self, db: &'db dyn Db) -> Option<Specialization<'db>> {
         match self {
-            ApplySpecialization::Specialization(specialization)
-            | ApplySpecialization::SpecializationWithSelfDomain(specialization)
+            ApplySpecialization::Specialization { specialization, .. }
             | ApplySpecialization::TypeAlias(specialization) => Some(specialization),
             ApplySpecialization::Partial {
                 generic_context,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2537,8 +2537,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// Build a specialization, using a caller-provided hook to select the solution for each
     /// typevar.
     ///
-    /// The `choose` hook is called for each typevar on the generic context with the typevar's
-    /// explicit lower and upper bounds.
+    /// The `choose` hook is called for each typevar on the generic context with the complete path
+    /// family and the typevar's explicit lower and upper bounds.
     /// Unmapped typevars receive `None` for their bounds and fall back to their default
     /// specialization if an alternative default type is not chosen.
     ///
@@ -2546,7 +2546,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// `None` to use the inferred type unchanged.
     pub(crate) fn build_with(
         &mut self,
-        mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
+        mut choose: impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<(&PathBounds<'db>, &PathBound<'db>)>,
+        ) -> Option<Type<'db>>,
     ) -> Specialization<'db> {
         let db = self.db;
         let generic_context = self.generic_context;
@@ -2572,10 +2575,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// Returns an error if the call-wide pending constraints are unsatisfiable.
     pub(crate) fn build_inference_with(
         &mut self,
-        mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
+        mut choose: impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<(&PathBounds<'db>, &PathBound<'db>)>,
+        ) -> Option<Type<'db>>,
     ) -> Result<TypeVarInference<'db>, ()> {
-        let types = self.solve_pending_with(self.generic_context, &mut choose)?;
-        Ok(self.typevar_inference(self.generic_context, &types))
+        let generic_context = self.generic_context;
+        let types = self.solve_pending_with(generic_context, &mut choose)?;
+        Ok(self.typevar_inference(generic_context, &types))
     }
 
     /// Build a diagnostic specialization after the call-wide constraints were unsatisfiable.
@@ -2586,7 +2593,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     pub(crate) fn build_diagnostic_inference_with(
         &mut self,
         argument_relations: impl IntoIterator<Item = (Type<'db>, Type<'db>)>,
-        mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
+        mut choose: impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<(&PathBounds<'db>, &PathBound<'db>)>,
+        ) -> Option<Type<'db>>,
     ) -> TypeVarInference<'db> {
         let db = self.db;
         for (formal, actual) in argument_relations {
@@ -2596,8 +2606,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             self.project_for_legacy_fallback(&analysis);
         }
 
-        let types = self.solve_hash_map_with(self.generic_context, &mut choose);
-        self.typevar_inference(self.generic_context, &types)
+        let generic_context = self.generic_context;
+        let types = self.solve_hash_map_with(generic_context, &mut choose);
+        self.typevar_inference(generic_context, &types)
     }
 
     fn typevar_inference(
@@ -2618,7 +2629,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     fn solve_pending_with(
         &mut self,
         generic_context: GenericContext<'db>,
-        choose: &mut impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
+        choose: &mut impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<(&PathBounds<'db>, &PathBound<'db>)>,
+        ) -> Option<Type<'db>>,
     ) -> Result<FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>, ()> {
         let db = self.db;
         // TODO: Move `ParamSpec` and `TypeVarTuple` handling to the new constraint solver.
@@ -2642,20 +2656,18 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // was not enough: `solutions_with` still performed the expensive path traversal, and the
         // skipped projection changed precision in LiteralString tests. See the
         // `ty_micro[pydantic_core_schema_dict]` benchmark for a minimized reproducer.
-        let solutions = match self.pending.pruned_solutions_with(
-            db,
-            self.env,
-            self.constraints,
-            self.inferable,
-            |_variance, path_bound| {
-                let typevar = path_bound.bound_typevar;
-                if let Some(ty) = choose(typevar, Some(path_bound)) {
-                    return Ok(Some(ty));
-                }
+        let mut path_bounds =
+            self.pending
+                .path_bounds(db, self.env, self.constraints, self.inferable);
+        path_bounds.prune_subsumed(db, self.env);
+        let solutions = match path_bounds.solve_with(|path_bounds, _variance, path_bound| {
+            let typevar = path_bound.bound_typevar;
+            if let Some(ty) = choose(typevar, Some((path_bounds, path_bound))) {
+                return Ok(Some(ty));
+            }
 
-                PathBounds::default_solve(db, self.env, self.constraints, path_bound)
-            },
-        ) {
+            path_bounds.default_solve(db, self.env, self.constraints, path_bound)
+        }) {
             Solutions::Unsatisfiable => return Err(()),
             Solutions::Unconstrained => {
                 return Ok(self.solve_hash_map_with(generic_context, choose));
@@ -2845,7 +2857,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     fn solve_hash_map_with(
         &mut self,
         generic_context: GenericContext<'db>,
-        choose: &mut impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
+        choose: &mut impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<(&PathBounds<'db>, &PathBound<'db>)>,
+        ) -> Option<Type<'db>>,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
         let db = self.db;
         generic_context
@@ -2859,7 +2874,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 let chosen = match mapped_ty {
                     Some(mapped_ty) => {
                         let path_bound = PathBound::exact(*variable, mapped_ty);
-                        choose(*variable, Some(&path_bound)).unwrap_or(mapped_ty)
+                        let path_bounds = PathBounds::from_legacy_path_bound(path_bound.clone());
+                        choose(*variable, Some((&path_bounds, &path_bound))).unwrap_or(mapped_ty)
                     }
                     None => choose(*variable, None)?,
                 };
@@ -2997,32 +3013,24 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     fn analyze_constraint_set(&self, set: ConstraintSet<'db, 'c>) -> ConstraintSetAnalysis<'db> {
         let db = self.db;
         let mut failures = SmallVec::new();
-        let solutions = set.pruned_solutions_with(
-            db,
-            self.env,
-            self.constraints,
-            self.inferable,
-            |_variance, path_bound| {
-                let solution =
-                    PathBounds::preliminary_solve(db, self.env, self.constraints, path_bound);
-                if solution.is_err()
-                    && let Some(failure) = self.constraint_failure_from_failed_bounds(path_bound)
-                {
-                    failures.push(failure);
-                }
-                solution
-            },
-        );
+        let mut path_bounds = set.path_bounds(db, self.env, self.constraints, self.inferable);
+        path_bounds.prune_subsumed(db, self.env);
+        let solutions = path_bounds.solve_with(|_path_bounds, _variance, path_bound| {
+            let solution =
+                PathBounds::preliminary_solve(db, self.env, self.constraints, path_bound);
+            if solution.is_err()
+                && let Some(failure) = self.constraint_failure_from_failed_bounds(path_bound)
+            {
+                failures.push(failure);
+            }
+            solution
+        });
 
         match solutions {
             Solutions::Unsatisfiable => {
                 if failures.is_empty()
-                    && let PathBounds::Constrained(paths) = set.unconjoined_path_bounds(
-                        db,
-                        self.env,
-                        self.constraints,
-                        self.inferable,
-                    )
+                    && let PathBounds::Constrained { paths, .. } =
+                        set.unconjoined_path_bounds(db, self.env, self.constraints, self.inferable)
                 {
                     failures.extend(paths.iter().flatten().filter_map(|path_bound| {
                         self.constraint_failure_from_failed_bounds(path_bound)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7363,7 +7363,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 let path_bounds =
                     identity_instance.assignable_solutions_with_inferable(db, env, tcx, inferable);
-                let solutions = path_bounds.solve_with(|variance, path_bound| {
+                let solutions = path_bounds.solve_with(|_path_bounds, variance, path_bound| {
                     let identity = path_bound.bound_typevar.identity(db);
                     elt_tcx_variance
                         .entry(identity)
@@ -7720,8 +7720,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class_type = collection_alias
             .origin(self.db())
             .apply_specialization(db, |_| {
-                builder.build_with(|current_typevar, bounds| {
-                    let lower = bounds?.evidence_lower?;
+                builder.build_with(|current_typevar, context| {
+                    let (_, bounds) = context?;
+                    let lower = bounds.evidence_lower?;
 
                     let lower = if is_empty_collection_type_context(tcx) {
                         // Constraints learned from later collection uses follow the same promotion

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6540,7 +6540,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
             CallableType::new(db, signatures, callable.kind(db), callable.provenance(db))
         });
-        let inferable = class_generic_context.inferable_typevars_with_bound_dependencies(db);
+        let inferable = class_generic_context.inferable_typevars(db);
         let constraints = ConstraintSetBuilder::new();
         let path_bounds = source_callable
             .into_type(db, env)
@@ -6857,9 +6857,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let inferable = KnownClass::Tuple
                 .try_to_class_literal(db, env)
                 .and_then(|class| class.generic_context(db))
-                .map(|generic_context| {
-                    generic_context.inferable_typevars_with_bound_dependencies(db)
-                })
+                .map(|generic_context| generic_context.inferable_typevars(db))
                 .unwrap_or(TypeVarSet::None);
             annotation.filter_disjoint_elements(
                 db,
@@ -7301,14 +7299,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let constraints = ConstraintSetBuilder::new();
-        let inferable = generic_context.inferable_typevars_with_bound_dependencies(db);
+        let inferable = generic_context.inferable_typevars(db);
         let identity_instance = Type::instance(db, env, ClassType::Generic(collection_alias));
-        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
-            db,
-            env,
-            &constraints,
-            generic_context,
-        );
+        let mut builder = SpecializationBuilder::new(db, env, &constraints, generic_context);
 
         // Remove any union elements of that are unrelated to the collection type.
         //
@@ -7812,7 +7805,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db,
             env,
             annotation,
-            generic_context.inferable_typevars_with_bound_dependencies(db),
+            generic_context.inferable_typevars(db),
         );
         let constraints = ConstraintSetBuilder::new();
         let Solutions::Constrained(solutions) = path_bounds.solve(db, env, &constraints) else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5532,11 +5532,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .signature
                     .generic_context
                     .map(|generic_context| generic_context.inferable_typevars(db))
-                    .unwrap_or(TypeVarSet::None)
-                    .merge(
-                        db,
-                        overload.signature.receiver_specialization_typevars(db, env),
-                    );
+                    .unwrap_or(TypeVarSet::None);
 
                 !overload
                     .return_ty

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7721,7 +7721,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .origin(self.db())
             .apply_specialization(db, |_| {
                 builder.build_with(|current_typevar, bounds| {
-                    let lower = bounds?.lower?;
+                    let lower = bounds?.evidence_lower?;
 
                     let lower = if is_empty_collection_type_context(tcx) {
                         // Constraints learned from later collection uses follow the same promotion

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5531,7 +5531,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let inferable = overload
                     .signature
                     .generic_context
-                    .map(|generic_context| generic_context.inferable_typevars(db))
+                    .map(|generic_context| {
+                        generic_context.inferable_typevars_with_bound_dependencies(db)
+                    })
                     .unwrap_or(TypeVarSet::None);
 
                 !overload
@@ -6538,7 +6540,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
             CallableType::new(db, signatures, callable.kind(db), callable.provenance(db))
         });
-        let inferable = class_generic_context.inferable_typevars(db);
+        let inferable = class_generic_context.inferable_typevars_with_bound_dependencies(db);
         let constraints = ConstraintSetBuilder::new();
         let path_bounds = source_callable
             .into_type(db, env)
@@ -6855,7 +6857,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let inferable = KnownClass::Tuple
                 .try_to_class_literal(db, env)
                 .and_then(|class| class.generic_context(db))
-                .map(|generic_context| generic_context.inferable_typevars(db))
+                .map(|generic_context| {
+                    generic_context.inferable_typevars_with_bound_dependencies(db)
+                })
                 .unwrap_or(TypeVarSet::None);
             annotation.filter_disjoint_elements(
                 db,
@@ -7297,9 +7301,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let constraints = ConstraintSetBuilder::new();
-        let inferable = generic_context.inferable_typevars(db);
+        let inferable = generic_context.inferable_typevars_with_bound_dependencies(db);
         let identity_instance = Type::instance(db, env, ClassType::Generic(collection_alias));
-        let mut builder = SpecializationBuilder::new(db, env, &constraints, inferable);
+        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+            db,
+            env,
+            &constraints,
+            generic_context,
+        );
 
         // Remove any union elements of that are unrelated to the collection type.
         //
@@ -7720,7 +7729,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class_type = collection_alias
             .origin(self.db())
             .apply_specialization(db, |_| {
-                builder.build_with(generic_context, |current_typevar, bounds| {
+                builder.build_with(|current_typevar, bounds| {
                     let lower = bounds?.lower?;
 
                     let lower = if is_empty_collection_type_context(tcx) {
@@ -7803,7 +7812,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db,
             env,
             annotation,
-            generic_context.inferable_typevars(db),
+            generic_context.inferable_typevars_with_bound_dependencies(db),
         );
         let constraints = ConstraintSetBuilder::new();
         let Solutions::Constrained(solutions) = path_bounds.solve(db, env, &constraints) else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5531,10 +5531,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let inferable = overload
                     .signature
                     .generic_context
-                    .map(|generic_context| {
-                        generic_context.inferable_typevars_with_bound_dependencies(db)
-                    })
-                    .unwrap_or(TypeVarSet::None);
+                    .map(|generic_context| generic_context.inferable_typevars(db))
+                    .unwrap_or(TypeVarSet::None)
+                    .merge(
+                        db,
+                        overload.signature.receiver_specialization_typevars(db, env),
+                    );
 
                 !overload
                     .return_ty

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -86,7 +86,7 @@ impl<'db> BoundMethodType<'db> {
         )
     }
 
-    pub(crate) fn with_distributed_receiver(
+    pub(crate) fn with_signature_receiver(
         self,
         db: &'db dyn Db,
         self_instance: Type<'db>,

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -31,6 +31,15 @@ pub struct BoundMethodType<'db> {
     /// attribute on a bound method object
     #[returns(copy)]
     pub(super) self_instance: Type<'db>,
+
+    /// The receiver type used to validate and specialize the function signature.
+    ///
+    /// This normally equals [`self_instance`][Self::self_instance]. They differ when member lookup
+    /// distributes over the declared constraints of a typevar: This field contains the particular
+    /// declared constraint that this bound method belongs to, while `self_instance` is the typevar
+    /// itself.
+    #[returns(copy)]
+    pub(super) signature_receiver: Type<'db>,
 }
 
 // The Salsa heap is tracked separately.
@@ -43,6 +52,7 @@ pub(super) fn walk_bound_method_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>
 ) {
     visitor.visit_function_type(db, method.function(db));
     visitor.visit_type(db, method.self_instance(db));
+    visitor.visit_type(db, method.signature_receiver(db));
 }
 
 #[salsa::tracked]
@@ -66,9 +76,23 @@ impl<'db> BoundMethodType<'db> {
     pub(crate) fn map_self_type(
         self,
         db: &'db dyn Db,
-        f: impl FnOnce(Type<'db>) -> Type<'db>,
+        mut f: impl FnMut(Type<'db>) -> Type<'db>,
     ) -> Self {
-        Self::new(db, self.function(db), f(self.self_instance(db)))
+        Self::new(
+            db,
+            self.function(db),
+            f(self.self_instance(db)),
+            f(self.signature_receiver(db)),
+        )
+    }
+
+    pub(crate) fn with_distributed_receiver(
+        self,
+        db: &'db dyn Db,
+        self_instance: Type<'db>,
+        signature_receiver: Type<'db>,
+    ) -> Self {
+        Self::new(db, self.function(db), self_instance, signature_receiver)
     }
 
     #[salsa::tracked(
@@ -114,7 +138,7 @@ impl<'db> BoundMethodType<'db> {
         let env =
             ProgramEnvironment::from_scope(function.literal(db).last_definition.body_scope(db));
         let typing_self_type = self.typing_self_type(db);
-        let receiver_type = self.self_instance(db);
+        let receiver_type = self.signature_receiver(db);
 
         self.bound_signatures_with_receiver(db, &env, receiver_type, typing_self_type)
     }
@@ -179,6 +203,8 @@ impl<'db> BoundMethodType<'db> {
             self.function(db)
                 .recursive_type_normalized_impl(db, env, div, nested)?,
             self.self_instance(db)
+                .recursive_type_normalized_impl(db, env, div, true)?,
+            self.signature_receiver(db)
                 .recursive_type_normalized_impl(db, env, div, true)?,
         ))
     }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -871,7 +871,7 @@ fn specialize_narrowing_target_from_intersection<'db>(
         db,
         env,
         &constraints,
-        generic_context.inferable_typevars_with_bound_dependencies(db),
+        generic_context.inferable_typevars(db),
     );
     let specialized_class =
         specialize_generic_class_from_solutions(db, env, target_class, solutions)?;
@@ -986,7 +986,7 @@ fn specialize_generic_class_for_subject<'db>(
             db,
             env,
             Type::instance(db, env, target),
-            generic_context.inferable_typevars_with_bound_dependencies(db),
+            generic_context.inferable_typevars(db),
         )
         .solve(db, env, &constraints);
 
@@ -2368,7 +2368,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 db,
                 &self.env,
                 Type::instance(db, &self.env, subject_class),
-                generic_context.inferable_typevars_with_bound_dependencies(db),
+                generic_context.inferable_typevars(db),
             )
             .solve_with(|variance, path_bound| {
                 let Some(lower) = path_bound.lower else {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2371,7 +2371,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 generic_context.inferable_typevars(db),
             )
             .solve_with(|variance, path_bound| {
-                let Some(lower) = path_bound.evidence_lower else {
+                let Some(lower) = path_bound.inference_lower(db, &self.env) else {
                     return Ok(None);
                 };
                 if variance != TypeVarVariance::Invariant

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -871,7 +871,7 @@ fn specialize_narrowing_target_from_intersection<'db>(
         db,
         env,
         &constraints,
-        generic_context.inferable_typevars(db),
+        generic_context.inferable_typevars_with_bound_dependencies(db),
     );
     let specialized_class =
         specialize_generic_class_from_solutions(db, env, target_class, solutions)?;
@@ -986,7 +986,7 @@ fn specialize_generic_class_for_subject<'db>(
             db,
             env,
             Type::instance(db, env, target),
-            generic_context.inferable_typevars(db),
+            generic_context.inferable_typevars_with_bound_dependencies(db),
         )
         .solve(db, env, &constraints);
 
@@ -2368,7 +2368,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 db,
                 &self.env,
                 Type::instance(db, &self.env, subject_class),
-                generic_context.inferable_typevars(db),
+                generic_context.inferable_typevars_with_bound_dependencies(db),
             )
             .solve_with(|variance, path_bound| {
                 let Some(lower) = path_bound.lower else {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2371,7 +2371,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 generic_context.inferable_typevars(db),
             )
             .solve_with(|variance, path_bound| {
-                let Some(lower) = path_bound.lower else {
+                let Some(lower) = path_bound.evidence_lower else {
                     return Ok(None);
                 };
                 if variance != TypeVarVariance::Invariant

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -36,7 +36,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 
 use super::UnionType;
 use super::call::CallArguments;
-use super::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
+use super::constraints::{ConstraintSetBuilder, Solutions};
 use super::equality::{
     ComparisonSoundnessPolicy, equality_exclusion_constraint, equality_truthiness,
     evaluate_type_equality, evaluate_type_inequality,
@@ -2370,7 +2370,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 Type::instance(db, &self.env, subject_class),
                 generic_context.inferable_typevars(db),
             )
-            .solve_with(|variance, path_bound| {
+            .solve_with(|path_bounds, variance, path_bound| {
                 let Some(lower) = path_bound.inference_lower(db, &self.env) else {
                     return Ok(None);
                 };
@@ -2379,7 +2379,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 {
                     return Ok(None);
                 }
-                PathBounds::default_solve(db, &self.env, &constraints, path_bound)
+                path_bounds.default_solve(db, &self.env, &constraints, path_bound)
             });
         let Solutions::Constrained(solutions) = solutions else {
             return None;

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -218,10 +218,12 @@ fn create_bound_method<'db>(
     builtins_class: Type<'db>,
 ) -> Type<'db> {
     let env = ProgramEnvironment::from_program(program);
+    let self_instance = builtins_class.to_instance_approximation(db, &env).unwrap();
     Type::BoundMethod(BoundMethodType::new(
         db,
         function.expect_function_literal(),
-        builtins_class.to_instance_approximation(db, &env).unwrap(),
+        self_instance,
+        self_instance,
     ))
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1295,7 +1295,8 @@ impl<'db> Signature<'db> {
 
         let constraints = ConstraintSetBuilder::new();
         let when = constraints.load(db, env, receiver_constraints);
-        let inferable = self.inferable_typevars_with_bound_dependencies(db);
+        let receiver_typevars = self.receiver_specialization_typevars(db, env);
+        let inferable = self.inferable_typevars(db).merge(db, receiver_typevars);
 
         match when.solutions(db, env, &constraints, inferable) {
             Solutions::Unsatisfiable => return None,
@@ -1312,11 +1313,12 @@ impl<'db> Signature<'db> {
             return Some(self.clone());
         };
 
-        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+        let mut builder = SpecializationBuilder::new_with_receiver_typevars(
             db,
             env,
             &constraints,
             generic_context,
+            receiver_typevars,
         );
         builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
@@ -1436,7 +1438,8 @@ impl<'db> Signature<'db> {
                 env,
                 expected_self_ty,
                 &constraints,
-                self.inferable_typevars_with_bound_dependencies(db),
+                self.inferable_typevars(db)
+                    .merge(db, self.receiver_specialization_typevars(db, env)),
             )
             .is_always_satisfied(db, env)
     }
@@ -1784,11 +1787,42 @@ impl<'db> Signature<'db> {
                 .any(|(_, parameter)| parameter.annotated_type().contains_self(db, env))
     }
 
-    fn inferable_typevars_with_bound_dependencies(&self, db: &'db dyn Db) -> TypeVarSet<'db> {
+    fn inferable_typevars(&self, db: &'db dyn Db) -> TypeVarSet<'db> {
         match self.generic_context {
-            Some(generic_context) => generic_context.inferable_typevars_with_bound_dependencies(db),
+            Some(generic_context) => generic_context.inferable_typevars(db),
             None => TypeVarSet::None,
         }
+    }
+
+    /// Returns unspecialized class typevars that a synthetic `Self` receiver can determine.
+    pub(crate) fn receiver_specialization_typevars(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> TypeVarSet<'db> {
+        let mut dependencies = Vec::new();
+        for self_typevar in self
+            .generic_context
+            .into_iter()
+            .flat_map(|context| context.variables(db))
+            .filter(|typevar| typevar.typevar(db).is_self(db))
+        {
+            let Some(bound) = self_typevar.typevar(db).upper_bound(db, env) else {
+                continue;
+            };
+            let Some((_, specialization)) = bound.class_specialization(db, env) else {
+                continue;
+            };
+
+            let owner_context = specialization.generic_context(db);
+            dependencies.extend(
+                TypeVarSet::from_typevar_occurrences(db, env, [bound])
+                    .iter(db)
+                    .filter(|typevar| owner_context.contains(db, typevar.identity(db))),
+            );
+        }
+
+        TypeVarSet::from_typevars(db, dependencies)
     }
 
     pub(crate) fn is_non_generic(&self) -> bool {
@@ -2364,34 +2398,26 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
 
-        // `inferable` has different roles in the two type-variable evaluation modes:
-        //
-        // * Eager comparisons decide whether the relation holds immediately. An unbound generic
-        //   method's `Self` can have an upper bound such as `C[T]`, so `T` must also be
-        //   inferable; otherwise, a concrete receiver such as `C[int]` is compared against a
-        //   fixed, symbolic `T` and valid higher-order calls are rejected.
-        // * Lazy comparisons record constraints for every type variable, regardless of whether
-        //   it is inferable. Here, `signature_inferable` also determines which type variables
-        //   `reduce_inferable` existentially removes below, so it must contain only variables
-        //   actually bound by these signatures. Including an enclosing class's `T` would turn a
-        //   decorator's return constraint `T <= R` into `exists T. T <= R`, losing the
-        //   relationship needed to infer `R = T`.
-        let include_bound_dependencies = self.typevar_evaluation == TypeVarEvaluation::Eager;
         let signature_typevars = |signature: &Signature<'db>| {
             signature
                 .generic_context
-                .map_or(TypeVarSet::None, |context| {
-                    if include_bound_dependencies {
-                        context.inferable_typevars_with_bound_dependencies(db)
-                    } else {
-                        context.inferable_typevars(db)
-                    }
-                })
+                .map_or(TypeVarSet::None, |context| context.inferable_typevars(db))
         };
-        let source_inferable = signature_typevars(source);
-        let target_inferable = signature_typevars(target);
-        let signature_inferable = source_inferable.merge(db, target_inferable);
-        let inferable = self.inferable.merge(db, signature_inferable);
+        let signature_typevars = signature_typevars(source).merge(db, signature_typevars(target));
+
+        // An eager relation against an unbound method also specializes identity-mapped class
+        // typevars through synthetic `Self`. These are explicit receiver dependencies, not
+        // arbitrary typevars discovered by recursively walking declared domains. Lazy relations
+        // leave them fixed so enclosing class occurrences remain visible to the caller.
+        let receiver_typevars = if self.typevar_evaluation == TypeVarEvaluation::Eager {
+            source
+                .receiver_specialization_typevars(db, env)
+                .merge(db, target.receiver_specialization_typevars(db, env))
+        } else {
+            TypeVarSet::None
+        };
+        let relation_typevars = signature_typevars.merge(db, receiver_typevars);
+        let inferable = self.inferable.merge(db, relation_typevars);
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
@@ -2417,7 +2443,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
-        when.reduce_inferable(db, env, self.constraints, signature_inferable)
+        when.reduce_inferable(db, env, self.constraints, relation_typevars)
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2365,10 +2365,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .generic_context
                 .map_or(TypeVarSet::None, |context| context.inferable_typevars(db))
         };
-        let signature_typevars = signature_typevars(source).merge(db, signature_typevars(target));
+        let source_inferable = signature_typevars(source);
+        let target_inferable = signature_typevars(target);
+        let signature_inferable = source_inferable.merge(db, target_inferable);
 
-        let relation_typevars = signature_typevars;
-        let inferable = self.inferable.merge(db, relation_typevars);
+        let inferable = self.inferable.merge(db, signature_inferable);
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
@@ -2394,7 +2395,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
-        when.reduce_inferable(db, env, self.constraints, relation_typevars)
+        when.reduce_inferable(db, env, self.constraints, signature_inferable)
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1295,8 +1295,7 @@ impl<'db> Signature<'db> {
 
         let constraints = ConstraintSetBuilder::new();
         let when = constraints.load(db, env, receiver_constraints);
-        let receiver_typevars = self.receiver_specialization_typevars(db, env);
-        let inferable = self.inferable_typevars(db).merge(db, receiver_typevars);
+        let inferable = self.inferable_typevars(db);
 
         match when.solutions(db, env, &constraints, inferable) {
             Solutions::Unsatisfiable => return None,
@@ -1313,13 +1312,7 @@ impl<'db> Signature<'db> {
             return Some(self.clone());
         };
 
-        let mut builder = SpecializationBuilder::new_with_receiver_typevars(
-            db,
-            env,
-            &constraints,
-            generic_context,
-            receiver_typevars,
-        );
+        let mut builder = SpecializationBuilder::new(db, env, &constraints, generic_context);
         builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
@@ -1438,8 +1431,7 @@ impl<'db> Signature<'db> {
                 env,
                 expected_self_ty,
                 &constraints,
-                self.inferable_typevars(db)
-                    .merge(db, self.receiver_specialization_typevars(db, env)),
+                self.inferable_typevars(db),
             )
             .is_always_satisfied(db, env)
     }
@@ -1632,8 +1624,9 @@ impl<'db> Signature<'db> {
     /// Returns this signature with the given specialization applied to parameters and return type.
     fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
         let env = &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
-        let type_mapping =
-            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
+        let type_mapping = TypeMapping::ApplySpecialization(
+            ApplySpecialization::SpecializationWithSelfDomain(specialization),
+        );
         self.apply_type_mapping_impl(
             db,
             &type_mapping,
@@ -1792,37 +1785,6 @@ impl<'db> Signature<'db> {
             Some(generic_context) => generic_context.inferable_typevars(db),
             None => TypeVarSet::None,
         }
-    }
-
-    /// Returns unspecialized class typevars that a synthetic `Self` receiver can determine.
-    pub(crate) fn receiver_specialization_typevars(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> TypeVarSet<'db> {
-        let mut dependencies = Vec::new();
-        for self_typevar in self
-            .generic_context
-            .into_iter()
-            .flat_map(|context| context.variables(db))
-            .filter(|typevar| typevar.typevar(db).is_self(db))
-        {
-            let Some(bound) = self_typevar.typevar(db).upper_bound(db, env) else {
-                continue;
-            };
-            let Some((_, specialization)) = bound.class_specialization(db, env) else {
-                continue;
-            };
-
-            let owner_context = specialization.generic_context(db);
-            dependencies.extend(
-                TypeVarSet::from_typevar_occurrences(db, env, [bound])
-                    .iter(db)
-                    .filter(|typevar| owner_context.contains(db, typevar.identity(db))),
-            );
-        }
-
-        TypeVarSet::from_typevars(db, dependencies)
     }
 
     pub(crate) fn is_non_generic(&self) -> bool {
@@ -2405,18 +2367,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         };
         let signature_typevars = signature_typevars(source).merge(db, signature_typevars(target));
 
-        // An eager relation against an unbound method also specializes identity-mapped class
-        // typevars through synthetic `Self`. These are explicit receiver dependencies, not
-        // arbitrary typevars discovered by recursively walking declared domains. Lazy relations
-        // leave them fixed so enclosing class occurrences remain visible to the caller.
-        let receiver_typevars = if self.typevar_evaluation == TypeVarEvaluation::Eager {
-            source
-                .receiver_specialization_typevars(db, env)
-                .merge(db, target.receiver_specialization_typevars(db, env))
-        } else {
-            TypeVarSet::None
-        };
-        let relation_typevars = signature_typevars.merge(db, receiver_typevars);
+        let relation_typevars = signature_typevars;
         let inferable = self.inferable.merge(db, relation_typevars);
 
         // `inner` will create a constraint set that references these newly inferable typevars.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1318,7 +1318,7 @@ impl<'db> Signature<'db> {
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
         let specialization = builder.build_with(|typevar, bounds| {
             if let Some(bounds) = bounds
-                && let Some(lower) = bounds.evidence_lower
+                && let Some(lower) = bounds.inference_lower(db, env)
                 && bounds.has_upper_evidence()
                 && let Some(upper) = bounds.upper.as_single_bound(db, env)
                 && lower.is_equivalent_to(db, env, upper)
@@ -1332,7 +1332,9 @@ impl<'db> Signature<'db> {
                 && bound_signature
                     .variance_of(db, env, typevar.identity(db))
                     .is_covariant()
-                && bounds.evidence_lower.is_some_and(|lower| !lower.is_never())
+                && bounds
+                    .inference_lower(db, env)
+                    .is_some_and(|lower| !lower.is_never())
                 && let Ok(Some(solution)) = PathBounds::default_solve(db, env, &constraints, bounds)
             {
                 return Some(solution);

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1318,7 +1318,8 @@ impl<'db> Signature<'db> {
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
         let specialization = builder.build_with(|typevar, bounds| {
             if let Some(bounds) = bounds
-                && let Some(lower) = bounds.lower
+                && let Some(lower) = bounds.evidence_lower
+                && bounds.has_upper_evidence()
                 && let Some(upper) = bounds.upper.as_single_bound(db, env)
                 && lower.is_equivalent_to(db, env, upper)
                 && let Ok(Some(solution)) = PathBounds::default_solve(db, env, &constraints, bounds)
@@ -1331,7 +1332,7 @@ impl<'db> Signature<'db> {
                 && bound_signature
                     .variance_of(db, env, typevar.identity(db))
                     .is_covariant()
-                && bounds.lower.is_some_and(|lower| !lower.is_never())
+                && bounds.evidence_lower.is_some_and(|lower| !lower.is_never())
                 && let Ok(Some(solution)) = PathBounds::default_solve(db, env, &constraints, bounds)
             {
                 return Some(solution);

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -24,7 +24,7 @@ use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
-    PathBounds, Solutions,
+    Solutions,
 };
 use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::{
@@ -1316,18 +1316,18 @@ impl<'db> Signature<'db> {
         builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
-        let specialization = builder.build_with(|typevar, bounds| {
-            if let Some(bounds) = bounds
+        let specialization = builder.build_with(|typevar, context| {
+            if let Some((path_bounds, bounds)) = context
                 && let Some(lower) = bounds.inference_lower(db, env)
                 && bounds.has_upper_evidence()
                 && let Some(upper) = bounds.upper.as_single_bound(db, env)
                 && lower.is_equivalent_to(db, env, upper)
-                && let Ok(Some(solution)) = PathBounds::default_solve(db, env, &constraints, bounds)
+                && let Ok(Some(solution)) = path_bounds.default_solve(db, env, &constraints, bounds)
             {
                 return Some(solution);
             }
 
-            if let Some(bounds) = bounds
+            if let Some((path_bounds, bounds)) = context
                 && concrete_class_receiver
                 && bound_signature
                     .variance_of(db, env, typevar.identity(db))
@@ -1335,7 +1335,7 @@ impl<'db> Signature<'db> {
                 && bounds
                     .inference_lower(db, env)
                     .is_some_and(|lower| !lower.is_never())
-                && let Ok(Some(solution)) = PathBounds::default_solve(db, env, &constraints, bounds)
+                && let Ok(Some(solution)) = path_bounds.default_solve(db, env, &constraints, bounds)
             {
                 return Some(solution);
             }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1295,7 +1295,7 @@ impl<'db> Signature<'db> {
 
         let constraints = ConstraintSetBuilder::new();
         let when = constraints.load(db, env, receiver_constraints);
-        let inferable = self.inferable_typevars(db);
+        let inferable = self.inferable_typevars_with_bound_dependencies(db);
 
         match when.solutions(db, env, &constraints, inferable) {
             Solutions::Unsatisfiable => return None,
@@ -1312,11 +1312,16 @@ impl<'db> Signature<'db> {
             return Some(self.clone());
         };
 
-        let mut builder = SpecializationBuilder::new(db, env, &constraints, inferable);
+        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+            db,
+            env,
+            &constraints,
+            generic_context,
+        );
         builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
-        let specialization = builder.build_with(generic_context, |typevar, bounds| {
+        let specialization = builder.build_with(|typevar, bounds| {
             if let Some(bounds) = bounds
                 && let Some(lower) = bounds.lower
                 && let Some(upper) = bounds.upper.as_single_bound(db, env)
@@ -1431,7 +1436,7 @@ impl<'db> Signature<'db> {
                 env,
                 expected_self_ty,
                 &constraints,
-                self.inferable_typevars(db),
+                self.inferable_typevars_with_bound_dependencies(db),
             )
             .is_always_satisfied(db, env)
     }
@@ -1779,9 +1784,9 @@ impl<'db> Signature<'db> {
                 .any(|(_, parameter)| parameter.annotated_type().contains_self(db, env))
     }
 
-    fn inferable_typevars(&self, db: &'db dyn Db) -> TypeVarSet<'db> {
+    fn inferable_typevars_with_bound_dependencies(&self, db: &'db dyn Db) -> TypeVarSet<'db> {
         match self.generic_context {
-            Some(generic_context) => generic_context.inferable_typevars(db),
+            Some(generic_context) => generic_context.inferable_typevars_with_bound_dependencies(db),
             None => TypeVarSet::None,
         }
     }
@@ -2377,9 +2382,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .generic_context
                 .map_or(TypeVarSet::None, |context| {
                     if include_bound_dependencies {
-                        context.inferable_typevars(db)
+                        context.inferable_typevars_with_bound_dependencies(db)
                     } else {
-                        TypeVarSet::from_typevars(db, context.variables(db))
+                        context.inferable_typevars(db)
                     }
                 })
         };

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1624,9 +1624,8 @@ impl<'db> Signature<'db> {
     /// Returns this signature with the given specialization applied to parameters and return type.
     fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
         let env = &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
-        let type_mapping = TypeMapping::ApplySpecialization(
-            ApplySpecialization::SpecializationWithSelfDomain(specialization),
-        );
+        let type_mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::specialization(specialization));
         self.apply_type_mapping_impl(
             db,
             &type_mapping,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1211,13 +1211,20 @@ impl<'db> BoundTypeVarInstance<'db> {
         specialization: Specialization<'db>,
         env: &ProgramEnvironment<'db>,
     ) -> Self {
+        let mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::specialization(specialization));
+        let visitor = ApplyTypeMappingVisitor::new(env);
+        self.apply_type_mapping_to_bound_or_constraints(db, &mapping, &visitor)
+    }
+
+    fn apply_type_mapping_to_bound_or_constraints(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'_, 'db>,
+        visitor: &ApplyTypeMappingVisitor<'_, 'db>,
+    ) -> Self {
         self.map_bound_or_constraints(db, |original| {
-            let original = original?;
-            let mapping = TypeMapping::ApplySpecialization(ApplySpecialization::specialization(
-                specialization,
-            ));
-            let visitor = ApplyTypeMappingVisitor::new(env);
-            Some(original.apply_type_mapping_impl(db, &mapping, &visitor))
+            original.map(|original| original.apply_type_mapping_impl(db, type_mapping, visitor))
         })
     }
 
@@ -1384,7 +1391,11 @@ impl<'db> BoundTypeVarInstance<'db> {
                         visitor,
                     ))
                 } else {
-                    Type::TypeVar(self)
+                    Type::TypeVar(self.apply_type_mapping_to_bound_or_constraints(
+                        db,
+                        type_mapping,
+                        visitor,
+                    ))
                 }
             }
             TypeMapping::Promote(..)

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1747,6 +1747,54 @@ pub(crate) enum TypeVarSet<'db> {
 }
 
 impl<'db> TypeVarSet<'db> {
+    /// Collects typevar occurrences from types without traversing their declared domains.
+    pub(crate) fn from_typevar_occurrences(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        types: impl IntoIterator<Item = Type<'db>>,
+    ) -> Self {
+        struct CollectTypeVars<'a, 'db> {
+            env: &'a ProgramEnvironment<'db>,
+            typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,
+            recursion_guard: TypeCollector<'db>,
+        }
+
+        impl<'db> TypeVisitor<'db> for CollectTypeVars<'_, 'db> {
+            fn program_environment(&self) -> &ProgramEnvironment<'db> {
+                self.env
+            }
+
+            fn should_visit_lazy_type_attributes(&self) -> bool {
+                false
+            }
+
+            fn visit_bound_type_var_type(
+                &self,
+                db: &'db dyn Db,
+                bound_typevar: BoundTypeVarInstance<'db>,
+            ) {
+                self.typevars
+                    .borrow_mut()
+                    .entry(bound_typevar.identity(db))
+                    .or_insert(bound_typevar);
+            }
+
+            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            }
+        }
+
+        let visitor = CollectTypeVars {
+            env,
+            typevars: RefCell::default(),
+            recursion_guard: TypeCollector::default(),
+        };
+        for ty in types {
+            visitor.visit_type(db, ty);
+        }
+        Self::from_typevars(db, visitor.typevars.into_inner().into_values())
+    }
+
     pub(crate) fn from_typevars(
         db: &'db dyn Db,
         typevars: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1213,7 +1213,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     ) -> Self {
         self.map_bound_or_constraints(db, |original| {
             let original = original?;
-            let mapping = TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
+            let mapping = TypeMapping::ApplySpecialization(ApplySpecialization::specialization(
                 specialization,
             ));
             let visitor = ApplyTypeMappingVisitor::new(env);
@@ -1299,22 +1299,27 @@ impl<'db> BoundTypeVarInstance<'db> {
                 })
             };
 
+        let possibly_apply_to_self = |specialization: &ApplySpecialization<'a, 'db>| {
+            if self.typevar(db).is_self(db)
+                && let ApplySpecialization::Specialization {
+                    specialization,
+                    specialize_self_domain: true,
+                } = specialization
+            {
+                Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
+                    db,
+                    *specialization,
+                    visitor.env,
+                ))
+            } else {
+                Type::TypeVar(self)
+            }
+        };
+
         match type_mapping {
             TypeMapping::ApplySpecialization(specialization) => {
-                mapped_specialization_type(specialization).unwrap_or_else(|| {
-                    if self.typevar(db).is_self(db)
-                        && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
-                            specialization
-                    {
-                        Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
-                            db,
-                            *specialization,
-                            visitor.env,
-                        ))
-                    } else {
-                        Type::TypeVar(self)
-                    }
-                })
+                mapped_specialization_type(specialization)
+                    .unwrap_or_else(|| possibly_apply_to_self(specialization))
             }
             TypeMapping::ApplySpecializationWithMaterialization {
                 specialization,
@@ -1348,20 +1353,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                         }
                     }
                 })
-                .unwrap_or_else(|| {
-                    if self.typevar(db).is_self(db)
-                        && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
-                            specialization
-                    {
-                        Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
-                            db,
-                            *specialization,
-                            visitor.env,
-                        ))
-                    } else {
-                        Type::TypeVar(self)
-                    }
-                }),
+                .unwrap_or_else(|| possibly_apply_to_self(specialization)),
             TypeMapping::BindSelf(binding) => {
                 if binding.should_bind(db, visitor.env, self) {
                     binding.self_type()

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -17,8 +17,9 @@ use crate::{
     types::{
         ApplySpecialization, ApplyTypeMappingVisitor, CycleDetector, DynamicType, GenericContext,
         InstanceProjection, IntersectionType, KnownClass, KnownInstanceType, MaterializationKind,
-        Parameter, Parameters, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarVariance,
-        UnionBuilder, UnionType, any_over_type, binding_type, definition_expression_type,
+        Parameter, Parameters, Specialization, Type, TypeAliasType, TypeContext, TypeMapping,
+        TypeVarVariance, UnionBuilder, UnionType, any_over_type, binding_type,
+        definition_expression_type,
         tuple::Tuple,
         variance::VarianceInferable,
         visitor::{self, TypeCollector, TypeVisitor, walk_type_with_recursion_guard},
@@ -1203,6 +1204,29 @@ impl<'db> BoundTypeVarInstance<'db> {
         Self::new(db, typevar, binding_context, None, TypeVarNonce::NONE)
     }
 
+    /// Applies a specialization to this occurrence's declared domain.
+    ///
+    /// If the domain is unchanged, this preserves the original instance and its lazy domain
+    /// representation.
+    fn apply_specialization_to_domain(
+        self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+        env: &ProgramEnvironment<'db>,
+    ) -> Self {
+        let typevar = self.typevar(db);
+        let original = typevar.bound_or_constraints(db, env);
+        let mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
+        let visitor = ApplyTypeMappingVisitor::new(env);
+        let mapped = original.map(|domain| domain.apply_type_mapping_impl(db, &mapping, &visitor));
+        if mapped == original {
+            self
+        } else {
+            self.map_bound_or_constraints(db, |_| mapped)
+        }
+    }
+
     /// Returns an identical type variable with its `TypeVarBoundOrConstraints` mapped by the
     /// provided closure.
     pub(crate) fn map_bound_or_constraints(
@@ -1283,7 +1307,20 @@ impl<'db> BoundTypeVarInstance<'db> {
 
         match type_mapping {
             TypeMapping::ApplySpecialization(specialization) => {
-                mapped_specialization_type(specialization).unwrap_or(Type::TypeVar(self))
+                mapped_specialization_type(specialization).unwrap_or_else(|| {
+                    if self.typevar(db).is_self(db)
+                        && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
+                            specialization
+                    {
+                        Type::TypeVar(self.apply_specialization_to_domain(
+                            db,
+                            *specialization,
+                            visitor.env,
+                        ))
+                    } else {
+                        Type::TypeVar(self)
+                    }
+                })
             }
             TypeMapping::ApplySpecializationWithMaterialization {
                 specialization,
@@ -1317,7 +1354,20 @@ impl<'db> BoundTypeVarInstance<'db> {
                         }
                     }
                 })
-                .unwrap_or(Type::TypeVar(self)),
+                .unwrap_or_else(|| {
+                    if self.typevar(db).is_self(db)
+                        && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
+                            specialization
+                    {
+                        Type::TypeVar(self.apply_specialization_to_domain(
+                            db,
+                            *specialization,
+                            visitor.env,
+                        ))
+                    } else {
+                        Type::TypeVar(self)
+                    }
+                }),
             TypeMapping::BindSelf(binding) => {
                 if binding.should_bind(db, visitor.env, self) {
                     binding.self_type()
@@ -1747,54 +1797,6 @@ pub(crate) enum TypeVarSet<'db> {
 }
 
 impl<'db> TypeVarSet<'db> {
-    /// Collects typevar occurrences from types without traversing their declared domains.
-    pub(crate) fn from_typevar_occurrences(
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        types: impl IntoIterator<Item = Type<'db>>,
-    ) -> Self {
-        struct CollectTypeVars<'a, 'db> {
-            env: &'a ProgramEnvironment<'db>,
-            typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,
-            recursion_guard: TypeCollector<'db>,
-        }
-
-        impl<'db> TypeVisitor<'db> for CollectTypeVars<'_, 'db> {
-            fn program_environment(&self) -> &ProgramEnvironment<'db> {
-                self.env
-            }
-
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
-            }
-
-            fn visit_bound_type_var_type(
-                &self,
-                db: &'db dyn Db,
-                bound_typevar: BoundTypeVarInstance<'db>,
-            ) {
-                self.typevars
-                    .borrow_mut()
-                    .entry(bound_typevar.identity(db))
-                    .or_insert(bound_typevar);
-            }
-
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
-            }
-        }
-
-        let visitor = CollectTypeVars {
-            env,
-            typevars: RefCell::default(),
-            recursion_guard: TypeCollector::default(),
-        };
-        for ty in types {
-            visitor.visit_type(db, ty);
-        }
-        Self::from_typevars(db, visitor.typevars.into_inner().into_values())
-    }
-
     pub(crate) fn from_typevars(
         db: &'db dyn Db,
         typevars: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1204,27 +1204,21 @@ impl<'db> BoundTypeVarInstance<'db> {
         Self::new(db, typevar, binding_context, None, TypeVarNonce::NONE)
     }
 
-    /// Applies a specialization to this occurrence's declared domain.
-    ///
-    /// If the domain is unchanged, this preserves the original instance and its lazy domain
-    /// representation.
-    fn apply_specialization_to_domain(
+    /// Applies a specialization to this occurrence's declared upper bound or constraints, if any.
+    fn apply_specialization_to_bound_or_constraints(
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
         env: &ProgramEnvironment<'db>,
     ) -> Self {
-        let typevar = self.typevar(db);
-        let original = typevar.bound_or_constraints(db, env);
-        let mapping =
-            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
-        let visitor = ApplyTypeMappingVisitor::new(env);
-        let mapped = original.map(|domain| domain.apply_type_mapping_impl(db, &mapping, &visitor));
-        if mapped == original {
-            self
-        } else {
-            self.map_bound_or_constraints(db, |_| mapped)
-        }
+        self.map_bound_or_constraints(db, |original| {
+            let original = original?;
+            let mapping = TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
+                specialization,
+            ));
+            let visitor = ApplyTypeMappingVisitor::new(env);
+            Some(original.apply_type_mapping_impl(db, &mapping, &visitor))
+        })
     }
 
     /// Returns an identical type variable with its `TypeVarBoundOrConstraints` mapped by the
@@ -1312,7 +1306,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                         && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
                             specialization
                     {
-                        Type::TypeVar(self.apply_specialization_to_domain(
+                        Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
                             db,
                             *specialization,
                             visitor.env,
@@ -1359,7 +1353,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                         && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
                             specialization
                     {
-                        Type::TypeVar(self.apply_specialization_to_domain(
+                        Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
                             db,
                             *specialization,
                             visitor.env,


### PR DESCRIPTION
Still TBD. This removes the ham-fisted heuristic in `default_solve`, and instead adds each typevar's "validity domain" (the declared upper bound or constraints of the typevar) to the constraint set before solving.