### PR TITLE
[ty] Simplify display implementations with std::fmt::from_fn

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -5,8 +5,7 @@ use ruff_db::files::FileRange;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextSize};
-use std::fmt;
-use std::fmt::Formatter;
+use std::fmt::{self, Display};
 use ty_python_core::ProgramFile;
 use ty_python_semantic::ProgramEnvironment;
 use ty_python_semantic::types::ide_support::{resolved_call_signature, typed_dict_key_hover};
@@ -230,12 +229,21 @@ pub struct Hover<'db> {
 
 impl<'db> Hover<'db> {
     /// Renders the hover to a string using the specified markup kind.
-    pub const fn display<'a>(&'a self, db: &'db dyn Db, kind: MarkupKind) -> DisplayHover<'db, 'a> {
-        DisplayHover {
-            db,
-            hover: self,
-            kind,
-        }
+    pub const fn display<'a>(&'a self, db: &'db dyn Db, kind: MarkupKind) -> impl Display {
+        std::fmt::from_fn(move |f| {
+            let mut first = true;
+            let env = ProgramEnvironment::from_file(self.program_file);
+            for content in &self.contents {
+                if !first {
+                    kind.horizontal_line().fmt(f)?;
+                }
+
+                content.display(db, &env, kind).fmt(f)?;
+                first = false;
+            }
+
+            Ok(())
+        })
     }
 
     fn iter(&self) -> std::slice::Iter<'_, HoverContent<'db>> {
@@ -258,30 +266,6 @@ impl<'a, 'db> IntoIterator for &'a Hover<'db> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-pub struct DisplayHover<'db, 'a> {
-    db: &'db dyn Db,
-    hover: &'a Hover<'db>,
-    kind: MarkupKind,
-}
-
-impl fmt::Display for DisplayHover<'_, '_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let db = self.db;
-        let mut first = true;
-        let env = ProgramEnvironment::from_file(self.hover.program_file);
-        for content in &self.hover.contents {
-            if !first {
-                self.kind.horizontal_line().fmt(f)?;
-            }
-
-            content.display(db, &env, self.kind).fmt(f)?;
-            first = false;
-        }
-
-        Ok(())
     }
 }
 

--- a/crates/ty_module_resolver/src/environment.rs
+++ b/crates/ty_module_resolver/src/environment.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use ruff_db::files::File;
 use ruff_python_ast::PythonVersion;
 
@@ -22,34 +20,20 @@ impl<'db> ResolverEnvironment<'db> {
         self,
         db: &'db dyn Db,
         mode: ModuleResolveMode,
-    ) -> DisplaySearchPaths<'db> {
-        DisplaySearchPaths {
-            db,
-            resolver_environment: self,
-            mode,
-        }
-    }
-}
+    ) -> impl std::fmt::Display {
+        std::fmt::from_fn(move |f| {
+            let mut paths = search_paths(db, self, mode).peekable();
 
-pub struct DisplaySearchPaths<'db> {
-    db: &'db dyn Db,
-    resolver_environment: ResolverEnvironment<'db>,
-    mode: ModuleResolveMode,
-}
+            if paths.peek().is_none() {
+                return f.write_str("[]");
+            }
 
-impl fmt::Display for DisplaySearchPaths<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut paths = search_paths(self.db, self.resolver_environment, self.mode).peekable();
-
-        if paths.peek().is_none() {
-            return f.write_str("[]");
-        }
-
-        writeln!(f, "[")?;
-        for path in paths {
-            writeln!(f, "  {path},")?;
-        }
-        f.write_str("]")
+            writeln!(f, "[")?;
+            for path in paths {
+                writeln!(f, "  {path},")?;
+            }
+            f.write_str("]")
+        })
     }
 }
 

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -325,137 +325,125 @@ fn bytes_to_mb(total: usize) -> f64 {
 
 impl SalsaMemoryDump {
     /// Returns a short report that provides total memory usage information.
-    pub fn display_short(&self) -> impl fmt::Display + '_ {
-        struct DisplayShort<'a>(&'a SalsaMemoryDump);
+    pub fn display_short(self) -> impl fmt::Display {
+        std::fmt::from_fn(move |f| {
+            let SalsaMemoryDump {
+                total_fields,
+                total_metadata,
+                total_memo_fields,
+                total_memo_metadata,
+                ref ingredients,
+                ref memos,
+            } = self;
 
-        impl fmt::Display for DisplayShort<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let SalsaMemoryDump {
-                    total_fields,
-                    total_metadata,
-                    total_memo_fields,
-                    total_memo_metadata,
-                    ref ingredients,
-                    ref memos,
-                } = *self.0;
+            writeln!(f, "=======SALSA SUMMARY=======")?;
 
-                writeln!(f, "=======SALSA SUMMARY=======")?;
+            writeln!(
+                f,
+                "TOTAL MEMORY USAGE: {:.2}MB",
+                bytes_to_mb(
+                    total_metadata + total_fields + total_memo_fields + total_memo_metadata
+                )
+            )?;
 
-                writeln!(
-                    f,
-                    "TOTAL MEMORY USAGE: {:.2}MB",
-                    bytes_to_mb(
-                        total_metadata + total_fields + total_memo_fields + total_memo_metadata
-                    )
-                )?;
+            writeln!(
+                f,
+                "    struct metadata = {:.2}MB",
+                bytes_to_mb(total_metadata),
+            )?;
+            writeln!(f, "    struct fields = {:.2}MB", bytes_to_mb(total_fields))?;
+            writeln!(
+                f,
+                "    memo metadata = {:.2}MB",
+                bytes_to_mb(total_memo_metadata),
+            )?;
+            writeln!(
+                f,
+                "    memo fields = {:.2}MB",
+                bytes_to_mb(total_memo_fields),
+            )?;
 
-                writeln!(
-                    f,
-                    "    struct metadata = {:.2}MB",
-                    bytes_to_mb(total_metadata),
-                )?;
-                writeln!(f, "    struct fields = {:.2}MB", bytes_to_mb(total_fields))?;
-                writeln!(
-                    f,
-                    "    memo metadata = {:.2}MB",
-                    bytes_to_mb(total_memo_metadata),
-                )?;
-                writeln!(
-                    f,
-                    "    memo fields = {:.2}MB",
-                    bytes_to_mb(total_memo_fields),
-                )?;
+            writeln!(f, "QUERY COUNT: {}", memos.len())?;
+            writeln!(f, "STRUCT COUNT: {}", ingredients.len())?;
 
-                writeln!(f, "QUERY COUNT: {}", memos.len())?;
-                writeln!(f, "STRUCT COUNT: {}", ingredients.len())?;
-
-                Ok(())
-            }
-        }
-
-        DisplayShort(self)
+            Ok(())
+        })
     }
 
     /// Returns a short report that provides fine-grained memory usage information per
     /// Salsa ingredient.
