### PR TITLE
[ty] Preserve enum exhaustiveness with custom _missing_ methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -283,7 +283,8 @@ def match_non_exhaustive(x: Color):
             assert_never(x)  # error: [type-assertion-failure]
 ```
 
-Matching every named member is not exhaustive for enums that can also have unnamed members.
+Matching every named member is not exhaustive for `Flag` classes. Custom `_missing_` methods do not
+change the static member set of other enums, even when they create unnamed members at runtime.
 
 ```py
 from enum import Enum, Flag
@@ -303,10 +304,43 @@ def match_flag(value: Permission) -> int:  # error: [invalid-return-type]
         case Permission.READ:
             return 1
 
-def match_open_enum(value: MissingValueEnum) -> int:  # error: [invalid-return-type]
+def match_custom_missing_enum(value: MissingValueEnum) -> int:
     match value:
         case MissingValueEnum.ONLY:
             return 1
+```
+
+## Checks on enums with custom missing methods
+
+An enum remains exhaustive when it overrides `_missing_`, even if its value comes from a function
+with the enum as its return type.
+
+```py
+from enum import Enum
+from typing import assert_never
+
+class FallbackColor(Enum):
+    RED = 1
+    BLUE = 2
+
+    @classmethod
+    def _missing_(cls, value: object) -> "FallbackColor":
+        for member in cls:
+            if member.value == value:
+                return member
+        return FallbackColor.RED
+
+def get_color() -> FallbackColor:
+    return FallbackColor.BLUE
+
+color = get_color()
+match color:
+    case FallbackColor.RED:
+        pass
+    case FallbackColor.BLUE:
+        pass
+    case _:
+        assert_never(color)
 ```
 
 ## Checks on enum literal subsets

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -283,8 +283,11 @@ def match_non_exhaustive(x: Color):
             assert_never(x)  # error: [type-assertion-failure]
 ```
 
-Matching every named member is not exhaustive for `Flag` classes. Custom `_missing_` methods do not
-change the static member set of other enums, even when they create unnamed members at runtime.
+Matching every named member is not exhaustive for `Flag` classes.
+
+Custom `_missing_` methods technically could create a new undeclared member via `object.__new__`,
+but this is also possible outside a `_missing_` method. We choose to in general ignore this
+possibility; we don't assume that a `_missing_` method will do this.
 
 ```py
 from enum import Enum, Flag
@@ -297,7 +300,7 @@ class MissingValueEnum(Enum):
 
     @classmethod
     def _missing_(cls, value: object) -> "MissingValueEnum":
-        return object.__new__(cls)
+        return cls.ONLY
 
 def match_flag(value: Permission) -> int:  # error: [invalid-return-type]
     match value:
@@ -325,9 +328,6 @@ class FallbackColor(Enum):
 
     @classmethod
     def _missing_(cls, value: object) -> "FallbackColor":
-        for member in cls:
-            if member.value == value:
-                return member
         return FallbackColor.RED
 
 def get_color() -> FallbackColor:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -323,7 +323,7 @@ class MissingValueEnum(Enum):
 
     @classmethod
     def _missing_(cls, value: object) -> "MissingValueEnum":
-        return object.__new__(cls)
+        return cls.ONLY
 
 def compare_custom_missing_enums(left: MissingValueEnum, right: MissingValueEnum):
     reveal_type(left == right)  # revealed: Literal[True]
@@ -688,6 +688,22 @@ def compare_custom_missing_identity(
         reveal_type(left)  # revealed: CustomMissingIdentity
 ```
 
+A metaclass can inject undeclared members, leaving an identity-comparing enum genuinely open.
+Comparing against its declared members can still exclude those undeclared members.
+
+```py
+class OpenIdentity(Enum, metaclass=InjectingEnumMeta):
+    A = "a"
+    B = "b"
+
+def compare_open_identity(
+    left: OpenIdentity | OtherIdentity,
+    right: Literal[OpenIdentity.A, OpenIdentity.B],
+):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[OpenIdentity.A, OpenIdentity.B]
+```
+
 Integer comparison keys normalize booleans in the same way as Python equality:
 
 ```py
@@ -759,6 +775,18 @@ def compare_custom_missing(left: CustomMissingLeft, right: CustomRight):
         reveal_type(left)  # revealed: CustomMissingLeft
 ```
 
