### PR TITLE
[ty] Preserve static upper bounds of gradual solutions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1164,6 +1164,25 @@ def mean(data: DataFrame) -> float:
 x23: Mapping[Hashable, AggregateSpec] = {"col1": ["sum", mean], "col2": mean}
 ```
 
+## Recursive aliases remain stable in invariant collection contexts
+
+An invariant collection context can infer the same recursive type as both bounds. Because recursive
+inference introduces `Divergent`, intersecting those bounds should not discard any element of the
+union.
+
+```py
+from collections.abc import MutableMapping, MutableSequence
+from typing import TypeAlias, TypedDict
+
+class Leaf(TypedDict, total=False):
+    path: str
+
+RecursiveValue: TypeAlias = int | Leaf | MutableSequence["RecursiveValue | None"] | MutableMapping[str, "RecursiveValue | None"]
+RecursiveMapping: TypeAlias = MutableMapping[str, RecursiveValue | None]
+
+recursive: RecursiveMapping = {}
+```
+
 ## Implicit generic class specialization
 
 Callable type context is also used to inform the implicit specialization of a generic class:
@@ -2050,6 +2069,23 @@ def _(callback: TakesInt) -> None:
         # TODO: Perform fixpoint iteration when evaluating callable intersections.
         x2 = callback("str", lambda value: reveal_type(value) + "!")  # revealed: Unknown
         reveal_type(x2)  # revealed: str
+```
+
+A structural type context can infer a gradual lower bound and a static upper bound before dictionary
+values contribute their constraints. The preliminary solution should retain the gradual lower bound.
+
+```py
+T_co = TypeVar("T_co", covariant=True)
+
+class DictLike(Protocol[T_co]):
+    def __getitem__(self, key: str, /) -> T_co: ...
+    def __setitem__(self, key: str, value: Any, /) -> None: ...
+
+class Command: ...
+
+def _(command: Any):
+    # revealed: dict[str, Any]
+    mapping: DictLike[type[Command]] = reveal_type({"command": command})
 ```
 
 Note that long chains of callables with constraint dependencies in reverse source-order may require

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1348,11 +1348,11 @@ def g[T: A](b: B[T]):
 
 ## Inferred upper bounds restrict the range of gradual solutions
 
-Gradual lower bounds are intersected with their concrete upper bounds.
+Gradual lower bounds are intersected with their inferred upper bounds.
 
 ```py
 from collections.abc import Iterable
-from typing import Any, Callable
+from typing import Any, Callable, TypeAlias
 from ty_extensions._internal import Unknown
 
 def infer[T](lower: T, upper: Callable[[T], None]) -> T:
@@ -1361,6 +1361,60 @@ def infer[T](lower: T, upper: Callable[[T], None]) -> T:
 def _(any_value: Any, unknown_value: Unknown, upper: Callable[[int], None]):
     reveal_type(infer(any_value, upper))  # revealed: int & Any
     reveal_type(infer(unknown_value, upper))  # revealed: int & Unknown
+```
+
+All inferred upper bounds contribute to the intersection, whether they are static or gradual:
+
+```py
+def infer_multiple[T](
+    value: T,
+    first: Callable[[T], None],
+    second: Callable[[T], None],
+) -> T:
+    return value
+
+def _(
+    any_value: Any,
+    unknown_value: Unknown,
+    static: Callable[[int], None],
+    first: Callable[[int | list[Any]], None],
+    second: Callable[[int | dict[str, Any]], None],
+):
+    reveal_type(infer_multiple(any_value, static, first))  # revealed: int & Any
+    reveal_type(infer_multiple(any_value, first, second))  # revealed: int & Any
+    reveal_type(infer_multiple(unknown_value, first, second))  # revealed: int & Unknown
+```
+
+An unsatisfiable gradual range falls back to unioning the inferred bounds for diagnostic recovery:
+
+```py
+def _(
+    unknown_value: Unknown,
+    static: Callable[[int], None],
+    incompatible: Callable[[list[Any]], None],
+):
+    result = infer_multiple(
+        unknown_value,
+        static,  # error: [invalid-argument-type]
+        incompatible,  # error: [invalid-argument-type]
+    )
+    reveal_type(result)  # revealed: Unknown | int | list[Any]
+```
+
+A gradual upper bound contributes its top materialization without replacing the gradual lower bound:
+
+```py
+def _(
+    any_value: Any,
+    unknown_value: Unknown,
+    list_upper: Callable[[list[Any]], None],
+    tuple_upper: Callable[[tuple[Any, ...]], None],
+    callable_upper: Callable[[Callable[[Any], int]], None],
+):
+    reveal_type(infer(any_value, list_upper))  # revealed: Top[list[Any]] & Any
+    reveal_type(infer(unknown_value, list_upper))  # revealed: Top[list[Any]] & Unknown
+    reveal_type(infer(any_value, tuple_upper))  # revealed: tuple[object, ...] & Any
+    reveal_type(infer(any_value, callable_upper))  # revealed: ((Never, /) -> int) & Any
 ```
 
 The inferred upper bound is also retained when an invariant return type triggers promotion:
