### PR TITLE
[ty] Collect type context from function calls during full-scope bidirectional inference

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4538,14 +4538,14 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     // An annotated assignment assigning the collection object to a new binding.
                     ruff_python_ast::Stmt::AnnAssign(_) => true,
 
-                    // A bound-method call on the collection object.
+                    // A bound method on the collection, or a function that receives it.
                     ruff_python_ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
                         match value.as_ref() {
                             ast::Expr::Call(ast::ExprCall { func, .. }) => match func.as_ref() {
-                                ruff_python_ast::Expr::Attribute(ast::ExprAttribute {
-                                    value,
-                                    ..
-                                }) => ExpressionNodeKey::from(value) == *use_expression,
+                                ast::Expr::Attribute(ast::ExprAttribute { value, .. }) => {
+                                    ExpressionNodeKey::from(value) == *use_expression
+                                }
+                                ast::Expr::Name(_) => true,
                                 _ => false,
                             },
                             _ => false,

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -2349,15 +2349,24 @@ def _(flag: bool):
         reveal_type(x2)  # revealed: list[str]
 ```
 
+The declared parameter type of a function call provides type context for an unannotated collection,
+whether that collection is empty or already contains compatible elements:
+
 ```py
 def takes_list_int(x: list[int]): ...
+def takes_list_object(x: list[object]): ...
 
 x3 = []
 takes_list_int(x3)
-# TODO: This should reveal `list[int]`, but we do not currently record
-# argument constraints for arbitrary function calls.
-reveal_type(x3)  # revealed: list[Unknown]
+reveal_type(x3)  # revealed: list[int]
+
+def _(value: str):
+    x1 = [value]
+    takes_list_object(x1)
+    reveal_type(x1)  # revealed: list[object]
 ```
+
+A generic call can also infer the collection's element type from its other arguments:
 
 ```py
 def append[T](x: list[T], y: T):
@@ -2366,9 +2375,7 @@ def append[T](x: list[T], y: T):
 x4 = []
 append(x4, 1)
 append(x4, "2")
-# TODO: This should reveal `list[int | str]`, but we do not currently record
-# argument constraints for arbitrary function calls.
-reveal_type(x4)  # revealed: list[Unknown]
+reveal_type(x4)  # revealed: list[int | str]
 ```
 
 ```py
@@ -2533,6 +2540,92 @@ reveal_type(x23)  # revealed: list[float | str | None]
 x24 = {"a": 1}
 x24[1] = "b"
 reveal_type(x24)  # revealed: dict[int | str, str | int]
+```
+
+A generic parameter constrains the collection regardless of argument order or whether it is passed
+by keyword:
+
+```py
+def append_value[T](value: T, values: list[T]): ...
+
+x25 = []
+append_value(1, x25)
+reveal_type(x25)  # revealed: list[int]
+
+x26 = []
+append(y="foo", x=x26)
+reveal_type(x26)  # revealed: list[str]
+```
+
+Existing elements remain in the inferred union when another argument introduces a different type:
+
+```py
+x27 = [0]
+append(x27, "foo")
+reveal_type(x27)  # revealed: list[str | int]
+```
+
+Only a matching overload may constrain the collection. An incompatible overload cannot introduce its
+element type into a populated collection or prevent another argument from constraining an empty one:
+
+```py
+from collections.abc import Iterable
+from typing import overload
+
+@overload
+def first(values: Iterable[str]) -> str: ...
+@overload
+def first[T: int](values: Iterable[T]) -> T: ...
+def first(values: object) -> object: ...
+
+x28 = [1]
+first(x28)
+reveal_type(x28)  # revealed: list[int]
+
+@overload
+def append_overload(values: list[str], value: str) -> None: ...
+@overload
+def append_overload[T: int](values: list[T], value: T) -> None: ...
+def append_overload(values: object, value: object) -> None: ...
+
+x29 = []
+append_overload(x29, 1)
+reveal_type(x29)  # revealed: list[int]
+```
+
+Literal arguments are promoted before they become context for a populated nested collection:
+
+```py
+def scale[T](values: list[list[T]], factor: T): ...
+
+x30 = [[1]]
+scale(x30, 2)
+reveal_type(x30)  # revealed: list[list[int]]
+```
+
+An explicitly annotated literal remains precise because its annotation prevents promotion:
+
+```py
+from typing import Literal
+
+value: Literal[1] = 1
+x31 = []
+append(x31, value)
+reveal_type(x31)  # revealed: list[Literal[1]]
+```
+
+Calls with multiple unannotated collections do not yet propagate context to either argument:
+
+```py
+def append_both[T](left: list[T], right: list[T], value: T): ...
+
+x32 = []
+x33 = []
+append_both(x32, x33, 1)
+
+# TODO: Both collections should be inferred as `list[int]`.
+reveal_type(x32)  # revealed: list[Unknown]
+reveal_type(x33)  # revealed: list[Unknown]
 ```
 
 ## Multi-inference diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_structural_relation.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_structural_relation.md
@@ -289,3 +289,71 @@ def s(value: Options[U]) -> list[U]:
     reveal_type(result)  # revealed: list[U@s | Iterable[M] | Iterable[Iterable[M]] | Iterable[U@s] | F[U@s] | M]
     return result  # error: [invalid-return-type]
 ```
+
+## Unconstrained collection arguments
+
+A generic call cannot constrain a collection using an element type inferred from that collection
+itself. Feeding the inferred type back into its initializer would recurse through the protocol
+without contributing an independent constraint.
+
+```py
+from collections.abc import Iterable
+from typing import Protocol, TypeAlias, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class Recursive(Protocol[T_co]):
+    def nested(self): ...
+
+class Marker(Protocol):
+    def marker(self): ...
+
+Nested: TypeAlias = Iterable[T_co] | Recursive[T_co] | Marker
+
+def identity[T](x: T) -> T:
+    return x
+
+def _(value: Nested[T_co]) -> list[T_co]:
+    x1 = [value]
+    identity(x1)
+    return x1  # error: [invalid-return-type]
+```
+
+The same restriction applies when the generic parameter is explicitly a collection:
+
+```py
+def list_identity[T](x: list[T]) -> list[T]:
+    return x
+
+def _(value: Nested[T_co]) -> list[T_co]:
+    x2 = [value]
+    list_identity(x2)
+    return x2  # error: [invalid-return-type]
+```
+
+## Independently constrained collection arguments
+
+Another argument can independently constrain a collection even when its existing elements include a
+recursive protocol. The collection's inferred type must not be recorded as an additional constraint
+on itself.
+
+```py
+from collections.abc import Iterable
+from typing import Protocol, TypeAlias, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class Recursive(Protocol[T_co]):
+    def nested(self): ...
+
+class Marker(Protocol):
+    def marker(self): ...
+
+Nested: TypeAlias = Iterable[T_co] | Recursive[T_co] | Marker
+
+def append[T](values: list[T], value: T) -> None: ...
+def _(value: Nested[T_co]) -> list[T_co]:
+    x1 = [value]
+    append(x1, value)
+    return x1  # error: [invalid-return-type]
+```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9242,10 +9242,50 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             &bindings,
         );
 