+A metaclass can add undeclared scalar members, so cross-enum comparison must retain the full open
+enum:
+
+```py
+class OpenLeft(StrEnum, metaclass=InjectingEnumMeta):
+    MEMBER = "shared"
+
+def compare_open(left: OpenLeft, right: CustomRight):
+    if left == right:
+        reveal_type(left)  # revealed: OpenLeft
+```
+
 A custom equality method must still determine the result when the enum is combined with `None`:
 
 ```py
@@ -774,6 +802,15 @@ combined with `None`:
 def compare_optional_custom_missing(left: CustomMissingLeft | None, right: CustomRight):
     if left == right:
         reveal_type(left)  # revealed: CustomMissingLeft
+```
+
+Undeclared members of a genuinely open scalar enum must survive cross-enum comparison even when the
+enum is combined with `None`:
+
+```py
+def compare_optional_open(left: OpenLeft | None, right: CustomRight):
+    if left == right:
+        reveal_type(left)  # revealed: OpenLeft
 ```
 
 The same narrowing applies when comparing enum members directly with their inherited integer or

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -312,8 +312,8 @@ def compare_functional_flags(left: FunctionalPermission, right: FunctionalPermis
     reveal_type(left == right)  # revealed: bool
 ```
 
-An enum with a custom `_missing_` method can create unnamed members, so two values need not be equal
-even when only one member is declared:
+A custom `_missing_` method does not change the enum's static member set, so an enum with one
+declared member remains a singleton:
 
 ```py
 from enum import Enum
@@ -325,11 +325,11 @@ class MissingValueEnum(Enum):
     def _missing_(cls, value: object) -> "MissingValueEnum":
         return object.__new__(cls)
 
-def compare_open_enums(left: MissingValueEnum, right: MissingValueEnum):
-    reveal_type(left == right)  # revealed: bool
+def compare_custom_missing_enums(left: MissingValueEnum, right: MissingValueEnum):
+    reveal_type(left == right)  # revealed: Literal[True]
 
     if left != right:
-        reveal_type(left)  # revealed: MissingValueEnum
+        reveal_type(left)  # revealed: Never
 ```
 
 A custom enum metaclass can add members that do not appear in the class body. Two values of a
@@ -662,30 +662,30 @@ def compare_false_to_integer_enum(left: MixedLeft1 | Literal[False], right: Mixe
         reveal_type(right)  # revealed: Literal[MixedRight0.A]
 ```
 
-An open identity-comparing enum can still be narrowed to all of its declared members. Undeclared
-runtime members are not retained merely because every declared member matches:
+An identity-comparing enum with a custom `_missing_` method remains equivalent to the union of its
+declared members:
 
 ```py
 from enum import Enum
 from typing import Literal
 
-class OpenIdentity(Enum):
+class CustomMissingIdentity(Enum):
     A = "a"
     B = "b"
 
     @classmethod
-    def _missing_(cls, value: object) -> "OpenIdentity":
+    def _missing_(cls, value: object) -> "CustomMissingIdentity":
         raise ValueError
 
 class OtherIdentity(Enum):
     C = "c"
 
-def compare_open_identity(
-    left: OpenIdentity | OtherIdentity,
-    right: Literal[OpenIdentity.A, OpenIdentity.B],
+def compare_custom_missing_identity(
+    left: CustomMissingIdentity | OtherIdentity,
+    right: Literal[CustomMissingIdentity.A, CustomMissingIdentity.B],
 ):
     if left == right:
-        reveal_type(left)  # revealed: Literal[OpenIdentity.A, OpenIdentity.B]
+        reveal_type(left)  # revealed: CustomMissingIdentity
 ```
 
 Integer comparison keys normalize booleans in the same way as Python equality:
@@ -709,7 +709,8 @@ reveal_type(IntegerAliases.ZERO == IntegerAliases.FALSE)  # revealed: Literal[Tr
 ```
 
 Plain enum members from different classes use identity comparison, even when their declared values
-are equal. Custom comparison methods and open scalar enums remain ambiguous:
+are equal. Custom comparison methods remain ambiguous, while scalar enums can compare across enum
+classes:
 
 ```py
 from enum import Enum, StrEnum
@@ -746,16 +747,16 @@ class CustomNeLeft(StrEnum):
 reveal_type(CustomNeLeft.MEMBER == CustomRight.MEMBER)  # revealed: Literal[True]
 reveal_type(CustomNeLeft.MEMBER != CustomRight.MEMBER)  # revealed: bool
 
-class OpenLeft(StrEnum):
+class CustomMissingLeft(StrEnum):
     MEMBER = "shared"
 
     @classmethod
-    def _missing_(cls, value: object) -> "OpenLeft":
+    def _missing_(cls, value: object) -> "CustomMissingLeft":
         raise ValueError
 
-def compare_open(left: OpenLeft, right: CustomRight):
+def compare_custom_missing(left: CustomMissingLeft, right: CustomRight):
     if left == right:
-        reveal_type(left)  # revealed: OpenLeft
+        reveal_type(left)  # revealed: CustomMissingLeft
 ```
 
 A custom equality method must still determine the result when the enum is combined with `None`:
@@ -766,13 +767,13 @@ def compare_optional_custom(left: CustomLeft | None, right: CustomRight):
         reveal_type(left)  # revealed: CustomLeft
 ```
 
-An enum with `_missing_` may have members that do not appear in its definition. Adding `None` must
-not cause the comparison to assume that its declared member is the only possible match:
+A custom `_missing_` method does not affect comparison narrowing, including when the enum is
+combined with `None`:
 
 ```py
-def compare_optional_open(left: OpenLeft | None, right: CustomRight):
+def compare_optional_custom_missing(left: CustomMissingLeft | None, right: CustomRight):
     if left == right:
-        reveal_type(left)  # revealed: OpenLeft
+        reveal_type(left)  # revealed: CustomMissingLeft
 ```
 
 The same narrowing applies when comparing enum members directly with their inherited integer or

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -311,9 +311,8 @@ pub struct EnumClassLiteral<'db> {
     pub(super) aliases_are_known: bool,
     /// Whether the canonical members exhaust the runtime values of this enum class.
     ///
-    /// `Flag` classes, transforming metaclasses, and enums with a custom `_missing_` method can
-    /// create runtime members beyond those declared in the class body, so their declared members
-    /// are not a closed value set.
+    /// `Flag` classes and transforming metaclasses can create runtime members beyond those
+    /// declared in the class body, so their declared members are not a closed value set.
     #[returns(copy)]
     pub(crate) members_are_exhaustive: bool,
 }
