### PR TITLE
Fix PERF comprehension rewrites with zero-argument super()

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401_super.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401_super.py
@@ -1,0 +1,86 @@
+class Parent:
+    def value(self):
+        return 1
+
+    def values(self):
+        return [1]
+
+
+class Child(Parent):
+    def element(self):
+        result = []
+        for _ in range(1):
+            result.append(super().value())
+
+    def condition(self):
+        result = []
+        for value in range(1):
+            if super().value():
+                result.append(value)
+
+    def extend(self):
+        result = [0]
+        for _ in range(1):
+            result.append(super().value())
+
+    def extend_condition(self):
+        result = [0]
+        for value in range(1):
+            if super().value():
+                result.append(value)
+
+    async def async_list_comprehension(self, values):
+        result = []
+        async for _ in values:
+            result.append(super().value())
+
+    async def async_extend(self, values):
+        result = [0]
+        async for _ in values:
+            result.append(super().value())
+
+    def iterable(self):
+        result = []
+        for value in super().values():
+            result.append(value + 1)
+
+    def extend_iterable(self):
+        result = [0]
+        for value in super().values():
+            result.append(value + 1)
+
+    def explicit(self):
+        result = []
+        for _ in range(1):
+            result.append(super(Child, self).value())
+
+    def shadowed(self):
+        super = lambda: 1
+        result = []
+        for _ in range(1):
+            result.append(super())
+
+    def starred(self):
+        result = []
+        for _ in range(1):
+            result.append(super(*()).value())
+
+    def extend_starred(self):
+        result = [0]
+        for _ in range(1):
+            result.append(super(*()).value())
+
+    def lambda_body(self):
+        result = []
+        for _ in range(1):
+            result.append(lambda instance: super().value())
+
+    def lambda_default(self):
+        result = []
+        for _ in range(1):
+            result.append(lambda value=super().value(): value)
+
+    def nested_generator_iterable(self):
+        result = []
+        for _ in range(1):
+            result.append(value for value in super().values())

--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF402.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF402.py
@@ -50,3 +50,16 @@ def f():
     result = []
     async for i in items:
         result.append(i)  # PERF402
+
+
+class Parent:
+    def items(self):
+        return [1, 2, 3, 4]
+
+
+class Child(Parent):
+    def f(self):
+        result = []
+        # PERF402 remains valid because `list(super().items())` evaluates `super()` in this method.
+        for item in super().items():
+            result.append(item)  # PERF402

--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF403_super.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF403_super.py
@@ -1,0 +1,38 @@
+class Parent:
+    def condition(self):
+        return True
+
+    def pairs(self):
+        return [("key", 1)]
+
+
+class Child(Parent):
+    def condition_in_comprehension(self, pairs):
+        result = {}
+        for key, value in pairs:
+            if super().condition():
+                result[key] = value
+
+    def update(self, pairs):
+        result = {"existing": 0}
+        for key, value in pairs:
+            if super().condition():
+                result[key] = value
+
+    def iterable(self):
+        result = {}
+        for key, value in super().pairs():
+            result[key] = value
+
+    def explicit(self, pairs):
+        result = {}
+        for key, value in pairs:
+            if super(Child, self).condition():
+                result[key] = value
+
+    def shadowed(self, pairs):
+        super = lambda: Parent()
+        result = {}
+        for key, value in pairs:
+            if super().condition():
+                result[key] = value

--- a/crates/ruff_linter/src/rules/perflint/helpers.rs
+++ b/crates/ruff_linter/src/rules/perflint/helpers.rs
@@ -1,3 +1,7 @@
+use ruff_python_ast::{
+    self as ast, Expr,
+    visitor::{Visitor, walk_expr},
+};
 use ruff_python_trivia::{
     BackwardsTokenizer, PythonWhitespace, SimpleToken, SimpleTokenKind, SimpleTokenizer,
 };
