### PR TITLE
[ty] Centralize matched argument relations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1376,8 +1376,9 @@ with_default(1, 2)
 
 ### Unpacked variadic elements preserve generic bounds
 
-Ordinary type variables are inferred from individual unpacked elements, even beside an unresolved
-type-variable tuple. Their upper bounds remain enforced.
+Ordinary type variables are inferred from individual unpacked elements in homogeneous or
+heterogeneous tuples, even beside an unresolved type-variable tuple. Their upper bounds remain
+enforced.
 
 ```toml
 [environment]
@@ -1396,40 +1397,17 @@ fixed(1)  # error: [invalid-argument-type]
 
 reveal_type(suffix("prefix", "valid"))  # revealed: Literal["valid"]
 suffix("prefix", 1)  # error: [invalid-argument-type]
-```
 
-### Homogeneous unpacked parameters infer individual elements
-
-An unpacked homogeneous tuple applies its element type to every argument.
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```py
 def homogeneous[T: str](*args: *tuple[T, ...]) -> T:
     return args[0]
 
 reveal_type(homogeneous("first", "second"))  # revealed: Literal["first", "second"]
 homogeneous("valid", 1)  # error: [invalid-argument-type]
-```
 
-### Heterogeneous unpacked parameters infer individual elements
-
-A fixed heterogeneous tuple applies the corresponding element type, including when the arguments
-themselves are unpacked.
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```py
-def heterogeneous[T: str](*args: *tuple[int, T, bytes]) -> T:
+def heterogeneous[T: str](*args: *tuple[int, T]) -> T:
     return args[1]
 
-def _(valid: tuple[int, str, bytes], invalid: tuple[int, int, bytes]) -> None:
+def _(valid: tuple[int, str], invalid: tuple[int, int]) -> None:
     reveal_type(heterogeneous(*valid))  # revealed: str
     heterogeneous(*invalid)  # error: [invalid-argument-type]
 ```
@@ -1640,19 +1618,17 @@ f(**Foo(a=1, b=2))
 Each named value in an unpacked `TypedDict` must be related to its own generic parameter instead of
 using the type of the complete mapping.
 
-```toml
-[environment]
-python-version = "3.12"
-```
-
 ```py
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
 
 class Values(TypedDict, closed=True):
     first: int
     second: str
 
-def combine[T, U](*, first: T, second: U) -> tuple[T, U]:
+def combine(*, first: T, second: U) -> tuple[T, U]:
     return first, second
 
 values: Values = {"first": 1, "second": "value"}

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -12,15 +12,21 @@ reveal_type(get_int())  # revealed: int
 ## Gradual variadic parameters
 
 ```py
-from typing import Any
+from typing import Any, TypeVar
+
+T = TypeVar("T")
 
 def accepts_anything(first: int, *args: Any, **kwargs: Any) -> None: ...
 def accepts_only_gradual(*args: Any, **kwargs: Any) -> None: ...
+def preserves_first(first: T, *args: Any, **kwargs: Any) -> T:
+    return first
 
 accepts_anything(1, "one", object(), keyword=object())
 accepts_anything("not an int")  # error: [invalid-argument-type]
 accepts_only_gradual(1, "one", keyword=object())
 accepts_only_gradual(**{1: "one"})  # error: [invalid-argument-type]
+
+reveal_type(preserves_first(1, "other", keyword=object()))  # revealed: Literal[1]
 ```
 
 ## Object variadic parameters
@@ -1392,6 +1398,42 @@ reveal_type(suffix("prefix", "valid"))  # revealed: Literal["valid"]
 suffix("prefix", 1)  # error: [invalid-argument-type]
 ```
 
+### Homogeneous unpacked parameters infer individual elements
+
+An unpacked homogeneous tuple applies its element type to every argument.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+def homogeneous[T: str](*args: *tuple[T, ...]) -> T:
+    return args[0]
+
+reveal_type(homogeneous("first", "second"))  # revealed: Literal["first", "second"]
+homogeneous("valid", 1)  # error: [invalid-argument-type]
+```
+
+### Heterogeneous unpacked parameters infer individual elements
+
+A fixed heterogeneous tuple applies the corresponding element type, including when the arguments
+themselves are unpacked.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+def heterogeneous[T: str](*args: *tuple[int, T, bytes]) -> T:
+    return args[1]
+
+def _(valid: tuple[int, str, bytes], invalid: tuple[int, int, bytes]) -> None:
+    reveal_type(heterogeneous(*valid))  # revealed: str
+    heterogeneous(*invalid)  # error: [invalid-argument-type]
+```
+
 ### Callable protocols enforce unpacked variadic requirements
 
 Calling a callable protocol uses the same tuple element types and argument-count bounds as calling
