### PR TITLE
[ty] Improve diagnostic hints for assignability mismatches with protocols and TypedDicts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -796,7 +796,7 @@ error[invalid-assignment]: Object of type `PersonWithAge` is not assignable to `
    |             |
    |             Declared type
 info: field "age" is required in TypedDict `PersonWithAge` but not required and mutable in TypedDict `PersonWithOptionalAge`
-help: The required field could be removed through a destructive operation like `del` on the target.
+help: The required field could be removed through a destructive operation like `del` on the target
 ```
 
 Assigning a `TypedDict` to a `dict`
@@ -815,8 +815,8 @@ error[invalid-assignment]: Object of type `Person` is not assignable to `dict[st
    |             |
    |             Declared type
 info: TypedDict `Person` is not assignable to `dict`
-help: A TypedDict is not usually assignable to any `dict[..]` type; `dict` types allow destructive operations like `clear()`.
-help: Consider using `Mapping[..]` instead of `dict[..]`.
+help: A TypedDict is not usually assignable to any `dict[..]` type; `dict` types allow destructive operations like `clear()`
+help: Consider using `Mapping[..]` instead of `dict[..]`
 ```
 
 Assigning an open `TypedDict` to a specialized `Mapping`:
@@ -842,7 +842,7 @@ error[invalid-return-type]: Return type does not match returned value
 40 |     return d  # snapshot
    |            ^ expected `Mapping[str, int]`, found `D`
 info: TypedDict `D` is not assignable to `Mapping[str, int]`
-help: `D` would be assignable to `Mapping[str, int]` if it were declared with `closed=True`, but TypedDicts are open by default.
+help: `D` would be assignable to `Mapping[str, int]` if it were declared with `closed=True`, but TypedDicts are open by default
 help: A subclass of `D` could validly add a new field of an arbitrary type, violating subtyping with `Mapping[str, int]`
 ```
 
@@ -873,9 +873,9 @@ error[invalid-return-type]: Return type does not match returned value
 info: type `Empty` is not assignable to any element of the union `Mapping[str, int] | Mapping[str, str]`
 info: ├── TypedDict `Empty` is not assignable to `Mapping[str, int]`
 info: └── TypedDict `Empty` is not assignable to `Mapping[str, str]`
-help: `Empty` would be assignable to `Mapping[str, int]` if it were declared with `closed=True`, but TypedDicts are open by default.
+help: `Empty` would be assignable to `Mapping[str, int]` if it were declared with `closed=True`, but TypedDicts are open by default
 help: A subclass of `Empty` could validly add a new field of an arbitrary type, violating subtyping with `Mapping[str, int]`
-help: `Empty` would be assignable to `Mapping[str, str]` if it were declared with `closed=True`, but TypedDicts are open by default.
+help: `Empty` would be assignable to `Mapping[str, str]` if it were declared with `closed=True`, but TypedDicts are open by default
 help: A subclass of `Empty` could validly add a new field of an arbitrary type, violating subtyping with `Mapping[str, str]`
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -842,8 +842,41 @@ error[invalid-return-type]: Return type does not match returned value
 40 |     return d  # snapshot
    |            ^ expected `Mapping[str, int]`, found `D`
 info: TypedDict `D` is not assignable to `Mapping[str, int]`
-help: `D` would be assignable to this `Mapping` type if it were declared with `closed=True`, but TypedDicts are open by default.
-help: A subclass of `D` could validly add a new field of an arbitrary type, violating subtyping with the `Mapping` type
+help: `D` would be assignable to `Mapping[str, int]` if it were declared with `closed=True`, but TypedDicts are open by default.
+help: A subclass of `D` could validly add a new field of an arbitrary type, violating subtyping with `Mapping[str, int]`
+```
+
+## Open `TypedDict` and a union of specialized mappings
+
+Each mapping in a union receives its own explanation when an open `TypedDict` is incompatible with
+every alternative.
+
+```py
+from collections.abc import Mapping
+from typing import TypedDict
+
+class Empty(TypedDict):
+    pass
+
+def _(value: Empty) -> Mapping[str, int] | Mapping[str, str]:
+    return value  # snapshot
+```
+
+```snapshot
+error[invalid-return-type]: Return type does not match returned value
+ --> src/mdtest_snippet.py:8:12
+  |
+7 | def _(value: Empty) -> Mapping[str, int] | Mapping[str, str]:
+  |                        ------------------------------------- Expected `Mapping[str, int] | Mapping[str, str]` because of return type
+8 |     return value  # snapshot
+  |            ^^^^^ expected `Mapping[str, int] | Mapping[str, str]`, found `Empty`
+info: type `Empty` is not assignable to any element of the union `Mapping[str, int] | Mapping[str, str]`
+info: ├── TypedDict `Empty` is not assignable to `Mapping[str, int]`
+info: └── TypedDict `Empty` is not assignable to `Mapping[str, str]`
+help: `Empty` would be assignable to `Mapping[str, int]` if it were declared with `closed=True`, but TypedDicts are open by default.
+help: A subclass of `Empty` could validly add a new field of an arbitrary type, violating subtyping with `Mapping[str, int]`
+help: `Empty` would be assignable to `Mapping[str, str]` if it were declared with `closed=True`, but TypedDicts are open by default.
+help: A subclass of `Empty` could validly add a new field of an arbitrary type, violating subtyping with `Mapping[str, str]`
 ```
 
 ## Generic `TypedDict` field conflicts in overload diagnostics