-    pub fn display_full(&self) -> impl fmt::Display + '_ {
-        struct DisplayFull<'a>(&'a SalsaMemoryDump);
+    pub fn display_full(self) -> impl fmt::Display {
+        std::fmt::from_fn(move |f| {
+            let SalsaMemoryDump {
+                total_fields,
+                total_metadata,
+                total_memo_fields,
+                total_memo_metadata,
+                ref ingredients,
+                ref memos,
+            } = self;
 
-        impl fmt::Display for DisplayFull<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let SalsaMemoryDump {
-                    total_fields,
-                    total_metadata,
-                    total_memo_fields,
-                    total_memo_metadata,
-                    ref ingredients,
-                    ref memos,
-                } = *self.0;
+            writeln!(f, "=======SALSA STRUCTS=======")?;
 
-                writeln!(f, "=======SALSA STRUCTS=======")?;
-
-                for ingredient in ingredients {
-                    let size_of_fields =
-                        ingredient.size_of_fields() + ingredient.heap_size_of_fields().unwrap_or(0);
-
-                    writeln!(
-                        f,
-                        "{:<50} metadata={:<8} fields={:<8} count={}",
-                        format!("`{}`", ingredient.debug_name()),
-                        format!("{:.2}MB", bytes_to_mb(ingredient.size_of_metadata())),
-                        format!("{:.2}MB", bytes_to_mb(size_of_fields)),
-                        ingredient.count()
-                    )?;
-                }
-
-                writeln!(f, "=======SALSA QUERIES=======")?;
-
-                for (query_fn, memo) in memos {
-                    let size_of_fields =
-                        memo.size_of_fields() + memo.heap_size_of_fields().unwrap_or(0);
-
-                    writeln!(f, "`{query_fn} -> {}`", memo.debug_name())?;
-
-                    writeln!(
-                        f,
-                        "    metadata={:<8} fields={:<8} count={}",
-                        format!("{:.2}MB", bytes_to_mb(memo.size_of_metadata())),
-                        format!("{:.2}MB", bytes_to_mb(size_of_fields)),
-                        memo.count()
-                    )?;
-                }
-
-                writeln!(f, "=======SALSA SUMMARY=======")?;
-                writeln!(
-                    f,
-                    "TOTAL MEMORY USAGE: {:.2}MB",
-                    bytes_to_mb(
-                        total_metadata + total_fields + total_memo_fields + total_memo_metadata
-                    )
-                )?;
+            for ingredient in ingredients {
+                let size_of_fields =
+                    ingredient.size_of_fields() + ingredient.heap_size_of_fields().unwrap_or(0);
 
                 writeln!(
                     f,
-                    "    struct metadata = {:.2}MB",
-                    bytes_to_mb(total_metadata),
+                    "{:<50} metadata={:<8} fields={:<8} count={}",
+                    format!("`{}`", ingredient.debug_name()),
+                    format!("{:.2}MB", bytes_to_mb(ingredient.size_of_metadata())),
+                    format!("{:.2}MB", bytes_to_mb(size_of_fields)),
+                    ingredient.count()
                 )?;
-                writeln!(f, "    struct fields = {:.2}MB", bytes_to_mb(total_fields))?;
-                writeln!(
-                    f,
-                    "    memo metadata = {:.2}MB",
-                    bytes_to_mb(total_memo_metadata),
-                )?;
-                writeln!(
-                    f,
-                    "    memo fields = {:.2}MB",
-                    bytes_to_mb(total_memo_fields),
-                )?;
-
-                Ok(())
             }
-        }
 
-        DisplayFull(self)
+            writeln!(f, "=======SALSA QUERIES=======")?;
+
+            for (query_fn, memo) in memos {
+                let size_of_fields =
+                    memo.size_of_fields() + memo.heap_size_of_fields().unwrap_or(0);
+
+                writeln!(f, "`{query_fn} -> {}`", memo.debug_name())?;
+
+                writeln!(
+                    f,
+                    "    metadata={:<8} fields={:<8} count={}",
+                    format!("{:.2}MB", bytes_to_mb(memo.size_of_metadata())),
+                    format!("{:.2}MB", bytes_to_mb(size_of_fields)),
+                    memo.count()
+                )?;
+            }
+
+            writeln!(f, "=======SALSA SUMMARY=======")?;
+            writeln!(
+                f,
+                "TOTAL MEMORY USAGE: {:.2}MB",
+                bytes_to_mb(
+                    total_metadata + total_fields + total_memo_fields + total_memo_metadata
+                )
+            )?;
+
+            writeln!(
+                f,
+                "    struct metadata = {:.2}MB",
+                bytes_to_mb(total_metadata),
+            )?;
+            writeln!(f, "    struct fields = {:.2}MB", bytes_to_mb(total_fields))?;
+            writeln!(
+                f,
+                "    memo metadata = {:.2}MB",
+                bytes_to_mb(total_memo_metadata),
+            )?;
+            writeln!(
+                f,
+                "    memo fields = {:.2}MB",
+                bytes_to_mb(total_memo_fields),
+            )?;
+
+            Ok(())
+        })
     }
 
     /// Serializes the memory dump to JSON.

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -459,85 +459,35 @@ impl<'a, 'db> CallArguments<'a, 'db> {
             }
         }
 
