### PR TITLE
[ty] Respect third-party keyword-only fields before Python 3.10

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -1468,6 +1468,48 @@ class InvalidKWOnlyDefaultModel:
     z: bytes = field(kw_only=False)  # error: [dataclass-field-order]
 ```
 
+### Keyword-only field specifiers before Python 3.10
+
+Although `dataclasses.field` does not support `kw_only` before Python 3.10, third-party field
+specifiers can support it on earlier Python versions. Inherited keyword-only fields must retain that
+setting so they do not participate in positional field ordering.
+
+```toml
+[environment]
+python-version = "3.9"
+```
+
+```py
+from typing import Any, TypeVar
+from typing_extensions import dataclass_transform
+
+T = TypeVar("T")
+
+def custom_field(*, default: Any = ..., kw_only: bool = False) -> Any: ...
+@dataclass_transform(field_specifiers=(custom_field,))
+def custom_dataclass(cls: type[T]) -> type[T]:
+    return cls
+
+@custom_dataclass
+class Base:
+    optional: float = custom_field(default=1.0, kw_only=True)
+
+@custom_dataclass
+class Child(Base):
+    required: str
+
+reveal_type(Child.__init__)  # revealed: (self: Child, required: str, *, optional: float = ...) -> None
+
+Child("value")
+Child("value", optional=2.0)
+Child("value", 2.0)  # error: [too-many-positional-arguments]
+
+@custom_dataclass
+class InvalidChild(Base):
+    positional_default: str = custom_field(default="default", kw_only=False)
+    required: int  # error: [dataclass-field-order]
+```
+
 ### For metaclass-based transformers
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1494,6 +1494,26 @@ class A:
     y: int
 ```
 
+The field-level argument is also ignored, so fields remain positional and still participate in
+constructor ordering:
+
+```py
+from dataclasses import dataclass, field
+
+@dataclass
+class PositionalField:
+    value: int = field(default=1, kw_only=True)
+
+reveal_type(PositionalField.__init__)  # revealed: (self: PositionalField, value: int = 1) -> None
+
+PositionalField(1)
+
+@dataclass
+class InvalidFieldOrder:
+    optional: int = field(default=1, kw_only=True)
+    required: str  # error: [dataclass-field-order]
+```
+
 ### `kw_only` - Python 3.13
 
 ```toml

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1986,7 +1986,11 @@ impl<'db> Bindings<'db> {
                             .map(|init| !init.bool(db, env).is_always_false())
                             .unwrap_or(true);
 
-                        let kw_only = if env.python_version(db) >= PythonVersion::PY310 {
+                        // Only the standard-library field specifier requires Python 3.10 for
+                        // `kw_only`; third-party field specifiers can support it earlier.
+                        let kw_only = if env.python_version(db) >= PythonVersion::PY310
+                            || !function_type.is_known(db, KnownFunction::Field)
+                        {
                             match kw_only.and_then(Type::as_literal_value_kind) {
                                 // We are more conservative here when turning the type for `kw_only`
                                 // into a bool, because a field specifier in a stub might use


### PR DESCRIPTION
## Summary

Previously, we ignored `kw_only=True` on every dataclass field specifier when targeting Python 3.9, even though libraries such as `attrs` support keyword-only fields independently of the standard library:

```python
import attr

@attr.s(auto_attribs=True)
class Base:
    optional: float = attr.ib(default=1.0, kw_only=True)

@attr.s(auto_attribs=True)
class Child(Base):
    required: str
```

We now restrict the Python 3.10 requirement to `dataclasses.field`, preserving keyword-only behavior for third-party field specifiers on earlier Python versions. Inherited keyword-only fields no longer trigger `dataclass-field-order`, and synthesized constructors retain the correct argument ordering.

Closes https://github.com/astral-sh/ty/issues/4242.
