### PR TITLE
[ty] Unify polarity-aware relation construction

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -1864,6 +1864,29 @@ class Example:
         pass
 ```
 
+An invalid descriptor receiver must not discard the inferred `ParamSpec` for its bound callable.
+Even though `Concatenate` makes the receiver positional-only, the remaining parameters still retain
+their precise types.
+
+```py
+class Decorator(Generic[P]):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+    def __get__(self: "Decorator[Concatenate[Any, P2]]", instance: Any, owner: Any) -> "Decorator[P2]":
+        raise NotImplementedError
+
+def decorate(fn: Callable[P, Any]) -> Decorator[P]:
+    raise NotImplementedError
+
+class Decorated:
+    @decorate
+    def method(self, value: str) -> None: ...
+
+# error: [invalid-attribute-access]
+bound = Decorated().method
+reveal_type(bound)  # revealed: Decorator[(value: str)]
+bound(1)  # error: [invalid-argument-type]
+```
+
 [descriptors]: https://docs.python.org/3/howto/descriptor.html
 [precedence chain]: https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L5393-L5481
 [simple example]: https://docs.python.org/3/howto/descriptor.html#simple-example-a-descriptor-that-returns-a-constant

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -776,7 +776,7 @@ The same callback is compatible with a contravariant wrapper, and its remaining 
 still be inferred precisely enough to reject an incompatible later argument.
 
 ```py
-from typing import Callable, Concatenate, Generic, ParamSpec
+from typing import Callable, Concatenate, Generic, ParamSpec, TypeVar
 
 P = ParamSpec("P", contravariant=True)
 
@@ -791,6 +791,124 @@ def original(first: object, value: str) -> None: ...
 remaining = without_first(Callback(original))
 reveal_type(remaining)  # revealed: (value: str) -> None
 remaining(1)  # error: [invalid-argument-type]
+```
+
+A contravariant callback can accept a broader positional-only prefix than a bounded type variable
+requires. The witness determines the narrower specialization without rejecting the valid callback.
+
+```py
+class Base: ...
+class Middle(Base): ...
+class Other: ...
+
+Bounded = TypeVar("Bounded", bound=Middle)
+Q = ParamSpec("Q")
+
+def accepts_base(first: Base, /, value: str) -> None: ...
+def bounded(callback: Callback[Concatenate[Bounded, Q]], witness: Bounded) -> tuple[Bounded, Callable[Q, None]]:
+    raise NotImplementedError
+
+bounded_result = bounded(Callback(accepts_base), Middle())
+reveal_type(bounded_result)  # revealed: tuple[Middle, (value: str) -> None]
+bounded_result[1](1)  # error: [invalid-argument-type]
+```
+
+The same contravariant relationship remains valid when the prefix type variable has explicit
+constraints instead of an upper bound.
+
+```py
+Constrained = TypeVar("Constrained", Middle, Other)
+
+def constrained(callback: Callback[Concatenate[Constrained, Q]], witness: Constrained) -> tuple[Constrained, Callable[Q, None]]:
+    raise NotImplementedError
+
+constrained_result = constrained(Callback(accepts_base), Middle())
+reveal_type(constrained_result)  # revealed: tuple[Middle, (value: str) -> None]
+constrained_result[1](1)  # error: [invalid-argument-type]
+```
+
+## Inferring a covariant `ParamSpec` through `Concatenate`
+
+A covariant wrapper containing a callback with a narrower positional-only prefix remains valid,
+whether the wrapper is stored first or constructed inline.
+
+```py
+from typing import Callable, Concatenate, Generic, ParamSpec
+
+P = ParamSpec("P", covariant=True)
+Q = ParamSpec("Q")
+
+class Base: ...
+class Middle(Base): ...
+
+class Callback(Generic[P]):
+    def __init__(self, callback: Callable[P, None]) -> None: ...
+
+def without_first(callback: Callback[Concatenate[Base, Q]]) -> Callable[Q, None]:
+    raise NotImplementedError
+
+def original(first: Middle, /, value: str) -> None: ...
+
+wrapped = Callback(original)
+# TODO: Should reveal `(value: str) -> None`.
+reveal_type(without_first(wrapped))  # revealed: (...) -> None
+# TODO: Should reveal `(value: str) -> None`.
+reveal_type(without_first(Callback(original)))  # revealed: (...) -> None
+```
+
+## Inferring through unions of structural `ParamSpec` protocols
+
+Different protocols with the same parameter list can satisfy a target protocol structurally, even
+when they appear in a union nested inside an invariant or contravariant wrapper.
+
+```py
+from typing import Generic, ParamSpec, Protocol, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+TContra = TypeVar("TContra", contravariant=True)
+
+class Invariant(Generic[T]):
+    value: T
+
+class Contravariant(Generic[TContra]):
+    def put(self, value: TContra) -> None: ...
+
+class Target(Protocol[P]):
+    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+class Actual(Protocol[P]):
+    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+class Other(Protocol[P]):
+    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+def invariant(value: Invariant[Target[P]]) -> Target[P]:
+    raise NotImplementedError
+
+def contravariant(value: Contravariant[Target[P]]) -> Target[P]:
+    raise NotImplementedError
+
+def compatible(
+    first: Invariant[Actual[[str]] | Other[[str]]],
+    second: Contravariant[Actual[[str]] | Other[[str]]],
+) -> None:
+    reveal_type(invariant(first))  # revealed: Target[(str, /)]
+    reveal_type(contravariant(second))  # revealed: Target[(str, /)]
+```
+
+Union members with incompatible parameter lists cannot satisfy either wrapper. Their signatures must
+remain visible in the inferred result instead of collapsing to a gradual parameter list.
+
+```py
+def incompatible(
+    first: Invariant[Actual[[str]] | Other[[bytes]]],
+    second: Contravariant[Actual[[str]] | Other[[bytes]]],
+) -> None:
+    # error: [invalid-argument-type]
+    reveal_type(invariant(first))  # revealed: Target[((str, /)) | ((bytes, /))]
+    # error: [invalid-argument-type]
+    reveal_type(contravariant(second))  # revealed: Target[((str, /)) | ((bytes, /))]
 ```
 
 ## `ParamSpec` cannot specialize a `TypeVar`, and vice versa

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -794,7 +794,8 @@ remaining(1)  # error: [invalid-argument-type]
 ```
 
 A contravariant callback can accept a broader positional-only prefix than a bounded type variable
-requires. The witness determines the narrower specialization without rejecting the valid callback.
+requires. The separate `Middle()` argument determines the narrower specialization without rejecting
+the valid callback.
 
 ```py
 class Base: ...
@@ -850,9 +851,9 @@ def without_first(callback: Callback[Concatenate[Base, Q]]) -> Callable[Q, None]
 def original(first: Middle, /, value: str) -> None: ...
 
 wrapped = Callback(original)
-# TODO: Should reveal `(value: str) -> None`.
+# TODO: Should reveal `(value: str) -> None`. Needs ParamSpecs in the new constraint solver.
 reveal_type(without_first(wrapped))  # revealed: (...) -> None
-# TODO: Should reveal `(value: str) -> None`.
+# TODO: Should reveal `(value: str) -> None`. Needs ParamSpecs in the new constraint solver.
 reveal_type(without_first(Callback(original)))  # revealed: (...) -> None
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -746,6 +746,53 @@ takes_int_job(defaulted_job)
 takes_int_job(wrong_job)  # error: [invalid-argument-type]
 ```
 