@@ -5,6 +9,87 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
+
+/// Returns `true` if moving `expr` into a nested scope could change a `super` call to use the
+/// nested scope's implicit argument.
+pub(super) fn contains_potentially_zero_argument_super_call<'a>(
+    checker: &Checker<'a>,
+    expr: &'a Expr,
+) -> bool {
+    let mut finder = PotentiallyZeroArgumentSuperCallFinder {
+        checker,
+        found: false,
+    };
+    finder.visit_expr(expr);
+    finder.found
+}
+
+struct PotentiallyZeroArgumentSuperCallFinder<'checker, 'ast> {
+    checker: &'checker Checker<'ast>,
+    found: bool,
+}
+
+impl<'ast> PotentiallyZeroArgumentSuperCallFinder<'_, 'ast> {
+    fn visit_outermost_comprehension_iter(&mut self, generators: &'ast [ast::Comprehension]) {
+        if let Some(generator) = generators.first() {
+            self.visit_expr(&generator.iter);
+        }
+    }
+}
+
+impl<'ast> Visitor<'ast> for PotentiallyZeroArgumentSuperCallFinder<'_, 'ast> {
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        if self.found {
+            return;
+        }
+
+        if let Expr::Call(call) = expr {
+            let arguments = &call.arguments;
+            if arguments.keywords.is_empty()
+                && arguments
+                    .args
+                    .iter()
+                    .all(|argument| matches!(argument, Expr::Starred(_)))
+                && self
+                    .checker
+                    .semantic()
+                    .match_builtin_expr(&call.func, "super")
+            {
+                self.found = true;
+                return;
+            }
+        }
+
+        match expr {
+            // A lambda body remains in its own scope, but defaults are evaluated while the lambda
+            // is created and therefore move with the surrounding expression.
+            Expr::Lambda(lambda) => {
+                if let Some(parameters) = &lambda.parameters {
+                    for parameter in parameters.iter_non_variadic_params() {
+                        if let Some(default) = parameter.default() {
+                            self.visit_expr(default);
+                        }
+                    }
+                }
+            }
+            // The outermost iterable of a comprehension or generator is evaluated in its
+            // surrounding scope. The remaining parts already execute in the nested scope.
+            Expr::ListComp(list_comprehension) => {
+                self.visit_outermost_comprehension_iter(&list_comprehension.generators);
+            }
+            Expr::SetComp(set_comprehension) => {
+                self.visit_outermost_comprehension_iter(&set_comprehension.generators);
+            }
+            Expr::DictComp(dict_comprehension) => {
+                self.visit_outermost_comprehension_iter(&dict_comprehension.generators);
+            }
+            Expr::Generator(generator) => {
+                self.visit_outermost_comprehension_iter(&generator.generators);
+            }
+            _ => walk_expr(self, expr),
+        }
+    }
+}
 
 pub(super) fn comment_strings_in_range<'a>(
     checker: &'a Checker,

--- a/crates/ruff_linter/src/rules/perflint/mod.rs
+++ b/crates/ruff_linter/src/rules/perflint/mod.rs
@@ -9,17 +9,19 @@ mod tests {
     use ruff_python_ast::PythonVersion;
     use test_case::test_case;
 
-    use crate::assert_diagnostics;
     use crate::registry::Rule;
     use crate::settings::LinterSettings;
     use crate::test::test_path;
+    use crate::{assert_diagnostics, assert_diagnostics_diff};
 
     #[test_case(Rule::UnnecessaryListCast, Path::new("PERF101.py"))]
     #[test_case(Rule::IncorrectDictIterator, Path::new("PERF102.py"))]
     #[test_case(Rule::TryExceptInLoop, Path::new("PERF203.py"))]
     #[test_case(Rule::ManualListComprehension, Path::new("PERF401.py"))]
+    #[test_case(Rule::ManualListComprehension, Path::new("PERF401_super.py"))]
     #[test_case(Rule::ManualListCopy, Path::new("PERF402.py"))]
     #[test_case(Rule::ManualDictComprehension, Path::new("PERF403.py"))]
+    #[test_case(Rule::ManualDictComprehension, Path::new("PERF403_super.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(
@@ -33,7 +35,9 @@ mod tests {
     #[test_case(Rule::IncorrectDictIterator, Path::new("PERF102.py"))]
     // TODO: remove this test case when the fixes for `perf401` and `perf403` are stabilized
     #[test_case(Rule::ManualDictComprehension, Path::new("PERF403.py"))]
+    #[test_case(Rule::ManualDictComprehension, Path::new("PERF403_super.py"))]
     #[test_case(Rule::ManualListComprehension, Path::new("PERF401.py"))]
+    #[test_case(Rule::ManualListComprehension, Path::new("PERF401_super.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",
@@ -47,6 +51,23 @@ mod tests {
                 .with_target_version(PythonVersion::PY310),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::ManualListComprehension, Path::new("PERF401_super.py"))]
+    #[test_case(Rule::ManualDictComprehension, Path::new("PERF403_super.py"))]
+    fn super_calls_python_version_diff(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("diff_{}_{}", rule_code.noqa_code(), path.to_string_lossy());
+        assert_diagnostics_diff!(
+            snapshot,
+            Path::new("perflint").join(path).as_path(),
+            &LinterSettings::for_rule(rule_code)
+                .with_preview_mode()
+                .with_target_version(PythonVersion::PY311),
+            &LinterSettings::for_rule(rule_code)
+                .with_preview_mode()
+                .with_target_version(PythonVersion::PY312),
+        );
         Ok(())
     }
 }

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_dict_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_dict_comprehension.rs
@@ -1,6 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{
-    self as ast, Expr, Stmt, comparable::ComparableExpr, helpers::any_over_expr,
+    self as ast, Expr, PythonVersion, Stmt, comparable::ComparableExpr, helpers::any_over_expr,
 };
 use ruff_python_semantic::{Binding, analyze::typing::is_dict};
 use ruff_source_file::LineRanges;
