### PR TITLE
[ty] Audit and correct traversals of lazy type attributes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -366,6 +366,49 @@ def expects_str_return(c: Callable[[int | str], str]) -> None:
 expects_str_return(wide_return_converter)
 ```
 
+## Overload coverage with nested `Any`
+
+An overload set can cover a union parameter even when one of the union's elements contains `Any`.
+Here, the overloads accept both `int` and an alias to `list[Any]`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, Callable, overload
+
+type Gradual = list[Any]
+
+@overload
+def aliased(value: int) -> int: ...
+@overload
+def aliased(value: Gradual) -> str: ...
+def aliased(value: object) -> int | str:
+    raise NotImplementedError
+
+x: Callable[[int | Gradual], int | str] = aliased
+```
+
+An `Any`-typed protocol member does not prevent the same assignment:
+
+```py
+from typing import Protocol
+
+class Item(Protocol):
+    value: Any
+
+@overload
+def structural(value: int) -> int: ...
+@overload
+def structural(value: Item) -> str: ...
+def structural(value: object) -> int | str:
+    raise NotImplementedError
+
+y: Callable[[int | Item], int | str] = structural
+```
+
 ## Union
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -641,6 +641,32 @@ class C(Generic[T]):
         reveal_type(self.foo)  # revealed: T@C
 ```
 
+## `Self` in aliased annotations
+
+Inherited attributes and methods bind `Self` to the receiver's class, even through an alias.
+`Ignored[Self]` still resolves to `int` because its value does not use the argument.
+
+```py
+from typing import Self
+
+type Alias[T] = T
+type Ignored[T] = int
+
+class Parent:
+    attribute: Alias[Self]
+    ignored: Ignored[Self]
+
+    def method(self) -> Alias[Self]:
+        return self
+
+class Child(Parent): ...
+
+def _(child: Child) -> None:
+    reveal_type(child.attribute)  # revealed: Child
+    reveal_type(child.ignored)  # revealed: int
+    reveal_type(child.method())  # revealed: Child
+```
+
 ## Callable attributes that return `Self`
 
 Attributes annotated as callables returning `Self` should bind to the concrete class.

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -396,6 +396,59 @@ reveal_type(p(2))  # revealed: tuple[int, int]
 reveal_type(p(2)[1])  # revealed: int
 ```
 
+### Literal preservation with independent parameters
+
+Binding `1` infers `T` as `Literal[1]` when no remaining parameter depends on `T`. Later calls
+cannot constrain `T`, so the partial preserves that literal type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from functools import partial
+from typing import Literal
+
+def f[T](value: T, other: int) -> T:
+    return value
+
+p1 = partial(f, 1)
+reveal_type(p1)  # revealed: partial[(other: int) -> Literal[1]]
+x1: Literal[1] = p1(2)
+```
+
+`Ignored[T]` always denotes `int`, so it does not let later calls constrain `T` either:
+
+```py
+type Ignored[T] = int
+
+def g[T](value: T, other: Ignored[T]) -> T:
+    return value
+
+p2 = partial(g, 1)
+reveal_type(p2)  # revealed: partial[(other: Ignored[Literal[1]]) -> Literal[1]]
+x2: Literal[1] = p2(2)
+p2("string")  # error: [invalid-argument-type]
+```
+
+If the remaining parameter is `Alias[T]`, binding `1` should instead widen `T` to `int`, allowing
+later calls to pass other integer values. We currently miss this dependency through the alias:
+
+```py
+type Alias[T] = T
+
+def h[T](value: T, other: Alias[T]) -> T:
+    return value
+
+p3 = partial(h, 1)
+reveal_type(p3)  # revealed: partial[(other: Alias[Literal[1]]) -> Literal[1]]
+# TODO: Promote `T` to `int` and accept this call.
+# error: [invalid-argument-type]
+reveal_type(p3(2))  # revealed: Literal[1]
+p3("string")  # error: [invalid-argument-type]
+```
+
 ### Variadic generic functions with no bound arguments
 
 A partial with no bound arguments preserves its variadic type parameter until the resulting callable

--- a/crates/ty_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/cast.md
@@ -116,6 +116,89 @@ def cast_gradual_tuple_class(value: type[tuple[object, Unknown]]) -> None:
     cast(type[tuple[object, Unknown]], value)
 ```
 
+## Redundant casts of type variables
+
+Casting a value of type `T` back to `T` is redundant when its bound is fully static:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import cast
+
+class Box[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def set(self, value: T) -> None: ...
+
+def _[T: Box[int]](value: T) -> None:
+    cast(T, value)  # error: [redundant-cast]
+```
+
+`Unknown` in the bound suppresses the diagnostic. Casting `Top[T]` back to `T` can restore writes
+that the materialized bound rejects:
+
+```py
+from ty_extensions import Top
+from ty_extensions._internal import Unknown
+
+def _[T: Box[Unknown]](top: Top[T]) -> None:
+    value = cast(T, top)
+    reveal_type(value.get())  # revealed: Unknown
+    value.set(1)
+
+    reveal_type(top.get())  # revealed: object
+    top.set(1)  # error: [invalid-argument-type]
+```
+
+`Unknown` also suppresses the diagnostic in legacy type-variable bounds and in constraints:
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T", bound=Box[Unknown])
+
+def _(value: T) -> None:
+    result = cast(T, value)
+    reveal_type(result.get())  # revealed: Unknown
+    result.set(1)
+
+def _[T: (Box[Unknown], int)](value: T) -> None:
+    cast(T, value)
+```
+
+An explicit `Any` should permit the same cast. We currently report a false positive because
+type-variable equivalence ignores differences in materialized bounds:
+
+```py
+from typing import Any
+
+def _[T: Box[Any]](top: Top[T]) -> None:
+    # TODO: This cast is not redundant.
+    value = cast(T, top)  # error: [redundant-cast]
+    reveal_type(value.get())  # revealed: Any
+    value.set(1)
+
+    reveal_type(top.get())  # revealed: object
+    top.set(1)  # error: [invalid-argument-type]
+```
+
+A bound whose recursive members keep nesting another `list` cannot be fully inspected. We omit the
+diagnostic:
+
+```py
+from typing import Protocol
+
+class Recursive[T](Protocol):
+    next: "Recursive[list[T]]"
+
+def _[T: Recursive[int]](value: T) -> None:
+    cast(T, value)
+```
+
 ## Disjoint casts
 
 ### Basics

--- a/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
@@ -88,6 +88,30 @@ Using a keyword-variadic parameter:
 lambda **kwargs: reveal_type(kwargs)  # revealed: dict[str, Unknown]
 ```
 
+## Protocol context for lambda parameters
+
+The first argument supplies `Item` as context for the lambda's parameter. An `Any`-typed member does
+not prevent us from inferring `item.name` as `str` and rejecting it where `int` is expected:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, Callable, Protocol
+
+class Item(Protocol):
+    extra: Any
+    name: str
+
+def use[T](value: T, callback: Callable[[T], None]) -> None: ...
+def accept_int(value: int) -> None: ...
+def _(value: Item) -> None:
+    # error: [invalid-argument-type] "Expected `int`, found `str`"
+    use(value, lambda item: accept_int(item.name))
+```
+
 ## Nested `lambda` expressions
 
 Here, a `lambda` expression is used as the default value for a parameter in another `lambda`

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -212,6 +212,328 @@ class Child(Base[T]): ...
 child: Child[int]
 ```
 
+## Protocol instances as generic arguments
+
+`Generic` and `Protocol` expect type variables, not protocol instances. This also applies to a
+specialized protocol whose methods use its type parameter:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generic, Protocol
+
+class HasMethod[T](Protocol):
+    def method(self) -> T: ...
+
+def _(value: HasMethod[int]) -> None:
+    Generic[value]  # error: [invalid-argument-type]
+    Protocol[value]  # error: [invalid-argument-type]
+    class C(Generic[value]): ...  # error: [invalid-argument-type]
+    class D(Protocol[value]): ...  # error: [invalid-argument-type]
+```
+
+A method's own type parameter does not make the protocol instance a valid argument either. Here, `U`
+appears in the method signature, but the returned protocol does not use its argument:
+
+```py
+class Q[T](Protocol):
+    value: int
+
+class HasGenericMethod[T](Protocol):
+    def method[U](self, value: U) -> Q[U]: ...
+
+def _(value: HasGenericMethod[int]) -> None:
+    Generic[value]  # error: [invalid-argument-type]
+    Protocol[value]  # error: [invalid-argument-type]
+```
+
+A finite nested specialization is likewise invalid, whether it appears in a method return type or an
+attribute:
+
+```py
+def _(value: HasMethod[HasMethod[int]]) -> None:
+    Generic[value]  # error: [invalid-argument-type]
+    Protocol[value]  # error: [invalid-argument-type]
+
+class P[T](Protocol):
+    value: T
+
+def _(value: P[P[int]]) -> None:
+    Generic[value]  # error: [invalid-argument-type]
+    Protocol[value]  # error: [invalid-argument-type]
+    class C(Generic[value]): ...  # error: [invalid-argument-type]
+    class D(Protocol[value]): ...  # error: [invalid-argument-type]
+```
+
+## Finite recursive protocols as generic arguments
+
+`Generic` and `Protocol` should reject protocol instances even when their methods are recursive. We
+currently miss these errors because the recursion guard treats the method as potentially growing,
+although it always returns `P[int]`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Generic, Protocol, TypeVarTuple
+
+class P[T](Protocol):
+    def method(self) -> P[int]: ...
+
+def _(value: P[int]) -> None:
+    # TODO: Reject protocol instances as `Generic` and `Protocol` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Protocol[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    class C(Generic[value]): ...
+    class D(Protocol[value]): ...
+```
+
+The same limitation applies to other starting specializations, including an unused `TypeVarTuple`
+argument:
+
+```py
+def _(value: P[str], unused: P[TypeVarTuple]) -> None:
+    # TODO: Reject protocol instances as `Generic` and `Protocol` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Protocol[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Generic[unused])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Protocol[unused])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+A property that swaps its type arguments returns to the original specialization after two steps. We
+miss the invalid-argument diagnostics for this finite cycle too:
+
+```py
+class Swapped[A, B](Protocol):
+    @property
+    def next(self) -> Swapped[B, A]: ...
+
+def _(value: Swapped[int, str]) -> None:
+    # TODO: Reject protocol instances as `Generic` and `Protocol` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Protocol[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+## Runtime `TypeVarTuple` arguments
+
+A list is not a valid argument to `Generic` or `Protocol`, but lists containing runtime
+`TypeVarTuple` objects currently go unchecked:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generic, Protocol, TypeVarTuple
+
+def _(value: TypeVarTuple) -> None:
+    reveal_type(Generic[[value]])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Protocol[[value]])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+
+    class GenericBase(Generic[[value]]): ...
+    class ProtocolBase(Protocol[[value]]): ...
+```
+
+The `typing_extensions` variant has the same behavior:
+
+```py
+from typing_extensions import TypeVarTuple as TypeVarTupleExtensions
+
+def _(value: TypeVarTupleExtensions) -> None:
+    reveal_type(Generic[[value]])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Protocol[[value]])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+This limitation also applies when an alias, `NewType`, or type-variable bound contains the
+`TypeVarTuple`:
+
+```py
+from typing import NewType, TypeVar
+
+type Alias = list[TypeVarTuple]
+X = NewType("X", list[TypeVarTuple])
+T = TypeVar("T", bound=list[TypeVarTuple])
+
+def _(alias: Alias, newtype: X, bounded: T) -> None:
+    reveal_type(Generic[alias])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Generic[newtype])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Generic[bounded])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+An unused protocol argument does not trigger this limitation. We reject the protocol instance as an
+invalid `Generic` argument:
+
+```py
+class Unused[T](Protocol):
+    value: int
+
+def _(value: Unused[TypeVarTuple]) -> None:
+    Generic[value]  # error: [invalid-argument-type]
+    class C(Generic[value]): ...  # error: [invalid-argument-type]
+```
+
+We still treat a `TypeVarTuple` exposed through a protocol member as unsupported:
+
+```py
+class Used[T](Protocol):
+    value: T
+
+def _(value: Used[TypeVarTuple]) -> None:
+    # TODO: Reject protocol instances as `Generic` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+A protocol parameter's bound can trigger the same limitation, even when the protocol is specialized
+with `Any`:
+
+```py
+from typing import Any
+
+class Bounded[T: list[TypeVarTuple]](Protocol):
+    def method(self) -> T: ...
+
+def _(value: Bounded[Any]) -> None:
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+## Type variable defaults in generic arguments
+
+A type-variable default does not restrict values annotated with that type variable. We currently
+leave these invalid arguments unchecked when the default contains a `TypeVarTuple`:
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Generic, Protocol, TypeVar, TypeVarTuple
+
+T = TypeVar("T", default=list[TypeVarTuple])
+
+def _(value: T) -> None:
+    # TODO: Reject these arguments; a default does not constrain every value of `T`.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    reveal_type(Protocol[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+## Recursive structural types in generic arguments
+
+A recursive protocol instance is not a valid `Generic` argument. When its members keep changing
+specialization, we currently treat the instance as unsupported instead of reporting an invalid
+argument:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Generic, Protocol, TypedDict
+
+class Recursive[T](Protocol):
+    next: Recursive[list[T]]
+
+def _(value: Recursive[int]) -> None:
+    # TODO: Reject protocol instances as `Generic` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    class X(Generic[value]): ...
+```
+
+The recursive reference can also appear in a method's return type:
+
+```py
+class RecursiveMethod[T](Protocol):
+    def method(self) -> RecursiveMethod[list[T]]: ...
+
+def _(value: RecursiveMethod[int]) -> None:
+    # TODO: Reject protocol instances as `Generic` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+Properties whose return types keep changing specialization have the same limitation:
+
+```py
+class RecursiveProperty[T](Protocol):
+    @property
+    def next(self) -> RecursiveProperty[list[T]]: ...
+
+def _(value: RecursiveProperty[int]) -> None:
+    # TODO: Reject protocol instances as `Generic` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+Mutually recursive methods can keep changing specialization too. Each round below adds another
+`list` around the argument:
+
+```py
+class Left[T](Protocol):
+    def method(self) -> Right[list[T]]: ...
+
+class Right[U](Protocol):
+    def method(self) -> Left[U]: ...
+
+def _(value: Left[int]) -> None:
+    # TODO: Reject protocol instances as `Generic` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+The same limitation applies when a non-generic protocol's method returns the growing type:
+
+```py
+class Root(Protocol):
+    def method(self) -> Left[int]: ...
+
+def _(value: Root) -> None:
+    # TODO: Reject protocol instances as `Generic` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
+A growing recursive `TypedDict` is also treated as unsupported:
+
+```py
+class Payload[T](TypedDict):
+    child: Payload[list[T]]
+
+def _(value: Payload[int]) -> None:
+    # TODO: Reject `TypedDict` instances as `Generic` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+    class X(Generic[value]): ...
+```
+
+## Recursive bounds in generic arguments
+
+A recursive bound on an unused protocol parameter does not make the protocol instance a valid
+`Generic` argument. We currently leave this argument unchecked:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, Generic, Protocol
+
+type Recursive[T] = list[Recursive[list[T]]]
+
+class P[T: Recursive[int]](Protocol):
+    def method(self) -> int: ...
+
+def _(value: P[Any]) -> None:
+    # TODO: Reject protocol instances as `Generic` arguments.
+    reveal_type(Generic[value])  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+```
+
 ## Specializing classes with unavailable generic context
 
 When an earlier error prevents ty from determining a class's generic context, specializing the class

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -484,6 +484,30 @@ def bad_return(x: T) -> T:
     return x + 1
 ```
 
+## `Self` satisfies variadic constraints
+
+`Box[*tuple[Any, ...]]` accepts any specialization of `Box`, including the implicit `Self` type
+inside its methods:
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Any, Generic, TypeVar, TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+
+class Box(Generic[Unpack[Ts]]):
+    def _(self) -> None:
+        accept(self)
+
+T = TypeVar("T", Box[Unpack[tuple[Any, ...]]], str)
+
+def accept(value: T) -> None: ...
+```
+
 ## All occurrences of the same typevar have the same type
 
 If a typevar appears multiple times in a function signature, all occurrences have the same type.

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -281,6 +281,19 @@ reveal_type(generic_context(outside_callable(1)))
 outside_callable(1)("string")
 ```
 
+A recursively specialized parameter alias also keeps `T` in the function's generic context, rather
+than the returned `Callable`'s:
+
+```py
+type Recursive[T] = list[Recursive[list[T]]]
+
+def f[T](value: Recursive[T]) -> Callable[[], T]:
+    raise NotImplementedError
+
+# revealed: ty_extensions._internal.GenericContext[T@f]
+reveal_type(generic_context(f))
+```
+
 ## Naming a generic `Callable` with paramspecs: function return values
 
 The same pattern holds if the callable involves a paramspec.

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1095,6 +1095,25 @@ def target(name: str, callback: Callable[[int], Any]): ...
 forward(target, callback=lambda value: value)  # error: [missing-argument]
 ```
 
