### PR TITLE
[ty] Avoid introducing boolean literals when narrowing integers

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -567,7 +567,7 @@ the subject after that pattern succeeds.
 
 Value patterns use `==`, and `as` binds the original subject rather than the value written in the
 pattern. Broad builtin types are treated as if they use builtin equality, so matching `1` narrows
-`x` to that integer literal without adding the Boolean literal that compares equal to it. After that
+`x` to that integer literal without adding the boolean literal that compares equal to it. After that
 pattern fails, matching `"foo"` narrows `x` to that string literal.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -567,8 +567,8 @@ the subject after that pattern succeeds.
 
 Value patterns use `==`, and `as` binds the original subject rather than the value written in the
 pattern. Broad builtin types are treated as if they use builtin equality, so matching `1` narrows
-`x` to the integer and boolean literals that compare equal to it. After that pattern fails, matching
-`"foo"` narrows `x` to that string literal.
+`x` to that integer literal without adding the Boolean literal that compares equal to it. After that
+pattern fails, matching `"foo"` narrows `x` to that string literal.
 
 ```py
 def _(target: int | str):
@@ -577,7 +577,7 @@ def _(target: int | str):
     match target:
         case 1 as x:
             y = 2
-            reveal_type(x)  # revealed: Literal[1, True]
+            reveal_type(x)  # revealed: Literal[1]
         case "foo" as x:
             y = 3
             reveal_type(x)  # revealed: Literal["foo"]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
@@ -5,7 +5,7 @@
 ```py
 def _(x: int):
     if x == 1:
-        reveal_type(x)  # revealed: Literal[1, True]
+        reveal_type(x)  # revealed: Literal[1]
     elif x == 2:
         reveal_type(x)  # revealed: Literal[2]
     elif x != 3:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1628,8 +1628,8 @@ def custom_equality(value: AlwaysEqual | None, other: AlwaysEqual):
 
 ## Narrowing builtin types to literals
 
-Equality with a literal narrows broad `str`, `int`, and `bytes` types to the values that compare
-equal to that literal:
+Equality with a literal narrows broad `str`, `int`, and `bytes` types to that literal. By default,
+integer literals do not introduce the Boolean values that compare equal to `0` or `1`:
 
 ```py
 def narrow_string(value: str):
@@ -1644,8 +1644,15 @@ def narrow_reversed_string(value: str):
 
 def narrow_integer(value: int):
     if value == 1:
-        # `True == 1` at runtime.
-        reveal_type(value)  # revealed: Literal[1, True]
+        reveal_type(value)  # revealed: Literal[1]
+
+def narrow_zero(value: int):
+    if value == 0:
+        reveal_type(value)  # revealed: Literal[0]
+
+def narrow_reversed_integer(value: int):
+    if 1 == value:
+        reveal_type(value)  # revealed: Literal[1]
 
 def narrow_bytes(value: bytes):
     if value == b"a":
@@ -2618,6 +2625,10 @@ def broad(value: str):
         reveal_type(value)  # revealed: str
     else:
         reveal_type(value)  # revealed: str & ~Literal["a"]
+
+def broad_integer(value: int):
+    if value == 1:
+        reveal_type(value)  # revealed: int
 
 def inequality(value: str):
     if value != "a":

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1629,7 +1629,7 @@ def custom_equality(value: AlwaysEqual | None, other: AlwaysEqual):
 ## Narrowing builtin types to literals
 
 Equality with a literal narrows broad `str`, `int`, and `bytes` types to that literal. By default,
-integer literals do not introduce the Boolean values that compare equal to `0` or `1`:
+integer literals do not introduce the boolean values that compare equal to `0` or `1`:
 
 ```py
 def narrow_string(value: str):
@@ -2171,6 +2171,64 @@ def _(b: bool, i: Literal[1, 2]):
         reveal_type(i)  # revealed: Literal[1]
     else:
         reveal_type(i)  # revealed: Literal[2]
+```
+
+## Integers and booleans with non-strict equality semantics
+
+With non-strict equality semantics, broad integers narrow to integer literals, while boolean
+literals that compare equal remain in explicitly annotated literal unions.
+
+```toml
+[analysis]
+strict-equality-semantics = false
+```
+
+```py
+from typing import Literal
+
+reveal_type(1 == True)  # revealed: Literal[True]
+
+def f(x: int, y: Literal[1, True, 2]):
+    if x == 1:
+        reveal_type(x)  # revealed: Literal[1]
+
+    if y == 1:
+        reveal_type(y)  # revealed: Literal[1, True]
+
+    if x in [1, 2]:
+        reveal_type(x)  # revealed: Literal[1, 2]
+
+    if y in [1, True]:
+        reveal_type(y)  # revealed: Literal[1, True]
+```
+
+## Integers and booleans with strict equality semantics
+
+With strict equality semantics, broad integers are preserved, while explicitly annotated literal
+unions still narrow to the integer and boolean literals that compare equal.
+
+```toml
+[analysis]
+strict-equality-semantics = true
+```
+
+```py
+from typing import Literal
+
+reveal_type(1 == True)  # revealed: Literal[True]
+
+def f(x: int, y: Literal[1, True, 2]):
+    if x == 1:
+        reveal_type(x)  # revealed: int
+
+    if y == 1:
+        reveal_type(y)  # revealed: Literal[1, True]
+
+    if x in [1, 2]:
+        reveal_type(x)  # revealed: int
+
+    if y in [1, True]:
+        reveal_type(y)  # revealed: Literal[1, True]
 ```
 
 ## Final subclasses of scalar builtins

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -2,10 +2,13 @@
 
 ## `in` for tuples
 
+Broad integer subjects narrow to the integer literals present in the tuple. By default, equality
+narrowing does not add the Boolean literals that also compare equal to `0` or `1`.
+
 ```py
 def _(x: int):
     if x in (1, 2, 3):