+## Inferring an invariant `ParamSpec` through `Concatenate`
+
+A `Concatenate` prefix is positional-only, so a callback whose first parameter also accepts a
+keyword is not compatible with an invariant wrapper. Even though that argument is rejected, its
+remaining parameters must still be inferred precisely.
+
+```py
+from typing import Callable, Concatenate, Generic, ParamSpec
+
+P = ParamSpec("P")
+
+class Callback(Generic[P]):
+    def __init__(self, callback: Callable[P, None]) -> None: ...
+
+def without_first(callback: Callback[Concatenate[object, P]]) -> Callable[P, None]:
+    raise NotImplementedError
+
+def original(first: object, value: str) -> None: ...
+
+remaining = without_first(Callback(original))  # error: [invalid-argument-type]
+reveal_type(remaining)  # revealed: (value: str) -> None
+remaining(1)  # error: [invalid-argument-type]
+```
+
+## Inferring a contravariant `ParamSpec` through `Concatenate`
+
+The same callback is compatible with a contravariant wrapper, and its remaining parameters must
+still be inferred precisely enough to reject an incompatible later argument.
+
+```py
+from typing import Callable, Concatenate, Generic, ParamSpec
+
+P = ParamSpec("P", contravariant=True)
+
+class Callback(Generic[P]):
+    def __init__(self, callback: Callable[P, None]) -> None: ...
+
+def without_first(callback: Callback[Concatenate[object, P]]) -> Callable[P, None]:
+    raise NotImplementedError
+
+def original(first: object, value: str) -> None: ...
+
+remaining = without_first(Callback(original))
+reveal_type(remaining)  # revealed: (value: str) -> None
+remaining(1)  # error: [invalid-argument-type]
+```
+
 ## `ParamSpec` cannot specialize a `TypeVar`, and vice versa
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -339,16 +339,19 @@ Callable return types are covariant, but nesting a callable inside a contravaria
 generic class changes which constraints its return type supplies.
 
 ```py
-from typing import Callable
+from typing import Callable, overload
 
 class Covariant[T]:
+    def __init__(self, *values: T) -> None: ...
     def get(self) -> T:
         raise NotImplementedError
 
 class Contravariant[T]:
+    def __init__(self, *values: T) -> None: ...
     def put(self, value: T) -> None: ...
 
 class Invariant[T]:
+    def __init__(self, *values: T) -> None: ...
     value: T
 
 def covariant[T](container: Covariant[Callable[[], T]], value: T) -> T:
@@ -415,22 +418,11 @@ additionally require the formal callable to cover every overload, so an extra `s
 incompatible with a callable accepting only `int`.
 
 ```py
-from typing import overload
-
 @overload
 def overloaded(value: int, /) -> Middle: ...
 @overload
 def overloaded(value: str, /) -> Middle: ...
 def overloaded(value: int | str, /) -> Middle:
-    raise NotImplementedError
-
-def wrap_covariant[T](value: T) -> Covariant[T]:
-    raise NotImplementedError
-
-def wrap_contravariant[T](value: T) -> Contravariant[T]:
-    raise NotImplementedError
-
-def wrap_invariant[T](value: T) -> Invariant[T]:
     raise NotImplementedError
 
 def covariant_overload[T](container: Covariant[Callable[[int], T]]) -> T:
@@ -442,9 +434,9 @@ def contravariant_overload[T](container: Contravariant[Callable[[int], T]]) -> T
 def invariant_overload[T](container: Invariant[Callable[[int], T]]) -> T:
     raise NotImplementedError
 
-reveal_type(covariant_overload(wrap_covariant(overloaded)))  # revealed: Middle
-contravariant_overload(wrap_contravariant(overloaded))  # error: [invalid-argument-type]
-invariant_overload(wrap_invariant(overloaded))  # error: [invalid-argument-type]
+reveal_type(covariant_overload(Covariant(overloaded)))  # revealed: Middle
+contravariant_overload(Contravariant(overloaded))  # error: [invalid-argument-type]
+invariant_overload(Invariant(overloaded))  # error: [invalid-argument-type]
 ```
 
 When every overload is covered by the formal `int` parameter, all three wrapper variances accept it.
@@ -457,9 +449,9 @@ def covered(value: int, /) -> Middle: ...
 def covered(value: int, /) -> Middle:
     raise NotImplementedError
 
-reveal_type(covariant_overload(wrap_covariant(covered)))  # revealed: Middle
-reveal_type(contravariant_overload(wrap_contravariant(covered)))  # revealed: Middle
-reveal_type(invariant_overload(wrap_invariant(covered)))  # revealed: Middle
+reveal_type(covariant_overload(Covariant(covered)))  # revealed: Middle
+reveal_type(contravariant_overload(Contravariant(covered)))  # revealed: Middle
+reveal_type(invariant_overload(Invariant(covered)))  # revealed: Middle
 ```
 
 Callable parameter types are already contravariant. An outer contravariant class reverses their

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -274,6 +274,21 @@ reveal_type(invariant(Invariant[Producer[Middle]](), Middle()))  # revealed: Mid
 invariant(Invariant[Producer[Middle]](), Base())  # error: [invalid-argument-type]
 ```
 
+When the same protocol specialization appears first contravariantly and then covariantly, both
+relationships contribute their constraints even though the formal and actual types are identical.
+
+```py
+class MixedVariance[First, Second]:
+    def put(self, value: First) -> None: ...
+    def get(self) -> Second:
+        raise NotImplementedError
+
+def repeated_polarity[T](container: MixedVariance[Producer[T], Producer[T]], witness: T) -> T:
+    return witness
+
+reveal_type(repeated_polarity(MixedVariance[Producer[Middle], Producer[Middle]](), Derived()))  # revealed: Middle
+```
+
 A consuming protocol reverses the relationship once more. Nesting that protocol inside a
 contravariant class therefore turns its upper bound back into a lower bound.
 
@@ -353,6 +368,21 @@ reveal_type(covariant(Covariant[Callable[[], Middle]](), Base()))  # revealed: B
 reveal_type(contravariant(Contravariant[Callable[[], Middle]](), Derived()))  # revealed: Derived
 reveal_type(invariant(Invariant[Callable[[], Middle]](), Middle()))  # revealed: Middle
 invariant(Invariant[Callable[[], Middle]](), Base())  # error: [invalid-argument-type]
+```
+
+The same callable specialization can contribute both an upper and a lower bound when it appears
+first in a contravariant position and then in a covariant position.
+
+```py
+class MixedVariance[First, Second]:
+    def put(self, value: First) -> None: ...
+    def get(self) -> Second:
+        raise NotImplementedError
+
+def repeated_polarity[T](container: MixedVariance[Callable[[], T], Callable[[], T]], witness: T) -> T:
+    return witness
+
+reveal_type(repeated_polarity(MixedVariance[Callable[[], Middle], Callable[[], Middle]](), Derived()))  # revealed: Middle
 ```
 
 An unrelated variadic type parameter currently sends the entire inference context through the legacy

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -291,6 +291,33 @@ reveal_type(consumer(Covariant[Consumer[Middle]](), Derived()))  # revealed: Der
 reveal_type(double_contravariant(Contravariant[Consumer[Middle]](), Derived()))  # revealed: Middle
 ```
 
+A structural protocol method must also preserve its inferred parameters under either outer variance,
+even when its nominal implementation is rejected by the wrapper.
+
+```py
+from typing import Callable
+
+class Runner[**P](Protocol):
+    def run(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+class StringRunner:
+    def run(self, value: str) -> None: ...
+
+def invariant_runner[**P](container: Invariant[Runner[P]]) -> Callable[P, None]:
+    raise NotImplementedError
+
+def contravariant_runner[**P](container: Contravariant[Runner[P]]) -> Callable[P, None]:
+    raise NotImplementedError
+
+invariant_run = invariant_runner(Invariant[StringRunner]())  # error: [invalid-argument-type]
+reveal_type(invariant_run)  # revealed: (value: str) -> None
+invariant_run(1)  # error: [invalid-argument-type]
+
+contravariant_run = contravariant_runner(Contravariant[StringRunner]())  # error: [invalid-argument-type]
+reveal_type(contravariant_run)  # revealed: (value: str) -> None
+contravariant_run(1)  # error: [invalid-argument-type]
+```
+
 ## Inferring through nested generic callables
 
 Callable return types are covariant, but nesting a callable inside a contravariant or invariant
