### PR TITLE
[ty] Specialize type variables determined by bound receivers

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -5003,13 +5003,13 @@ C.<CURSOR>
         __name__ :: str
         __ne__ :: def __ne__(self, value: object, /) -> bool
         __new__ :: def __new__[Self](cls) -> Self
-        __or__ :: bound method <class 'C'>.__or__[Self](value: Any, /) -> UnionType | Self
+        __or__ :: bound method <class 'C'>.__or__(value: Any, /) -> UnionType | <class 'C'>
         __prepare__ :: bound method <class 'Meta'>.__prepare__(name: str, bases: tuple[type, ...], /, **kwds: Any) -> MutableMapping[str, object]
         __qualname__ :: str
         __reduce__ :: def __reduce__(self) -> str | tuple[Any, ...]
         __reduce_ex__ :: def __reduce_ex__(self, protocol: SupportsIndex, /) -> str | tuple[Any, ...]
         __repr__ :: def __repr__(self) -> str
-        __ror__ :: bound method <class 'C'>.__ror__[Self](value: Any, /) -> UnionType | Self
+        __ror__ :: bound method <class 'C'>.__ror__(value: Any, /) -> UnionType | <class 'C'>
         __setattr__ :: def __setattr__(self, name: str, value: Any, /) -> None
         __sizeof__ :: def __sizeof__(self) -> int
         __str__ :: def __str__(self) -> str
@@ -5202,13 +5202,13 @@ Quux.<CURSOR>
         __name__ :: str
         __ne__ :: def __ne__(self, value: object, /) -> bool
         __new__ :: def __new__[Self](cls) -> Self
-        __or__ :: bound method <class 'Quux'>.__or__[Self](value: Any, /) -> UnionType | Self
+        __or__ :: bound method <class 'Quux'>.__or__(value: Any, /) -> UnionType | <class 'Quux'>
         __prepare__ :: bound method <class 'type'>.__prepare__(name: str, bases: tuple[type, ...], /, **kwds: Any) -> MutableMapping[str, object]
         __qualname__ :: str
         __reduce__ :: def __reduce__(self) -> str | tuple[Any, ...]
         __reduce_ex__ :: def __reduce_ex__(self, protocol: SupportsIndex, /) -> str | tuple[Any, ...]
         __repr__ :: def __repr__(self) -> str
-        __ror__ :: bound method <class 'Quux'>.__ror__[Self](value: Any, /) -> UnionType | Self
+        __ror__ :: bound method <class 'Quux'>.__ror__(value: Any, /) -> UnionType | <class 'Quux'>
         __setattr__ :: def __setattr__(self, name: str, value: Any, /) -> None
         __sizeof__ :: def __sizeof__(self) -> int
         __str__ :: def __str__(self) -> str
@@ -5265,14 +5265,14 @@ Answer.<CURSOR>
                 __flags__ :: int
                 __format__ :: def __format__(self, format_spec: str) -> str
                 __getattribute__ :: def __getattribute__(self, name: str, /) -> Any
-                __getitem__ :: bound method <class 'Answer'>.__getitem__[_EnumMemberT](name: str) -> _EnumMemberT
+                __getitem__ :: bound method <class 'Answer'>.__getitem__(name: str) -> Answer
                 __getstate__ :: def __getstate__(self) -> object
                 __hash__ :: def __hash__(self) -> int
                 __init__ :: def __init__(self) -> None
                 __init_subclass__ :: bound method <class 'Answer'>.__init_subclass__() -> None
                 __instancecheck__ :: bound method <class 'Answer'>.__instancecheck__(instance: Any, /) -> bool
                 __itemsize__ :: int
-                __iter__ :: bound method <class 'Answer'>.__iter__[_EnumMemberT]() -> Iterator[_EnumMemberT]
+                __iter__ :: bound method <class 'Answer'>.__iter__() -> Iterator[Answer]
                 __len__ :: bound method <class 'Answer'>.__len__() -> int
                 __members__ :: MappingProxyType[str, Answer]
                 __module__ :: str
