### PR TITLE
Use eight-core runners for native Linux PGO builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -11,7 +11,7 @@ self-hosted-runner:
     - namespace-profile-macos-15
     - namespace-profile-windows-2022-x86-64-16x32
     - depot-ubuntu-22.04-arm-4
-    - depot-ubuntu-24.04-arm-4
+    - depot-ubuntu-24.04-arm-8
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16
     - codspeed-macro

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -335,7 +335,7 @@ jobs:
 
   linux-aarch64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-24.04-arm-4
+    runs-on: depot-ubuntu-24.04-arm-8
     env:
       # see https://github.com/astral-sh/ruff/issues/3791
       # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -265,7 +265,7 @@ jobs:
 
   linux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && 'depot-ubuntu-24.04-8' || 'depot-ubuntu-24.04-4' }}
     strategy:
       matrix:
         target:


### PR DESCRIPTION
## Summary

Previously, our native Linux x86-64 and ARM64 PGO release builds both used four-core Depot runners. The ARM64 build finished in 13m 39s and could delay the release.

We now use pinned, eight-core Ubuntu 24.04 Depot runners for both native PGO targets, matching ty. Linux i686, cross builds, musl builds, and source distributions retain their four-core runners. The previous eight-core ARM benchmark finished in 12m 25s, down from 13m 39s (9%).
