### PR TITLE
[`pylint`] Allow `os._exit` imports in `import-private-name` (`PLC2701`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_self/SLF001.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_self/SLF001.py
@@ -78,6 +78,10 @@ import os
 
 os._exit()
 
+import os as operating_system
+
+operating_system._exit(1)
+
 
 from enum import Enum
 

--- a/crates/ruff_linter/resources/test/fixtures/pylint/import_private_name/submodule/__main__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/import_private_name/submodule/__main__.py
@@ -50,3 +50,10 @@ def generic[T: _nn](arg: T) -> T:
     return arg
 
 from foo.    _bar import baz
+
+# PLC2701 exceptions: `os._exit` is considered public despite leading underscore.
+from os import _exit
+from os import _exit as process_exit
+from another_module import _exit as another_exit
+from os import _private_member
+from os import _exit as os_exit, _other_private_member

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -11,7 +11,7 @@ use ruff_text_size::Ranged;
 use crate::Violation;
 use crate::checkers::ast::Checker;
 use crate::rules::pylint::helpers::{
-    is_dunder_operator_method, is_exceptionally_public_module_member,
+    is_dunder_operator_method, is_underscore_prefixed_public_member,
 };
 
 /// ## What it does
@@ -106,7 +106,7 @@ pub(crate) fn private_member_access(checker: &Checker, expr: &Expr) {
 
     // Allow some public functions whose names start with an underscore, like `os._exit()`.
     if let Some(qualified_name) = semantic.resolve_qualified_name(expr) {
-        if is_exceptionally_public_module_member(&qualified_name) {
+        if is_underscore_prefixed_public_member(&qualified_name) {
             return;
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -10,7 +10,9 @@ use ruff_text_size::Ranged;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
-use crate::rules::pylint::helpers::is_dunder_operator_method;
+use crate::rules::pylint::helpers::{
+    is_dunder_operator_method, is_exceptionally_public_module_member,
+};
 
 /// ## What it does
 /// Checks for accesses on "private" class members.
@@ -104,7 +106,7 @@ pub(crate) fn private_member_access(checker: &Checker, expr: &Expr) {
 
     // Allow some public functions whose names start with an underscore, like `os._exit()`.
     if let Some(qualified_name) = semantic.resolve_qualified_name(expr) {
-        if matches!(qualified_name.segments(), ["os", "_exit"]) {
+        if is_exceptionally_public_module_member(&qualified_name) {
             return;
         }
     }

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -1,5 +1,6 @@
 use ruff_python_ast as ast;
 use ruff_python_ast::ExceptHandler;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{Arguments, Expr, Stmt, visitor};
 use ruff_python_semantic::analyze::function_type;
@@ -7,6 +8,12 @@ use ruff_python_semantic::{ScopeKind, SemanticModel};
 use ruff_text_size::TextRange;
 
 use crate::settings::LinterSettings;
+
+/// Returns `true` if a module member is public despite having an
+/// underscore-prefixed name.
+pub(crate) fn is_exceptionally_public_module_member(qualified_name: &QualifiedName) -> bool {
+    matches!(qualified_name.segments(), ["os", "_exit"])
+}
 
 /// Returns the value of the `name` parameter to, e.g., a `TypeVar` constructor.
 pub(super) fn type_param_name(arguments: &Arguments) -> Option<&str> {

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -11,7 +11,7 @@ use crate::settings::LinterSettings;
 
 /// Returns `true` if a module member is public despite having an
 /// underscore-prefixed name.
-pub(crate) fn is_exceptionally_public_module_member(qualified_name: &QualifiedName) -> bool {
+pub(crate) fn is_underscore_prefixed_public_member(qualified_name: &QualifiedName) -> bool {
     matches!(qualified_name.segments(), ["os", "_exit"])
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -11,7 +11,7 @@ use ruff_text_size::Ranged;
 use crate::Violation;
 use crate::checkers::ast::Checker;
 use crate::package::PackageRoot;
-use crate::rules::pylint::helpers::is_exceptionally_public_module_member;
+use crate::rules::pylint::helpers::is_underscore_prefixed_public_member;
 
 /// ## What it does
 /// Checks for import statements that import a private name (a name starting
@@ -123,7 +123,7 @@ pub(crate) fn import_private_name(checker: &Checker, scope: &Scope) {
             continue;
         };
 
-        if is_exceptionally_public_module_member(import_info.qualified_name) {
+        if is_underscore_prefixed_public_member(import_info.qualified_name) {
             continue;
         }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -11,6 +11,7 @@ use ruff_text_size::Ranged;
 use crate::Violation;
 use crate::checkers::ast::Checker;
 use crate::package::PackageRoot;
+use crate::rules::pylint::helpers::is_exceptionally_public_module_member;
 
 /// ## What it does
 /// Checks for import statements that import a private name (a name starting
@@ -121,6 +122,10 @@ pub(crate) fn import_private_name(checker: &Checker, scope: &Scope) {
         else {
             continue;
         };
+
+        if is_exceptionally_public_module_member(import_info.qualified_name) {
+            continue;
+        }
 
         // Ignore private imports used exclusively for typing.
         if !binding.references.is_empty()

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2701_import_private_name__submodule____main__.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2701_import_private_name__submodule____main__.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
-assertion_line: 256
 ---
 PLC2701 Private name import `_a`
  --> __main__.py:2:6
@@ -84,3 +83,35 @@ PLC2701 Private name import `_bar` from external module `foo`
 51 |
 52 | from foo.    _bar import baz
    |              ^^^^
+53 |
+54 | # PLC2701 exceptions: `os._exit` is considered public despite leading underscore.
+   |
+
+PLC2701 Private name import `_exit` from external module `another_module`
+  --> __main__.py:57:28
+   |
+55 | from os import _exit
+56 | from os import _exit as process_exit
+57 | from another_module import _exit as another_exit
+   |                            ^^^^^
+58 | from os import _private_member
+59 | from os import _exit as os_exit, _other_private_member
+   |
+
+PLC2701 Private name import `_private_member` from external module `os`
+  --> __main__.py:58:16
+   |
+56 | from os import _exit as process_exit
+57 | from another_module import _exit as another_exit
+58 | from os import _private_member
+   |                ^^^^^^^^^^^^^^^
+59 | from os import _exit as os_exit, _other_private_member
+   |
+
+PLC2701 Private name import `_other_private_member` from external module `os`
+  --> __main__.py:59:34
+   |
+57 | from another_module import _exit as another_exit
+58 | from os import _private_member
+59 | from os import _exit as os_exit, _other_private_member
+   |                                  ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

`PLC2701` currently reports `from os import _exit` as a private import, even though `os._exit` is a documented public API. `SLF001` already handles `os._exit` as an exception to the usual leading-underscore rule.

This change moves that exception into a shared helper so `PLC2701` and `SLF001` treat `os._exit` consistently.

Fixes #18143.

## Test Plan

- Added tests for direct and aliased `os._exit` imports.
- Added negative cases to make sure `_exit` from other modules and other private `os` members are still reported.
- Added coverage for mixed imports and aliased `SLF001` access.
- Ran the relevant Ruff tests, Clippy, formatting checks, and `prek`.