### PR TITLE
[ruff] Fix RUF066 false negatives for nested lambdas and Protocol-nested classes

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF066.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF066.py
@@ -68,3 +68,16 @@ class File:  # Extra tests for things like yield/yield from/raise
     @property
     def children(self):  # OK: Raises
         raise ValueError("File does not have children")
+
+
+class Nested:  # A `yield` in a nested lambda belongs to the lambda, not the property
+    @property
+    def generator_lambda(self):  # ERROR: The property itself falls through
+        lambda: (yield 1)
+
+
+class OuterProtocol(typing.Protocol):  # A concrete class nested in a Protocol is not a protocol
+    class Concrete:
+        @property
+        def nested_concrete_property(self):  # ERROR: Owning class is concrete, not a protocol
+            self.value

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF066.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF066.py
@@ -75,6 +75,14 @@ class Nested:  # A `yield` in a nested lambda belongs to the lambda, not the pro
     def generator_lambda(self):  # ERROR: The property itself falls through
         lambda: (yield 1)
 
+    @property
+    def yield_in_lambda_default(self):  # OK: the default runs in this scope, so it yields
+        lambda x=(yield 1): None
+
+    @property
+    def yield_in_nested_default(self):  # OK: the default runs in this scope, so it yields
+        def inner(x=(yield 1)): ...
+
 
 class OuterProtocol(typing.Protocol):  # A concrete class nested in a Protocol is not a protocol
     class Concrete:

--- a/crates/ruff_linter/src/rules/ruff/rules/property_without_return.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/property_without_return.rs
@@ -2,7 +2,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::map_subscript;
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
-use ruff_python_ast::{Expr, Stmt, StmtFunctionDef};
+use ruff_python_ast::{Expr, Parameters, Stmt, StmtFunctionDef};
 use ruff_python_semantic::ScopeKind;
 use ruff_python_semantic::analyze::{function_type, visibility};
 
@@ -112,6 +112,18 @@ struct PropertyVisitor {
     found: bool,
 }
 
+impl PropertyVisitor {
+    /// Visit the parameter defaults of a nested function or lambda. Defaults are evaluated
+    /// eagerly in the enclosing scope, so a `yield` in one belongs to the property.
+    fn visit_parameter_defaults(&mut self, parameters: &Parameters) {
+        for parameter in parameters.iter_non_variadic_params() {
+            if let Some(default) = parameter.default() {
+                self.visit_expr(default);
+            }
+        }
+    }
+}
+
 // NOTE: We are actually searching for the presence of
 // `yield`/`yield from`/`raise`/`return` statement/expression,
 // as having one of those indicates that there's likely no implementation mistake
@@ -123,9 +135,13 @@ impl Visitor<'_> for PropertyVisitor {
 
         match expr {
             Expr::Yield(_) | Expr::YieldFrom(_) => self.found = true,
-            // Lambdas are a separate scope; a `yield` (or any fall-through) inside a
-            // lambda body belongs to the lambda, not the enclosing property.
-            Expr::Lambda(_) => {}
+            // A lambda body is a separate scope, so a `yield` there belongs to the lambda.
+            // Its parameter defaults, however, are evaluated in the enclosing scope.
+            Expr::Lambda(lambda) => {
+                if let Some(parameters) = &lambda.parameters {
+                    self.visit_parameter_defaults(parameters);
+                }
+            }
             _ => walk_expr(self, expr),
         }
     }
