### PR TITLE
[ty] More consistent encoding of which typevars are inferable

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2350,8 +2350,7 @@ class ChildOfParentDataclass[T](ParentDataclass[T]): ...
 def uses_dataclass[T](x: T) -> ChildOfParentDataclass[T]:
     return ChildOfParentDataclass(x)
 
-# TODO: ParentDataclass.__init__ should show generic types, not Unknown
-# revealed: (self: ParentDataclass[Unknown], value: Unknown) -> None
+# revealed: [T](self: ParentDataclass[T], value: T) -> None
 reveal_type(ParentDataclass.__init__)
 
 # revealed: [T](self: ParentDataclass[T], value: T) -> None

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -1203,10 +1203,10 @@ class C:
 C().value
 ```
 
-### Property getters reject invalid receiver specializations
+### Property getters do not infer fixed owner type variables
 
-A property getter checks the same specialized receiver as an ordinary method. A generic alias with
-alternatives that impose different type-variable bounds can produce an invalid property access.
+A property getter treats type variables fixed by the owner specialization as evidence, not as
+inference targets.
 
 ```py
 from collections.abc import Callable
@@ -1229,9 +1229,11 @@ AnyCallback = TypeVar("AnyCallback", bound=Callable[..., str])
 Command = A[AnyCallback] | B[AnyCallback]
 Callback = TypeVar("Callback", bound=Callable[[int], str])
 
+# TODO: `Command[Callback]` produces `B[Callback]`, but `Callback` does not satisfy `BItem`'s
+# upper bound. Report this at `Command[Callback]` once specialization validation can prove that
+# every possible specialization of a symbolic assignment satisfies the destination domain.
 def access(value: Callback | Command[Callback]) -> None:
     if isinstance(value, A | B):
-        # error: [invalid-attribute-access]
         value.callback
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
@@ -180,8 +180,6 @@ T = TypeVar("T", A, B)
 
 def _(x: T, y: int) -> T:
     # error: [invalid-argument-type]
-    # error: [invalid-argument-type]
-    # error: [invalid-argument-type]
     return x.foo(y)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1205,6 +1205,63 @@ def use_stream(stream: Stream) -> Stream:
     return stream.clone()
 ```
 
+## Members of type variables with union upper bounds
+
+Unlike constraints, a union upper bound does not enumerate the possible assignments of a type
+variable. Member lookup can still use the upper bound to prove that a common member is available.
+
+```py
+from typing_extensions import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    @property
+    def value(self) -> T:
+        raise NotImplementedError
+
+class A(Base[int]): ...
+class B(Base[str]): ...
+
+U = TypeVar("U", bound=A | B)
+
+def use_union(value: A | B):
+    # revealed: int | str
+    reveal_type(value.value)
+
+def use_typevar(value: U):
+    # TODO: This should not error once member lookup supports union upper bounds.
+    # error: [invalid-attribute-access] "Invalid access to descriptor attribute `value`"
+    # revealed: int | str
+    reveal_type(value.value)
+```
+
+## Correlated constrained receiver calls
+
+Multiple occurrences of the same constrained type variable have the same assignment. Distributing
+member lookup over the receiver's constraints must preserve that correlation when checking method
+arguments.
+
+```py
+from typing_extensions import TypeVar
+
+class A:
+    def combine(self, other: "A") -> None: ...
+
+class B:
+    def combine(self, other: "B") -> None: ...
+
+T = TypeVar("T", A, B)
+
+def combine(left: T, right: T) -> None:
+    # revealed: (bound method T@combine when A.combine(other: A) -> None) | (bound method T@combine when B.combine(other: B) -> None)
+    reveal_type(left.combine)
+    # TODO: This should not error once callable binding preserves the receiver branch correlation.
+    # error: [invalid-argument-type] "Argument to bound method `A.combine` is incorrect"
+    # error: [invalid-argument-type] "Argument to bound method `B.combine` is incorrect"
+    left.combine(right)
+```
+
 ## Specializations propagate
 
 In a specialized generic alias, the specialization is applied to the attributes and methods of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1166,6 +1166,45 @@ reveal_type(generic_context(c.method))
 reveal_type(generic_context(c.generic_method))
 ```
 
+## Members of constrained type variables
+
+Member lookup distributes over the constraints of a non-inferable type variable. Each member is
+bound to its matching receiver alternative, while `Self` continues to refer to the original type
+variable.
+
+```py
+from typing_extensions import Self, TypeVar
+
+class TextStream:
+    @property
+    def closed(self) -> bool:
+        return False
+
+    def close(self) -> None: ...
+    def clone(self) -> Self:
+        raise NotImplementedError
+
+class BinaryStream:
+    @property
+    def closed(self) -> bool:
+        return False
+
+    def close(self) -> None: ...
+    def clone(self) -> Self:
+        raise NotImplementedError
+
+Stream = TypeVar("Stream", TextStream, BinaryStream)
+
+def use_stream(stream: Stream) -> Stream:
+    # revealed: bool
+    reveal_type(stream.closed)
+    # revealed: (bound method Stream@use_stream when TextStream.close() -> None) | (bound method Stream@use_stream when BinaryStream.close() -> None)
+    reveal_type(stream.close)
+    if not stream.closed:
+        stream.close()
+    return stream.clone()
+```
+
 ## Specializations propagate
 
 In a specialized generic alias, the specialization is applied to the attributes and methods of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -820,6 +820,23 @@ reveal_type(generic_context(c.method))
 reveal_type(generic_context(c.generic_method))
 ```
 
+A class TypeVar remains fixed when a method is called from an enclosing generic function. The call
+cannot specialize that enclosing occurrence merely because it also appears in synthetic `Self`'s
+upper bound.
+
+```py
+class Container[T]:
+    def replace(self, value: T) -> T:
+        return value
+
+def preserve[T](container: Container[T], value: T) -> T:
+    return container.replace(value)
+
+def cannot_choose_outer[T](container: Container[T]) -> T:
+    # error: [invalid-argument-type]
+    return container.replace(1)
+```
+
 ## Specializations propagate
 
 In a specialized generic alias, the specialization is applied to the attributes and methods of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -521,6 +521,39 @@ reveal_type(generic_context(into_regular_callable(D)))
 reveal_type(D(1))  # revealed: C[Unknown, int]
 ```
 
+### Explicit access to constructors of bare generic classes
+
+Bare `__new__` and `__init__` members retain the class type variables in their generic contexts.
+Each call can infer an owner specialization, while an explicit class specialization remains
+authoritative.
+
+```py
+from typing import Self
+from ty_extensions._internal import generic_context
+
+class C[T = int]:
+    def __new__(cls, value: T) -> Self:
+        return super().__new__(cls)
+
+    def __init__(self, value: T) -> None: ...
+
+# revealed: ty_extensions._internal.GenericContext[Self@__new__, T@C]
+reveal_type(generic_context(C.__new__))
+# revealed: ty_extensions._internal.GenericContext[Self@__init__, T@C]
+reveal_type(generic_context(C.__init__))
+
+reveal_type(C.__new__(C[str], "value"))  # revealed: C[str]
+
+def calls(c_str: C[str], c_int: C[int]) -> None:
+    C.__init__(c_str, "value")
+    C.__init__(c_int, 1)
+
+    C[int].__init__(c_int, 1)
+
+    # error: [invalid-argument-type]
+    C[int].__init__(c_str, 1)
+```
+
 ### Generic class inherits `__init__` from generic base class
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1175,8 +1175,8 @@ reveal_type(invoke(lift_invariant, 1))
 
 ## Passing unbound generic methods to generic functions
 
-An unbound method of a generic class can be passed to a generic higher-order function. The class
-type parameter must still be inferred from the concrete receiver expected by that function.
+An unbound method accessed through a bare generic class uses the class's default specialization. The
+higher-order function can still infer its own type parameter from its other arguments.
 
 ```py
 from __future__ import annotations
@@ -1187,6 +1187,9 @@ class Box[T]:
     def merge(self, other: Box[T]) -> Box[T]:
         return self
 
+reveal_type(Box.merge)  # revealed: def merge(self, other: Box[Unknown]) -> Box[Unknown]
+reveal_type(Box[str].merge)  # revealed: def merge(self, other: Box[str]) -> Box[str]
+
 def fold[T](function: Callable[[T, T], T], values: list[T]) -> T:
     return values[0]
 
@@ -1194,7 +1197,8 @@ def merge_boxes(values: list[Box[str]]) -> Box[str]:
     return fold(Box.merge, values)
 ```
 
-The same applies to the standard-library `set.union` method passed to `functools.reduce`.
+The same applies to the standard-library `set.union` method passed to `functools.reduce`: `reduce`
+infers its result from the iterable rather than reopening `set`'s default specialization.
 
 ```py
 from functools import reduce

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -219,6 +219,36 @@ class Array[*Ts]:
         return self
 ```
 
+### Constrained inference from synthetic `Self`
+
+A fixed synthetic `Self` domain should provide evidence for inferring a fresh constrained type
+variable, without making the owner's type variables inference targets. This currently fails when the
+matching constraint contains a `TypeVarTuple`.
+
+```py
+from typing import Any, Generic, TypeVar
+
+class Other: ...
+
+class Container[T, *Ts]:
+    values: tuple[T, *Ts]
+
+    def interface(self) -> "Interface[Container[Any, *tuple[Any, ...]]]":
+        # TODO: This should not error once fixed `TypeVarTuple` relations are supported.
+        # error: [invalid-argument-type] "Argument to `Interface.__init__` is incorrect"
+        return Interface(self)
+
+C = TypeVar(
+    "C",
+    Container[Any, *tuple[Any, ...]],
+    Other,
+    covariant=True,
+)
+
+class Interface(Generic[C]):
+    def __init__(self, value: C) -> None: ...
+```
+
 ## Functions
 
 ### Multiple type variable tuples

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -116,7 +116,7 @@ reveal_type(bound_method.__func__)  # revealed: def f(self, x: int) -> str
 reveal_type(C[int]().f(1))  # revealed: str
 reveal_type(bound_method(1))  # revealed: str
 
-# error: [invalid-argument-type] "Argument to function `C.f` is incorrect: Argument type `Literal[1]` does not satisfy upper bound `C[T@C]` of type variable `Self`"
+# error: [invalid-argument-type] "Argument to function `C.f` is incorrect: Argument type `Literal[1]` does not satisfy upper bound `C[int]` of type variable `Self`"
 C[int].f(1)  # error: [missing-argument]
 reveal_type(C[int].f(C[int](), 1))  # revealed: str
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -87,6 +87,88 @@ c.m2(1)
 c.m2("string")
 ```
 
+## Passing bounded class typevars to broader parameters
+
+A class typevar is fixed by the receiver. Passing it to an `object` parameter must not infer a new
+specialization of the class typevar from that parameter's annotation.
+
+```py
+class G[T: int]:
+    def takes_object(self, value: object) -> None: ...
+    def echo(self, value: T) -> T:
+        return value
+
+    def caller(self, value: T, other: "G[int]") -> None:
+        self.takes_object(value)
+        other.takes_object(value)
+        reveal_type(self.echo(value))  # revealed: T@G
+        # error: [invalid-argument-type] "Expected `int`"
+        other.echo("bad")
+
+    def explicit_receiver(self: "G[T]", value: T) -> None:
+        self.takes_object(value)
+```
+
+The same applies to classmethods and to membership tests, which call `__contains__`.
+
+```py
+class Container[T: int]:
+    @classmethod
+    def takes_object(cls, value: object) -> None: ...
+    def __contains__(self, value: object) -> bool:
+        return False
+
+    def caller(self, value: T) -> None:
+        self.takes_object(value)
+        self.__contains__(value)
+        reveal_type(value in self)  # revealed: bool
+```
+
+## Passing class typevars to a superclass of their bound
+
+The parameter need not be `object`: any superclass of the typevar's bound accepts its values.
+
+```py
+class Base: ...
+class Child(Base): ...
+
+class G[T: Child]:
+    def takes_base(self, value: Base) -> None: ...
+    def caller(self, value: T) -> None:
+        self.takes_base(value)
+```
+
+## Passing constrained class typevars to broader parameters
+
+Every allowed specialization is assignable to `object`, without selecting one of the constraints
+again at the method call.
+
+```py
+class G[T: (int, str)]:
+    def takes_object(self, value: object) -> None: ...
+    def echo(self, value: T) -> T:
+        return value
+
+    def caller(self, value: T) -> None:
+        self.takes_object(value)
+        reveal_type(self.echo(value))  # revealed: T@G
+```
+
+## Passing legacy class typevars to broader parameters
+
+Legacy class typevars follow the same rule.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound=int)
+
+class G(Generic[T]):
+    def takes_object(self, value: object) -> None: ...
+    def caller(self, value: T) -> None:
+        self.takes_object(value)
+```
+
 ## Functions on generic classes are descriptors
 
 This repeats the tests in the [Functions as descriptors](./call/methods.md) test suite, but on a

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Attribute_access_on_…_(7bdb97302c27c412).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Attribute_access_on_…_(7bdb97302c27c412).snap
@@ -27,47 +27,23 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 12 | 
 13 | def _(x: T, y: int) -> T:
 14 |     # error: [invalid-argument-type]