@@ -5280,14 +5280,14 @@ Answer.<CURSOR>
                 __name__ :: str
                 __ne__ :: def __ne__(self, value: object, /) -> bool
                 __new__ :: def __new__[Self](cls, value: object) -> Self
-                __or__ :: bound method <class 'Answer'>.__or__[Self](value: Any, /) -> UnionType | Self
+                __or__ :: bound method <class 'Answer'>.__or__(value: Any, /) -> UnionType | <class 'Answer'>
                 __order__ :: str
                 __prepare__ :: bound method <class 'EnumMeta'>.__prepare__(cls: str, bases: tuple[type, ...], **kwds: Any) -> _EnumDict
                 __qualname__ :: str
                 __reduce__ :: def __reduce__(self) -> str | tuple[Any, ...]
                 __repr__ :: def __repr__(self) -> str
-                __reversed__ :: bound method <class 'Answer'>.__reversed__[_EnumMemberT]() -> Iterator[_EnumMemberT]
-                __ror__ :: bound method <class 'Answer'>.__ror__[Self](value: Any, /) -> UnionType | Self
+                __reversed__ :: bound method <class 'Answer'>.__reversed__() -> Iterator[Answer]
+                __ror__ :: bound method <class 'Answer'>.__ror__(value: Any, /) -> UnionType | <class 'Answer'>
                 __setattr__ :: def __setattr__(self, name: str, value: Any, /) -> None
                 __sizeof__ :: def __sizeof__(self) -> int
                 __str__ :: def __str__(self) -> str

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -316,6 +316,51 @@ reveal_type(ReceiverGeneric[str]().single)
 reveal_type(ReceiverGeneric[str]().single(1))  # revealed: tuple[str, Literal[1]]
 ```
 
+Type aliases in the receiver, return type, or another parameter must not conceal a method type
+variable determined by the receiver.
+
+```py
+type ReceiverAlias[T] = ReceiverGeneric[T]
+type ValueAlias[T] = T
+
+class AliasedReceiver[T](ReceiverGeneric[T]):
+    def aliased_return[S](self: ReceiverAlias[S]) -> tuple[ValueAlias[S]]:
+        return (self.value,)
+
+    def aliased_argument[S](self: ReceiverGeneric[S], value: ValueAlias[S]) -> None: ...
+
+value = AliasedReceiver[str]()
+
+# revealed: bound method AliasedReceiver[str].aliased_return() -> tuple[ValueAlias[str]]
+reveal_type(value.aliased_return)
+
+# revealed: bound method AliasedReceiver[str].aliased_argument(value: ValueAlias[str]) -> None
+reveal_type(value.aliased_argument)
+# error: [invalid-argument-type] "Expected `ValueAlias[str]`, found `Literal[1]`"
+value.aliased_argument(1)
+```
+
+## Method type variables used only in the receiver
+
+A method type variable that appears only in the receiver does not affect argument inference or the
+return type, so binding the method does not need to specialize it.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class Factory:
+    @classmethod
+    def describe[Receiver](cls: type[Receiver], value: int) -> str:
+        return str(value)
+
+# revealed: bound method <class 'Factory'>.describe[Receiver](value: int) -> str
+reveal_type(Factory.describe)
+reveal_type(Factory.describe(1))  # revealed: str
+```
+
 ## Constrained method type variables inferred from `self`
 
 Matching a receiver against a value-constrained method type variable must reject values outside that

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -274,7 +274,7 @@ def union_receiver(reader: Reader[int | str]):
 
 ## Method type variables inferred from `self`
 
