### PR TITLE
[ty] Preserve uv error context in script diagnostics

### DIFF
--- a/crates/ty/tests/cli/scripts.rs
+++ b/crates/ty/tests/cli/scripts.rs
@@ -1707,4 +1707,49 @@ mod uv_metadata {
 
         Ok(())
     }
+
+    #[test]
+    fn invalid_script_dependency_preserves_uv_error_context() -> anyhow::Result<()> {
+        assert_uv_supports_script_metadata()?;
+
+        let case = CliTest::with_file(
+            "script.py",
+            "# /// script\n# dependencies = [\"httpx\", \"\"]\n# ///\n",
+        )?
+        .with_filter(r"(?m)^(info:)[ ]$", "$1");
+
+        assert_cmd_snapshot!(command_with_script_uv(&case).arg("script.py"), @r#"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+        error[uv-metadata]: `uv workspace metadata` failed with status exit status: 2: error: TOML parse error at line 1, column 26
+        --> script.py:1:1
+        info:   |
+        info: 1 | dependencies = ["httpx", ""]
+        info:   |                          ^^
+        info: Empty field is not allowed for PEP508
+        info:
+        info: ^
+
+        Found 1 diagnostic
+
+        ----- stderr -----
+        "#);
+        assert_cmd_snapshot!(
+            command_with_script_uv(&case)
+                .arg("script.py")
+                .args(["--output-format", "concise"]),
+            @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+        script.py: error[uv-metadata] `uv workspace metadata` failed with status exit status: 2: error: TOML parse error at line 1, column 26
+        Found 1 diagnostic
+
+        ----- stderr -----
+        "
+        );
+
+        Ok(())
+    }
 }

--- a/crates/ty_project/src/script.rs
+++ b/crates/ty_project/src/script.rs
@@ -351,10 +351,17 @@ impl ScriptConfigurationDiagnostics {
 }
 
 fn uv_metadata_diagnostic(file: File, message: &str) -> Diagnostic {
-    let mut diagnostic = Diagnostic::new(DiagnosticId::UvMetadata, Severity::Error, message);
+    let mut lines = message.lines();
+    let headline = lines.next().unwrap_or(message);
+    let mut diagnostic = Diagnostic::new(DiagnosticId::UvMetadata, Severity::Error, headline);
     let mut annotation = Annotation::primary(Span::from(file));
     annotation.hide_snippet(true);
     diagnostic.annotate(annotation);
+
+    for line in lines {
+        diagnostic.sub(SubDiagnostic::new(SubDiagnosticSeverity::Info, line));
+    }
+
     diagnostic
 }
 

--- a/crates/ty_server/tests/e2e/pull_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/pull_diagnostics.rs
@@ -1482,6 +1482,8 @@ fn extract_result_ids_from_response(response: &WorkspaceDiagnosticReport) -> Vec
 
 mod uv_metadata {
     use lsp_types::{Code, TextDocumentContentChangeEvent, TextDocumentContentChangeWholeDocument};
+    #[cfg(feature = "test-uv")]
+    use ruff_db::system::{OsSystem, System as _};
     use ty_project::UseUv;
 
     use super::{DocumentDiagnosticReport, Result, SystemPath, TestServerBuilder};
@@ -1518,6 +1520,47 @@ mod uv_metadata {
                 }),
             "expected the script synchronization failure to be reported: {report:?}"
         );
+
+        Ok(())
+    }
+
+    #[cfg(feature = "test-uv")]
+    #[test]
+    fn invalid_script_dependency_preserves_uv_error_context() -> Result<()> {
+        let workspace_root = SystemPath::new("src");
+        let script = SystemPath::new("src/script.py");
+        let source = "# /// script\n# dependencies = [\"httpx\", \"\"]\n# ///\n";
+
+        let mut server = TestServerBuilder::new()?
+            .with_workspace(workspace_root, None)?
+            .with_file(script, source)?
+            .with_use_uv(UseUv::Scripts)
+            .with_env_var("UV", OsSystem::default().which("uv")?.into_string())
+            .enable_workspace_diagnostic_refresh(true)
+            .build()
+            .wait_until_workspaces_are_initialized();
+
+        server.open_text_document(script, source, 1);
+        server.await_diagnostic_refresh();
+
+        let report = server.document_diagnostic_request(script, None);
+        let DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) = report else {
+            anyhow::bail!("expected a full diagnostic report for the script");
+        };
+        let diagnostic = report
+            .full_document_diagnostic_report
+            .items
+            .iter()
+            .find(|diagnostic| diagnostic.code == Some(Code::String("uv-metadata".to_string())))
+            .ok_or_else(|| anyhow::anyhow!("expected the script synchronization error"))?;
+        let lsp_types::Message::String(message) = &diagnostic.message else {
+            anyhow::bail!("expected a plain-text diagnostic message");
+        };
+
+        assert!(message.contains("TOML parse error at line 1, column 26"));
+        assert!(message.contains("\ninfo: 1 | dependencies = [\"httpx\", \"\"]"));
+        assert!(message.contains("\ninfo:   |                          ^^"));
+        assert!(message.contains("\ninfo: Empty field is not allowed for PEP508\ninfo: \ninfo: ^"));
 
         Ok(())
     }


### PR DESCRIPTION
Stacked on #27619.

Preserve uv's multiline error output as informational diagnostic context so script synchronization failures render consistently in editors and the CLI.

Testing: Added integration coverage and ran the affected CLI and language-server test suites.