+        let generic_collection_argument = if func.is_name_expr()
+            && bindings.iter_flat().any(|binding| {
+                binding
+                    .matching_overloads()
+                    .any(|(_, overload)| overload.signature.generic_context.is_some())
+            }) {
+            arguments
+                .iter_source_order()
+                .enumerate()
+                .filter_map(|(argument_index, argument)| {
+                    if argument.is_variadic() {
+                        return None;
+                    }
+
+                    let value = argument.value();
+                    self.index
+                        .unannotated_collection_initializer(value)
+                        .map(|collection_def| (value, collection_def, argument_index))
+                })
+                .exactly_one()
+                .ok()
+        } else {
+            None
+        };
+
         let bindings_result = self.infer_and_check_argument_types(
             ArgumentsIter::from_ast(arguments),
             &mut call_arguments,
-            &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
+            &mut |builder, (argument_index, expr, tcx)| {
+                // The parameter may already be specialized from this collection. Reusing that
+                // specialization feeds the inferred element type back into the initializer, so
+                // infer independent constraints from the identity collection below instead. An
+                // enclosing annotation does not depend on the collection and remains useful.
+                let tcx = if call_expression_tcx.annotation.is_none()
+                    && generic_collection_argument
+                        .is_some_and(|(_, _, collection_index)| collection_index == argument_index)
+                {
+                    TypeContext::default()
+                } else {
+                    tcx
+                };
+
+                builder.infer_expression(expr, tcx)
+            },
             &mut bindings,
             call_expression_tcx,
         );