-        struct DisplayCallArguments<'env, 'a, 'db> {
-            call_arguments: &'a CallArguments<'a, 'db>,
-            db: &'db dyn Db,
-            env: &'env ProgramEnvironment<'db>,
-        }
-
-        impl std::fmt::Display for DisplayCallArguments<'_, '_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_str("(")?;
-                for (index, (argument, types)) in self.call_arguments.iter().enumerate() {
-                    if index > 0 {
-                        write!(f, ", ")?;
+        std::fmt::from_fn(move |f| {
+            f.write_str("(")?;
+            for (index, (argument, types)) in self.iter().enumerate() {
+                if index > 0 {
+                    write!(f, ", ")?;
+                }
+                match argument {
+                    Argument::Synthetic => {
+                        write!(f, "self: {}", DisplayCallArgumentTypes { types, db, env })?;
                     }
-                    match argument {
-                        Argument::Synthetic => {
-                            write!(
-                                f,
-                                "self: {}",
-                                DisplayCallArgumentTypes {
-                                    types,
-                                    db: self.db,
-                                    env: self.env,
-                                }
-                            )?;
-                        }
-                        Argument::Positional => {
-                            write!(
-                                f,
-                                "{}",
-                                DisplayCallArgumentTypes {
-                                    types,
-                                    db: self.db,
-                                    env: self.env,
-                                }
-                            )?;
-                        }
-                        Argument::Variadic => {
-                            write!(
-                                f,
-                                "*{}",
-                                DisplayCallArgumentTypes {
-                                    types,
-                                    db: self.db,
-                                    env: self.env,
-                                }
-                            )?;
-                        }
-                        Argument::Keyword(name) => write!(
-                            f,
-                            "{}={}",
-                            name,
-                            DisplayCallArgumentTypes {
-                                types,
-                                db: self.db,
-                                env: self.env,
-                            }
-                        )?,
-                        Argument::Keywords => {
-                            write!(
-                                f,
-                                "**{}",
-                                DisplayCallArgumentTypes {
-                                    types,
-                                    db: self.db,
-                                    env: self.env,
-                                }
-                            )?;
-                        }
+                    Argument::Positional => {
+                        write!(f, "{}", DisplayCallArgumentTypes { types, db, env })?;
+                    }
+                    Argument::Variadic => {
+                        write!(f, "*{}", DisplayCallArgumentTypes { types, db, env })?;
+                    }
+                    Argument::Keyword(name) => write!(
+                        f,
+                        "{}={}",
+                        name,
+                        DisplayCallArgumentTypes { types, db, env }
+                    )?,
+                    Argument::Keywords => {
+                        write!(f, "**{}", DisplayCallArgumentTypes { types, db, env })?;
                     }
                 }
-                f.write_str(")")
             }
-        }
-
-        DisplayCallArguments {
-            call_arguments: self,
-            db,
-            env,
-        }
+            f.write_str(")")
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1017,30 +1017,14 @@ impl KnownClass {
     }
 
     pub(crate) fn display(self, python_version: PythonVersion) -> impl std::fmt::Display {
-        struct KnownClassDisplay {
-            class: KnownClass,
-            python_version: PythonVersion,
-        }
-
-        impl std::fmt::Display for KnownClassDisplay {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let KnownClassDisplay {
-                    class: known_class,
-                    python_version,
-                } = *self;
-                write!(
-                    f,
-                    "{module}.{class}",
-                    module = known_class.canonical_module(python_version),
-                    class = known_class.name(python_version)
-                )
-            }
-        }
-
-        KnownClassDisplay {
-            class: self,
-            python_version,
-        }
+        std::fmt::from_fn(move |f| {
+            write!(
+                f,
+                "{module}.{class}",
+                module = self.canonical_module(python_version),
+                class = self.name(python_version)
+            )
+        })
     }
 
     /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing all
@@ -2007,62 +1991,42 @@ impl<'db> KnownClassLookupError<'db> {
     }
 
     fn display<'env>(
-        &self,
+        self,
         db: &'db dyn Db,
         env: &'env ProgramEnvironment<'db>,
         class: KnownClass,
     ) -> impl std::fmt::Display + 'env {
-        struct ErrorDisplay<'env, 'db> {
-            db: &'db dyn Db,
-            env: &'env ProgramEnvironment<'db>,
-            class: KnownClass,
-            error: KnownClassLookupError<'db>,
-        }
+        std::fmt::from_fn(move |f| {
+            let python_version = env.python_version(db);
+            let class = class.display(python_version);
+            let location = if self.is_third_party() {
+                ""
+            } else {
+                " in typeshed"
+            };
 
-        impl std::fmt::Display for ErrorDisplay<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let db = self.db;
-                let ErrorDisplay {
-                    db: _,
-                    env,
-                    class,
-                    error,
-                } = self;
-
-                let python_version = env.python_version(db);
-                let class = class.display(python_version);
-                let location = if error.is_third_party() {
-                    ""
-                } else {
-                    " in typeshed"
-                };
-
-                match error {
-                    KnownClassLookupError::ClassNotFound { .. } => write!(
-                        f,
-                        "Could not find class `{class}`{location} on Python {python_version}",
-                    ),
-                    KnownClassLookupError::SymbolNotAClass { found_type, .. } => write!(
-                        f,
-                        "Error looking up `{class}`{location}: expected to find a class definition \
-                        on Python {python_version}, but found a symbol of type `{found_type}` instead",
-                        found_type = found_type.display(db, env),
-                    ),
-                    KnownClassLookupError::ClassPossiblyUnbound { .. } => write!(
-                        f,
-                        "Error looking up `{class}`{location} on Python {python_version}: expected \
-                        to find a fully bound symbol, but found one that is possibly unbound",
-                    ),
-                }
+            match self {
+                KnownClassLookupError::ClassNotFound { .. } => write!(
+                    f,
+                    "Could not find class `{class}`{location} on Python {python_version}",
+                ),
+                KnownClassLookupError::SymbolNotAClass { found_type, .. } => write!(
+                    f,
+                    "Error looking up `{class}`{location}: \
+                    expected to find a class definition \
+                    on Python {python_version}, \
+                    but found a symbol of type `{found_type}` instead",
+                    found_type = found_type.display(db, env),
+                ),
+                KnownClassLookupError::ClassPossiblyUnbound { .. } => write!(
+                    f,
+                    "Error looking up `{class}`{location} \
+                    on Python {python_version}: expected \
+                    to find a fully bound symbol, \
+                    but found one that is possibly unbound",
+                ),
             }
-        }
-
-        ErrorDisplay {
-            db,
-            env,
-            class,
-            error: *self,
-        }
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::ProgramEnvironment;
 use crate::types::class::CodeGeneratorKind;
 use crate::types::generics::{ApplySpecialization, Specialization};
@@ -490,37 +492,18 @@ impl<'db> ClassBase<'db> {
         db: &'db dyn Db,
         env: &'env ProgramEnvironment<'db>,
         display_settings: DisplaySettings<'db>,
-    ) -> impl std::fmt::Display + 'env {
-        struct ClassBaseDisplay<'env, 'db> {
-            db: &'db dyn Db,
-            env: &'env ProgramEnvironment<'db>,
-            base: ClassBase<'db>,
-            settings: DisplaySettings<'db>,
-        }
-
-        impl std::fmt::Display for ClassBaseDisplay<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let db = self.db;
-                match self.base {
-                    ClassBase::Any => f.write_str("Any"),
-                    ClassBase::Dynamic(dynamic) => dynamic.fmt(f),
-                    ClassBase::Divergent(_) => f.write_str("Divergent"),
-                    ClassBase::Class(class) => Type::from(class)
-                        .display_with(db, self.env, self.settings.clone())
-                        .fmt(f),
-                    ClassBase::Protocol => f.write_str("typing.Protocol"),
-                    ClassBase::Generic => f.write_str("typing.Generic"),
-                    ClassBase::TypedDict(_) => f.write_str("typing.TypedDict"),
-                }
-            }
-        }
-
-        ClassBaseDisplay {
-            db,
-            env,
-            base: self,
-            settings: display_settings,
-        }
+    ) -> impl Display + 'env {
+        std::fmt::from_fn(move |f| match self {
+            ClassBase::Any => f.write_str("Any"),
+            ClassBase::Dynamic(dynamic) => dynamic.fmt(f),
+            ClassBase::Divergent(_) => f.write_str("Divergent"),
+            ClassBase::Class(class) => Type::from(class)
+                .display_with(db, env, display_settings.clone())
+                .fmt(f),
+            ClassBase::Protocol => f.write_str("typing.Protocol"),
+            ClassBase::Generic => f.write_str("typing.Generic"),
+            ClassBase::TypedDict(_) => f.write_str("typing.TypedDict"),
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -877,26 +877,10 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         db: &'db dyn Db,
         env: &'c ProgramEnvironment<'db>,
     ) -> impl Display + 'c {
-        struct DisplayConstraintSet<'c, 'db> {
-            node: NodeId,
-            db: &'db dyn Db,
-            env: &'c ProgramEnvironment<'db>,
-            builder: &'c ConstraintSetBuilder<'db>,
-        }
-
-        impl Display for DisplayConstraintSet<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let storage = self.builder.storage.borrow();
-                Display::fmt(&self.node.display(self.db, self.env, &storage), f)
-            }
-        }
-
-        DisplayConstraintSet {
-            node: self.node,
-            db,
-            env,
-            builder: self.builder,
-        }
+        std::fmt::from_fn(move |f| {
+            let storage = self.builder.storage.borrow();
+            self.node.display(db, env, &storage).fmt(f)
+        })
     }
 
     #[expect(dead_code)] // Keep this around for debugging purposes
