### PR TITLE
[ty] Infer typevars through a nominal `type[…]` formal

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -172,59 +172,88 @@ reveal_type(pick([1]))  # revealed: bool
 
 ## Inferring a class-object parameter through a generic factory
 
+A factory can infer its type arguments from a specialized subclass of its class-object parameter.
+
 ```py
 from typing import Generic, TypeVar
 
-RequestT = TypeVar("RequestT")
-ResponseT = TypeVar("ResponseT")
+T = TypeVar("T")
+U = TypeVar("U")
 
-class BaseService(Generic[RequestT, ResponseT]):
-    Request: type[RequestT]
-    Response: type[ResponseT]
+class Base(Generic[T, U]): ...
+class Specialized(Base[int, str]): ...
 
-class Future(Generic[ResponseT]):
-    def result(self) -> ResponseT | None:
-        raise NotImplementedError
-
-class Client(Generic[RequestT, ResponseT]):
-    def call_async(self, request: RequestT) -> Future[ResponseT]:
-        raise NotImplementedError
-
-def create_client(srv: type[BaseService[RequestT, ResponseT]]) -> Client[RequestT, ResponseT]:
+def create(cls: type[Base[T, U]]) -> tuple[T, U]:
     raise NotImplementedError
 
-class MyRequest: ...
-class MyResponse: ...
-class MyService(BaseService[MyRequest, MyResponse]): ...
-
-def _() -> None:
-    client = create_client(MyService)
-    reveal_type(client)  # revealed: Client[MyRequest, MyResponse]
-    future = client.call_async(MyRequest())
-    reveal_type(future)  # revealed: Future[MyResponse]
-    reveal_type(future.result())  # revealed: MyResponse | None
+reveal_type(create(Specialized))  # revealed: tuple[int, str]
 ```
 
-The same shape as a method, where the specialization comes from the argument's bases:
+## Inferring a class-object parameter through a generic method
+
+A method can likewise infer a type argument from the specialized bases of its class-object
+parameter.
 
 ```py
-from collections.abc import Sequence
 from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
 class Option(Generic[T]): ...
-class StringOptions(Option[Sequence[str]]): ...
+class StringOption(Option[str]): ...
 
 class Options:
     def get_value_for(self, option: type[Option[T]]) -> T:
         raise NotImplementedError
 
-def _(options: Options) -> None:
-    values = options.get_value_for(StringOptions)
-    reveal_type(values)  # revealed: Sequence[str]
-    # error: [unresolved-attribute] "Object of type `Sequence[str]` has no attribute `nonexistent`"
-    values.nonexistent()
+reveal_type(Options().get_value_for(StringOption))  # revealed: str
+```
+
+## Inferring a class-object parameter in a contravariant position
+
+A class-object parameter inside a contravariant generic places an upper bound on its inferred type
+argument. A more specific witness should determine the result, including when the type variable has
+its own declared upper bound.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+StrT = TypeVar("StrT", bound=str)
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class Covariant(Generic[T_co]): ...
+class Sink(Generic[T_contra]): ...
+
+def infer(sink: Sink[type[Covariant[T]]], witness: T) -> T:
+    return witness
+
+def infer_bounded(sink: Sink[type[Covariant[StrT]]], witness: StrT) -> StrT:
+    return witness
+
+def _(sink: Sink[type[Covariant[object]]]) -> None:
+    reveal_type(infer(sink, 1))  # revealed: Literal[1]
+    reveal_type(infer_bounded(sink, "ok"))  # revealed: Literal["ok"]
+```
+
+## Inferring a class-object parameter for a final generic class
+
+A final generic class has no subclasses, so its class-object parameter is an exact generic alias.
+Its type arguments should still participate in inference.
+
+```py
+from typing import Generic, TypeVar, final
+
+T = TypeVar("T")
+
+@final
+class Final(Generic[T]): ...
+
+def infer(cls: type[Final[T]]) -> T:
+    raise NotImplementedError
+
+reveal_type(infer(Final[int]))  # revealed: int
 ```
 
 ## Inferring tuple parameter types

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -121,6 +121,11 @@ def takes_in_type(x: type[T]) -> type[T]:
     return x
 
 reveal_type(takes_in_type(int))  # revealed: type[int]
+
+def takes_in_type_of_list(x: type[list[T]]) -> T:
+    raise NotImplementedError
+
+reveal_type(takes_in_type_of_list(list[int]))  # revealed: int
 ```
 
 This also works when passing in arguments that are subclasses of the parameter type.
@@ -134,6 +139,9 @@ reveal_type(takes_in_protocol(Sub()))  # revealed: int
 
 reveal_type(takes_in_list(GenericSub[str]()))  # revealed: list[str]
 reveal_type(takes_in_protocol(GenericSub[str]()))  # revealed: str