@@ -9308,56 +9348,128 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        // Record the constraints for the receiver of a bound method call, if the receiver is an
-        // unannotated collection initializer.
-        if let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) = func.as_ref() {
-            let value_type = self.expression_type(value);
-
-            if let Some(collection_def) = self.index.unannotated_collection_initializer(value)
-                && let Some((collection_literal, _)) = value_type.class_specialization(db, env)
+        // Bound methods and generic calls both constrain collection elements. Generic calls
+        // currently require exactly one collection argument.
+        let collection_receiver = match func.as_ref() {
+            ast::Expr::Attribute(attribute) => self
+                .index
+                .unannotated_collection_initializer(&attribute.value)
+                .map(|collection_def| {
+                    (
+                        attribute.value.as_ref(),
+                        collection_def,
+                        None,
+                        Some(attribute),
+                    )
+                }),
+            ast::Expr::Name(_)
+                if bindings.iter_flat().any(|binding| {
+                    binding
+                        .matching_overloads()
+                        .any(|(_, overload)| overload.signature.generic_context.is_some())
+                }) =>
             {
-                let identity_instance =
-                    Type::instance(db, env, collection_literal.identity_specialization(db));
-                let collection_generic_context = collection_literal.generic_context(db);
-                let mut identity_bindings = self
-                    .infer_attribute_load_impl(attribute, identity_instance)
+                generic_collection_argument.map(|(value, collection_def, argument_index)| {
+                    (value, collection_def, Some(argument_index), None)
+                })
+            }
+            _ => None,
+        };
+
+        if let Some((value, collection_def, collection_argument_index, attribute)) =
+            collection_receiver
+            && let Some((collection_literal, _)) =
+                self.expression_type(value).class_specialization(db, env)
+        {
+            let identity_instance =
+                Type::instance(db, env, collection_literal.identity_specialization(db));
+            let collection_generic_context = collection_literal.generic_context(db);
+            let identity_callable_type = attribute.map_or(callable_type, |attribute| {
+                self.infer_attribute_load_impl(attribute, identity_instance)
                     .unwrap_or_else(|recovery_ty| recovery_ty)
-                    .bindings(db, env)
-                    .match_parameters(db, env, &call_arguments)
-                    // Perform inference against the type variables on the receiver's generic context.
-                    .with_generic_context(self.db(), collection_generic_context);
+            });
+            let mut identity_bindings = identity_callable_type
+                .bindings(db, env)
+                .match_parameters(db, env, &call_arguments)
+                // Infer constraints against the collection's own type variables.
+                .with_generic_context(self.db(), collection_generic_context);
 
-                let call_result = self
-                    .speculate_without_diagnostics()
-                    .infer_and_check_argument_types(
-                        ArgumentsIter::from_ast(arguments),
-                        &mut call_arguments,
-                        // TODO: The argument types have already been inferred and stored in `call_arguments`.
-                        // However, `value` would have been inferred to a be a collection with `Divergent`
-                        // element types, meaning the type context for a given argument, by which the inferred
-                        // type is keyed, may not be the same as the type context we get here. It is not immediately
-                        // clear how to retrieve those types, and so we just re-infer the argument expressions
-                        // for simplicity.
-                        &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
-                        &mut identity_bindings,
-                        call_expression_tcx,
-                    );
+            let call_result = self
+                .speculate_without_diagnostics()
+                .infer_and_check_argument_types(
+                    ArgumentsIter::from_ast(arguments),
+                    &mut call_arguments,
+                    // TODO: Reuse the argument types stored in `call_arguments`. Collection
+                    // elements may initially be `Divergent`, so their original type context
+                    // can differ from the context used for the identity-specialized call.
+                    &mut |builder, (argument_index, expr, tcx)| {
+                        if collection_argument_index == Some(argument_index) {
+                            // Keep the collection's type variables free. Its literal elements
+                            // are incorporated separately when the initializer is inferred.
+                            identity_instance
+                        } else {
+                            builder.infer_expression(expr, tcx)
+                        }
+                    },
+                    &mut identity_bindings,
+                    call_expression_tcx,
+                );
 
-                if call_result.is_ok() {
-                    let db = self.db();
-                    for call_specialization in identity_bindings
-                        .iter_flat()
-                        .flat_map(CallableBinding::matching_overloads)
-                        .filter_map(|(_, identity_overload)| identity_overload.specialization(db))
+            if call_result.is_ok() {
+                let db = self.db();
+                for (identity_binding, original_binding) in
+                    identity_bindings.iter_flat().zip(bindings.iter_flat())
+                {
+                    for (overload_index, identity_overload) in identity_binding.matching_overloads()
                     {
-                        // Record the constraints on the receiver's generic context formed by
-                        // the arguments to this bound method call.
+                        // The identity collection can match an overload rejected by the actual
+                        // argument. Only an originally matching overload may constrain its
+                        // element type.
+                        if collection_argument_index.is_some()
+                            && !original_binding
+                                .matching_overloads()
+                                .any(|(matching_index, _)| matching_index == overload_index)
+                        {
+                            continue;
+                        }
+
+                        let Some(call_specialization) = identity_overload.specialization(db) else {
+                            continue;
+                        };
+
+                        // An unconstrained collection type variable defaults to `Unknown`, which
+                        // does not independently constrain its element type.
+                        // TODO: Distinguish an unconstrained variable from an explicitly inferred
+                        // `Unknown`.
+                        if collection_argument_index.is_some()
+                            && collection_generic_context.is_some_and(|generic_context| {
+                                generic_context.variables(db).any(|typevar| {
+                                    call_specialization
+                                        .get(db, typevar)
+                                        .is_none_or(|ty| ty.is_unknown())
+                                })
+                            })
+                        {
+                            continue;
+                        }
+
+                        // Project the call's constraints onto the collection's type variables.
                         let Some(constraints) = self.collection_use_constraint_from_specialization(
                             identity_instance,
                             collection_generic_context,
                             call_specialization,
                         ) else {
                             continue;
+                        };
+
+                        // Unannotated collection elements promote literal values. Apply the same
+                        // promotion before a sibling's literal becomes nested collection context.
+                        let constraints = if collection_argument_index.is_some()
+                            && call_expression_tcx.annotation.is_none()
+                        {
+                            constraints.promote(db, env)
+                        } else {
+                            constraints
                         };
 
                         self.collection_use_constraints


### PR DESCRIPTION
Resolves https://github.com/astral-sh/ty/issues/4145.