@@ -1238,6 +1271,126 @@ info: └── protocol member `check` is incompatible
 info:     └── parameter `y` has an incompatible type: `str` is not assignable to `bytes`
 ```
 
+## Protocol method parameter names
+
+Assignability errors against protocols are often caused because a method in the protocol class
+should have used positional-only parameters, but didn't. In this situation, we point out the likely
+cause of the assignability error in a dedicated `help:` message that points out that the issue may
+be due to the protocol itself rather than the type being assigned to the protocol:
+
+```py
+from typing import Protocol
+
+class Target(Protocol):
+    def run(self, expected: int) -> None: ...
+
+class Source:
+    def run(self, actual: int) -> None: ...
+
+target: Target = Source()  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Source` is not assignable to `Target`
+ --> src/mdtest_snippet.py:9:18
+  |
+9 | target: Target = Source()  # snapshot
+  |         ------   ^^^^^^^^ Incompatible value of type `Source`
+  |         |
+  |         Declared type
+info: type `Source` is not assignable to protocol `Target`
+info: └── protocol member `run` is incompatible
+info:     └── the parameter named `actual` does not match `expected` (and can be used as a keyword parameter)
+help: `Source` might be assignable to `Target` if the parameter `expected` were made positional-only in `Target.run`
+```
+
+The same suggestion applies for the case where a positional-or-keyword parameter was apparently
+demanded by a protocol member, but only a positional-only parameter was supplied in the type that
+was assigned to the protocol:
+
+```py
+class Target2(Protocol):
+    def run(self, expected: int) -> None: ...
+
+class Source2:
+    def run(self, actual: int, /) -> None: ...
+
+target: Target2 = Source2()  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Source2` is not assignable to `Target2`
+  --> src/mdtest_snippet.py:16:19
+   |
+16 | target: Target2 = Source2()  # snapshot
+   |         -------   ^^^^^^^^^ Incompatible value of type `Source2`
+   |         |
+   |         Declared type
+info: type `Source2` is not assignable to protocol `Target2`
+info: └── protocol member `run` is incompatible
+info:     └── parameter `actual` is positional-only but must also accept keyword arguments
+help: `Source2` might be assignable to `Target2` if the parameter `expected` were made positional-only in `Target2.run`
+```
+
+Making a parameter positional-only resolves a name mismatch but does not necessarily make the method
+compatible, because its parameter type can still be incorrect. For this reason, we hedge our bets a
+little in our `help:` message (we say "*might* be assignable", rather than "*will* be assignable"):
+
+```py
+class Target3(Protocol):
+    def run(self, expected: int) -> None: ...
+
+class Source3:
+    def run(self, actual: str) -> None: ...
+
+target: Target3 = Source3()  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Source3` is not assignable to `Target3`
+  --> src/mdtest_snippet.py:23:19
+   |
+23 | target: Target3 = Source3()  # snapshot
+   |         -------   ^^^^^^^^^ Incompatible value of type `Source3`
+   |         |
+   |         Declared type
+info: type `Source3` is not assignable to protocol `Target3`
+info: └── protocol member `run` is incompatible
+info:     └── the parameter named `actual` does not match `expected` (and can be used as a keyword parameter)
+help: `Source3` might be assignable to `Target3` if the parameter `expected` were made positional-only in `Target3.run`
+```
+
+Suggestions for inherited protocol methods name the protocol that actually declares the method.
+
+```py
+from typing import Protocol
+
+class Parent(Protocol):
+    def run(self, expected: int) -> None: ...
+
+class Child(Parent, Protocol):
+    pass
+
+class Source4:
+    def run(self, actual: int) -> None: ...
+
+target: Child = Source4()  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Source4` is not assignable to `Child`
+  --> src/mdtest_snippet.py:35:17
+   |
+35 | target: Child = Source4()  # snapshot
+   |         -----   ^^^^^^^^^ Incompatible value of type `Source4`
+   |         |
+   |         Declared type
+info: type `Source4` is not assignable to protocol `Child`
+info: └── protocol member `run` is incompatible
+info:     └── the parameter named `actual` does not match `expected` (and can be used as a keyword parameter)
+help: `Source4` might be assignable to `Child` if the parameter `expected` were made positional-only in `Parent.run`
+```
+
 ## Type aliases
 
 Type aliases should be expanded in diagnostics to understand the underlying incompatibilities:
@@ -1441,6 +1594,7 @@ error[invalid-assignment]: Object of type `IncompatibleFoo` is not assignable to
 info: type `IncompatibleFoo` is not assignable to protocol `SupportsFooAndBar`
 info: └── protocol member `foo` is incompatible
 info:     └── the parameter named `name_` does not match `name` (and can be used as a keyword parameter)
+help: `IncompatibleFoo` might be assignable to `SupportsFooAndBar` if the parameter `name` were made positional-only in `SupportsFooAndBar.foo`
 ```
 
 ## Assigning to `Iterable`

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -400,7 +400,11 @@ impl<'db> ProtocolInterfaceView<'db> {
         })
     }
 
