### PR TITLE
[ty] Restrict equality impossibility to static bounds

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -436,10 +436,11 @@ def consume_callback(callback: Callable[[Row], None]) -> Row:
 reveal_type(consume_callback(callback))  # revealed: tuple[Any, ...]
 ```
 
-## Incompatible invariant protocol members
+## Gradual invariant protocol members
 
-When the same inferred type variable appears in multiple invariant protocol members, those members
-must agree on one exact specialization. Gradual consistency between their types is not sufficient.
+When the same inferred type variable appears in multiple invariant protocol members, fully static
+member types must agree on one exact specialization. Gradual members remain conservative
+alternatives because their equality cannot justify a transitive sequent proof.
 
 ```py
 from typing import Any, Generic, Protocol, TypeVar
@@ -460,7 +461,7 @@ def infer_pair(value: Pair[T]) -> T:
 
 def check_pair(value: GradualPair[U]) -> None:
     # TODO: error: [invalid-argument-type] "Argument to function `infer_pair` is incorrect"
-    reveal_type(infer_pair(value))  # revealed: Unknown
+    reveal_type(infer_pair(value))  # revealed: tuple[U@check_pair, Any] | tuple[U@check_pair, int]
 ```
 
 ## Prefer specific compatible constraints over gradual constraints

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -372,40 +372,49 @@ def lower_bounds[T]():
 
 ### Intersection of two equality constraints
 
-A type variable cannot be exactly equal to two non-equivalent types. This is stronger than checking
-whether the types are disjoint: two classes can have a common subclass, which makes their
-upper-bound constraints compatible, but that subclass is not exactly equal to either class.
+A type variable cannot be exactly equal to two non-equivalent fully static types. This is stronger
+than checking whether the types are disjoint: two classes can have a common subclass, which makes
+their upper-bound constraints compatible, but that subclass is not exactly equal to either class.
+
+Gradual bounds cannot prove this incompatibility. Sequent maps derive facts via transitivity, but
+gradual assignability is not transitive. That means equality constraints containing dynamic types
+remain conservatively satisfiable. Type variables nested inside a bound are treated as opaque
+symbolic atoms; their declared bounds do not make an otherwise static proof gradual.
 
 ```py
 from typing import Any
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
-class Row: ...
-class RowTuple(Row, tuple[Any, ...]): ...
+class Left: ...
+class Right: ...
+class Both(Left, Right): ...
 
-def _[T, U, V]() -> None:
-    row = ConstraintSet.equality(T, Row)
-    tuple_ = ConstraintSet.equality(T, tuple[Any, ...])
-    static_assert(~(row & tuple_))
+def _[T, U: Any, V]() -> None:
+    left = ConstraintSet.equality(T, Left)
+    right = ConstraintSet.equality(T, Right)
+    static_assert(~(left & right))
 
-    equivalent = row & row
-    static_assert(equivalent == row)
+    equivalent = left & left
+    static_assert(equivalent == left)
 
-    upper_bounds = ConstraintSet.upper_bound(T, Row) & ConstraintSet.upper_bound(T, tuple[Any, ...])
+    upper_bounds = ConstraintSet.upper_bound(T, Left) & ConstraintSet.upper_bound(T, Right)
     static_assert(not ~upper_bounds)
 
-    row_tuple = ConstraintSet.equality(T, RowTuple)
-    static_assert(row_tuple & upper_bounds == row_tuple)
+    both = ConstraintSet.equality(T, Both)
+    static_assert(both & upper_bounds == both)
+
+    symbolic_static_mismatch = ConstraintSet.equality(T, tuple[U, int]) & ConstraintSet.equality(T, tuple[U, str])
+    static_assert(~symbolic_static_mismatch)
 
     gradual_mismatch = ConstraintSet.equality(T, list[Any]) & ConstraintSet.equality(T, list[int])
-    static_assert(~gradual_mismatch)
+    static_assert(not ~gradual_mismatch)
 
     any_mismatch = ConstraintSet.equality(T, Any) & ConstraintSet.equality(T, int)
-    static_assert(~any_mismatch)
+    static_assert(not ~any_mismatch)
 
-    symbolic_mismatch = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, int])
-    static_assert(~symbolic_mismatch)
+    symbolic_gradual_mismatch = ConstraintSet.equality(T, tuple[U, Any]) & ConstraintSet.equality(T, tuple[U, int])
+    static_assert(not ~symbolic_gradual_mismatch)
 
     symbolic_match = ConstraintSet.equality(T, list[U]) & ConstraintSet.equality(T, list[V])
     static_assert(not ~symbolic_match)

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2643,7 +2643,6 @@ X = TypedDict("X", {"type": Literal["x"]})
 Item = A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X
 
 def takes_bare_dict(value: dict[Any]) -> None: ...