@@ -354,8 +353,7 @@ fn enum_class_literal<'db>(
             db,
             &env,
             KnownClass::Flag.to_subclass_of(db, &env),
-        )
-        && !enum_has_custom_missing(db, class);
+        );
 
     Some(EnumClassLiteral::new(
         db,
@@ -365,20 +363,6 @@ fn enum_class_literal<'db>(
         metadata.aliases_are_known,
         members_are_exhaustive,
     ))
-}
-
-/// Return whether enum construction may create pseudo-members through a custom `_missing_` method.
-fn enum_has_custom_missing<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
-    let ClassLiteral::Static(class) = class else {
-        return false;
-    };
-
-    class
-        .iter_mro(db, None)
-        .filter_map(ClassBase::into_class)
-        .take_while(|base| base.known(db) != Some(KnownClass::Enum))
-        .filter_map(|base| base.class_literal(db).as_static())
-        .any(|base| custom_enum_method(db, base.body_scope(db), "_missing_").is_some())
 }
 
 impl<'db> EnumClassLiteral<'db> {


### PR DESCRIPTION
## Summary

Previously, we treated enums that override `_missing_` as non-exhaustive because those methods can manufacture undeclared enum members.

```python
from enum import Enum
from typing import assert_never

class Color(Enum):
    RED = 1
    BLUE = 2

    @classmethod
    def _missing_(cls, value: object) -> "Color":
        return cls.RED

def handle(color: Color) -> None:
    match color:
        case Color.RED | Color.BLUE:
            pass
        case _:
            assert_never(color)
```

We now ignore `_missing_` when determining enum exhaustiveness, matching mypy and Pyright. Any code can construct undeclared enum instances with `object.__new__`, so `_missing_` is not a meaningful boundary. `Flag` classes remain non-exhaustive.

Closes https://github.com/astral-sh/ty/issues/4241.