@@ -1591,6 +1633,31 @@ def _(kwargs: dict[str, int]) -> None:
 f(**{"a": 1, "b": 2})
 f(**dict(a=1, b=2))
 f(**Foo(a=1, b=2))
+```
+
+### Unpacked keyword values retain their individual generic types
+
+Each named value in an unpacked `TypedDict` must be related to its own generic parameter instead of
+using the type of the complete mapping.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing_extensions import TypedDict
+
+class Values(TypedDict, closed=True):
+    first: int
+    second: str
+
+def combine[T, U](*, first: T, second: U) -> tuple[T, U]:
+    return first, second
+
+values: Values = {"first": 1, "second": "value"}
+
+reveal_type(combine(**values))  # revealed: tuple[int, str]
 ```
 
 ### Keyword-only parameters

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1056,6 +1056,27 @@ def _(x: int):
     reveal_type(C().implicit_self(x))  # revealed: tuple[C, int]
 ```
 
+## Generic method errors account for the implicit receiver
+
+An implicit `self` participates in generic inference but is absent from the call-site argument list.
+Bound violations must still identify the correct positional or keyword argument.
+
+```py
+class Box[T]:
+    def accept[U: int](self, value: U, *, other: U) -> tuple[T, U]:
+        raise NotImplementedError
+
+box = Box[str]()
+
+reveal_type(box.accept(1, other=2))  # revealed: tuple[str, Literal[1, 2]]
+
+# error: 12 [invalid-argument-type] "does not satisfy upper bound `int`"
+box.accept("invalid", other=1)
+
+# error: 15 [invalid-argument-type] "does not satisfy upper bound `int`"
+box.accept(1, other="invalid")
+```
+
 ## `~T` is never assignable to `T`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1062,13 +1062,13 @@ An implicit `self` participates in generic inference but is absent from the call
 Bound violations must still identify the correct positional or keyword argument.
 
 ```py
-class Box[T]:
-    def accept[U: int](self, value: U, *, other: U) -> tuple[T, U]:
-        raise NotImplementedError
+class Box:
+    def accept[T: int](self, value: T, *, other: T) -> T:
+        return value
 
-box = Box[str]()
+box = Box()
 
-reveal_type(box.accept(1, other=2))  # revealed: tuple[str, Literal[1, 2]]
+reveal_type(box.accept(1, other=2))  # revealed: Literal[1, 2]
 
 # error: 12 [invalid-argument-type] "does not satisfy upper bound `int`"
 box.accept("invalid", other=1)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5413,6 +5413,23 @@ struct ArgumentTypeChecker<'a, 'db> {
     constraint_set_errors: Vec<bool>,
 }
 
+/// The formal and actual types associated with one matched argument-parameter pair.
+///
+/// An unpacked argument can produce multiple relations, each with its own matched parameter and
+/// actual element type.
+#[derive(Clone, Copy, Debug)]
+struct ArgumentRelation<'db> {
+    argument_index: usize,
+
+    /// The source argument index, or `None` for a synthetic receiver.
+    adjusted_argument_index: Option<usize>,
+
+    matched_parameter: MatchedParameter<'db>,
+    declared_type: Type<'db>,
+    argument_type: Type<'db>,
+    has_starred_annotation: bool,
+}
+
 /// Result of checking only the key type of a keyword-unpack argument.
 enum KeywordUnpackKeyTypeCheck<'db> {
     /// The argument type is handled by a more specific path, or does not expose mapping keys.
@@ -5493,8 +5510,14 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
     fn enumerate_argument_types(
         &self,
-    ) -> impl Iterator<Item = (usize, Option<usize>, Argument<'a>, &CallArgumentTypes<'db>)> + 'a
-    {
+    ) -> impl Iterator<
+        Item = (
+            usize,
+            Option<usize>,
+            Argument<'a>,
+            &'a CallArgumentTypes<'db>,
+        ),
+    > + 'a {
         let mut iter = self.arguments.iter().enumerate();
         let mut num_synthetic_args = 0;
         std::iter::from_fn(move || {
@@ -5517,6 +5540,46 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 argument_types,
             ))
         })
