### PR TITLE
fix(EXE001): only flag shebang-not-executable for the first comment

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_executable/EXE001_4.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_executable/EXE001_4.py
@@ -1,0 +1,4 @@
+# test.py — not executable
+def f():
+    #! This is an ordinary comment that happens to start with #!
+    return 1

--- a/crates/ruff_linter/src/rules/flake8_executable/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/mod.rs
@@ -17,6 +17,7 @@ mod tests {
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_1.py"))]
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_2.py"))]
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_3.py"))]
+    #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_4.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_1.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_2.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_3.py"))]

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
@@ -7,6 +7,8 @@ pub(crate) use shebang_missing_python::*;
 pub(crate) use shebang_not_executable::*;
 pub(crate) use shebang_not_first_line::*;
 
+use ruff_text_size::TextSize;
+
 use crate::Locator;
 use crate::checkers::ast::LintContext;
 use crate::codes::Rule;
@@ -32,13 +34,26 @@ pub(crate) fn from_tokens(
 
             shebang_missing_python(range, &shebang, context);
 
-            if context.is_rule_enabled(Rule::ShebangNotExecutable) {
-                shebang_not_executable(path, range, context);
-            }
-
             shebang_leading_whitespace(context, range, locator);
 
             shebang_not_first_line(range, locator, context);
+        }
+    }
+
+    // EXE001: Only check the first comment for shebang-not-executable.
+    // A shebang must be at the beginning of the file (possibly with leading
+    // whitespace). Any `#!` appearing in a later comment is a regular
+    // comment, not a shebang — see https://github.com/astral-sh/ruff/issues/27028.
+    if let Some(&range) = comment_ranges.first() {
+        let comment = locator.slice(range);
+        if ShebangDirective::try_extract(comment).is_some() {
+            // Only report EXE001 if the shebang is at the beginning of the file.
+            // A `#!` that appears after code is a regular comment, not a shebang.
+            if range.start() == TextSize::from(0) {
+                if context.is_rule_enabled(Rule::ShebangNotExecutable) {
+                    shebang_not_executable(path, range, context);
+                }
+            }
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE001_4.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE001_4.py.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ruff_linter/src/rules/flake8_executable/mod.rs
+assertion_line: 47
+---
+


### PR DESCRIPTION
## Summary

`EXE001` currently treats every `#!`-prefixed comment as a shebang, even when the `#!` appears inside a function body. A shebang must be the first comment at the beginning of the file.

## Changes

1. **`from_tokens` in `rules/mod.rs`**: Moved the `ShebangNotExecutable` (EXE001) check out of the loop that iterates over all comment ranges. Only the first comment in the file can be a shebang directive, and EXE001 only fires if that comment starts at position 0 (beginning of file). Other shebang rules (EXE003, EXE004, EXE005) continue to check all `#!`-prefixed comments, maintaining existing behavior.

2. **Added test fixture `EXE001_4.py`**: Verifies that a `#!` comment inside a function body does not trigger EXE001.

## Test Plan

All 18 flake8_executable tests pass:

```
test result: ok. 18 passed; 0 failed
```

Closes #27028