@@ -910,33 +894,10 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         'db: 'a,
         'c: 'a,
     {
-        struct DisplayConstraintSet<'a, 'c, 'db> {
-            node: NodeId,
-            prefix: &'a dyn Display,
-            db: &'db dyn Db,
-            env: &'a ProgramEnvironment<'db>,
-            builder: &'c ConstraintSetBuilder<'db>,
-        }
-
-        impl Display for DisplayConstraintSet<'_, '_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let storage = self.builder.storage.borrow();
-                Display::fmt(
-                    &self
-                        .node
-                        .display_graph(self.db, self.env, &storage, self.prefix),
-                    f,
-                )
-            }
-        }
-
-        DisplayConstraintSet {
-            node: self.node,
-            prefix,
-            db,
-            env,
-            builder: self.builder,
-        }
+        std::fmt::from_fn(move |f| {
+            let storage = self.builder.storage.borrow();
+            self.node.display_graph(db, env, &storage, prefix).fmt(f)
+        })
     }
 }
 
@@ -3321,36 +3282,14 @@ impl NodeId {
         // Render the BDD directly as an unsimplified DNF formula. Each root-to-true path becomes
         // one clause, with true, uncertain, and false edges contributing positive, unconstrained,
         // and negative assignments respectively.
-        struct DisplayNode<'db, 'c> {
-            node: NodeId,
-            db: &'db dyn Db,
-            env: &'c ProgramEnvironment<'db>,
-            storage: &'c ConstraintSetStorage<'db>,
-        }
-
-        impl Display for DisplayNode<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                match self.node.node() {
-                    Node::AlwaysTrue => f.write_str("always"),
-                    Node::AlwaysFalse => f.write_str("never"),
-                    Node::Interior(_) => Display::fmt(
-                        &self.node.satisfied_clauses(self.storage).display(
-                            self.db,
-                            self.env,
-                            self.storage,
-                        ),
-                        f,
-                    ),
-                }
-            }
-        }
-
-        DisplayNode {
-            node: self,
-            db,
-            env,
-            storage,
-        }
+        std::fmt::from_fn(move |f| match self.node() {
+            Node::AlwaysTrue => f.write_str("always"),
+            Node::AlwaysFalse => f.write_str("never"),
+            Node::Interior(_) => Display::fmt(
+                &self.satisfied_clauses(storage).display(db, env, storage),
+                f,
+            ),
+        })
     }
 
     /// Displays the full graph structure of this BDD. `prefix` will be output before each line
