### PR TITLE
Pin Depot runners to Ubuntu 24.04

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,7 +5,7 @@ self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
     - depot-ubuntu-24.04-4
-    - depot-ubuntu-latest-8
+    - depot-ubuntu-24.04-8
     - depot-ubuntu-22.04-16
     - depot-ubuntu-22.04-32
     - namespace-profile-macos-15

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -491,7 +491,7 @@ jobs:
 
   cargo-build-msrv:
     name: "cargo build (msrv)"
-    runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-latest-8' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-24.04-8' || 'ubuntu-latest' }}
     needs: determine_changes
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20
@@ -625,7 +625,7 @@ jobs:
 
   ecosystem:
     name: "ecosystem"
-    runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-latest-8' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-24.04-8' || 'ubuntu-latest' }}
     needs: determine_changes
     # Only runs on pull requests, since that is the only we way we can find the base version for comparison.
     # Ecosystem check needs linter and/or formatter changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "depot-ubuntu-latest-4"
+    runs-on: "depot-ubuntu-24.04-4"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
@@ -153,7 +153,7 @@ jobs:
       - custom-build-binaries
       - custom-build-docker
       - custom-build-wasm
-    runs-on: "depot-ubuntu-latest-4"
+    runs-on: "depot-ubuntu-24.04-4"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -206,7 +206,7 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-build-binaries.result == 'skipped' || needs.custom-build-binaries.result == 'success') && (needs.custom-build-docker.result == 'skipped' || needs.custom-build-docker.result == 'success') && (needs.custom-build-wasm.result == 'skipped' || needs.custom-build-wasm.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "depot-ubuntu-latest-4"
+    runs-on: "depot-ubuntu-24.04-4"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -304,7 +304,7 @@ jobs:
     # `custom-publish-crates` is intentionally not a dependency because a crates.io outage should
     # not block the rest of the release.
     if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') && (needs.custom-publish-wasm.result == 'skipped' || needs.custom-publish-wasm.result == 'success') }}
-    runs-on: "depot-ubuntu-latest-4"
+    runs-on: "depot-ubuntu-24.04-4"
     permissions:
       "attestations": "write"
       "contents": "write"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -74,7 +74,7 @@ hosting = ["simple", "github"]
 simple-download-url = "https://releases.astral.sh/github/ruff/releases/download/{tag}"
 
 [dist.github-custom-runners]
-global = "depot-ubuntu-latest-4"
+global = "depot-ubuntu-24.04-4"
 
 [dist.github-action-commits]
 "actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2


### PR DESCRIPTION
## Summary

Previously, our Depot-backed CI and release jobs used floating Ubuntu runner labels. We now pin the four-core release runners and eight-core CI runners to Ubuntu 24.04, update actionlint accordingly, and keep the cargo-dist runner configuration aligned with the generated release workflow.

The existing release approval gate and checksum-verified cargo-dist installation remain unchanged.
