### PR TITLE
Document file-watcher sandbox limitations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Run all tests (using `nextest` for faster execution and setting `INSTA_FORCE_PAS
 CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_LTO=off INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run
 ```
 
+File-watcher tests do not work inside the sandbox. It is usually unnecessary to run them locally before filing a change unless you are certain that the change affects file-watching behavior.
+
 Run tests for a specific crate:
 
 ```sh


### PR DESCRIPTION
File-watcher tests do not work inside the Codex sandbox, but whenever it feels the need to run the full test suite, my codex always wastes time trying to debug why this is and figuring out how to escape its sandbox.

It's very rare that you actually _need_ to run the file-watcher tests locally, so this PR updates AGENTS.md to inform future codexes (codices?) of this.