### PR TITLE
[ty] Update typing conformance suite pin

### DIFF
--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -36,7 +36,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
-  CONFORMANCE_SUITE_COMMIT: f4f2952f3ac94d7af819c5c71b60a50a100370e0
+  CONFORMANCE_SUITE_COMMIT: bee91c2646261629c9835dc0adad16e0d554b4a5
   PYTHON_VERSION: 3.12
 
 jobs:


### PR DESCRIPTION
Update the typing conformance workflow to use [`python/typing@bee91c2646`](https://github.com/python/typing/commit/bee91c2646261629c9835dc0adad16e0d554b4a5), the latest commit on `python/typing`'s `main` branch.

This advances the pin by 20 upstream commits and includes recent conformance coverage for enum expansion, constructor overrides, `ClassVar` and `Final` in named tuples and typed dictionaries, generic variance, and `ClassVar` protocol compatibility.

[Compare the previous and updated upstream revisions](https://github.com/python/typing/compare/f4f2952f3ac94d7af819c5c71b60a50a100370e0...bee91c2646261629c9835dc0adad16e0d554b4a5).