### PR TITLE
[ty] Specialize inherited members of unspecialized generic classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2246,7 +2246,8 @@ reveal_type(WrappedIntAndExtraData[bytes].__init__)
 This is a regression test for <https://github.com/astral-sh/ty/issues/1427>.
 
 When a non-dataclass inherits from a generic dataclass, the generic type parameters should still be
-properly inferred when calling the inherited `__init__` method.
+properly inferred during construction. Explicit access to the inherited `__init__` instead uses the
+class's default type arguments.
 
 ```py
 from dataclasses import dataclass
@@ -2261,11 +2262,10 @@ class ChildOfParentDataclass[T](ParentDataclass[T]): ...
 def uses_dataclass[T](x: T) -> ChildOfParentDataclass[T]:
     return ChildOfParentDataclass(x)
 
-# TODO: ParentDataclass.__init__ should show generic types, not Unknown
 # revealed: (self: ParentDataclass[Unknown], value: Unknown) -> None
 reveal_type(ParentDataclass.__init__)
 
-# revealed: [T](self: ParentDataclass[T], value: T) -> None
+# revealed: (self: ParentDataclass[Unknown], value: Unknown) -> None
 reveal_type(ChildOfParentDataclass.__init__)
 
 result_int = uses_dataclass(42)

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2246,8 +2246,7 @@ reveal_type(WrappedIntAndExtraData[bytes].__init__)
 This is a regression test for <https://github.com/astral-sh/ty/issues/1427>.
 
 When a non-dataclass inherits from a generic dataclass, the generic type parameters should still be
-properly inferred during construction. Explicit access to the inherited `__init__` instead uses the
-class's default type arguments.
+properly inferred when calling the inherited `__init__` method.
 
 ```py
 from dataclasses import dataclass
@@ -2262,10 +2261,11 @@ class ChildOfParentDataclass[T](ParentDataclass[T]): ...
 def uses_dataclass[T](x: T) -> ChildOfParentDataclass[T]:
     return ChildOfParentDataclass(x)
 
+# TODO: ParentDataclass.__init__ should show generic types, not Unknown
 # revealed: (self: ParentDataclass[Unknown], value: Unknown) -> None
 reveal_type(ParentDataclass.__init__)
 
-# revealed: (self: ParentDataclass[Unknown], value: Unknown) -> None
+# revealed: [T](self: ParentDataclass[T], value: T) -> None
 reveal_type(ChildOfParentDataclass.__init__)
 
 result_int = uses_dataclass(42)

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1024,7 +1024,7 @@ When a generic subclass fills its superclass's type parameter with one of its ow
 propagate through:
 
 ```py
-from typing_extensions import Generic, TypeVar
+from typing_extensions import Generic, Self, TypeVar
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -1033,6 +1033,17 @@ W = TypeVar("W")
 
 class Parent(Generic[T]):
     x: T
+
+    @staticmethod
+    def static(value: T) -> T:
+        return value
+
+    @classmethod
+    def class_method(cls, value: T) -> T:
+        return value
+
+    def method(self, value: T, other: U) -> U:
+        return other
 
 class ExplicitlyGenericChild(Parent[U], Generic[U]): ...
 class ExplicitlyGenericGrandchild(ExplicitlyGenericChild[V], Generic[V]): ...
@@ -1048,6 +1059,68 @@ reveal_type(ExplicitlyGenericGrandchild[int]().x)  # revealed: int
 reveal_type(ImplicitlyGenericGrandchild[int]().x)  # revealed: int
 reveal_type(ExplicitlyGenericGreatgrandchild[int]().x)  # revealed: int
 reveal_type(ImplicitlyGenericGreatgrandchild[int]().x)  # revealed: int
+```
+
+Implicitly generic subclasses, explicitly generic subclasses, and longer inheritance chains all
+replace an unresolved class type variable with `Unknown`.
+
+```py
+reveal_type(Parent.x)  # revealed: Unknown
+reveal_type(ExplicitlyGenericChild.x)  # revealed: Unknown
+reveal_type(ImplicitlyGenericChild.x)  # revealed: Unknown
+reveal_type(ImplicitlyGenericGrandchild.x)  # revealed: Unknown
+```
+
+The same specialization applies to inherited static methods, class methods, and ordinary methods.
+Type variables belonging to a method remain generic.
+
+```py
+# revealed: def static(value: Unknown) -> Unknown
+reveal_type(ImplicitlyGenericChild.static)
+# revealed: bound method <class 'ImplicitlyGenericChild'>.class_method(value: Unknown) -> Unknown
+reveal_type(ImplicitlyGenericChild.class_method)
+# revealed: def method[U](self, value: Unknown, other: U) -> U
+reveal_type(ImplicitlyGenericChild.method)
+
+ImplicitlyGenericChild.static(1)
+ImplicitlyGenericChild.class_method(1)
+reveal_type(ImplicitlyGenericChild[int].static(1))  # revealed: int
+```
+
+Explicitly accessing constructor methods also applies the default specialization. Calling the class
+itself instead keeps its type variables available for constructor inference.
+
+```py
+class ConstructorParent(Generic[T]):
+    def __new__(cls, value: T) -> Self:
+        return super().__new__(cls)
+
+    def __init__(self, value: T) -> None: ...
+
+class ConstructorChild(ConstructorParent[T]): ...
+
+# revealed: def __new__[Self](cls, value: Unknown) -> Self
+reveal_type(ConstructorChild.__new__)
+# revealed: def __init__(self, value: Unknown) -> None
+reveal_type(ConstructorChild.__init__)
+reveal_type(ConstructorChild(1))  # revealed: ConstructorChild[int]
+```
+
+A generic descriptor inherited from the parent also receives the receiver's specialization before
+its `__get__` method is called.
+
+```py
+class Descriptor(Generic[T]):
+    def __get__(self, instance: object | None, owner: type[object]) -> T:
+        raise NotImplementedError
+
+class DescriptorParent(Generic[T]):
+    descriptor: Descriptor[T] = Descriptor()
+
+class DescriptorChild(DescriptorParent[T]): ...
+
+reveal_type(DescriptorChild.descriptor)  # revealed: Unknown
+reveal_type(DescriptorChild[int].descriptor)  # revealed: int
 ```
 
 ## Generic methods

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1087,8 +1087,8 @@ ImplicitlyGenericChild.class_method(1)
 reveal_type(ImplicitlyGenericChild[int].static(1))  # revealed: int
 ```
 
-Explicitly accessing constructor methods also applies the default specialization. Calling the class
-itself instead keeps its type variables available for constructor inference.
+Constructor methods inherit their class's type variables into their own generic contexts, so they
+remain generic when accessed explicitly. Calling the class itself also infers its type arguments.
 
 ```py
 class ConstructorParent(Generic[T]):
