### PR TITLE
[perflint] Don't suggest comprehension for super()/__class__ below Python 3.12

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401_super_scope.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401_super_scope.py
@@ -34,6 +34,20 @@ class B(A):
             result.append(super(B, self).foo())  # explicit args: fine, still flagged
         return result
 
+    def with_variadic_super(self):
+        result = []
+        for _ in range(10):
+            # `super(*())` / `super(**{})` may expand to zero runtime arguments, so they
+            # still rely on the `__class__` cell: unsafe below 3.12.
+            result.append(super(*()).foo())
+        return result
+
+    def with_variadic_super_kwargs(self):
+        result = []
+        for _ in range(10):
+            result.append(super(**{}).foo())
+        return result
+
     def without_super(self):
         result = []
         for x in range(10):

--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401_super_scope.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401_super_scope.py
@@ -1,0 +1,41 @@
+# https://github.com/astral-sh/ruff/issues/27668
+# On Python < 3.12 a comprehension has its own scope and cannot see the enclosing
+# method's `__class__` cell, so a bare `super()` (or a `__class__` reference) moved
+# into a comprehension raises at runtime. RUF... PERF401 must not suggest the
+# conversion in that case (it is suggested normally on 3.12+).
+class A:
+    def foo(self):
+        return 1
+
+
+class B(A):
+    def with_super(self):
+        result = []
+        for _ in range(10):
+            result.append(super().foo())  # zero-arg super(): unsafe below 3.12
+        return result
+
+    def with_class_cell(self):
+        result = []
+        for _ in range(10):
+            result.append(__class__.__name__)  # __class__ reference: unsafe below 3.12
+        return result
+
+    def with_super_in_filter(self):
+        result = []
+        for x in range(10):
+            if super().foo():  # zero-arg super() in the filter: unsafe below 3.12
+                result.append(x)
+        return result
+
+    def with_explicit_super(self):
+        result = []
+        for _ in range(10):
+            result.append(super(B, self).foo())  # explicit args: fine, still flagged
+        return result
+
+    def without_super(self):
+        result = []
+        for x in range(10):
+            result.append(x + 1)  # no class cell: always flagged
+        return result

--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF403_super_scope.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF403_super_scope.py
@@ -31,6 +31,21 @@ class B(A):
                 result[i] = i
         return result
 
+    def filter_variadic_super(self):
+        result = {}
+        for i in range(10):
+            # `super(*())` may expand to zero runtime arguments: unsafe below 3.12.
+            if super(*()).cond():
+                result[i] = i
+        return result
+
+    def filter_variadic_super_kwargs(self):
+        result = {}
+        for i in range(10):
+            if super(**{}).cond():
+                result[i] = i
+        return result
+
     def filter_plain(self):
         result = {}
         for i in range(10):

--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF403_super_scope.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF403_super_scope.py
@@ -1,0 +1,39 @@
+# https://github.com/astral-sh/ruff/issues/27668
+# A dict comprehension has its own scope on Python < 3.12. PERF403 only copies loop
+# variables into the key/value, but its `if` filter is an arbitrary expression, so a
+# filter that relies on the `__class__` cell (a bare `super()` or `__class__`) cannot be
+# moved into the comprehension below 3.12. PERF403 must not suggest the conversion then
+# (it does on 3.12+).
+class A:
+    def cond(self):
+        return True
+
+
+class B(A):
+    def filter_super(self):
+        result = {}
+        for i in range(10):
+            if super().cond():  # zero-arg super() in the filter: unsafe below 3.12
+                result[i] = i
+        return result
+
+    def filter_class_cell(self):
+        result = {}
+        for i in range(10):
+            if __class__.__name__:  # __class__ reference in the filter: unsafe below 3.12
+                result[i] = i
+        return result
+
+    def filter_explicit_super(self):
+        result = {}
+        for i in range(10):
+            if super(B, self).cond():  # explicit args: fine, still flagged
+                result[i] = i
+        return result
+
+    def filter_plain(self):
+        result = {}
+        for i in range(10):
+            if i % 2:  # no class cell: always flagged
+                result[i] = i
+        return result

--- a/crates/ruff_linter/src/rules/perflint/helpers.rs
+++ b/crates/ruff_linter/src/rules/perflint/helpers.rs
@@ -1,3 +1,5 @@
+use ruff_python_ast::{Expr, helpers::any_over_expr};
+use ruff_python_semantic::SemanticModel;
 use ruff_python_trivia::{
     BackwardsTokenizer, PythonWhitespace, SimpleToken, SimpleTokenKind, SimpleTokenizer,
 };
