### PR TITLE
[ty] Ignore generic declaration metadata in staticness checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/cast.md
@@ -97,6 +97,20 @@ def f(x: RecursiveAlias):
     cast(RecursiveAlias, x)
 ```
 
+## Redundant casts of tuple classes with unknown elements
+
+A tuple class with an `Unknown` element is not fully static, even when its other element is `object`
+and their union simplifies to `object`. A cast involving that tuple class must not be reported as
+redundant.
+
+```py
+from typing import cast
+from ty_extensions._internal import Unknown
+
+def cast_gradual_tuple_class(value: type[tuple[object, Unknown]]) -> None:
+    cast(type[tuple[object, Unknown]], value)
+```
+
 ## Diagnostic snapshots
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -836,6 +836,90 @@ def returns_list_containing_any() -> list[int]:
     return [returns_any()]
 ```
 
+## Regression test: `unsound-return-statement` with gradual generic declarations
+
+A specialized generic type is fully static if it has been specialized with fully static types, even
+if the type parameter(s) it is generic over have non-fully-static bounds, constraints, or defaults.
+A previous version of the rule incorrectly considered these specialized generic types as being
+non-fully-static, leading to false negatives in the below examples:
+
+```toml
+[environment]
+python-version = "3.13"
+
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from typing import Any, Generator, Generic, TypeVar
+
+class Bounded[T: Any]: ...
+class Constrained[T: (int, Any)]: ...
+class Defaulted[T = Any]: ...
+
+# `Bounded[int]`, `Constrained[int]` and `Defaulted[int]` are all fully static,
+# despite their bounds/constraints/defaults not being fully static
+def returns_bounded(value: Any) -> Bounded[int]:
+    return value  # error: [unsound-return-statement]
+
+def returns_constrained(value: Any) -> Constrained[int]:
+    return value  # error: [unsound-return-statement]
+
+def returns_defaulted(value: Any) -> Defaulted[int]:
+    return value  # error: [unsound-return-statement]
+```
+
+The same applies to classes declared with legacy type variables:
+
+```py
+BoundedT = TypeVar("BoundedT", bound=Any)
+ConstrainedT = TypeVar("ConstrainedT", int, Any)
+DefaultedT = TypeVar("DefaultedT", default=Any)
+
+class LegacyBounded(Generic[BoundedT]): ...
+class LegacyConstrained(Generic[ConstrainedT]): ...
+class LegacyDefaulted(Generic[DefaultedT]): ...
+
+def returns_legacy_bounded(value: Any) -> LegacyBounded[int]:
+    return value  # error: [unsound-return-statement]
+
+def returns_legacy_constrained(value: Any) -> LegacyConstrained[int]:
+    return value  # error: [unsound-return-statement]
+
+def returns_legacy_defaulted(value: Any) -> LegacyDefaulted[int]:
+    return value  # error: [unsound-return-statement]
+```
+
+and to `return` statements in generator functions:
+
+```py
+def generator_returns_bounded(value: Any) -> Generator[None, None, Bounded[int]]:
+    yield
+    return value  # error: [unsound-return-statement]
+```
+
+A specialized generic type is nonetheless considered to be non-fully-static if it is specialized
+with non-fully-static types:
+
+```py
+def returns_gradual_bounded(value: Any) -> Bounded[Any]:
+    # no error
+    return value
+
+def returns_gradual_constrained(value: Any) -> Constrained[Any]:
+    # no error
+    return value
+
+def returns_gradual_defaulted(value: Any) -> Defaulted[Any]:
+    # no error
+    return value
+
+def returns_nested_gradual_bounded(value: Any) -> Bounded[list[Any]]:
+    # no error
+    return value
+```
+
 ## Regression test: `unsound-return-statement` uses "pure redundancy"
 
 Internally, the rule uses "pure redundancy" rather than "impure redundancy". The following example