@@ -1099,9 +1099,9 @@ class ConstructorParent(Generic[T]):
 
 class ConstructorChild(ConstructorParent[T]): ...
 
-# revealed: def __new__[Self](cls, value: Unknown) -> Self
+# revealed: def __new__[Self, T](cls, value: T) -> Self
 reveal_type(ConstructorChild.__new__)
-# revealed: def __init__(self, value: Unknown) -> None
+# revealed: def __init__[T](self, value: T) -> None
 reveal_type(ConstructorChild.__init__)
 reveal_type(ConstructorChild(1))  # revealed: ConstructorChild[int]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -730,6 +730,10 @@ propagate through:
 class Parent[T]:
     x: T
 
+    @staticmethod
+    def static(value: T) -> T:
+        return value
+
 class Child[U](Parent[U]): ...
 class Grandchild[V](Child[V]): ...
 class Greatgrandchild[W](Child[W]): ...
@@ -738,6 +742,38 @@ reveal_type(Parent[int]().x)  # revealed: int
 reveal_type(Child[int]().x)  # revealed: int
 reveal_type(Grandchild[int]().x)  # revealed: int
 reveal_type(Greatgrandchild[int]().x)  # revealed: int
+```
+
+Attributes and static methods inherited by an unspecialized generic subclass use its default type
+arguments instead of exposing its class-scoped type variables.
+
+```py
+reveal_type(Parent.x)  # revealed: Unknown
+reveal_type(Child.x)  # revealed: Unknown
+reveal_type(Grandchild.x)  # revealed: Unknown
+
+# revealed: def static(value: Unknown) -> Unknown
+reveal_type(Child.static)
+Child.static(1)
+reveal_type(Child[int].static(1))  # revealed: int
+```
+
+Declared defaults must be preserved, and concrete arguments in partially specialized bases must not
+be replaced with `Unknown`.
+
+```py
+class DefaultChild[T = int](Parent[T]): ...
+
+class PairParent[T, U]:
+    fixed: T
+    unresolved: U
+
+class PartiallyFixed[T](PairParent[int, T]): ...
+
+reveal_type(DefaultChild.x)  # revealed: int
+reveal_type(DefaultChild[str].x)  # revealed: str
+reveal_type(PartiallyFixed.fixed)  # revealed: int
+reveal_type(PartiallyFixed.unresolved)  # revealed: Unknown
 ```
 
 ## Generic methods

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1281,7 +1281,20 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, specialization))
+        let member =
+            self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, specialization));
+
+        // An unspecialized MRO retains mappings such as `Parent[T@Child]`, so members accessed
+        // through `Child` must still use its default arguments. Constructor calls already use the
+        // identity specialization to keep class type variables available for inference.
+        if specialization.is_none()
+            && let Some(generic_context) = self.generic_context(db)
+        {
+            let specialization = generic_context.default_specialization(db, self.known(db));
+            member.map_type(|ty| ty.apply_specialization(db, specialization))
+        } else {
+            member
+        }
     }
 
     pub(crate) fn class_member_from_mro(

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1284,10 +1284,12 @@ impl<'db> StaticClassLiteral<'db> {
         let member =
             self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, specialization));
 
-        // An unspecialized MRO retains mappings such as `Parent[T@Child]`, so members accessed
-        // through `Child` must still use its default arguments. Constructor calls already use the
-        // identity specialization to keep class type variables available for inference.
+        // An unspecialized MRO retains mappings such as `Parent[T@Child]`, so ordinary members
+        // accessed through `Child` must use its default arguments. Constructor methods are different:
+        // we add their class's type variables to the callable's generic context, so those variables
+        // are genuinely inferable and must remain generic instead of using the default arguments.
         if specialization.is_none()
+            && !matches!(name, "__new__" | "__init__")
             && let Some(generic_context) = self.generic_context(db)
         {
             let specialization = generic_context.default_specialization(db, self.known(db));


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4232.

- Apply an unspecialized generic class's default type arguments after inherited class-member lookup, without changing subclass-to-base specialization or the structural MRO.
- Preserve generic constructor inference through its existing identity specialization while correctly resolving explicit access to inherited `__new__` and `__init__` methods.
- Align inherited synthesized dataclass initializer access with ordinary inherited member access.

## Test plan

- Add legacy and PEP 695 mdtests covering inherited attributes, static methods, class methods, ordinary methods, method-scoped generics, generic descriptors, explicit and inferred constructor calls, declared type-parameter defaults, and partially specialized base classes.
- Update the existing generic dataclass mdtest to verify that explicit inherited initializer access resolves unspecialized class type variables while construction continues to infer its type arguments.
