### PR TITLE
[`pylint`] Improve handling of concatenated strings (`PLE1300`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_string_format_character.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_string_format_character.py
@@ -29,7 +29,7 @@ f"{H:s} {W:z}"  # [bad-format-character]
 
 f"{1:z}"  # [bad-format-character]
 
-## False negatives
+## Supporting concatenated strings
 
 print(("%" "z") % 1)
 

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1469,6 +1469,7 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                     Rule::PercentFormatPositionalCountMismatch,
                     Rule::PercentFormatStarRequiresSequence,
                     Rule::PercentFormatUnsupportedFormatCharacter,
+                    Rule::BadStringFormatCharacter,
                 ]) {
                     let location = expr.range();
                     match pyflakes::cformat::CFormatSummary::try_from(value.to_str()) {
@@ -1481,6 +1482,11 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                                 pyflakes::rules::PercentFormatUnsupportedFormatCharacter {
                                     char: c,
                                 },
+                                location,
+                            );
+                            // PLE1300
+                            checker.report_diagnostic_if_enabled(
+                                pylint::rules::BadStringFormatCharacter { format_char: c },
                                 location,
                             );
                         }
@@ -1534,13 +1540,6 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 }
                 if checker.is_rule_enabled(Rule::PrintfStringFormatting) {
                     pyupgrade::rules::printf_string_formatting(checker, bin_op, format_string);
-                }
-                if checker.is_rule_enabled(Rule::BadStringFormatCharacter) {
-                    pylint::rules::bad_string_format_character::percent(
-                        checker,
-                        expr,
-                        format_string,
-                    );
                 }
                 if checker.is_rule_enabled(Rule::BadStringFormatType) {
                     pylint::rules::bad_string_format_type(checker, bin_op, format_string);

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_character.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_character.rs
@@ -1,14 +1,10 @@
-use std::str::FromStr;
-
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{Expr, ExprStringLiteral, StringFlags, StringLiteral};
 use ruff_python_literal::{
-    cformat::{CFormatErrorType, CFormatString},
     format::FormatPart,
     format::FromTemplate,
     format::{FormatSpec, FormatSpecError, FormatString},
 };
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::TextRange;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
@@ -29,7 +25,7 @@ use crate::checkers::ast::Checker;
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.283")]
 pub(crate) struct BadStringFormatCharacter {
-    format_char: char,
+    pub(crate) format_char: char,
 }
 
 impl Violation for BadStringFormatCharacter {
@@ -68,29 +64,6 @@ pub(crate) fn call(checker: &Checker, string: &str, range: TextRange) {
                         }
                     }
                 }
-            }
-        }
-    }
-}
-
-/// PLE1300
-/// Ex) `"%z" % "1"`
-pub(crate) fn percent(checker: &Checker, expr: &Expr, format_string: &ExprStringLiteral) {
-    for StringLiteral {
-        value: _,
-        node_index: _,
-        range,
-        flags,
-    } in &format_string.value
-    {
-        let string = checker.locator().slice(range);
-        let string = &string
-            [usize::from(flags.opener_len())..(string.len() - usize::from(flags.closer_len()))];
-
-        // Parse the format string (e.g. `"%s"`) into a list of `PercentFormat`.
-        if let Err(format_error) = CFormatString::from_str(string) {
-            if let CFormatErrorType::UnsupportedFormatChar(format_char) = format_error.typ {
-                checker.report_diagnostic(BadStringFormatCharacter { format_char }, expr.range());
             }
         }
     }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1300_bad_string_format_character.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1300_bad_string_format_character.py.snap
@@ -67,6 +67,17 @@ PLE1300 Unsupported format character 'y'
 21 | "{0:.{foo}{bar}{foobar}y}".format(...)  # OK (cannot validate after nested placeholders)
    |
 
+PLE1300 Unsupported format character 'z'
+  --> bad_string_format_character.py:34:7
+   |
+32 | ## Supporting concatenated strings
+33 |
+34 | print(("%" "z") % 1)
+   |       ^^^^^^^^^^^^^
+35 |
+36 | ## `%b` is only valid for bytes formatting.
+   |
+
 PLE1300 Unsupported format character 'b'
   --> bad_string_format_character.py:37:1
    |


### PR DESCRIPTION
## Summary

https://docs.astral.sh/ruff/rules/bad-string-format-character/ (PLE1300) and https://docs.astral.sh/ruff/rules/percent-format-invalid-format/ (F509) check the same thing regarding percent string formatters (previously reported in https://github.com/astral-sh/ruff/issues/11403). This PR doesn't try to actually merge these rules, as it's postponed until new categorization introduced.

The easy fixable problem I've noticed with  `PLE1300` -  it doesn't rely on general cformat parsing in `expression.rs` and it has its own code, which is 
a) reparsing string again using `CFormatString::from_str`, when it's already done in `expression.rs` when processing other similar rules
b) in case of concatenated strings it's feeding each string to the parser separately, which may result in a false negative (though it's unlikely to occur in practice) - it was noted in the test case, but it's trivially solved just by passing full `StringLiteralValue` value into it.

https://github.com/astral-sh/ruff/blob/ed768f07cc536b54c0c8bc333831497110ba0499/crates/ruff_linter/resources/test/fixtures/pylint/bad_string_format_character.py#L32-L34

As a result we get minor performance gain, removed redundant code, rules now will stay in sync, until they actually get  merged. 

A minor note: previously `"%z" "%z"` would be reported by `PLE1300` twice - once for each concatenated string. Now there will be just 1 report, matching `F509`. But it doesn't seem important as it's a very rare case.

## Test Plan

All previous tests pass, one previous test started to correctly mark true positive.