-15 |     # error: [invalid-argument-type]
-16 |     # error: [invalid-argument-type]
-17 |     return x.foo(y)
+15 |     return x.foo(y)
 ```
 
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to bound method `A.foo` is incorrect
-  --> src/mdtest_snippet.py:17:12
-   |
-17 |     return x.foo(y)
-   |            ^^^^^^^^ Argument type `T@_` does not satisfy upper bound `A` of type variable `Self`
-info: Union variant `bound method T@_.foo(x: int) -> T@_` is incompatible with this call site
-info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`
-
-```
-
-```
 error[invalid-argument-type]: Argument to bound method `B.foo` is incorrect
-  --> src/mdtest_snippet.py:17:12
+  --> src/mdtest_snippet.py:15:18
    |
-17 |     return x.foo(y)
-   |            ^^^^^^^^ Argument type `T@_` does not satisfy upper bound `B` of type variable `Self`
-info: Union variant `bound method T@_.foo(x: str) -> T@_` is incompatible with this call site
-info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`
-
-```
-
-```
-error[invalid-argument-type]: Argument to bound method `B.foo` is incorrect
-  --> src/mdtest_snippet.py:17:18
-   |
-17 |     return x.foo(y)
+15 |     return x.foo(y)
    |                  ^ Expected `str`, found `int`
 info: Method defined here
  --> src/mdtest_snippet.py:8:9
   |
 8 |     def foo(self, x: str) -> Self:
   |         ^^^       ------ Parameter declared here
-info: Union variant `bound method T@_.foo(x: str) -> T@_` is incompatible with this call site
-info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`
+info: Union variant `bound method T@_ when B.foo(x: str) -> T@_` is incompatible with this call site
+info: Attempted to call union type `(bound method T@_ when A.foo(x: int) -> T@_) | (bound method T@_ when B.foo(x: str) -> T@_)`
 
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7732,6 +7732,20 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Applies an owner specialization to a class member, including the declared domains of any
+    /// retained synthetic `Self` variables in callable signatures.
+    fn apply_optional_member_specialization(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> Type<'db> {
+        if let Some(specialization) = specialization {
+            self.apply_specialization_inner(db, specialization, true)
+        } else {
+            self
+        }
+    }
+
     /// Applies a specialization to this type, replacing any typevars with the types that they are
     /// specialized to.
     ///
@@ -7793,13 +7807,13 @@ impl<'db> Type<'db> {
             return self;
         }
 
-        self.apply_specialization_inner(db, specialization)
+        self.apply_specialization_inner(db, specialization, false)
     }
 
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|_, id, _, _| Type::divergent(id),
-        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, specialization: Specialization<'db>| {
+        cycle_initial=|_, id, _, _, _| Type::divergent(id),
+        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, specialization: Specialization<'db>, _| {
             let env = ProgramEnvironment::from_program(
                 specialization.generic_context(db).program(db),
             );
@@ -7811,14 +7825,22 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
+        specialize_self_domains: bool,
     ) -> Type<'db> {
         let env = &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
         let type_mapping = match specialization.materialization_kind(db) {
+            None if specialize_self_domains => TypeMapping::ApplySpecialization(
+                ApplySpecialization::SpecializationWithSelfDomain(specialization),
+            ),
             None => TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
                 specialization,
             )),
             Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
-                specialization: ApplySpecialization::Specialization(specialization),
+                specialization: if specialize_self_domains {
+                    ApplySpecialization::SpecializationWithSelfDomain(specialization)
+                } else {
+                    ApplySpecialization::Specialization(specialization)
+                },
                 materialization_kind,
             },
         };
@@ -9386,6 +9408,46 @@ impl<'db> TypeMapping<'_, 'db> {
                         .apply_type_mapping(db, env, self, TypeContext::default())
                         .as_typevar()
                         .unwrap_or(bound_typevar)
+                }),
+            ),
+            TypeMapping::ApplySpecialization(
+                specialization @ ApplySpecialization::SpecializationWithSelfDomain(_),
+            ) => GenericContext::from_typevar_instances(
+                db,
+                env,
+                context.variables(db).filter_map(|bound_typevar| {
+                    match specialization.get(db, bound_typevar) {
+                        Some(Type::TypeVar(mapped))
+                            if mapped.identity(db) == bound_typevar.identity(db) => {}
+                        None => {}
+                        Some(_) => return None,
+                    }
+                    Type::TypeVar(bound_typevar)
+                        .apply_type_mapping(
+                            db,
+                            env,
+                            &TypeMapping::ApplySpecialization(*specialization),
+                            TypeContext::default(),
+                        )
+                        .as_typevar()
+                }),
+            ),
+            TypeMapping::ApplySpecializationWithMaterialization {
+                specialization: ApplySpecialization::SpecializationWithSelfDomain(specialization),
+                ..
+            } => GenericContext::from_typevar_instances(
+                db,
+                env,
+                context.variables(db).filter_map(|bound_typevar| {
+                    match specialization.get(db, bound_typevar) {
+                        Some(Type::TypeVar(mapped))
+                            if mapped.identity(db) == bound_typevar.identity(db) => {}
+                        None => {}
+                        Some(_) => return None,
+                    }
+                    Type::TypeVar(bound_typevar)
+                        .apply_type_mapping(db, env, self, TypeContext::default())
+                        .as_typevar()
                 }),
             ),
             TypeMapping::ApplySpecialization(specialization)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7732,15 +7732,18 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Applies an owner specialization to a class member, including the declared domains of any
-    /// retained synthetic `Self` variables in callable signatures.
-    fn apply_optional_member_specialization(
+    /// Projects a member from its generic owner, applying the owner's specialization to both
+    /// ordinary occurrences and the domain of any retained synthetic `Self` variable.
+    ///
+    /// Rewriting the `Self` domain is specific to this projection boundary. Inference and other
+    /// ordinary specializations must preserve that domain as fixed evidence.
+    fn apply_optional_owner_specialization_to_member(
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
     ) -> Type<'db> {
         if let Some(specialization) = specialization {
-            self.apply_specialization_inner(db, specialization, true)
+            self.apply_specialization_impl(db, specialization, true)
         } else {
             self
         }
@@ -7756,6 +7759,19 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
+    ) -> Type<'db> {
+        self.apply_specialization_impl(db, specialization, false)
+    }
+
+    /// Applies either an ordinary specialization or an enclosing-owner specialization.
+    ///
+    /// Both modes share the same leaf fast paths. They differ only in whether a retained synthetic
+    /// `Self` domain is part of the substitution.
+    fn apply_specialization_impl(
+        self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+        specialize_self_domain: bool,
     ) -> Type<'db> {
         if matches!(
             self,
@@ -7807,7 +7823,7 @@ impl<'db> Type<'db> {
             return self;
         }
 
-        self.apply_specialization_inner(db, specialization, false)
+        self.apply_specialization_inner(db, specialization, specialize_self_domain)
     }
 
     #[salsa::tracked(
@@ -7825,22 +7841,17 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
-        specialize_self_domains: bool,
+        specialize_self_domain: bool,
     ) -> Type<'db> {
         let env = &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
+        let apply_specialization = ApplySpecialization::Specialization {
+            specialization,
+            specialize_self_domain,
+        };
         let type_mapping = match specialization.materialization_kind(db) {
-            None if specialize_self_domains => TypeMapping::ApplySpecialization(
-                ApplySpecialization::SpecializationWithSelfDomain(specialization),
-            ),
-            None => TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
-                specialization,
-            )),
+            None => TypeMapping::ApplySpecialization(apply_specialization),
             Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
-                specialization: if specialize_self_domains {
-                    ApplySpecialization::SpecializationWithSelfDomain(specialization)
-                } else {
-                    ApplySpecialization::Specialization(specialization)
-                },
+                specialization: apply_specialization,
                 materialization_kind,
             },
         };
@@ -8111,7 +8122,7 @@ impl<'db> Type<'db> {
                         specialization, ..
                     } if matches!(
                         specialization,
-                        ApplySpecialization::Specialization(_)
+                        ApplySpecialization::Specialization { .. }
                             | ApplySpecialization::TypeAlias(_)
                             | ApplySpecialization::Partial { .. }
                     ) =>
@@ -9411,7 +9422,10 @@ impl<'db> TypeMapping<'_, 'db> {
                 }),
             ),
             TypeMapping::ApplySpecialization(
-                specialization @ ApplySpecialization::SpecializationWithSelfDomain(_),
+                specialization @ ApplySpecialization::Specialization {
+                    specialize_self_domain: true,
+                    ..
+                },
             ) => GenericContext::from_typevar_instances(
                 db,
                 env,
@@ -9433,7 +9447,11 @@ impl<'db> TypeMapping<'_, 'db> {
                 }),
             ),
             TypeMapping::ApplySpecializationWithMaterialization {
-                specialization: ApplySpecialization::SpecializationWithSelfDomain(specialization),
+                specialization:
+                    ApplySpecialization::Specialization {
+                        specialization,
+                        specialize_self_domain: true,
+                    },
                 ..
             } => GenericContext::from_typevar_instances(
                 db,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -852,6 +852,41 @@ fn map_member_lookup_type<'db>(
     }
 }
 