-Binding an overload whose explicit receiver introduces a method type variable should infer that
+Binding a method whose explicit receiver introduces a method type variable should infer that
 variable from the concrete receiver and apply it to the remainder of the signature.
 
 ```toml
@@ -295,6 +295,9 @@ class ReceiverGeneric[T]:
     def method(self, value: object) -> object:
         return value
 
+    def single[S, U](self: "ReceiverGeneric[S]", value: U) -> tuple[S, U]:
+        return self.value, value
+
 reveal_type(ReceiverGeneric[str]().method)  # revealed: Overload[(value: str) -> str, (value: bytes) -> bytes]
 
 def takes_callable(fn: Callable[..., Any]) -> None: ...
@@ -302,6 +305,15 @@ def use_generic_receiver[T](value: ReceiverGeneric[T]) -> None:
     # revealed: Overload[(value: T@use_generic_receiver) -> T@use_generic_receiver, (value: bytes) -> bytes]
     reveal_type(value.method)
     takes_callable(value.method)
+```
+
+Non-overloaded methods should also specialize receiver-determined type variables while preserving
+other type variables for argument inference.
+
+```py
+# revealed: bound method ReceiverGeneric[str].single[U](value: U) -> tuple[str, U]
+reveal_type(ReceiverGeneric[str]().single)
+reveal_type(ReceiverGeneric[str]().single(1))  # revealed: tuple[str, Literal[1]]
 ```
 
 ## Constrained method type variables inferred from `self`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5502,7 +5502,25 @@ impl<'db> Type<'db> {
                     binding.bake_bound_type_into_overloads(db, env);
                     binding.into()
                 } else {
-                    CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
+                    let typing_self_type = bound_method.typing_self_type(db);
+                    // Solve exact receiver constraints before checking the other arguments, but
+                    // retain the receiver itself for call inference and receiver diagnostics.
+                    let overloads = signature.overloads.iter().map(|overload| {
+                        if overload.has_explicit_positional_receiver_annotation()
+                            && let Some(specialized) = overload.specialize_for_bound_receiver(
+                                db,
+                                env,
+                                self_instance,
+                                typing_self_type,
+                            )
+                        {
+                            specialized
+                        } else {
+                            overload.clone()
+                        }
+                    });
+
+                    CallableBinding::from_overloads(self, overloads)
                         .with_bound_type(self_instance)
                         .into()
                 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5502,16 +5502,15 @@ impl<'db> Type<'db> {
                     binding.bake_bound_type_into_overloads(db, env);
                     binding.into()
                 } else {
-                    let typing_self_type = bound_method.typing_self_type(db);
                     // Solve exact receiver constraints before checking the other arguments, but
                     // retain the receiver itself for call inference and receiver diagnostics.
                     let overloads = signature.overloads.iter().map(|overload| {
-                        if overload.has_explicit_positional_receiver_annotation()
+                        if overload.has_receiver_determined_method_typevar(db, env)
                             && let Some(specialized) = overload.specialize_for_bound_receiver(
                                 db,
                                 env,
                                 self_instance,
-                                typing_self_type,
+                                bound_method.typing_self_type(db),
                             )
                         {
                             specialized

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -153,6 +153,10 @@ impl<'db> BoundMethodType<'db> {
             );
         };
 
+        let signature = signature
+            .specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
+            .unwrap_or_else(|| signature.clone());
+
         CallableSignature::single(signature.bind_self_with_receiver(
             db,
             env,

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -153,16 +153,18 @@ impl<'db> BoundMethodType<'db> {
             );
         };
 
-        let signature = signature
-            .specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
-            .unwrap_or_else(|| signature.clone());
+        let specialized = if signature.has_receiver_determined_method_typevar(db, env) {
+            signature.specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
+        } else {
+            None
+        };
 
-        CallableSignature::single(signature.bind_self_with_receiver(
-            db,
-            env,
-            Some(receiver_type),
-            Some(typing_self_type),
-        ))
+        CallableSignature::single(
+            specialized
+                .as_ref()
+                .unwrap_or(signature)
+                .bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type)),
+        )
     }
 
     pub(super) fn recursive_type_normalized_impl(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1442,6 +1442,56 @@ impl<'db> Signature<'db> {
             .is_some_and(|parameter| parameter.is_positional() && !parameter.inferred_annotation)
     }
 
+    /// Returns whether the receiver can determine a method type variable used elsewhere.
+    ///
+    /// Receiver-only variables cannot affect the rest of the signature, class type variables are
+    /// handled by class or constructor inference, and `typing.Self` is handled by receiver binding.
+    pub(crate) fn has_receiver_determined_method_typevar(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> bool {
+        let Some(receiver) = self
+            .parameters
+            .get(0)
+            .filter(|parameter| parameter.is_positional() && !parameter.inferred_annotation)
+        else {
+            return false;
+        };
+        let Some(generic_context) = self.generic_context else {
+            return false;
+        };
+        let Some(definition) = self.definition else {
+            return false;
+        };
+        let annotation = receiver.annotated_type();
+
+        let mut typevars = match annotation {
+            Type::TypeVar(typevar) => Either::Left(std::iter::once(typevar)),
+            Type::SubclassOf(subclass) if let Some(typevar) = subclass.into_type_var() => {
+                Either::Left(std::iter::once(typevar))
+            }
+            _ => Either::Right(generic_context.variables(db)),
+        };
+
+        typevars.any(|typevar| {
+            let variable = typevar.typevar(db);
+            let identity = variable.identity(db);
+
+            typevar.binding_context(db).definition() == Some(definition)
+                && !variable.is_self(db)
+                && annotation.references_typevar_through_aliases(db, env, identity)
+                && (self
+                    .return_ty
+                    .references_typevar_through_aliases(db, env, identity)
+                    || self.parameters.iter().skip(1).any(|parameter| {
+                        parameter
+                            .annotated_type()
+                            .references_typevar_through_aliases(db, env, identity)
+                    }))
+        })
+    }
+
     pub(crate) fn has_implicit_positional_receiver_annotation(&self) -> bool {
         self.parameters
             .get(0)

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1270,13 +1270,13 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Returns this signature bound to `receiver_type` if its explicit receiver annotation is
-    /// compatible with the bound receiver.
+    /// Specializes this signature using the type variables determined by its bound receiver.
     ///
     /// Matching the receiver can constrain type variables that occur elsewhere in the signature.
-    /// Exact bounds determine an unambiguous specialization; one-sided constraints remain attached
-    /// to the bound signature for later relation checks.
-    pub(crate) fn bind_self_if_compatible(
+    /// Exact bounds determine an unambiguous specialization; one-sided constraints remain
+    /// available to normal call inference. The receiver remains in the returned signature so
+    /// bound-method calls can still check it and report receiver-related diagnostics.
+    pub(crate) fn specialize_for_bound_receiver(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -1290,7 +1290,7 @@ impl<'db> Signature<'db> {
         let bound_signature =
             self.bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type));
         let Some(receiver_constraints) = bound_signature.receiver_constraints.as_ref() else {
-            return Some(bound_signature);
+            return Some(self.clone());
         };
 
         let constraints = ConstraintSetBuilder::new();
@@ -1299,17 +1299,17 @@ impl<'db> Signature<'db> {
 
         match when.solutions(db, env, &constraints, inferable) {
             Solutions::Unsatisfiable => return None,
-            Solutions::Unconstrained => return Some(bound_signature),
+            Solutions::Unconstrained => return Some(self.clone()),
             // Each receiver path can leave a different type variable unconstrained. Preserve the
             // original relation instead of combining those independent solutions.
             Solutions::Constrained(solutions) if solutions.len() > 1 => {
-                return Some(bound_signature);
+                return Some(self.clone());
             }
             Solutions::Constrained(_) => {}
         }
 
         let Some(generic_context) = self.generic_context else {
-            return Some(bound_signature);
+            return Some(self.clone());
         };
 
         let mut builder = SpecializationBuilder::new(db, env, &constraints, inferable);
@@ -1340,10 +1340,27 @@ impl<'db> Signature<'db> {
             Some(Type::TypeVar(typevar))
         });
 
-        Some(
-            self.apply_specialization(db, specialization)
-                .bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type)),
-        )
+        Some(self.apply_specialization(db, specialization))
+    }
+
+    /// Returns this signature bound to `receiver_type` if its explicit receiver annotation is
+    /// compatible with the bound receiver.
+    pub(crate) fn bind_self_if_compatible(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> Option<Self> {
+        self.specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
+            .map(|signature| {
+                signature.bind_self_with_receiver(
+                    db,
+                    env,
+                    Some(receiver_type),
+                    Some(typing_self_type),
+                )
+            })
     }
 
     /// Returns `true` if this signature's first parameter can accept the bound `self` type.

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -61,6 +61,28 @@ impl<'db> Type<'db> {
         })
     }
 
+    /// Inspects type-alias arguments without evaluating lazy alias bodies or other metadata.
+    pub(crate) fn references_typevar_through_aliases(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        typevar_id: TypeVarIdentity<'db>,
+    ) -> bool {
+        any_over_type(db, env, self, false, |ty| match ty {
+            Type::TypeVar(typevar) => typevar_id == typevar.typevar(db).identity(db),
+            Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
+                typevar_id == typevar.identity(db)
+            }
+            Type::TypeAlias(alias) => alias.specialization(db).is_some_and(|specialization| {
+                specialization
+                    .types(db)
+                    .iter()
+                    .any(|ty| ty.references_typevar_through_aliases(db, env, typevar_id))
+            }),
+            _ => false,
+        })
+    }
+
     pub(crate) fn has_non_self_typevar(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -61,7 +61,21 @@ impl<'db> Type<'db> {
         })
     }
 