@@ -8,7 +8,10 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_manual_dict_comprehension_enabled;
-use crate::rules::perflint::helpers::{comment_strings_in_range, statement_deletion_range};
+use crate::rules::perflint::helpers::{
+    comment_strings_in_range, contains_potentially_zero_argument_super_call,
+    statement_deletion_range,
+};
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -24,6 +27,10 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// Note that, as with all `perflint` rules, this is only intended as a
 /// micro-optimization, and will have a negligible impact on performance in
 /// most cases.
+///
+/// ## Known problems
+/// For targets before Python 3.12, this rule ignores loops whose rewrite would
+/// move a potentially zero-argument `super` call into a dictionary comprehension.
 ///
 /// ## Example
 /// ```python
@@ -82,7 +89,7 @@ impl Violation for ManualDictComprehension {
 }
 
 /// PERF403
-pub(crate) fn manual_dict_comprehension(checker: &Checker, for_stmt: &ast::StmtFor) {
+pub(crate) fn manual_dict_comprehension<'a>(checker: &Checker<'a>, for_stmt: &'a ast::StmtFor) {
     let ast::StmtFor { body, target, .. } = for_stmt;
     let body = body.as_slice();
     let target = target.as_ref();
@@ -138,6 +145,15 @@ pub(crate) fn manual_dict_comprehension(checker: &Checker, for_stmt: &ast::StmtF
     else {
         return;
     };
+
+    // Before Python 3.12, dictionary comprehensions ran in a nested function. Moving a condition
+    // containing a potentially zero-argument `super` call into one would make it use the
+    // comprehension's implicit `.0` iterator argument and raise a `TypeError` at runtime.
+    if checker.target_version() < PythonVersion::PY312
+        && if_test.is_some_and(|test| contains_potentially_zero_argument_super_call(checker, test))
+    {
+        return;
+    }
 
     // If any references to a target variable are after the loop,
     // then removing the loop would cause a NameError. Make sure none

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -1,13 +1,16 @@
-use ruff_python_ast::{self as ast, Arguments, Expr};
+use ruff_python_ast::{self as ast, Arguments, Expr, PythonVersion};
 
 use crate::{Edit, Fix, FixAvailability, Violation};
 use crate::{
-    checkers::ast::Checker, preview::is_fix_manual_list_comprehension_enabled,
-    rules::perflint::helpers::statement_deletion_range,
+    checkers::ast::Checker,
+    preview::is_fix_manual_list_comprehension_enabled,
+    rules::perflint::helpers::{
+        comment_strings_in_range, contains_potentially_zero_argument_super_call,
+        statement_deletion_range,
+    },
 };
 use anyhow::{Result, anyhow};
 
-use crate::rules::perflint::helpers::comment_strings_in_range;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_semantic::{Binding, analyze::typing::is_list};
@@ -27,6 +30,10 @@ use ruff_text_size::{Ranged, TextRange};
 /// Note that, as with all `perflint` rules, this is only intended as a
 /// micro-optimization, and will have a negligible impact on performance in
 /// most cases.
+///
+/// ## Known problems
+/// For targets before Python 3.12, this rule ignores loops whose rewrite would
+/// move a potentially zero-argument `super` call into a comprehension.
 ///
 /// ## Example
 /// ```python
@@ -94,7 +101,7 @@ impl Violation for ManualListComprehension {
 }
 
 /// PERF401
-pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtFor) {
+pub(crate) fn manual_list_comprehension<'a>(checker: &Checker<'a>, for_stmt: &'a ast::StmtFor) {
     let Expr::Name(ast::ExprName {
         id: for_stmt_target_id,
         ..
@@ -335,6 +342,27 @@ pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtF
         ComprehensionType::Extend
     };
 
+    let contains_potentially_zero_argument_super_call =
+        contains_potentially_zero_argument_super_call(checker, arg)
+            || if_test
+                .is_some_and(|test| contains_potentially_zero_argument_super_call(checker, test));
+
+    // Before Python 3.12, comprehensions ran in a nested function. A potentially zero-argument
+    // `super` call would then use the comprehension's implicit `.0` iterator argument and raise a
+    // `TypeError` at runtime.
+    if checker.target_version() < PythonVersion::PY312
+        && contains_potentially_zero_argument_super_call
+    {
+        return;
+    }
+
+    // Synchronous `list.extend` normally receives a generator expression, which always introduces
+    // a nested scope. When a potentially zero-argument `super` call is present, use a list
+    // comprehension instead. Python 3.12 inlines it, just as it does for the other fixes here.
+    let list_extend_uses_list_comprehension = contains_potentially_zero_argument_super_call
+        && comprehension_type == ComprehensionType::Extend
+        && !for_stmt.is_async;
+
     let mut diagnostic = checker.report_diagnostic(
         ManualListComprehension {
             is_async: for_stmt.is_async,
@@ -352,6 +380,7 @@ pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtF
                 for_stmt,
                 if_test.map(std::convert::AsRef::as_ref),
                 arg,
+                list_extend_uses_list_comprehension,
                 checker,
             )
         });
@@ -364,6 +393,7 @@ fn convert_to_list_extend(
     for_stmt: &ast::StmtFor,
     if_test: Option<&Expr>,
     to_append: &Expr,
+    list_extend_uses_list_comprehension: bool,
     checker: &Checker,
 ) -> Result<Fix> {
     let semantic = checker.semantic();
@@ -443,8 +473,10 @@ fn convert_to_list_extend(
 
     match fix_type {
         ComprehensionType::Extend => {
-            let generator_str = if for_stmt.is_async {
-                // generators do not implement __iter__, so `async for` requires the generator to be a list
+            let generator_str = if for_stmt.is_async || list_extend_uses_list_comprehension {
+                // Async generators do not implement `__iter__`, so `async for` requires a list.
+                // A synchronous loop uses a list too when `super` must remain in an inlined
+                // comprehension on Python 3.12+.
                 format!("[{generator_str}]")
             } else {
                 generator_str

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401_super.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401_super.py.snap
@@ -1,0 +1,62 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super.py:45:13
+   |
+43 |         result = []
+44 |         for value in super().values():
+45 |             result.append(value + 1)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+46 |
+47 |     def extend_iterable(self):
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use `list.extend` to create a transformed list
+  --> PERF401_super.py:50:13
+   |
+48 |         result = [0]
+49 |         for value in super().values():
+50 |             result.append(value + 1)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+51 |
+52 |     def explicit(self):
+   |
+help: Replace for loop with list.extend
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super.py:55:13
+   |
+53 |         result = []
+54 |         for _ in range(1):
+55 |             result.append(super(Child, self).value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+56 |
+57 |     def shadowed(self):
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super.py:61:13
+   |
+59 |         result = []
+60 |         for _ in range(1):
+61 |             result.append(super())
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+62 |
+63 |     def starred(self):
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super.py:76:13
+   |
+74 |         result = []
+75 |         for _ in range(1):
+76 |             result.append(lambda instance: super().value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+77 |
+78 |     def lambda_default(self):
+   |
+help: Replace for loop with list comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF402_PERF402.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF402_PERF402.py.snap
@@ -8,3 +8,11 @@ PERF402 Use `list` or `list.copy` to create a copy of a list
 4 |     for i in items:
 5 |         result.append(i)  # PERF402
   |         ^^^^^^^^^^^^^^^^
+
+PERF402 Use `list` or `list.copy` to create a copy of a list
+  --> PERF402.py:65:13
+   |
+63 |         # PERF402 remains valid because `list(super().items())` evaluates `super()` in this method.
+64 |         for item in super().items():
+65 |             result.append(item)  # PERF402
+   |             ^^^^^^^^^^^^^^^^^^^

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF403_PERF403_super.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF403_PERF403_super.py.snap
@@ -1,0 +1,35 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super.py:25:13
+   |
+23 |         result = {}
+24 |         for key, value in super().pairs():
+25 |             result[key] = value
+   |             ^^^^^^^^^^^^^^^^^^^
+26 |
+27 |     def explicit(self, pairs):
+   |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super.py:31:17
+   |
+29 |         for key, value in pairs:
+30 |             if super(Child, self).condition():
+31 |                 result[key] = value
+   |                 ^^^^^^^^^^^^^^^^^^^
+32 |
+33 |     def shadowed(self, pairs):
+   |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super.py:38:17
+   |
+36 |         for key, value in pairs:
+37 |             if super().condition():
+38 |                 result[key] = value
+   |                 ^^^^^^^^^^^^^^^^^^^
+help: Replace for loop with dict comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__diff_PERF401_PERF401_super.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__diff_PERF401_PERF401_super.py.snap
@@ -1,0 +1,224 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+--- Linter settings ---
+-linter.unresolved_target_version = 3.11
++linter.unresolved_target_version = 3.12
+
+--- Summary ---
+Removed: 0
+Added: 10
+
+--- Added ---
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:13:13
+   |
+11 |         result = []
+12 |         for _ in range(1):
+13 |             result.append(super().value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+14 |
+15 |     def condition(self):
+   |
+help: Replace for loop with list comprehension
+   |
+10 |     def element(self):
+   -         result = []
+   -         for _ in range(1):
+   -             result.append(super().value())
+11 +         result = [super().value() for _ in range(1)]
+12 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:19:17
+   |
+17 |         for value in range(1):
+18 |             if super().value():
+19 |                 result.append(value)
+   |                 ^^^^^^^^^^^^^^^^^^^^
+20 |
+21 |     def extend(self):
+   |
+help: Replace for loop with list comprehension
+   |
+15 |     def condition(self):
+   -         result = []
+   -         for value in range(1):
+   -             if super().value():
+   -                 result.append(value)
+16 +         result = [value for value in range(1) if super().value()]
+17 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use `list.extend` to create a transformed list
+  --> PERF401_super.py:24:13
+   |
+22 |         result = [0]
+23 |         for _ in range(1):
+24 |             result.append(super().value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+25 |
+26 |     def extend_condition(self):
+   |
+help: Replace for loop with list.extend
+   |
+22 |         result = [0]
+   -         for _ in range(1):
+   -             result.append(super().value())
+23 +         result.extend([super().value() for _ in range(1)])
+24 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use `list.extend` to create a transformed list
+  --> PERF401_super.py:30:17
+   |
+28 |         for value in range(1):
+29 |             if super().value():
+30 |                 result.append(value)
+   |                 ^^^^^^^^^^^^^^^^^^^^
+31 |
+32 |     async def async_list_comprehension(self, values):
+   |
+help: Replace for loop with list.extend
+   |
+27 |         result = [0]
+   -         for value in range(1):
+   -             if super().value():
+   -                 result.append(value)
+28 +         result.extend([value for value in range(1) if super().value()])
+29 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use an async list comprehension to create a transformed list
+  --> PERF401_super.py:35:13
+   |
+33 |         result = []
+34 |         async for _ in values:
+35 |             result.append(super().value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+36 |
+37 |     async def async_extend(self, values):
+   |
+help: Replace for loop with list comprehension
+   |
+32 |     async def async_list_comprehension(self, values):
+   -         result = []
+   -         async for _ in values:
+   -             result.append(super().value())
+33 +         result = [super().value() async for _ in values]
+34 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use `list.extend` with an async comprehension to create a transformed list
+  --> PERF401_super.py:40:13
+   |
+38 |         result = [0]
+39 |         async for _ in values:
+40 |             result.append(super().value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+41 |
+42 |     def iterable(self):
+   |
+help: Replace for loop with list.extend
+   |
+38 |         result = [0]
+   -         async for _ in values:
+   -             result.append(super().value())
+39 +         result.extend([super().value() async for _ in values])
+40 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:66:13
+   |
+64 |         result = []
+65 |         for _ in range(1):
+66 |             result.append(super(*()).value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+67 |
+68 |     def extend_starred(self):
+   |
+help: Replace for loop with list comprehension
+   |
+63 |     def starred(self):
+   -         result = []
+   -         for _ in range(1):
+   -             result.append(super(*()).value())
+64 +         result = [super(*()).value() for _ in range(1)]
+65 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use `list.extend` to create a transformed list
+  --> PERF401_super.py:71:13
+   |
+69 |         result = [0]
+70 |         for _ in range(1):
+71 |             result.append(super(*()).value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+72 |
+73 |     def lambda_body(self):
+   |
+help: Replace for loop with list.extend
+   |
+69 |         result = [0]
+   -         for _ in range(1):
+   -             result.append(super(*()).value())
+70 +         result.extend([super(*()).value() for _ in range(1)])
+71 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:81:13
+   |
+79 |         result = []
+80 |         for _ in range(1):
+81 |             result.append(lambda value=super().value(): value)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+82 |
+83 |     def nested_generator_iterable(self):
+   |
+help: Replace for loop with list comprehension
+   |
+78 |     def lambda_default(self):
+   -         result = []
+   -         for _ in range(1):
+   -             result.append(lambda value=super().value(): value)
+79 +         result = [lambda value=super().value(): value for _ in range(1)]
+80 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:86:13
+   |
+84 |         result = []
+85 |         for _ in range(1):
+86 |             result.append(value for value in super().values())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Replace for loop with list comprehension
+   |
+83 |     def nested_generator_iterable(self):
+   -         result = []
+   -         for _ in range(1):
+   -             result.append(value for value in super().values())
+84 +         result = [(value for value in super().values()) for _ in range(1)]
+   |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__diff_PERF403_PERF403_super.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__diff_PERF403_PERF403_super.py.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+--- Linter settings ---
+-linter.unresolved_target_version = 3.11
++linter.unresolved_target_version = 3.12
+
+--- Summary ---
+Removed: 0
+Added: 2
+
+--- Added ---
+PERF403 [*] Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super.py:14:17
+   |
+12 |         for key, value in pairs:
+13 |             if super().condition():
+14 |                 result[key] = value
+   |                 ^^^^^^^^^^^^^^^^^^^
+15 |
+16 |     def update(self, pairs):
+   |
+help: Replace for loop with dict comprehension
+   |
+10 |     def condition_in_comprehension(self, pairs):
+   -         result = {}
+   -         for key, value in pairs:
+   -             if super().condition():
+   -                 result[key] = value
+11 +         result = {key: value for key, value in pairs if super().condition()}
+12 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+
+PERF403 [*] Use `dict.update` instead of a for-loop
+  --> PERF403_super.py:20:17
+   |
+18 |         for key, value in pairs:
+19 |             if super().condition():
+20 |                 result[key] = value
+   |                 ^^^^^^^^^^^^^^^^^^^
+21 |
+22 |     def iterable(self):
+   |
+help: Replace for loop with `dict.update`
+   |
+17 |         result = {"existing": 0}
+   -         for key, value in pairs:
+   -             if super().condition():
+   -                 result[key] = value
+18 +         result.update({key: value for key, value in pairs if super().condition()})
+19 |
+   |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401_super.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401_super.py.snap
@@ -1,0 +1,106 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:45:13
+   |
+43 |         result = []
+44 |         for value in super().values():
+45 |             result.append(value + 1)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+46 |
+47 |     def extend_iterable(self):
+   |
+help: Replace for loop with list comprehension
+   |
+42 |     def iterable(self):
+   -         result = []
+   -         for value in super().values():
+   -             result.append(value + 1)
+43 +         result = [value + 1 for value in super().values()]
+44 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use `list.extend` to create a transformed list
+  --> PERF401_super.py:50:13
+   |
+48 |         result = [0]
+49 |         for value in super().values():
+50 |             result.append(value + 1)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+51 |
+52 |     def explicit(self):
+   |
+help: Replace for loop with list.extend
+   |
+48 |         result = [0]
+   -         for value in super().values():
+   -             result.append(value + 1)
+49 +         result.extend(value + 1 for value in super().values())
+50 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:55:13
+   |
+53 |         result = []
+54 |         for _ in range(1):
+55 |             result.append(super(Child, self).value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+56 |
+57 |     def shadowed(self):
+   |
+help: Replace for loop with list comprehension
+   |
+52 |     def explicit(self):
+   -         result = []
+   -         for _ in range(1):
+   -             result.append(super(Child, self).value())
+53 +         result = [super(Child, self).value() for _ in range(1)]
+54 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:61:13
+   |
+59 |         result = []
+60 |         for _ in range(1):
+61 |             result.append(super())
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+62 |
+63 |     def starred(self):
+   |
+help: Replace for loop with list comprehension
+   |
+58 |         super = lambda: 1
+   -         result = []
+   -         for _ in range(1):
+   -             result.append(super())
+59 +         result = [super() for _ in range(1)]
+60 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+PERF401 [*] Use a list comprehension to create a transformed list
+  --> PERF401_super.py:76:13
+   |
+74 |         result = []
+75 |         for _ in range(1):
+76 |             result.append(lambda instance: super().value())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+77 |
+78 |     def lambda_default(self):
+   |
+help: Replace for loop with list comprehension
+   |
+73 |     def lambda_body(self):
+   -         result = []
+   -         for _ in range(1):
+   -             result.append(lambda instance: super().value())
+74 +         result = [lambda instance: super().value() for _ in range(1)]
+75 |
+   |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF403_PERF403_super.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF403_PERF403_super.py.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+PERF403 [*] Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super.py:25:13
+   |
+23 |         result = {}
+24 |         for key, value in super().pairs():
+25 |             result[key] = value
+   |             ^^^^^^^^^^^^^^^^^^^
+26 |
+27 |     def explicit(self, pairs):
+   |
+help: Replace for loop with dict comprehension
+   |
+22 |     def iterable(self):
+   -         result = {}
+   -         for key, value in super().pairs():
+   -             result[key] = value
+23 +         result = {key: value for key, value in super().pairs()}
+24 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+PERF403 [*] Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super.py:31:17
+   |
+29 |         for key, value in pairs:
+30 |             if super(Child, self).condition():
+31 |                 result[key] = value
+   |                 ^^^^^^^^^^^^^^^^^^^
+32 |
+33 |     def shadowed(self, pairs):
+   |
+help: Replace for loop with dict comprehension
+   |
+27 |     def explicit(self, pairs):
+   -         result = {}
+   -         for key, value in pairs:
+   -             if super(Child, self).condition():
+   -                 result[key] = value
+28 +         result = {key: value for key, value in pairs if super(Child, self).condition()}
+29 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+PERF403 [*] Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super.py:38:17
+   |
+36 |         for key, value in pairs:
+37 |             if super().condition():
+38 |                 result[key] = value
+   |                 ^^^^^^^^^^^^^^^^^^^
+help: Replace for loop with dict comprehension
+   |
+34 |         super = lambda: Parent()
+   -         result = {}
+   -         for key, value in pairs:
+   -             if super().condition():
+   -                 result[key] = value
+35 +         result = {key: value for key, value in pairs if super().condition()}
+   |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Closes #27668.

Avoid PERF401 and PERF403 rewrites that would move built-in zero-argument `super()` into a separate comprehension scope on Python 3.11 and earlier.

On Python 3.12+, retain the diagnostics and fixes because PEP 709 inlines list and dictionary comprehensions. PERF401 uses `list.extend([…])` when necessary, avoiding an unsafe generator expression while preserving the diagnostic. The detection is semantic, ignores shadowed and explicit-context `super` calls, and accounts for lambda and nested-comprehension scope boundaries.

## Test Plan

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ruff_linter rules::perflint`
- `cargo clippy --offline -p ruff_linter --all-targets --all-features -- -D warnings`
- `uv run --only-group dev --locked prek run --files …`
