### PR TITLE
[flake8-executable] Avoid EXE005 false positive with leading shebang

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_executable/EXE005_4.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_executable/EXE005_4.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3
+print("Hello world")

--- a/crates/ruff_linter/src/rules/flake8_executable/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/mod.rs
@@ -31,6 +31,7 @@ mod tests {
     #[test_case(Rule::ShebangNotFirstLine, Path::new("EXE005_1.py"))]
     #[test_case(Rule::ShebangNotFirstLine, Path::new("EXE005_2.py"))]
     #[test_case(Rule::ShebangNotFirstLine, Path::new("EXE005_3.py"))]
+    #[test_case(Rule::ShebangNotFirstLine, Path::new("EXE005_4.py"))]
     fn rules(rule: Rule, path: &Path) -> Result<()> {
         if super::helpers::is_wsl() {
             // these rules are always ignored on WSL, so skip testing them in a WSL environment

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_first_line.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_first_line.rs
@@ -1,6 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_trivia::is_python_whitespace;
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::TextRange;
 
 use crate::Locator;
 use crate::Violation;
@@ -45,8 +45,9 @@ impl Violation for ShebangNotFirstLine {
 
 /// EXE005
 pub(crate) fn shebang_not_first_line(range: TextRange, locator: &Locator, context: &LintContext) {
-    // If the shebang is at the beginning of the file, abort.
-    if range.start() == TextSize::from(0) {
+    // If the file already has a leading shebang, later shebang-like lines are comments or
+    // tool-specific directives.
+    if locator.contents().starts_with("#!") {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE005_4.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE005_4.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_executable/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Closes #27691.

`nix-shell` scripts can use a regular shebang on the first line followed by a second `#!nix-shell` for arguments. EXE005 flagged th second line as a misplaced shebang.

Skip EXE005 when the file already starts with `#!`, since later `#!` lines are comments or tool-specific rather than shebangs.

Adds a regression test for the `nix-shell` case.

## Test Plan

- Added a regression test that fails before the fix and passes afterward
- Ran the full `ruff_linter` test suite, workspace Clippy, changed-file hooks, and `cargo dev generate-all`