@@ -3378,15 +3317,6 @@ impl NodeId {
         storage: &'a ConstraintSetStorage<'db>,
         prefix: &'a dyn Display,
     ) -> impl Display + 'a {
-        struct DisplayNode<'a, 'db> {
-            db: &'db dyn Db,
-            env: &'a ProgramEnvironment<'db>,
-            storage: &'a ConstraintSetStorage<'db>,
-            node: NodeId,
-            prefix: &'a dyn Display,
-            seen: RefCell<FxIndexSet<NodeId>>,
-        }
-
         fn format_node<'db>(
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,
@@ -3447,29 +3377,9 @@ impl NodeId {
             }
         }
 
-        impl Display for DisplayNode<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let db = self.db;
-                format_node(
-                    db,
-                    self.env,
-                    self.storage,
-                    self.node,
-                    self.prefix,
-                    &self.seen,
-                    f,
-                )
-            }
-        }
-
-        DisplayNode {
-            db,
-            env,
-            storage,
-            node: self,
-            prefix,
-            seen: RefCell::default(),
-        }
+        std::fmt::from_fn(move |f| {
+            format_node(db, env, storage, self, prefix, &RefCell::default(), f)
+        })
     }
 }
 
@@ -4689,91 +4599,61 @@ impl ConstraintAssignment {
         env: &'a ProgramEnvironment<'db>,
         storage: &'a ConstraintSetStorage<'db>,
     ) -> impl Display + 'a {
-        struct DisplayConstraintAssignment<'db, 'c> {
-            assignment: ConstraintAssignment,
-            db: &'db dyn Db,
-            env: &'c ProgramEnvironment<'db>,
-            storage: &'c ConstraintSetStorage<'db>,
-        }
+        let (equality_sign, range_prefix) = match self {
+            ConstraintAssignment::Positive(_) => ("=", ""),
+            ConstraintAssignment::Negative(_) => ("≠", "¬"),
+            ConstraintAssignment::Unconstrained(_) => ("=?", "?"),
+        };
 