@@ -1420,7 +1474,7 @@ def _(values: Iterable[Any]):
     reveal_type(reduce(combine, values))
 ```
 
-Declared upper bounds validate a gradual solution but do not restrict its range:
+Declared upper bounds validate a gradual solution but do not restrict its range on their own:
 
 ```py
 def bounded[T: A | B](value: T) -> T:
@@ -1432,6 +1486,56 @@ def bounded_with_upper[T: A | B](value: T, upper: Callable[[T], None]) -> T:
 def _(any_value: Any, upper: Callable[[object], None]):
     reveal_type(bounded(any_value))  # revealed: Any
     reveal_type(bounded_with_upper(any_value, upper))  # revealed: Any
+```
+
+An inferred upper bound cannot introduce materializations outside the declared upper bound:
+
+```py
+def bounded_range[T: int | str](value: T, upper: Callable[[T], None]) -> T:
+    return value
+
+def _(any_value: Any, unknown_value: Unknown, upper: Callable[[int | bytes], None]):
+    reveal_type(bounded_range(any_value, upper))  # revealed: int & Any
+    reveal_type(bounded_range(unknown_value, upper))  # revealed: int & Unknown
+
+def _(any_value: Any, upper: Callable[[bytes], None]):
+    reveal_type(bounded_range(any_value, upper))  # revealed: Any
+```
+
+Declared gradual bounds preserve the gradual type inferred from the lower bound:
+
+```py
+def bounded_any[T: Any](value: T, upper: Callable[[T], None]) -> T:
+    return value
+
+def bounded_gradual[T: list[Any]](value: T, upper: Callable[[T], None]) -> T:
+    return value
+
+def _(
+    unknown_value: Unknown,
+    int_upper: Callable[[int], None],
+    list_upper: Callable[[list[int]], None],
+):
+    reveal_type(bounded_any(unknown_value, int_upper))  # revealed: int & Unknown
+    reveal_type(bounded_gradual(unknown_value, list_upper))  # revealed: list[int] & Unknown
+```
+
+Recursive declared bounds do not introduce `Divergent` into a concrete solution:
+
+```py
+Recursive: TypeAlias = int | list["Recursive"]
+
+def bounded_recursive[T: Recursive](value: T, upper: Callable[[T], None]) -> T:
+    return value
+
+def _(any_value: Any, unknown_value: Unknown, upper: Callable[[list[int]], None]):
+    any_result = bounded_recursive(any_value, upper)
+    unknown_result = bounded_recursive(unknown_value, upper)
+
+    reveal_type(any_result)  # revealed: list[int] & Any
+    reveal_type(any_result[0])  # revealed: int & Any
+    reveal_type(unknown_result)  # revealed: list[int] & Unknown
+    reveal_type(unknown_result[0])  # revealed: int & Unknown
 ```
 
 ## Typevars in a union

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1346,6 +1346,94 @@ def g[T: A](b: B[T]):
     return f(b.x)  # Fine
 ```
 