@@ -328,6 +355,24 @@ reveal_type(invariant(Invariant[Callable[[], Middle]](), Middle()))  # revealed:
 invariant(Invariant[Callable[[], Middle]](), Base())  # error: [invalid-argument-type]
 ```
 
+An unrelated variadic type parameter currently sends the entire inference context through the legacy
+solver, so the ordinary callable loses the contravariant bound shown above.
+
+```py
+def with_paramspec[T, **P](container: Contravariant[Callable[[], T]], value: T, unrelated: Callable[P, None]) -> T:
+    return value
+
+def with_typevartuple[T, *Ts](container: Contravariant[Callable[[], T]], value: T, unrelated: tuple[*Ts]) -> T:
+    return value
+
+def unrelated(value: str) -> None: ...
+
+# TODO: Should reveal `Derived` when an unrelated ParamSpec no longer disables contravariance.
+reveal_type(with_paramspec(Contravariant[Callable[[], Middle]](), Derived(), unrelated))  # revealed: Middle
+# TODO: Should reveal `Derived` when an unrelated TypeVarTuple no longer disables contravariance.
+reveal_type(with_typevartuple(Contravariant[Callable[[], Middle]](), Derived(), ("value",)))  # revealed: Middle
+```
+
 A union of callable return types offers alternative upper bounds; a compatible arm must not be
 rejected just because another arm is incompatible.
 
@@ -347,6 +392,77 @@ def double_contravariant[T](container: Contravariant[Callable[[T], None]], value
 
 reveal_type(consumer(Covariant[Callable[[Middle], None]](), Derived()))  # revealed: Derived
 reveal_type(double_contravariant(Contravariant[Callable[[Middle], None]](), Derived()))  # revealed: Middle
+```
+
+A `Concatenate` prefix is positional-only, so these wrapped callbacks do not match the formal
+parameter exactly. Their remaining parameters and ordinary return type variable must still be
+inferred precisely under either outer polarity.
+
+```py
+from typing import Concatenate
+
+class InvariantCallback[T]:
+    def __init__(self, callback: T) -> None: ...
+    callback: T
+
+class ContravariantCallback[T]:
+    def __init__(self, callback: T) -> None: ...
+    def put(self, callback: T) -> None: ...
+
+def invariant_tail[**P, R](
+    container: InvariantCallback[Callable[Concatenate[object, P], R]],
+) -> Callable[P, R]:
+    raise NotImplementedError
+
+def contravariant_tail[**P, R](
+    container: ContravariantCallback[Callable[Concatenate[object, P], R]],
+) -> Callable[P, R]:
+    raise NotImplementedError
+
+def original(first: object, value: str) -> int:
+    return len(value)
+
+invariant_remaining = invariant_tail(InvariantCallback(original))  # error: [invalid-argument-type]
+reveal_type(invariant_remaining)  # revealed: (value: str) -> int
+invariant_remaining(1)  # error: [invalid-argument-type]
+invariant_remaining("valid").missing_attribute  # error: [unresolved-attribute]
+
+contravariant_remaining = contravariant_tail(ContravariantCallback(original))  # error: [invalid-argument-type]
+reveal_type(contravariant_remaining)  # revealed: (value: str) -> int
+contravariant_remaining(1)  # error: [invalid-argument-type]
+contravariant_remaining("valid").missing_attribute  # error: [unresolved-attribute]
+```
+
+A higher-order callback must retain its inferred parameter list under both outer variances, even
+when assigning the result causes the outer argument to be rejected. Its callback parameter can
+accept either the declared prefix or a narrower derived prefix.
+
+```py
+def accepts_exact(callback: Callable[[Base, str], None]) -> None: ...
+def accepts_narrower(callback: Callable[[Derived, str], None]) -> None: ...
+def invariant_higher_order[**P](
+    container: InvariantCallback[Callable[[Callable[Concatenate[Base, P], None]], None]],
+) -> Callable[P, None]:
+    raise NotImplementedError
+
+def contravariant_higher_order[**P](
+    container: ContravariantCallback[Callable[[Callable[Concatenate[Base, P], None]], None]],
+) -> Callable[P, None]:
+    raise NotImplementedError
+
+invariant_exact = invariant_higher_order(InvariantCallback(accepts_exact))  # error: [invalid-argument-type]
+reveal_type(invariant_exact)  # revealed: (str, /) -> None
+invariant_exact(1)  # error: [invalid-argument-type]
+
+invariant_narrower = invariant_higher_order(InvariantCallback(accepts_narrower))  # error: [invalid-argument-type]
+reveal_type(invariant_narrower)  # revealed: (str, /) -> None
+
+contravariant_exact = contravariant_higher_order(ContravariantCallback(accepts_exact))  # error: [invalid-argument-type]
+reveal_type(contravariant_exact)  # revealed: (str, /) -> None
+contravariant_exact(1)  # error: [invalid-argument-type]
+
+contravariant_narrower = contravariant_higher_order(ContravariantCallback(accepts_narrower))  # error: [invalid-argument-type]
+reveal_type(contravariant_narrower)  # revealed: (str, /) -> None
 ```
 
 ## Inferring through nested callable protocols
@@ -379,6 +495,54 @@ class Derived(Middle): ...
 
 reveal_type(covariant(Covariant[Callable[[], Middle]](), Base()))  # revealed: Base
 reveal_type(contravariant(Contravariant[Callable[[], Middle]](), Derived()))  # revealed: Derived
