### PR TITLE
Use a four-core Depot runner for Linux ARM64 PGO builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -11,6 +11,7 @@ self-hosted-runner:
     - namespace-profile-macos-15
     - namespace-profile-windows-2022-x86-64-16x32
     - depot-ubuntu-22.04-arm-4
+    - depot-ubuntu-24.04-arm-8
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16
     - codspeed-macro

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -11,7 +11,7 @@ self-hosted-runner:
     - namespace-profile-macos-15
     - namespace-profile-windows-2022-x86-64-16x32
     - depot-ubuntu-22.04-arm-4
-    - depot-ubuntu-24.04-arm-8
+    - depot-ubuntu-24.04-arm-4
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16
     - codspeed-macro

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -335,7 +335,7 @@ jobs:
 
   linux-aarch64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-24.04-arm-8
+    runs-on: depot-ubuntu-24.04-arm-4
     env:
       # see https://github.com/astral-sh/ruff/issues/3791
       # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -335,7 +335,7 @@ jobs:
 
   linux-aarch64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-24.04-arm
+    runs-on: depot-ubuntu-24.04-arm-8
     env:
       # see https://github.com/astral-sh/ruff/issues/3791
       # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963


### PR DESCRIPTION
## Summary

Previously, our Linux ARM64 PGO release build took 15m 26s on a four-core GitHub runner.

We now use a pinned, four-core Ubuntu 24.04 Depot ARM runner, which completed the same build in 13m 39s. An eight-core Depot runner finished in 12m 18s, but the existing Windows PGO lane completed only 14 seconds before the four-core ARM build, so additional ARM cores would not meaningfully shorten the release.