-        impl DisplayConstraintAssignment<'_, '_> {
-            fn equality_sign(&self) -> &'static str {
-                match self.assignment {
-                    ConstraintAssignment::Positive(_) => "=",
-                    ConstraintAssignment::Negative(_) => "≠",
-                    ConstraintAssignment::Unconstrained(_) => "=?",
+        std::fmt::from_fn(move |f| {
+            let constraint_data = storage.constraint_data(self.constraint());
+            let lower = constraint_data.bounds.materialized_lower();
+            let upper = constraint_data.bounds.materialized_upper();
+            let typevar = constraint_data.typevar;
+            if lower.is_equivalent_to(db, env, upper) {
+                // If this typevar is equivalent to another, output the constraint in a
+                // consistent alphabetical order, regardless of the salsa ordering that we are
+                // using the in BDD.
+                if let Type::TypeVar(bound) = lower {
+                    let bound = bound.identity(db).display(db).to_string();
+                    let typevar = typevar.identity(db).display(db).to_string();
+                    let (smaller, larger) = if bound < typevar {
+                        (bound, typevar)
+                    } else {
+                        (typevar, bound)
+                    };
+                    return write!(f, "({smaller} {equality_sign} {larger})");
                 }
+
+                return write!(
+                    f,
+                    "({} {} {})",
+                    typevar.identity(db).display(db),
+                    equality_sign,
+                    lower.display(db, env)
+                );
             }
 
-            fn range_prefix(&self) -> &'static str {
-                match self.assignment {
-                    ConstraintAssignment::Positive(_) => "",
-                    ConstraintAssignment::Negative(_) => "¬",
-                    ConstraintAssignment::Unconstrained(_) => "?",
-                }
+            if lower.is_never() && upper.is_object() {
+                return write!(
+                    f,
+                    "({} {} *)",
+                    typevar.identity(db).display(db),
+                    equality_sign
+                );
             }
-        }
 
-        impl Display for DisplayConstraintAssignment<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let db = self.db;
-
-                let constraint_data = self.storage.constraint_data(self.assignment.constraint());
-                let lower = constraint_data.bounds.materialized_lower();
-                let upper = constraint_data.bounds.materialized_upper();
-                let typevar = constraint_data.typevar;
-                if lower.is_equivalent_to(db, self.env, upper) {
-                    // If this typevar is equivalent to another, output the constraint in a
-                    // consistent alphabetical order, regardless of the salsa ordering that we are
-                    // using the in BDD.
-                    if let Type::TypeVar(bound) = lower {
-                        let bound = bound.identity(db).display(db).to_string();
-                        let typevar = typevar.identity(db).display(db).to_string();
-                        let (smaller, larger) = if bound < typevar {
-                            (bound, typevar)
-                        } else {
-                            (typevar, bound)
-                        };
-                        return write!(f, "({} {} {})", smaller, self.equality_sign(), larger);
-                    }
-
-                    return write!(
-                        f,
-                        "({} {} {})",
-                        typevar.identity(db).display(db),
-                        self.equality_sign(),
-                        lower.display(db, self.env)
-                    );
-                }
-
-                if lower.is_never() && upper.is_object() {
-                    return write!(
-                        f,
-                        "({} {} *)",
-                        typevar.identity(db).display(db),
-                        self.equality_sign()
-                    );
-                }
-
-                f.write_str(self.range_prefix())?;
-                f.write_str("(")?;
-                if !lower.is_never() {
-                    write!(f, "{} ≤ ", lower.display(db, self.env))?;
-                }
-                typevar.identity(db).display(db).fmt(f)?;
-                if !upper.is_object() {
-                    write!(f, " ≤ {}", upper.display(db, self.env))?;
-                }
-                f.write_str(")")
+            f.write_str(range_prefix)?;
+            f.write_str("(")?;
+            if !lower.is_never() {
+                write!(f, "{} ≤ ", lower.display(db, env))?;
             }
-        }
-
-        DisplayConstraintAssignment {
-            assignment: self,
-            db,
-            env,
-            storage,
-        }
+            typevar.identity(db).display(db).fmt(f)?;
+            if !upper.is_object() {
+                write!(f, " ≤ {}", upper.display(db, env))?;
+            }
+            f.write_str(")")
+        })
     }
 }
 
@@ -5932,78 +5812,59 @@ impl SequentMap {
         storage: &'a ConstraintSetStorage<'db>,
         prefix: &'a dyn Display,
     ) -> impl Display + 'a {
-        struct DisplaySequentMap<'a, 'db> {
-            map: &'a SequentMap,
-            prefix: &'a dyn Display,
-            db: &'db dyn Db,
-            env: &'a ProgramEnvironment<'db>,
-            storage: &'a ConstraintSetStorage<'db>,
-        }
-
-        impl Display for DisplaySequentMap<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let db = self.db;
-                let mut first = true;
-                let mut maybe_write_prefix = |f: &mut std::fmt::Formatter<'_>| {
-                    if first {
-                        first = false;
-                        Ok(())
-                    } else {
-                        write!(f, "\n{}", self.prefix)
-                    }
-                };
-
-                for sequent in &self.map.sequents {
-                    match sequent {
-                        Sequent::SingleTautology { .. } => {}
-
-                        Sequent::PairImpossibility { ante1, ante2 } => {
-                            maybe_write_prefix(f)?;
-                            write!(
-                                f,
-                                "{} ∧ {} → false",
-                                ante1.display(db, self.env, self.storage),
-                                ante2.display(db, self.env, self.storage),
-                            )?;
-                        }
-
-                        Sequent::PairImplication { ante1, ante2, post } => {
-                            maybe_write_prefix(f)?;
-                            write!(
-                                f,
-                                "{} ∧ {} → {}",
-                                ante1.display(db, self.env, self.storage),
-                                ante2.display(db, self.env, self.storage),
-                                post.display(db, self.env, self.storage),
-                            )?;
-                        }
-
-                        Sequent::SingleImplication { ante, post } => {
-                            maybe_write_prefix(f)?;
-                            write!(
-                                f,
-                                "{} → {}",
-                                ante.display(db, self.env, self.storage),
-                                post.display(db, self.env, self.storage)
-                            )?;
-                        }
-                    }
-                }
-
+        std::fmt::from_fn(move |f| {
+            let mut first = true;
+            let mut maybe_write_prefix = |f: &mut std::fmt::Formatter<'_>| {
                 if first {
-                    f.write_str("[no sequents]")?;
+                    first = false;
+                    Ok(())
+                } else {
+                    write!(f, "\n{prefix}")
                 }
-                Ok(())
-            }
-        }
+            };
 