-        reveal_type(x)  # revealed: Literal[1, 2, 3, True]
+        reveal_type(x)  # revealed: Literal[1, 2, 3]
     else:
         reveal_type(x)  # revealed: int & ~Literal[1] & ~Literal[True] & ~Literal[2] & ~Literal[3]
 ```
@@ -116,6 +119,14 @@ def inline_set(value: Choice):
         reveal_type(value)  # revealed: Literal["c"]
     else:
         reveal_type(value)  # revealed: Literal["a", "b"]
+
+def integer_list(value: int):
+    assert value in [1, 2]
+    reveal_type(value)  # revealed: Literal[1, 2]
+
+def integer_set(value: int):
+    assert value in {0, 2}
+    reveal_type(value)  # revealed: Literal[0, 2]
 
 def literal_locals(value: Choice):
     a = "a"
@@ -251,6 +262,10 @@ def inline_set(x: str):
         reveal_type(x)  # revealed: str
     else:
         reveal_type(x)  # revealed: str & ~Literal["a"] & ~Literal["b"]
+
+def integer_list(x: int):
+    if x in [1, 2]:
+        reveal_type(x)  # revealed: int
 
 class Bar: ...
 
@@ -752,7 +767,7 @@ def default_equality(x: Token | Literal[1]):
 
 def overlapping_union_member(x: int | Literal["missing"]):
     if x in ("missing", 1):
-        reveal_type(x)  # revealed: Literal[1, True, "missing"]
+        reveal_type(x)  # revealed: Literal[1, "missing"]
 
 def custom_equality(x: AlwaysEqual | Literal[1]):
     if x in (1,):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -3,7 +3,7 @@
 ## `in` for tuples
 
 Broad integer subjects narrow to the integer literals present in the tuple. By default, equality
-narrowing does not add the Boolean literals that also compare equal to `0` or `1`.
+narrowing does not add the boolean literals that also compare equal to `0` or `1`.
 
 ```py
 def _(x: int):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -3123,7 +3123,12 @@ def string_pattern(value: str):
 def integer_pattern(value: int):
     match value:
         case 1:
-            reveal_type(value)  # revealed: Literal[1, True]
+            reveal_type(value)  # revealed: Literal[1]
+
+def zero_pattern(value: int):
+    match value:
+        case 0:
+            reveal_type(value)  # revealed: Literal[0]
 
 def bytes_pattern(value: bytes):
     match value:

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1522,17 +1522,16 @@ fn compare_literal_to_other<'db>(
     };
     let condition_expects_equality = operator.condition_expects_equality(branch);
 
-    // Treat broad builtin types as if they exclude subclasses with custom equality. This is
-    // intentionally unsafe: an instance of such a subclass can compare equal to the literal
-    // without inhabiting its literal type. Explicitly typed subclasses do not take this path.
+    // Treat broad builtin types as if only the literal itself can compare equal. This is
+    // intentionally unsafe: subclasses, including `bool` for `int`, can compare equal without
+    // inhabiting the literal type. Explicitly typed subclasses do not take this path.
     if evaluator.soundness_policy.allow_unsafe_equality
         && condition_expects_equality
         && literal_operand == LiteralOperand::Other
-        && let Some(equal_to_literal) = builtin_literals_equal_to(db, env, literal_type, literal)
         && let Some(other_semantics) = unsafe_narrowable_builtin_semantics(db, other)
     {
         return if literal_semantics == other_semantics {
-            ComparisonResult::CanNarrow(equal_to_literal)
+            ComparisonResult::CanNarrow(literal_type)
         } else {
             operator.result_from_equality(false)
         };


### PR DESCRIPTION
## Summary

Previously, optimistic equality narrowing introduced `True` when narrowing an `int` against `1` and `False` when narrowing against `0`.

```python
def narrow(value: int) -> None:
    assert value in [1, 2]
    reveal_type(value)  # Literal[1, 2]
```

We now narrow to the integer literals themselves across equality checks, membership tests, and `match` patterns. Enabling `strict-equality-semantics` still preserves the original broad type, and comparisons between known integer and boolean literals retain their existing behavior.