-
 def _(item: Item) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
     takes_bare_dict(dict(item))

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2642,7 +2642,7 @@ X = TypedDict("X", {"type": Literal["x"]})
 
 Item = A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X
 
-def takes_bare_dict(value: dict[Any]) -> None: ...
+def takes_bare_dict(value: dict[Any, Any]) -> None: ...
 def _(item: Item) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
     takes_bare_dict(dict(item))

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2602,7 +2602,8 @@ def mixed(movie_or_int: Movie | int) -> None:
     dict(movie_or_int)  # error: [no-matching-overload]
 ```
 
-The same result is inferred efficiently for a union of `TypedDict`s:
+The same result is inferred efficiently for a union of `TypedDict`s, including when the result is
+checked against a bare `dict`:
 
 ```toml
 [environment]
@@ -2641,8 +2642,11 @@ X = TypedDict("X", {"type": Literal["x"]})
 
 Item = A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X
 
+def takes_bare_dict(value: dict[Any]) -> None: ...
+
 def _(item: Item) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
+    takes_bare_dict(dict(item))
 
 # Runtime narrowing preserves each `TypedDict` schema without exposing unrestricted dictionary
 # operations. The union should still reuse its common protocol constraints.

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1871,6 +1871,52 @@ pub(crate) struct ConstraintBounds<'db> {
     pub(crate) upper: Option<Type<'db>>,
 }
 
+impl<'db> Type<'db> {
+    /// Returns whether this type can participate in a transitive sequent proof.
+    ///
+    /// Gradual assignability is not transitive, so constraints with dynamic bounds are ineligible.
+    /// Note that we can't use [`is_fully_static`][Type::is_fully_static] here, since that
+    /// considers the declared bounds/constraints of typevars. In the context of a sequent map,
+    /// typevars are opaque symbolic atoms: considering their bounds or defaults could incorrectly
+    /// make their eligibility depend on a specialization that the sequent is meant to constrain.
+    fn is_static_sequent_eligible(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
+        struct EligibilityVisitor<'a, 'db> {
+            env: &'a ProgramEnvironment<'db>,
+            seen: TypeCollector<'db>,
+            eligible: Cell<bool>,
+        }
+
+        impl<'db> TypeVisitor<'db> for EligibilityVisitor<'_, 'db> {
+            fn program_environment(&self) -> &ProgramEnvironment<'db> {
+                self.env
+            }
+
+            fn should_visit_lazy_type_attributes(&self) -> bool {
+                false
+            }
+
+            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+                if !self.eligible.get() || ty.is_type_var() {
+                    return;
+                }
+                if ty.is_dynamic() {
+                    self.eligible.set(false);
+                    return;
+                }
+                walk_type_with_recursion_guard(db, ty, self, &self.seen);
+            }
+        }
+
+        let visitor = EligibilityVisitor {
+            env,
+            seen: TypeCollector::default(),
+            eligible: Cell::new(true),
+        };
+        visitor.visit_type(db, self);
+        visitor.eligible.get()
+    }
+}
+
 impl<'db> ConstraintBounds<'db> {
     pub(crate) fn new(lower: Option<Type<'db>>, upper: Option<Type<'db>>) -> Self {
         Self { lower, upper }
@@ -2514,12 +2560,13 @@ impl ConstraintId {
         let self_constraint = storage.constraint_data(self);
         let other_constraint = storage.constraint_data(other);
 
-        // A typevar cannot be exactly equal to two different types under any specialization. This
-        // is stronger than checking whether the types are disjoint: two classes can have a common
-        // subclass, which makes their upper-bound constraints compatible, but that subclass is not
-        // exactly equal to either class.
+        // A typevar cannot be exactly equal to two different statically eligible types under any
+        // specialization. Gradual bounds cannot prove this incompatibility because the resulting
+        // pair-impossibility sequent participates in transitive closure.
         if let Some(left) = self_constraint.bounds.as_equality()
             && let Some(right) = other_constraint.bounds.as_equality()
+            && left.is_static_sequent_eligible(db, env)
+            && right.is_static_sequent_eligible(db, env)
             && !left.can_be_constraint_set_equivalent_to(db, env, right)
         {
             return IntersectionResult::Disjoint;


### PR DESCRIPTION
This fixes the performance regression identified in https://github.com/astral-sh/ty/issues/4231.

Most of the derived facts that the sequent map adds to a constraint set depend on transitivity. That means that those sequents should only be derived for fully-static lower and upper bounds, since our definition of gradual assignability is not transitive.

That was the root cause of the regression; it caused us to add a quadratic number of new constraint relationships, which were built on incorrectly assuming a transitive type relationship through a dynamic bound.

Note that https://github.com/astral-sh/ruff/pull/27652 includes a more thorough update to make _all_ of the sequents be transitivity-safe. This is a pointed fix that only considers the logic introduced https://github.com/astral-sh/ruff/pull/27614.

Fixes https://github.com/astral-sh/ty/issues/4231