+    }
+
+    /// Yields the effective formal and actual types for each matched argument-parameter pair.
+    ///
+    /// Gradual variadic parameters do not contribute constraints. For unpacked tuple parameters,
+    /// the matched parameter can provide a more specific formal type for the corresponding element.
+    fn argument_relations(&self) -> impl Iterator<Item = ArgumentRelation<'db>> + 'a {
+        let signature: &'a Signature<'db> = self.signature;
+        let parameters = signature.parameters();
+        let argument_matches: &'a [MatchedArgument<'db>] = self.argument_matches;
+
+        self.enumerate_argument_types().flat_map(
+            move |(argument_index, adjusted_argument_index, _, argument_types)| {
+                argument_matches[argument_index]
+                    .iter()
+                    .filter_map(move |matched_parameter| {
+                        let parameter_index = matched_parameter.index;
+                        if Self::is_gradual_variadic_parameter(parameters, parameter_index) {
+                            return None;
+                        }
+
+                        let parameter = &parameters[parameter_index];
+                        let declared_type = matched_parameter
+                            .expected_type
+                            .unwrap_or_else(|| parameter.annotated_type());
+                        let argument_type = matched_parameter
+                            .argument_type
+                            .unwrap_or_else(|| argument_types.get_for_declared_type(declared_type));
+
+                        Some(ArgumentRelation {
+                            argument_index,
+                            adjusted_argument_index,
+                            matched_parameter,
+                            declared_type,
+                            argument_type,
+                            has_starred_annotation: parameter.has_starred_annotation(),
+                        })
+                    })
+            },
+        )
     }
 
     /// Returns argument-index mappings for arguments matched to the `ParamSpec` component.
@@ -5919,28 +5982,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         };
         let inference = match builder.build_inference_with(generic_context, &mut choose) {
             Ok(inference) => inference,
-            Err(()) => {
-                let parameters = self.signature.parameters();
-                let mut argument_relations = Vec::new();
-                for (argument_index, _, _, argument_types) in self.enumerate_argument_types() {
-                    for matched_parameter in self.argument_matches[argument_index].iter() {
-                        let parameter_index = matched_parameter.index;
-                        if self.is_gradual_variadic_parameter(parameter_index) {
-                            continue;
-                        }
-
-                        let formal = matched_parameter
-                            .expected_type
-                            .unwrap_or_else(|| parameters[parameter_index].annotated_type());
-                        let actual = matched_parameter
-                            .argument_type
-                            .unwrap_or_else(|| argument_types.get_for_declared_type(formal));
-                        argument_relations.push((formal, actual));
-                    }
-                }
-
-                builder.build_diagnostic_inference_with(generic_context, argument_relations, choose)
-            }
+            Err(()) => builder.build_diagnostic_inference_with(
+                generic_context,
+                self.argument_relations()
+                    .map(|relation| (relation.declared_type, relation.argument_type)),
+                choose,
+            ),
         };
         let specialization = inference.specialization(db);
 