+## Inferred upper bounds restrict the range of gradual solutions
+
+Gradual lower bounds are intersected with their concrete upper bounds.
+
+```py
+from collections.abc import Iterable
+from typing import Any, Callable
+from ty_extensions._internal import Unknown
+
+def infer[T](lower: T, upper: Callable[[T], None]) -> T:
+    return lower
+
+def _(any_value: Any, unknown_value: Unknown, upper: Callable[[int], None]):
+    reveal_type(infer(any_value, upper))  # revealed: int & Any
+    reveal_type(infer(unknown_value, upper))  # revealed: int & Unknown
+```
+
+The inferred upper bound is also retained when an invariant return type triggers promotion:
+
+```py
+def infer_list[T](lower: T, upper: Callable[[T], None]) -> list[T]:
+    return [lower]
+
+def _(any_value: Any, upper: Callable[[int], None]):
+    reveal_type(infer_list(any_value, upper))  # revealed: list[int & Any]
+```
+
+Promotion must also preserve the upper bound when a gradual solution contains promotable literals:
+
+```py
+def infer_promoted[T](static: T, gradual: T, upper: Callable[[T], None]) -> list[T]:
+    return [static, gradual]
+
+def _(any_value: Any, unknown_value: Unknown, upper: Callable[[int | str], None]):
+    reveal_type(infer_promoted(1, any_value, upper))  # revealed: list[int | (str & Any)]
+    reveal_type(infer_promoted(1, unknown_value, upper))  # revealed: list[int | (str & Unknown)]
+```
+
+The same restriction applies when a type variable occurs in a callable's parameter and return types:
+
+```py
+class Base: ...
+class Derived(Base): ...
+
+def predicate(value: Derived) -> bool:
+    return True
+
+def gradual_rule(value: Derived) -> Unknown:
+    raise NotImplementedError
+
+def condition[T](predicate: Callable[[T], bool], rule: Callable[[T], T]) -> Callable[[T], T]:
+    raise NotImplementedError
+
+reveal_type(condition(predicate, gradual_rule))  # revealed: (Derived & Unknown, /) -> Derived & Unknown
+```
+
+If the upper bound is a union, it is distributed across the gradual lower bound:
+
+```py
+class A: ...
+class B: ...
+class Result(A): ...
+
+def reduce[T](function: Callable[[T, T], T], values: Iterable[T]) -> T:
+    raise NotImplementedError
+
+def combine(left: A | B, right: A | B) -> Result:
+    raise NotImplementedError
+
+def _(values: Iterable[Any]):
+    # revealed: Result | (A & Any) | (B & Any)
+    reveal_type(reduce(combine, values))
+```
+
+Declared upper bounds validate a gradual solution but do not restrict its range:
+
+```py
+def bounded[T: A | B](value: T) -> T:
+    return value
+
+def bounded_with_upper[T: A | B](value: T, upper: Callable[[T], None]) -> T:
+    return value
+
+def _(any_value: Any, upper: Callable[[object], None]):
+    reveal_type(bounded(any_value))  # revealed: Any
+    reveal_type(bounded_with_upper(any_value, upper))  # revealed: Any
+```
+
 ## Typevars in a union
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5846,7 +5846,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         .entry(identity)
                         .and_modify(|current| *current = current.join(variance))
                         .or_insert(variance);
