### PR TITLE
Fix Git metadata tracking in linked worktrees

### DIFF
--- a/crates/ruff/build.rs
+++ b/crates/ruff/build.rs
@@ -31,9 +31,9 @@ fn commit_info(workspace_root: &Path) {
         if let Ok(git_head_contents) = git_head_contents {
             // The contents are either a commit or a reference in the following formats
             // - "<commit>" when the head is detached
-            // - "ref <ref>" when working on a branch
+            // - "ref: <ref>" when working on a branch
             // If a commit, checking if the HEAD file has changed is sufficient
-            // If a ref, we need to add the head file for that ref to rebuild on commit
+            // If a ref, we also need to watch where Git stores its current commit
             let mut git_ref_parts = git_head_contents.split_whitespace();
             git_ref_parts.next();
             if let Some(git_ref) = git_ref_parts.next() {
@@ -85,21 +85,22 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
         return None;
     }
 
+    // Watch the pointer in case the worktree's Git directory changes.
     println!("cargo:rerun-if-changed={}", git_dir.display());
-    // If `.git/HEAD` doesn't exist and `.git` is actually a file,
-    // then let's try to attempt to read it as a worktree. If it's
-    // a worktree, then its contents will look like this, e.g.:
+    // A linked worktree has a `.git` file instead of a `.git` directory.
+    // Its contents point to the worktree-specific Git directory, e.g.:
     //
-    //     gitdir: /home/andrew/astral/uv/main/.git/worktrees/pr2
+    //     gitdir: /home/andrew/astral/ruff/main/.git/worktrees/pr2
     //
     // And the HEAD file we want to watch will be at:
     //
-    //     /home/andrew/astral/uv/main/.git/worktrees/pr2/HEAD
+    //     /home/andrew/astral/ruff/main/.git/worktrees/pr2/HEAD
     let contents = fs::read_to_string(git_dir).ok()?;
     let (label, worktree_path) = contents.split_once(':')?;
     if label != "gitdir" {
         return None;
     }
+    // Relative `gitdir:` paths are relative to the directory containing `.git`.
     let worktree_path = PathBuf::from(worktree_path.trim());
     let worktree_path = if worktree_path.is_absolute() {
         worktree_path
@@ -109,11 +110,14 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
     Some(worktree_path.join("HEAD"))
 }
 
+/// Watch the loose or packed Git reference for the current branch.
 fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
     let Some(worktree_git_dir) = git_head_path.parent() else {
         return;
     };
 
+    // Worktrees have their own HEAD, but branch refs live in the shared Git directory. Their
+    // `commondir` file points to that directory, either absolutely or relative to this Git directory.
     let common_dir_path = worktree_git_dir.join("commondir");
     let common_git_dir = if let Ok(common_dir) = fs::read_to_string(&common_dir_path) {
         println!("cargo:rerun-if-changed={}", common_dir_path.display());
@@ -131,10 +135,15 @@ fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
     if git_ref_path.exists() {
         println!("cargo:rerun-if-changed={}", git_ref_path.display());
     } else {
+        // A packed branch ref has no loose ref file. Watch `packed-refs` instead of the missing
+        // loose ref, since Cargo would rebuild on every invocation for a nonexistent watched path.
         let packed_refs = common_git_dir.join("packed-refs");
         if packed_refs.exists() {
             println!("cargo:rerun-if-changed={}", packed_refs.display());
         }
+        // A later commit can recreate the loose ref, even when its parent directories do not exist
+        // yet. Watch the nearest existing ancestor so Cargo notices that transition. This can
+        // also rebuild when another ref in that directory changes.
         if let Some(parent) = git_ref_path.ancestors().find(|parent| parent.is_dir()) {
             println!("cargo:rerun-if-changed={}", parent.display());
         }

--- a/crates/ruff/build.rs
+++ b/crates/ruff/build.rs
@@ -27,7 +27,7 @@ fn commit_info(workspace_root: &Path) {
     if let Some(git_head_path) = git_head(&git_dir) {
         println!("cargo:rerun-if-changed={}", git_head_path.display());
 
-        let git_head_contents = fs::read_to_string(git_head_path);
+        let git_head_contents = fs::read_to_string(&git_head_path);
         if let Ok(git_head_contents) = git_head_contents {
             // The contents are either a commit or a reference in the following formats
             // - "<commit>" when the head is detached
@@ -37,8 +37,7 @@ fn commit_info(workspace_root: &Path) {
             let mut git_ref_parts = git_head_contents.split_whitespace();
             git_ref_parts.next();
             if let Some(git_ref) = git_ref_parts.next() {
-                let git_ref_path = git_dir.join(git_ref);
-                println!("cargo:rerun-if-changed={}", git_ref_path.display());
+                watch_git_ref(&git_head_path, git_ref);
             }
         }
     }
@@ -79,13 +78,14 @@ fn commit_info(workspace_root: &Path) {
 
 fn git_head(git_dir: &Path) -> Option<PathBuf> {
     // The typical case is a standard git repository.
-    let git_head_path = git_dir.join("HEAD");
-    if git_head_path.exists() {
-        return Some(git_head_path);
+    if git_dir.is_dir() {
+        return Some(git_dir.join("HEAD"));
     }
     if !git_dir.is_file() {
         return None;
     }
+
+    println!("cargo:rerun-if-changed={}", git_dir.display());
     // If `.git/HEAD` doesn't exist and `.git` is actually a file,
     // then let's try to attempt to read it as a worktree. If it's
     // a worktree, then its contents will look like this, e.g.:
@@ -100,6 +100,43 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
     if label != "gitdir" {
         return None;
     }
-    let worktree_path = worktree_path.trim();
-    Some(PathBuf::from(worktree_path))
+    let worktree_path = PathBuf::from(worktree_path.trim());
+    let worktree_path = if worktree_path.is_absolute() {
+        worktree_path
+    } else {
+        git_dir.parent()?.join(worktree_path)
+    };
+    Some(worktree_path.join("HEAD"))
+}
+
+fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
+    let Some(worktree_git_dir) = git_head_path.parent() else {
+        return;
+    };
+
+    let common_dir_path = worktree_git_dir.join("commondir");
+    let common_git_dir = if let Ok(common_dir) = fs::read_to_string(&common_dir_path) {
+        println!("cargo:rerun-if-changed={}", common_dir_path.display());
+        let common_dir = PathBuf::from(common_dir.trim());
+        if common_dir.is_absolute() {
+            common_dir
+        } else {
+            worktree_git_dir.join(common_dir)
+        }
+    } else {
+        worktree_git_dir.to_path_buf()
+    };
+
+    let git_ref_path = common_git_dir.join(git_ref);
+    if git_ref_path.exists() {
+        println!("cargo:rerun-if-changed={}", git_ref_path.display());
+    } else {
+        let packed_refs = common_git_dir.join("packed-refs");
+        if packed_refs.exists() {
+            println!("cargo:rerun-if-changed={}", packed_refs.display());
+        }
+        if let Some(parent) = git_ref_path.ancestors().find(|parent| parent.is_dir()) {
+            println!("cargo:rerun-if-changed={}", parent.display());
+        }
+    }
 }

--- a/crates/ty/build.rs
+++ b/crates/ty/build.rs
@@ -14,7 +14,8 @@ fn main() {
 
     version_info(&ty_workspace_root);
 
-    // If not in a git repository, do not attempt to retrieve commit information
+    // An independent ty checkout has its own dist-workspace.toml. Without one, a parent Git
+    // repository is unrelated, so use the nested Ruff checkout's commit information instead.
     let git_dir = ty_workspace_root.join(".git");
     if ty_workspace_root.join("dist-workspace.toml").is_file() && git_dir.exists() {
         commit_info(&git_dir, &ty_workspace_root, false);
@@ -65,9 +66,9 @@ fn commit_info(git_dir: &Path, workspace_root: &Path, is_ruff: bool) {
         if let Ok(git_head_contents) = git_head_contents {
             // The contents are either a commit or a reference in the following formats
             // - "<commit>" when the head is detached
-            // - "ref <ref>" when working on a branch
+            // - "ref: <ref>" when working on a branch
             // If a commit, checking if the HEAD file has changed is sufficient
-            // If a ref, we need to add the head file for that ref to rebuild on commit
+            // If a ref, we also need to watch where Git stores its current commit
             let mut git_ref_parts = git_head_contents.split_whitespace();
             git_ref_parts.next();
             if let Some(git_ref) = git_ref_parts.next() {
@@ -123,21 +124,22 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
         return None;
     }
 
+    // Watch the pointer in case the worktree's Git directory changes.
     println!("cargo:rerun-if-changed={}", git_dir.display());
-    // If `.git/HEAD` doesn't exist and `.git` is actually a file,
-    // then let's try to attempt to read it as a worktree. If it's
-    // a worktree, then its contents will look like this, e.g.:
+    // A linked worktree has a `.git` file instead of a `.git` directory.
+    // Its contents point to the worktree-specific Git directory, e.g.:
     //
-    //     gitdir: /home/andrew/astral/uv/main/.git/worktrees/pr2
+    //     gitdir: /home/andrew/astral/ruff/main/.git/worktrees/pr2
     //
     // And the HEAD file we want to watch will be at:
     //
-    //     /home/andrew/astral/uv/main/.git/worktrees/pr2/HEAD
+    //     /home/andrew/astral/ruff/main/.git/worktrees/pr2/HEAD
     let contents = fs::read_to_string(git_dir).ok()?;
     let (label, worktree_path) = contents.split_once(':')?;
     if label != "gitdir" {
         return None;
     }
+    // Relative `gitdir:` paths are relative to the directory containing `.git`.
     let worktree_path = PathBuf::from(worktree_path.trim());
     let worktree_path = if worktree_path.is_absolute() {
         worktree_path
@@ -147,11 +149,14 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
     Some(worktree_path.join("HEAD"))
 }
 
+/// Watch the loose or packed Git reference for the current branch.
 fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
     let Some(worktree_git_dir) = git_head_path.parent() else {
         return;
     };
 
+    // Worktrees have their own HEAD, but branch refs live in the shared Git directory. Their
+    // `commondir` file points to that directory, either absolutely or relative to this Git directory.
     let common_dir_path = worktree_git_dir.join("commondir");
     let common_git_dir = if let Ok(common_dir) = fs::read_to_string(&common_dir_path) {
         println!("cargo:rerun-if-changed={}", common_dir_path.display());
@@ -169,10 +174,15 @@ fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
     if git_ref_path.exists() {
         println!("cargo:rerun-if-changed={}", git_ref_path.display());
     } else {
+        // A packed branch ref has no loose ref file. Watch `packed-refs` instead of the missing
+        // loose ref, since Cargo would rebuild on every invocation for a nonexistent watched path.
         let packed_refs = common_git_dir.join("packed-refs");
         if packed_refs.exists() {
             println!("cargo:rerun-if-changed={}", packed_refs.display());
         }
+        // A later commit can recreate the loose ref, even when its parent directories do not exist
+        // yet. Watch the nearest existing ancestor so Cargo notices that transition. This can
+        // also rebuild when another ref in that directory changes.
         if let Some(parent) = git_ref_path.ancestors().find(|parent| parent.is_dir()) {
             println!("cargo:rerun-if-changed={}", parent.display());
         }

--- a/crates/ty/build.rs
+++ b/crates/ty/build.rs
@@ -16,7 +16,7 @@ fn main() {
 
     // If not in a git repository, do not attempt to retrieve commit information
     let git_dir = ty_workspace_root.join(".git");
-    if git_dir.exists() {
+    if ty_workspace_root.join("dist-workspace.toml").is_file() && git_dir.exists() {
         commit_info(&git_dir, &ty_workspace_root, false);
     } else {
         // Try if we're inside the ruff repository and, if so, use that commit hash.
@@ -61,7 +61,7 @@ fn commit_info(git_dir: &Path, workspace_root: &Path, is_ruff: bool) {
     if let Some(git_head_path) = git_head(git_dir) {
         println!("cargo:rerun-if-changed={}", git_head_path.display());
 
-        let git_head_contents = fs::read_to_string(git_head_path);
+        let git_head_contents = fs::read_to_string(&git_head_path);
         if let Ok(git_head_contents) = git_head_contents {
             // The contents are either a commit or a reference in the following formats
             // - "<commit>" when the head is detached
@@ -71,8 +71,7 @@ fn commit_info(git_dir: &Path, workspace_root: &Path, is_ruff: bool) {
             let mut git_ref_parts = git_head_contents.split_whitespace();
             git_ref_parts.next();
             if let Some(git_ref) = git_ref_parts.next() {
-                let git_ref_path = git_dir.join(git_ref);
-                println!("cargo:rerun-if-changed={}", git_ref_path.display());
+                watch_git_ref(&git_head_path, git_ref);
             }
         }
     }
@@ -117,13 +116,14 @@ fn commit_info(git_dir: &Path, workspace_root: &Path, is_ruff: bool) {
 
 fn git_head(git_dir: &Path) -> Option<PathBuf> {
     // The typical case is a standard git repository.
-    let git_head_path = git_dir.join("HEAD");
-    if git_head_path.exists() {
-        return Some(git_head_path);
+    if git_dir.is_dir() {
+        return Some(git_dir.join("HEAD"));
     }
     if !git_dir.is_file() {
         return None;
     }
+
+    println!("cargo:rerun-if-changed={}", git_dir.display());
     // If `.git/HEAD` doesn't exist and `.git` is actually a file,
     // then let's try to attempt to read it as a worktree. If it's
     // a worktree, then its contents will look like this, e.g.:
@@ -138,6 +138,43 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
     if label != "gitdir" {
         return None;
     }
-    let worktree_path = worktree_path.trim();
-    Some(PathBuf::from(worktree_path))
+    let worktree_path = PathBuf::from(worktree_path.trim());
+    let worktree_path = if worktree_path.is_absolute() {
+        worktree_path
+    } else {
+        git_dir.parent()?.join(worktree_path)
+    };
+    Some(worktree_path.join("HEAD"))
+}
+
+fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
+    let Some(worktree_git_dir) = git_head_path.parent() else {
+        return;
+    };
+
+    let common_dir_path = worktree_git_dir.join("commondir");
+    let common_git_dir = if let Ok(common_dir) = fs::read_to_string(&common_dir_path) {
+        println!("cargo:rerun-if-changed={}", common_dir_path.display());
+        let common_dir = PathBuf::from(common_dir.trim());
+        if common_dir.is_absolute() {
+            common_dir
+        } else {
+            worktree_git_dir.join(common_dir)
+        }
+    } else {
+        worktree_git_dir.to_path_buf()
+    };
+
+    let git_ref_path = common_git_dir.join(git_ref);
+    if git_ref_path.exists() {
+        println!("cargo:rerun-if-changed={}", git_ref_path.display());
+    } else {
+        let packed_refs = common_git_dir.join("packed-refs");
+        if packed_refs.exists() {
+            println!("cargo:rerun-if-changed={}", packed_refs.display());
+        }
+        if let Some(parent) = git_ref_path.ancestors().find(|parent| parent.is_dir()) {
+            println!("cargo:rerun-if-changed={}", parent.display());
+        }
+    }
 }

--- a/crates/ty_wasm/build.rs
+++ b/crates/ty_wasm/build.rs
@@ -25,7 +25,7 @@ fn commit_info(workspace_root: &Path) {
     if let Some(git_head_path) = git_head(&git_dir) {
         println!("cargo:rerun-if-changed={}", git_head_path.display());
 
-        let git_head_contents = fs::read_to_string(git_head_path);
+        let git_head_contents = fs::read_to_string(&git_head_path);
         if let Ok(git_head_contents) = git_head_contents {
             // The contents are either a commit or a reference in the following formats
             // - "<commit>" when the head is detached
@@ -35,8 +35,7 @@ fn commit_info(workspace_root: &Path) {
             let mut git_ref_parts = git_head_contents.split_whitespace();
             git_ref_parts.next();
             if let Some(git_ref) = git_ref_parts.next() {
-                let git_ref_path = git_dir.join(git_ref);
-                println!("cargo:rerun-if-changed={}", git_ref_path.display());
+                watch_git_ref(&git_head_path, git_ref);
             }
         }
     }
@@ -64,13 +63,14 @@ fn commit_info(workspace_root: &Path) {
 
 fn git_head(git_dir: &Path) -> Option<PathBuf> {
     // The typical case is a standard git repository.
-    let git_head_path = git_dir.join("HEAD");
-    if git_head_path.exists() {
-        return Some(git_head_path);
+    if git_dir.is_dir() {
+        return Some(git_dir.join("HEAD"));
     }
     if !git_dir.is_file() {
         return None;
     }
+
+    println!("cargo:rerun-if-changed={}", git_dir.display());
     // If `.git/HEAD` doesn't exist and `.git` is actually a file,
     // then let's try to attempt to read it as a worktree. If it's
     // a worktree, then its contents will look like this, e.g.:
@@ -85,6 +85,43 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
     if label != "gitdir" {
         return None;
     }
-    let worktree_path = worktree_path.trim();
-    Some(PathBuf::from(worktree_path))
+    let worktree_path = PathBuf::from(worktree_path.trim());
+    let worktree_path = if worktree_path.is_absolute() {
+        worktree_path
+    } else {
+        git_dir.parent()?.join(worktree_path)
+    };
+    Some(worktree_path.join("HEAD"))
+}
+
+fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
+    let Some(worktree_git_dir) = git_head_path.parent() else {
+        return;
+    };
+
+    let common_dir_path = worktree_git_dir.join("commondir");
+    let common_git_dir = if let Ok(common_dir) = fs::read_to_string(&common_dir_path) {
+        println!("cargo:rerun-if-changed={}", common_dir_path.display());
+        let common_dir = PathBuf::from(common_dir.trim());
+        if common_dir.is_absolute() {
+            common_dir
+        } else {
+            worktree_git_dir.join(common_dir)
+        }
+    } else {
+        worktree_git_dir.to_path_buf()
+    };
+
+    let git_ref_path = common_git_dir.join(git_ref);
+    if git_ref_path.exists() {
+        println!("cargo:rerun-if-changed={}", git_ref_path.display());
+    } else {
+        let packed_refs = common_git_dir.join("packed-refs");
+        if packed_refs.exists() {
+            println!("cargo:rerun-if-changed={}", packed_refs.display());
+        }
+        if let Some(parent) = git_ref_path.ancestors().find(|parent| parent.is_dir()) {
+            println!("cargo:rerun-if-changed={}", parent.display());
+        }
+    }
 }

--- a/crates/ty_wasm/build.rs
+++ b/crates/ty_wasm/build.rs
@@ -29,9 +29,9 @@ fn commit_info(workspace_root: &Path) {
         if let Ok(git_head_contents) = git_head_contents {
             // The contents are either a commit or a reference in the following formats
             // - "<commit>" when the head is detached
-            // - "ref <ref>" when working on a branch
+            // - "ref: <ref>" when working on a branch
             // If a commit, checking if the HEAD file has changed is sufficient
-            // If a ref, we need to add the head file for that ref to rebuild on commit
+            // If a ref, we also need to watch where Git stores its current commit
             let mut git_ref_parts = git_head_contents.split_whitespace();
             git_ref_parts.next();
             if let Some(git_ref) = git_ref_parts.next() {
@@ -70,21 +70,22 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
         return None;
     }
 
+    // Watch the pointer in case the worktree's Git directory changes.
     println!("cargo:rerun-if-changed={}", git_dir.display());
-    // If `.git/HEAD` doesn't exist and `.git` is actually a file,
-    // then let's try to attempt to read it as a worktree. If it's
-    // a worktree, then its contents will look like this, e.g.:
+    // A linked worktree has a `.git` file instead of a `.git` directory.
+    // Its contents point to the worktree-specific Git directory, e.g.:
     //
-    //     gitdir: /home/andrew/astral/uv/main/.git/worktrees/pr2
+    //     gitdir: /home/andrew/astral/ruff/main/.git/worktrees/pr2
     //
     // And the HEAD file we want to watch will be at:
     //
-    //     /home/andrew/astral/uv/main/.git/worktrees/pr2/HEAD
+    //     /home/andrew/astral/ruff/main/.git/worktrees/pr2/HEAD
     let contents = fs::read_to_string(git_dir).ok()?;
     let (label, worktree_path) = contents.split_once(':')?;
     if label != "gitdir" {
         return None;
     }
+    // Relative `gitdir:` paths are relative to the directory containing `.git`.
     let worktree_path = PathBuf::from(worktree_path.trim());
     let worktree_path = if worktree_path.is_absolute() {
         worktree_path
@@ -94,11 +95,14 @@ fn git_head(git_dir: &Path) -> Option<PathBuf> {
     Some(worktree_path.join("HEAD"))
 }
 
+/// Watch the loose or packed Git reference for the current branch.
 fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
     let Some(worktree_git_dir) = git_head_path.parent() else {
         return;
     };
 
+    // Worktrees have their own HEAD, but branch refs live in the shared Git directory. Their
+    // `commondir` file points to that directory, either absolutely or relative to this Git directory.
     let common_dir_path = worktree_git_dir.join("commondir");
     let common_git_dir = if let Ok(common_dir) = fs::read_to_string(&common_dir_path) {
         println!("cargo:rerun-if-changed={}", common_dir_path.display());
@@ -116,10 +120,15 @@ fn watch_git_ref(git_head_path: &Path, git_ref: &str) {
     if git_ref_path.exists() {
         println!("cargo:rerun-if-changed={}", git_ref_path.display());
     } else {
+        // A packed branch ref has no loose ref file. Watch `packed-refs` instead of the missing
+        // loose ref, since Cargo would rebuild on every invocation for a nonexistent watched path.
         let packed_refs = common_git_dir.join("packed-refs");
         if packed_refs.exists() {
             println!("cargo:rerun-if-changed={}", packed_refs.display());
         }
+        // A later commit can recreate the loose ref, even when its parent directories do not exist
+        // yet. Watch the nearest existing ancestor so Cargo notices that transition. This can
+        // also rebuild when another ref in that directory changes.
         if let Some(parent) = git_ref_path.ancestors().find(|parent| parent.is_dir()) {
             println!("cargo:rerun-if-changed={}", parent.display());
         }


### PR DESCRIPTION
## Summary

Previously, we tracked Git metadata incorrectly in several cases:

- Linked worktrees watched their entire worktree metadata directory, so staging an unrelated file invalidated the build even when the commit had not changed.
- Branch references updated outside the worktree were not watched, potentially leaving embedded commit hashes, dates, tags, and tag distances stale.
- Packed branch references and relative worktree paths registered nonexistent Cargo inputs, forcing a rebuild on every invocation.
- A Ruff checkout nested directly inside an unrelated Git repository caused ty to embed the parent repository's commit instead of Ruff's.

We now track each worktree's actual `HEAD`, resolve branch references through the shared Git directory, handle relative paths and packed references, and ignore unrelated parent repositories when selecting ty's commit metadata.

When the current branch is packed, we also watch the nearest existing reference directory so a newly created loose reference becomes visible. This can invalidate a packed-reference worktree when another branch in the same repository changes.