@@ -5956,50 +6003,32 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let db = self.db;
-        let parameters = self.signature.parameters();
-        for (argument_index, adjusted_argument_index, _, argument_types) in
-            self.enumerate_argument_types()
-        {
-            for matched_parameter in self.argument_matches[argument_index].iter() {
-                let parameter_index = matched_parameter.index;
-                let parameter = &parameters[parameter_index];
-                let parameter_type = parameter.annotated_type();
-                // TODO: Infer a `TypeVarTuple` from all matched positional arguments as a single
-                // tuple. Fixed elements beside that pack can still infer ordinary type variables.
-                if parameter.has_starred_annotation()
-                    && matched_parameter.expected_type.is_none()
-                    && (matches!(
-                        parameter_type,
-                        Type::TypeVar(typevar) if typevar.is_typevartuple(db)
-                    ) || matches!(
-                        parameter_type.exact_tuple_instance_spec(db).as_deref(),
-                        Some(TupleSpec::Variable(variable))
-                            if matches!(
-                                variable.variable(),
-                                VariableSegment::TypeVarTuple(_)
-                            )
-                    ))
-                {
-                    continue;
-                }
-                if self.is_gradual_variadic_parameter(parameter_index) {
-                    continue;
-                }
+        for relation in self.argument_relations() {
+            // TODO: Infer a `TypeVarTuple` from all matched positional arguments as a single
+            // tuple. Fixed elements beside that pack can still infer ordinary type variables.
+            if relation.has_starred_annotation
+                && relation.matched_parameter.expected_type.is_none()
+                && (matches!(
+                    relation.declared_type,
+                    Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                ) || matches!(
+                    relation.declared_type.exact_tuple_instance_spec(db).as_deref(),
+                    Some(TupleSpec::Variable(variable))
+                        if matches!(
+                            variable.variable(),
+                            VariableSegment::TypeVarTuple(_)
+                        )
+                ))
+            {
+                continue;
+            }
 
-                let declared_type = matched_parameter.expected_type.unwrap_or(parameter_type);
-                let argument_type = argument_types.get_for_declared_type(declared_type);
-                let specialization_result = builder.infer(
-                    declared_type,
-                    matched_parameter.argument_type.unwrap_or(argument_type),
-                );
-
-                if let Err(error) = specialization_result {
-                    self.constraint_set_errors[argument_index] = true;
-                    specialization_errors.push(BindingError::SpecializationError {
-                        error,
-                        argument_index: adjusted_argument_index,
-                    });
-                }
+            if let Err(error) = builder.infer(relation.declared_type, relation.argument_type) {
+                self.constraint_set_errors[relation.argument_index] = true;
+                specialization_errors.push(BindingError::SpecializationError {
+                    error,
+                    argument_index: relation.adjusted_argument_index,
+                });
             }
         }
 
@@ -6024,7 +6053,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let parameter_index = matched_parameter.index;
         let parameters = self.signature.parameters();
         let parameter = &parameters[parameter_index];
-        if self.is_gradual_variadic_parameter(parameter_index) {
+        if Self::is_gradual_variadic_parameter(parameters, parameter_index) {
             return;
         }
 
@@ -6171,8 +6200,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         }
     }
 
-    fn is_gradual_variadic_parameter(&self, parameter_index: usize) -> bool {
-        let parameters = self.signature.parameters();
+    fn is_gradual_variadic_parameter(parameters: &Parameters<'db>, parameter_index: usize) -> bool {
         let parameter = &parameters[parameter_index];
 
         matches!(parameters.kind(), ParametersKind::Gradual)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5568,8 +5568,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     /// Gradual variadic parameters do not contribute constraints. For unpacked tuple parameters,
     /// the matched parameter can provide a more specific formal type for the corresponding element.
     fn argument_relations(&self) -> impl Iterator<Item = ArgumentRelation<'db>> + 'a {
-        let signature: &'a Signature<'db> = self.signature;
-        let parameters = signature.parameters();
+        let parameters: &'a Parameters<'db> = self.signature.parameters();
         let argument_matches: &'a [MatchedArgument<'db>] = self.argument_matches;
 
         self.enumerate_argument_types().flat_map(

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5430,6 +5430,27 @@ struct ArgumentRelation<'db> {
     has_starred_annotation: bool,
 }
 
+impl<'db> ArgumentRelation<'db> {
+    fn new(
+        argument_index: usize,
+        adjusted_argument_index: Option<usize>,
+        parameter: &Parameter<'db>,
+        matched_parameter: MatchedParameter<'db>,
+        argument_type: Type<'db>,
+    ) -> Self {
+        Self {
+            argument_index,
+            adjusted_argument_index,
+            matched_parameter,
+            declared_type: matched_parameter
+                .expected_type
+                .unwrap_or_else(|| parameter.annotated_type()),
+            argument_type,
+            has_starred_annotation: parameter.has_starred_annotation(),
+        }
+    }
+}
+
 /// Result of checking only the key type of a keyword-unpack argument.
 enum KeywordUnpackKeyTypeCheck<'db> {
     /// The argument type is handled by a more specific path, or does not expose mapping keys.
@@ -5569,14 +5590,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             .argument_type
                             .unwrap_or_else(|| argument_types.get_for_declared_type(declared_type));
 
-                        Some(ArgumentRelation {
+                        Some(ArgumentRelation::new(
                             argument_index,
                             adjusted_argument_index,
+                            parameter,
                             matched_parameter,
-                            declared_type,
                             argument_type,
-                            has_starred_annotation: parameter.has_starred_annotation(),
-                        })
+                        ))
                     })
             },
         )