-                    PathBounds::default_solve(db, self.env, constraints, path_bound)
+                    PathBounds::preliminary_solve(db, self.env, constraints, path_bound)
                 });
 
                 let Solutions::Constrained(solutions) = solutions else {
@@ -7652,7 +7652,10 @@ impl<'db> Binding<'db> {
                 generic_context.inferable_typevars(db),
             );
 
-            if let Solutions::Constrained(solutions) = path_bounds.solve(db, env, constraints) {
+            let solutions = path_bounds.solve_with(|_variance, path_bound| {
+                PathBounds::preliminary_solve(db, env, constraints, path_bound)
+            });
+            if let Solutions::Constrained(solutions) = solutions {
                 for solution in solutions {
                     for binding in solution {
                         let identity = binding.bound_typevar.identity(db);

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3976,7 +3976,7 @@ impl<'db> PathBounds<'db> {
         ))
     }
 
-    /// Selects a preliminary solution for type-context inference.
+    /// Selects a preliminary solution to use as type context during generic call inference.
     ///
     /// Unlike [`Self::default_solve`], the range of a gradual solution is not restricted by inferred
     /// upper bounds, as the inferred types may not have stabilized yet.

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3537,6 +3537,74 @@ impl<'db> PathBound<'db> {
     fn has_only_gradual_evidence(&self) -> bool {
         self.has_only_gradual_evidence
     }
+
+    /// Restricts the range of a gradual solution by any concrete upper bounds inferred for this
+    /// constraint.
+    fn restrict_gradual_solution(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        solution: Type<'db>,
+    ) -> Type<'db> {
+        if self.lower != Some(solution)
+            || solution.bottom_materialization(db, env) == solution.top_materialization(db, env)
+            || !self.has_upper()
+        {
+            return solution;
+        }
+
+        // Unresolved type-variable relationships must not escape into the specialization.
+        if solution.has_typevar(db, env) || solution.has_unspecialized_type_var(db, env) {
+            return solution;
+        }
+
+        // Constrained type variables select solutions from their own set of constraints.
+        if matches!(
+            self.bound_typevar.typevar(db).bound_or_constraints(db, env),
+            Some(TypeVarBoundOrConstraints::Constraints(_))
+        ) {
+            return solution;
+        }
+
+        // `Divergent` is not safely reflexive, so we cannot intersect identical bounds.
+        if self.upper.clauses.len() == 1 && self.upper.clauses.contains(&solution) {
+            return solution;
+        }
+
+        // Ignore gradual or unresolved upper bounds.
+        if !self.upper.clauses.iter().all(|upper| {
+            upper.is_fully_static(db, env)
+                && !upper.has_typevar(db, env)
+                && !upper.has_unspecialized_type_var(db, env)
+        }) {
+            return solution;
+        }
+
+        // Restrict the range of each gradual solution by the upper bound of this constraint.
+        let restrict = |element: Type<'db>| {
+            if element.bottom_materialization(db, env) == element.top_materialization(db, env) {
+                Some(element)
+            } else {
+                IntersectionType::bounded_from_elements(
+                    db,
+                    env,
+                    self.upper
+                        .clauses
+                        .iter()
+                        .copied()
+                        .chain(iter::once(element)),
+                )
+            }
+        };
+
+        let restricted = match solution {
+            Type::Union(union) => union.try_map(db, env, |element| restrict(*element)),
+            _ => restrict(solution),
+        };
+
+        // Keep the original gradual type if the intersection exceeds the DNF expansion limit.
+        restricted.unwrap_or(solution)
+    }
 }
 
 impl<'db> Type<'db> {
@@ -3894,6 +3962,25 @@ impl<'db> PathBounds<'db> {
     /// - `Ok(None)` if the typevar is unsolved (no solution added)
     /// - `Err(())` if the path is invalid (bounds violate the typevar's declared constraints)
     pub(crate) fn default_solve(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &ConstraintSetBuilder<'db>,
+        path_bound: &PathBound<'db>,
+    ) -> Result<Option<Type<'db>>, ()> {
+        let Some(solution) = Self::preliminary_solve(db, env, builder, path_bound)? else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            path_bound.restrict_gradual_solution(db, env, solution),
+        ))
+    }
+
+    /// Selects a preliminary solution for type-context inference.
+    ///
+    /// Unlike [`Self::default_solve`], the range of a gradual solution is not restricted by inferred
+    /// upper bounds, as the inferred types may not have stabilized yet.
+    pub(crate) fn preliminary_solve(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         builder: &ConstraintSetBuilder<'db>,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3538,8 +3538,7 @@ impl<'db> PathBound<'db> {
         self.has_only_gradual_evidence
     }
 