--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -920,6 +920,43 @@ def returns_nested_gradual_bounded(value: Any) -> Bounded[list[Any]]:
     return value
 ```
 
+## Regression test: `unsound-return-statement` with tuple class objects
+
+A tuple class has only one generic parameter, so its element types are combined into a union. Its
+original element types must still determine whether the tuple class is fully static.
+
+```toml
+[environment]
+python-version = "3.11"
+
+[rules]
+unsound-return-statement = "error"
+```
+
+A tuple class with fully static elements forms a fully static return boundary:
+
+```py
+from typing import Any
+
+def returns_static_tuple_class(value: Any) -> type[tuple[int, object]]:
+    return value  # error: [unsound-return-statement]
+```
+
+A tuple class with an `Any` element remains gradual even though the union `object | Any` simplifies
+to `object`:
+
+```py
+def returns_gradual_tuple_class(value: Any) -> type[tuple[object, Any]]:
+    return value
+```
+
+An unpacked gradual tuple likewise makes the entire tuple class gradual:
+
+```py
+def returns_gradual_variadic_tuple_class(value: Any) -> type[tuple[object, *tuple[Any, ...]]]:
+    return value
+```
+
 ## Regression test: `unsound-return-statement` uses "pure redundancy"
 
 Internally, the rule uses "pure redundancy" rather than "impure redundancy". The following example

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1227,12 +1227,22 @@ pub struct Specialization<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for Specialization<'_> {}
 
+/// Visit specialization arguments and the generic declaration.
 pub(super) fn walk_specialization<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     specialization: Specialization<'db>,
     visitor: &V,
 ) {
     walk_generic_context(db, specialization.generic_context(db), visitor);
+    walk_specialization_types(db, specialization, visitor);
+}
+
+/// Visit specialization arguments without walking the generic declaration.
+pub(super) fn walk_specialization_types<'db, V: TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    specialization: Specialization<'db>,
+    visitor: &V,
+) {
     for ty in specialization.types(db) {
         visitor.visit_type(db, *ty);
     }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -17,6 +17,7 @@ use crate::types::{
     class::walk_generic_alias,
     cyclic::ActiveRecursionDetector,
     function::{FunctionType, walk_function_type},
+    generics::walk_specialization_types,
     instance::{walk_nominal_instance_type, walk_protocol_instance_type},
     known_instance::walk_known_instance_type,
     method::{walk_bound_method_type, walk_method_wrapper_type},
@@ -496,12 +497,11 @@ fn dynamic_content_impl<'db>(
         }
 
         fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
-            // Avoid walking the bounds/constraints/defaults of the generic context.
+            // Use `walk_specialization_types` rather than `walk_specialization` to avoid walking
+            // the bounds/constraints/defaults of the generic context.
             // Only the types the class was actually specialized with are relevant to whether
             // the `GenericAlias` contains a dynamic type.
-            for ty in alias.specialization(db).types(db) {
-                self.visit_type(db, *ty);
-            }
+            walk_specialization_types(db, alias.specialization(db), self);
         }
 
         fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -495,6 +495,15 @@ fn dynamic_content_impl<'db>(
             walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
         }
 
+        fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+            // Avoid walking the bounds/constraints/defaults of the generic context.
+            // Only the types the class was actually specialized with are relevant to whether
+            // the `GenericAlias` contains a dynamic type.
+            for ty in alias.specialization(db).types(db) {
+                self.visit_type(db, *ty);
+            }
+        }
+
         fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
             self.active_type_aliases.visit(
                 &alias.definition(db),


### PR DESCRIPTION
## Summary

- Treat generic aliases as fully static when their actual type arguments are fully static, even if their type parameters have gradual bounds, constraints, or defaults.
- Visit only a generic alias's concrete specialization when checking dynamic content, matching the existing protocol-specific traversal.
- Cover modern and legacy generic declarations, generator return statements, and genuinely gradual specializations.

This fixes the false negatives for the `unsound-*` rules identified in https://github.com/astral-sh/ty/issues/4238.