+```
+
+A callback protocol with a positional-only prefix must likewise preserve its inferred parameter
+tail, even when the wrapped callable is rejected.
+
+```py
+class InvariantCallback[T]:
+    def __init__(self, callback: T) -> None: ...
+    callback: T
+
+class ContravariantCallback[T]:
+    def __init__(self, callback: T) -> None: ...
+    def put(self, callback: T) -> None: ...
+
+class VariadicCallback[**P](Protocol):
+    def __call__(self, first: object, /, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+def invariant_tail[**P](container: InvariantCallback[VariadicCallback[P]]) -> Callable[P, None]:
+    raise NotImplementedError
+
+def contravariant_tail[**P](container: ContravariantCallback[VariadicCallback[P]]) -> Callable[P, None]:
+    raise NotImplementedError
+
+def original(first: object, value: str) -> None: ...
+
+invariant_remaining = invariant_tail(InvariantCallback(original))  # error: [invalid-argument-type]
+reveal_type(invariant_remaining)  # revealed: (value: str) -> None
+invariant_remaining(1)  # error: [invalid-argument-type]
+
+contravariant_remaining = contravariant_tail(ContravariantCallback(original))  # error: [invalid-argument-type]
+reveal_type(contravariant_remaining)  # revealed: (value: str) -> None
+contravariant_remaining(1)  # error: [invalid-argument-type]
+```
+
+A nominal callable object's `__call__` method must likewise preserve the callback protocol's
+inferred parameters under both wrapper variances.
+
+```py
+class CallableObject:
+    def __call__(self, first: object, value: str) -> None: ...
+
+invariant_object = invariant_tail(InvariantCallback(CallableObject()))  # error: [invalid-argument-type]
+reveal_type(invariant_object)  # revealed: (value: str) -> None
+invariant_object(1)  # error: [invalid-argument-type]
+
+contravariant_object = contravariant_tail(ContravariantCallback(CallableObject()))  # error: [invalid-argument-type]
+reveal_type(contravariant_object)  # revealed: (value: str) -> None
+contravariant_object(1)  # error: [invalid-argument-type]
 ```
 
 ## Bound violations inferred through protocols

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -410,6 +410,58 @@ rejected just because another arm is incompatible.
 reveal_type(contravariant(Contravariant[Callable[[], Middle] | Callable[[], str]](), Derived()))  # revealed: Derived
 ```
 
+Covariance accepts an overloaded callable when one overload matches. Contravariance and invariance
+additionally require the formal callable to cover every overload, so an extra `str` overload is
+incompatible with a callable accepting only `int`.
+
+```py
+from typing import overload
+
+@overload
+def overloaded(value: int, /) -> Middle: ...
+@overload
+def overloaded(value: str, /) -> Middle: ...
+def overloaded(value: int | str, /) -> Middle:
+    raise NotImplementedError
+
+def wrap_covariant[T](value: T) -> Covariant[T]:
+    raise NotImplementedError
+
+def wrap_contravariant[T](value: T) -> Contravariant[T]:
+    raise NotImplementedError
+
+def wrap_invariant[T](value: T) -> Invariant[T]:
+    raise NotImplementedError
+
+def covariant_overload[T](container: Covariant[Callable[[int], T]]) -> T:
+    raise NotImplementedError
+
+def contravariant_overload[T](container: Contravariant[Callable[[int], T]]) -> T:
+    raise NotImplementedError
+
+def invariant_overload[T](container: Invariant[Callable[[int], T]]) -> T:
+    raise NotImplementedError
+
+reveal_type(covariant_overload(wrap_covariant(overloaded)))  # revealed: Middle
+contravariant_overload(wrap_contravariant(overloaded))  # error: [invalid-argument-type]
+invariant_overload(wrap_invariant(overloaded))  # error: [invalid-argument-type]
+```
+
+When every overload is covered by the formal `int` parameter, all three wrapper variances accept it.
+
+```py
+@overload
+def covered(value: bool, /) -> Middle: ...
+@overload
+def covered(value: int, /) -> Middle: ...
+def covered(value: int, /) -> Middle:
+    raise NotImplementedError
+
+reveal_type(covariant_overload(wrap_covariant(covered)))  # revealed: Middle
+reveal_type(contravariant_overload(wrap_contravariant(covered)))  # revealed: Middle
+reveal_type(invariant_overload(wrap_invariant(covered)))  # revealed: Middle
+```
+
 Callable parameter types are already contravariant. An outer contravariant class reverses their
 relationship a second time, producing the same lower bound as a covariant callable return type.
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -186,6 +186,201 @@ def _(a: A, b: B, x: A | B):
     reveal_type(takes_in_supports_foo(x))  # revealed: A | B
 ```
 
+## Inferring through nested nominal generic classes
+
+When a nominal generic class is nested inside another, the outer class determines whether the inner
+specialization contributes a lower bound, an upper bound, or both.
+
+```py
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Contravariant[T]:
+    def put(self, value: T) -> None: ...
+
+class Invariant[T]:
+    value: T
+
+class Producer[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def covariant[T](container: Covariant[Producer[T]], value: T) -> T:
+    return value
+
+def contravariant[T](container: Contravariant[Producer[T]], value: T) -> T:
+    return value
+
+def invariant[T](container: Invariant[Producer[T]], value: T) -> T:
+    return value
+```
+
+Covariance permits the broader `Base`, contravariance accepts the narrower `Derived`, and invariance
+preserves `Middle`.
+
+```py
+class Base: ...
+class Middle(Base): ...
+class Derived(Middle): ...
+
+reveal_type(covariant(Covariant[Producer[Middle]](), Base()))  # revealed: Base
+reveal_type(contravariant(Contravariant[Producer[Middle]](), Derived()))  # revealed: Derived
+reveal_type(invariant(Invariant[Producer[Middle]](), Middle()))  # revealed: Middle
+```
+
+## Inferring through nested generic protocols
+
+Generic protocols must preserve the variance of the outer class when constructing their structural
+constraints, just as nominal generic classes do.
+
+```py
+from typing import Protocol
+
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Contravariant[T]:
+    def put(self, value: T) -> None: ...
+
+class Invariant[T]:
+    value: T
+
+class Producer[T](Protocol):
+    def get(self) -> T: ...
+
+def covariant[T](container: Covariant[Producer[T]], value: T) -> T:
+    return value
+
+def contravariant[T](container: Contravariant[Producer[T]], value: T) -> T:
+    return value
+
+def invariant[T](container: Invariant[Producer[T]], value: T) -> T:
+    return value
+```
+
+A covariant outer class permits the broader `Base`, a contravariant class accepts the narrower
+`Derived`, and an invariant class requires exactly `Middle`.
+
+```py
+class Base: ...
+class Middle(Base): ...
+class Derived(Middle): ...
+
+reveal_type(covariant(Covariant[Producer[Middle]](), Base()))  # revealed: Base
+reveal_type(contravariant(Contravariant[Producer[Middle]](), Derived()))  # revealed: Derived
+reveal_type(invariant(Invariant[Producer[Middle]](), Middle()))  # revealed: Middle
+invariant(Invariant[Producer[Middle]](), Base())  # error: [invalid-argument-type]
+```
+
+A consuming protocol reverses the relationship once more. Nesting that protocol inside a
+contravariant class therefore turns its upper bound back into a lower bound.
+
+```py
+class Consumer[T](Protocol):
+    def put(self, value: T) -> None: ...
+
+def consumer[T](container: Covariant[Consumer[T]], value: T) -> T:
+    return value
+
+def double_contravariant[T](container: Contravariant[Consumer[T]], value: T) -> T:
+    return value
+
+reveal_type(consumer(Covariant[Consumer[Middle]](), Derived()))  # revealed: Derived
+reveal_type(double_contravariant(Contravariant[Consumer[Middle]](), Derived()))  # revealed: Middle
+```
+
+## Inferring through nested generic callables
+
+Callable return types are covariant, but nesting a callable inside a contravariant or invariant
+generic class changes which constraints its return type supplies.
+
+```py
+from typing import Callable
+
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Contravariant[T]:
+    def put(self, value: T) -> None: ...
+
+class Invariant[T]:
+    value: T
+
+def covariant[T](container: Covariant[Callable[[], T]], value: T) -> T:
+    return value
+
+def contravariant[T](container: Contravariant[Callable[[], T]], value: T) -> T:
+    return value
+
+def invariant[T](container: Invariant[Callable[[], T]], value: T) -> T:
+    return value
+
+class Base: ...
+class Middle(Base): ...
+class Derived(Middle): ...
+
+reveal_type(covariant(Covariant[Callable[[], Middle]](), Base()))  # revealed: Base
+reveal_type(contravariant(Contravariant[Callable[[], Middle]](), Derived()))  # revealed: Derived
+reveal_type(invariant(Invariant[Callable[[], Middle]](), Middle()))  # revealed: Middle
+invariant(Invariant[Callable[[], Middle]](), Base())  # error: [invalid-argument-type]
+```
+
+A union of callable return types offers alternative upper bounds; a compatible arm must not be
+rejected just because another arm is incompatible.
+
+```py
+reveal_type(contravariant(Contravariant[Callable[[], Middle] | Callable[[], str]](), Derived()))  # revealed: Derived
+```
+
+Callable parameter types are already contravariant. An outer contravariant class reverses their
+relationship a second time, producing the same lower bound as a covariant callable return type.
+
+```py
+def consumer[T](container: Covariant[Callable[[T], None]], value: T) -> T:
+    return value
+
+def double_contravariant[T](container: Contravariant[Callable[[T], None]], value: T) -> T:
+    return value
+
+reveal_type(consumer(Covariant[Callable[[Middle], None]](), Derived()))  # revealed: Derived
+reveal_type(double_contravariant(Contravariant[Callable[[Middle], None]](), Derived()))  # revealed: Middle
+```
+
+## Inferring through nested callable protocols
+
+A callable assigned to a callback protocol contributes the same return-type constraints through its
+signature, including when an outer generic class reverses their direction.
+
+```py
+from typing import Callable, Protocol
+
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Contravariant[T]:
+    def put(self, value: T) -> None: ...
+
+class Callback[T](Protocol):
+    def __call__(self) -> T: ...
+
+def covariant[T](container: Covariant[Callback[T]], value: T) -> T:
+    return value
+
+def contravariant[T](container: Contravariant[Callback[T]], value: T) -> T:
+    return value
+
+class Base: ...
+class Middle(Base): ...
+class Derived(Middle): ...
+
+reveal_type(covariant(Covariant[Callable[[], Middle]](), Base()))  # revealed: Base
+reveal_type(contravariant(Contravariant[Callable[[], Middle]](), Derived()))  # revealed: Derived
+```
+
 ## Bound violations inferred through protocols
 
 If matching a protocol argument infers a type that violates a type variable's bound, the call should

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -392,6 +392,105 @@ reveal_type(simple(variadic2))  # revealed: tuple[Unknown, ...]
 reveal_type(simple(keyword_only))  # revealed: tuple[Unknown, ...]
 ```
 
+### Callable inference through invariant and contravariant wrappers
+
+An unpacked `TypeVarTuple` keeps its precise inferred parameter types when a callable or callable
+protocol is nested inside an invariant or contravariant wrapper.
+
+```py
+from typing import Callable, Protocol
+
+class Invariant[T]:
+    def __init__(self, callback: T) -> None: ...
+    callback: T
+
+class Contravariant[T]:
+    def __init__(self, callback: T) -> None: ...
+    def put(self, callback: T) -> None: ...
+
+def invariant[*Ts](wrapper: Invariant[Callable[[*Ts], None]]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def contravariant[*Ts](wrapper: Contravariant[Callable[[*Ts], None]]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def callback(first: object, value: str) -> None: ...
+
+reveal_type(invariant(Invariant(callback)))  # revealed: tuple[object, str]
+reveal_type(contravariant(Contravariant(callback)))  # revealed: tuple[object, str]
+```
+
+A callable protocol preserves the same inferred parameters through both wrapper variances.
+
+```py
+class Callback[*Ts](Protocol):
+    def __call__(self, *args: *Ts) -> None: ...
+
+def invariant_protocol[*Ts](wrapper: Invariant[Callback[*Ts]]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def contravariant_protocol[*Ts](wrapper: Contravariant[Callback[*Ts]]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+reveal_type(invariant_protocol(Invariant(callback)))  # revealed: tuple[object, str]
+reveal_type(contravariant_protocol(Contravariant(callback)))  # revealed: tuple[object, str]
+```
+
+Separately declared protocols with equivalent variadic methods also preserve the exact inferred
+tuple under both wrapper variances.
+
+```py
+class Target[*Ts](Protocol):
+    def call(self, *args: *Ts) -> None: ...
+
+class Actual[*Ts](Protocol):
+    def call(self, *args: *Ts) -> None: ...
+
+def invariant_structural[*Ts](wrapper: Invariant[Target[*Ts]]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def contravariant_structural[*Ts](wrapper: Contravariant[Target[*Ts]]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def check_structural(
+    invariant_wrapper: Invariant[Actual[str]],
+    contravariant_wrapper: Contravariant[Actual[str]],
+) -> None:
+    reveal_type(invariant_structural(invariant_wrapper))  # revealed: tuple[str]
+    reveal_type(contravariant_structural(contravariant_wrapper))  # revealed: tuple[str]
+```
+
+Unions of structurally compatible protocols retain the same tuple. Incompatible alternatives are
+rejected without widening their inferred tuple to an unknown-length tuple.
+
+```py
+class Other[*Ts](Protocol):
+    def call(self, *args: *Ts) -> None: ...
+
+def check_unions(
+    invariant_match: Invariant[Actual[str] | Other[str]],
+    contravariant_match: Contravariant[Actual[str] | Other[str]],
+    invariant_mismatch: Invariant[Actual[str] | Other[bytes]],
+    contravariant_mismatch: Contravariant[Actual[str] | Other[bytes]],
+) -> None:
+    reveal_type(invariant_structural(invariant_match))  # revealed: tuple[str]
+    reveal_type(contravariant_structural(contravariant_match))  # revealed: tuple[str]
+    # error: [invalid-argument-type]
+    reveal_type(invariant_structural(invariant_mismatch))  # revealed: tuple[()]
+    # error: [invalid-argument-type]
+    reveal_type(contravariant_structural(contravariant_mismatch))  # revealed: tuple[()]
+```
+
+A nominal class implementing the same variadic protocol retains its precise method parameter.
+
+```py
+class StringRunner:
+    def call(self, value: str) -> None: ...
+
+reveal_type(invariant_structural(Invariant(StringRunner())))  # revealed: tuple[str]
+reveal_type(contravariant_structural(Contravariant(StringRunner())))  # revealed: tuple[str]
+```
+
 ### Callable return inference
 
 An unpacked `TypeVarTuple` in a callable return type is inferred as one packed tuple, including

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -2007,7 +2007,25 @@ def materialized_inference(inherited: Top[InheritedInferenceAny]) -> None:
 
 def materialized_structural_inference(structural: Top[StructuralInferenceAny]) -> None:
     reveal_type(infer_item(structural))  # revealed: object
+```
 
+A top-materialized structural protocol nested inside a contravariant class supplies an upper bound
+without widening a narrower argument.
+
+```py
+class Contravariant[T]:
+    def put(self, value: T) -> None: ...
+
+def infer_contravariant_item[T](container: Contravariant[InferenceBase[T]], value: T) -> T:
+    return value
+
+def nested_inference(container: Contravariant[Top[StructuralInferenceAny]], value: bool) -> None:
+    reveal_type(infer_contravariant_item(container, value))  # revealed: bool
+```
+
+Bounds and constraints still reject a materialized `object` property when its type is incompatible.
+
+```py
 def bounded_item[T: str](value: InferenceBase[T]) -> T:
     raise NotImplementedError
 
@@ -2154,6 +2172,47 @@ def recursive_materialized_inference(
     reveal_type(infer_recursive_value(top))  # revealed: object
     reveal_type(infer_recursive_value(valid))  # revealed: str
     reveal_type(infer_recursive_value(bottom))  # revealed: Never
+```
+
+A materialized recursive protocol nested inside a contravariant class contributes an upper bound
+without expanding its recursive property.
+
+```py
+class Contravariant[T]:
+    def put(self, value: T) -> None: ...
+
+def infer_contravariant_value[T](container: Contravariant[RecursiveValue[T]], value: T) -> T:
+    return value
+
+def nested_recursive_inference(container: Contravariant[Top[RecursiveAny]], value: bool) -> None:
+    reveal_type(infer_contravariant_value(container, value))  # revealed: bool
+```
+
+When a materialized protocol has no nonrecursive members, inference must defer to a separate
+argument rather than expand its recursive requirement or reject the call.
+
+```py
+class RecursiveOnlyTarget[T](Protocol):
+    @property
+    def child(self) -> RecursiveOnlyTarget[T]: ...
+
+class RecursiveOnlySource[T](Protocol):
+    @property
+    def child(self) -> RecursiveOnlySource[T]: ...
+
+def infer_recursive_only[T](value: RecursiveOnlyTarget[T], witness: T) -> T:
+    return witness
+
+def infer_contravariant_recursive_only[T](value: Contravariant[RecursiveOnlyTarget[T]], witness: T) -> T:
+    return witness
+
+def no_finite_recursive_members(
+    top: Top[RecursiveOnlySource[Any]],
+    contravariant: Contravariant[Top[RecursiveOnlySource[Any]]],
+    witness: bool,
+) -> None:
+    reveal_type(infer_recursive_only(top, witness))  # revealed: bool
+    reveal_type(infer_contravariant_recursive_only(contravariant, witness))  # revealed: bool
 ```
 
 The nonrecursive property is used only to infer the specialization. The complete protocol must still

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::types::callable::walk_callable_type;
+use crate::types::callable::{CallableTypeKind, walk_callable_type};
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
@@ -3263,10 +3263,31 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     ) -> Result<(), SpecializationError<'db>> {
         let db = self.db;
         if !matches!(polarity, TypeVarVariance::Covariant) {
+            let preserve_paramspec_mapping =
+                matches!(formal.kind(db), CallableTypeKind::ParamSpecValue)
+                    && !matches!(polarity, TypeVarVariance::Bivariant);
             let actual = actual_callables
                 .map(|callable| callable.into_regular(db))
                 .into_type(db, self.env);
             let formal = Type::Callable(formal.into_regular(db));
+
+            // ParamSpecs are still solved from the legacy mapping table. Preserve any usable
+            // mapping from the forward relation before the full relation becomes unsatisfiable;
+            // for example, `Concatenate[object, P]` has a positional-only prefix, while an
+            // actual method receiver can also be passed by keyword. Do not add the forward
+            // relation to `pending`: doing so would turn a contravariant comparison invariant.
+            // TODO: Move ParamSpecs into the new constraint solver and align nominal inference
+            // with `specialization_variance`, which accounts for their callable representation.
+            if preserve_paramspec_mapping {
+                let forward =
+                    self.constraint_for_relation(formal, actual, TypeVarVariance::Covariant);
+                if let Err(ConstraintSetInferenceError::InvalidTypeVar(error)) =
+                    self.add_type_mappings_from_constraint_set(forward)
+                {
+                    return Err(error);
+                }
+            }
+
             let when = self.constraint_for_relation(formal, actual, polarity);
             return self.infer_from_constraint_set(when);
         }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -19,9 +19,7 @@ use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation,
     TypeRelationChecker, TypeVarEvaluation,
 };
-use crate::types::signatures::{
-    CallableSignature, Parameters, ReturnCallableTypeVarScope, SignatureRelationVisitor,
-};
+use crate::types::signatures::{Parameters, ReturnCallableTypeVarScope, SignatureRelationVisitor};
 use crate::types::tuple::{
     TupleSpec, TupleSpecBuilder, TupleType, VariableSegment, walk_tuple_type,
 };
@@ -3019,6 +3017,42 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
+    /// Returns the directional comparisons required by this comparison's polarity.
+    ///
+    /// A covariant comparison requires `actual <= formal`, a contravariant comparison requires
+    /// `formal <= actual`, and an invariant comparison requires both. Bivariant comparisons add
+    /// no constraints.
+    fn relation_directions<T: Copy>(
+        formal: T,
+        actual: T,
+        polarity: TypeVarVariance,
+    ) -> impl Iterator<Item = (T, T)> {
+        [
+            (!polarity.is_contravariant()).then_some((actual, formal)),
+            (!polarity.is_covariant()).then_some((formal, actual)),
+        ]
+        .into_iter()
+        .flatten()
+    }
+
+    /// Returns the assignability constraints required by this comparison's polarity.
+    fn constraint_for_relation(
+        &self,
+        formal: Type<'db>,
+        actual: Type<'db>,
+        polarity: TypeVarVariance,
+    ) -> ConstraintSet<'db, 'c> {
+        let db = self.db;
+        Self::relation_directions(formal, actual, polarity).when_all(
+            db,
+            self.constraints,
+            |(source, target)| {
+                let when = source.when_constraint_set_assignable_to_owned(db, self.env, target);
+                self.constraints.load(db, self.env, &when)
+            },
+        )
+    }
+
     /// Returns common protocol constraints for the `TypedDict` members of a union when every such
     /// member has the same constraints as their shared `Mapping[str, object]` fallback.
     fn common_typed_dict_protocol_constraints(
@@ -3223,12 +3257,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// are returned for immediate diagnosis.
     fn infer_from_callable_signature(
         &mut self,
-        formal_signature: &CallableSignature<'db>,
-        actual_callables: &CallableTypes<'db>,
+        formal: CallableType<'db>,
+        actual_callables: CallableTypes<'db>,
+        polarity: TypeVarVariance,
     ) -> Result<(), SpecializationError<'db>> {
         let db = self.db;
-        let formal_is_single_paramspec = formal_signature.is_single_paramspec().is_some();
+        if !matches!(polarity, TypeVarVariance::Covariant) {
+            let actual = actual_callables
+                .map(|callable| callable.into_regular(db))
+                .into_type(db, self.env);
+            let formal = Type::Callable(formal.into_regular(db));
+            let when = self.constraint_for_relation(formal, actual, polarity);
+            return self.infer_from_constraint_set(when);
+        }
 
+        let formal_signature = formal.signatures(db);
+        let formal_is_single_paramspec = formal_signature.is_single_paramspec().is_some();
         for actual_callable in actual_callables.as_slice() {
             if formal_is_single_paramspec {
                 let when = actual_callable
@@ -3737,24 +3781,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 || matches!(formal, Type::SubclassOf(subclass)
                     if matches!(subclass.subclass_of(), SubclassOfInner::Class(_))) =>
             {
-                let when = match polarity {
-                    TypeVarVariance::Covariant | TypeVarVariance::Invariant => {
-                        actual.when_constraint_set_assignable_to_owned(db, self.env, formal)
-                    }
-                    TypeVarVariance::Contravariant => {
-                        formal.when_constraint_set_assignable_to_owned(db, self.env, actual)
-                    }
-                    TypeVarVariance::Bivariant => return Ok(()),
-                };
-                let mut when = self.constraints.load(db, self.env, &when);
-                if matches!(polarity, TypeVarVariance::Invariant) {
-                    let reverse =
-                        formal.when_constraint_set_assignable_to_owned(db, self.env, actual);
-                    let reverse = self.constraints.load(db, self.env, &reverse);
-                    when.intersect(db, self.constraints, reverse);
-                }
-                self.infer_from_constraint_set(when)?;
-                return Ok(());
+                let when = self.constraint_for_relation(formal, actual, polarity);
+                return self.infer_from_constraint_set(when);
             }
 
             (Type::SubclassOf(subclass_of), ty) | (ty, Type::SubclassOf(subclass_of))
@@ -3798,29 +3826,54 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     && let Some(actual_origin) = actual_protocol.materialized_origin(db)
                     && let Some(formal_origin) = formal_protocol.class_origin(db)
                 {
-                    let nominally_inherited = actual_origin
-                        .iter_mro(db)
-                        .filter_map(ClassBase::into_class)
-                        .any(|base| base.class_literal(db) == formal_origin.class_literal(db));
-                    let when = if nominally_inherited
-                        || formal_protocol.interface(db).has_only_finite_members(db)
-                    {
-                        Some(actual.when_constraint_set_assignable_to_owned(db, self.env, formal))
-                    } else {
-                        actual_protocol
-                            .when_non_recursive_members_assignable_to_owned(db, formal_protocol)
-                            .map(Cow::Borrowed)
-                    };
-
                     // Materialized protocols cannot be replaced by their nominal origin: doing
                     // so would recover the original `Any` requirements. Infer from the complete
                     // interface when doing so is cycle-safe; otherwise use its nonrecursive
                     // requirements and leave full recursive compatibility to argument checking.
+                    let when = Self::relation_directions(
+                        (formal_protocol, formal_origin),
+                        (actual_protocol, actual_origin),
+                        polarity,
+                    )
+                    .try_fold(
+                        ConstraintSet::from_bool(self.constraints, true),
+                        |mut combined, ((source, source_origin), (target, target_origin))| {
+                            if combined.is_trivially_never_satisfied() {
+                                return Some(combined);
+                            }
+
+                            let when = if source_origin
+                                .is_subtype_of_class_literal(db, target_origin.class_literal(db))
+                                || target.interface(db).has_only_finite_members(db)
+                            {
+                                Type::ProtocolInstance(source)
+                                    .when_constraint_set_assignable_to_owned(
+                                        db,
+                                        self.env,
+                                        Type::ProtocolInstance(target),
+                                    )
+                            } else {
+                                Cow::Borrowed(
+                                    source.when_non_recursive_members_assignable_to_owned(
+                                        db, target,
+                                    )?,
+                                )
+                            };
+                            let next = self.constraints.load(db, self.env, &when);
+                            Some(combined.intersect(db, self.constraints, next))
+                        },
+                    );
+
                     if let Some(when) = when {
-                        let when = self.constraints.load(db, self.env, &when);
-                        self.infer_from_constraint_set(when)?;
-                        return Ok(());
+                        return self.infer_from_constraint_set(when);
                     }
+                }
+
+                // Converting the actual protocol to its nominal origin makes the reversed
+                // comparison impossible: a protocol cannot be assignable to a nominal class.
+                if matches!(formal, Type::ProtocolInstance(_)) && !polarity.is_covariant() {
+                    let when = self.constraint_for_relation(formal, actual, polarity);
+                    return self.infer_from_constraint_set(when);
                 }
 
                 // TODO: This will only handle protocol classes that explicit inherit
@@ -3944,11 +3997,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         // will handle implicitly implemented protocols and generic protocols. We
                         // eventually want this logic to be used for _all_ nominal instances
                         // (replacing the logic below).
-                        let when =
-                            actual.when_constraint_set_assignable_to_owned(db, self.env, formal);
-                        let when = self.constraints.load(db, self.env, &when);
-                        self.infer_from_constraint_set(when)?;
-                        return Ok(());
+                        let when = self.constraint_for_relation(formal, actual, polarity);
+                        return self.infer_from_constraint_set(when);
                     }
 
                     _ => None,
@@ -3986,25 +4036,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // union, but the old solver isn't well-equipped to handle that (due to side effects
             // from even failed matches), so for now we handle this particular case.
             (formal @ Type::ProtocolInstance(_), actual @ Type::Union(actual_union)) => {
-                let when = self
-                    .common_typed_dict_protocol_constraints(formal, actual_union)
-                    .unwrap_or_else(|| {
-                        actual.when_constraint_set_assignable_to(
-                            db,
-                            self.env,
-                            formal,
-                            self.constraints,
-                        )
-                    });
-                self.infer_from_constraint_set(when)?;
-                return Ok(());
+                // Common TypedDict constraints prove only `actual <= formal`. Contravariance
+                // reverses that relation, while invariance additionally requires the reverse.
+                let when = if matches!(polarity, TypeVarVariance::Covariant)
+                    && let Some(common) =
+                        self.common_typed_dict_protocol_constraints(formal, actual_union)
+                {
+                    common
+                } else {
+                    self.constraint_for_relation(formal, actual, polarity)
+                };
+                return self.infer_from_constraint_set(when);
             }
 
             (formal @ Type::ProtocolInstance(_), actual @ Type::TypedDict(_)) => {
-                let when = actual.when_constraint_set_assignable_to_owned(db, self.env, formal);
-                let when = self.constraints.load(db, self.env, &when);
-                self.infer_from_constraint_set(when)?;
-                return Ok(());
+                let when = self.constraint_for_relation(formal, actual, polarity);
+                return self.infer_from_constraint_set(when);
             }
 
             // When the formal type is a protocol with a `__call__` method, infer the specialization
@@ -4021,18 +4068,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
                 // The protocol interface exposes the callable signature already bound for
                 // instance access.
-                let formal_signature = call_method.signatures(db);
-
-                self.infer_from_callable_signature(formal_signature, &actual_callables)?;
+                self.infer_from_callable_signature(call_method, actual_callables, polarity)?;
             }
 
             (Type::Callable(formal_callable), _) => {
                 let Some(actual_callables) = actual.try_upcast_to_callable(db, self.env) else {
                     return Ok(());
                 };
-                let formal_signature = formal_callable.signatures(db);
-
-                self.infer_from_callable_signature(formal_signature, &actual_callables)?;
+                self.infer_from_callable_signature(formal_callable, actual_callables, polarity)?;
             }
 
             // Expand type aliases in the actual type.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3344,7 +3344,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         formal: Type<'db>,
         actual: Type<'db>,
         polarity: TypeVarVariance,
-        seen: &mut FxHashSet<(Type<'db>, Type<'db>)>,
+        seen: &mut FxHashSet<(Type<'db>, Type<'db>, TypeVarVariance)>,
     ) -> Result<(), SpecializationError<'db>> {
         let db = self.db;
         // TODO: Eventually, the builder will maintain a constraint set, instead of a hash-map of
@@ -3360,8 +3360,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             return Ok(());
         }
 
-        // Avoid infinite recursion
-        if !seen.insert((formal, actual)) {
+        // Avoid infinite recursion while retaining comparisons under different polarities.
+        if !seen.insert((formal, actual, polarity)) {
             return Ok(());
         }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::types::callable::{CallableTypeKind, walk_callable_type};
+use crate::types::callable::walk_callable_type;
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
@@ -3263,31 +3263,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     ) -> Result<(), SpecializationError<'db>> {
         let db = self.db;
         if !matches!(polarity, TypeVarVariance::Covariant) {
-            let preserve_paramspec_mapping =
-                matches!(formal.kind(db), CallableTypeKind::ParamSpecValue)
-                    && !matches!(polarity, TypeVarVariance::Bivariant);
             let actual = actual_callables
                 .map(|callable| callable.into_regular(db))
                 .into_type(db, self.env);
             let formal = Type::Callable(formal.into_regular(db));
-
-            // ParamSpecs are still solved from the legacy mapping table. Preserve any usable
-            // mapping from the forward relation before the full relation becomes unsatisfiable;
-            // for example, `Concatenate[object, P]` has a positional-only prefix, while an
-            // actual method receiver can also be passed by keyword. Do not add the forward
-            // relation to `pending`: doing so would turn a contravariant comparison invariant.
-            // TODO: Move ParamSpecs into the new constraint solver and align nominal inference
-            // with `specialization_variance`, which accounts for their callable representation.
-            if preserve_paramspec_mapping {
-                let forward =
-                    self.constraint_for_relation(formal, actual, TypeVarVariance::Covariant);
-                if let Err(ConstraintSetInferenceError::InvalidTypeVar(error)) =
-                    self.add_type_mappings_from_constraint_set(forward)
-                {
-                    return Err(error);
-                }
-            }
-
             let when = self.constraint_for_relation(formal, actual, polarity);
             return self.infer_from_constraint_set(when);
         }
@@ -3393,6 +3372,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // specialize `T` to `int`, and so ignore the `None`.
         let actual = actual.filter_disjoint_elements(db, self.env, formal, self.inferable);
         let formal = formal.filter_disjoint_elements(db, self.env, actual, self.inferable);
+
+        // ParamSpecs and TypeVarTuples still use the forward-only legacy mapping table. Keep
+        // their entire inference context on the existing signature path, and use forward
+        // structural relations so nested variadics and ordinary type variables retain their
+        // mappings. Preserve the original polarity for recursive and ordinary inference.
+        // TODO: Apply full polarity once variadics are supported by the new constraint solver.
+        let relation_polarity = if !polarity.is_covariant()
+            && self
+                .inferable
+                .iter(db)
+                .any(|typevar| typevar.is_paramspec(db) || typevar.is_typevartuple(db))
+        {
+            TypeVarVariance::Covariant
+        } else {
+            polarity
+        };
 
         match (formal, actual) {
             // Expand PEP 695 type aliases in the formal type.
@@ -3802,7 +3797,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 || matches!(formal, Type::SubclassOf(subclass)
                     if matches!(subclass.subclass_of(), SubclassOfInner::Class(_))) =>
             {
-                let when = self.constraint_for_relation(formal, actual, polarity);
+                let when = self.constraint_for_relation(formal, actual, relation_polarity);
                 return self.infer_from_constraint_set(when);
             }
 
@@ -3854,7 +3849,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     let when = Self::relation_directions(
                         (formal_protocol, formal_origin),
                         (actual_protocol, actual_origin),
-                        polarity,
+                        relation_polarity,
                     )
                     .try_fold(
                         ConstraintSet::from_bool(self.constraints, true),
@@ -3892,8 +3887,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
                 // Converting the actual protocol to its nominal origin makes the reversed
                 // comparison impossible: a protocol cannot be assignable to a nominal class.
-                if matches!(formal, Type::ProtocolInstance(_)) && !polarity.is_covariant() {
-                    let when = self.constraint_for_relation(formal, actual, polarity);
+                if matches!(formal, Type::ProtocolInstance(_)) && !relation_polarity.is_covariant()
+                {
+                    let when = self.constraint_for_relation(formal, actual, relation_polarity);
                     return self.infer_from_constraint_set(when);
                 }
 
@@ -4018,7 +4014,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         // will handle implicitly implemented protocols and generic protocols. We
                         // eventually want this logic to be used for _all_ nominal instances
                         // (replacing the logic below).
-                        let when = self.constraint_for_relation(formal, actual, polarity);
+                        let when = self.constraint_for_relation(formal, actual, relation_polarity);
                         return self.infer_from_constraint_set(when);
                     }
 
@@ -4059,19 +4055,19 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             (formal @ Type::ProtocolInstance(_), actual @ Type::Union(actual_union)) => {
                 // Common TypedDict constraints prove only `actual <= formal`. Contravariance
                 // reverses that relation, while invariance additionally requires the reverse.
-                let when = if matches!(polarity, TypeVarVariance::Covariant)
+                let when = if matches!(relation_polarity, TypeVarVariance::Covariant)
                     && let Some(common) =
                         self.common_typed_dict_protocol_constraints(formal, actual_union)
                 {
                     common
                 } else {
-                    self.constraint_for_relation(formal, actual, polarity)
+                    self.constraint_for_relation(formal, actual, relation_polarity)
                 };
                 return self.infer_from_constraint_set(when);
             }
 
             (formal @ Type::ProtocolInstance(_), actual @ Type::TypedDict(_)) => {
-                let when = self.constraint_for_relation(formal, actual, polarity);
+                let when = self.constraint_for_relation(formal, actual, relation_polarity);
                 return self.infer_from_constraint_set(when);
             }
 
@@ -4089,14 +4085,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
                 // The protocol interface exposes the callable signature already bound for
                 // instance access.
-                self.infer_from_callable_signature(call_method, actual_callables, polarity)?;
+                self.infer_from_callable_signature(
+                    call_method,
+                    actual_callables,
+                    relation_polarity,
+                )?;
             }
 
             (Type::Callable(formal_callable), _) => {
                 let Some(actual_callables) = actual.try_upcast_to_callable(db, self.env) else {
                     return Ok(());
                 };
-                self.infer_from_callable_signature(formal_callable, actual_callables, polarity)?;
+                self.infer_from_callable_signature(
+                    formal_callable,
+                    actual_callables,
+                    relation_polarity,
+                )?;
             }
 
             // Expand type aliases in the actual type.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2439,6 +2439,24 @@ enum ConstraintSetInferenceError<'db> {
     Unsatisfiable,
 }
 
+/// Returns the directional comparisons required by this comparison's polarity.
+///
+/// A covariant comparison requires `actual <= formal`, a contravariant comparison requires
+/// `formal <= actual`, and an invariant comparison requires both. Bivariant comparisons add
+/// no constraints.
+fn relation_directions<T: Copy>(
+    formal: T,
+    actual: T,
+    polarity: TypeVarVariance,
+) -> impl Iterator<Item = (T, T)> {
+    [
+        (!polarity.is_contravariant()).then_some((actual, formal)),
+        (!polarity.is_covariant()).then_some((formal, actual)),
+    ]
+    .into_iter()
+    .flatten()
+}
+
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     pub(crate) fn new(
         db: &'db dyn Db,
@@ -3017,24 +3035,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
-    /// Returns the directional comparisons required by this comparison's polarity.
-    ///
-    /// A covariant comparison requires `actual <= formal`, a contravariant comparison requires
-    /// `formal <= actual`, and an invariant comparison requires both. Bivariant comparisons add
-    /// no constraints.
-    fn relation_directions<T: Copy>(
-        formal: T,
-        actual: T,
-        polarity: TypeVarVariance,
-    ) -> impl Iterator<Item = (T, T)> {
-        [
-            (!polarity.is_contravariant()).then_some((actual, formal)),
-            (!polarity.is_covariant()).then_some((formal, actual)),
-        ]
-        .into_iter()
-        .flatten()
-    }
-
     /// Returns the assignability constraints required by this comparison's polarity.
     fn constraint_for_relation(
         &self,
@@ -3043,7 +3043,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         polarity: TypeVarVariance,
     ) -> ConstraintSet<'db, 'c> {
         let db = self.db;
-        Self::relation_directions(formal, actual, polarity).when_all(
+        relation_directions(formal, actual, polarity).when_all(
             db,
             self.constraints,
             |(source, target)| {
@@ -3846,7 +3846,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     // so would recover the original `Any` requirements. Infer from the complete
                     // interface when doing so is cycle-safe; otherwise use its nonrecursive
                     // requirements and leave full recursive compatibility to argument checking.
-                    let when = Self::relation_directions(
+                    let when = relation_directions(
                         (formal_protocol, formal_origin),
                         (actual_protocol, actual_origin),
                         relation_polarity,


### PR DESCRIPTION
## Summary

Part of astral-sh/ty#3557 and the second step in rebooting #26712 as smaller focused changes.

On `main`, generic inference does not consistently propagate the variance of an enclosing generic class into structural-protocol and callable comparisons. Those comparisons instead construct the forward `actual <= formal` relation even when the surrounding position is contravariant or invariant. This produces incorrect bounds and inferred types:

```py
from typing import Callable

class Middle: ...
class Derived(Middle): ...

class Sink[T]:
    def put(self, value: T) -> None: ...

def infer[T](sink: Sink[Callable[[], T]], value: T) -> T:
    return value

reveal_type(infer(Sink[Callable[[], Middle]](), Derived()))
# main: Middle
# this PR: Derived
```

This PR centralizes relation construction so inference consistently follows the surrounding polarity: covariance requires `actual <= formal`, contravariance requires `formal <= actual`, invariance requires both, and bivariance adds no constraints. The fix applies to nested generic protocols, callable signatures, callback protocols, TypedDict/protocol relations, and materialized protocols while preserving existing nominal inference, callable-union alternatives, TypedDict-union optimizations, and cycle-safe handling of recursive protocols.

## Limitation

The new constraint solver does not yet support `ParamSpec` or `TypeVarTuple`. Whenever an inference context includes either variadic, all affected relations must continue through the old, forward-only inference path, including comparisons involving ordinary type variables alongside an unrelated variadic. This deliberately avoids regressions in parameter inference, structural protocols, descriptor signatures, and downstream argument diagnostics, but it also means the polarity fixes in this PR do not apply whenever variadics are involved. Focused TODO tests document cases that still incorrectly infer `Middle` instead of `Derived`; fixing those cases requires adding variadic support to the new solver.

## Test plan

Added mdtests cover nested nominal classes, generic protocols, callable signatures, and callback protocols under covariance, contravariance, and invariance; double contravariance, callable-union alternatives, and invariant rejection; finite, recursive, and recursive-only materialized protocols; invariant, contravariant, and covariant `ParamSpec` inference through `Concatenate`; bounded and constrained prefixes, descriptor receivers, structural protocol unions, nominal callable objects, higher-order callbacks, and mixed ordinary/variadic inference; analogous `TypeVarTuple` callable, protocol, structural-union, and nominal-implementation cases; and explicit TODO coverage for unrelated variadics suppressing otherwise-correct polarity.

Additional mdtests cover repeated comparisons of the same protocol or callable under opposite polarities, plus overloaded callable acceptance and rejection across covariant, contravariant, and invariant wrappers.