-    /// Restricts the range of a gradual solution by any concrete upper bounds inferred for this
-    /// constraint.
+    /// Restricts the range of a gradual solution by the upper bounds inferred for this constraint.
     fn restrict_gradual_solution(
         &self,
         db: &'db dyn Db,
@@ -3547,8 +3546,8 @@ impl<'db> PathBound<'db> {
         solution: Type<'db>,
     ) -> Type<'db> {
         if self.lower != Some(solution)
-            || solution.bottom_materialization(db, env) == solution.top_materialization(db, env)
             || !self.has_upper()
+            || solution.bottom_materialization(db, env) == solution.top_materialization(db, env)
         {
             return solution;
         }
@@ -3558,48 +3557,57 @@ impl<'db> PathBound<'db> {
             return solution;
         }
 
-        // Constrained type variables select solutions from their own set of constraints.
-        if matches!(
-            self.bound_typevar.typevar(db).bound_or_constraints(db, env),
-            Some(TypeVarBoundOrConstraints::Constraints(_))
-        ) {
-            return solution;
-        }
-
         // `Divergent` is not safely reflexive, so we cannot intersect identical bounds.
         if self.upper.clauses.len() == 1 && self.upper.clauses.contains(&solution) {
             return solution;
         }
 
-        // Ignore gradual or unresolved upper bounds.
-        if !self.upper.clauses.iter().all(|upper| {
-            upper.is_fully_static(db, env)
-                && !upper.has_typevar(db, env)
-                && !upper.has_unspecialized_type_var(db, env)
-        }) {
+        // Gradual upper bounds are top-materialized, as the lower bound is already gradual.
+        let materialize_upper = |bound: Type<'db>| {
+            (!bound.has_typevar(db, env) && !bound.has_unspecialized_type_var(db, env))
+                .then(|| bound.top_materialization(db, env))
+                .filter(|bound| !bound.is_object())
+        };
+
+        let declared_upper = match self.bound_typevar.typevar(db).bound_or_constraints(db, env) {
+            // Constrained type variables select solutions from their own set of constraints.
+            Some(TypeVarBoundOrConstraints::Constraints(_)) => return solution,
+            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => materialize_upper(bound),
+            _ => None,
+        };
+
+        let mut upper_bounds = self
+            .upper
+            .clauses
+            .iter()
+            .copied()
+            .filter_map(materialize_upper);
+        let Some(first_upper) = upper_bounds.next() else {
             return solution;
-        }
+        };
+
+        let Some(upper_bound) = IntersectionType::bounded_from_elements(
+            db,
+            env,
+            iter::once(first_upper)
+                .chain(upper_bounds)
+                .chain(declared_upper),
+        ) else {
+            return solution;
+        };
 
         // Restrict the range of each gradual solution by the upper bound of this constraint.
-        let restrict = |element: Type<'db>| {
+        let restrict_gradual = |element: Type<'db>| {
             if element.bottom_materialization(db, env) == element.top_materialization(db, env) {
                 Some(element)
             } else {
-                IntersectionType::bounded_from_elements(
-                    db,
-                    env,
-                    self.upper
-                        .clauses
-                        .iter()
-                        .copied()
-                        .chain(iter::once(element)),
-                )
+                IntersectionType::bounded_from_elements(db, env, [upper_bound, element])
             }
         };
 
         let restricted = match solution {
-            Type::Union(union) => union.try_map(db, env, |element| restrict(*element)),
-            _ => restrict(solution),
+            Type::Union(union) => union.try_map(db, env, |element| restrict_gradual(*element)),
+            _ => restrict_gradual(solution),
         };
 
         // Keep the original gradual type if the intersection exceeds the DNF expansion limit.
@@ -3971,9 +3979,14 @@ impl<'db> PathBounds<'db> {
             return Ok(None);
         };
 
-        Ok(Some(
-            path_bound.restrict_gradual_solution(db, env, solution),
-        ))
+        let restricted = path_bound.restrict_gradual_solution(db, env, solution);
+
+        // An empty gradual range makes the constraint path unsatisfiable.
+        if restricted.is_never() && !solution.is_never() {
+            return Err(());
+        }
+
+        Ok(Some(restricted))
     }
 
     /// Selects a preliminary solution to use as type context during generic call inference.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2966,7 +2966,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             self.inferable,
             |_variance, path_bound| {
                 let solution =
-                    PathBounds::default_solve(db, self.env, self.constraints, path_bound);
+                    PathBounds::preliminary_solve(db, self.env, self.constraints, path_bound);
                 if solution.is_err() && first_error.is_none() {
                     first_error = self.specialization_error_from_failed_bounds(path_bound);
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7347,7 +7347,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .entry(identity)
                         .and_modify(|current| *current = current.join(variance))
                         .or_insert(variance);
-                    PathBounds::default_solve(db, env, &constraints, path_bound)
+                    PathBounds::preliminary_solve(db, env, &constraints, path_bound)
                 });
 
                 match solutions {


### PR DESCRIPTION
We currently ignore concrete upper bounds when inferring a gradual solution. We should instead be intersecting the gradual type with its upper bound, e.g.,

```py
from typing import Any, Callable

def infer[T](lower: T, upper: Callable[[T], None]) -> T:
    return lower

def _(x: Any, upper: Callable[[int], None]):
    reveal_type(infer(x, upper))  # revealed: int & Any
```