@@ -137,8 +153,14 @@ impl Visitor<'_> for PropertyVisitor {
 
         match stmt {
             Stmt::Return(_) | Stmt::Raise(_) => self.found = true,
-            Stmt::FunctionDef(_) => {
-                // Do not recurse into nested functions; they're evaluated separately.
+            // A nested function's body is a separate scope, but its decorators and parameter
+            // defaults are evaluated in the enclosing scope, so a `yield` there belongs to the
+            // property.
+            Stmt::FunctionDef(function_def) => {
+                for decorator in &function_def.decorator_list {
+                    self.visit_expr(&decorator.expression);
+                }
+                self.visit_parameter_defaults(&function_def.parameters);
             }
             _ => walk_stmt(self, stmt),
         }

--- a/crates/ruff_linter/src/rules/ruff/rules/property_without_return.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/property_without_return.rs
@@ -1,7 +1,9 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_python_ast::helpers::map_subscript;
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
 use ruff_python_ast::{Expr, Stmt, StmtFunctionDef};
+use ruff_python_semantic::ScopeKind;
 use ruff_python_semantic::analyze::{function_type, visibility};
 
 use crate::checkers::ast::Checker;
@@ -55,7 +57,7 @@ impl Violation for PropertyWithoutReturn {
 pub(crate) fn property_without_return(checker: &Checker, function_def: &StmtFunctionDef) {
     let semantic = checker.semantic();
 
-    if checker.source_type.is_stub() || semantic.in_protocol_or_abstract_method() {
+    if checker.source_type.is_stub() {
         return;
     }
 
@@ -69,8 +71,25 @@ pub(crate) fn property_without_return(checker: &Checker, function_def: &StmtFunc
     let extra_property_decorators = checker.settings().pydocstyle.property_decorators();
     if !visibility::is_property(decorator_list, extra_property_decorators, semantic)
         || visibility::is_overload(decorator_list, semantic)
+        || visibility::is_abstract(decorator_list, semantic)
         || function_type::is_stub(function_def, semantic)
     {
+        return;
+    }
+
+    // A property is only exempt when its *owning* class is a protocol — the class the
+    // method is directly defined in. A concrete class does not become a protocol just
+    // because an enclosing class is one, so we check the nearest class scope rather than
+    // any ancestor.
+    let owner_is_protocol = matches!(
+        semantic.current_scope().kind,
+        ScopeKind::Class(class_def)
+            if class_def
+                .bases()
+                .iter()
+                .any(|base| semantic.match_typing_expr(map_subscript(base), "Protocol"))
+    );
+    if owner_is_protocol {
         return;
     }
 
@@ -104,6 +123,9 @@ impl Visitor<'_> for PropertyVisitor {
 
         match expr {
             Expr::Yield(_) | Expr::YieldFrom(_) => self.found = true,
+            // Lambdas are a separate scope; a `yield` (or any fall-through) inside a
+            // lambda body belongs to the lambda, not the enclosing property.
+            Expr::Lambda(_) => {}
             _ => walk_expr(self, expr),
         }
     }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF066_RUF066.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF066_RUF066.py.snap
@@ -29,3 +29,23 @@ RUF066 `prop2` is a property without a `return` statement
    |         ^^^^^
 44 |         50
    |
+
+RUF066 `generator_lambda` is a property without a `return` statement
+  --> RUF066.py:75:9
+   |
+73 | class Nested:  # A `yield` in a nested lambda belongs to the lambda, not the property
+74 |     @property
+75 |     def generator_lambda(self):  # ERROR: The property itself falls through
+   |         ^^^^^^^^^^^^^^^^
+76 |         lambda: (yield 1)
+   |
+
+RUF066 `nested_concrete_property` is a property without a `return` statement
+  --> RUF066.py:82:13
+   |
+80 |     class Concrete:
+81 |         @property
+82 |         def nested_concrete_property(self):  # ERROR: Owning class is concrete, not a protocol
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+83 |             self.value
+   |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF066_RUF066.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF066_RUF066.py.snap
@@ -41,11 +41,11 @@ RUF066 `generator_lambda` is a property without a `return` statement
    |
 
 RUF066 `nested_concrete_property` is a property without a `return` statement
-  --> RUF066.py:82:13
+  --> RUF066.py:90:13
    |
-80 |     class Concrete:
-81 |         @property
-82 |         def nested_concrete_property(self):  # ERROR: Owning class is concrete, not a protocol
+88 |     class Concrete:
+89 |         @property
+90 |         def nested_concrete_property(self):  # ERROR: Owning class is concrete, not a protocol
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
-83 |             self.value
+91 |             self.value
    |


### PR DESCRIPTION
## Summary

Fixes #27027. `property-without-return` (RUF066) missed two cases where a property falls through without returning:

1. **Nested lambda `yield`** — a `yield` inside a nested lambda (e.g. `lambda: (yield 1)`) is a generator belonging to the *lambda*, not the property, but the body visitor treated it as the property yielding. The visitor already skips nested `def`s; it now also skips `lambda` bodies (a separate scope).

2. **Concrete class nested in a `Protocol`** — the protocol exemption used `in_protocol_or_abstract_method()`, which walks *every* enclosing scope. A concrete class nested inside a `Protocol` was therefore treated as a protocol, and its properties were wrongly exempted. The exemption now checks only the **owning** (nearest) class; abstract methods are exempted explicitly via their decorators (`visibility::is_abstract`).

Both properties in the issue's reproduction are now correctly reported.

## Test Plan

Extended the `RUF066.py` fixture with the two cases from the issue (a `generator_lambda` property with a nested `lambda: (yield 1)`, and a concrete `Concrete` class nested inside an `OuterProtocol(Protocol)`), and updated the snapshot — both are now diagnosed.

Verified that no existing behavior regressed: the full `rules::ruff::tests::rules` suite passes (89 tests), and the pre-existing exemptions all still hold — genuine `yield`/`yield from`/`raise` properties, stub (`...`) properties, `@abc.abstractmethod` properties, and direct `Protocol` stub properties remain un-flagged. `cargo fmt --check` and `cargo clippy -p ruff_linter` are clean.

---

Per the [Astral AI policy](https://github.com/astral-sh/.github/blob/main/AI_POLICY.md): this change was drafted with AI assistance and reviewed and tested by a human before submission.