+fn distribute_member_lookup_over_bound_or_constraints<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    bound_or_constraints: TypeVarBoundOrConstraints<'db>,
+    symbolic_receiver: Type<'db>,
+    name: &str,
+    policy: MemberLookupPolicy,
+) -> MemberLookupResult<'db> {
+    match bound_or_constraints {
+        TypeVarBoundOrConstraints::UpperBound(bound) => bound
+            .member_lookup_with_policy_and_receiver(db, env, name, policy, Some(symbolic_receiver)),
+        TypeVarBoundOrConstraints::Constraints(constraints) => {
+            let mut error = None;
+            let member = constraints.map_with_boundness_and_qualifiers(db, env, |constraint| {
+                let result = constraint.member_lookup_with_policy_and_receiver(
+                    db,
+                    env,
+                    name,
+                    policy,
+                    Some(*constraint),
+                );
+                let result = map_member_lookup_type(db, result, |ty| match ty {
+                    Type::BoundMethod(method) => Type::BoundMethod(
+                        method.with_distributed_receiver(db, symbolic_receiver, *constraint),
+                    ),
+                    _ => ty,
+                });
+                error = error.or_else(|| result.err().map(|error| error.kind(db)));
+                result.unwrap_or_else(|error| error.fallback_member(db))
+            });
+            member_lookup_result(db, member, error)
+        }
+    }
+}
+
 fn member_lookup_or_fall_back_to<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -4190,11 +4225,11 @@ impl<'db> Type<'db> {
         // for every function and access context.
         if let Type::FunctionLiteral(function) = self {
             let return_type = if function.is_classmethod(db) {
-                Type::BoundMethod(BoundMethodType::new(db, function, owner))
+                Type::BoundMethod(BoundMethodType::new(db, function, owner, owner))
             } else if let Some(instance) = instance
                 && !function.is_staticmethod(db)
             {
-                Type::BoundMethod(BoundMethodType::new(db, function, instance))
+                Type::BoundMethod(BoundMethodType::new(db, function, instance, instance))
             } else {
                 self
             };
@@ -5235,17 +5270,14 @@ impl<'db> Type<'db> {
                     if let Some(bound_or_constraints) =
                         typevar.typevar(db).bound_or_constraints(db, env)
                     {
-                        // Use the bound's complete lookup behavior, but retain the original
-                        // receiver so descriptors and `Self` remain correctly specialized.
-                        bound_or_constraints
-                            .as_type(db, env)
-                            .member_lookup_with_policy_and_receiver(
-                                db,
-                                env,
-                                name_str,
-                                policy,
-                                Some(receiver),
-                            )
+                        distribute_member_lookup_over_bound_or_constraints(
+                            db,
+                            env,
+                            bound_or_constraints,
+                            receiver,
+                            name_str,
+                            policy,
+                        )
                     } else {
                         instance_like_member_lookup(db, env, key, receiver)
                     }
@@ -5635,20 +5667,21 @@ impl<'db> Type<'db> {
             Type::BoundMethod(bound_method) => {
                 let signature = bound_method.function(db).signature(db);
                 let self_instance = bound_method.self_instance(db);
+                let signature_receiver = bound_method.signature_receiver(db);
                 // Class-based protocol member lookup has already specialized the method for this
                 // receiver. Bake an implicit positional receiver into the signature instead of
                 // checking it structurally again during call inference.
-                if self_instance
+                let protocol_receiver_is_specialized = self_instance
                     .as_protocol_instance()
                     .is_some_and(|protocol| protocol.class_origin(db).is_some())
                     && signature
                         .overloads
                         .iter()
-                        .all(Signature::has_implicit_positional_receiver_annotation)
-                {
+                        .all(Signature::has_implicit_positional_receiver_annotation);
+                if protocol_receiver_is_specialized || signature_receiver != self_instance {
                     let mut binding =
                         CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
-                            .with_bound_type(bound_method.typing_self_type(db));
+                            .with_bound_type(signature_receiver);
                     binding.bake_bound_type_into_overloads(db, env);
                     binding.into()
                 } else {
@@ -7941,6 +7974,12 @@ impl<'db> Type<'db> {
                 method
                     .self_instance(db)
                     .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                method.signature_receiver(db).apply_type_mapping_impl(
+                    db,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                ),
             )),
 
             Type::NominalInstance(instance)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -873,12 +873,13 @@ fn distribute_member_lookup_over_bound_or_constraints<'db>(
                     policy,
                     Some(*constraint),
                 );
-                let result = map_member_lookup_type(db, result, |ty| match ty {
-                    Type::BoundMethod(method) => Type::BoundMethod(
-                        method.with_distributed_receiver(db, symbolic_receiver, *constraint),
-                    ),
-                    _ => ty,
-                });
+                let result =
+                    map_member_lookup_type(db, result, |ty| match ty {
+                        Type::BoundMethod(method) => Type::BoundMethod(
+                            method.with_signature_receiver(db, symbolic_receiver, *constraint),
+                        ),
+                        _ => ty,
+                    });
                 error = error.or_else(|| result.err().map(|error| error.kind(db)));
                 result.unwrap_or_else(|error| error.fallback_member(db))
             });
@@ -9460,73 +9461,37 @@ impl<'db> TypeMapping<'_, 'db> {
                         .unwrap_or(bound_typevar)
                 }),
             ),
