### PR TITLE
[ty] Track place load deferredness in the semantic index

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -11,6 +11,7 @@ use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::{SourceText, source_text};
 use ruff_index::IndexVec;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::statement_visitor::{self, StatementVisitor};
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_keyword, walk_pattern, walk_stmt};
 use ruff_python_ast::{self as ast, AtomicNodeIndex, NodeIndex, PySourceType, PythonVersion};
 use ruff_python_parser::semantic_errors::{
@@ -228,6 +229,7 @@ impl ConditionFlowSnapshot {
     }
 }
 
+#[expect(clippy::struct_excessive_bools)]
 pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     // Builder state
     db: &'db dyn Db,
@@ -251,8 +253,24 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
 
     /// Flags about the file's global scope
     has_future_annotations: bool,
+    /// Whether the module contains a `from __future__ import annotations` import.
+    ///
+    /// This must be pre-computed in order to initialize the correct state for
+    /// determining place load deferredness before we walk the AST. That is what
+    /// allows earlier annotation loads to account for a later import (matching
+    /// type inference's permissive misplaced import policy).
+    ///
+    /// Conversely, `has_future_annotations` must be updated on-the-fly so that
+    /// syntax checking can behave differently before versus after the import.
+    has_future_annotations_for_place_loads: bool,
     /// Whether we are currently visiting an `if TYPE_CHECKING` block.
     in_type_checking_block: bool,
+    /// Whether place loads in the current expression use all bindings reachable
+    /// in its scope.
+    ///
+    /// `None` means that we can't (easily) determine whether to use either
+    /// point-in-time or all reachable bindings.
+    place_load_is_deferred: Option<bool>,
 
     // Used for checking semantic syntax errors
     resolver_environment: ResolverEnvironment<'db>,
@@ -272,6 +290,8 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     use_def_maps: IndexVec<FileScopeId, Box<UseDefMapBuilder<'db>>>,
     scopes_by_node: FxHashMap<NodeWithScopeKey, FileScopeId>,
     scopes_by_expression: ExpressionsScopeMapBuilder,
+    deferred_place_loads: FxHashSet<ExpressionNodeKey>,
+    unclassified_place_loads: FxHashSet<ExpressionNodeKey>,
     definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>,
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
     unpacks_by_target: FxHashMap<ExpressionNodeKey, Unpack<'db>>,
@@ -304,6 +324,42 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     alias_predicates: FxHashMap<ExpressionNodeKey, NarrowingAliasPredicate<'db>>,
 }
 