-    fn member_by_name<'a>(self, db: &'db dyn Db, name: &'a str) -> Option<ProtocolMember<'a, 'db>> {
+    pub(super) fn member_by_name<'a>(
+        self,
+        db: &'db dyn Db,
+        name: &'a str,
+    ) -> Option<ProtocolMember<'a, 'db>> {
         self.interface
             .inner(db)
             .get(name)

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -519,18 +519,18 @@ impl<'db> HelpMessages<'db> {
         std::fmt::from_fn(move |f| match self {
             HelpMessages::RequiredFieldCouldBeRemoved => f.write_str(
                 "The required field could be removed through a destructive operation \
-                like `del` on the target.",
+                like `del` on the target",
             ),
             HelpMessages::TypedDictNotAssignableToDict(relation) => {
                 write!(
                     f,
                     "A TypedDict is not usually {} any `dict[..]` type; \
-                    `dict` types allow destructive operations like `clear()`.",
+                    `dict` types allow destructive operations like `clear()`",
                     relation.description()
                 )
             }
             HelpMessages::ConsiderUsingMappingInsteadOfDict => {
-                f.write_str("Consider using `Mapping[..]` instead of `dict[..]`.")
+                f.write_str("Consider using `Mapping[..]` instead of `dict[..]`")
             }
             HelpMessages::OpenTypedDictNotAssignableToMapping {
                 typed_dict_name,
@@ -544,7 +544,7 @@ impl<'db> HelpMessages<'db> {
                     f,
                     "{name} would be {relation} `{mapping}` \
                     if it were declared with `closed=True`, \
-                    but TypedDicts are open by default.",
+                    but TypedDicts are open by default",
                     relation = relation.description(),
                     mapping = mapping_target.display(db, env)
                 )

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -6,8 +6,10 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use ruff_python_ast::name::Name;
+use ty_python_core::semantic_index;
 
 use crate::types::context::LintDiagnosticGuard;
+use crate::types::infer::nearest_enclosing_class;
 use crate::types::tuple::TupleLength;
 use crate::types::{DisplaySettings, Type, TypedDictType};
 use crate::{FxOrderSet, ProgramEnvironment};
@@ -177,7 +179,7 @@ impl<'db> ErrorContext<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         relation: TypeRelation,
-        help_messages: &mut FxOrderSet<HelpMessages>,
+        help_messages: &mut FxOrderSet<HelpMessages<'db>>,
     ) -> Option<String> {
         let typed_dict_name = |typed_dict: &TypedDictType<'db>| match typed_dict {
             TypedDictType::Class(class) => format!("TypedDict `{}`", class.name(db)),
@@ -311,11 +313,12 @@ impl<'db> ErrorContext<'db> {
             Self::OpenTypedDictNotAssignableToMapping { source, target } => {
                 let name = source.defining_class().map(|class| class.name(db));
                 help_messages.insert(HelpMessages::OpenTypedDictNotAssignableToMapping {
-                    typed_dict_name: name.cloned(),
-                    relation,
+                    typed_dict_name: name,
+                    mapping_target: *target,
                 });
                 help_messages.insert(HelpMessages::ExplainOpenTypedDictUnsoundness {
-                    typed_dict_name: name.cloned(),
+                    typed_dict_name: name,
+                    mapping_target: *target,
                 });
 
                 format!(
@@ -481,7 +484,7 @@ impl<'db> ErrorContext<'db> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-enum HelpMessages {
+enum HelpMessages<'db> {
     RequiredFieldCouldBeRemoved,
     TypedDictNotAssignableToDict(TypeRelation),
     ConsiderUsingMappingInsteadOfDict,
@@ -490,17 +493,30 @@ enum HelpMessages {
         parameter_name: Option<Name>,
     },
     OpenTypedDictNotAssignableToMapping {
-        typed_dict_name: Option<Name>,
-        relation: TypeRelation,
+        typed_dict_name: Option<&'db Name>,
+        mapping_target: Type<'db>,
     },
     ExplainOpenTypedDictUnsoundness {
-        typed_dict_name: Option<Name>,
+        typed_dict_name: Option<&'db Name>,
+        mapping_target: Type<'db>,
+    },
+    SuggestMakingParameterPositionalOnly {
+        ty: Type<'db>,
+        protocol: Type<'db>,
+        declaring_protocol_name: &'db Name,
+        method_name: Name,
+        parameter_name: Name,
     },
 }
 
-impl std::fmt::Display for HelpMessages {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
+impl<'db> HelpMessages<'db> {
+    fn display(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment,
+        relation: TypeRelation,
+    ) -> impl std::fmt::Display {
+        std::fmt::from_fn(move |f| match self {
             HelpMessages::RequiredFieldCouldBeRemoved => f.write_str(
                 "The required field could be removed through a destructive operation \
                 like `del` on the target.",
@@ -518,7 +534,7 @@ impl std::fmt::Display for HelpMessages {
             }
             HelpMessages::OpenTypedDictNotAssignableToMapping {
                 typed_dict_name,
-                relation,
+                mapping_target,
             } => {
                 let name = typed_dict_name
                     .as_ref()
@@ -526,13 +542,17 @@ impl std::fmt::Display for HelpMessages {
                     .unwrap_or_else(|| "this TypedDict".to_string());
                 write!(
                     f,
-                    "{name} would be {relation} this `Mapping` type \
+                    "{name} would be {relation} `{mapping}` \
                     if it were declared with `closed=True`, \
                     but TypedDicts are open by default.",
-                    relation = relation.description()
+                    relation = relation.description(),
+                    mapping = mapping_target.display(db, env)
                 )
             }
-            HelpMessages::ExplainOpenTypedDictUnsoundness { typed_dict_name } => {
+            HelpMessages::ExplainOpenTypedDictUnsoundness {
+                typed_dict_name,
+                mapping_target,
+            } => {
                 let name = typed_dict_name
                     .as_ref()
                     .map(|name| format!("`{name}`"))
@@ -540,7 +560,8 @@ impl std::fmt::Display for HelpMessages {
                 write!(
                     f,
                     "A subclass of {name} could validly add a new field \
-                    of an arbitrary type, violating subtyping with the `Mapping` type"
+                    of an arbitrary type, violating subtyping with `{mapping_type}`",
+                    mapping_type = mapping_target.display(db, env)
                 )
             }
             HelpMessages::TopCallableExplanation => f.write_str(
@@ -552,7 +573,26 @@ impl std::fmt::Display for HelpMessages {
                 Some(name) => write!(f, "Parameter `{name}` must have a default value"),
                 None => f.write_str("The parameter must have a default value"),
             },
-        }
+            HelpMessages::SuggestMakingParameterPositionalOnly {
+                ty,
+                protocol,
+                declaring_protocol_name,
+                method_name,
+                parameter_name,
+            } => {
+                let settings =
+                    DisplaySettings::from_possibly_ambiguous_types(db, env, [*ty, *protocol]);
+                write!(
+                    f,
+                    "`{source}` might be {relation} `{target}` \
+                    if the parameter `{parameter_name}` were made positional-only \
+                    in `{declaring_protocol_name}.{method_name}`",
+                    source = ty.display_with(db, env, settings.clone()),
+                    relation = relation.description(),
+                    target = protocol.display_with(db, env, settings),
+                )
+            }
+        })
     }
 }
 
@@ -584,12 +624,38 @@ impl<'db> ErrorContextNode<'db> {
         env: &ProgramEnvironment<'db>,
         relation: TypeRelation,
         output_lines: &mut Vec<String>,
-        help_messages: &mut FxOrderSet<HelpMessages>,
+        help_messages: &mut FxOrderSet<HelpMessages<'db>>,
         prefix: &str,
         continuation: &str,
     ) {
         if let Some(line) = self.context.render(db, env, relation, help_messages) {
             output_lines.push(format!("{prefix}{line}"));
+        }
+
+        if let ErrorContext::TypeNotCompatibleWithProtocol { ty, protocol } = &self.context
+            && let Type::ProtocolInstance(proto_instance) = protocol
+            && let [single_child] = self.children.as_slice()
+            && let ErrorContext::ProtocolMemberIncompatible { member_name } = &single_child.context
+            && let [single_grandchild] = single_child.children.as_slice()
+            && let ErrorContext::ParameterNameMismatch { target_name, .. }
+            | ErrorContext::ParameterMustAcceptKeywordArguments { target_name, .. } =
+                &single_grandchild.context
+            && let Some(protocol_member) =
+                proto_instance.interface(db).member_by_name(db, member_name)
+            && let Some(definition) = protocol_member.definition()
+            && let Some(declaring_protocol) = nearest_enclosing_class(
+                db,
+                semantic_index(db, definition.program_file(db)),
+                definition.scope(db),
+            )
+        {
+            help_messages.insert(HelpMessages::SuggestMakingParameterPositionalOnly {
+                ty: *ty,
+                protocol: *protocol,
+                declaring_protocol_name: declaring_protocol.name(db),
+                method_name: member_name.clone(),
+                parameter_name: target_name.clone(),
+            });
         }
 
         let num_children = self.children.len();
@@ -722,7 +788,7 @@ impl<'db> ErrorContextTree<'db> {
             diag.info(line);
         }
         for help_message in help_messages {
-            diag.help(help_message.to_string());
+            diag.help(help_message.display(db, env, self.relation));
         }
     }
 }


### PR DESCRIPTION
## Summary

Protocol assignability errors caused by incompatible method parameter names often indicate a problem with the protocol declaration, not with the object being assigned to it. For example:

```py
from typing import Protocol

class _HasVersionFieldProtocol(Protocol):
    def __getitem__(self, s: str) -> str: ...

class Foo:
    def __getitem__(self, key: str) -> str:
        return ""

value: _HasVersionFieldProtocol = Foo()
```

`_HasVersionFieldProtocol.__getitem__` promises that its argument can be passed as the keyword `s`, but `Foo.__getitem__` accepts the keyword `key` instead. The existing diagnostic explains the parameter-name mismatch, but leaves users to infer that the protocol itself probably should have declared `s` as positional-only:

```py
def __getitem__(self, s: str, /) -> str: ...
```

This PR adds a dedicated `help:` message that points directly to the protocol method and parameter that should probably change:

![Terminal screenshot showing ty suggesting that the protocol parameter s be made positional-only](https://gist.githubusercontent.com/AlexWaygood/6755c58446a398d49e877d3560576a6f/raw/352fee5c7c1c58a5682d6658af47748b66bce9af/ty-pr-27717-protocol-diagnostic.svg)

The suggestion also handles implementations whose corresponding parameter is already positional-only, and names the protocol that actually declares the method when the method is inherited. It says the object *might* become assignable because changing the parameter kind does not resolve other incompatibilities, such as an incorrect parameter type.

This probably would have helped the reporter of https://github.com/astral-sh/ty/issues/4245 identify the missing positional-only marker in `_HasVersionFieldProtocol.__getitem__`, instead of wondering whether ty should implicitly treat dunder-method parameters as positional-only.

## TypedDict diagnostics

As a related improvement, hints explaining why an open `TypedDict` is incompatible with a specialized `Mapping` now name the concrete mapping type instead of referring vaguely to "this `Mapping` type". When a `TypedDict` is incompatible with multiple specialized mappings in a union, each mapping now receives its own explanation.

Closes https://github.com/astral-sh/ty/issues/4245