@@ -5,6 +7,27 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
+
+/// Returns `true` if `expr` relies on the implicit `__class__` cell — i.e. it contains a
+/// zero-argument `super()` call or a `__class__` reference.
+///
+/// Such an expression cannot be moved into a comprehension on Python < 3.12: before [PEP 709]
+/// comprehensions have their own scope, which does not have access to the enclosing method's
+/// `__class__` cell, so a bare `super()` raises `RuntimeError`/`TypeError` at runtime.
+///
+/// [PEP 709]: https://peps.python.org/pep-0709/
+pub(super) fn references_class_cell(expr: &Expr, semantic: &SemanticModel) -> bool {
+    any_over_expr(expr, |expr| match expr {
+        // A zero-argument `super()` call. `super(cls, self)` takes explicit arguments and does
+        // not rely on the `__class__` cell, so it is unaffected.
+        Expr::Call(call) => {
+            call.arguments.is_empty() && semantic.match_builtin_expr(&call.func, "super")
+        }
+        // A direct `__class__` load.
+        Expr::Name(name) => name.id.as_str() == "__class__" && name.ctx.is_load(),
+        _ => false,
+    })
+}
 
 pub(super) fn comment_strings_in_range<'a>(
     checker: &'a Checker,

--- a/crates/ruff_linter/src/rules/perflint/helpers.rs
+++ b/crates/ruff_linter/src/rules/perflint/helpers.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::{Expr, helpers::any_over_expr};
+use ruff_python_ast::{Arguments, Expr, helpers::any_over_expr};
 use ruff_python_semantic::SemanticModel;
 use ruff_python_trivia::{
     BackwardsTokenizer, PythonWhitespace, SimpleToken, SimpleTokenKind, SimpleTokenizer,
@@ -19,14 +19,27 @@ use crate::checkers::ast::Checker;
 pub(super) fn references_class_cell(expr: &Expr, semantic: &SemanticModel) -> bool {
     any_over_expr(expr, |expr| match expr {
         // A zero-argument `super()` call. `super(cls, self)` takes explicit arguments and does
-        // not rely on the `__class__` cell, so it is unaffected.
+        // not rely on the `__class__` cell, so it is unaffected. Variadic calls such as
+        // `super(*())` or `super(**{})` may still expand to zero runtime arguments, so they are
+        // treated conservatively as potentially cell-dependent.
         Expr::Call(call) => {
-            call.arguments.is_empty() && semantic.match_builtin_expr(&call.func, "super")
+            super_may_have_zero_args(&call.arguments)
+                && semantic.match_builtin_expr(&call.func, "super")
         }
         // A direct `__class__` load.
         Expr::Name(name) => name.id.as_str() == "__class__" && name.ctx.is_load(),
         _ => false,
     })
+}
+
+/// Returns `true` if a call with these `arguments` may be invoked with zero runtime arguments.
+///
+/// A non-starred positional argument (e.g. `super(cls, self)`) guarantees at least one runtime
+/// argument. Unpackings such as `*()` or `**{}` may expand to nothing, so a call whose only
+/// arguments are unpackings — or which has no arguments at all — is treated as possibly
+/// zero-argument.
+fn super_may_have_zero_args(arguments: &Arguments) -> bool {
+    !arguments.args.iter().any(|arg| !arg.is_starred_expr())
 }
 
 pub(super) fn comment_strings_in_range<'a>(

--- a/crates/ruff_linter/src/rules/perflint/mod.rs
+++ b/crates/ruff_linter/src/rules/perflint/mod.rs
@@ -18,13 +18,29 @@ mod tests {
     #[test_case(Rule::IncorrectDictIterator, Path::new("PERF102.py"))]
     #[test_case(Rule::TryExceptInLoop, Path::new("PERF203.py"))]
     #[test_case(Rule::ManualListComprehension, Path::new("PERF401.py"))]
+    #[test_case(Rule::ManualListComprehension, Path::new("PERF401_super_scope.py"))]
     #[test_case(Rule::ManualListCopy, Path::new("PERF402.py"))]
     #[test_case(Rule::ManualDictComprehension, Path::new("PERF403.py"))]
+    #[test_case(Rule::ManualDictComprehension, Path::new("PERF403_super_scope.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("perflint").join(path).as_path(),
             &LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY310),
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    // On Python 3.12+ comprehensions are inlined (PEP 709), so `super()`/`__class__` inside a
+    // comprehension is fine and the conversion is suggested as usual.
+    #[test_case(Rule::ManualListComprehension, Path::new("PERF401_super_scope.py"))]
+    #[test_case(Rule::ManualDictComprehension, Path::new("PERF403_super_scope.py"))]
+    fn rules_super_scope_py312(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("py312_{}_{}", rule_code.noqa_code(), path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("perflint").join(path).as_path(),
+            &LinterSettings::for_rule(rule_code).with_target_version(PythonVersion::PY312),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_dict_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_dict_comprehension.rs
@@ -1,6 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{
-    self as ast, Expr, Stmt, comparable::ComparableExpr, helpers::any_over_expr,
+    self as ast, Expr, PythonVersion, Stmt, comparable::ComparableExpr, helpers::any_over_expr,
 };
 use ruff_python_semantic::{Binding, analyze::typing::is_dict};
 use ruff_source_file::LineRanges;
@@ -8,7 +8,9 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_manual_dict_comprehension_enabled;
-use crate::rules::perflint::helpers::{comment_strings_in_range, statement_deletion_range};
+use crate::rules::perflint::helpers::{
+    comment_strings_in_range, references_class_cell, statement_deletion_range,
+};
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -184,6 +186,17 @@ pub(crate) fn manual_dict_comprehension(checker: &Checker, for_stmt: &ast::StmtF
         return;
     };
     if !is_dict(binding, checker.semantic()) {
+        return;
+    }
+
+    // On Python < 3.12, comprehensions have their own scope (pre-PEP 709), so a key, value, or
+    // filter that relies on the `__class__` cell — a bare `super()` or `__class__` — cannot be
+    // moved into a dict comprehension without raising at runtime. Don't suggest the conversion.
+    if checker.target_version() < PythonVersion::PY312
+        && (references_class_cell(key, checker.semantic())
+            || references_class_cell(value, checker.semantic())
+            || if_test.is_some_and(|test| references_class_cell(test, checker.semantic())))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::{self as ast, Arguments, Expr};
+use ruff_python_ast::{self as ast, Arguments, Expr, PythonVersion};
 
 use crate::{Edit, Fix, FixAvailability, Violation};
 use crate::{
@@ -7,7 +7,7 @@ use crate::{
 };
 use anyhow::{Result, anyhow};
 
-use crate::rules::perflint::helpers::comment_strings_in_range;
+use crate::rules::perflint::helpers::{comment_strings_in_range, references_class_cell};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_semantic::{Binding, analyze::typing::is_list};
@@ -174,6 +174,16 @@ pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtF
     let Some(list_name) = value.as_name_expr() else {
         return;
     };
+
+    // On Python < 3.12, comprehensions have their own scope (pre-PEP 709), so an appended value
+    // or filter that relies on the `__class__` cell — a bare `super()` or `__class__` — cannot be
+    // moved into a list comprehension without raising at runtime. Don't suggest the conversion.
+    if checker.target_version() < PythonVersion::PY312
+        && (references_class_cell(arg, checker.semantic())
+            || if_test.is_some_and(|test| references_class_cell(test, checker.semantic())))
+    {
+        return;
+    }
 
     // Ignore direct list copies (e.g., `for x in y: filtered.append(x)`), unless it's async, which
     // `manual-list-copy` doesn't cover.

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401_super_scope.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401_super_scope.py.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:34:13
+   |
+32 |         result = []
+33 |         for _ in range(10):
+34 |             result.append(super(B, self).foo())  # explicit args: fine, still flagged
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+35 |         return result
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:40:13
+   |
+38 |         result = []
+39 |         for x in range(10):
+40 |             result.append(x + 1)  # no class cell: always flagged
+   |             ^^^^^^^^^^^^^^^^^^^^
+41 |         return result
+   |
+help: Replace for loop with list comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401_super_scope.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401_super_scope.py.snap
@@ -13,12 +13,12 @@ PERF401 Use a list comprehension to create a transformed list
 help: Replace for loop with list comprehension
 
 PERF401 Use a list comprehension to create a transformed list
-  --> PERF401_super_scope.py:40:13
+  --> PERF401_super_scope.py:54:13
    |
-38 |         result = []
-39 |         for x in range(10):
-40 |             result.append(x + 1)  # no class cell: always flagged
+52 |         result = []
+53 |         for x in range(10):
+54 |             result.append(x + 1)  # no class cell: always flagged
    |             ^^^^^^^^^^^^^^^^^^^^
-41 |         return result
+55 |         return result
    |
 help: Replace for loop with list comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF403_PERF403_super_scope.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF403_PERF403_super_scope.py.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super_scope.py:31:17
+   |
+29 |         for i in range(10):
+30 |             if super(B, self).cond():  # explicit args: fine, still flagged
+31 |                 result[i] = i
+   |                 ^^^^^^^^^^^^^
+32 |         return result
+   |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super_scope.py:38:17
+   |
+36 |         for i in range(10):
+37 |             if i % 2:  # no class cell: always flagged
+38 |                 result[i] = i
+   |                 ^^^^^^^^^^^^^
+39 |         return result
+   |
+help: Replace for loop with dict comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF403_PERF403_super_scope.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF403_PERF403_super_scope.py.snap
@@ -13,12 +13,12 @@ PERF403 Use a dictionary comprehension instead of a for-loop
 help: Replace for loop with dict comprehension
 
 PERF403 Use a dictionary comprehension instead of a for-loop
-  --> PERF403_super_scope.py:38:17
+  --> PERF403_super_scope.py:53:17
    |
-36 |         for i in range(10):
-37 |             if i % 2:  # no class cell: always flagged
-38 |                 result[i] = i
+51 |         for i in range(10):
+52 |             if i % 2:  # no class cell: always flagged
+53 |                 result[i] = i
    |                 ^^^^^^^^^^^^^
-39 |         return result
+54 |         return result
    |
 help: Replace for loop with dict comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__py312_PERF401_PERF401_super_scope.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__py312_PERF401_PERF401_super_scope.py.snap
@@ -1,0 +1,57 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:15:13
+   |
+13 |         result = []
+14 |         for _ in range(10):
+15 |             result.append(super().foo())  # zero-arg super(): unsafe below 3.12
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+16 |         return result
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:21:13
+   |
+19 |         result = []
+20 |         for _ in range(10):
+21 |             result.append(__class__.__name__)  # __class__ reference: unsafe below 3.12
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+22 |         return result
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:28:17
+   |
+26 |         for x in range(10):
+27 |             if super().foo():  # zero-arg super() in the filter: unsafe below 3.12
+28 |                 result.append(x)
+   |                 ^^^^^^^^^^^^^^^^
+29 |         return result
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:34:13
+   |
+32 |         result = []
+33 |         for _ in range(10):
+34 |             result.append(super(B, self).foo())  # explicit args: fine, still flagged
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+35 |         return result
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:40:13
+   |
+38 |         result = []
+39 |         for x in range(10):
+40 |             result.append(x + 1)  # no class cell: always flagged
+   |             ^^^^^^^^^^^^^^^^^^^^
+41 |         return result
+   |
+help: Replace for loop with list comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__py312_PERF401_PERF401_super_scope.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__py312_PERF401_PERF401_super_scope.py.snap
@@ -46,12 +46,34 @@ PERF401 Use a list comprehension to create a transformed list
 help: Replace for loop with list comprehension
 
 PERF401 Use a list comprehension to create a transformed list
-  --> PERF401_super_scope.py:40:13
+  --> PERF401_super_scope.py:42:13
    |
-38 |         result = []
-39 |         for x in range(10):
-40 |             result.append(x + 1)  # no class cell: always flagged
+40 |             # `super(*())` / `super(**{})` may expand to zero runtime arguments, so they
+41 |             # still rely on the `__class__` cell: unsafe below 3.12.
+42 |             result.append(super(*()).foo())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+43 |         return result
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:48:13
+   |
+46 |         result = []
+47 |         for _ in range(10):
+48 |             result.append(super(**{}).foo())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+49 |         return result
+   |
+help: Replace for loop with list comprehension
+
+PERF401 Use a list comprehension to create a transformed list
+  --> PERF401_super_scope.py:54:13
+   |
+52 |         result = []
+53 |         for x in range(10):
+54 |             result.append(x + 1)  # no class cell: always flagged
    |             ^^^^^^^^^^^^^^^^^^^^
-41 |         return result
+55 |         return result
    |
 help: Replace for loop with list comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__py312_PERF403_PERF403_super_scope.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__py312_PERF403_PERF403_super_scope.py.snap
@@ -35,12 +35,34 @@ PERF403 Use a dictionary comprehension instead of a for-loop
 help: Replace for loop with dict comprehension
 
 PERF403 Use a dictionary comprehension instead of a for-loop
-  --> PERF403_super_scope.py:38:17
+  --> PERF403_super_scope.py:39:17
    |
-36 |         for i in range(10):
-37 |             if i % 2:  # no class cell: always flagged
-38 |                 result[i] = i
+37 |             # `super(*())` may expand to zero runtime arguments: unsafe below 3.12.
+38 |             if super(*()).cond():
+39 |                 result[i] = i
    |                 ^^^^^^^^^^^^^
-39 |         return result
+40 |         return result
+   |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super_scope.py:46:17
+   |
+44 |         for i in range(10):
+45 |             if super(**{}).cond():
+46 |                 result[i] = i
+   |                 ^^^^^^^^^^^^^
+47 |         return result
+   |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super_scope.py:53:17
+   |
+51 |         for i in range(10):
+52 |             if i % 2:  # no class cell: always flagged
+53 |                 result[i] = i
+   |                 ^^^^^^^^^^^^^
+54 |         return result
    |
 help: Replace for loop with dict comprehension

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__py312_PERF403_PERF403_super_scope.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__py312_PERF403_PERF403_super_scope.py.snap
@@ -1,0 +1,46 @@
+---
+source: crates/ruff_linter/src/rules/perflint/mod.rs
+---
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super_scope.py:17:17
+   |
+15 |         for i in range(10):
+16 |             if super().cond():  # zero-arg super() in the filter: unsafe below 3.12
+17 |                 result[i] = i
+   |                 ^^^^^^^^^^^^^
+18 |         return result
+   |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super_scope.py:24:17
+   |
+22 |         for i in range(10):
+23 |             if __class__.__name__:  # __class__ reference in the filter: unsafe below 3.12
+24 |                 result[i] = i
+   |                 ^^^^^^^^^^^^^
+25 |         return result
+   |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super_scope.py:31:17
+   |
+29 |         for i in range(10):
+30 |             if super(B, self).cond():  # explicit args: fine, still flagged
+31 |                 result[i] = i
+   |                 ^^^^^^^^^^^^^
+32 |         return result
+   |
+help: Replace for loop with dict comprehension
+
+PERF403 Use a dictionary comprehension instead of a for-loop
+  --> PERF403_super_scope.py:38:17
+   |
+36 |         for i in range(10):
+37 |             if i % 2:  # no class cell: always flagged
+38 |                 result[i] = i
+   |                 ^^^^^^^^^^^^^
+39 |         return result
+   |
+help: Replace for loop with dict comprehension


### PR DESCRIPTION
## Summary

Fixes #27668. `PERF401` (manual-list-comprehension) and `PERF403` (manual-dict-comprehension) rewrite a `for`-loop into a comprehension, moving an expression into the comprehension: the appended value or `if` filter for PERF401, and the `if` filter for PERF403 (PERF403's key/value are constrained to loop variables).

On **Python < 3.12** a comprehension has its own scope (before [PEP 709] inlining), which does **not** have access to the enclosing method's `__class__` cell. So a moved expression containing a zero-argument `super()` or a `__class__` reference raises at runtime:

```python
class B(A):
    def f(self):
        res = []
        for _ in range(10):
            res.append(super().foo())     # works
        return res
```

Ruff flagged this and offered:

```python
return [super().foo() for _ in range(10)]  # TypeError on <3.12
```

Both rules now skip the suggestion below 3.12 when the moved expression relies on the `__class__` cell (a bare `super()` or `__class__`). `super(cls, self)` (explicit arguments, which does not use the cell) and everything on 3.12+ are unaffected.

`PERF402` is not affected — it rewrites to `list(y)`, not a comprehension.

## Implementation

- New helper `perflint::helpers::references_class_cell`, using `any_over_expr` + `semantic().match_builtin_expr(func, "super")`, detects a zero-arg `super()` call or a `__class__` load.
- PERF401 checks the appended value and the filter; PERF403 checks the filter (and, defensively, key/value). Both gate on `target_version() < PythonVersion::PY312`, mirroring the existing `PERF203` version gate in the same module.

## Test Plan

Added `PERF401_super_scope.py` and `PERF403_super_scope.py`, each exercised at **two** versions:
- **PY310** (`rules`): `super()` / `__class__` cases are **not** flagged; `super(B, self)` and plain cases still are.
- **PY312** (new `rules_super_scope_py312`): **all** cases are flagged (conversion is safe there).

Full `perflint` suite passes (13 tests); existing `PERF401.py` / `PERF403.py` snapshots are unchanged. `cargo fmt --check` and `cargo clippy` are clean.

[PEP 709]: https://peps.python.org/pep-0709/

---

Per the [Astral AI policy](https://github.com/astral-sh/.github/blob/main/AI_POLICY.md): drafted with AI assistance and reviewed and tested by a human before submission.