+### Type context with gradual `TypedDict` fields
+
+The parameter annotation supplies `list[Payload]` as context for the list literal, even though
+`Payload` has an `Any`-typed field. Forwarding the call through `ParamSpec` preserves that context:
+
+```py
+from typing import Any, Callable, TypedDict
+
+class Payload(TypedDict):
+    value: Any
+
+def accept(value: list[Payload]) -> None: ...
+def forward[**P, R](callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return callback(*args, **kwargs)
+
+accept(reveal_type([{"value": 1}]))  # revealed: list[Payload]
+forward(accept, reveal_type([{"value": 1}]))  # revealed: list[Payload]
+```
+
 ### Specializing `ParamSpec` with another `ParamSpec`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -310,6 +310,21 @@ def g[S]():
     reveal_type(S.__constraints__)  # revealed: tuple[()]
 ```
 
+### Bounds and constraints with unused alias arguments
+
+An unused alias argument does not make a bound or constraint generic. `Ignored[S]` resolves to
+`int`, so these declarations restrict `T` to concrete types:
+
+```py
+type Ignored[T] = int
+
+def _[S, T: Ignored[S]](value: T) -> T:
+    return value
+
+def _[S, T: (Ignored[S], str)](value: T) -> T:
+    return value
+```
+
 ### Cannot have only one constraint
 
 > `TypeVar` supports constraining parametric types to a fixed set of possible types...There should

--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -813,12 +813,43 @@ type GrowingAlias[T] = T | list[Co[GrowingAlias[list[T]]] & Child[object]]
 class GrowingRecord[T](TypedDict):
     child: Co[GrowingRecord[list[T]]] & Child[object]
 
+class GrowingProtocol[T](Protocol):
+    child: GrowingProtocol[list[T]]
+
 def _(
     alias: Co[GrowingAlias[int]] & Child[object],
     record: Co[GrowingRecord[int]] & Child[object],
+    protocol: Co[GrowingProtocol[int]] & Child[object],
 ):
     reveal_type(alias)  # revealed: Co[GrowingAlias[int]] & Child[object]
     reveal_type(record)  # revealed: Co[GrowingRecord[int]] & Child[object]
+    reveal_type(protocol)  # revealed: Co[GrowingProtocol[int]] & Child[object]
+```
+
+Growing specializations in a non-generic protocol's members or a type variable's bound also prevent
+simplification:
+
+```pyi
+class Wrapper(Protocol):
+    value: GrowingAlias[int]
+
+def _[T: GrowingAlias[int]](
+    protocol: Co[Wrapper] & Child[object],
+    bound: Co[T] & Child[object],
+):
+    reveal_type(protocol)  # revealed: Co[Wrapper] & Child[object]
+    reveal_type(bound)  # revealed: Co[T@_] & Child[object]
+```
+
+We also leave the intersection unsimplified when a protocol argument contains a growing
+specialization, even if the protocol's members do not use that argument:
+
+```pyi
+class Unused[T](Protocol):
+    value: int
+
+def _(value: Co[Unused[GrowingAlias[int]]] & Child[object]):
+    reveal_type(value)  # revealed: Co[Unused[GrowingAlias[int]]] & Child[object]
 ```
 
 ### Inherited properties with recursive protocol bounds

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -38,6 +38,42 @@ reveal_type(x[0].__name__)  # revealed: str
 reveal_type([1, (1, 2), (1, 2, 3)])
 ```
 
+## Recursive members do not block tuple promotion
+
+`Recursive[int]` is a protocol instance, not a tuple. Its tuple-valued and recursive members do not
+prevent neighboring tuple literals from being promoted:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Recursive[T](Protocol):
+    next: Recursive[list[T]]
+    pair: tuple[int, str]
+
+def _(x: Recursive[int]) -> None:
+    reveal_type([(1,), (1, 2), x])  # revealed: list[Recursive[int] | tuple[int, ...]]
+```
+
+The same applies to tuple-valued `TypedDict` fields:
+
+```py
+from typing import TypedDict
+
+class Payload[T](TypedDict):
+    child: Payload[list[T]]
+    pair: tuple[int, str]
+
+def _(x: Payload[int]) -> None:
+    reveal_type([(1,), (1, 2), x])  # revealed: list[Payload[int] | tuple[int, ...]]
+```
+
 ## None promotion
 
 `None` is promoted to `None | Unknown` in list literals when it is the only element type, so that

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -892,6 +892,54 @@ def excludes_bounded_generic_subclass(
     return cls
 ```
 
+### Strict narrowing preserves type-variable bounds
+
+Strict narrowing preserves the bound of an existing type variable. After narrowing `Covariant[T]` to
+`Invariant`, `get` still returns `T`:
+
+```toml
+[environment]
+python-version = "3.12"
+
+[analysis]
+strict-generic-narrowing = true
+```
+
+```py
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Invariant[T](Covariant[T]):
+    def set(self, value: T) -> None: ...
+
+def _[T: int](value: Covariant[T]) -> None:
+    if isinstance(value, Invariant):
+        reveal_type(value.get().bit_length())  # revealed: int
+```
+
+An `Any` argument in the bound remains `Any`, so `Invariant[Any]` still accepts writes of any type:
+
+```py
+from typing import Any
+
+def _[T: Invariant[Any]](value: Covariant[T]) -> None:
+    if isinstance(value, Invariant):
+        reveal_type(value.get().get())  # revealed: Any
+        value.get().set(1)
+```
+
+The same applies when narrowing a sequence of lists. Each list retains its `Any` element type:
+
+```py
+from collections.abc import Sequence
+
+def _[T: list[Any]](values: Sequence[T]) -> None:
+    if isinstance(values, list):
+        reveal_type(values[0][0])  # revealed: Any
+        values[0].append(1)
+```
+
 ### Gradual mode
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2929,6 +2929,366 @@ def test_match_exact_tuple_sequence_subclass(value: Pair) -> None:
             reveal_type(value)  # revealed: Pair
 ```
 
+## Negative sequence narrowing through aliases
+
+Aliases do not prevent narrowing individual tuple elements when their values are fully static. This
+includes finite nesting of the same alias:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Alias[T] = T
+
+def _(x: tuple[Alias[Alias[int]], int | str]) -> str:
+    match x:
+        case (_, int()):
+            return "matched"
+        case _:
+            reveal_type(x[1])  # revealed: str
+            return x[1]
+```
+
+An alias that discards `Any` also has a fully static value:
+
+```py
+from typing import Any
+
+type Ignored[T] = int
+
+def _(x: tuple[Ignored[Any], int | str]) -> None:
+    match x:
+        case (_, int()):
+            pass
+        case _:
+            reveal_type(x)  # revealed: tuple[Ignored[Any], str]
+```
+
+In contrast, preserving `Any` prevents this precise narrowing:
+
+```py
+def _(x: tuple[Alias[Any], int | str]) -> None:
+    match x:
+        case (_, int()):
+            pass
+        case _:
+            # revealed: tuple[Alias[Any], int | str] & ~<Protocol with members '__getitem__', '__len__'>
+            reveal_type(x)
+```
+
+## Negative sequence narrowing with structural types
+
+Narrowing individual tuple elements also requires protocol members and `TypedDict` fields to be
+fully static:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class Static(Protocol):
+    member: int
+
+def _(x: tuple[Static, int | str]) -> None:
+    match x:
+        case (_, int()):
+            pass
+        case _:
+            reveal_type(x)  # revealed: tuple[Static, str]
+```
+
+A finite nesting of the same `TypedDict` also has fully static fields:
+
+```py
+from typing import TypedDict
+
+class Payload[T](TypedDict):
+    item: T
+
+def _(x: tuple[Payload[Payload[int]], int | str]) -> str:
+    match x:
+        case (_, int()):
+            return "matched"
+        case _:
+            reveal_type(x[1])  # revealed: str
+            return x[1]
+```
+
+A protocol member of type `Any` makes the protocol gradual:
+
+```py
+from typing import Any
+
+class Gradual(Protocol):
+    member: Any
+
+def _(x: tuple[Gradual, int | str]) -> None:
+    match x:
+        case (_, int()):
+            pass
+        case _:
+            # revealed: tuple[Gradual, int | str] & ~<Protocol with members '__getitem__', '__len__'>
+            reveal_type(x)
+```
+
+A `TypedDict` field containing `Any` has the same effect:
+
+```py
+class GradualPayload(TypedDict):
+    member: Any
+
+def _(x: tuple[GradualPayload, int | str]) -> None:
+    match x:
+        case (_, int()):
+            pass
+        case _:
+            # revealed: tuple[GradualPayload, int | str] & ~<Protocol with members '__getitem__', '__len__'>
+            reveal_type(x)
+```
+
+## Negative sequence narrowing with `NewType`
+
+A `NewType` with a fully static base permits narrowing individual tuple elements:
+
+```py
+from typing import Any, NewType
+
+Static = NewType("Static", list[int])
+
+def _(x: tuple[Static, int | str]) -> None:
+    match x:
+        case (_, int()):
+            pass
+        case _:
+            reveal_type(x)  # revealed: tuple[Static, str]
+```
+
+Replacing the base's `int` argument with `Any` makes the `NewType` gradual and prevents this
+narrowing:
+
+```py
+Gradual = NewType("Gradual", list[Any])
+
+def _(x: tuple[Gradual, int | str]) -> None:
+    match x:
+        case (_, int()):
+            pass
+        case _:
+            # revealed: tuple[Gradual, int | str] & ~<Protocol with members '__getitem__', '__len__'>
+            reveal_type(x)
+```
+
+## Negative sequence narrowing with recursive callable bounds
+
+A recursive bound can still be fully static. This method's type variable is bounded by the protocol
+itself. Converting the method to a callable preserves that bound, so rejecting the `int` pattern
+leaves `str`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Callable, Protocol
+
+class P(Protocol):
+    def method[T: P](self, value: T) -> T: ...
+
+def as_callable[**P, R](value: Callable[P, R]) -> Callable[P, R]:
+    return value
+
+def _(value: P, item: int | str) -> str:
+    callback = as_callable(value.method)
+    pair = (callback, item)
+    match pair:
+        case (_, int()):
+            return "matched"
+        case _:
+            reveal_type(pair[1])  # revealed: str
+            return pair[1]
+```
+
+An `Any` member makes the same bound gradual, even if it appears after the recursive method. This
+prevents element-wise narrowing:
+
+```py
+from typing import Any
+
+class Gradual(Protocol):
+    def method[T: Gradual](self, value: T) -> T: ...
+    value: Any
+
+def _(value: Gradual, item: int | str) -> str:
+    callback = as_callable(value.method)
+    pair = (callback, item)
+    match pair:
+        case (_, int()):
+            return "matched"
+        case _:
+            reveal_type(pair[1])  # revealed: int | str
+            return pair[1]  # error: [invalid-return-type]
+```
+
+## Negative sequence narrowing with finite recursive members
+
+A recursive protocol can have fully static members even when its recursive references change
+specialization. This method always returns `Reset[int]`, so starting from `Reset[int]` reaches an
+exact cycle and permits narrowing the neighboring tuple element:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Reset[T](Protocol):
+    def method(self) -> Reset[int]: ...
+
+def _(pair: tuple[Reset[int], int | str]) -> str:
+    match pair:
+        case (_, int()):
+            return "matched"
+        case _:
+            reveal_type(pair[1])  # revealed: str
+            return pair[1]
+```
+
+Starting from `Reset[str]` also reaches only `Reset[int]`, but we do not yet recognize that this
+permits the same narrowing:
+
+```py
+def _(pair: tuple[Reset[str], int | str]) -> str:
+    match pair:
+        case (_, int()):
+            return "matched"
+        case _:
+            # TODO: This should narrow to `str`.
+            reveal_type(pair[1])  # revealed: int | str
+            return pair[1]  # error: [invalid-return-type]
+```
+
+Swapping two type arguments produces a finite cycle too, but has the same limitation:
+
+```py
+class Rotated[A, B](Protocol):
+    def method(self) -> Rotated[B, A]: ...
+
+def _(pair: tuple[Rotated[int, str], int | str]) -> str:
+    match pair:
+        case (_, int()):
+            return "matched"
+        case _:
+            # TODO: This should narrow to `str`.
+            reveal_type(pair[1])  # revealed: int | str
+            return pair[1]  # error: [invalid-return-type]
+```
+
+The same applies when an attribute swaps the arguments:
+
+```py
+class Data[A, B](Protocol):
+    next: Data[B, A]
+
+def _(pair: tuple[Data[int, str], int | str]) -> str:
+    match pair:
+        case (_, int()):
+            return "matched"
+        case _:
+            # TODO: This should narrow to `str`.
+            reveal_type(pair[1])  # revealed: int | str
+            return pair[1]  # error: [invalid-return-type]
+```
+
+An argument can stabilize through union normalization. Adding `int` again does not change
+`str | int`, but we do not yet recognize that these members remain fully static:
+
+```py
+class Normalized[T](Protocol):
+    next: Normalized[T | int]
+
+def _(pair: tuple[Normalized[str], int | str]) -> str:
+    match pair:
+        case (_, int()):
+            return "matched"
+        case _:
+            # TODO: This should narrow to `str`.
+            reveal_type(pair[1])  # revealed: int | str
+            return pair[1]  # error: [invalid-return-type]
+```
+
+A `TypedDict` whose field swaps its type arguments likewise has only two specializations, but
+currently prevents element-wise narrowing:
+
+```py
+from typing import TypedDict
+
+class Record[A, B](TypedDict):
+    next: Record[B, A]
+
+def _(pair: tuple[Record[int, str], int | str]) -> str:
+    match pair:
+        case (_, int()):
+            return "matched"
+        case _:
+            # TODO: This should narrow to `str`.
+            reveal_type(pair[1])  # revealed: int | str
+            return pair[1]  # error: [invalid-return-type]
+```
+
+## Negative sequence narrowing with growing recursive members
+
+When inspecting a member would expand an unbounded sequence of specializations, we retain the
+original tuple type instead of narrowing its elements:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Recursive[T](Protocol):
+    next: Recursive[list[T]]
+
+def _(x: tuple[Recursive[int], int]) -> None:
+    match x:
+        case (_, 1):
+            pass
+        case _:
+            reveal_type(x)  # revealed: tuple[Recursive[int], int]
+```
+
+A `TypedDict` whose recursive field keeps nesting another `list` has the same behavior:
+
+```py
+from typing import TypedDict
+
+class Payload[T](TypedDict):
+    child: Payload[list[T]]
+
+def _(x: tuple[Payload[int], int]) -> None:
+    match x:
+        case (_, 1):
+            pass
+        case _:
+            reveal_type(x)  # revealed: tuple[Payload[int], int]
+```
+
 ## Nested sequence patterns
 
 Nested patterns narrow values captured from the positions they inspect. For subjects without a known

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -183,6 +183,145 @@ def takes_list(value: ListAlias) -> None:
 takes_list([1])
 ```
 
+### Finite nesting preserves specialization
+
+`Nested[Nested[int]]` uses the same alias twice, but is not recursive. Specializing the containing
+legacy alias replaces `T` without changing the nested element:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypeAlias, TypeVar
+
+type Nested[U] = list[U]
+
+T = TypeVar("T")
+Alias: TypeAlias = tuple[T, Nested[Nested[int]]]
+
+def _(x: Alias[str]) -> None:
+    reveal_type(x)  # revealed: tuple[str, Nested[Nested[int]]]
+    y: int = x[0]  # error: [invalid-assignment]
+```
+
+### Recursive aliases inside a generic alias
+
+An inner alias can be recursive without referring back to the outer alias. We can still specialize
+`T` in the outer alias while preserving the recursive element:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypeAlias, TypeVar
+
+type Recursive[U] = list[Recursive[list[U]]]
+
+T = TypeVar("T")
+Alias: TypeAlias = tuple[T, Recursive[int]]
+
+def _(x: Alias[str]) -> None:
+    reveal_type(x)  # revealed: tuple[str, Recursive[int]]
+    y: int = x[0]  # error: [invalid-assignment]
+```
+
+The nested alias can also contain a recursive legacy alias without preventing specialization:
+
+```py
+LegacyRecursive: TypeAlias = int | list["LegacyRecursive"]
+type Nested = LegacyRecursive
+
+NestedAlias: TypeAlias = tuple[T, Nested]
+
+def _(x: NestedAlias[str]) -> None:
+    reveal_type(x)  # revealed: tuple[str, Nested]
+    y: int = x[0]  # error: [invalid-assignment]
+```
+
+### Recursive structural types inside a generic alias
+
+A protocol's recursive members do not make a containing alias recursive. The alias's type parameter
+can still be specialized:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol, TypeAlias, TypeVar
+
+class Recursive[U](Protocol):
+    next: Recursive[list[U]]
+
+T = TypeVar("T")
+Alias: TypeAlias = tuple[T, Recursive[int]]
+
+def _(x: Alias[str]) -> None:
+    reveal_type(x)  # revealed: tuple[str, Recursive[int]]
+```
+
+Recursive `TypedDict` fields do not prevent specialization either:
+
+```py
+from typing import TypedDict
+
+class Payload[U](TypedDict):
+    child: Payload[list[U]]
+
+PayloadAlias: TypeAlias = tuple[T, Payload[int]]
+
+def _(x: PayloadAlias[str]) -> None:
+    reveal_type(x)  # revealed: tuple[str, Payload[int]]
+```
+
+### Recursive type-variable bounds preserve specialization
+
+A recursive bound does not prevent specializing a type variable used in an alias. `Alias[int]` still
+denotes `list[int]`:
+
+```py
+from typing import TypeAlias, TypeVar
+
+Recursive: TypeAlias = int | list["Recursive"]
+T = TypeVar("T", bound=Recursive)
+Alias: TypeAlias = list[T]
+
+def _(x: Alias[int]) -> None:
+    reveal_type(x)  # revealed: list[int]
+    x.append("a")  # error: [invalid-argument-type]
+```
+
+The supplied argument is still checked against the recursive bound:
+
+```py
+def _(x: Alias[str]) -> None: ...  # error: [invalid-type-arguments]
+```
+
+### Recursive `NewType` bases preserve specialization
+
+A `NewType` keeps its nominal identity when its base contains a recursive type. The containing alias
+can still be specialized independently of that recursion:
+
+```py
+from typing import NewType, TypeAlias, TypeVar
+
+Recursive: TypeAlias = int | list["Recursive"]
+Wrapped = NewType("Wrapped", list[Recursive])
+T = TypeVar("T")
+Alias: TypeAlias = tuple[T, Wrapped]
+
+def _(x: Alias[str]) -> None:
+    reveal_type(x)  # revealed: tuple[str, Wrapped]
+    y: int = x[0]  # error: [invalid-assignment]
+```
+
 ## Class-scoped type variables
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -306,6 +306,112 @@ segments: Mapping[str, Any] = {"start": (1, 2), "end": (3, 4, 5)}
 reveal_type(segments)  # revealed: dict[str, tuple[int, ...]]
 ```
 
+## Non-tuple elements do not block tuple-size promotion
+
+A non-literal tuple blocks tuple-size promotion because its shape must be preserved. A tuple nested
+inside a non-tuple element's type arguments does not:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class Box[T]: ...
+
+def _(box: Box[tuple[int, str]]) -> None:
+    # revealed: list[Box[tuple[int, str]] | tuple[int, ...]]
+    reveal_type([(1,), (1, 2), box])
+```
+
+A tuple in a callable's return type does not prevent promotion either:
+
+```py
+from collections.abc import Callable
+
+def _(callback: Callable[[], tuple[int, str]]) -> None:
+    # revealed: list[(() -> tuple[int, str]) | tuple[int, ...]]
+    reveal_type([(1,), (1, 2), callback])
+```
+
+Protocol members and `TypedDict` fields can also contain tuples without blocking promotion:
+
+```py
+from typing import Protocol, TypedDict
+
+class Proto(Protocol):
+    pair: tuple[int, str]
+
+class Payload(TypedDict):
+    pair: tuple[int, str]
+
+def _(protocol: Proto, payload: Payload) -> None:
+    reveal_type([(1,), (1, 2), protocol])  # revealed: list[Proto | tuple[int, ...]]
+    reveal_type([(1,), (1, 2), payload])  # revealed: list[Payload | tuple[int, ...]]
+```
+
+## Type parameter declarations do not block tuple-size promotion
+
+A class parameter's bound or default does not describe the shape of instances of that class. A tuple
+in either declaration does not prevent promotion of neighboring tuple literals.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound=int | tuple[int, str])
+U = TypeVar("U", default=tuple[int, str])
+
+class Bounded(Generic[T]): ...
+class Defaulted(Generic[U]): ...
+
+def _(x: Bounded[int]) -> None:
+    # revealed: list[Bounded[int] | tuple[int, ...]]
+    reveal_type([(1,), (1, 2), x])
+
+def _(x: Defaulted[int]) -> None:
+    # revealed: list[Defaulted[int] | tuple[int, ...]]
+    reveal_type([(1,), (1, 2), x])
+```
+
+A default also does not fix the type of a value annotated with the type variable:
+
+```py
+def _(x: U) -> None:
+    reveal_type([(1,), (1, 2), x])  # revealed: list[U@_ | tuple[int, ...]]
+```
+
+## Tuple-size promotion uses alias values
+
+Tuple-size promotion inspects alias values. `Alias[Alias[str]]` resolves to `str`, so it does not
+block promotion:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Alias[T] = T
+
+def _(x: Alias[Alias[str]]) -> None:
+    reveal_type([(1,), (1, 2), x])  # revealed: list[str | tuple[int, ...]]
+```
+
+Even a recursively specialized alias permits promotion when its value is a `list`:
+
+```py
+type Recursive[T] = list[Recursive[list[T]]]
+
+def _(x: Recursive[int]) -> None:
+    # revealed: list[list[Recursive[list[int]]] | tuple[int, ...]]
+    reveal_type([(1,), (1, 2), x])
+```
+
 ## Invariant and contravariant return types are promoted
 
 We promote in non-covariant position in the return type of a generic function, or constructor of a

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3447,6 +3447,278 @@ def update_bounded_value(value: HasBoundedValue) -> None:
     value.bounded_value = "bad"  # error: [invalid-assignment]
 ```
 
+### Local protocol setter types
+
+A setter's unused type parameter does not affect the accepted value type, even when that type is a
+local protocol. A property setter accepting the same protocol satisfies the writable member:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+def _() -> None:
+    class Local(Protocol):
+        member: int
+
+    class Descriptor:
+        def __init__(self, getter: object) -> None: ...
+        def __get__(self, instance: object, owner: type | None = None) -> int:
+            return 1
+
+        def __set__[U](self, instance: object, value: Local) -> None: ...
+
+    class HasValue(Protocol):
+        @Descriptor
+        def value(self) -> int: ...
+
+    class Implementation:
+        @property
+        def value(self) -> int:
+            return 1
+
+        @value.setter
+        def value(self, value: Local) -> None: ...
+
+    static_assert(is_subtype_of(Implementation, HasValue))
+```
+
+### Specialized protocol setter value types
+
+`P[int]` does not depend on the setter's unused `U`. A property setter accepting `P[int]` therefore
+satisfies the same writable member, including for strict subtyping:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class P[T](Protocol):
+    def method(self) -> T: ...
+
+class Descriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> object:
+        return object()
+
+    def __set__[U](self, instance: object, value: P[int]) -> None: ...
+
+class HasValue(Protocol):
+    @Descriptor
+    def value(self) -> object: ...
+
+class Implementation:
+    @property
+    def value(self) -> object:
+        return object()
+
+    @value.setter
+    def value(self, value: P[int]) -> None: ...
+
+static_assert(is_subtype_of(Implementation, HasValue))
+x: HasValue = Implementation()
+```
+
+A setter accepting only `P[Literal[1]]` is too narrow:
+
+```py
+from typing import Literal
+
+class Narrowed:
+    @property
+    def value(self) -> object:
+        return object()
+
+    @value.setter
+    def value(self, value: P[Literal[1]]) -> None: ...
+
+static_assert(not is_subtype_of(Narrowed, HasValue))
+x1: HasValue = Narrowed()  # error: [invalid-assignment]
+```
+
+An ordinary `int` attribute cannot accept `P[int]` values either:
+
+```py
+class IntAttribute:
+    value: int
+
+x2: HasValue = IntAttribute()  # error: [invalid-assignment]
+```
+
+### Setter value types with finite protocol recursion
+
+`P[int]` does not depend on the setter's `U`, so a matching property setter should satisfy the
+writable member. We currently fail to recognize this subtype relation because the recursion guard
+treats the fixed `P[int]` return type as potentially growing:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class P[T](Protocol):
+    def method(self) -> P[int]: ...
+
+class Descriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> object:
+        return object()
+
+    def __set__[U](self, instance: object, value: P[int]) -> None: ...
+
+class HasValue(Protocol):
+    @Descriptor
+    def value(self) -> object: ...
+
+class Implementation:
+    @property
+    def value(self) -> object:
+        return object()
+
+    @value.setter
+    def value(self, value: P[int]) -> None: ...
+
+# TODO: Recognize the matching property setter as a subtype.
+static_assert(is_subtype_of(Implementation, HasValue))  # error: [static-assert-error]
+x: HasValue = Implementation()
+```
+
+An `int` attribute cannot accept `P[int]` values, but we currently miss this diagnostic too:
+
+```py
+class IntAttribute:
+    value: int
+
+# TODO: Reject the incompatible writable attribute.
+y: HasValue = IntAttribute()
+```
+
+### Recursive setter types independent of method type parameters
+
+The accepted value type can also be recursive without depending on `__set__`'s type parameter.
+Assignments are checked against `Recursive[int]`, not an arbitrary specialization:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Recursive[T](Protocol):
+    next: Recursive[list[T]]
+
+class Descriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__[U](self, instance: object, value: Recursive[int]) -> None: ...
+
+class HasValue(Protocol):
+    @Descriptor
+    def value(self) -> int: ...
+
+def _(x: HasValue, value: Recursive[int]) -> None:
+    x.value = value
+    x.value = 1  # error: [invalid-assignment]
+```
+
+A `TypedDict` can likewise recur without referring to the setter's `U`:
+
+```py
+from typing import TypedDict
+
+class Payload[T](TypedDict):
+    child: Payload[list[T]]
+
+class PayloadDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__[U](self, instance: object, value: Payload[int]) -> None: ...
+
+class HasPayload(Protocol):
+    @PayloadDescriptor
+    def value(self) -> int: ...
+
+def _(x: HasPayload, value: Payload[int]) -> None:
+    x.value = value
+    x.value = 1  # error: [invalid-assignment]
+```
+
+A recursive alias that does not refer to the setter's `U` behaves the same way:
+
+```py
+type RecursiveAlias[T] = list[RecursiveAlias[list[T]]]
+
+class AliasDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__[U](self, instance: object, value: RecursiveAlias[int]) -> None: ...
+
+class HasAlias(Protocol):
+    @AliasDescriptor
+    def value(self) -> int: ...
+
+def _(x: HasAlias, value: RecursiveAlias[int]) -> None:
+    x.value = value
+    x.value = 1  # error: [invalid-assignment]
+```
+
+### Recursive aliases in generic setters
+
+A generic setter still rejects values incompatible with the outer type of a recursive alias.
+`Recursive[T]` always denotes a `list`, so an `int` assignment is invalid:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+type Recursive[T] = list[Recursive[list[T]]]
+
+class Descriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__[T](self, instance: object, value: Recursive[T]) -> None: ...
+
+class HasValue(Protocol):
+    @Descriptor
+    def value(self) -> int: ...
+
+def _(x: HasValue) -> None:
+    x.value = 1  # error: [invalid-assignment]
+```
+
 ### Type variables from the surrounding function
 
 A type variable supplied by the surrounding function is still the descriptor's value type. Assigning
@@ -3522,6 +3794,37 @@ Assignments through the protocol accept `int` but reject `str`:
 def update_aliased_receiver(value: HasAliasedReceiver) -> None:
     value.value = 1
     value.value = "bad"  # error: [invalid-assignment]
+```
+
+### Unused alias arguments do not constrain setters
+
+`Ignored[T]` always denotes `int`, so the setter accepts `int` independently of its type parameter
+and rejects `str`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+type Ignored[T] = int
+
+class Descriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__[T](self, instance: object, value: Ignored[T]) -> None: ...
+
+class HasValue(Protocol):
+    @Descriptor
+    def value(self) -> int: ...
+
+def _(x: HasValue) -> None:
+    x.value = 1
+    x.value = "bad"  # error: [invalid-assignment]
 ```
 
 ### Constrained generic setters
@@ -6421,6 +6724,32 @@ class NestedRightProtocol[T](Protocol):
 
 # TODO: These structurally equivalent protocols should be recognized as subtypes.
 static_assert(not is_subtype_of(NestedLeftProtocol[int], NestedRightProtocol[int]))
+```
+
+### Generic calls with recursive protocol arguments
+
+A recursively specialized protocol remains a valid argument to a generic function. Its members can
+recurse through independent definitions:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+type Alias[T] = list[Alias[list[T]]]
+
+class Recursive[T](Protocol):
+    child: Recursive[list[T]]
+    payload: Alias[int]
+
+def f[T](x: Recursive[T]) -> None: ...
+def _(x: Recursive[int]) -> None:
+    f(x)
 ```
 
 ### Disjointness of recursive protocol and recursive final type

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -1657,6 +1657,146 @@ def typevartuple_subject[*Us]() -> None:
     ConstraintSet.range(Callable[[int], None], Us, Callable[[int], None])  # error: [invalid-type-form]
 ```
 
+## Type-variable dependencies
+
+### Constraints through type aliases
+
+An alias that preserves its argument also preserves the constraint's dependency on that argument.
+`T ≤ Alias[U]` relates `T` and `U` just like `T ≤ U`:
+
+```py
+from ty_extensions._internal import ConstraintSet
+
+type Alias[V] = V
+
+def _[T, U]() -> None:
+    constraints = ConstraintSet.upper_bound(T, Alias[U]) & ConstraintSet.lower_bound(int, U)
+    # revealed: tuple[Solution[T=U@_, U=int]]
+    reveal_type(constraints.solutions(inferable=tuple[T, U]))
+```
+
+Existentially quantifying `U` leaves no constraint on `T`: choosing `U = object` satisfies both
+bounds for any `T`. This also removes `U` from inside the alias:
+
+```py
+from ty_extensions import static_assert
+
+def _[T, U]() -> None:
+    constraints = ConstraintSet.upper_bound(T, Alias[U]) & ConstraintSet.lower_bound(int, U)
+    quantified = constraints.exists(tuple[U])
+    static_assert(quantified == ConstraintSet.always())
+    reveal_type(quantified.solutions(inferable=tuple[T]))  # revealed: tuple[()]
+```
+
+An alias that ignores its argument leaves the concrete bound `int`, which does not depend on `U`:
+
+```py
+type Ignored[V] = int
+
+def _[T, U]() -> None:
+    constraints = ConstraintSet.upper_bound(T, Ignored[U]) & ConstraintSet.lower_bound(int, U)
+    # revealed: tuple[Solution[T=int, U=int]]
+    reveal_type(constraints.solutions(inferable=tuple[T, U]))
+```
+
+### Constraints on runtime alias objects
+
+Passing a local alias to a generic function infers the type of its runtime object, regardless of
+type variables in the alias's value:
+
+```py
+def identity[T](value: T) -> T:
+    return value
+
+def _[U]() -> None:
+    type Alias = U
+    reveal_type(identity(Alias))  # revealed: TypeAliasType
+```
+
+The same distinction applies to constraints. `TypeOf[Alias]` describes the runtime alias object, so
+quantifying `U` does not remove the constraint on `T`:
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet, TypeOf
+
+def _[T, U]() -> None:
+    type Alias = U
+    constraints = ConstraintSet.upper_bound(T, TypeOf[Alias])
+    quantified = constraints.exists(tuple[U])
+    static_assert(quantified == constraints)
+    reveal_type(quantified.solutions(inferable=tuple[T]))  # revealed: tuple[Solution[T=TypeAliasType]]
+```
+
+Using `Alias` as an annotation instead constrains `T` by `U`, so quantifying `U` removes that
+constraint:
+
+```py
+def _[T, U]() -> None:
+    type Alias = U
+    constraints = ConstraintSet.upper_bound(T, Alias)
+    static_assert(constraints.exists(tuple[U]) == ConstraintSet.always())
+```
+
+### Constraints through recursive aliases
+
+We retain type variables in recursive alias arguments even when expansion keeps changing the
+specialization:
+
+```py
+from ty_extensions._internal import ConstraintSet
+
+type Recursive[V] = list[Recursive[list[V]]]
+
+def _[T, U]() -> None:
+    constraints = ConstraintSet.upper_bound(T, Recursive[U]) & ConstraintSet.lower_bound(int, U)
+    # revealed: tuple[Solution[T=list[Recursive[list[U@_]]], U=int]]
+    reveal_type(constraints.solutions(inferable=tuple[T, U]))
+```
+
+An unused argument still introduces no dependency, even when the alias's value is recursive:
+
+```py
+type Ignored[V] = Recursive[int]
+
+def _[T, U]() -> None:
+    constraints = ConstraintSet.upper_bound(T, Ignored[U]) & ConstraintSet.lower_bound(int, U)
+    # revealed: tuple[Solution[T=list[Recursive[list[int]]], U=int]]
+    reveal_type(constraints.solutions(inferable=tuple[T, U]))
+```
+
+### Concrete structural bounds
+
+`U ≤ list[T]` relates two type variables, while `T ≤ Recursive[int]` gives `T` a concrete bound. The
+protocol's recursive members do not introduce another type-variable dependency:
+
+```py
+from __future__ import annotations
+
+from typing import Protocol, TypedDict
+from ty_extensions._internal import ConstraintSet
+
+class Recursive[V](Protocol):
+    next: Recursive[list[V]]
+
+def _[T, U]() -> None:
+    constraints = ConstraintSet.upper_bound(T, Recursive[int]) & ConstraintSet.upper_bound(U, list[T])
+    # revealed: tuple[Solution[T=Recursive[int], U=list[T@_]]]
+    reveal_type(constraints.solutions(inferable=tuple[T, U]))
+```
+
+Recursive `TypedDict` fields do not introduce a dependency either:
+
+```py
+class Payload[V](TypedDict):
+    child: Payload[list[V]]
+
+def _[T, U]() -> None:
+    constraints = ConstraintSet.upper_bound(T, Payload[int]) & ConstraintSet.upper_bound(U, list[T])
+    # revealed: tuple[Solution[T=Payload[int], U=list[T@_]]]
+    reveal_type(constraints.solutions(inferable=tuple[T, U]))
+```
+
 ## Displaying constraints
 
 The `with_detailed_display` method can be used to print out the boolean formula that a constraint

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -172,6 +172,24 @@ class D[T]:
     y: ClassVar[dict[str, T]]
 ```
 
+We do not yet reject type variables inside aliases. An unused alias argument is harmless, but an
+argument exposed by the alias's value should be rejected:
+
+```py
+type Alias[T] = T
+type Ignored[T] = int
+type Recursive[T] = list[Recursive[list[T]]]
+
+class Aliased[T]:
+    # TODO: Reject the type variable exposed by the alias.
+    generic: ClassVar[Alias[T]]
+
+    concrete: ClassVar[Ignored[T]]
+
+    # TODO: Reject the type variable inside the recursive alias.
+    recursive: ClassVar[Recursive[T]]
+```
+
 ## `ClassVar` can contain `Self`
 
 `Self` is allowed inside `ClassVar`.
@@ -199,6 +217,22 @@ reveal_type(Base.all_instances)  # revealed: list[Base]
 class Sub(Base): ...
 
 reveal_type(Sub.all_instances)  # revealed: list[Sub]
+```
+
+`Self` should also be valid in a generic class, but type parameters in its bound currently produce a
+false positive:
+
+```py
+from typing import Generic, TypeVar
+
+U = TypeVar("U")
+
+class GenericBase(Generic[U]):
+    # TODO: Do not reject type variables in `Self`'s bound.
+    # error: [invalid-type-form] "`ClassVar` cannot contain type variables"
+    direct: ClassVar[Self]
+    # error: [invalid-type-form] "`ClassVar` cannot contain type variables"
+    nested: ClassVar[list[Self]]
 ```
 
 Assignments through class objects should bind `Self` when writing a `ClassVar`, matching read-side
@@ -246,6 +280,114 @@ class DynamicSaved:
 def store_any(cls: type[Any], value: Any) -> None:
     cls.count = value
     reveal_type(cls.count)  # revealed: Any
+```
+
+## Protocols with generic methods
+
+A protocol's generic methods bind their own type parameters, so the protocol is valid in a
+`ClassVar` annotation:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import ClassVar, Protocol
+
+class Callback(Protocol):
+    def __call__[T](self, value: T) -> T: ...
+
+class Holder:
+    callback: ClassVar[Callback]
+```
+
+This remains valid when the protocol is defined inside a function:
+
+```py
+def _() -> None:
+    class Callback(Protocol):
+        def __call__[T](self, value: T) -> T: ...
+
+    class Holder:
+        callback: ClassVar[Callback]
+```
+
+## Generic callable signatures
+
+A generic callable also binds its own type parameters, but we currently reject them in `ClassVar`
+annotations. `CallableTypeOf` preserves the generic signature without specializing it:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import ClassVar
+from ty_extensions._internal import CallableTypeOf
+
+def identity[T](value: T) -> T:
+    return value
+
+class Holder:
+    # TODO: Permit type variables bound by the callable's own signature.
+    # error: [invalid-type-form] "`ClassVar` cannot contain type variables"
+    callback: ClassVar[CallableTypeOf[identity]]
+```
+
+## Captured type variables in structural types
+
+A local protocol or `TypedDict` can capture an outer type variable. These captures are not yet
+diagnosed in `ClassVar` annotations:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import ClassVar, Protocol, TypedDict
+
+def _[T]() -> None:
+    class Captured(Protocol):
+        value: T
+
+    class Payload(TypedDict):
+        value: T
+
+    class Holder:
+        # TODO: Reject the captured type variable in the protocol member.
+        protocol: ClassVar[Captured]
+        # TODO: Reject the captured type variable in the TypedDict field.
+        payload: ClassVar[Payload]
+```
+
+## Recursive structural types
+
+Concrete recursive protocols and `TypedDict`s are also valid `ClassVar` types. This includes members
+whose recursive references keep changing specialization:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import ClassVar, Protocol, TypedDict
+
+def _() -> None:
+    class Recursive[T](Protocol):
+        next: Recursive[list[T]]
+
+    class Payload[T](TypedDict):
+        next: Payload[list[T]]
+
+    class Holder:
+        protocol: ClassVar[Recursive[int]]
+        payload: ClassVar[Payload[int]]
 ```
 
 ## Assignments through generic aliases

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4370,6 +4370,49 @@ class AliasBox[T](TypedDict):
 reveal_type(AliasBox(value=[1]))  # revealed: AliasBox[int]
 ```
 
+### Constructor inference ignores unused alias arguments
+
+The `fixed` field has type `int`; `Inner[T]` appears only in an unused alias argument. The
+constructor can still infer `T` from `value`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypedDict
+
+type Ignored[T] = int
+
+class Inner[T](TypedDict):
+    value: T
+
+class Outer[T](TypedDict):
+    fixed: Ignored[Inner[T]]
+    value: T
+
+reveal_type(Outer(fixed=1, value=1))  # revealed: Outer[int]
+```
+
+Wrapping the alias in a tuple does not introduce a dependency on `T`:
+
+```py
+class Nested[T](TypedDict):
+    fixed: tuple[Ignored[Inner[T]]]
+    value: T
+
+reveal_type(Nested(fixed=(1,), value=1))  # revealed: Nested[int]
+```
+
+An unused alias argument in the expected type also does not prevent constructor inference:
+
+```py
+def _[T]() -> None:
+    # revealed: Outer[int]
+    x: Outer[int] | tuple[Ignored[Outer[T]]] = reveal_type(Outer(fixed=1, value=1))
+```
+
 ### Constructor inference with upper bounds
 
 A literal upper bound preserves its literal, while an ordinary `int` upper bound permits the usual

--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -538,6 +538,23 @@ def expanded_tuples(values: list[str]):
     reveal_type(last)  # revealed: Literal[False]
 ```
 
+A protocol's tuple-valued member does not prevent promotion of tuple literals collected alongside
+the protocol instance.
+
+```py
+from typing import Protocol
+
+class P(Protocol):
+    pair: tuple[int, int]
+
+def _(value: P) -> None:
+    first, *rest = [0, (1,), (2, 3), value]
+    reveal_type(rest)  # revealed: list[P | tuple[int, ...]]
+
+    first, *rest = (0, (1,), (2, 3), value)
+    reveal_type(rest)  # revealed: list[P | tuple[int, ...]]
+```
+
 ### Starred expressions on the right-hand side
 
 A starred element can contribute an unknown number of values. The literal's AST length does not

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2132,6 +2132,7 @@ impl<'db> Type<'db> {
         })
     }
 
+    /// Return whether this type is known to contain no dynamic types, including in lazy attributes.
     fn is_fully_static(self, db: &'db dyn Db, env: &ProgramEnvironment) -> bool {
         dynamic_content(db, env, self).is_absent()
     }
@@ -2260,10 +2261,10 @@ impl<'db> Type<'db> {
         // still ensures convergence in cases that are prone to oscillation.
         if cycle.iteration() <= crate::TAINTED_CYCLES {
             let self_degraded_by_overload =
-                any_over_type(db, env, self, false, |ty| {
+                any_over_type(db, env, self, |ty| {
                     matches!(ty, Type::Dynamic(DynamicType::AmbiguousOverload))
-                }) && !any_over_type(db, env, self, false, |ty| ty.is_divergent())
-                    && any_over_type(db, env, previous, false, |ty| ty.is_divergent());
+                }) && !any_over_type(db, env, self, |ty| ty.is_divergent())
+                    && any_over_type(db, env, previous, |ty| ty.is_divergent());
             // Generally, the precision of type inference improves with each iteration.
             // However, overload is an exception; as iterations progress, overload matching may become ambiguous, and a reversal of precision can occur.
             // This kind of precision degradation can be determined by whether the type contains `DynamicType::AmbiguousOverload`.
@@ -2626,8 +2627,9 @@ impl<'db> Type<'db> {
         )
     }
 
+    /// Return whether this type contains a dynamic type without expanding lazy attributes.
     fn has_dynamic(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
-        any_over_type(db, env, self, false, |ty| ty.is_dynamic())
+        any_over_type(db, env, self, |ty| ty.is_dynamic())
     }
 
     const fn as_special_form(self) -> Option<SpecialFormType> {

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -13,6 +13,7 @@ use ty_python_core::use_def_map;
 
 use super::call::CallArguments;
 use super::callable::CallableTypeKind;
+use super::visitor::any_over_typevar_including_lazy_attributes;
 use super::{
     IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Parameter, Signature,
     Type, TypeQualifiers, TypeVarBoundOrConstraints, UnionType,
@@ -1048,7 +1049,7 @@ fn contains_signature_typevar<'db>(
     ty: Type<'db>,
 ) -> bool {
     signature.generic_context.is_some_and(|generic_context| {
-        super::visitor::any_over_type(db, env, ty, true, |ty| {
+        any_over_typevar_including_lazy_attributes(db, env, ty, |ty| {
             matches!(ty, Type::TypeVar(typevar) if generic_context.contains(db, typevar.identity(db)))
         })
     })

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -169,10 +169,6 @@ fn generic_contexts_mentioned_in_type<'db>(
             self.env
         }
 
-        fn should_visit_lazy_type_attributes(&self) -> bool {
-            false
-        }
-
         fn visit_callable_type(&self, db: &'db dyn Db, callable: CallableType<'db>) {
             for signature in &callable.signatures(db).overloads {
                 self.visit_signature(db, signature);
@@ -6803,7 +6799,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let parameters_contain_typevartuple = declared_callables.iter().any(|callable| {
             callable.signatures(db).iter().any(|signature| {
                 signature.parameters().iter().any(|parameter| {
-                    any_over_type(db, self.env, parameter.annotated_type(), false, |ty| {
+                    any_over_type(db, self.env, parameter.annotated_type(), |ty| {
                         matches!(
                             ty,
                             Type::TypeVar(typevar) if typevar.is_typevartuple(db)
@@ -7392,10 +7388,6 @@ fn inferable_typevar_occurrences<'db>(
     impl<'db> TypeVisitor<'db> for InferableTypeVarVisitor<'_, 'db> {
         fn program_environment(&self) -> &ProgramEnvironment<'db> {
             self.env
-        }
-
-        fn should_visit_lazy_type_attributes(&self) -> bool {
-            false
         }
 
         fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -504,10 +504,6 @@ impl<'db> StaticClassLiteral<'db> {
                 self.env
             }
 
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
-            }
-
             fn visit_bound_type_var_type(
                 &self,
                 _db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -106,13 +106,16 @@ use ty_static::EnvVars;
 use crate::types::class::GenericAlias;
 use crate::types::constraints::projection::{ProjectionError, SolutionBudget};
 use crate::types::constraints::support::{Support, SupportId};
+use crate::types::cyclic::{ActiveRecursionDetector, TypeIdentity};
+use crate::types::type_alias::walk_type_alias_with_recursion_guard;
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarInstance, TypeVarSet};
 use crate::types::visitor::{
     TypeCollector, TypeKind, TypeVisitor, walk_non_atomic_type, walk_type_with_recursion_guard,
 };
 use crate::types::{
-    ApplyTypeMappingVisitor, BoundTypeVarInstance, IntersectionType, Parameters, Type, TypeContext,
-    TypeMapping, TypePair, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
+    ApplyTypeMappingVisitor, BoundTypeVarInstance, IntersectionType, KnownInstanceType, Parameters,
+    Type, TypeAliasType, TypeContext, TypeMapping, TypePair, TypeVarBoundOrConstraints,
+    TypeVarVariance, UnionType,
 };
 use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet, ProgramEnvironment};
 
@@ -1345,15 +1348,12 @@ impl<'db> ConstraintSetStorage<'db> {
             storage: RefCell<&'a mut ConstraintSetStorage<'db>>,
             support: RefCell<&'a mut Support>,
             recursion_guard: TypeCollector<'db>,
+            active_type_aliases: ActiveRecursionDetector<TypeIdentity<'db>>,
         }
 
         impl<'db> TypeVisitor<'db> for InternMentionedTypevars<'_, 'db> {
             fn program_environment(&self) -> &ProgramEnvironment<'db> {
                 self.env
-            }
-
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
             }
 
             fn notify_skipped_lazy_type_attributes(&self) {
@@ -1371,7 +1371,17 @@ impl<'db> ConstraintSetStorage<'db> {
                 }
             }
 
+            fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
+                walk_type_alias_with_recursion_guard(db, alias, self, &self.active_type_aliases);
+            }
+
             fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+                if matches!(ty, Type::KnownInstance(KnownInstanceType::TypeAliasType(_))) {
+                    // The alias's value type does not describe its runtime object.
+                    self.notify_skipped_lazy_type_attributes();
+                    return;
+                }
+
                 if let Type::TypeVar(bound_typevar) = ty {
                     let mut storage = self.storage.borrow_mut();
                     let typevar = storage.intern_typevar(db, bound_typevar);
@@ -1387,6 +1397,7 @@ impl<'db> ConstraintSetStorage<'db> {
             storage: RefCell::new(self),
             support: RefCell::new(support),
             recursion_guard: TypeCollector::default(),
+            active_type_aliases: ActiveRecursionDetector::default(),
         }
         .visit_type(db, ty);
     }
@@ -2352,10 +2363,6 @@ fn max_constructor_and_typevar_depth<'db>(
         impl<'db> TypeVisitor<'db> for TypeDepthVisitor<'_, 'db> {
             fn program_environment(&self) -> &ProgramEnvironment<'db> {
                 self.env
-            }
-
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
             }
 
             fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
@@ -4289,6 +4296,13 @@ impl<'db> PathBounds<'db> {
 
                     let constraint = storage.constraint_data(interior.constraint);
                     if !constraint.typevar.is_inferable(db, inferable) {
+                        return ControlFlow::Continue(None);
+                    }
+
+                    // Support includes the constraint's own type variable. A second variable
+                    // can occur in an alias value, which the `has_typevar` check below skips.
+                    let support = storage.constraint_support(interior.constraint);
+                    if support.iter().nth(1).is_some() {
                         return ControlFlow::Continue(None);
                     }
 

--- a/crates/ty_python_semantic/src/types/constraints/sequents.rs
+++ b/crates/ty_python_semantic/src/types/constraints/sequents.rs
@@ -12,7 +12,8 @@ use crate::types::constraints::{
 use crate::types::typevar::TypeVarSet;
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::{
-    TypeCollector, TypeVisitor, any_over_type, walk_type_with_recursion_guard,
+    TypeCollector, TypeVisitor, any_over_typevar_including_lazy_attributes,
+    walk_type_with_recursion_guard,
 };
 use crate::types::{BoundTypeVarInstance, Type, TypeVarVariance};
 use crate::{Db, ProgramEnvironment};
@@ -705,10 +706,11 @@ impl SequentMap {
     ) {
         // Keep this precheck aligned with `variance_of`, which visits lazy types.
         let has_typevar_bound = |constraint: Constraint<'db>| {
-            constraint
-                .iter_stored_bounds()
-                .any(|bound| any_over_type(db, env, bound.ty(), true, Type::is_type_var))
+            constraint.iter_stored_bounds().any(|bound| {
+                any_over_typevar_including_lazy_attributes(db, env, bound.ty(), Type::is_type_var)
+            })
         };
+
         if !has_typevar_bound(storage.constraint_data(left_constraint))
             && !has_typevar_bound(storage.constraint_data(right_constraint))
         {
@@ -1395,10 +1397,8 @@ impl<'db> Type<'db> {
     /// Returns whether this type can participate in a transitive sequent proof.
     ///
     /// Gradual assignability is not transitive, so constraints with dynamic bounds are ineligible.
-    /// Note that we can't use [`is_fully_static`][Type::is_fully_static] here, since that
-    /// considers the declared bounds/constraints of typevars. In the context of a sequent map,
-    /// typevars are opaque symbolic atoms: considering their bounds or defaults could incorrectly
-    /// make their eligibility depend on a specialization that the sequent is meant to constrain.
+    /// Lazy attributes are not expanded, and type variables are treated as symbolic atoms rather
+    /// than inspecting their bounds or defaults.
     pub(super) fn is_static_sequent_eligible(
         self,
         db: &'db dyn Db,
@@ -1413,10 +1413,6 @@ impl<'db> Type<'db> {
         impl<'db> TypeVisitor<'db> for EligibilityVisitor<'_, 'db> {
             fn program_environment(&self) -> &ProgramEnvironment<'db> {
                 self.env
-            }
-
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
             }
 
             fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -33,11 +33,15 @@ use smallvec::SmallVec;
 use ty_python_core::definition::Definition;
 
 use crate::types::function::FunctionLiteral;
-use crate::types::generics::{GenericContext, Specialization};
+use crate::types::generics::{GenericContext, Specialization, walk_specialization_types};
+use crate::types::newtype::{NewType, walk_newtype_base};
+use crate::types::protocol_class::walk_protocol_instance_interface;
+use crate::types::typed_dict::walk_typed_dict_fields;
+use crate::types::typevar::{TypeVarInstance, walk_type_var_attributes};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
 use crate::types::{
-    BoundTypeVarIdentity, BoundTypeVarInstance, ProtocolInstanceType, StaticClassLiteral, Type,
-    TypeAliasType, TypedDictType,
+    BoundTypeVarIdentity, BoundTypeVarInstance, KnownInstanceType, ProtocolInstanceType,
+    StaticClassLiteral, Type, TypeAliasType, TypedDictType,
 };
 use crate::{Db, ProgramEnvironment};
 
@@ -53,6 +57,26 @@ pub enum TypeIdentity<'db> {
 }
 
 impl<'db> Type<'db> {
+    /// Return whether expanding lazy attributes may encounter unbounded recursive specialization.
+    ///
+    /// Specialization-flow analysis omits protocol methods, so a different specialization of an
+    /// active protocol definition is conservatively considered growing.
+    pub(super) fn contains_growing_type(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> bool {
+        let visitor = GrowingTypeVisitor {
+            env,
+            visited_types: TypeCollector::default(),
+            active_types: ActiveRecursionDetector::default(),
+            active_class_protocols: ActiveRecursionDetector::default(),
+            found: Cell::new(false),
+        };
+        visitor.visit_type(db, self);
+        visitor.found.get()
+    }
+
     pub(crate) fn to_type_identity(self, db: &'db dyn Db) -> TypeIdentity<'db> {
         self.recursive_identity(db)
             .unwrap_or(TypeIdentity::Other(self))
@@ -112,6 +136,109 @@ impl<'db> Type<'db> {
             }
             _ => None,
         }
+    }
+}
+
+struct GrowingTypeVisitor<'a, 'db> {
+    env: &'a ProgramEnvironment<'db>,
+    visited_types: TypeCollector<'db>,
+    active_types: ActiveRecursionDetector<TypeIdentity<'db>>,
+    active_class_protocols: ActiveRecursionDetector<StaticClassLiteral<'db>>,
+    found: Cell<bool>,
+}
+
+impl<'db> GrowingTypeVisitor<'_, 'db> {
+    fn visit_lazy_type(&self, db: &'db dyn Db, ty: Type<'db>, visit: impl FnOnce()) {
+        if self.found.get() {
+            return;
+        }
+
+        let identity = ty.to_type_identity(db);
+        if matches!(
+            identity,
+            TypeIdentity::GrowingTypeAlias(_)
+                | TypeIdentity::GrowingProtocol(_)
+                | TypeIdentity::GrowingTypedDict(_)
+        ) && RecursiveDefinition::from_type(db, ty)
+            .is_some_and(|reference| reference.target.generic_context(db).is_some())
+        {
+            self.found.set(true);
+            return;
+        }
+
+        self.active_types.visit(&identity, || {}, visit);
+    }
+}
+
+impl<'db> TypeVisitor<'db> for GrowingTypeVisitor<'_, 'db> {
+    fn program_environment(&self) -> &ProgramEnvironment<'db> {
+        self.env
+    }
+
+    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+        if !self.found.get() {
+            walk_type_with_recursion_guard(db, ty, self, &self.visited_types);
+        }
+    }
+
+    fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
+        self.visit_lazy_type(db, Type::TypeAlias(alias), || {
+            self.visit_type(db, alias.value_type(db));
+        });
+    }
+
+    fn visit_protocol_instance_type(&self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) {
+        let ty = Type::ProtocolInstance(protocol);
+        self.visit_lazy_type(db, ty, || {
+            let visit_members = || {
+                // Bind implicit receivers so a method's `Self` bound does not count as recursion.
+                // Explicit receiver annotations are still inspected.
+                walk_protocol_instance_interface(db, protocol.interface(db), ty, self);
+            };
+
+            let Some((origin, specialization)) = protocol
+                .class_origin(db)
+                .and_then(|class| class.static_class_literal(db))
+            else {
+                visit_members();
+                return;
+            };
+
+            if let Some(specialization) = specialization {
+                // Visit arguments before guarding the definition so `P[P[int]]` is not mistaken
+                // for a recursive protocol definition.
+                walk_specialization_types(db, specialization, self);
+                if self.found.get() {
+                    return;
+                }
+            }
+
+            self.active_class_protocols
+                .visit(&origin, || self.found.set(true), visit_members);
+        });
+    }
+
+    fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
+        self.visit_lazy_type(db, Type::TypedDict(typed_dict), || {
+            if let Some(class) = typed_dict.defining_class() {
+                self.visit_type(db, class.into());
+            }
+            walk_typed_dict_fields(db, typed_dict, self);
+        });
+    }
+
+    fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+        self.visit_lazy_type(
+            db,
+            Type::KnownInstance(KnownInstanceType::TypeVar(typevar)),
+            || walk_type_var_attributes(db, typevar, self),
+        );
+    }
+
+    fn visit_newtype_instance_type(&self, db: &'db dyn Db, newtype: NewType<'db>) {
+        self.visit_lazy_type(db, Type::NewTypeInstance(newtype), || {
+            walk_newtype_base(db, newtype, self);
+        });
     }
 }
 
@@ -625,10 +752,6 @@ impl<'db> TypeVisitor<'db> for SpecializationFlowVisitor<'db> {
         &self.env
     }
 
-    fn should_visit_lazy_type_attributes(&self) -> bool {
-        false
-    }
-
     fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
         if let Type::TypeVar(typevar) = ty {
             let identity = RecursiveDefinition::parameter_identity(db, typevar);
@@ -692,10 +815,6 @@ impl<'a, 'db> SourceParameterCollector<'a, 'db> {
 impl<'db> TypeVisitor<'db> for SourceParameterCollector<'_, 'db> {
     fn program_environment(&self) -> &ProgramEnvironment<'db> {
         self.env
-    }
-
-    fn should_visit_lazy_type_attributes(&self) -> bool {
-        false
     }
 
     fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -658,10 +658,6 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'_, 'db> {
         self.env
     }
 
-    fn should_visit_lazy_type_attributes(&self) -> bool {
-        false
-    }
-
     fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
         match ty {
             Type::ClassLiteral(class) => self.record_class(db, class),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -16,6 +16,7 @@ use crate::types::constraints::{
     Constraint, ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, PathBound,
     PathBoundSolution, PathBounds, SolutionPaths, Solutions, TypeVarSolution,
 };
+use crate::types::cyclic::{ActiveRecursionDetector, TypeIdentity};
 use crate::types::infer::original_class_type;
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation,
@@ -25,7 +26,7 @@ use crate::types::signatures::{Parameters, ReturnCallableTypeVarScope, Signature
 use crate::types::tuple::{
     TupleSpec, TupleSpecBuilder, TupleType, VariableSegment, walk_tuple_type,
 };
-use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
+use crate::types::type_alias::walk_type_alias_with_recursion_guard;
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, TypeVarSet};
 use crate::types::visitor::{
     TypeCollector, TypeVisitor, any_over_type, any_over_type_expanding_aliases,
@@ -745,6 +746,7 @@ impl<'db> GenericContext<'db> {
             env: &'a ProgramEnvironment<'db>,
             locations: RefCell<TypeVarLocations<'db>>,
             recursion_guard: TypeCollector<'db>,
+            active_type_aliases: ActiveRecursionDetector<TypeIdentity<'db>>,
             in_return_type: bool,
             in_callable_type: Cell<Option<CallableType<'db>>>,
         }
@@ -752,10 +754,6 @@ impl<'db> GenericContext<'db> {
         impl<'db> TypeVisitor<'db> for FindTypeVarLocations<'_, 'db> {
             fn program_environment(&self) -> &ProgramEnvironment<'db> {
                 self.env
-            }
-
-            fn should_visit_lazy_type_attributes(&self) -> bool {
-                false
             }
 
             fn visit_bound_type_var_type(
@@ -797,17 +795,12 @@ impl<'db> GenericContext<'db> {
             }
 
             fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
-                // The default implementation would do this for us if we returned `true` from
-                // `should_visit_lazy_type_attributes`. However, this is the _only_ lazy type
-                // attribute that we want to recurse into, so we do it by hand.
-                match type_alias {
-                    TypeAliasType::PEP695(type_alias) => {
-                        walk_pep_695_type_alias(db, type_alias, self);
-                    }
-                    TypeAliasType::ManualPEP695(type_alias) => {
-                        walk_manual_pep_695_type_alias(db, type_alias, self);
-                    }
-                }
+                walk_type_alias_with_recursion_guard(
+                    db,
+                    type_alias,
+                    self,
+                    &self.active_type_aliases,
+                );
             }
 
             fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
@@ -827,6 +820,7 @@ impl<'db> GenericContext<'db> {
             env: &env,
             locations: RefCell::default(),
             recursion_guard: TypeCollector::default(),
+            active_type_aliases: ActiveRecursionDetector::default(),
             in_return_type: false,
             in_callable_type: Cell::default(),
         };
@@ -1721,7 +1715,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // Performance only: `source_top != source` below already handles unchanged
             // arguments. Without expanding aliases, treat them as potentially gradual.
             source.types(db).iter().any(|ty| {
-                any_over_type(db, env, *ty, false, |ty| {
+                any_over_type(db, env, *ty, |ty| {
                     ty.is_dynamic() || matches!(ty, Type::TypeAlias(_))
                 })
             })
@@ -3115,7 +3109,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 .iter_positive(db)
                 .chain(intersection.iter_negative(db))
                 .any(|element| self.has_expanding_cycle(generic_context, types, identity, element)),
-            _ => any_over_type(db, self.env, ty, false, |nested| {
+            _ => any_over_type(db, self.env, ty, |nested| {
                 nested.as_typevar().is_some_and(|dependency| {
                     let dependency = dependency.identity(db);
                     dependency != identity
@@ -3149,7 +3143,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
 
         types.get(&identity).is_some_and(|ty| {
-            any_over_type(db, self.env, *ty, false, |nested| {
+            any_over_type(db, self.env, *ty, |nested| {
                 nested.as_typevar().is_some_and(|dependency| {
                     let dependency = dependency.identity(db);
                     // Recursive specialization skips a typevar's own slot. Only references

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8907,10 +8907,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // types learned for the collection. Until collection-use constraints are represented as
         // projected constraint sets, avoid leaking those method-local typevars into the inferred
         // collection literal type.
-        if any_over_type(db, env, constraint, false, |ty| {
-            ty.as_typevar().is_some_and(|typevar| {
-                !receiver_generic_context.contains(self.db(), typevar.identity(self.db()))
-            })
+        if any_over_type(db, env, constraint, |ty| {
+            ty.as_typevar()
+                .is_some_and(|typevar| !receiver_generic_context.contains(db, typevar.identity(db)))
         }) {
             return None;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -205,7 +205,7 @@ fn check_pep695_function_legacy_typevars<'db>(
     let env = context.program_environment();
     let mut has_legacy_default = false;
     for default in type_params.iter().filter_map(ast::TypeParam::default) {
-        let Some(typevar) = find_over_type(db, env, file_expression_type(default), false, |ty| {
+        let Some(typevar) = find_over_type(db, env, file_expression_type(default), |ty| {
             if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
                 && matches!(
                     typevar.kind(db),
@@ -365,7 +365,7 @@ fn check_legacy_typevar_defaults<'db>(
             continue;
         };
 
-        let first_bad_tvar = find_over_type(db, env, default_ty, false, |t| {
+        let first_bad_tvar = find_over_type(db, env, default_ty, |t| {
             let tvar = match t {
                 Type::TypeVar(tvar) => tvar.typevar(db),
                 Type::KnownInstance(KnownInstanceType::TypeVar(tvar)) => tvar,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -952,7 +952,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                     continue;
                 };
 
-                let first_bad_tvar = find_over_type(db, env, default_ty, false, |t| {
+                let first_bad_tvar = find_over_type(db, env, default_ty, |t| {
                     let tvar = match t {
                         Type::TypeVar(tvar) => tvar.typevar(db),
                         Type::KnownInstance(KnownInstanceType::TypeVar(tvar)) => tvar,

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -27,12 +27,13 @@ use crate::types::typed_dict::{
     TypedDictAssignmentKind, TypedDictExtraItems, TypedDictKeyAssignment,
 };
 use crate::types::typevar::{BindingContext, TypeVarSet};
+use crate::types::visitor::any_over_typevar_including_lazy_attributes;
 use crate::types::{
     BoundTypeVarInstance, CallArguments, CallDunderError, CallableBinding, CycleDetector,
     DisplaySettings, DynamicType, InternedType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
     MemberLookupPolicy, Parameter, Parameters, SpecialFormType, StaticClassLiteral, Type,
     TypeAliasType, TypeAndQualifiers, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-    UnionType, UnionTypeInstance, any_over_type, todo_type,
+    UnionType, UnionTypeInstance, todo_type,
 };
 use crate::{Db, FxOrderSet, ProgramEnvironment};
 use ty_python_core::definition::Definition;
@@ -2559,9 +2560,9 @@ fn legacy_generic_class_context<'db>(
             )
         {
             return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked(None));
-        } else if any_over_type(db, env, argument_ty, true, |inner_ty| match inner_ty {
-            Type::NominalInstance(nominal) => matches!(
-                nominal.known_class(db),
+        } else if any_over_typevar_including_lazy_attributes(db, env, argument_ty, |ty| match ty {
+            Type::NominalInstance(instance) => matches!(
+                instance.known_class(db),
                 Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple)
             ),
             _ => false,

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1593,9 +1593,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // variables with a `@Todo` type (since we don't know which of the type arguments
         // belongs to the remaining type variables).
         //
-        // A lazily inferred class member can contain its own unrelated recursive type, so only
-        // inspect the alias structure and generic arguments when checking whether it is recursive.
-        if any_over_type(db, env, value_ty, false, |ty| ty.is_divergent()) {
+        // Recursion in a lazy attribute does not lose type variables from the stored alias type.
+        if any_over_type(db, env, value_ty, |ty| ty.is_divergent()) {
             let value_ty = value_ty.apply_specialization(
                 db,
                 generic_context.specialize(

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -38,7 +38,7 @@ fn contains_generic_typed_dict<'db>(
     ty: Type<'db>,
     active_aliases: &ActiveRecursionDetector<Definition<'db>>,
 ) -> bool {
-    any_over_type(db, env, ty, false, |nested| match nested {
+    any_over_type(db, env, ty, |nested| match nested {
         Type::TypedDict(_) => nested.has_typevar(db, env),
         Type::TypeAlias(alias) => active_aliases.visit(
             &alias.definition(db),
@@ -542,7 +542,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .as_static()
             .zip(call_expression_tcx.annotation)
             .is_some_and(|(class_literal, annotation)| {
-                any_over_type(db, env, annotation.resolve_type_alias(db), false, |ty| {
+                any_over_type(db, env, annotation.resolve_type_alias(db), |ty| {
                     ty.resolve_type_alias(db)
                         .specialization_of(db, env, class_literal)
                         .is_some_and(|specialization| {

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -490,7 +490,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
         let expected_binding = BindingContext::Definition(expected_binding_def);
 
-        let outer_tv = find_over_type(db, self.program_environment(), default_ty, false, |ty| {
+        let outer_tv = find_over_type(db, self.program_environment(), default_ty, |ty| {
             if let Type::TypeVar(bound_tv) = ty
                 && bound_tv.binding_context(db) != expected_binding
             {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1045,15 +1045,11 @@ fn non_recursive_protocol_interface<'db>(
             self.env
         }
 
-        fn should_visit_lazy_type_attributes(&self) -> bool {
-            false
-        }
-
-        fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
+        fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
             self.active_aliases.visit(
-                &Type::TypeAlias(type_alias).to_type_identity(db),
+                &Type::TypeAlias(alias).to_type_identity(db),
                 || self.found.set(true),
-                || self.visit_type(db, type_alias.value_type(db)),
+                || self.visit_type(db, alias.value_type(db)),
             );
         }
 
@@ -1065,9 +1061,7 @@ fn non_recursive_protocol_interface<'db>(
             if ty
                 .as_protocol_instance()
                 .and_then(|protocol| protocol.nominal_origin_instance(db))
-                .is_some_and(|instance| {
-                    instance.class_literal(db, self.program_environment()) == self.origin
-                })
+                .is_some_and(|instance| instance.class_literal(db, self.env) == self.origin)
             {
                 self.found.set(true);
                 return;
@@ -1302,26 +1296,22 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
     protocol: ProtocolInstanceType<'db>,
     visitor: &V,
 ) {
-    if visitor.should_visit_lazy_type_attributes() {
-        walk_protocol_interface(db, protocol.interface(db), visitor);
-    } else {
-        match protocol.inner {
-            Protocol::FromClass(_) | Protocol::Materialized(_) => {
-                visitor.notify_skipped_lazy_type_attributes();
-                if let Some((_, Some(specialization))) = protocol
-                    .class_origin(db)
-                    .and_then(|class| class.static_class_literal(db))
-                {
-                    walk_specialization(db, specialization, visitor);
-                }
+    match protocol.inner {
+        Protocol::FromClass(_) | Protocol::Materialized(_) => {
+            visitor.notify_skipped_lazy_type_attributes();
+            if let Some((_, Some(specialization))) = protocol
+                .class_origin(db)
+                .and_then(|class| class.static_class_literal(db))
+            {
+                walk_specialization(db, specialization, visitor);
             }
-            Protocol::Synthesized(synthesized) => {
-                walk_protocol_interface(
-                    db,
-                    ProtocolInterfaceView::new(synthesized.interface(), None),
-                    visitor,
-                );
-            }
+        }
+        Protocol::Synthesized(synthesized) => {
+            walk_protocol_interface(
+                db,
+                ProtocolInterfaceView::new(synthesized.interface(), None),
+                visitor,
+            );
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -15,7 +15,6 @@ use crate::types::equality::{
 };
 use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
-use crate::types::visitor::any_over_type;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass,
     Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext,
@@ -1017,7 +1016,7 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
     if tuple
         .all_elements()
         .iter()
-        .any(|element| any_over_type(db, env, *element, true, |ty| ty.is_dynamic()))
+        .any(|element| !element.is_fully_static(db, env))
     {
         return Ok(None);
     }

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -255,23 +255,29 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
     }
 }
 
-pub(crate) fn walk_newtype_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+/// Visit a newtype's base if it is already stored, without evaluating the declaration.
+pub(super) fn walk_newtype_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     newtype: NewType<'db>,
     visitor: &V,
 ) {
-    let base = if visitor.should_visit_lazy_type_attributes() {
-        Some(newtype.base(db))
-    } else {
-        let base = newtype.eager_base(db);
-        if base.is_none() {
-            visitor.notify_skipped_lazy_type_attributes();
-        }
-        base
-    };
-    if let Some(base) = base {
+    if let Some(base) = newtype.eager_base(db) {
         visitor.visit_type(db, base.instance_type(db, visitor.program_environment()));
+    } else {
+        visitor.notify_skipped_lazy_type_attributes();
     }
+}
+
+/// Evaluate and visit the instance type of a newtype's base.
+///
+/// The caller must guard against recursive newtypes.
+pub(super) fn walk_newtype_base<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    newtype: NewType<'db>,
+    visitor: &V,
+) {
+    let base = newtype.base(db);
+    visitor.visit_type(db, base.instance_type(db, visitor.program_environment()));
 }
 
 /// `typing.NewType` typically wraps a class type, but it can also wrap another newtype.

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2295,7 +2295,7 @@ fn descriptor_decorated_protocol_member<'db>(
     // variable can currently materialize that variable as `Unknown`. Reducing the descriptor to
     // its `__get__` result would then erase the remaining descriptor structure and weaken the
     // protocol member to a bare `Unknown`.
-    if super::visitor::any_over_type(db, env, descriptor_ty, false, |ty| ty.is_unknown()) {
+    if super::visitor::any_over_type(db, env, descriptor_ty, |ty| ty.is_unknown()) {
         return None;
     }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1079,9 +1079,7 @@ impl<'db> UnionBuilder<'db> {
                 // type arguments. A recursive alias can rebuild this union during specialization.
                 if !self.unpack_aliases
                     && [ty, element_type].into_iter().any(|ty| {
-                        any_over_type(db, &self.env, ty, false, |ty| {
-                            matches!(ty, Type::TypeAlias(_))
-                        })
+                        any_over_type(db, &self.env, ty, |ty| matches!(ty, Type::TypeAlias(_)))
                     })
                 {
                     continue;

--- a/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
@@ -1,6 +1,5 @@
 use crate::types::generics::specialization_variance;
 use crate::types::tuple::TupleSpec;
-use crate::types::visitor::contains_growing_type;
 use crate::types::{
     ClassBase, ClassType, IntersectionType, KnownClass, MaterializationKind, Type, TypeVarVariance,
     UnionType,
@@ -105,7 +104,7 @@ fn base_top_intersection<'db>(
     // Inspect lazy attributes only after establishing that the classes are related. Expanding a
     // recursive generic alias or member can re-enter intersection simplification with ever-growing
     // type arguments. Exact recursive specializations can still be checked.
-    if contains_growing_type(db, env, base) {
+    if base.contains_growing_type(db, env) {
         return Some(GenericIntersection::Recursive);
     }
     if base_specialization.materialization_kind(db).is_some()

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2565,7 +2565,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             && target.resolve_type_alias(db).is_dynamic()
             && let Type::TypeVar(typevar) = source.return_ty.resolve_type_alias(db)
             && source.parameters().iter().any(|parameter| {
-                any_over_type(db, self.env, parameter.annotated_type(), false, |ty| {
+                any_over_type(db, self.env, parameter.annotated_type(), |ty| {
                     matches!(ty, Type::TypeVar(other) if other.is_same_typevar_as(db, typevar))
                 })
             })

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -1,13 +1,104 @@
 use crate::Db;
 use crate::ProgramEnvironment;
 use rustc_hash::FxHashSet;
+use std::cell::Cell;
 
 use ruff_python_ast::{self as ast};
 
+use crate::types::cyclic::{ActiveRecursionDetector, TypeIdentity};
+use crate::types::newtype::{NewType, walk_newtype_base};
 use crate::types::tuple::TupleSpec;
-use crate::types::typevar::BoundTypeVarIdentity;
-use crate::types::visitor::any_over_type;
-use crate::types::{Type, UnionBuilder};
+use crate::types::typevar::{BoundTypeVarIdentity, TypeVarInstance, walk_type_var_bounds};
+use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
+use crate::types::{IntersectionType, KnownInstanceType, Type, TypeAliasType, UnionBuilder};
+
+/// Return whether the outer type may be a tuple, without searching nested arguments or members.
+/// A recursion cutoff conservatively counts as a possible tuple.
+fn may_be_tuple<'db>(db: &'db dyn Db, env: &ProgramEnvironment<'db>, ty: Type<'db>) -> bool {
+    struct TupleShapeVisitor<'a, 'db> {
+        env: &'a ProgramEnvironment<'db>,
+        recursion_guard: TypeCollector<'db>,
+        active_types: ActiveRecursionDetector<TypeIdentity<'db>>,
+        may_be_tuple: Cell<bool>,
+    }
+
+    impl<'db> TupleShapeVisitor<'_, 'db> {
+        fn visit_guarded(&self, db: &'db dyn Db, ty: Type<'db>, visit: impl FnOnce()) {
+            self.active_types.visit(
+                &ty.to_type_identity(db),
+                || self.may_be_tuple.set(true),
+                visit,
+            );
+        }
+    }
+
+    impl<'db> TypeVisitor<'db> for TupleShapeVisitor<'_, 'db> {
+        fn program_environment(&self) -> &ProgramEnvironment<'db> {
+            self.env
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.may_be_tuple.get() {
+                return;
+            }
+
+            if ty.tuple_instance_spec(db, self.env).is_some() {
+                self.may_be_tuple.set(true);
+                return;
+            }
+
+            if matches!(
+                ty,
+                Type::Union(_)
+                    | Type::Intersection(_)
+                    | Type::TypeAlias(_)
+                    | Type::NewTypeInstance(_)
+                    | Type::TypeVar(_)
+            ) {
+                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            }
+        }
+
+        fn visit_intersection_type(&self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
+            for element in intersection.iter_positive(db) {
+                self.visit_type(db, element);
+            }
+        }
+
+        fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
+            self.visit_guarded(db, Type::TypeAlias(alias), || {
+                self.visit_type(db, alias.value_type(db));
+            });
+        }
+
+        fn visit_newtype_instance_type(&self, db: &'db dyn Db, newtype: NewType<'db>) {
+            self.visit_guarded(db, Type::NewTypeInstance(newtype), || {
+                walk_newtype_base(db, newtype, self);
+            });
+        }
+
+        fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+            self.visit_guarded(
+                db,
+                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)),
+                || {
+                    if let Some(bounds) = typevar.bound_or_constraints(db, self.env) {
+                        walk_type_var_bounds(db, bounds, self);
+                    }
+                },
+            );
+        }
+    }
+
+    let visitor = TupleShapeVisitor {
+        env,
+        recursion_guard: TypeCollector::default(),
+        active_types: ActiveRecursionDetector::default(),
+        may_be_tuple: Cell::new(false),
+    };
+    visitor.visit_type(db, ty);
+    visitor.may_be_tuple.get()
+}
 
 /// Tracks the typevars of a collection to which tuple size promotion should **not** apply.
 #[derive(Default)]
@@ -35,8 +126,7 @@ impl<'db> TupleSizePromotionConstraints<'db> {
         }
     }
 
-    /// Records that a typevar is ineligible for tuple size promotion if the given type contains
-    /// a tuple type.
+    /// Block tuple size promotion if this type variable is assigned a possible tuple type.
     pub(crate) fn record_unpromotable_type(
         &mut self,
         db: &'db dyn Db,
@@ -73,9 +163,7 @@ impl<'db> TupleSizePromotionConstraints<'db> {
     ) -> bool {
         expression
             .is_some_and(|expression| Self::is_promotable_tuple_literal(db, env, expression, ty))
-            || !any_over_type(db, env, ty, true, |ty| {
-                ty.tuple_instance_spec(db, env).is_some()
-            })
+            || !may_be_tuple(db, env, ty)
     }
 
     /// Returns true if the given expression is either a non-starred homogeneous tuple literal or the

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -6,9 +6,11 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
         GenericContext, KnownClass, KnownInstanceType, MaterializationKind, Type, TypeContext,
-        TypeMapping, TypeRecursionContext, TypingModule, VarianceTerm, definition_expression_type,
+        TypeMapping, TypeRecursionContext, TypingModule, VarianceTerm,
+        cyclic::{ActiveRecursionDetector, TypeIdentity},
+        definition_expression_type,
         display::qualified_name_components_from_scope,
-        generics::{ApplySpecialization, Specialization, bind_typevar},
+        generics::{ApplySpecialization, Specialization, bind_typevar, walk_specialization_types},
         variance::{VarianceInferable, VarianceOrigin},
         visitor,
     },
@@ -116,14 +118,6 @@ pub struct PEP695TypeAliasType<'db> {
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for PEP695TypeAliasType<'_> {}
-
-pub(super) fn walk_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
-    db: &'db dyn Db,
-    type_alias: PEP695TypeAliasType<'db>,
-    visitor: &V,
-) {
-    visitor.visit_type(db, TypeAliasType::PEP695(type_alias).value_type(db));
-}
 
 #[salsa::tracked]
 impl<'db> PEP695TypeAliasType<'db> {
@@ -236,14 +230,6 @@ pub struct ManualPEP695TypeAliasType<'db> {
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for ManualPEP695TypeAliasType<'_> {}
-
-pub(super) fn walk_manual_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
-    db: &'db dyn Db,
-    type_alias: ManualPEP695TypeAliasType<'db>,
-    visitor: &V,
-) {
-    visitor.visit_type(db, TypeAliasType::ManualPEP695(type_alias).value_type(db));
-}
 
 #[salsa::tracked]
 impl<'db> ManualPEP695TypeAliasType<'db> {
@@ -387,23 +373,33 @@ pub enum TypeAliasType<'db> {
     ManualPEP695(ManualPEP695TypeAliasType<'db>),
 }
 
-pub(super) fn walk_type_alias_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+/// Visit an alias's type arguments without evaluating its value.
+pub(super) fn walk_type_alias_arguments<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     type_alias: TypeAliasType<'db>,
     visitor: &V,
 ) {
-    if !visitor.should_visit_lazy_type_attributes() {
-        visitor.notify_skipped_lazy_type_attributes();
-        return;
+    if let Some(specialization) = type_alias.specialization(db) {
+        walk_specialization_types(db, specialization, visitor);
     }
-    match type_alias {
-        TypeAliasType::PEP695(type_alias) => {
-            walk_pep_695_type_alias(db, type_alias, visitor);
-        }
-        TypeAliasType::ManualPEP695(type_alias) => {
-            walk_manual_pep_695_type_alias(db, type_alias, visitor);
-        }
-    }
+}
+
+/// Visit an alias's value, falling back to its arguments when the recursion guard is hit.
+/// A skipped value is reported through [`visitor::TypeVisitor::notify_skipped_lazy_type_attributes`].
+pub(super) fn walk_type_alias_with_recursion_guard<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    alias: TypeAliasType<'db>,
+    visitor: &V,
+    recursion_guard: &ActiveRecursionDetector<TypeIdentity<'db>>,
+) {
+    recursion_guard.visit(
+        &Type::TypeAlias(alias).to_type_identity(db),
+        || {
+            visitor.notify_skipped_lazy_type_attributes();
+            walk_type_alias_arguments(db, alias, visitor);
+        },
+        || visitor.visit_type(db, alias.value_type(db)),
+    );
 }
 
 #[salsa::tracked]

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1353,13 +1353,19 @@ pub(crate) fn walk_typed_dict_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
 ) {
     if let TypedDictType::Class(defining_class) = typed_dict {
         visitor.visit_type(db, defining_class.into());
-
-        if !visitor.should_visit_lazy_type_attributes() {
-            visitor.notify_skipped_lazy_type_attributes();
-            return;
-        }
+        visitor.notify_skipped_lazy_type_attributes();
+        return;
     }
 
+    walk_typed_dict_fields(db, typed_dict, visitor);
+}
+
+/// Visit a `TypedDict`'s declared field types, including its extra-item type.
+pub(super) fn walk_typed_dict_fields<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    visitor: &V,
+) {
     for field in typed_dict.items(db).values() {
         visitor.visit_type(db, field.declared_ty);
     }

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -18,11 +18,14 @@ use crate::{
         ApplySpecialization, ApplyTypeMappingVisitor, CycleDetector, DynamicType, GenericContext,
         InstanceProjection, IntersectionType, KnownClass, KnownInstanceType, MaterializationKind,
         Parameter, Parameters, Specialization, Type, TypeAliasType, TypeContext, TypeMapping,
-        TypeVarVariance, UnionBuilder, UnionType, any_over_type,
-        any_over_type_including_alias_arguments, binding_type, definition_expression_type,
+        TypeVarVariance, UnionBuilder, UnionType, any_over_type, binding_type,
+        definition_expression_type,
         tuple::Tuple,
         variance::VarianceInferable,
-        visitor::{self, TypeCollector, TypeVisitor, walk_type_with_recursion_guard},
+        visitor::{
+            self, TypeCollector, TypeVisitor, any_over_type_including_alias_arguments,
+            walk_type_with_recursion_guard,
+        },
     },
 };
 use ty_python_core::{
@@ -43,8 +46,9 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Return whether this type contains type variables without expanding lazy attributes.
     pub(crate) fn has_typevar(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
-        any_over_type(db, env, self, false, |ty| matches!(ty, Type::TypeVar(_)))
+        any_over_type(db, env, self, Type::is_type_var)
     }
 
     pub(crate) fn references_typevar(
@@ -53,8 +57,8 @@ impl<'db> Type<'db> {
         env: &ProgramEnvironment<'db>,
         typevar_id: TypeVarIdentity<'db>,
     ) -> bool {
-        any_over_type(db, env, self, false, |ty| match ty {
-            Type::TypeVar(bound_typevar) => typevar_id == bound_typevar.typevar(db).identity(db),
+        any_over_type(db, env, self, |ty| match ty {
+            Type::TypeVar(typevar) => typevar_id == typevar.typevar(db).identity(db),
             Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
                 typevar_id == typevar.identity(db)
             }
@@ -101,8 +105,7 @@ impl<'db> Type<'db> {
             db,
             env,
             self,
-            false,
-            |ty| matches!(ty, Type::TypeVar(tv) if !tv.typevar(db).is_self(db)),
+            |ty| matches!(ty, Type::TypeVar(typevar) if !typevar.typevar(db).is_self(db)),
         )
     }
 
@@ -111,7 +114,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> bool {
-        any_over_type(db, env, self, false, |ty| {
+        any_over_type(db, env, self, |ty| {
             matches!(
                 ty,
                 Type::KnownInstance(KnownInstanceType::TypeVar(_)) | Type::TypeVar(_)
@@ -124,7 +127,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> bool {
-        any_over_type(db, env, self, false, |ty| {
+        any_over_type(db, env, self, |ty| {
             matches!(ty, Type::Dynamic(DynamicType::UnspecializedTypeVar))
         })
     }
@@ -134,7 +137,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> bool {
-        any_over_type(db, env, self, false, |ty| {
+        any_over_type(db, env, self, |ty| {
             ty.as_dynamic()
                 .is_some_and(DynamicType::is_provisional_marker)
         })
@@ -203,38 +206,38 @@ pub(super) fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     typevar: TypeVarInstance<'db>,
     visitor: &V,
 ) {
-    if let Some(bound_or_constraints) = if visitor.should_visit_lazy_type_attributes() {
-        typevar.bound_or_constraints(db, visitor.program_environment())
-    } else {
-        match typevar._bound_or_constraints(db) {
-            Some(TypeVarBoundOrConstraintsEvaluation::Eager(bound_or_constraints)) => {
-                Some(bound_or_constraints)
-            }
-            Some(
-                TypeVarBoundOrConstraintsEvaluation::LazyUpperBound
-                | TypeVarBoundOrConstraintsEvaluation::LazyConstraints,
-            ) => {
-                visitor.notify_skipped_lazy_type_attributes();
-                None
-            }
-            _ => None,
+    match typevar._bound_or_constraints(db) {
+        Some(TypeVarBoundOrConstraintsEvaluation::Eager(bounds)) => {
+            walk_type_var_bounds(db, bounds, visitor);
         }
-    } {
-        walk_type_var_bounds(db, bound_or_constraints, visitor);
+        Some(
+            TypeVarBoundOrConstraintsEvaluation::LazyUpperBound
+            | TypeVarBoundOrConstraintsEvaluation::LazyConstraints,
+        ) => visitor.notify_skipped_lazy_type_attributes(),
+        None => {}
     }
-    if let Some(default_type) = if visitor.should_visit_lazy_type_attributes() {
-        typevar.default_type(db, visitor.program_environment())
-    } else {
-        match typevar._default(db) {
-            Some(TypeVarDefaultEvaluation::Eager(default_type)) => Some(default_type),
-            Some(TypeVarDefaultEvaluation::Lazy) => {
-                visitor.notify_skipped_lazy_type_attributes();
-                None
-            }
-            _ => None,
-        }
-    } {
-        visitor.visit_type(db, default_type);
+
+    match typevar._default(db) {
+        Some(TypeVarDefaultEvaluation::Eager(default)) => visitor.visit_type(db, default),
+        Some(TypeVarDefaultEvaluation::Lazy) => visitor.notify_skipped_lazy_type_attributes(),
+        None => {}
+    }
+}
+
+/// Evaluate and visit a type variable's bounds, constraints, and default.
+///
+/// The caller must guard against recursive types.
+pub(super) fn walk_type_var_attributes<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+    db: &'db dyn Db,
+    typevar: TypeVarInstance<'db>,
+    visitor: &V,
+) {
+    let env = visitor.program_environment();
+    if let Some(bounds) = typevar.bound_or_constraints(db, env) {
+        walk_type_var_bounds(db, bounds, visitor);
+    }
+    if let Some(default) = typevar.default_type(db, env) {
+        visitor.visit_type(db, default);
     }
 }
 
@@ -536,7 +539,7 @@ impl<'db> TypeVarInstance<'db> {
             self_identity: TypeVarIdentity<'db>,
         ) -> bool {
             let db = state.db;
-            any_over_type(db, state.env, ty, false, |inner_ty| match inner_ty {
+            any_over_type(db, state.env, ty, |inner_ty| match inner_ty {
                 Type::TypeVar(bound_typevar) => typevar_default_is_self_referential(
                     state,
                     bound_typevar.typevar(db),
@@ -946,10 +949,6 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
     impl<'db> TypeVisitor<'db> for MatchingFreshnessCollector<'_, 'db> {
         fn program_environment(&self) -> &ProgramEnvironment<'db> {
             self.env
-        }
-
-        fn should_visit_lazy_type_attributes(&self) -> bool {
-            false
         }
 
         fn visit_bound_type_var_type(
@@ -2188,7 +2187,7 @@ pub enum TypeVarBoundOrConstraints<'db> {
     Constraints(TypeVarConstraints<'db>),
 }
 
-fn walk_type_var_bounds<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
+pub(super) fn walk_type_var_bounds<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     bounds: TypeVarBoundOrConstraints<'db>,
     visitor: &V,

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -22,27 +22,24 @@ use crate::types::{
     instance::{walk_nominal_instance_type, walk_protocol_instance_type},
     known_instance::walk_known_instance_type,
     method::{walk_bound_method_type, walk_method_wrapper_type},
-    newtype::{NewType, walk_newtype_instance_type},
-    protocol_class::walk_protocol_instance_interface,
+    newtype::{NewType, walk_newtype_base, walk_newtype_instance_type},
+    protocol_class::{walk_protocol_instance_interface, walk_protocol_interface},
     set_theoretic::{walk_intersection_type, walk_union},
     subclass_of::walk_subclass_of_type,
-    type_alias::walk_type_alias_type,
+    type_alias::walk_type_alias_arguments,
     type_form::walk_typeform_type,
-    typed_dict::walk_typed_dict_type,
-    typevar::{TypeVarInstance, walk_bound_type_var_type, walk_type_var_type},
+    typed_dict::{walk_typed_dict_fields, walk_typed_dict_type},
+    typevar::{
+        TypeVarInstance, walk_bound_type_var_type, walk_type_var_attributes, walk_type_var_type,
+    },
     walk_property_instance_type, walk_typeguard_type, walk_typeis_type,
 };
 
-/// A visitor trait that recurses into nested types.
+/// Visit a type and the types it contains.
 ///
-/// The trait does not guard against infinite recursion out of the box,
-/// but it makes it easy for implementors of the trait to do so.
-/// See [`any_over_type`] for an example of how to do this.
+/// Lazy type attributes are skipped by default, and recursion guards are left to the visitor.
 pub(crate) trait TypeVisitor<'db> {
     fn program_environment(&self) -> &ProgramEnvironment<'db>;
-
-    /// Should the visitor trigger inference of and visit lazily-inferred type attributes?
-    fn should_visit_lazy_type_attributes(&self) -> bool;
 
     /// Notify the visitor that lazily-inferred type attributes were not visited.
     fn notify_skipped_lazy_type_attributes(&self) {}
@@ -135,8 +132,8 @@ pub(crate) trait TypeVisitor<'db> {
         walk_known_instance_type(db, known_instance, self);
     }
 
-    fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
-        walk_type_alias_type(db, type_alias, self);
+    fn visit_type_alias_type(&self, _db: &'db dyn Db, _type_alias: TypeAliasType<'db>) {
+        self.notify_skipped_lazy_type_attributes();
     }
 
     fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
@@ -445,9 +442,9 @@ pub(super) fn dynamic_content<'db>(
 
 /// Whether both materializations preserve the requirements described by `ty`.
 ///
-/// Unlike ordinary static-content checks, this proof cannot ignore lazy function signatures or
-/// the wrapped callable of a partial. It does not compare metadata such as parameter-default types,
-/// which do not affect whether one callable satisfies another's requirements.
+/// This also accounts for lazy function signatures and a partial's wrapped callable, which ordinary
+/// staticness checks can skip. Parameter-default types do not affect callable compatibility and are
+/// not inspected.
 pub(super) fn materialization_is_noop<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -457,6 +454,9 @@ pub(super) fn materialization_is_noop<'db>(
 }
 
 /// Determine whether `ty` contains a dynamic type other than `Any`.
+///
+/// Type-variable bounds and constraints are included. A bound of `Unknown` prevents a redundant-cast
+/// diagnostic even when the source and target types are considered equivalent.
 ///
 /// Class-based protocol interfaces can be recursively specialized. An exact recursive cycle adds
 /// no new information, but revisiting the same protocol definition under a different
@@ -491,7 +491,7 @@ fn dynamic_content_impl<'db>(
         recursion_guard: TypeCollector<'db>,
         active_class_protocols: ActiveRecursionDetector<StaticClassLiteral<'db>>,
         active_class_typed_dicts: ActiveRecursionDetector<StaticClassLiteral<'db>>,
-        active_type_aliases: ActiveRecursionDetector<Definition<'db>>,
+        active_types: ActiveRecursionDetector<TypeIdentity<'db>>,
         content: Cell<DynamicContent>,
         mode: DynamicContentMode,
     }
@@ -507,10 +507,6 @@ fn dynamic_content_impl<'db>(
     impl<'db> TypeVisitor<'db> for DynamicContentVisitor<'_, 'db> {
         fn program_environment(&self) -> &ProgramEnvironment<'db> {
             self.env
-        }
-
-        fn should_visit_lazy_type_attributes(&self) -> bool {
-            true
         }
 
         fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
@@ -562,6 +558,20 @@ fn dynamic_content_impl<'db>(
             }
         }
 
+        fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+            if !self.content.get().is_absent() {
+                return;
+            }
+
+            // Revisiting this type variable adds no new content. The original visit still
+            // checks its remaining bounds and default.
+            self.active_types.visit(
+                &Type::KnownInstance(KnownInstanceType::TypeVar(typevar)).to_type_identity(db),
+                || {},
+                || walk_type_var_attributes(db, typevar, self),
+            );
+        }
+
         fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
             // Use `walk_specialization_types` rather than `walk_specialization` to avoid walking
             // the bounds/constraints/defaults of the generic context.
@@ -571,135 +581,19 @@ fn dynamic_content_impl<'db>(
         }
 
         fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
-            self.active_type_aliases.visit(
-                &alias.definition(db),
+            self.active_types.visit(
+                &Type::TypeAlias(alias).to_type_identity(db),
                 || self.record(DynamicContent::Indeterminate),
-                || walk_type_alias_type(db, alias, self),
+                || self.visit_type(db, alias.value_type(db)),
             );
         }
 
-        fn visit_protocol_instance_type(
-            &self,
-            db: &'db dyn Db,
-            protocol: ProtocolInstanceType<'db>,
-        ) {
-            let protocol_ty = Type::ProtocolInstance(protocol);
-            let Some(class) = protocol.class_origin(db) else {
-                walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
-                return;
-            };
-            let Some((origin, specialization)) = class.static_class_literal(db) else {
-                walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
-                return;
-            };
-
-            if let Some(specialization) = specialization {
-                // Bounds and defaults in the generic context do not describe the specialized
-                // instance; only inspect the types assigned to its parameters.
-                for ty in specialization.types(db) {
-                    self.visit_type(db, *ty);
-                    if !self.content.get().is_absent() {
-                        return;
-                    }
-                }
-            }
-
-            self.active_class_protocols.visit(
-                &origin,
+        fn visit_newtype_instance_type(&self, db: &'db dyn Db, newtype: NewType<'db>) {
+            self.active_types.visit(
+                &Type::NewTypeInstance(newtype).to_type_identity(db),
                 || self.record(DynamicContent::Indeterminate),
-                || {
-                    walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
-                },
+                || walk_newtype_base(db, newtype, self),
             );
-        }
-
-        fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
-            let Some(class) = typed_dict.defining_class() else {
-                walk_typed_dict_type(db, typed_dict, self);
-                return;
-            };
-            let Some((origin, _)) = class.static_class_literal(db) else {
-                walk_typed_dict_type(db, typed_dict, self);
-                return;
-            };
-
-            self.active_class_typed_dicts.visit(
-                &origin,
-                || self.record(DynamicContent::Indeterminate),
-                || walk_typed_dict_type(db, typed_dict, self),
-            );
-        }
-    }
-
-    let visitor = DynamicContentVisitor {
-        env,
-        recursion_guard: TypeCollector::default(),
-        active_class_protocols: ActiveRecursionDetector::default(),
-        active_class_typed_dicts: ActiveRecursionDetector::default(),
-        active_type_aliases: ActiveRecursionDetector::default(),
-        content: Cell::new(DynamicContent::Absent),
-        mode,
-    };
-    visitor.visit_type(db, ty);
-    visitor.content.get()
-}
-
-/// Whether inspecting `ty` can encounter recursive types with changing specializations.
-///
-/// Exact recursive types are safe to inspect once. For protocol methods, conservatively treat
-/// a new specialization of an active protocol definition as potentially growing: their signatures
-/// are not included in the specialization-flow analysis used by [`TypeIdentity`].
-pub(super) fn contains_growing_type<'db>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    ty: Type<'db>,
-) -> bool {
-    struct GrowingTypeVisitor<'a, 'db> {
-        env: &'a ProgramEnvironment<'db>,
-        recursion_guard: TypeCollector<'db>,
-        active_class_protocols: ActiveRecursionDetector<StaticClassLiteral<'db>>,
-        found: Cell<bool>,
-    }
-
-    impl<'db> TypeVisitor<'db> for GrowingTypeVisitor<'_, 'db> {
-        fn program_environment(&self) -> &ProgramEnvironment<'db> {
-            self.env
-        }
-
-        fn should_visit_lazy_type_attributes(&self) -> bool {
-            true
-        }
-
-        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-            if self.found.get() {
-                return;
-            }
-
-            let is_generic = match ty {
-                Type::TypeAlias(alias) => alias.generic_context(db).is_some(),
-                Type::ProtocolInstance(protocol) => protocol
-                    .class_origin(db)
-                    .and_then(|class| class.class_literal(db).generic_context(db))
-                    .is_some(),
-                Type::TypedDict(typed_dict) => typed_dict
-                    .defining_class()
-                    .and_then(|class| class.class_literal(db).generic_context(db))
-                    .is_some(),
-                _ => false,
-            };
-            if is_generic
-                && matches!(
-                    ty.to_type_identity(db),
-                    TypeIdentity::GrowingTypeAlias(_)
-                        | TypeIdentity::GrowingProtocol(_)
-                        | TypeIdentity::GrowingTypedDict(_)
-                )
-            {
-                self.found.set(true);
-                return;
-            }
-
-            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
         }
 
         fn visit_protocol_instance_type(
@@ -717,218 +611,348 @@ pub(super) fn contains_growing_type<'db>(
             };
 
             if let Some(specialization) = specialization {
-                // Inspect arguments before activating the definition so finite nesting such as
-                // `P[P[int]]` does not look like an expanding recursive declaration.
                 walk_specialization_types(db, specialization, self);
-                if self.found.get() {
+                if !self.content.get().is_absent() {
                     return;
                 }
             }
 
             self.active_class_protocols.visit(
                 &origin,
-                || self.found.set(true),
+                || self.record(DynamicContent::Indeterminate),
                 || {
-                    // Bind implicit receivers so they do not introduce recursive edges of their
-                    // own. Explicitly recursive method signatures still need to be inspected.
                     walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
                 },
             );
         }
+
+        fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
+            let Some((origin, specialization)) = typed_dict
+                .defining_class()
+                .and_then(|class| class.static_class_literal(db))
+            else {
+                walk_typed_dict_fields(db, typed_dict, self);
+                return;
+            };
+
+            if let Some(specialization) = specialization {
+                walk_specialization_types(db, specialization, self);
+                if !self.content.get().is_absent() {
+                    return;
+                }
+            }
+
+            self.active_class_typed_dicts.visit(
+                &origin,
+                || self.record(DynamicContent::Indeterminate),
+                || walk_typed_dict_fields(db, typed_dict, self),
+            );
+        }
     }
 
-    let visitor = GrowingTypeVisitor {
+    let visitor = DynamicContentVisitor {
         env,
         recursion_guard: TypeCollector::default(),
         active_class_protocols: ActiveRecursionDetector::default(),
+        active_class_typed_dicts: ActiveRecursionDetector::default(),
+        active_types: ActiveRecursionDetector::default(),
+        content: Cell::new(DynamicContent::Absent),
+        mode,
+    };
+    visitor.visit_type(db, ty);
+    visitor.content.get()
+}
+
+/// Search for type-variable occurrences, including in lazy attributes.
+///
+/// This includes variables bound by nested callables, not just free variables. Return `true` if
+/// recursive specialization prevents a complete search.
+pub(super) fn any_over_typevar_including_lazy_attributes<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+    query: impl Fn(Type<'db>) -> bool,
+) -> bool {
+    struct TypeVarOccurrenceVisitor<'a, 'db> {
+        env: &'a ProgramEnvironment<'db>,
+        query: &'a dyn Fn(Type<'db>) -> bool,
+        visited_types: TypeCollector<'db>,
+        active_types: ActiveRecursionDetector<TypeIdentity<'db>>,
+        active_protocols: ActiveRecursionDetector<Definition<'db>>,
+        found: Cell<bool>,
+    }
+
+    impl<'db> TypeVarOccurrenceVisitor<'_, 'db> {
+        fn visit_guarded(&self, db: &'db dyn Db, ty: Type<'db>, visit: impl FnOnce()) {
+            let identity = ty.to_type_identity(db);
+            self.active_types.visit(
+                &identity,
+                || {
+                    // A coarsened identity can hide occurrences in a different specialization.
+                    // An exact cycle adds no new occurrences.
+                    if !matches!(identity, TypeIdentity::Other(_)) {
+                        self.found.set(true);
+                    }
+                },
+                visit,
+            );
+        }
+    }
+
+    impl<'db> TypeVisitor<'db> for TypeVarOccurrenceVisitor<'_, 'db> {
+        fn program_environment(&self) -> &ProgramEnvironment<'db> {
+            self.env
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.found.get() {
+                return;
+            }
+
+            if (self.query)(ty) {
+                self.found.set(true);
+                return;
+            }
+
+            walk_type_with_recursion_guard(db, ty, self, &self.visited_types);
+        }
+
+        fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
+            self.visit_guarded(db, Type::TypeAlias(alias), || {
+                self.visit_type(db, alias.value_type(db));
+            });
+        }
+
+        fn visit_protocol_instance_type(
+            &self,
+            db: &'db dyn Db,
+            protocol: ProtocolInstanceType<'db>,
+        ) {
+            let ty = Type::ProtocolInstance(protocol);
+            let visit_members = || walk_protocol_interface(db, protocol.interface(db), self);
+
+            let Some(definition) = protocol
+                .class_origin(db)
+                .and_then(|class| class.definition(db))
+            else {
+                self.visit_guarded(db, ty, visit_members);
+                return;
+            };
+
+            self.active_protocols.visit(
+                &definition,
+                || {
+                    // A repeated definition can come from finite nesting (`P[P[int]]`) or
+                    // an implicit receiver's bound (`P[T]`). Check for growth before stopping.
+                    if ty.contains_growing_type(db, self.env) {
+                        self.found.set(true);
+                    } else {
+                        visit_members();
+                    }
+                },
+                visit_members,
+            );
+        }
+
+        fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
+            self.visit_guarded(db, Type::TypedDict(typed_dict), || {
+                if let Some(class) = typed_dict.defining_class() {
+                    self.visit_type(db, class.into());
+                }
+                walk_typed_dict_fields(db, typed_dict, self);
+            });
+        }
+
+        fn visit_newtype_instance_type(&self, db: &'db dyn Db, newtype: NewType<'db>) {
+            self.visit_guarded(db, Type::NewTypeInstance(newtype), || {
+                walk_newtype_base(db, newtype, self);
+            });
+        }
+
+        fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
+            self.visit_guarded(
+                db,
+                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)),
+                || walk_type_var_attributes(db, typevar, self),
+            );
+        }
+    }
+
+    let visitor = TypeVarOccurrenceVisitor {
+        env,
+        query: &query,
+        visited_types: TypeCollector::default(),
+        active_types: ActiveRecursionDetector::default(),
+        active_protocols: ActiveRecursionDetector::default(),
         found: Cell::new(false),
     };
     visitor.visit_type(db, ty);
     visitor.found.get()
 }
 
-#[derive(Clone, Copy)]
-enum TypeSearchMode {
-    SkipLazyAttributes,
-    IncludeLazyAttributes,
-    /// Visit alias arguments without evaluating alias bodies or other lazy attributes.
-    IncludeAliasArguments,
-}
-
-impl TypeSearchMode {
-    const fn should_visit_lazy_type_attributes(self) -> bool {
-        matches!(self, Self::IncludeLazyAttributes)
-    }
-
-    const fn should_visit_alias_arguments(self) -> bool {
-        matches!(self, Self::IncludeAliasArguments)
-    }
-}
-
-/// Shared implementation for type searches.
-fn any_over_type_impl<'db, F, T>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    ty: Type<'db>,
-    mode: TypeSearchMode,
-    query: F,
-) -> T
-where
-    T: Copy + Default + PartialEq,
-    F: Fn(Type<'db>) -> T,
-{
-    struct AnyOverTypeVisitor<'db, 'a, U> {
-        env: &'a ProgramEnvironment<'db>,
-        query: &'a dyn Fn(Type<'db>) -> U,
-        recursion_guard: TypeCollector<'db>,
-        found_matching_type: Cell<U>,
-        mode: TypeSearchMode,
-    }
-
-    impl<'db, U> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_, U>
-    where
-        U: Copy + Default + PartialEq,
-    {
-        fn program_environment(&self) -> &ProgramEnvironment<'db> {
-            self.env
-        }
-
-        fn should_visit_lazy_type_attributes(&self) -> bool {
-            self.mode.should_visit_lazy_type_attributes()
-        }
-
-        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-            let default_value = U::default();
-            let pre_existing = self.found_matching_type.get();
-            if pre_existing != default_value {
-                return;
-            }
-            let new_value = (self.query)(ty);
-            self.found_matching_type.set(new_value);
-            if new_value != default_value {
-                return;
-            }
-            if self.mode.should_visit_alias_arguments()
-                && let Type::TypeAlias(alias) = ty
-            {
-                if !self.recursion_guard.type_was_already_seen(ty)
-                    && let Some(specialization) = alias.specialization(db)
-                {
-                    walk_specialization_types(db, specialization, self);
-                }
-            } else {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
-            }
-        }
-    }
-
-    let visitor = AnyOverTypeVisitor {
-        env,
-        query: &query,
-        recursion_guard: TypeCollector::default(),
-        found_matching_type: Cell::default(),
-        mode,
-    };
-    visitor.visit_type(db, ty);
-    visitor.found_matching_type.get()
-}
-
-/// Return `true` if `ty`, or any of the types contained in `ty`, match the closure passed in.
-///
-/// The function guards against infinite recursion
-/// by keeping track of the non-atomic types it has already seen.
-///
-/// The `should_visit_lazy_type_attributes` parameter controls whether deferred type attributes
-/// (value of a type alias, attributes of a class-based protocol, bounds/constraints of a typevar)
-/// are visited or not.
-pub(super) fn any_over_type<'db>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    ty: Type<'db>,
-    should_visit_lazy_type_attributes: bool,
-    query: impl Fn(Type<'db>) -> bool,
-) -> bool {
-    let mode = if should_visit_lazy_type_attributes {
-        TypeSearchMode::IncludeLazyAttributes
-    } else {
-        TypeSearchMode::SkipLazyAttributes
-    };
-    any_over_type_impl(db, env, ty, mode, query)
-}
-
-/// Searches through the arguments of [`Type::TypeAlias`] without evaluating alias bodies or other
-/// lazy attributes.
-/// This also visits arguments that the alias's value does not use.
-/// Shared arguments use the same recursion guard, so their descendants are not visited repeatedly.
+/// Search stored types and type-alias arguments, including unused arguments.
+/// Alias values and other lazy attributes are not expanded.
 pub(super) fn any_over_type_including_alias_arguments<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, env, ty, TypeSearchMode::IncludeAliasArguments, query)
+    struct AliasArgumentVisitor<'a, 'db> {
+        env: &'a ProgramEnvironment<'db>,
+        query: &'a dyn Fn(Type<'db>) -> bool,
+        visited_types: TypeCollector<'db>,
+        found: Cell<bool>,
+    }
+
+    impl<'db> TypeVisitor<'db> for AliasArgumentVisitor<'_, 'db> {
+        fn program_environment(&self) -> &ProgramEnvironment<'db> {
+            self.env
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.found.get() {
+                return;
+            }
+
+            if (self.query)(ty) {
+                self.found.set(true);
+                return;
+            }
+
+            if let Type::TypeAlias(alias) = ty {
+                if !self.visited_types.type_was_already_seen(ty) {
+                    walk_type_alias_arguments(db, alias, self);
+                }
+            } else {
+                walk_type_with_recursion_guard(db, ty, self, &self.visited_types);
+            }
+        }
+    }
+
+    let visitor = AliasArgumentVisitor {
+        env,
+        query: &query,
+        visited_types: TypeCollector::default(),
+        found: Cell::new(false),
+    };
+    visitor.visit_type(db, ty);
+    visitor.found.get()
 }
 
-/// Searches through type aliases without forcing other lazily inferred type attributes.
+/// Search stored types and alias values without expanding other lazy attributes.
 ///
-/// Revisiting a recursive alias counts as a match because its specialization can grow on each
-/// visit. Distinct specializations of a nonrecursive alias remain separate, so nested uses such as
-/// `Identity[Identity[int]]` are still considered finite.
+/// Return `true` on an alias cycle, even if `query` has not matched a type.
 pub(super) fn any_over_type_expanding_aliases<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    fn search<'db>(
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        ty: Type<'db>,
-        query: &impl Fn(Type<'db>) -> bool,
-        active_aliases: &ActiveRecursionDetector<TypeIdentity<'db>>,
-    ) -> bool {
-        any_over_type(db, env, ty, false, |nested| {
-            query(nested)
-                || matches!(nested, Type::TypeAlias(alias) if active_aliases.visit(
-                    &Type::TypeAlias(alias).to_type_identity(db),
-                    || true,
-                    || search(db, env, alias.value_type(db), query, active_aliases),
-                ))
-        })
+    struct AliasSearchVisitor<'a, 'db> {
+        env: &'a ProgramEnvironment<'db>,
+        query: &'a dyn Fn(Type<'db>) -> bool,
+        recursion_guard: TypeCollector<'db>,
+        active_aliases: ActiveRecursionDetector<TypeIdentity<'db>>,
+        found: Cell<bool>,
     }
 
-    search(db, env, ty, &query, &ActiveRecursionDetector::default())
+    impl<'db> TypeVisitor<'db> for AliasSearchVisitor<'_, 'db> {
+        fn program_environment(&self) -> &ProgramEnvironment<'db> {
+            self.env
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.found.get() {
+                return;
+            }
+
+            if (self.query)(ty) {
+                self.found.set(true);
+                return;
+            }
+
+            if let Type::TypeAlias(alias) = ty {
+                // Check for cycles before deduplicating, since an exact cycle also returns true.
+                self.active_aliases.visit(
+                    &Type::TypeAlias(alias).to_type_identity(db),
+                    || self.found.set(true),
+                    || {
+                        if !self.recursion_guard.type_was_already_seen(ty) {
+                            self.visit_type(db, alias.value_type(db));
+                        }
+                    },
+                );
+            } else {
+                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            }
+        }
+    }
+
+    let visitor = AliasSearchVisitor {
+        env,
+        query: &query,
+        recursion_guard: TypeCollector::default(),
+        active_aliases: ActiveRecursionDetector::default(),
+        found: Cell::new(false),
+    };
+    visitor.visit_type(db, ty);
+    visitor.found.get()
 }
 
-/// Recurse into a type and calls the passed-in closure on every nested type
-/// encountered, returning the first non-`None` value returned by the closure.
+/// Return whether `query` matches `ty` or any of its nested types.
 ///
-/// For example, if `ty` is `list[tuple[int, T]]` where `T` is a type variable
-/// and the closure passed in is `|t| matches!(t, Type::TypeVar(_))`, then this
-/// function will return `Some(T)`.
-///
-/// The function guards against infinite recursion
-/// by keeping track of the non-atomic types it has already seen.
-///
-/// The `should_visit_lazy_type_attributes` parameter controls whether deferred type attributes
-/// (value of a type alias, attributes of a class-based protocol, bounds/constraints of a typevar)
-/// are visited or not.
-pub(super) fn find_over_type<'db, T>(
+/// Note that lazy type attributes are not visited by this method, and require a custom type visitor.
+pub(super) fn any_over_type<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
-    should_visit_lazy_type_attributes: bool,
+    query: impl Fn(Type<'db>) -> bool,
+) -> bool {
+    find_over_type(db, env, ty, |ty| query(ty).then_some(())).is_some()
+}
+
+/// Return the first non-`None` result of `query`, using the same traversal as [`any_over_type`].
+pub(super) fn find_over_type<'db, T: Copy>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
     query: impl Fn(Type<'db>) -> Option<T>,
-) -> Option<T>
-where
-    T: Copy + PartialEq,
-{
-    let mode = if should_visit_lazy_type_attributes {
-        TypeSearchMode::IncludeLazyAttributes
-    } else {
-        TypeSearchMode::SkipLazyAttributes
+) -> Option<T> {
+    struct FindTypeVisitor<'a, 'db, T> {
+        env: &'a ProgramEnvironment<'db>,
+        query: &'a dyn Fn(Type<'db>) -> Option<T>,
+        recursion_guard: TypeCollector<'db>,
+        found: Cell<Option<T>>,
+    }
+
+    impl<'db, T: Copy> TypeVisitor<'db> for FindTypeVisitor<'_, 'db, T> {
+        fn program_environment(&self) -> &ProgramEnvironment<'db> {
+            self.env
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.found.get().is_some() {
+                return;
+            }
+
+            if let Some(found) = (self.query)(ty) {
+                self.found.set(Some(found));
+                return;
+            }
+
+            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+        }
+    }
+
+    let visitor = FindTypeVisitor {
+        env,
+        query: &query,
+        recursion_guard: TypeCollector::default(),
+        found: Cell::new(None),
     };
-    any_over_type_impl(db, env, ty, mode, query)
+    visitor.visit_type(db, ty);
+    visitor.found.get()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There are a few cases where we traversal over types using the `any_over_type` helper with `visit_lazy_type_attributes` set to `true`. It turns out that this is almost never correct, as it can trivially lead to stack overflows with unbounded recursive types, and also often misclassifies the relevance of a type occurrence within a lazy type attribute, e.g., the occurrence of a `tuple` type within a protocol method does not make the outer type "tuple-like". This PR removes the unsafe `visit_lazy_type_attributes` option from `any_over_type`, and adds specialized type visitors for each call-site with the correct semantics.