-            TypeMapping::ApplySpecialization(
-                specialization @ ApplySpecialization::Specialization {
-                    specialize_self_domain: true,
-                    ..
-                },
-            ) => GenericContext::from_typevar_instances(
-                db,
-                env,
-                context.variables(db).filter_map(|bound_typevar| {
-                    match specialization.get(db, bound_typevar) {
-                        Some(Type::TypeVar(mapped))
-                            if mapped.identity(db) == bound_typevar.identity(db) => {}
-                        None => {}
-                        Some(_) => return None,
-                    }
-                    Type::TypeVar(bound_typevar)
-                        .apply_type_mapping(
-                            db,
-                            env,
-                            &TypeMapping::ApplySpecialization(*specialization),
-                            TypeContext::default(),
-                        )
-                        .as_typevar()
-                }),
-            ),
-            TypeMapping::ApplySpecializationWithMaterialization {
-                specialization:
-                    ApplySpecialization::Specialization {
-                        specialization,
-                        specialize_self_domain: true,
-                    },
-                ..
-            } => GenericContext::from_typevar_instances(
-                db,
-                env,
-                context.variables(db).filter_map(|bound_typevar| {
-                    match specialization.get(db, bound_typevar) {
-                        Some(Type::TypeVar(mapped))
-                            if mapped.identity(db) == bound_typevar.identity(db) => {}
-                        None => {}
-                        Some(_) => return None,
-                    }
-                    Type::TypeVar(bound_typevar)
-                        .apply_type_mapping(db, env, self, TypeContext::default())
-                        .as_typevar()
-                }),
-            ),
             TypeMapping::ApplySpecialization(specialization)
             | TypeMapping::ApplySpecializationWithMaterialization { specialization, .. } => {
                 // Filter out type variables that are already specialized
                 // (i.e., mapped to a non-TypeVar type)
-                GenericContext::from_typevar_instances(
-                    db,
-                    env,
-                    context.variables(db).filter(|bound_typevar| {
-                        // Keep the type variable if it's not in the specialization
-                        // or if it's mapped to itself (still a TypeVar)
-                        match specialization.get(db, *bound_typevar) {
-                            None => true,
-                            Some(Type::TypeVar(mapped_typevar)) => {
-                                // Still a TypeVar, keep it if it's mapping to itself
-                                mapped_typevar.identity(db) == bound_typevar.identity(db)
-                            }
-                            Some(_) => false, // Specialized to a concrete type, filter out
+                let kept = context.variables(db).filter(|bound_typevar| {
+                    // Keep the type variable if it's not in the specialization
+                    // or if it's mapped to itself (still a TypeVar)
+                    match specialization.get(db, *bound_typevar) {
+                        None => true,
+                        Some(Type::TypeVar(mapped_typevar)) => {
+                            // Still a TypeVar, keep it if it's mapping to itself
+                            mapped_typevar.identity(db) == bound_typevar.identity(db)
                         }
-                    }),
-                )
+                        Some(_) => false, // Specialized to a concrete type, filter out
+                    }
+                });
+                if specialization.specialize_self_domain() {
+                    let kept = kept.filter_map(|bound_typevar| {
+                        Type::TypeVar(bound_typevar)
+                            .apply_type_mapping(
+                                db,
+                                env,
+                                &TypeMapping::ApplySpecialization(*specialization),
+                                TypeContext::default(),
+                            )
+                            .as_typevar()
+                    });
+                    GenericContext::from_typevar_instances(db, env, kept)
+                } else {
+                    GenericContext::from_typevar_instances(db, env, kept)
+                }
             }
             TypeMapping::Promote(..)
             | TypeMapping::BindLegacyTypevars(_)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5807,19 +5807,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         let return_with_tcx = Some(self.return_ty).zip(self.call_expression_tcx.annotation);
 
-        let receiver_typevars = self
-            .signature
-            .receiver_specialization_typevars(db, self.env);
-        self.inferable_typevars = generic_context
-            .inferable_typevars(db)
-            .merge(db, receiver_typevars);
-        let mut builder = SpecializationBuilder::new_with_receiver_typevars(
-            db,
-            self.env,
-            constraints,
-            generic_context,
-            receiver_typevars,
-        );
+        self.inferable_typevars = generic_context.inferable_typevars(db);
+        let mut builder = SpecializationBuilder::new(db, self.env, constraints, generic_context);
 
         // Type variables for which we inferred a declared type based on a partially specialized
         // type from an outer generic context. For these type variables, we may infer types that
@@ -5977,13 +5966,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Note that this will still lead to an invalid specialization, but may
         // produce more precise diagnostics.
         if !assignable_to_declared_type {
-            builder = SpecializationBuilder::new_with_receiver_typevars(
-                db,
-                self.env,
-                constraints,
-                generic_context,
-                receiver_typevars,
-            );
+            builder = SpecializationBuilder::new(db, self.env, constraints, generic_context);
             specialization_errors.clear();
             self.constraint_set_errors.fill(false);
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1586,7 +1586,7 @@ impl<'db> Bindings<'db> {
                             match overload.parameter_types() {
                                 [_, Some(owner)] => {
                                     overload.set_return_type(Type::BoundMethod(
-                                        BoundMethodType::new(db, function, *owner),
+                                        BoundMethodType::new(db, function, *owner, *owner),
                                     ));
                                 }
                                 [Some(instance), None] => {
@@ -1594,6 +1594,7 @@ impl<'db> Bindings<'db> {
                                         BoundMethodType::new(
                                             db,
                                             function,
+                                            instance.to_meta_type(db, env),
                                             instance.to_meta_type(db, env),
                                         ),
                                     ));
@@ -1607,7 +1608,7 @@ impl<'db> Bindings<'db> {
                                 overload.set_return_type(Type::FunctionLiteral(function));
                             } else {
                                 overload.set_return_type(Type::BoundMethod(BoundMethodType::new(
-                                    db, function, *first,
+                                    db, function, *first, *first,
                                 )));
                             }
                         }
@@ -1621,7 +1622,7 @@ impl<'db> Bindings<'db> {
                                 match overload.parameter_types() {
                                     [_, _, Some(owner)] => {
                                         overload.set_return_type(Type::BoundMethod(
-                                            BoundMethodType::new(db, *function, *owner),
+                                            BoundMethodType::new(db, *function, *owner, *owner),
                                         ));
                                     }
 
@@ -1630,6 +1631,7 @@ impl<'db> Bindings<'db> {
                                             BoundMethodType::new(
                                                 db,
                                                 *function,
+                                                instance.to_meta_type(db, env),
                                                 instance.to_meta_type(db, env),
                                             ),
                                         ));
@@ -1646,7 +1648,9 @@ impl<'db> Bindings<'db> {
                                     }
                                     [_, Some(instance), _] => {
                                         overload.set_return_type(Type::BoundMethod(
-                                            BoundMethodType::new(db, *function, *instance),
+                                            BoundMethodType::new(
+                                                db, *function, *instance, *instance,
+                                            ),
                                         ));
                                     }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5807,9 +5807,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         let return_with_tcx = Some(self.return_ty).zip(self.call_expression_tcx.annotation);
 
-        self.inferable_typevars = generic_context.inferable_typevars(db);
-        let mut builder =
-            SpecializationBuilder::new(db, self.env, constraints, self.inferable_typevars);
+        self.inferable_typevars = generic_context.inferable_typevars_with_bound_dependencies(db);
+        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+            db,
+            self.env,
+            constraints,
+            generic_context,
+        );
 
         // Type variables for which we inferred a declared type based on a partially specialized
         // type from an outer generic context. For these type variables, we may infer types that
@@ -5967,8 +5971,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Note that this will still lead to an invalid specialization, but may
         // produce more precise diagnostics.
         if !assignable_to_declared_type {
-            builder =
-                SpecializationBuilder::new(db, self.env, constraints, self.inferable_typevars);
+            builder = SpecializationBuilder::new_with_bound_dependencies(
+                db,
+                self.env,
+                constraints,
+                generic_context,
+            );
             specialization_errors.clear();
             self.constraint_set_errors.fill(false);
 
@@ -6046,10 +6054,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
             maybe_promote(typevar, bounds)
         };
-        let inference = match builder.build_inference_with(generic_context, &mut choose) {
+        let inference = match builder.build_inference_with(&mut choose) {
             Ok(inference) => inference,
             Err(()) => builder.build_diagnostic_inference_with(
-                generic_context,
                 self.argument_relations()
                     .map(|relation| (relation.declared_type, relation.argument_type)),
                 choose,
@@ -6134,8 +6141,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             (error, argument_index)
         })?;
 
-        if let Some(generic_context) = self.signature.generic_context {
-            let specialization = builder.build_with(generic_context, |_, _| None);
+        if self.signature.generic_context.is_some() {
+            let specialization = builder.build_with(|_, _| None);
             let expected_ty = formal.apply_specialization(db, specialization);
 
             // The legacy solver keeps the first pack when another occurrence has a different length.
@@ -7349,7 +7356,7 @@ impl<'db> Binding<'db> {
             return 0;
         };
 
-        let inferable_typevars = generic_context.inferable_typevars(db);
+        let inferable_typevars = generic_context.inferable_typevars_with_bound_dependencies(db);
         argument
             .parameters
             .iter()
@@ -7685,7 +7692,7 @@ impl<'db> Binding<'db> {
                 db,
                 env,
                 declared_return_ty,
-                generic_context.inferable_typevars(db),
+                generic_context.inferable_typevars_with_bound_dependencies(db),
             );
 
             let solutions = path_bounds.solve_with(|_variance, path_bound| {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5807,12 +5807,18 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         let return_with_tcx = Some(self.return_ty).zip(self.call_expression_tcx.annotation);
 
-        self.inferable_typevars = generic_context.inferable_typevars_with_bound_dependencies(db);
-        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+        let receiver_typevars = self
+            .signature
+            .receiver_specialization_typevars(db, self.env);
+        self.inferable_typevars = generic_context
+            .inferable_typevars(db)
+            .merge(db, receiver_typevars);
+        let mut builder = SpecializationBuilder::new_with_receiver_typevars(
             db,
             self.env,
             constraints,
             generic_context,
+            receiver_typevars,
         );
 
         // Type variables for which we inferred a declared type based on a partially specialized
@@ -5971,11 +5977,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Note that this will still lead to an invalid specialization, but may
         // produce more precise diagnostics.
         if !assignable_to_declared_type {
-            builder = SpecializationBuilder::new_with_bound_dependencies(
+            builder = SpecializationBuilder::new_with_receiver_typevars(
                 db,
                 self.env,
                 constraints,
                 generic_context,
+                receiver_typevars,
             );
             specialization_errors.clear();
             self.constraint_set_errors.fill(false);
@@ -7356,7 +7363,7 @@ impl<'db> Binding<'db> {
             return 0;
         };
 
-        let inferable_typevars = generic_context.inferable_typevars_with_bound_dependencies(db);
+        let inferable_typevars = generic_context.inferable_typevars(db);
         argument
             .parameters
             .iter()
@@ -7692,7 +7699,7 @@ impl<'db> Binding<'db> {
                 db,
                 env,
                 declared_return_ty,
-                generic_context.inferable_typevars_with_bound_dependencies(db),
+                generic_context.inferable_typevars(db),
             );
 
             let solutions = path_bounds.solve_with(|_variance, path_bound| {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1826,7 +1826,7 @@ impl<'db> ClassType<'db> {
                 .map(|specialization| specialization.tuple_runtime_element_specialization(db));
             class_literal
                 .own_class_member(db, env, inherited_generic_context, specialization, name)
-                .map_type(|ty| ty.apply_optional_member_specialization(db, specialization))
+                .map_type(|ty| ty.apply_optional_owner_specialization_to_member(db, specialization))
         };
 
         match name {
@@ -2142,7 +2142,9 @@ impl<'db> ClassType<'db> {
 
                 class_literal
                     .instance_member(db, env, specialization, name)
-                    .map_type(|ty| ty.apply_optional_member_specialization(db, specialization))
+                    .map_type(|ty| {
+                        ty.apply_optional_owner_specialization_to_member(db, specialization)
+                    })
             }
         }
     }
@@ -2198,7 +2200,7 @@ impl<'db> ClassType<'db> {
                     .origin(db)
                     .own_instance_member(db, env, name)
                     .map_type(|ty| {
-                        ty.apply_optional_member_specialization(db, Some(specialization))
+                        ty.apply_optional_owner_specialization_to_member(db, Some(specialization))
                     })
             }
         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1826,7 +1826,7 @@ impl<'db> ClassType<'db> {
                 .map(|specialization| specialization.tuple_runtime_element_specialization(db));
             class_literal
                 .own_class_member(db, env, inherited_generic_context, specialization, name)
-                .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                .map_type(|ty| ty.apply_optional_member_specialization(db, specialization))
         };
 
         match name {
@@ -2142,7 +2142,7 @@ impl<'db> ClassType<'db> {
 
                 class_literal
                     .instance_member(db, env, specialization, name)
-                    .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                    .map_type(|ty| ty.apply_optional_member_specialization(db, specialization))
             }
         }
     }
@@ -2197,7 +2197,9 @@ impl<'db> ClassType<'db> {
                 generic
                     .origin(db)
                     .own_instance_member(db, env, name)
-                    .map_type(|ty| ty.apply_optional_specialization(db, Some(specialization)))
+                    .map_type(|ty| {
+                        ty.apply_optional_member_specialization(db, Some(specialization))
+                    })
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1342,21 +1342,35 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        let member =
-            self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, specialization));
-
         // An unspecialized MRO retains mappings such as `Parent[T@Child]`, so ordinary members
         // accessed through `Child` must use its default arguments. Constructor methods are different:
         // we add their class's type variables to the callable's generic context, so those variables
         // are genuinely inferable and must remain generic instead of using the default arguments.
         if specialization.is_none()
-            && !matches!(name, "__new__" | "__init__")
             && let Some(generic_context) = self.generic_context(db)
         {
-            let specialization = generic_context.default_specialization(db, self.known(db));
-            member.map_type(|ty| ty.apply_specialization(db, specialization))
+            match name {
+                "__new__" | "__init__" => {
+                    // Specifically apply the identity specialization; otherwise `iter_mro` will
+                    // apply the default specialization for us.
+                    let specialization = generic_context.identity_specialization(db);
+                    self.class_member_from_mro(
+                        db,
+                        env,
+                        name,
+                        policy,
+                        self.iter_mro(db, Some(specialization)),
+                    )
+                }
+                _ => {
+                    let member =
+                        self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, None));
+                    let specialization = generic_context.default_specialization(db, self.known(db));
+                    member.map_type(|ty| ty.apply_specialization(db, specialization))
+                }
+            }
         } else {
-            member
+            self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, specialization))
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -405,7 +405,7 @@ impl<'db> ClassBase<'db> {
                 &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
             let new_self = self.apply_type_mapping_impl(
                 db,
-                &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
+                &TypeMapping::ApplySpecialization(ApplySpecialization::specialization(
                     specialization,
                 )),
                 TypeContext::default(),

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1232,6 +1232,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
             Type::BoundMethod(bound_method) => {
                 let function = bound_method.function(db);
                 let self_ty = bound_method.self_instance(db);
+                let receiver_ty = bound_method.signature_receiver(db);
                 let bound_signatures = bound_method.bound_signatures(db);
 
                 match bound_signatures.overloads.as_slice() {
@@ -1252,6 +1253,16 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                             settings: self.settings.singleline(),
                         }
                         .fmt_detailed(f)?;
+                        if self_ty != receiver_ty {
+                            f.write_str(" when ")?;
+                            DisplayMaybeParenthesizedType {
+                                ty: receiver_ty,
+                                db,
+                                env: self.env,
+                                settings: self.settings.singleline(),
+                            }
+                            .fmt_detailed(f)?;
+                        }
                         f.write_char('.')?;
                         f.with_type(self.ty).write_str(function.name(db))?;
                         type_parameters.fmt_detailed(f)?;

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1853,14 +1853,16 @@ impl KnownComparisonSemantics {
             (KnownClass::Tuple, Self::Tuple),
             (KnownClass::Dict, Self::Dict),
         ] {
-            if dunder
-                == lookup_dunder(
+            if same_member_implementation(
+                db,
+                dunder,
+                lookup_dunder(
                     db,
                     env,
                     known_class.to_class_literal(db, env),
                     operator.dunder(),
-                )
-            {
+                ),
+            ) {
                 return Some(semantics);
             }
         }
@@ -1900,6 +1902,28 @@ fn has_known_identity_comparison_semantics<'db>(
                 && KnownComparisonSemantics::of_type(db, env, ty, operator)
                     == Some(KnownComparisonSemantics::Object)
         }
+    }
+}
+
+/// Return whether two looked-up members originate from the same implementation.
+fn same_member_implementation(
+    db: &dyn Db,
+    left: PlaceAndQualifiers<'_>,
+    right: PlaceAndQualifiers<'_>,
+) -> bool {
+    if left.qualifiers != right.qualifiers {
+        return false;
+    }
+
+    match (
+        left.ignore_possibly_undefined()
+            .and_then(Type::as_function_literal),
+        right
+            .ignore_possibly_undefined()
+            .and_then(Type::as_function_literal),
+    ) {
+        (Some(left), Some(right)) => left.literal(db) == right.literal(db),
+        _ => left == right,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1665,7 +1665,7 @@ impl<'db> FunctionType<'db> {
         db: &'db dyn Db,
         self_instance: Type<'db>,
     ) -> BoundMethodType<'db> {
-        BoundMethodType::new(db, self, self_instance)
+        BoundMethodType::new(db, self, self_instance, self_instance)
     }
 
     pub(crate) fn find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -502,9 +502,17 @@ impl<'db> GenericContext<'db> {
         remove_self_inner(db, self, binding_context)
     }
 
-    /// Returns the typevars that are inferable in this generic context. This set might include
-    /// more typevars than the ones directly bound by the generic context. For instance, consider a
-    /// method of a generic class:
+    /// Returns the typevars directly bound by this generic context.
+    pub(crate) fn inferable_typevars(self, db: &'db dyn Db) -> TypeVarSet<'db> {
+        TypeVarSet::from_typevars(db, self.variables(db))
+    }
+
+    /// Returns the typevars directly bound by this generic context and any typevars reachable from
+    /// their declared bounds or constraints.
+    ///
+    /// This is a transitional compatibility scope for callers that have not yet separated
+    /// receiver specialization from ordinary inference. For instance, consider a method of a
+    /// generic class:
     ///
     /// ```py
     /// class C[A]:
@@ -514,7 +522,10 @@ impl<'db> GenericContext<'db> {
     /// In this example, `method`'s generic context binds `Self` and `T`, but its inferable set
     /// also includes `A@C`. This is needed because at each call site, we need to infer the
     /// specialized class instance type whose method is being invoked.
-    pub(crate) fn inferable_typevars(self, db: &'db dyn Db) -> TypeVarSet<'db> {
+    pub(crate) fn inferable_typevars_with_bound_dependencies(
+        self,
+        db: &'db dyn Db,
+    ) -> TypeVarSet<'db> {
         struct CollectTypeVars<'a, 'db> {
             env: &'a ProgramEnvironment<'db>,
             typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,
@@ -2367,6 +2378,7 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     db: &'db dyn Db,
     env: &'c ProgramEnvironment<'db>,
     constraints: &'c ConstraintSetBuilder<'db>,
+    generic_context: GenericContext<'db>,
     inferable: TypeVarSet<'db>,
     pending: ConstraintSet<'db, 'c>,
     types: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>>,
@@ -2552,21 +2564,35 @@ fn relation_directions<T: Copy>(
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
+    /// Creates a builder that infers only the typevars directly owned by `generic_context`.
     pub(crate) fn new(
         db: &'db dyn Db,
         env: &'c ProgramEnvironment<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
-        inferable: TypeVarSet<'db>,
+        generic_context: GenericContext<'db>,
     ) -> Self {
         Self {
             db,
             env,
             constraints,
-            inferable,
+            generic_context,
+            inferable: generic_context.inferable_typevars(db),
             pending: ConstraintSet::from_bool(constraints, true),
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
         }
+    }
+
+    /// Creates a transitional builder that also infers typevars reachable through bounds.
+    pub(crate) fn new_with_bound_dependencies(
+        db: &'db dyn Db,
+        env: &'c ProgramEnvironment<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        generic_context: GenericContext<'db>,
+    ) -> Self {
+        let mut builder = Self::new(db, env, constraints, generic_context);
+        builder.inferable = generic_context.inferable_typevars_with_bound_dependencies(db);
+        builder
     }
 
     /// Adds a constraint set to the pending specialization and projects its valid solutions into
@@ -2590,10 +2616,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// `None` to use the inferred type unchanged.
     pub(crate) fn build_with(
         &mut self,
-        generic_context: GenericContext<'db>,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> Specialization<'db> {
         let db = self.db;
+        let generic_context = self.generic_context;
         let types = self
             .solve_pending_with(generic_context, &mut choose)
             .unwrap_or_else(|()| self.solve_hash_map_with(generic_context, &mut choose));
@@ -2616,11 +2642,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// Returns an error if the call-wide pending constraints are unsatisfiable.
     pub(crate) fn build_inference_with(
         &mut self,
-        generic_context: GenericContext<'db>,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> Result<TypeVarInference<'db>, ()> {
-        let types = self.solve_pending_with(generic_context, &mut choose)?;
-        Ok(self.typevar_inference(generic_context, &types))
+        let types = self.solve_pending_with(self.generic_context, &mut choose)?;
+        Ok(self.typevar_inference(self.generic_context, &types))
     }
 
     /// Build a diagnostic specialization after the call-wide constraints were unsatisfiable.
@@ -2630,7 +2655,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// even when a migrated inference path only populated `pending`.
     pub(crate) fn build_diagnostic_inference_with(
         &mut self,
-        generic_context: GenericContext<'db>,
         argument_relations: impl IntoIterator<Item = (Type<'db>, Type<'db>)>,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> TypeVarInference<'db> {
@@ -2642,8 +2666,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             self.project_for_legacy_fallback(&analysis);
         }
 
-        let types = self.solve_hash_map_with(generic_context, &mut choose);
-        self.typevar_inference(generic_context, &types)
+        let types = self.solve_hash_map_with(self.generic_context, &mut choose);
+        self.typevar_inference(self.generic_context, &types)
     }
 
     fn typevar_inference(
@@ -4249,7 +4273,7 @@ mod tests {
         });
         let context = GenericContext::from_typevar_instances(db, &env, [t]);
 
-        let inferable = context.inferable_typevars(db);
+        let inferable = context.inferable_typevars_with_bound_dependencies(db);
         assert_eq!(inferable.iter(db).collect::<Vec<_>>(), [t, u]);
         assert!(t.is_inferable(db, inferable));
         assert!(u.is_inferable(db, inferable));
@@ -4268,8 +4292,7 @@ mod tests {
         );
         let context = GenericContext::from_typevar_instances(db, &env, [typevar]);
         let constraints = ConstraintSetBuilder::new();
-        let mut builder =
-            SpecializationBuilder::new(db, &env, &constraints, context.inferable_typevars(db));
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
         let int = KnownClass::Int.to_instance(db, &env);
         let set = ConstraintSet::constrain_typevar(db, &env, &constraints, typevar, int, int);
 
@@ -4301,8 +4324,7 @@ mod tests {
         .map_bound_or_constraints(db, |_| Some(TypeVarBoundOrConstraints::UpperBound(int)));
         let context = GenericContext::from_typevar_instances(db, &env, [typevar]);
         let constraints = ConstraintSetBuilder::new();
-        let mut builder =
-            SpecializationBuilder::new(db, &env, &constraints, context.inferable_typevars(db));
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
         let lower_only =
             ConstraintSet::constrain_typevar_lower_bound(db, &env, &constraints, typevar, str);
         let rejected = ConstraintSet::constrain_typevar(db, &env, &constraints, typevar, str, str);

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -25,9 +25,7 @@ use crate::types::tuple::{
     TupleSpec, TupleSpecBuilder, TupleType, VariableSegment, walk_tuple_type,
 };
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
-use crate::types::typevar::{
-    BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, TypeVarSet, walk_type_var_bounds,
-};
+use crate::types::typevar::{BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, TypeVarSet};
 use crate::types::visitor::{
     TypeCollector, TypeVisitor, any_over_type, walk_type_with_recursion_guard,
 };
@@ -505,86 +503,6 @@ impl<'db> GenericContext<'db> {
     /// Returns the typevars directly bound by this generic context.
     pub(crate) fn inferable_typevars(self, db: &'db dyn Db) -> TypeVarSet<'db> {
         TypeVarSet::from_typevars(db, self.variables(db))
-    }
-
-    /// Returns the typevars directly bound by this generic context and any typevars reachable from
-    /// their declared bounds or constraints.
-    ///
-    /// This is a transitional compatibility scope for callers that have not yet separated
-    /// receiver specialization from ordinary inference. For instance, consider a method of a
-    /// generic class:
-    ///
-    /// ```py
-    /// class C[A]:
-    ///     def method[T](self, t: T):
-    /// ```
-    ///
-    /// In this example, `method`'s generic context binds `Self` and `T`, but its inferable set
-    /// also includes `A@C`. This is needed because at each call site, we need to infer the
-    /// specialized class instance type whose method is being invoked.
-    pub(crate) fn inferable_typevars_with_bound_dependencies(
-        self,
-        db: &'db dyn Db,
-    ) -> TypeVarSet<'db> {
-        struct CollectTypeVars<'a, 'db> {
-            env: &'a ProgramEnvironment<'db>,
-            typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,
-            recursion_guard: TypeCollector<'db>,
-        }
-
-        impl<'db> TypeVisitor<'db> for CollectTypeVars<'_, 'db> {
-            fn program_environment(&self) -> &ProgramEnvironment<'db> {
-                self.env
-            }
-
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
-            }
-
-            fn visit_bound_type_var_type(
-                &self,
-                db: &'db dyn Db,
-                bound_typevar: BoundTypeVarInstance<'db>,
-            ) {
-                self.typevars
-                    .borrow_mut()
-                    .entry(bound_typevar.identity(db))
-                    .or_insert(bound_typevar);
-                let typevar = bound_typevar.typevar(db);
-                if let Some(bound_or_constraints) =
-                    typevar.bound_or_constraints(db, self.program_environment())
-                {
-                    walk_type_var_bounds(db, bound_or_constraints, self);
-                }
-            }
-
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
-            }
-        }
-
-        #[salsa::tracked(
-            returns(copy),
-            cycle_initial=|_, _, _| TypeVarSet::None,
-            heap_size=ruff_memory_usage::heap_size,
-        )]
-        fn inferable_typevars_inner<'db>(
-            db: &'db dyn Db,
-            generic_context: GenericContext<'db>,
-        ) -> TypeVarSet<'db> {
-            let env = ProgramEnvironment::from_program(generic_context.program(db));
-            let visitor = CollectTypeVars {
-                env: &env,
-                typevars: RefCell::default(),
-                recursion_guard: TypeCollector::default(),
-            };
-            for bound_typevar in generic_context.variables(db) {
-                visitor.visit_bound_type_var_type(db, bound_typevar);
-            }
-            TypeVarSet::from_typevars(db, visitor.typevars.into_inner().into_values())
-        }
-
-        inferable_typevars_inner(db, self)
     }
 
     pub(crate) fn variables(
@@ -2583,15 +2501,16 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
-    /// Creates a transitional builder that also infers typevars reachable through bounds.
-    pub(crate) fn new_with_bound_dependencies(
+    /// Creates a context-owned builder that can also solve explicit receiver dependencies.
+    pub(crate) fn new_with_receiver_typevars(
         db: &'db dyn Db,
         env: &'c ProgramEnvironment<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         generic_context: GenericContext<'db>,
+        receiver_typevars: TypeVarSet<'db>,
     ) -> Self {
         let mut builder = Self::new(db, env, constraints, generic_context);
-        builder.inferable = generic_context.inferable_typevars_with_bound_dependencies(db);
+        builder.inferable = builder.inferable.merge(db, receiver_typevars);
         builder
     }
 
@@ -4250,34 +4169,6 @@ mod tests {
     use ruff_python_ast::name::Name;
 
     use crate::db::tests::setup_db;
-
-    #[test]
-    fn generic_context_inferable_typevars_retain_instances_from_bounds() {
-        let db = setup_db();
-        let db = &db;
-        let env = db.program_environment();
-        let u = BoundTypeVarInstance::synthetic(
-            db,
-            &env,
-            Name::new_static("U"),
-            TypeVarVariance::Invariant,
-        );
-        let t = BoundTypeVarInstance::synthetic(
-            db,
-            &env,
-            Name::new_static("T"),
-            TypeVarVariance::Invariant,
-        )
-        .map_bound_or_constraints(db, |_| {
-            Some(TypeVarBoundOrConstraints::UpperBound(Type::TypeVar(u)))
-        });
-        let context = GenericContext::from_typevar_instances(db, &env, [t]);
-
-        let inferable = context.inferable_typevars_with_bound_dependencies(db);
-        assert_eq!(inferable.iter(db).collect::<Vec<_>>(), [t, u]);
-        assert!(t.is_inferable(db, inferable));
-        assert!(u.is_inferable(db, inferable));
-    }
 
     #[test]
     fn recording_constraints_does_not_project_legacy_mappings() {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2183,6 +2183,9 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub enum ApplySpecialization<'a, 'db> {
     Specialization(Specialization<'db>),
+    /// Assignments from a specialization that also apply to the declared domains of retained
+    /// synthetic `Self` variables.
+    SpecializationWithSelfDomain(Specialization<'db>),
     TypeAlias(Specialization<'db>),
     Partial {
         generic_context: GenericContext<'db>,
@@ -2207,6 +2210,7 @@ impl<'db> ApplySpecialization<'_, 'db> {
     ) -> Option<Type<'db>> {
         match self {
             ApplySpecialization::Specialization(specialization)
+            | ApplySpecialization::SpecializationWithSelfDomain(specialization)
             | ApplySpecialization::TypeAlias(specialization) => {
                 specialization.get(db, bound_typevar)
             }
@@ -2241,6 +2245,7 @@ impl<'db> ApplySpecialization<'_, 'db> {
     pub(crate) fn as_specialization(self, db: &'db dyn Db) -> Option<Specialization<'db>> {
         match self {
             ApplySpecialization::Specialization(specialization)
+            | ApplySpecialization::SpecializationWithSelfDomain(specialization)
             | ApplySpecialization::TypeAlias(specialization) => Some(specialization),
             ApplySpecialization::Partial {
                 generic_context,
@@ -2499,19 +2504,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
         }
-    }
-
-    /// Creates a context-owned builder that can also solve explicit receiver dependencies.
-    pub(crate) fn new_with_receiver_typevars(
-        db: &'db dyn Db,
-        env: &'c ProgramEnvironment<'db>,
-        constraints: &'c ConstraintSetBuilder<'db>,
-        generic_context: GenericContext<'db>,
-        receiver_typevars: TypeVarSet<'db>,
-    ) -> Self {
-        let mut builder = Self::new(db, env, constraints, generic_context);
-        builder.inferable = builder.inferable.merge(db, receiver_typevars);
-        builder
     }
 
     /// Adds a constraint set to the pending specialization and projects its valid solutions into

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2213,6 +2213,16 @@ impl<'db> ApplySpecialization<'_, 'db> {
         }
     }
 
+    pub(crate) fn specialize_self_domain(self) -> bool {
+        match self {
+            Self::Specialization {
+                specialize_self_domain,
+                ..
+            } => specialize_self_domain,
+            _ => false,
+        }
+    }
+
     /// Returns the type that a typevar is mapped to, or None if the typevar isn't part of this
     /// mapping.
     pub(crate) fn get(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2487,7 +2487,6 @@ fn relation_directions<T: Copy>(
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
-    /// Creates a builder that infers only the typevars directly owned by `generic_context`.
     pub(crate) fn new(
         db: &'db dyn Db,
         env: &'c ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1342,7 +1342,7 @@ impl<'db> Specialization<'db> {
         let new_specialization = self.apply_type_mapping(
             db,
             env,
-            &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(other)),
+            &TypeMapping::ApplySpecialization(ApplySpecialization::specialization(other)),
         );
         match other.materialization_kind(db) {
             None => new_specialization,
@@ -2182,10 +2182,15 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 /// substitute types for type variables before we have fully constructed a [`Specialization`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub enum ApplySpecialization<'a, 'db> {
-    Specialization(Specialization<'db>),
-    /// Assignments from a specialization that also apply to the declared domains of retained
-    /// synthetic `Self` variables.
-    SpecializationWithSelfDomain(Specialization<'db>),
+    Specialization {
+        specialization: Specialization<'db>,
+        /// Whether to substitute free owner variables in the declared domain of a retained
+        /// synthetic `Self`.
+        ///
+        /// This is only set when projecting a member from its enclosing generic owner. Ordinary
+        /// specialization preserves that domain as fixed evidence.
+        specialize_self_domain: bool,
+    },
     TypeAlias(Specialization<'db>),
     Partial {
         generic_context: GenericContext<'db>,
@@ -2201,6 +2206,13 @@ pub enum ApplySpecialization<'a, 'db> {
 }
 
 impl<'db> ApplySpecialization<'_, 'db> {
+    pub(crate) fn specialization(specialization: Specialization<'db>) -> Self {
+        Self::Specialization {
+            specialization,
+            specialize_self_domain: false,
+        }
+    }
+
     /// Returns the type that a typevar is mapped to, or None if the typevar isn't part of this
     /// mapping.
     pub(crate) fn get(
@@ -2209,8 +2221,7 @@ impl<'db> ApplySpecialization<'_, 'db> {
         bound_typevar: BoundTypeVarInstance<'db>,
     ) -> Option<Type<'db>> {
         match self {
-            ApplySpecialization::Specialization(specialization)
-            | ApplySpecialization::SpecializationWithSelfDomain(specialization)
+            ApplySpecialization::Specialization { specialization, .. }
             | ApplySpecialization::TypeAlias(specialization) => {
                 specialization.get(db, bound_typevar)
             }
@@ -2244,8 +2255,7 @@ impl<'db> ApplySpecialization<'_, 'db> {
     /// context, preserving skipped type variables in partial specializations as identity mappings.
     pub(crate) fn as_specialization(self, db: &'db dyn Db) -> Option<Specialization<'db>> {
         match self {
-            ApplySpecialization::Specialization(specialization)
-            | ApplySpecialization::SpecializationWithSelfDomain(specialization)
+            ApplySpecialization::Specialization { specialization, .. }
             | ApplySpecialization::TypeAlias(specialization) => Some(specialization),
             ApplySpecialization::Partial {
                 generic_context,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6540,7 +6540,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
             CallableType::new(db, signatures, callable.kind(db), callable.provenance(db))
         });
-        let inferable = class_generic_context.inferable_typevars_with_bound_dependencies(db);
+        let inferable = class_generic_context.inferable_typevars(db);
         let constraints = ConstraintSetBuilder::new();
         let path_bounds = source_callable
             .into_type(db, env)
@@ -6857,9 +6857,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let inferable = KnownClass::Tuple
                 .try_to_class_literal(db, env)
                 .and_then(|class| class.generic_context(db))
-                .map(|generic_context| {
-                    generic_context.inferable_typevars_with_bound_dependencies(db)
-                })
+                .map(|generic_context| generic_context.inferable_typevars(db))
                 .unwrap_or(TypeVarSet::None);
             annotation.filter_disjoint_elements(
                 db,
@@ -7301,14 +7299,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let constraints = ConstraintSetBuilder::new();
-        let inferable = generic_context.inferable_typevars_with_bound_dependencies(db);
+        let inferable = generic_context.inferable_typevars(db);
         let identity_instance = Type::instance(db, env, ClassType::Generic(collection_alias));
-        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
-            db,
-            env,
-            &constraints,
-            generic_context,
-        );
+        let mut builder = SpecializationBuilder::new(db, env, &constraints, generic_context);
 
         // Remove any union elements of that are unrelated to the collection type.
         //
@@ -7812,7 +7805,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db,
             env,
             annotation,
-            generic_context.inferable_typevars_with_bound_dependencies(db),
+            generic_context.inferable_typevars(db),
         );
         let constraints = ConstraintSetBuilder::new();
         let Solutions::Constrained(solutions) = path_bounds.solve(db, env, &constraints) else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5532,11 +5532,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .signature
                     .generic_context
                     .map(|generic_context| generic_context.inferable_typevars(db))
-                    .unwrap_or(TypeVarSet::None)
-                    .merge(
-                        db,
-                        overload.signature.receiver_specialization_typevars(db, env),
-                    );
+                    .unwrap_or(TypeVarSet::None);
 
                 !overload
                     .return_ty

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5531,7 +5531,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let inferable = overload
                     .signature
                     .generic_context
-                    .map(|generic_context| generic_context.inferable_typevars(db))
+                    .map(|generic_context| {
+                        generic_context.inferable_typevars_with_bound_dependencies(db)
+                    })
                     .unwrap_or(TypeVarSet::None);
 
                 !overload
@@ -6538,7 +6540,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
             CallableType::new(db, signatures, callable.kind(db), callable.provenance(db))
         });
-        let inferable = class_generic_context.inferable_typevars(db);
+        let inferable = class_generic_context.inferable_typevars_with_bound_dependencies(db);
         let constraints = ConstraintSetBuilder::new();
         let path_bounds = source_callable
             .into_type(db, env)
@@ -6855,7 +6857,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let inferable = KnownClass::Tuple
                 .try_to_class_literal(db, env)
                 .and_then(|class| class.generic_context(db))
-                .map(|generic_context| generic_context.inferable_typevars(db))
+                .map(|generic_context| {
+                    generic_context.inferable_typevars_with_bound_dependencies(db)
+                })
                 .unwrap_or(TypeVarSet::None);
             annotation.filter_disjoint_elements(
                 db,
@@ -7297,9 +7301,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let constraints = ConstraintSetBuilder::new();
-        let inferable = generic_context.inferable_typevars(db);
+        let inferable = generic_context.inferable_typevars_with_bound_dependencies(db);
         let identity_instance = Type::instance(db, env, ClassType::Generic(collection_alias));
-        let mut builder = SpecializationBuilder::new(db, env, &constraints, inferable);
+        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+            db,
+            env,
+            &constraints,
+            generic_context,
+        );
 
         // Remove any union elements of that are unrelated to the collection type.
         //
@@ -7720,7 +7729,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class_type = collection_alias
             .origin(self.db())
             .apply_specialization(db, |_| {
-                builder.build_with(generic_context, |current_typevar, bounds| {
+                builder.build_with(|current_typevar, bounds| {
                     let lower = bounds?.lower?;
 
                     let lower = if is_empty_collection_type_context(tcx) {
@@ -7803,7 +7812,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db,
             env,
             annotation,
-            generic_context.inferable_typevars(db),
+            generic_context.inferable_typevars_with_bound_dependencies(db),
         );
         let constraints = ConstraintSetBuilder::new();
         let Solutions::Constrained(solutions) = path_bounds.solve(db, env, &constraints) else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5531,10 +5531,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let inferable = overload
                     .signature
                     .generic_context
-                    .map(|generic_context| {
-                        generic_context.inferable_typevars_with_bound_dependencies(db)
-                    })
-                    .unwrap_or(TypeVarSet::None);
+                    .map(|generic_context| generic_context.inferable_typevars(db))
+                    .unwrap_or(TypeVarSet::None)
+                    .merge(
+                        db,
+                        overload.signature.receiver_specialization_typevars(db, env),
+                    );
 
                 !overload
                     .return_ty

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -86,7 +86,7 @@ impl<'db> BoundMethodType<'db> {
         )
     }
 
-    pub(crate) fn with_distributed_receiver(
+    pub(crate) fn with_signature_receiver(
         self,
         db: &'db dyn Db,
         self_instance: Type<'db>,

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -31,6 +31,15 @@ pub struct BoundMethodType<'db> {
     /// attribute on a bound method object
     #[returns(copy)]
     pub(super) self_instance: Type<'db>,
+
+    /// The receiver type used to validate and specialize the function signature.
+    ///
+    /// This normally equals [`self_instance`][Self::self_instance]. They differ when member lookup
+    /// distributes over the declared constraints of a typevar: This field contains the particular
+    /// declared constraint that this bound method belongs to, while `self_instance` is the typevar
+    /// itself.
+    #[returns(copy)]
+    pub(super) signature_receiver: Type<'db>,
 }
 
 // The Salsa heap is tracked separately.
@@ -43,6 +52,7 @@ pub(super) fn walk_bound_method_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>
 ) {
     visitor.visit_function_type(db, method.function(db));
     visitor.visit_type(db, method.self_instance(db));
+    visitor.visit_type(db, method.signature_receiver(db));
 }
 
 #[salsa::tracked]
@@ -66,9 +76,23 @@ impl<'db> BoundMethodType<'db> {
     pub(crate) fn map_self_type(
         self,
         db: &'db dyn Db,
-        f: impl FnOnce(Type<'db>) -> Type<'db>,
+        mut f: impl FnMut(Type<'db>) -> Type<'db>,
     ) -> Self {
-        Self::new(db, self.function(db), f(self.self_instance(db)))
+        Self::new(
+            db,
+            self.function(db),
+            f(self.self_instance(db)),
+            f(self.signature_receiver(db)),
+        )
+    }
+
+    pub(crate) fn with_distributed_receiver(
+        self,
+        db: &'db dyn Db,
+        self_instance: Type<'db>,
+        signature_receiver: Type<'db>,
+    ) -> Self {
+        Self::new(db, self.function(db), self_instance, signature_receiver)
     }
 
     #[salsa::tracked(
@@ -114,7 +138,7 @@ impl<'db> BoundMethodType<'db> {
         let env =
             ProgramEnvironment::from_scope(function.literal(db).last_definition.body_scope(db));
         let typing_self_type = self.typing_self_type(db);
-        let receiver_type = self.self_instance(db);
+        let receiver_type = self.signature_receiver(db);
 
         self.bound_signatures_with_receiver(db, &env, receiver_type, typing_self_type)
     }
@@ -179,6 +203,8 @@ impl<'db> BoundMethodType<'db> {
             self.function(db)
                 .recursive_type_normalized_impl(db, env, div, nested)?,
             self.self_instance(db)
+                .recursive_type_normalized_impl(db, env, div, true)?,
+            self.signature_receiver(db)
                 .recursive_type_normalized_impl(db, env, div, true)?,
         ))
     }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -871,7 +871,7 @@ fn specialize_narrowing_target_from_intersection<'db>(
         db,
         env,
         &constraints,
-        generic_context.inferable_typevars_with_bound_dependencies(db),
+        generic_context.inferable_typevars(db),
     );
     let specialized_class =
         specialize_generic_class_from_solutions(db, env, target_class, solutions)?;
@@ -986,7 +986,7 @@ fn specialize_generic_class_for_subject<'db>(
             db,
             env,
             Type::instance(db, env, target),
-            generic_context.inferable_typevars_with_bound_dependencies(db),
+            generic_context.inferable_typevars(db),
         )
         .solve(db, env, &constraints);
 
@@ -2368,7 +2368,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 db,
                 &self.env,
                 Type::instance(db, &self.env, subject_class),
-                generic_context.inferable_typevars_with_bound_dependencies(db),
+                generic_context.inferable_typevars(db),
             )
             .solve_with(|variance, path_bound| {
                 let Some(lower) = path_bound.lower else {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -871,7 +871,7 @@ fn specialize_narrowing_target_from_intersection<'db>(
         db,
         env,
         &constraints,
-        generic_context.inferable_typevars(db),
+        generic_context.inferable_typevars_with_bound_dependencies(db),
     );
     let specialized_class =
         specialize_generic_class_from_solutions(db, env, target_class, solutions)?;
@@ -986,7 +986,7 @@ fn specialize_generic_class_for_subject<'db>(
             db,
             env,
             Type::instance(db, env, target),
-            generic_context.inferable_typevars(db),
+            generic_context.inferable_typevars_with_bound_dependencies(db),
         )
         .solve(db, env, &constraints);
 
@@ -2368,7 +2368,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 db,
                 &self.env,
                 Type::instance(db, &self.env, subject_class),
-                generic_context.inferable_typevars(db),
+                generic_context.inferable_typevars_with_bound_dependencies(db),
             )
             .solve_with(|variance, path_bound| {
                 let Some(lower) = path_bound.lower else {

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -218,10 +218,12 @@ fn create_bound_method<'db>(
     builtins_class: Type<'db>,
 ) -> Type<'db> {
     let env = ProgramEnvironment::from_program(program);
+    let self_instance = builtins_class.to_instance_approximation(db, &env).unwrap();
     Type::BoundMethod(BoundMethodType::new(
         db,
         function.expect_function_literal(),
-        builtins_class.to_instance_approximation(db, &env).unwrap(),
+        self_instance,
+        self_instance,
     ))
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1295,7 +1295,8 @@ impl<'db> Signature<'db> {
 
         let constraints = ConstraintSetBuilder::new();
         let when = constraints.load(db, env, receiver_constraints);
-        let inferable = self.inferable_typevars_with_bound_dependencies(db);
+        let receiver_typevars = self.receiver_specialization_typevars(db, env);
+        let inferable = self.inferable_typevars(db).merge(db, receiver_typevars);
 
         match when.solutions(db, env, &constraints, inferable) {
             Solutions::Unsatisfiable => return None,
@@ -1312,11 +1313,12 @@ impl<'db> Signature<'db> {
             return Some(self.clone());
         };
 
-        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+        let mut builder = SpecializationBuilder::new_with_receiver_typevars(
             db,
             env,
             &constraints,
             generic_context,
+            receiver_typevars,
         );
         builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
@@ -1436,7 +1438,8 @@ impl<'db> Signature<'db> {
                 env,
                 expected_self_ty,
                 &constraints,
-                self.inferable_typevars_with_bound_dependencies(db),
+                self.inferable_typevars(db)
+                    .merge(db, self.receiver_specialization_typevars(db, env)),
             )
             .is_always_satisfied(db, env)
     }
@@ -1784,11 +1787,42 @@ impl<'db> Signature<'db> {
                 .any(|(_, parameter)| parameter.annotated_type().contains_self(db, env))
     }
 
-    fn inferable_typevars_with_bound_dependencies(&self, db: &'db dyn Db) -> TypeVarSet<'db> {
+    fn inferable_typevars(&self, db: &'db dyn Db) -> TypeVarSet<'db> {
         match self.generic_context {
-            Some(generic_context) => generic_context.inferable_typevars_with_bound_dependencies(db),
+            Some(generic_context) => generic_context.inferable_typevars(db),
             None => TypeVarSet::None,
         }
+    }
+
+    /// Returns unspecialized class typevars that a synthetic `Self` receiver can determine.
+    pub(crate) fn receiver_specialization_typevars(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> TypeVarSet<'db> {
+        let mut dependencies = Vec::new();
+        for self_typevar in self
+            .generic_context
+            .into_iter()
+            .flat_map(|context| context.variables(db))
+            .filter(|typevar| typevar.typevar(db).is_self(db))
+        {
+            let Some(bound) = self_typevar.typevar(db).upper_bound(db, env) else {
+                continue;
+            };
+            let Some((_, specialization)) = bound.class_specialization(db, env) else {
+                continue;
+            };
+
+            let owner_context = specialization.generic_context(db);
+            dependencies.extend(
+                TypeVarSet::from_typevar_occurrences(db, env, [bound])
+                    .iter(db)
+                    .filter(|typevar| owner_context.contains(db, typevar.identity(db))),
+            );
+        }
+
+        TypeVarSet::from_typevars(db, dependencies)
     }
 
     pub(crate) fn is_non_generic(&self) -> bool {
@@ -2364,34 +2398,26 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
 
-        // `inferable` has different roles in the two type-variable evaluation modes:
-        //
-        // * Eager comparisons decide whether the relation holds immediately. An unbound generic
-        //   method's `Self` can have an upper bound such as `C[T]`, so `T` must also be
-        //   inferable; otherwise, a concrete receiver such as `C[int]` is compared against a
-        //   fixed, symbolic `T` and valid higher-order calls are rejected.
-        // * Lazy comparisons record constraints for every type variable, regardless of whether
-        //   it is inferable. Here, `signature_inferable` also determines which type variables
-        //   `reduce_inferable` existentially removes below, so it must contain only variables
-        //   actually bound by these signatures. Including an enclosing class's `T` would turn a
-        //   decorator's return constraint `T <= R` into `exists T. T <= R`, losing the
-        //   relationship needed to infer `R = T`.
-        let include_bound_dependencies = self.typevar_evaluation == TypeVarEvaluation::Eager;
         let signature_typevars = |signature: &Signature<'db>| {
             signature
                 .generic_context
-                .map_or(TypeVarSet::None, |context| {
-                    if include_bound_dependencies {
-                        context.inferable_typevars_with_bound_dependencies(db)
-                    } else {
-                        context.inferable_typevars(db)
-                    }
-                })
+                .map_or(TypeVarSet::None, |context| context.inferable_typevars(db))
         };
-        let source_inferable = signature_typevars(source);
-        let target_inferable = signature_typevars(target);
-        let signature_inferable = source_inferable.merge(db, target_inferable);
-        let inferable = self.inferable.merge(db, signature_inferable);
+        let signature_typevars = signature_typevars(source).merge(db, signature_typevars(target));
+
+        // An eager relation against an unbound method also specializes identity-mapped class
+        // typevars through synthetic `Self`. These are explicit receiver dependencies, not
+        // arbitrary typevars discovered by recursively walking declared domains. Lazy relations
+        // leave them fixed so enclosing class occurrences remain visible to the caller.
+        let receiver_typevars = if self.typevar_evaluation == TypeVarEvaluation::Eager {
+            source
+                .receiver_specialization_typevars(db, env)
+                .merge(db, target.receiver_specialization_typevars(db, env))
+        } else {
+            TypeVarSet::None
+        };
+        let relation_typevars = signature_typevars.merge(db, receiver_typevars);
+        let inferable = self.inferable.merge(db, relation_typevars);
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
@@ -2417,7 +2443,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
-        when.reduce_inferable(db, env, self.constraints, signature_inferable)
+        when.reduce_inferable(db, env, self.constraints, relation_typevars)
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2365,10 +2365,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .generic_context
                 .map_or(TypeVarSet::None, |context| context.inferable_typevars(db))
         };
-        let signature_typevars = signature_typevars(source).merge(db, signature_typevars(target));
+        let source_inferable = signature_typevars(source);
+        let target_inferable = signature_typevars(target);
+        let signature_inferable = source_inferable.merge(db, target_inferable);
 
-        let relation_typevars = signature_typevars;
-        let inferable = self.inferable.merge(db, relation_typevars);
+        let inferable = self.inferable.merge(db, signature_inferable);
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
@@ -2394,7 +2395,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
-        when.reduce_inferable(db, env, self.constraints, relation_typevars)
+        when.reduce_inferable(db, env, self.constraints, signature_inferable)
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1295,8 +1295,7 @@ impl<'db> Signature<'db> {
 
         let constraints = ConstraintSetBuilder::new();
         let when = constraints.load(db, env, receiver_constraints);
-        let receiver_typevars = self.receiver_specialization_typevars(db, env);
-        let inferable = self.inferable_typevars(db).merge(db, receiver_typevars);
+        let inferable = self.inferable_typevars(db);
 
         match when.solutions(db, env, &constraints, inferable) {
             Solutions::Unsatisfiable => return None,
@@ -1313,13 +1312,7 @@ impl<'db> Signature<'db> {
             return Some(self.clone());
         };
 
-        let mut builder = SpecializationBuilder::new_with_receiver_typevars(
-            db,
-            env,
-            &constraints,
-            generic_context,
-            receiver_typevars,
-        );
+        let mut builder = SpecializationBuilder::new(db, env, &constraints, generic_context);
         builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
@@ -1438,8 +1431,7 @@ impl<'db> Signature<'db> {
                 env,
                 expected_self_ty,
                 &constraints,
-                self.inferable_typevars(db)
-                    .merge(db, self.receiver_specialization_typevars(db, env)),
+                self.inferable_typevars(db),
             )
             .is_always_satisfied(db, env)
     }
@@ -1632,8 +1624,9 @@ impl<'db> Signature<'db> {
     /// Returns this signature with the given specialization applied to parameters and return type.
     fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
         let env = &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
-        let type_mapping =
-            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
+        let type_mapping = TypeMapping::ApplySpecialization(
+            ApplySpecialization::SpecializationWithSelfDomain(specialization),
+        );
         self.apply_type_mapping_impl(
             db,
             &type_mapping,
@@ -1792,37 +1785,6 @@ impl<'db> Signature<'db> {
             Some(generic_context) => generic_context.inferable_typevars(db),
             None => TypeVarSet::None,
         }
-    }
-
-    /// Returns unspecialized class typevars that a synthetic `Self` receiver can determine.
-    pub(crate) fn receiver_specialization_typevars(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> TypeVarSet<'db> {
-        let mut dependencies = Vec::new();
-        for self_typevar in self
-            .generic_context
-            .into_iter()
-            .flat_map(|context| context.variables(db))
-            .filter(|typevar| typevar.typevar(db).is_self(db))
-        {
-            let Some(bound) = self_typevar.typevar(db).upper_bound(db, env) else {
-                continue;
-            };
-            let Some((_, specialization)) = bound.class_specialization(db, env) else {
-                continue;
-            };
-
-            let owner_context = specialization.generic_context(db);
-            dependencies.extend(
-                TypeVarSet::from_typevar_occurrences(db, env, [bound])
-                    .iter(db)
-                    .filter(|typevar| owner_context.contains(db, typevar.identity(db))),
-            );
-        }
-
-        TypeVarSet::from_typevars(db, dependencies)
     }
 
     pub(crate) fn is_non_generic(&self) -> bool {
@@ -2405,18 +2367,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         };
         let signature_typevars = signature_typevars(source).merge(db, signature_typevars(target));
 
-        // An eager relation against an unbound method also specializes identity-mapped class
-        // typevars through synthetic `Self`. These are explicit receiver dependencies, not
-        // arbitrary typevars discovered by recursively walking declared domains. Lazy relations
-        // leave them fixed so enclosing class occurrences remain visible to the caller.
-        let receiver_typevars = if self.typevar_evaluation == TypeVarEvaluation::Eager {
-            source
-                .receiver_specialization_typevars(db, env)
-                .merge(db, target.receiver_specialization_typevars(db, env))
-        } else {
-            TypeVarSet::None
-        };
-        let relation_typevars = signature_typevars.merge(db, receiver_typevars);
+        let relation_typevars = signature_typevars;
         let inferable = self.inferable.merge(db, relation_typevars);
 
         // `inner` will create a constraint set that references these newly inferable typevars.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1295,7 +1295,7 @@ impl<'db> Signature<'db> {
 
         let constraints = ConstraintSetBuilder::new();
         let when = constraints.load(db, env, receiver_constraints);
-        let inferable = self.inferable_typevars(db);
+        let inferable = self.inferable_typevars_with_bound_dependencies(db);
 
         match when.solutions(db, env, &constraints, inferable) {
             Solutions::Unsatisfiable => return None,
@@ -1312,11 +1312,16 @@ impl<'db> Signature<'db> {
             return Some(self.clone());
         };
 
-        let mut builder = SpecializationBuilder::new(db, env, &constraints, inferable);
+        let mut builder = SpecializationBuilder::new_with_bound_dependencies(
+            db,
+            env,
+            &constraints,
+            generic_context,
+        );
         builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
-        let specialization = builder.build_with(generic_context, |typevar, bounds| {
+        let specialization = builder.build_with(|typevar, bounds| {
             if let Some(bounds) = bounds
                 && let Some(lower) = bounds.lower
                 && let Some(upper) = bounds.upper.as_single_bound(db, env)
@@ -1431,7 +1436,7 @@ impl<'db> Signature<'db> {
                 env,
                 expected_self_ty,
                 &constraints,
-                self.inferable_typevars(db),
+                self.inferable_typevars_with_bound_dependencies(db),
             )
             .is_always_satisfied(db, env)
     }
@@ -1779,9 +1784,9 @@ impl<'db> Signature<'db> {
                 .any(|(_, parameter)| parameter.annotated_type().contains_self(db, env))
     }
 
-    fn inferable_typevars(&self, db: &'db dyn Db) -> TypeVarSet<'db> {
+    fn inferable_typevars_with_bound_dependencies(&self, db: &'db dyn Db) -> TypeVarSet<'db> {
         match self.generic_context {
-            Some(generic_context) => generic_context.inferable_typevars(db),
+            Some(generic_context) => generic_context.inferable_typevars_with_bound_dependencies(db),
             None => TypeVarSet::None,
         }
     }
@@ -2377,9 +2382,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .generic_context
                 .map_or(TypeVarSet::None, |context| {
                     if include_bound_dependencies {
-                        context.inferable_typevars(db)
+                        context.inferable_typevars_with_bound_dependencies(db)
                     } else {
-                        TypeVarSet::from_typevars(db, context.variables(db))
+                        context.inferable_typevars(db)
                     }
                 })
         };

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1624,9 +1624,8 @@ impl<'db> Signature<'db> {
     /// Returns this signature with the given specialization applied to parameters and return type.
     fn apply_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
         let env = &ProgramEnvironment::from_program(specialization.generic_context(db).program(db));
-        let type_mapping = TypeMapping::ApplySpecialization(
-            ApplySpecialization::SpecializationWithSelfDomain(specialization),
-        );
+        let type_mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::specialization(specialization));
         self.apply_type_mapping_impl(
             db,
             &type_mapping,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1747,6 +1747,54 @@ pub(crate) enum TypeVarSet<'db> {
 }
 
 impl<'db> TypeVarSet<'db> {
+    /// Collects typevar occurrences from types without traversing their declared domains.
+    pub(crate) fn from_typevar_occurrences(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        types: impl IntoIterator<Item = Type<'db>>,
+    ) -> Self {
+        struct CollectTypeVars<'a, 'db> {
+            env: &'a ProgramEnvironment<'db>,
+            typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,
+            recursion_guard: TypeCollector<'db>,
+        }
+
+        impl<'db> TypeVisitor<'db> for CollectTypeVars<'_, 'db> {
+            fn program_environment(&self) -> &ProgramEnvironment<'db> {
+                self.env
+            }
+
+            fn should_visit_lazy_type_attributes(&self) -> bool {
+                false
+            }
+
+            fn visit_bound_type_var_type(
+                &self,
+                db: &'db dyn Db,
+                bound_typevar: BoundTypeVarInstance<'db>,
+            ) {
+                self.typevars
+                    .borrow_mut()
+                    .entry(bound_typevar.identity(db))
+                    .or_insert(bound_typevar);
+            }
+
+            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            }
+        }
+
+        let visitor = CollectTypeVars {
+            env,
+            typevars: RefCell::default(),
+            recursion_guard: TypeCollector::default(),
+        };
+        for ty in types {
+            visitor.visit_type(db, ty);
+        }
+        Self::from_typevars(db, visitor.typevars.into_inner().into_values())
+    }
+
     pub(crate) fn from_typevars(
         db: &'db dyn Db,
         typevars: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1213,7 +1213,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     ) -> Self {
         self.map_bound_or_constraints(db, |original| {
             let original = original?;
-            let mapping = TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
+            let mapping = TypeMapping::ApplySpecialization(ApplySpecialization::specialization(
                 specialization,
             ));
             let visitor = ApplyTypeMappingVisitor::new(env);
@@ -1299,22 +1299,27 @@ impl<'db> BoundTypeVarInstance<'db> {
                 })
             };
 
+        let possibly_apply_to_self = |specialization: &ApplySpecialization<'a, 'db>| {
+            if self.typevar(db).is_self(db)
+                && let ApplySpecialization::Specialization {
+                    specialization,
+                    specialize_self_domain: true,
+                } = specialization
+            {
+                Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
+                    db,
+                    *specialization,
+                    visitor.env,
+                ))
+            } else {
+                Type::TypeVar(self)
+            }
+        };
+
         match type_mapping {
             TypeMapping::ApplySpecialization(specialization) => {
-                mapped_specialization_type(specialization).unwrap_or_else(|| {
-                    if self.typevar(db).is_self(db)
-                        && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
-                            specialization
-                    {
-                        Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
-                            db,
-                            *specialization,
-                            visitor.env,
-                        ))
-                    } else {
-                        Type::TypeVar(self)
-                    }
-                })
+                mapped_specialization_type(specialization)
+                    .unwrap_or_else(|| possibly_apply_to_self(specialization))
             }
             TypeMapping::ApplySpecializationWithMaterialization {
                 specialization,
@@ -1348,20 +1353,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                         }
                     }
                 })
-                .unwrap_or_else(|| {
-                    if self.typevar(db).is_self(db)
-                        && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
-                            specialization
-                    {
-                        Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
-                            db,
-                            *specialization,
-                            visitor.env,
-                        ))
-                    } else {
-                        Type::TypeVar(self)
-                    }
-                }),
+                .unwrap_or_else(|| possibly_apply_to_self(specialization)),
             TypeMapping::BindSelf(binding) => {
                 if binding.should_bind(db, visitor.env, self) {
                     binding.self_type()

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -17,8 +17,9 @@ use crate::{
     types::{
         ApplySpecialization, ApplyTypeMappingVisitor, CycleDetector, DynamicType, GenericContext,
         InstanceProjection, IntersectionType, KnownClass, KnownInstanceType, MaterializationKind,
-        Parameter, Parameters, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarVariance,
-        UnionBuilder, UnionType, any_over_type, binding_type, definition_expression_type,
+        Parameter, Parameters, Specialization, Type, TypeAliasType, TypeContext, TypeMapping,
+        TypeVarVariance, UnionBuilder, UnionType, any_over_type, binding_type,
+        definition_expression_type,
         tuple::Tuple,
         variance::VarianceInferable,
         visitor::{self, TypeCollector, TypeVisitor, walk_type_with_recursion_guard},
@@ -1203,6 +1204,29 @@ impl<'db> BoundTypeVarInstance<'db> {
         Self::new(db, typevar, binding_context, None, TypeVarNonce::NONE)
     }
 
+    /// Applies a specialization to this occurrence's declared domain.
+    ///
+    /// If the domain is unchanged, this preserves the original instance and its lazy domain
+    /// representation.
+    fn apply_specialization_to_domain(
+        self,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+        env: &ProgramEnvironment<'db>,
+    ) -> Self {
+        let typevar = self.typevar(db);
+        let original = typevar.bound_or_constraints(db, env);
+        let mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
+        let visitor = ApplyTypeMappingVisitor::new(env);
+        let mapped = original.map(|domain| domain.apply_type_mapping_impl(db, &mapping, &visitor));
+        if mapped == original {
+            self
+        } else {
+            self.map_bound_or_constraints(db, |_| mapped)
+        }
+    }
+
     /// Returns an identical type variable with its `TypeVarBoundOrConstraints` mapped by the
     /// provided closure.
     pub(crate) fn map_bound_or_constraints(
@@ -1283,7 +1307,20 @@ impl<'db> BoundTypeVarInstance<'db> {
 
         match type_mapping {
             TypeMapping::ApplySpecialization(specialization) => {
-                mapped_specialization_type(specialization).unwrap_or(Type::TypeVar(self))
+                mapped_specialization_type(specialization).unwrap_or_else(|| {
+                    if self.typevar(db).is_self(db)
+                        && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
+                            specialization
+                    {
+                        Type::TypeVar(self.apply_specialization_to_domain(
+                            db,
+                            *specialization,
+                            visitor.env,
+                        ))
+                    } else {
+                        Type::TypeVar(self)
+                    }
+                })
             }
             TypeMapping::ApplySpecializationWithMaterialization {
                 specialization,
@@ -1317,7 +1354,20 @@ impl<'db> BoundTypeVarInstance<'db> {
                         }
                     }
                 })
-                .unwrap_or(Type::TypeVar(self)),
+                .unwrap_or_else(|| {
+                    if self.typevar(db).is_self(db)
+                        && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
+                            specialization
+                    {
+                        Type::TypeVar(self.apply_specialization_to_domain(
+                            db,
+                            *specialization,
+                            visitor.env,
+                        ))
+                    } else {
+                        Type::TypeVar(self)
+                    }
+                }),
             TypeMapping::BindSelf(binding) => {
                 if binding.should_bind(db, visitor.env, self) {
                     binding.self_type()
@@ -1747,54 +1797,6 @@ pub(crate) enum TypeVarSet<'db> {
 }
 
 impl<'db> TypeVarSet<'db> {
-    /// Collects typevar occurrences from types without traversing their declared domains.
-    pub(crate) fn from_typevar_occurrences(
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        types: impl IntoIterator<Item = Type<'db>>,
-    ) -> Self {
-        struct CollectTypeVars<'a, 'db> {
-            env: &'a ProgramEnvironment<'db>,
-            typevars: RefCell<FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>>,
-            recursion_guard: TypeCollector<'db>,
-        }
-
-        impl<'db> TypeVisitor<'db> for CollectTypeVars<'_, 'db> {
-            fn program_environment(&self) -> &ProgramEnvironment<'db> {
-                self.env
-            }
-
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
-            }
-
-            fn visit_bound_type_var_type(
-                &self,
-                db: &'db dyn Db,
-                bound_typevar: BoundTypeVarInstance<'db>,
-            ) {
-                self.typevars
-                    .borrow_mut()
-                    .entry(bound_typevar.identity(db))
-                    .or_insert(bound_typevar);
-            }
-
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
-            }
-        }
-
-        let visitor = CollectTypeVars {
-            env,
-            typevars: RefCell::default(),
-            recursion_guard: TypeCollector::default(),
-        };
-        for ty in types {
-            visitor.visit_type(db, ty);
-        }
-        Self::from_typevars(db, visitor.typevars.into_inner().into_values())
-    }
-
     pub(crate) fn from_typevars(
         db: &'db dyn Db,
         typevars: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1204,27 +1204,21 @@ impl<'db> BoundTypeVarInstance<'db> {
         Self::new(db, typevar, binding_context, None, TypeVarNonce::NONE)
     }
 
-    /// Applies a specialization to this occurrence's declared domain.
-    ///
-    /// If the domain is unchanged, this preserves the original instance and its lazy domain
-    /// representation.
-    fn apply_specialization_to_domain(
+    /// Applies a specialization to this occurrence's declared upper bound or constraints, if any.
+    fn apply_specialization_to_bound_or_constraints(
         self,
         db: &'db dyn Db,
         specialization: Specialization<'db>,
         env: &ProgramEnvironment<'db>,
     ) -> Self {
-        let typevar = self.typevar(db);
-        let original = typevar.bound_or_constraints(db, env);
-        let mapping =
-            TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
-        let visitor = ApplyTypeMappingVisitor::new(env);
-        let mapped = original.map(|domain| domain.apply_type_mapping_impl(db, &mapping, &visitor));
-        if mapped == original {
-            self
-        } else {
-            self.map_bound_or_constraints(db, |_| mapped)
-        }
+        self.map_bound_or_constraints(db, |original| {
+            let original = original?;
+            let mapping = TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
+                specialization,
+            ));
+            let visitor = ApplyTypeMappingVisitor::new(env);
+            Some(original.apply_type_mapping_impl(db, &mapping, &visitor))
+        })
     }
 
     /// Returns an identical type variable with its `TypeVarBoundOrConstraints` mapped by the
@@ -1312,7 +1306,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                         && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
                             specialization
                     {
-                        Type::TypeVar(self.apply_specialization_to_domain(
+                        Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
                             db,
                             *specialization,
                             visitor.env,
@@ -1359,7 +1353,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                         && let ApplySpecialization::SpecializationWithSelfDomain(specialization) =
                             specialization
                     {
-                        Type::TypeVar(self.apply_specialization_to_domain(
+                        Type::TypeVar(self.apply_specialization_to_bound_or_constraints(
                             db,
                             *specialization,
                             visitor.env,


### PR DESCRIPTION
This PR establishes a new invariant that the set of typevars that are inferable when calling a generic function is _exactly and only_ the typevars in the function's `GenericContext`.

Surprisingly, this used to not be the case! The main wrinkle is invoking the constructor of a generic class. In this case, the class typevars are also inferable. For the most part, we encode that by adding the class typevars to the generic context of the constructors. But when those class typevars have an upper bound that contain _other_ typevars, we were previously including those other typevars in the inferable set as well. They shouldn't be; this was a hack to cause us to include those upper bounds correctly when inferring the specialization. This hack comes from before we had the new solver available. The new solver is perfectly capable of expressing cross-typevar relationships, and so as long as we include the upper bounds as additional constraints, we're good to go.

This pattern also applies to the `Self` typevar that appears in instance methods, since those implicitly have an upper bound of the class itself. If the class is generic, we would therefore include the class typevars in the inferable set — which is actually _incorrect_, since by this point we already have a specialization for the class, and its typevars are no longer inferable.

Closes https://github.com/astral-sh/ty/issues/4303