@@ -6043,12 +6063,17 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     fn check_argument_type(
         &mut self,
         constraints: &ConstraintSetBuilder<'db>,
-        argument_index: usize,
-        adjusted_argument_index: Option<usize>,
         argument: Argument<'a>,
-        mut argument_type: Type<'db>,
-        matched_parameter: MatchedParameter<'db>,
+        relation: ArgumentRelation<'db>,
     ) {
+        let ArgumentRelation {
+            argument_index,
+            adjusted_argument_index,
+            matched_parameter,
+            declared_type,
+            mut argument_type,
+            has_starred_annotation,
+        } = relation;
         let db = self.db;
         let parameter_index = matched_parameter.index;
         let parameters = self.signature.parameters();
@@ -6097,9 +6122,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 Type::SubclassOf(subclass_of) if subclass_of.into_type_var().is_some()
             );
 
-        let mut expected_ty = matched_parameter
-            .expected_type
-            .unwrap_or_else(|| parameter.annotated_type());
+        let mut expected_ty = declared_type;
         if let Some(specialization) = self.specialization() {
             if !constructor_receiver {
                 argument_type = argument_type.apply_specialization(db, specialization);
@@ -6139,7 +6162,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // An unresolved `*Ts` still has no per-element expected type.
         if !self.constraint_set_errors[argument_index]
             && !constructor_receiver
-            && (!parameter.has_starred_annotation() || matched_parameter.expected_type.is_some())
+            && (!has_starred_annotation || matched_parameter.expected_type.is_some())
             && !is_valid_isinstance_target()
             && argument_type
                 .when_assignable_to(
@@ -6353,18 +6376,18 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             continue;
                         }
 
-                        let declared_type =
-                            self.signature.parameters()[parameter_index].annotated_type();
-                        let argument_type = argument_types.get_for_declared_type(declared_type);
-
-                        self.check_argument_type(
-                            constraints,
+                        let parameter = &self.signature.parameters()[parameter_index];
+                        let argument_type =
+                            argument_types.get_for_declared_type(parameter.annotated_type());
+                        let relation = ArgumentRelation::new(
                             argument_index,
                             adjusted_argument_index,
-                            argument,
-                            argument_type,
+                            parameter,
                             matched_parameter,
+                            argument_type,
                         );
+
+                        self.check_argument_type(constraints, argument, relation);
                     }
                 }
             }
@@ -6534,16 +6557,17 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 continue;
             }
 
-            self.check_argument_type(
-                constraints,
+            let relation = ArgumentRelation::new(
                 argument_index,
                 adjusted_argument_index,
-                argument,
+                &self.signature.parameters()[parameter_index],
+                matched_parameter,
                 matched_parameter
                     .argument_type
                     .unwrap_or_else(Type::unknown),
-                matched_parameter,
             );
+
+            self.check_argument_type(constraints, argument, relation);
         }
     }
 
@@ -6608,14 +6632,15 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     .unwrap_or(Type::unknown())
             };
 
-            self.check_argument_type(
-                constraints,
+            let relation = ArgumentRelation::new(
                 argument_index,
                 adjusted_argument_index,
-                Argument::Keywords,
-                value_type,
+                &self.signature.parameters()[parameter_index],
                 matched_parameter,
+                value_type,
             );
+
+            self.check_argument_type(constraints, Argument::Keywords, relation);
         }
     }
 


### PR DESCRIPTION
## Summary

Part of astral-sh/ty#3557. This is the first focused step toward rebooting #26712 as a stack of smaller solver changes.

Introduce `ArgumentRelation` as the shared representation of a matched argument/parameter pair and use it for generic specialization inference, unsatisfiable-constraint diagnostic recovery, and ordinary, positional-unpack, and keyword-unpack argument checking. Preserve effective per-element formal types, each checking path's existing actual-type lookup, synthetic receiver/source argument indices, gradual variadic filtering, and existing `TypeVarTuple` handling without changing solver behavior.

## Test plan

Added mdtests covering generic bound-method diagnostics after an implicit receiver, positional and keyword source locations, homogeneous and heterogeneous unpacked generic parameters, unpacked positional element types, per-key `TypedDict` generic inference, and gradual variadic arguments that must not affect inference.