-    /// Inspects type-alias arguments without evaluating lazy alias bodies or other metadata.
+    /// Returns whether this type might reference `typevar_id`, including type-alias arguments.
+    ///
+    /// Other non-lazy type-variable visitors stop at type aliases because inspecting an alias's
+    /// value can trigger lazy inference or expand a recursive definition. Receiver specialization
+    /// still needs to notice `T` in `Alias[T]`, so this visitor inspects the already-available
+    /// specialization arguments without evaluating the alias body.
+    ///
+    /// This deliberately over-approximates: `type Alias[T] = int` does not actually depend on
+    /// `T`, and specialization can also erase an argument. That can cause an unnecessary
+    /// receiver-specialization attempt, but actual receiver constraints are still solved before
+    /// changing the signature. Applying the same traversal to visitors that use type-variable
+    /// occurrences to drive inference or diagnostics can instead change behavior.
+    ///
+    /// TODO: Explore whether other type-variable visitors can safely inspect alias arguments,
+    /// accounting for unused parameters and arguments erased by specialization.
     pub(crate) fn references_typevar_through_aliases(
         self,
         db: &'db dyn Db,


### PR DESCRIPTION
## What was the problem?

Checking an expression such as `pd.Series([1.0]) + np.array([1.0])` could hang indefinitely. The Series already determines one of the addition method's type variables, but ty tried to infer it together with the remaining arguments. That left too many possibilities to consider across NumPy's many operator overloads.

## How does this fix it?

When a method explicitly annotates `self` or `cls`, first determine any method type variables fixed by that object. Use those known types when checking the remaining arguments and describing the bound method, while leaving unrelated variables available for normal argument inference.

Only do this extra work when the variable also appears in another parameter or the return type. Variables used only in the receiver, variables belonging to the class, and `typing.Self` cannot help with argument checking. Skipping them avoids unnecessary work and preserves performance on `DateType` and `hydra-zen`. Type aliases are handled without expanding their definitions.

Fixes astral-sh/ty#4246.

## Test plan

- Cover a generic method where the receiver determines one type variable and another argument determines a separate variable.
- Cover type aliases in receiver annotations, return types, and other parameters.
- Cover type variables used only in the receiver, which should remain unspecialized.
- Verify pandas Series addition and multiplication with NumPy arrays, with no performance regressions on `DateType` or `hydra-zen`.