+fn module_has_future_annotations(module: &ParsedModuleRef) -> bool {
+    // We intentionally don't enforce the rules about the location of `__future__` imports here.
+    // The syntax checker reports a misplaced import, but type checking still follows the user's
+    // apparent intent and treats it as applying to the module.
+    let mut finder = FutureAnnotationsFinder(false);
+    finder.visit_body(module.suite());
+    finder.0
+}
+
+/// Finds `from __future__ import annotations` statements anywhere in a module.
+struct FutureAnnotationsFinder(bool);
+
+impl<'ast> StatementVisitor<'ast> for FutureAnnotationsFinder {
+    fn visit_stmt(&mut self, statement: &'ast ast::Stmt) {
+        if self.0 {
+            return;
+        }
+        if let ast::Stmt::ImportFrom(import) = statement
+            && imports_future_annotations(import)
+        {
+            self.0 = true;
+        } else {
+            statement_visitor::walk_stmt(self, statement);
+        }
+    }
+}
+
+fn imports_future_annotations(import: &ast::StmtImportFrom) -> bool {
+    !import.is_lazy
+        && import.module.as_deref() == Some("__future__")
+        && import
+            .names
+            .iter()
+            .any(|alias| alias.name.id == "annotations")
+}
+
 impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     pub(super) fn new(
         db: &'db dyn Db,
@@ -323,7 +379,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             exception_context_stack_manager: ExceptionContextStackManager::default(),
 
             has_future_annotations: false,
+            has_future_annotations_for_place_loads: module_has_future_annotations(module_ref),
             in_type_checking_block: false,
+            place_load_is_deferred: Some(false),
 
             scopes: IndexVec::new(),
             place_tables: IndexVec::new(),
@@ -332,6 +390,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             use_def_maps: IndexVec::new(),
 
             scopes_by_expression: ExpressionsScopeMapBuilder::new(),
+            deferred_place_loads: FxHashSet::default(),
+            unclassified_place_loads: FxHashSet::default(),
             scopes_by_node: FxHashMap::default(),
             definitions_by_node: FxHashMap::default(),
             expressions_by_node: FxHashMap::default(),
@@ -373,6 +433,36 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.scope_stack
             .last_mut()
             .expect("SemanticIndexBuilder should have created a root scope")
+    }
+
+    fn annotations_use_deferred_place_loads(&self) -> bool {
+        self.source_type.is_stub()
+            || self.has_future_annotations_for_place_loads
+            || self.python_version >= PythonVersion::PY314
+    }
+
+    fn with_place_load_deferredness<T>(
+        &mut self,
+        is_deferred: Option<bool>,
+        visit: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        let previous = std::mem::replace(&mut self.place_load_is_deferred, is_deferred);
+        let result = visit(self);
+        self.place_load_is_deferred = previous;
+        result
+    }
+
+    fn record_place_load_deferredness(&mut self, expression: ast::ExprRef<'_>) {
+        match self.place_load_is_deferred {
+            Some(false) => {}
+            Some(true) => {
+                self.deferred_place_loads.insert(expression.into());
+            }
+            None if !self.source_type.is_stub() => {
+                self.unclassified_place_loads.insert(expression.into());
+            }
+            None => {}
+        }
     }
 
     fn current_scope(&self) -> FileScopeId {
@@ -2871,10 +2961,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 self.mark_place_bound(symbol.into());
                 self.mark_place_declared(symbol.into());
                 if let Some(bounds) = bound {
-                    self.visit_expr(bounds);
+                    self.with_place_load_deferredness(Some(true), |builder| {
+                        builder.visit_expr(bounds);
+                    });
                 }
                 if let Some(default) = default {
-                    self.visit_expr(default);
+                    self.with_place_load_deferredness(Some(true), |builder| {
+                        builder.visit_expr(default);
+                    });
                 }
                 match type_param {
                     ast::TypeParam::TypeVar(node) => self.add_definition(symbol.into(), node),
@@ -2933,6 +3027,17 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         self.push_scope(scope);
         let comprehension_scope = self.current_scope();
+        // Generator bodies use point-in-time bindings for their locals but all reachable bindings
+        // for enclosing names. Deferred comprehensions have the same split. Neither mode
+        // represents both.
+        let nested_deferredness = match self.place_load_is_deferred {
+            Some(false) if !matches!(scope, NodeWithScopeRef::GeneratorExpression(_)) => {
+                Some(false)
+            }
+            _ => None,
+        };
+        let outer_deferredness =
+            std::mem::replace(&mut self.place_load_is_deferred, nested_deferredness);
 
         if generators.iter().any(|generator| generator.is_async) {
             self.async_comprehensions.insert(comprehension_scope);
@@ -2979,6 +3084,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             self.flow_merge(filtered_out_path);
         }
         self.record_exception_checkpoint_if(loopback_can_raise);
+        self.place_load_is_deferred = outer_deferredness;
         let nested_bindings = self.pop_scope();
         self.synthesize_comprehension_binding_definitions(nested_bindings);
         self.record_exception_checkpoint();
@@ -3233,6 +3339,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             scope_ids_by_scope: self.scope_ids_by_scope.into(),
             ast_ids,
             scopes_by_expression: self.scopes_by_expression.build(),
+            deferred_place_loads: FrozenSet::from(self.deferred_place_loads),
+            unclassified_place_loads: FrozenSet::from(self.unclassified_place_loads),
+            place_loads_are_unclassified_by_default: self.source_type.is_stub(),
             scopes_by_node: self.scopes_by_node,
             use_def_maps: self
                 .use_def_maps
@@ -3441,7 +3550,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .iter_non_variadic_params()
                     .filter_map(|param| param.default.as_deref())
                 {
-                    self.visit_expr(default);
+                    self.with_place_load_deferredness(
+                        Some(self.source_type.is_stub()),
+                        |builder| {
+                            builder.visit_expr(default);
+                        },
+                    );
                 }
 
                 let nested_bindings = self.with_type_params(
@@ -3540,7 +3654,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     class.type_params.as_deref(),
                     |builder| {
                         if let Some(arguments) = &class.arguments {
-                            builder.visit_arguments(arguments);
+                            builder.with_place_load_deferredness(
+                                Some(builder.source_type.is_stub()),
+                                |builder| builder.visit_arguments(arguments),
+                            );
                         }
 
                         builder.push_scope(NodeWithScopeRef::Class(class));
@@ -3580,7 +3697,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     type_alias.type_params.as_deref(),
                     |builder| {
                         builder.push_scope(NodeWithScopeRef::TypeAlias(type_alias));
-                        builder.visit_expr(&type_alias.value);
+                        builder.with_place_load_deferredness(
+                            Some(builder.source_type.is_stub()),
+                            |builder| builder.visit_expr(&type_alias.value),
+                        );
                         builder.pop_scope()
                     },
                 );
@@ -3616,6 +3736,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             ast::Stmt::ImportFrom(node) => {
                 self.record_exception_checkpoint();
+
+                // Look for eager imports `from __future__ import annotations`, ignore `as ...`
+                // We intentionally don't enforce the rules about location of `__future__`
+                // imports here, we assume the user's intent was to apply the `__future__`
+                // import, so we still check using it (and will also emit a diagnostic about a
+                // miss-placed `__future__` import.)
+                self.has_future_annotations |= imports_future_annotations(node);
 
                 // If we see:
                 //
@@ -3813,15 +3940,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         (&alias.name.id, is_self_import)
                     };
 
-                    // Look for eager imports `from __future__ import annotations`, ignore `as ...`
-                    // We intentionally don't enforce the rules about location of `__future__`
-                    // imports here, we assume the user's intent was to apply the `__future__`
-                    // import, so we still check using it (and will also emit a diagnostic about a
-                    // miss-placed `__future__` import.)
-                    self.has_future_annotations |= !node.is_lazy
-                        && alias.name.id == "annotations"
-                        && node.module.as_deref() == Some("__future__");
-
                     let symbol = self.add_symbol(symbol_name.clone());
 
                     self.add_definition(
@@ -3927,7 +4045,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // not discard the declared type. The value is still bound only after the RHS
                 // completes, so a handler can observe an earlier binding (or an unbound name).
                 let pending = self.begin_annotated_assignment(node);
-                self.visit_expr(&node.annotation);
+                self.visit_annotation(&node.annotation);
                 if let Some(value) = &node.value {
                     self.visit_expr(value);
                     if self.is_method_or_eagerly_executed_in_method().is_some() {
@@ -5274,6 +5392,13 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             .record_multi_use(member_places.into_iter().flatten(), use_id);
     }
 
+    fn visit_annotation(&mut self, expression: &'ast ast::Expr) {
+        self.with_place_load_deferredness(
+            Some(self.annotations_use_deferred_place_loads()),
+            |builder| builder.visit_expr(expression),
+        );
+    }
+
     fn visit_expr(&mut self, expr: &'ast ast::Expr) {
         self.with_semantic_checker(|semantic, context| semantic.visit_expr(expr, context));
 
@@ -5284,6 +5409,10 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             ast::Expr::Name(ast::ExprName { ctx, .. })
             | ast::Expr::Attribute(ast::ExprAttribute { ctx, .. })
             | ast::Expr::Subscript(ast::ExprSubscript { ctx, .. }) => {
+                if ctx.is_load() {
+                    self.record_place_load_deferredness(ast::ExprRef::from(expr));
+                }
+
                 // Record place effects after walking the expression. For names, this is
                 // equivalent because `walk_expr` is a no-op; for attribute/subscript places,
                 // child evaluation can introduce bindings (for example via walrus operators),
@@ -5390,11 +5519,18 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 if let Some(parameters) = &lambda.parameters {
                     // The default value of the parameters needs to be evaluated in the
                     // enclosing scope.
+                    let defaults_are_deferred = if self.source_type.is_stub() {
+                        Some(true)
+                    } else {
+                        self.place_load_is_deferred
+                    };
                     for default in parameters
                         .iter_non_variadic_params()
                         .filter_map(|param| param.default.as_deref())
                     {
-                        self.visit_expr(default);
+                        self.with_place_load_deferredness(defaults_are_deferred, |builder| {
+                            builder.visit_expr(default);
+                        });
                     }
                     self.visit_parameters(parameters);
                 }
@@ -5405,7 +5541,10 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     self.declare_lambda_parameters(parameters, lambda);
                 }
 
-                self.visit_expr(lambda.body.as_ref());
+                // The body is evaluated when the lambda is called, not when it is created.
+                self.with_place_load_deferredness(Some(false), |builder| {
+                    builder.visit_expr(lambda.body.as_ref());
+                });
                 self.pop_scope();
             }
             ast::Expr::If(node) => self.visit_if_expression(node),

--- a/crates/ty_python_core/src/db.rs
+++ b/crates/ty_python_core/src/db.rs
@@ -156,6 +156,11 @@ pub(crate) mod tests {
             self
         }
 
+        pub(crate) fn with_python_version(mut self, python_version: PythonVersion) -> Self {
+            self.python_version = python_version;
+            self
+        }
+
         pub(crate) fn build(self) -> anyhow::Result<TestDb> {
             let mut db = TestDb::new();
 

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -291,6 +291,19 @@ pub struct SemanticIndex<'db> {
     /// Map expressions to their corresponding scope.
     scopes_by_expression: ExpressionsScopeMap,
 
+    /// Place loads that use all bindings reachable in their scope (e.g., `Foo`
+    /// in a deferred annotation like `x: Foo`) as opposed to bindings available
+    /// at a specific point in execution (e.g., `x = 1; print(x)`).
+    deferred_place_loads: FrozenSet<ExpressionNodeKey>,
+
+    /// Place loads that are specifically unclassified with respect to the
+    /// bindings that they use.
+    unclassified_place_loads: FrozenSet<ExpressionNodeKey>,
+
+    /// Whether place loads not recorded as deferred in [`SemanticIndex::deferred_place_loads`]
+    /// are considered unclassified rather than eager by default.
+    place_loads_are_unclassified_by_default: bool,
+
     /// Map from a node creating a definition to its definition.
     definitions_by_node: DefinitionsByNode<'db>,
 
@@ -414,6 +427,24 @@ impl<'db> SemanticIndex<'db> {
         E: HasTrackedScope,
     {
         self.scopes_by_expression.try_get(expression)
+    }
+
+    /// Returns whether a place load uses all bindings reachable in its scope.
+    ///
+    /// Returns `None` when the binding state is specifically unclassified
+    /// (ultimately helping callers to fail closed).
+    pub fn place_load_is_deferred(&self, expression: ast::ExprRef<'_>) -> Option<bool> {
+        let expression = ExpressionNodeKey::from(expression);
+
+        if self.deferred_place_loads.contains(&expression) {
+            Some(true)
+        } else if self.place_loads_are_unclassified_by_default
+            || self.unclassified_place_loads.contains(&expression)
+        {
+            None
+        } else {
+            Some(false)
+        }
     }
 
     /// Returns the [`Scope`] of the `expression`'s enclosing scope.
@@ -1073,7 +1104,10 @@ mod tests {
         files::{File, system_path_to_file},
         parsed::ParsedModuleRef,
     };
-    use ruff_python_ast as ast;
+    use ruff_python_ast::{
+        self as ast, PythonVersion,
+        visitor::{Visitor, walk_expr},
+    };
     use ruff_text_size::{Ranged, TextRange};
 
     use super::*;
@@ -1169,6 +1203,120 @@ mod tests {
             declaration.kind(&db),
             DefinitionKind::AnnotatedAssignment(_)
         ));
+    }
+
+    #[test]
+    fn place_load_deferredness() {
+        // A misplaced future import still defers annotations throughout the module.
+        assert_place_load_deferredness(
+            "test.py",
+            PythonVersion::PY313,
+            r#"
+model = load_model()
+handler: Handler
+metadata: Annotated[str, (lambda value=load_metadata(): value)]
+callback: Annotated[str, (lambda: load_from_lambda_body)()]
+member: package.Member
+element: items[key]
+fallback = load_fallback()
+
+from __future__ import annotations
+"#,
+            &[
+                ("load_model", false),
+                ("Handler", true),
+                ("load_metadata", true),
+                ("load_from_lambda_body", false),
+                ("package.Member", true),
+                ("items[key]", true),
+                ("load_fallback", false),
+            ],
+        );
+
+        // Stub annotations are deferred; unannotated assignments require type inference to determine
+        // whether they define type aliases.
+        assert_place_load_classifications(
+            "test.pyi",
+            PythonVersion::PY313,
+            r#"
+default_handler = default_handler_value
+handler: Handler
+fallback_handler = fallback_handler_value
+"#,
+            &[("Handler", true)],
+            &["default_handler_value", "fallback_handler_value"],
+        );
+
+        // Annotations are deferred by default on Python 3.14.
+        assert_place_load_deferredness(
+            "test.py",
+            PythonVersion::PY314,
+            "before = load_before()\nannotation: Annotation\nafter = load_after()",
+            &[
+                ("load_before", false),
+                ("Annotation", true),
+                ("load_after", false),
+            ],
+        );
+    }
+
+    #[test]
+    fn place_load_deferredness_in_declaration_expressions() {
+        assert_place_load_deferredness(
+            "test.py",
+            PythonVersion::PY313,
+            r#"
+def function[T: TypeBound = TypeDefault](argument=function_default): ...
+class Generic[T](Base, metaclass=metaclass): ...
+type Alias = alias_value
+"#,
+            &[
+                ("TypeBound", true),
+                ("TypeDefault", true),
+                ("function_default", false),
+                ("Base", false),
+                ("metaclass", false),
+                ("alias_value", false),
+            ],
+        );
+
+        assert_place_load_deferredness(
+            "test.pyi",
+            PythonVersion::PY313,
+            r#"
+def function(argument=function_default): ...
+class Class(Base, metaclass=metaclass): ...
+type Alias = alias_value
+"#,
+            &[
+                ("function_default", true),
+                ("Base", true),
+                ("metaclass", true),
+                ("alias_value", true),
+            ],
+        );
+    }
+
+    #[test]
+    fn place_load_deferredness_in_comprehensions() {
+        assert_place_load_classifications(
+            "test.py",
+            PythonVersion::PY313,
+            r#"
+from __future__ import annotations
+
+eager = [eager_element for item in eager_iterable]
+deferred: Annotated[int, [deferred_element for item in deferred_iterable]]
+generator = (generator_element for item in generator_iterable)
+"#,
+            &[
+                ("eager_element", false),
+                ("eager_iterable", false),
+                ("deferred_iterable", true),
+                ("generator_iterable", false),
+            ],
+            &["deferred_element", "generator_element"],
+        );
     }
 
     #[test]
@@ -2032,5 +2180,69 @@ match 1:
             .unwrap();
 
         assert!(matches!(binding.kind(&db), DefinitionKind::For(_)));
+    }
+
+    fn assert_place_load_deferredness(
+        path: &str,
+        python_version: PythonVersion,
+        python_source: &str,
+        expected: &[(&str, bool)],
+    ) {
+        assert_place_load_classifications(path, python_version, python_source, expected, &[]);
+    }
+
+    fn assert_place_load_classifications(
+        path: &str,
+        python_version: PythonVersion,
+        python_source: &str,
+        expected: &[(&str, bool)],
+        unclassified: &[&str],
+    ) {
+        let db = TestDbBuilder::new()
+            .with_python_version(python_version)
+            .with_file(path, python_source)
+            .build()
+            .unwrap();
+        let file = system_path_to_file(&db, path).unwrap();
+        let file = program_file(&db, file);
+        let module = parsed_module(&db, file.python_file(&db)).load(&db);
+        let index = semantic_index(&db, file);
+        let mut finder = PlaceLoadFinder::default();
+        finder.visit_body(module.suite());
+
+        let actual = |text: &str| {
+            let expression = finder
+                .expressions
+                .iter()
+                .find(|expression| &python_source[expression.range()] == text)
+                .expect("expected place load in test source");
+            index.place_load_is_deferred(*expression)
+        };
+
+        for &(name, expected) in expected {
+            assert_eq!(actual(name), Some(expected), "{path}: {name}");
+        }
+
+        for &name in unclassified {
+            assert_eq!(actual(name), None, "{path}: {name}");
+        }
+    }
+
+    #[derive(Default)]
+    struct PlaceLoadFinder<'a> {
+        expressions: Vec<ast::ExprRef<'a>>,
+    }
+
+    impl<'a> Visitor<'a> for PlaceLoadFinder<'a> {
+        fn visit_expr(&mut self, expression: &'a ast::Expr) {
+            if let ast::Expr::Name(ast::ExprName { ctx, .. })
+            | ast::Expr::Attribute(ast::ExprAttribute { ctx, .. })
+            | ast::Expr::Subscript(ast::ExprSubscript { ctx, .. }) = expression
+                && ctx.is_load()
+            {
+                self.expressions.push(expression.into());
+            }
+            walk_expr(self, expression);
+        }
     }
 }

--- a/crates/ty_python_semantic/src/definition_resolution.rs
+++ b/crates/ty_python_semantic/src/definition_resolution.rs
@@ -1,0 +1,113 @@
+use smallvec::SmallVec;
+use ty_module_resolver::Module;
+use ty_python_core::definition::{Definition, DefinitionState};
+use ty_python_core::{
+    BindingWithConstraintsIterator, Program, ProgramFile, global_scope, place_table, use_def_map,
+};
+
+use crate::Db;
+use crate::reachability::ReachabilityConstraintsExtension;
+
+/// Returns the definitions that may supply the value for a module global at the end of its scope.
+pub(crate) fn definitions_for_module_global<'db>(
+    db: &'db dyn Db,
+    program: Program<'db>,
+    module: Module<'db>,
+    name: &str,
+) -> Option<DefinitionResolution<'db>> {
+    let file = ProgramFile::new(db, module.file(db)?, program);
+    let scope = global_scope(db, file);
+    let symbol = place_table(db, scope).symbol_id(name)?;
+
+    Some(DefinitionResolution::from_bindings(
+        db,
+        use_def_map(db, scope).end_of_scope_symbol_bindings(symbol),
+    ))
+}
+
+/// A set of definitions found by name resolution along with facts about their availability.
+pub(crate) struct DefinitionResolution<'db> {
+    definitions: SmallVec<[Definition<'db>; 2]>,
+}
+
+impl<'db> DefinitionResolution<'db> {
+    /// Returns the definitions found by name resolution.
+    pub(crate) fn definitions(&self) -> &[Definition<'db>] {
+        &self.definitions
+    }
+
+    fn from_bindings(
+        db: &'db dyn Db,
+        mut bindings: BindingWithConstraintsIterator<'db, 'db>,
+    ) -> Self {
+        let mut resolution = Self {
+            definitions: SmallVec::new(),
+        };
+
+        while let Some(binding) = bindings.next() {
+            let reachability = bindings.reachability_constraints().evaluate(
+                db,
+                bindings.predicates(),
+                binding.reachability_constraint,
+            );
+            if reachability.is_always_false() {
+                continue;
+            }
+
+            match binding.binding {
+                DefinitionState::Defined(definition) => {
+                    resolution.push_definition(definition);
+                }
+                DefinitionState::Deleted | DefinitionState::Undefined => {}
+            }
+        }
+
+        resolution
+    }
+
+    fn push_definition(&mut self, definition: Definition<'db>) {
+        if !self.definitions.contains(&definition) {
+            self.definitions.push(definition);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ty_python_core::ProgramFile;
+
+    use super::definitions_for_module_global;
+    use crate::SemanticModel;
+    use crate::db::tests::TestDbBuilder;
+
+    #[test]
+    fn definitions_for_module_global_retains_conditional_definitions() {
+        let db = TestDbBuilder::new()
+            .with_file(
+                "/src/pkg/__init__.py",
+                r#"
+if flag:
+    from . import first as value
+else:
+    from . import second as value
+"#,
+            )
+            .with_file("/src/pkg/first.py", "")
+            .with_file("/src/pkg/second.py", "")
+            .with_file("/src/use.py", "import pkg")
+            .build()
+            .expect("valid TestDb setup");
+        let file = system_path_to_file(&db, "/src/use.py").expect("test file should exist");
+        let program = db.program_environment().program(&db);
+        let model = SemanticModel::new(&db, ProgramFile::new(&db, file, program));
+        let module = model
+            .resolve_module(Some("pkg"), 0)
+            .expect("test package should resolve");
+
+        let resolution = definitions_for_module_global(&db, program, module, "value")
+            .expect("module global should exist");
+
+        assert_eq!(resolution.definitions().len(), 2);
+    }
+}

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -54,6 +54,7 @@ pub use types::{
 };
 
 mod db;
+mod definition_resolution;
 mod dunder_all;
 mod fixes;
 pub mod lint;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Following on from https://github.com/astral-sh/ruff/pull/27319, adds a new interface to the semantic index (`SemanticIndex::place_load_is_deferred`) the reports whether the bindings to consider for a particular place load are any of the following:

1. The bindings available to the place at a specific point in execution.
2. All bindings reachable in the place's scope.
3. Explicitly unclassified as either of the previous two options (because we can't make that determination easily or without inference[^1])..

Previously this information was only available to type inference, but we will soon need it for https://github.com/astral-sh/ty/issues/1560, https://github.com/astral-sh/ty/issues/3410, and https://github.com/astral-sh/ty/issues/3411. 

[^1]: e.g., An unannotated assignment in a stub file that might define a type alias. If inference determines that it does in fact define a type alias, then the place load should be deferred, but otherwise it should resolve eagerly.

As an example of why this is necessary for file name refactor support, consider the following snippet:

```py
value = package.Member
import package
```

Here, `package` is an early runtime reference and must not be connected to the later import. However:

```py
from __future__ import annotations

class Container:
    member: package.Member

import package
```

Here, `package.Member` appears in an annotation and can legitimately refer to the later import. If `package.py` is renamed, a refactor should rewrite the import in both examples and the annotation in the second, but should leave the first example’s `package.Member` expression untouched.

**Whether or not the semantic index is the appropriate place to store this data is worth discussion.** In my opinion, the small increase in memory usage is acceptable. An alternative might be to build a separate index on demand for the language server, but I don't think that's justified at the moment.

## Test Plan

See included tests.
<!-- How was it tested? -->