+
+reveal_type(takes_in_type_of_list(Sub))  # revealed: int
+reveal_type(takes_in_type_of_list(GenericSub[str]))  # revealed: str
 
 class ExplicitSub(ExplicitlyImplements[int]): ...
 class ExplicitGenericSub(ExplicitlyImplements[T]): ...
@@ -160,6 +168,63 @@ def pick(x: object) -> str | bool:
     raise NotImplementedError
 
 reveal_type(pick([1]))  # revealed: bool
+```
+
+## Inferring a class-object parameter through a generic factory
+
+```py
+from typing import Generic, TypeVar
+
+RequestT = TypeVar("RequestT")
+ResponseT = TypeVar("ResponseT")
+
+class BaseService(Generic[RequestT, ResponseT]):
+    Request: type[RequestT]
+    Response: type[ResponseT]
+
+class Future(Generic[ResponseT]):
+    def result(self) -> ResponseT | None:
+        raise NotImplementedError
+
+class Client(Generic[RequestT, ResponseT]):
+    def call_async(self, request: RequestT) -> Future[ResponseT]:
+        raise NotImplementedError
+
+def create_client(srv: type[BaseService[RequestT, ResponseT]]) -> Client[RequestT, ResponseT]:
+    raise NotImplementedError
+
+class MyRequest: ...
+class MyResponse: ...
+class MyService(BaseService[MyRequest, MyResponse]): ...
+
+def _() -> None:
+    client = create_client(MyService)
+    reveal_type(client)  # revealed: Client[MyRequest, MyResponse]
+    future = client.call_async(MyRequest())
+    reveal_type(future)  # revealed: Future[MyResponse]
+    reveal_type(future.result())  # revealed: MyResponse | None
+```
+
+The same shape as a method, where the specialization comes from the argument's bases:
+
+```py
+from collections.abc import Sequence
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Option(Generic[T]): ...
+class StringOptions(Option[Sequence[str]]): ...
+
+class Options:
+    def get_value_for(self, option: type[Option[T]]) -> T:
+        raise NotImplementedError
+
+def _(options: Options) -> None:
+    values = options.get_value_for(StringOptions)
+    reveal_type(values)  # revealed: Sequence[str]
+    # error: [unresolved-attribute] "Object of type `Sequence[str]` has no attribute `nonexistent`"
+    values.nonexistent()
 ```
 
 ## Inferring tuple parameter types

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3728,14 +3728,31 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (
-                Type::SubclassOf(formal_subclass),
+                formal @ (Type::SubclassOf(_) | Type::GenericAlias(_)),
                 Type::ClassLiteral(_)
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
                 | Type::Union(_),
-            ) if matches!(formal_subclass.subclass_of(), SubclassOfInner::Class(_)) => {
-                let when = actual.when_constraint_set_assignable_to_owned(db, self.env, formal);
-                let when = self.constraints.load(db, self.env, &when);
+            ) if formal.is_generic_alias()
+                || matches!(formal, Type::SubclassOf(subclass)
+                    if matches!(subclass.subclass_of(), SubclassOfInner::Class(_))) =>
+            {
+                let when = match polarity {
+                    TypeVarVariance::Covariant | TypeVarVariance::Invariant => {
+                        actual.when_constraint_set_assignable_to_owned(db, self.env, formal)
+                    }
+                    TypeVarVariance::Contravariant => {
+                        formal.when_constraint_set_assignable_to_owned(db, self.env, actual)
+                    }
+                    TypeVarVariance::Bivariant => return Ok(()),
+                };
+                let mut when = self.constraints.load(db, self.env, &when);
+                if matches!(polarity, TypeVarVariance::Invariant) {
+                    let reverse =
+                        formal.when_constraint_set_assignable_to_owned(db, self.env, actual);
+                    let reverse = self.constraints.load(db, self.env, &reverse);
+                    when.intersect(db, self.constraints, reverse);
+                }
                 self.infer_from_constraint_set(when)?;
                 return Ok(());
             }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3727,6 +3727,19 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 );
             }
 
+            (
+                Type::SubclassOf(formal_subclass),
+                Type::ClassLiteral(_)
+                | Type::GenericAlias(_)
+                | Type::SubclassOf(_)
+                | Type::Union(_),
+            ) if matches!(formal_subclass.subclass_of(), SubclassOfInner::Class(_)) => {
+                let when = actual.when_constraint_set_assignable_to_owned(db, self.env, formal);
+                let when = self.constraints.load(db, self.env, &when);
+                self.infer_from_constraint_set(when)?;
+                return Ok(());
+            }
+
             (Type::SubclassOf(subclass_of), ty) | (ty, Type::SubclassOf(subclass_of))
                 if let Some(type_var) = subclass_of.into_type_var()
                     && let Some(actual_instance) = ty.to_instance_approximation(db, self.env) =>


### PR DESCRIPTION
## Summary
This adds typevar inference through a nominal `type[…]` formal.

Closes astral-sh/ty#3576.

## Test Plan
Added mdtests.