-        DisplaySequentMap {
-            map: self,
-            prefix,
-            db,
-            env,
-            storage,
-        }
+            for sequent in &self.sequents {
+                match sequent {
+                    Sequent::SingleTautology { .. } => {}
+
+                    Sequent::PairImpossibility { ante1, ante2 } => {
+                        maybe_write_prefix(f)?;
+                        write!(
+                            f,
+                            "{} ∧ {} → false",
+                            ante1.display(db, env, storage),
+                            ante2.display(db, env, storage),
+                        )?;
+                    }
+
+                    Sequent::PairImplication { ante1, ante2, post } => {
+                        maybe_write_prefix(f)?;
+                        write!(
+                            f,
+                            "{} ∧ {} → {}",
+                            ante1.display(db, env, storage),
+                            ante2.display(db, env, storage),
+                            post.display(db, env, storage),
+                        )?;
+                    }
+
+                    Sequent::SingleImplication { ante, post } => {
+                        maybe_write_prefix(f)?;
+                        write!(
+                            f,
+                            "{} → {}",
+                            ante.display(db, env, storage),
+                            post.display(db, env, storage)
+                        )?;
+                    }
+                }
+            }
+
+            if first {
+                f.write_str("[no sequents]")?;
+            }
+            Ok(())
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1586,42 +1586,24 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
 
 impl<'db> BoundTypeVarIdentity<'db> {
     pub(crate) fn display(self, db: &'db dyn Db) -> impl Display {
-        DisplayBoundTypeVarIdentity {
-            bound_typevar_identity: self,
-            db,
-            settings: DisplaySettings::default(),
-        }
+        self.display_with(db, DisplaySettings::default())
     }
 
     fn display_with(self, db: &'db dyn Db, settings: DisplaySettings<'db>) -> impl Display {
-        DisplayBoundTypeVarIdentity {
-            bound_typevar_identity: self,
-            db,
-            settings,
-        }
-    }
-}
-
-struct DisplayBoundTypeVarIdentity<'db> {
-    bound_typevar_identity: BoundTypeVarIdentity<'db>,
-    db: &'db dyn Db,
-    settings: DisplaySettings<'db>,
-}
-
-impl Display for DisplayBoundTypeVarIdentity<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(self.bound_typevar_identity.identity.name(self.db))?;
-        let binding_context = self.bound_typevar_identity.binding_context;
-        if let Some(binding_context_name) = binding_context.name(self.db)
-            && let Some(definition) = binding_context.definition()
-            && !self.settings.active_scopes.contains(&definition)
-        {
-            write!(f, "@{binding_context_name}")?;
-        }
-        if let Some(paramspec_attr) = self.bound_typevar_identity.paramspec_attr {
-            write!(f, ".{paramspec_attr}")?;
-        }
-        Ok(())
+        std::fmt::from_fn(move |f| {
+            f.write_str(self.identity.name(db))?;
+            let binding_context = self.binding_context;
+            if let Some(binding_context_name) = binding_context.name(db)
+                && let Some(definition) = binding_context.definition()
+                && !settings.active_scopes.contains(&definition)
+            {
+                write!(f, "@{binding_context_name}")?;
+            }
+            if let Some(paramspec_attr) = self.paramspec_attr {
+                write!(f, ".{paramspec_attr}")?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -3596,29 +3578,19 @@ impl Display for DisplayTypeArray<'_, '_> {
 }
 
 impl<'db> StringLiteralType<'db> {
-    fn display(self, db: &'db dyn Db) -> DisplayStringLiteralType<'db> {
-        DisplayStringLiteralType {
-            string: self.value(db),
-        }
-    }
-}
-
-struct DisplayStringLiteralType<'db> {
-    string: &'db str,
-}
-
-impl Display for DisplayStringLiteralType<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_char('"')?;
-        for ch in self.string.chars() {
-            match ch {
-                // `escape_debug` will escape even single quotes, which is not necessary for our
-                // use case as we are already using double quotes to wrap the string.
-                '\'' => f.write_char('\''),
-                _ => ch.escape_debug().fmt(f),
-            }?;
-        }
-        f.write_char('"')
+    fn display(self, db: &'db dyn Db) -> impl std::fmt::Display {
+        std::fmt::from_fn(move |f| {
+            f.write_char('"')?;
+            for ch in self.value(db).chars() {
+                match ch {
+                    // `escape_debug` will escape even single quotes, which is not necessary for our
+                    // use case as we are already using double quotes to wrap the string.
+                    '\'' => f.write_char('\''),
+                    _ => ch.escape_debug().fmt(f),
+                }?;
+            }
+            f.write_char('"')
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -903,31 +903,16 @@ impl<'db> ProtocolInterface<'db> {
         db: &'db dyn Db,
         env: &'env ProgramEnvironment<'db>,
     ) -> impl std::fmt::Display + 'env {
-        struct ProtocolInterfaceDisplay<'env, 'db> {
-            db: &'db dyn Db,
-            env: &'env ProgramEnvironment<'db>,
-            interface: ProtocolInterface<'db>,
-        }
-
-        impl std::fmt::Display for ProtocolInterfaceDisplay<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let db = self.db;
-                f.write_char('{')?;
-                for (i, (name, data)) in self.interface.inner(db).iter().enumerate() {
-                    write!(f, "\"{name}\": {data}", data = data.display(db, self.env))?;
-                    if i < self.interface.inner(db).len() - 1 {
-                        f.write_str(", ")?;
-                    }
+        std::fmt::from_fn(move |f| {
+            f.write_char('{')?;
+            for (i, (name, data)) in self.inner(db).iter().enumerate() {
+                write!(f, "\"{name}\": {data}", data = data.display(db, env))?;
+                if i < self.inner(db).len() - 1 {
+                    f.write_str(", ")?;
                 }
-                f.write_char('}')
             }
-        }
-
-        ProtocolInterfaceDisplay {
-            db,
-            env,
-            interface: self,
-        }
+            f.write_char('}')
+        })
     }
 }
 
@@ -1617,60 +1602,37 @@ impl<'db> ProtocolMemberData<'db> {
         }
     }
 
-    fn display<'env>(
-        &self,
+    fn display<'a, 'env>(
+        &'a self,
         db: &'db dyn Db,
         env: &'env ProgramEnvironment<'db>,
-    ) -> impl std::fmt::Display + 'env {
-        struct ProtocolMemberDataDisplay<'env, 'db> {
-            db: &'db dyn Db,
-            env: &'env ProgramEnvironment<'db>,
-            kind: ProtocolMemberKind<'db>,
-            qualifiers: TypeQualifiers,
-        }
-
-        impl std::fmt::Display for ProtocolMemberDataDisplay<'_, '_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let db = self.db;
-                match self.kind {
-                    ProtocolMemberKind::Method(member, _) => {
-                        write!(f, "MethodMember(`{}`)", member.ty().display(db, self.env))
-                    }
-                    ProtocolMemberKind::Property { read, write } => {
-                        let env = self.env;
-                        let mut d = f.debug_struct("PropertyMember");
-                        if let Some(read) = read.and_then(|read| read.resolve(db, env)) {
-                            d.field(
-                                "read",
-                                &format_args!("`{}`", read.ty().display(db, self.env)),
-                            );
-                        }
-                        if let Some(write) = write.and_then(|write| write.display_type(db, env)) {
-                            d.field(
-                                "write",
-                                &format_args!("`{}`", write.ty().display(db, self.env)),
-                            );
-                        }
-                        d.finish()
-                    }
-                    ProtocolMemberKind::Attribute(attribute) => {
-                        f.write_str("AttributeMember(")?;
-                        write!(f, "`{}`", attribute.ty().display(db, self.env))?;
-                        if self.qualifiers.contains(TypeQualifiers::CLASS_VAR) {
-                            f.write_str("; ClassVar")?;
-                        }
-                        f.write_char(')')
-                    }
-                }
+    ) -> impl std::fmt::Display + 'a
+    where
+        'env: 'a,
+    {
+        std::fmt::from_fn(move |f| match self.kind {
+            ProtocolMemberKind::Method(member, _) => {
+                write!(f, "MethodMember(`{}`)", member.ty().display(db, env))
             }
-        }
-
-        ProtocolMemberDataDisplay {
-            db,
-            env,
-            kind: self.kind,
-            qualifiers: self.qualifiers,
-        }
+            ProtocolMemberKind::Property { read, write } => {
+                let mut d = f.debug_struct("PropertyMember");
+                if let Some(read) = read.and_then(|read| read.resolve(db, env)) {
+                    d.field("read", &format_args!("`{}`", read.ty().display(db, env)));
+                }
+                if let Some(write) = write.and_then(|write| write.display_type(db, env)) {
+                    d.field("write", &format_args!("`{}`", write.ty().display(db, env)));
+                }
+                d.finish()
+            }
+            ProtocolMemberKind::Attribute(attribute) => {
+                f.write_str("AttributeMember(")?;
+                write!(f, "`{}`", attribute.ty().display(db, env))?;
+                if self.qualifiers.contains(TypeQualifiers::CLASS_VAR) {
+                    f.write_str("; ClassVar")?;
+                }
+                f.write_char(')')
+            }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

**This is significantly easier to review with GitHub's "hide whitespace changes" setting enabled on the "Files changed" tab**

Replace small, hand-written `Display` adapter structs throughout ty's semantic model and IDE hover rendering with `std::fmt::from_fn`.

`std::fmt::from_fn` was stabilised in 1.93.0 and stabilised in `const` contexts in 1.95.0. Our MSRV currently is 1.95.0.