### PR TITLE
[ty] Treat generator-expression exceptions as eagerly evaluated

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2216,8 +2216,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     /// enclosing scope.
     ///
     /// Generator expressions follow the eager comprehension-scope convention used throughout our
-    /// flow model: although generators are lazy at runtime, their bodies are assumed to execute
-    /// immediately.
+    /// flow model. Although generators are lazy at runtime, their bodies are assumed to execute
+    /// immediately, since in practice they are almost always eagerly iterated over.
     ///
     /// ```python
     /// try:

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2213,22 +2213,20 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     }
 
     /// Returns whether an exception raised while evaluating `scope` can propagate directly to its
-    /// enclosing scope. Generator-expression bodies are lazy even though they share the
-    /// comprehension scope kind; their eagerly evaluated first iterable is visited before entering
-    /// the generator scope.
+    /// enclosing scope.
     ///
-    /// Only the list comprehension's call can reach the handler immediately:
+    /// Generator expressions follow the eager comprehension-scope convention used throughout our
+    /// flow model: although generators are lazy at runtime, their bodies are assumed to execute
+    /// immediately.
     ///
     /// ```python
     /// try:
-    ///     [may_raise() for _ in [0]]
     ///     (may_raise() for _ in [0])
     /// except Exception:
     ///     ...
     /// ```
     fn exception_checkpoint_crosses_scope_boundary(&self, scope_id: FileScopeId) -> bool {
-        let scope = &self.scopes[scope_id];
-        scope.is_eager() && !matches!(scope.node(), NodeWithScopeKind::GeneratorExpression(_))
+        self.scopes[scope_id].is_eager()
     }
 
     /// Records the current flow state immediately before an operation that may raise an exception.
@@ -2896,9 +2894,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.record_exception_checkpoint_if(loopback_can_raise);
         let nested_bindings = self.pop_scope();
         self.synthesize_comprehension_binding_definitions(nested_bindings);
-        if !matches!(scope, NodeWithScopeRef::GeneratorExpression(_)) {
-            self.record_exception_checkpoint();
-        }
+        self.record_exception_checkpoint();
 
         self.current_assignments = saved_assignments;
 

--- a/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
@@ -791,7 +791,7 @@ except:
 reveal_type(y)  # revealed: Literal[0, 1]
 ```
 
-A generator expression does not run its body until the generator is consumed:
+Generator expressions are also assumed to run eagerly for exception-flow analysis:
 
 ```py
 z = 0
@@ -800,7 +800,7 @@ try:
 except:
     z = 1
 
-reveal_type(z)  # revealed: Literal[0]
+reveal_type(z)  # revealed: Literal[0, 1]
 ```
 
 A nested function body also runs later, so its exceptions cannot reach the handler surrounding its
@@ -870,22 +870,24 @@ def dict_comprehension_assignment() -> None:
         reveal_type(state)  # revealed: Literal["before"] | int
 ```
 
-## Assignments in lazy generator expressions
+## Assignments in generator expressions
 
-Assignments and calls in a generator expression do not execute when the generator is created, so
-they do not make the surrounding exception handler reachable:
+Generator expressions are assumed to run eagerly, so their assignments and calls can reach the
+surrounding exception handler:
 
 ```py
 def generator_may_raise() -> None: ...
-def lazy_generator_assignment() -> None:
+def generator_assignment() -> None:
     state = 0
     caught = False
     try:
         ((state := 1, generator_may_raise()) for _ in [0])
     except:
+        reveal_type(state)  # revealed: int
         caught = True
 
-    reveal_type(caught)  # revealed: Literal[False]
+    reveal_type(caught)  # revealed: bool
+    reveal_type(state)  # revealed: int
 ```
 
 ## Nested comprehension assignments

--- a/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
@@ -791,7 +791,8 @@ except:
 reveal_type(y)  # revealed: Literal[0, 1]
 ```
 
-Generator expressions are also assumed to run eagerly for exception-flow analysis:
+Generator expressions are also assumed to run eagerly for exception-flow analysis, since in practice
+they are almost always eagerly consumed in real-world code:
 
 ```py
 z = 0
@@ -873,7 +874,8 @@ def dict_comprehension_assignment() -> None:
 ## Assignments in generator expressions
 
 Generator expressions are assumed to run eagerly, so their assignments and calls can reach the
-surrounding exception handler:
+surrounding exception handler. Strictly speaking generator expressions *can* be lazy, but in
+practice they are almost always eagerly consumed in real-world code:
 
 ```py
 def generator_may_raise() -> None: ...


### PR DESCRIPTION
## Summary

Previously, generator expressions were assumed to execute eagerly for name resolution and assignment expressions, but lazily when determining whether exceptions could reach surrounding handlers:

```python
def may_raise() -> None: ...

caught = False
try:
    ((value := 1, may_raise()) for _ in [0])
except Exception:
    caught = True

reveal_type(value)   # int
reveal_type(caught)  # Previously: Literal[False]; now: bool
```

We now apply the same eager-execution assumption to exception flow, allowing potentially raising operations inside generator expressions to reach enclosing exception handlers. Generator expressions now follow the existing exception-flow behavior of list, set, and dictionary comprehensions.
