### PR TITLE
[ty] Expand nested union aliases when finding a TypedDict or callable

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2077,6 +2077,22 @@ class UsesMaybeGeneratedDescriptorWithDynamicBase(DynamicGeneratedBase, metaclas
 reveal_type(UsesMaybeGeneratedDescriptorWithDynamicBase().generated_descriptor)  # revealed: Literal["descriptor"] | Any
 ```
 
+A union alias must not hide a non-descriptor member: the same dynamic fallback remains possible
+after expanding it:
+
+```py
+from typing_extensions import TypeAliasType
+
+GeneratedDescriptorOrInt = TypeAliasType("GeneratedDescriptorOrInt", GeneratedDescriptor | int)
+
+class AliasedDescriptorMeta(MaybeDescriptorMeta):
+    generated_descriptor: GeneratedDescriptorOrInt | GeneratedDescriptor
+
+class UsesAliasedDescriptorWithDynamicBase(DynamicGeneratedBase, metaclass=AliasedDescriptorMeta): ...
+
+reveal_type(UsesAliasedDescriptorWithDynamicBase().generated_descriptor)  # revealed: Literal["descriptor"] | Any
+```
+
 Dynamic bases are ignored when descriptor detection requires a concrete `__get__` method:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -746,6 +746,31 @@ x1: dict[Hashable, Callable[..., object]] = {"x": lambda: 1}
 x2: dict[Hashable, Callable[..., object]] = dict(x=lambda: 1)
 ```
 
+## Type context behind a type alias
+
+A type alias is expanded when looking for the callable in the type context, including when the alias
+resolves to a union and is itself one element of a larger union:
+
+```py
+from typing import Callable
+from typing_extensions import TypeAliasType
+
+type IntCallback = Callable[[int], None]
+type IntCallbackOrInt = Callable[[int], None] | int
+IntCallbackOrIntAliasType = TypeAliasType("IntCallbackOrIntAliasType", Callable[[int], None] | int)
+
+def consume(value: int) -> None:
+    pass
+
+x1: Callable[[int], None] | str = lambda value: consume(reveal_type(value))  # revealed: int
+x2: IntCallbackOrInt | str = lambda value: consume(reveal_type(value))  # revealed: int
+x3: IntCallbackOrIntAliasType | str = lambda value: consume(reveal_type(value))  # revealed: int
+
+# TODO: An alias that does not resolve to a union is not expanded here, so the parameter is not
+# inferred from the type context.
+x4: IntCallback = lambda value: consume(reveal_type(value))  # revealed: Unknown
+```
+
 ## Generic call argument inference
 
 A function's arguments are also inferred using the type context:

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -746,53 +746,6 @@ x1: dict[Hashable, Callable[..., object]] = {"x": lambda: 1}
 x2: dict[Hashable, Callable[..., object]] = dict(x=lambda: 1)
 ```
 
-## Type context behind a type alias
-
-A type alias is expanded when looking for the callable in the type context, including when the alias
-resolves to a union and is itself one element of a larger union:
-
-```py
-from typing import Callable
-from typing_extensions import TypeAliasType
-
-type IntCallback = Callable[[int], None]
-type IntCallbackOrInt = Callable[[int], None] | int
-IntCallbackOrIntAliasType = TypeAliasType("IntCallbackOrIntAliasType", Callable[[int], None] | int)
-
-def consume(value: int) -> None:
-    pass
-
-x1: Callable[[int], None] | str = lambda value: consume(reveal_type(value))  # revealed: int
-x2: IntCallbackOrInt | str = lambda value: consume(reveal_type(value))  # revealed: int
-x3: IntCallbackOrIntAliasType | str = lambda value: consume(reveal_type(value))  # revealed: int
-
-# TODO: An alias that does not resolve to a union is not expanded here, so the parameter is not
-# inferred from the type context.
-x4: IntCallback = lambda value: consume(reveal_type(value))  # revealed: Unknown
-```
-
-## Type context behind a pre-PEP-695 type alias
-
-```toml
-[environment]
-python-version = "3.11"
-```
-
-Expansion is not tied to the `type` statement. `TypeAliasType` is expanded the same way on versions
-that predate it:
-
-```py
-from typing import Callable
-from typing_extensions import TypeAliasType
-
-IntCallbackOrInt = TypeAliasType("IntCallbackOrInt", Callable[[int], None] | int)
-
-def consume(value: int) -> None:
-    pass
-
-y1: IntCallbackOrInt | str = lambda value: consume(reveal_type(value))  # revealed: int
-```
-
 ## Generic call argument inference
 
 A function's arguments are also inferred using the type context:
@@ -1872,6 +1825,53 @@ f12 = lambda: [1]
 # TODO: This should not error.
 _: list[int | str] = f12()  # error: [invalid-assignment]
 reveal_type(f12)  # revealed: () -> list[int]
+```
+
+## Lambda contextual inference through union type aliases
+
+A lambda parameter is inferred from a callable behind a union-valued type alias, including when that
+alias is itself an element of another union:
+
+```py
+from typing import Callable
+from typing_extensions import TypeAliasType
+
+type IntCallback = Callable[[int], None]
+type IntCallbackOrInt = Callable[[int], None] | int
+IntCallbackOrIntAliasType = TypeAliasType("IntCallbackOrIntAliasType", Callable[[int], None] | int)
+
+def consume(value: int) -> None:
+    pass
+
+x1: Callable[[int], None] | str = lambda value: consume(reveal_type(value))  # revealed: int
+x2: IntCallbackOrInt | str = lambda value: consume(reveal_type(value))  # revealed: int
+x3: IntCallbackOrIntAliasType | str = lambda value: consume(reveal_type(value))  # revealed: int
+
+# TODO: An alias that does not resolve to a union is not expanded here, so the parameter is not
+# inferred from the type context.
+x4: IntCallback = lambda value: consume(reveal_type(value))  # revealed: Unknown
+```
+
+## Lambda contextual inference through `TypeAliasType` on Python 3.11
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+On Python 3.11, `typing_extensions.TypeAliasType` provides the same alias semantics without the
+`type` statement:
+
+```py
+from typing import Callable
+from typing_extensions import TypeAliasType
+
+IntCallbackOrInt = TypeAliasType("IntCallbackOrInt", Callable[[int], None] | int)
+
+def consume(value: int) -> None:
+    pass
+
+y1: IntCallbackOrInt | str = lambda value: consume(reveal_type(value))  # revealed: int
 ```
 
 ## Unified call inference

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -771,6 +771,28 @@ x3: IntCallbackOrIntAliasType | str = lambda value: consume(reveal_type(value)) 
 x4: IntCallback = lambda value: consume(reveal_type(value))  # revealed: Unknown
 ```
 
+## Type context behind a pre-PEP-695 type alias
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+Expansion is not tied to the `type` statement. `TypeAliasType` is expanded the same way on versions
+that predate it:
+
+```py
+from typing import Callable
+from typing_extensions import TypeAliasType
+
+IntCallbackOrInt = TypeAliasType("IntCallbackOrInt", Callable[[int], None] | int)
+
+def consume(value: int) -> None:
+    pass
+
+y1: IntCallbackOrInt | str = lambda value: consume(reveal_type(value))  # revealed: int
+```
+
 ## Generic call argument inference
 
 A function's arguments are also inferred using the type context:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -773,14 +773,11 @@ type Ok1[T, *Ts] = tuple[T, *Ts]
 ## Solving a typevar through a generic union alias
 
 Expanding aliases must not disturb the solver. The parameter here is a generic union alias whose
-first arm is itself a generic alias, and both mention the typevar being solved. Expanding such an
-alias where union elements are filtered for disjointness drops the arm carrying the typevar, and the
-call infers `Unknown` instead of selecting the overload the argument matches.
+first arm is itself a generic alias, and both mention the typevar being solved: the call still
+selects the overload the argument matches, rather than inferring `Unknown`.
 
-Reduced from `scipy.stats.differential_entropy`, whose parameter is
-`_ToArrayMax1D[InexactT, InexactT]`. Every element below is load-bearing: flattening either alias,
-replacing `CanArray1D` with a builtin generic, dropping either overload, dropping the bound, or
-dropping the `PyScalarT` arm all stop reproducing it.
+Reduced from `scipy.stats.differential_entropy`. Simplifying any part of the shape stops exercising
+the case.
 
 ```py
 from typing import assert_type, overload

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -769,3 +769,40 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 # These are fine:
 type Ok1[T, *Ts] = tuple[T, *Ts]
 ```
+
+## Solving a typevar through a generic union alias
+
+Expanding aliases must not disturb the solver. Here the parameter is a generic union alias whose
+first element is itself a generic alias, and both mention the typevar being solved. Expanding such
+an alias where union elements are filtered for disjointness drops the arms carrying the typevar, and
+the call then infers `Unknown` rather than picking the overload the argument matches.
+
+Reduced from `scipy.stats.differential_entropy`, whose parameter is
+`_ToArrayMax1D[InexactT, InexactT]`.
+
+```py
+from typing import assert_type, overload
+
+class Number: ...
+class Bool: ...
+class Integer(Number): ...
+class Inexact(Number): ...
+class Float64(Inexact): ...
+class CanArray1D[ScalarT]: ...
+
+type Strict1D[PyScalarT, ScalarT] = CanArray1D[ScalarT] | list[PyScalarT | ScalarT]
+type ToArrayStrict1D[PyScalarT, ScalarT] = Strict1D[PyScalarT, ScalarT]
+
+type AsFloat64 = Float64 | Integer | Bool
+type ToArrayMax1D[ScalarT: Number | Bool, PyScalarT] = ToArrayStrict1D[PyScalarT, ScalarT] | PyScalarT | ScalarT
+
+@overload
+def entropy[InexactT: Inexact](values: ToArrayMax1D[InexactT, InexactT]) -> InexactT: ...
+@overload
+def entropy(values: ToArrayMax1D[AsFloat64, float]) -> Float64: ...
+def entropy(values: object) -> object:
+    raise NotImplementedError
+
+def probe(scalar: float) -> None:
+    assert_type(entropy(scalar), Float64)
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -769,34 +769,3 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 # These are fine:
 type Ok1[T, *Ts] = tuple[T, *Ts]
 ```
-
-## Solving a typevar through a generic union alias
-
-Expanding aliases exposes a bug in constraint solving. The parameter here is a generic union alias
-whose first arm is itself a generic alias, and both mention the typevar being solved; once the alias
-is expanded the call fails to select the overload the argument matches.
-
-Reduced from `scipy.stats.differential_entropy`. Simplifying any part of the shape stops exercising
-the case.
-
-```py
-from typing import assert_type, overload
-
-class Float64: ...
-class CanArray1D[ScalarT]: ...
-
-type ToArrayStrict1D[ScalarT] = CanArray1D[ScalarT]
-type ToArrayMax1D[ScalarT, PyScalarT] = ToArrayStrict1D[ScalarT] | PyScalarT
-
-@overload
-def entropy[InexactT: Float64](values: ToArrayMax1D[InexactT, InexactT]) -> InexactT: ...
-@overload
-def entropy(values: ToArrayMax1D[Float64, float]) -> Float64: ...
-def entropy(values: object) -> object:
-    raise NotImplementedError
-
-def probe(scalar: float) -> None:
-    # TODO: this should select the second overload and infer `Float64`.
-    # error: [type-assertion-failure] "Type `Unknown` does not match asserted type `Float64`"
-    assert_type(entropy(scalar), Float64)
-```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -772,9 +772,9 @@ type Ok1[T, *Ts] = tuple[T, *Ts]
 
 ## Solving a typevar through a generic union alias
 
-Expanding aliases must not disturb the solver. The parameter here is a generic union alias whose
-first arm is itself a generic alias, and both mention the typevar being solved: the call still
-selects the overload the argument matches, rather than inferring `Unknown`.
+Expanding aliases exposes a bug in constraint solving. The parameter here is a generic union alias
+whose first arm is itself a generic alias, and both mention the typevar being solved; once the alias
+is expanded the call fails to select the overload the argument matches.
 
 Reduced from `scipy.stats.differential_entropy`. Simplifying any part of the shape stops exercising
 the case.
@@ -796,5 +796,7 @@ def entropy(values: object) -> object:
     raise NotImplementedError
 
 def probe(scalar: float) -> None:
+    # TODO: this should select the second overload and infer `Float64`.
+    # error: [type-assertion-failure] "Type `Unknown` does not match asserted type `Float64`"
     assert_type(entropy(scalar), Float64)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -772,34 +772,29 @@ type Ok1[T, *Ts] = tuple[T, *Ts]
 
 ## Solving a typevar through a generic union alias
 
-Expanding aliases must not disturb the solver. Here the parameter is a generic union alias whose
-first element is itself a generic alias, and both mention the typevar being solved. Expanding such
-an alias where union elements are filtered for disjointness drops the arms carrying the typevar, and
-the call then infers `Unknown` rather than picking the overload the argument matches.
+Expanding aliases must not disturb the solver. The parameter here is a generic union alias whose
+first arm is itself a generic alias, and both mention the typevar being solved. Expanding such an
+alias where union elements are filtered for disjointness drops the arm carrying the typevar, and the
+call infers `Unknown` instead of selecting the overload the argument matches.
 
 Reduced from `scipy.stats.differential_entropy`, whose parameter is
-`_ToArrayMax1D[InexactT, InexactT]`.
+`_ToArrayMax1D[InexactT, InexactT]`. Every element below is load-bearing: flattening either alias,
+replacing `CanArray1D` with a builtin generic, dropping either overload, dropping the bound, or
+dropping the `PyScalarT` arm all stop reproducing it.
 
 ```py
 from typing import assert_type, overload
 
-class Number: ...
-class Bool: ...
-class Integer(Number): ...
-class Inexact(Number): ...
-class Float64(Inexact): ...
+class Float64: ...
 class CanArray1D[ScalarT]: ...
 
-type Strict1D[PyScalarT, ScalarT] = CanArray1D[ScalarT] | list[PyScalarT | ScalarT]
-type ToArrayStrict1D[PyScalarT, ScalarT] = Strict1D[PyScalarT, ScalarT]
-
-type AsFloat64 = Float64 | Integer | Bool
-type ToArrayMax1D[ScalarT: Number | Bool, PyScalarT] = ToArrayStrict1D[PyScalarT, ScalarT] | PyScalarT | ScalarT
+type ToArrayStrict1D[ScalarT] = CanArray1D[ScalarT]
+type ToArrayMax1D[ScalarT, PyScalarT] = ToArrayStrict1D[ScalarT] | PyScalarT
 
 @overload
-def entropy[InexactT: Inexact](values: ToArrayMax1D[InexactT, InexactT]) -> InexactT: ...
+def entropy[InexactT: Float64](values: ToArrayMax1D[InexactT, InexactT]) -> InexactT: ...
 @overload
-def entropy(values: ToArrayMax1D[AsFloat64, float]) -> Float64: ...
+def entropy(values: ToArrayMax1D[Float64, float]) -> Float64: ...
 def entropy(values: object) -> object:
     raise NotImplementedError
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1386,6 +1386,38 @@ def _(x: list[int], y: dict[int, int]):
     reveal_type(h(y))  # revealed: int | None
 ```
 
+A bounded type variable should still be enforced when it appears in multiple union members and the
+argument is itself a union. This currently exposes <https://github.com/astral-sh/ty/issues/4277>:
+
+```py
+class Box[T]: ...
+
+def unbox[T: bytes](value: Box[T] | T) -> T:
+    raise NotImplementedError
+
+def invalid_union(value: int | str) -> None:
+    # TODO: This should report [invalid-argument-type]: neither `int` nor `str` satisfies `T: bytes`.
+    reveal_type(unbox(value))  # revealed: Unknown
+```
+
+The same missing constraint lets an incompatible generic overload win over a matching overload:
+
+```py
+from typing import assert_type, overload
+
+@overload
+def select[T: bytes](value: Box[T] | T) -> T: ...
+@overload
+def select(value: int | str) -> bool: ...
+def select(value: object) -> object:
+    raise NotImplementedError
+
+def selects_invalid_overload(value: int | str) -> None:
+    # TODO: This should select the second overload and infer `bool`.
+    # error: [type-assertion-failure] "Type `Unknown` does not match asserted type `bool`"
+    assert_type(select(value), bool)
+```
+
 ## Bounded typevar call context through a union
 
 Regression test for an `invalid-assignment` false positive: `list(items)` should be assignable to

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1125,6 +1125,33 @@ Keys are still validated against the aliased `TypedDict`:
 unknown_key: PersonOrId | str = {"name": "Alice", "age": 30, "nickname": "Ali"}
 ```
 
+Expanding can leave a single `TypedDict` rather than a union, when every arm aliases the same one.
+Such an annotation is still validated field by field:
+
+```py
+type FirstPerson = Person
+type SecondPerson = Person
+
+collapsed: FirstPerson | SecondPerson = {"name": "Alice", "age": 30}
+reveal_type(collapsed)  # revealed: Person
+
+# error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
+collapsed_unknown_key: FirstPerson | SecondPerson = {"name": "Alice", "age": 30, "nickname": "Ali"}
+```
+
+The same holds where the annotation is a parameter default or a nested field:
+
+```py
+class Team(TypedDict):
+    lead: FirstPerson | SecondPerson
+
+# error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
+def hire(person: FirstPerson | SecondPerson = {"name": "Alice", "age": 30, "nickname": "Ali"}): ...
+
+# error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
+team: Team = {"lead": {"name": "Alice", "age": 30, "nickname": "Ali"}}
+```
+
 ## Type ignore compatibility issues
 
 Users should be able to ignore TypedDict validation errors with `# type: ignore`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1160,6 +1160,31 @@ accepted_by_fallback: PersonOrId | dict[str, str] = dict(other="x")
 reveal_type(accepted_by_fallback)  # revealed: dict[str, str]
 ```
 
+That holds wherever the union supplies the type context, not just in an assignment:
+
+```py
+class Roster(TypedDict):
+    lead: PersonOrId | dict[str, str]
+
+def takes_fallback(value: PersonOrId | dict[str, str]) -> None: ...
+
+takes_fallback(dict(other="x"))
+
+def returns_fallback() -> PersonOrId | dict[str, str]:
+    return dict(other="x")
+
+nested_fallback: Roster = {"lead": dict(other="x")}
+```
+
+A wider arm serves as well as an exact one:
+
+```py
+from typing import Any, Mapping
+
+any_fallback: PersonOrId | Any = dict(other="x")
+mapping_fallback: PersonOrId | Mapping[str, str] = dict(other="x")
+```
+
 With no arm to fall back to, the call is validated against the `TypedDict` as before:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1194,6 +1194,33 @@ With no arm to fall back to, the call is validated against the `TypedDict` as be
 no_fallback: PersonOrId = dict(other="x")
 ```
 
+## `TypedDict` behind a pre-PEP-695 type alias
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+Expansion is not tied to the `type` statement. `TypeAliasType` is expanded the same way on versions
+that predate it, and the `TypedDict` behind one is still found and validated:
+
+```py
+from typing import TypedDict
+from typing_extensions import TypeAliasType
+
+class Person(TypedDict):
+    name: str
+    age: int | None
+
+PersonOrId = TypeAliasType("PersonOrId", Person | int)
+
+union_alias_in_union: PersonOrId | str = {"name": "Alice", "age": 30}
+reveal_type(union_alias_in_union)  # revealed: Person
+
+# error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
+unknown_key: PersonOrId | str = {"name": "Alice", "age": 30, "nickname": "Ali"}
+```
+
 ## Type ignore compatibility issues
 
 Users should be able to ignore TypedDict validation errors with `# type: ignore`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1152,15 +1152,22 @@ def hire(person: FirstPerson | SecondPerson = {"name": "Alice", "age": 30, "nick
 team: Team = {"lead": {"name": "Alice", "age": 30, "nickname": "Ali"}}
 ```
 
-Finding a `TypedDict` behind an alias is not on its own a reason to validate a `dict(...)` call as
-one, when another arm of the union already accepts it:
+Once the `TypedDict` behind an alias is visible, a `dict(...)` call is validated against it even
+when another arm of the union already accepts the call. That is a pre-existing bug in the
+constructor path rather than something expansion introduces: the same union written without an alias
+behaves identically on `main`, and the dictionary-literal path gets it right. Expansion only makes
+it reachable through an alias.
 
 ```py
+# TODO: the `dict[str, str]` arm accepts this call, so none of these should be emitted.
+# error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
+# error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 accepted_by_fallback: PersonOrId | dict[str, str] = dict(other="x")
-reveal_type(accepted_by_fallback)  # revealed: dict[str, str]
+reveal_type(accepted_by_fallback)  # revealed: Person
 ```
 
-That holds wherever the union supplies the type context, not just in an assignment:
+It applies wherever the union supplies the type context, not just in an assignment:
 
 ```py
 class Roster(TypedDict):
@@ -1168,24 +1175,41 @@ class Roster(TypedDict):
 
 def takes_fallback(value: PersonOrId | dict[str, str]) -> None: ...
 
+# TODO: none of these should be emitted, here or in the two cases below.
+# error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
+# error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 takes_fallback(dict(other="x"))
 
 def returns_fallback() -> PersonOrId | dict[str, str]:
+    # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
+    # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
+    # error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
     return dict(other="x")
 
+# error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
+# error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 nested_fallback: Roster = {"lead": dict(other="x")}
 ```
 
-A wider arm serves as well as an exact one:
+A wider arm fares no better:
 
 ```py
 from typing import Any, Mapping
 
+# TODO: neither of these should be emitted.
+# error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
+# error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 any_fallback: PersonOrId | Any = dict(other="x")
+# error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
+# error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 mapping_fallback: PersonOrId | Mapping[str, str] = dict(other="x")
 ```
 
-With no arm to fall back to, the call is validated against the `TypedDict` as before:
+With no arm to fall back to, validating against the `TypedDict` is correct:
 
 ```py
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1080,6 +1080,51 @@ def takes_td_or_iterable(value: TD | Iterable[int]) -> None:
 takes_td_or_iterable({42: 42})
 ```
 
+## Union of `TypedDict` behind a type alias
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+A `TypedDict` is still found when the annotation reaches it through a type alias, including when the
+alias resolves to a union and is itself one element of a larger union:
+
+```py
+from typing import TypedDict
+from typing_extensions import TypeAliasType
+
+class Person(TypedDict):
+    name: str
+    age: int | None
+
+type PersonAlias = Person
+type PersonOrId = Person | int
+PersonOrIdAliasType = TypeAliasType("PersonOrIdAliasType", Person | int)
+
+aliased: PersonAlias = {"name": "Alice", "age": 30}
+reveal_type(aliased)  # revealed: Person
+
+aliased_in_union: PersonAlias | str = {"name": "Alice", "age": 30}
+reveal_type(aliased_in_union)  # revealed: Person
+
+union_alias: PersonOrId = {"name": "Alice", "age": 30}
+reveal_type(union_alias)  # revealed: Person
+
+union_alias_in_union: PersonOrId | str = {"name": "Alice", "age": 30}
+reveal_type(union_alias_in_union)  # revealed: Person
+
+alias_type_in_union: PersonOrIdAliasType | str = {"name": "Alice", "age": 30}
+reveal_type(alias_type_in_union)  # revealed: Person
+```
+
+Keys are still validated against the aliased `TypedDict`:
+
+```py
+# error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
+unknown_key: PersonOrId | str = {"name": "Alice", "age": 30, "nickname": "Ali"}
+```
+
 ## Type ignore compatibility issues
 
 Users should be able to ignore TypedDict validation errors with `# type: ignore`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1152,6 +1152,23 @@ def hire(person: FirstPerson | SecondPerson = {"name": "Alice", "age": 30, "nick
 team: Team = {"lead": {"name": "Alice", "age": 30, "nickname": "Ali"}}
 ```
 
+Finding a `TypedDict` behind an alias is not on its own a reason to validate a `dict(...)` call as
+one, when another arm of the union already accepts it:
+
+```py
+accepted_by_fallback: PersonOrId | dict[str, str] = dict(other="x")
+reveal_type(accepted_by_fallback)  # revealed: dict[str, str]
+```
+
+With no arm to fall back to, the call is validated against the `TypedDict` as before:
+
+```py
+# error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
+# error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
+no_fallback: PersonOrId = dict(other="x")
+```
+
 ## Type ignore compatibility issues
 
 Users should be able to ignore TypedDict validation errors with `# type: ignore`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1118,6 +1118,13 @@ alias_type_in_union: PersonOrIdAliasType | str = {"name": "Alice", "age": 30}
 reveal_type(alias_type_in_union)  # revealed: Person
 ```
 
+A dictionary constructed with keyword arguments uses the same aliased `TypedDict` context:
+
+```py
+constructed: PersonOrId | str = dict(name="Alice", age=30)
+reveal_type(constructed)  # revealed: Person
+```
+
 Keys are still validated against the aliased `TypedDict`:
 
 ```py
@@ -1135,8 +1142,18 @@ type SecondPerson = Person
 collapsed: FirstPerson | SecondPerson = {"name": "Alice", "age": 30}
 reveal_type(collapsed)  # revealed: Person
 
+collapsed_constructor: FirstPerson | SecondPerson = dict(name="Alice", age=30)
+reveal_type(collapsed_constructor)  # revealed: Person
+
 # error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
 collapsed_unknown_key: FirstPerson | SecondPerson = {"name": "Alice", "age": 30, "nickname": "Ali"}
+
+collapsed_constructor_unknown_key: FirstPerson | SecondPerson = dict(
+    name="Alice",
+    age=30,
+    # error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
+    nickname="Ali",
+)
 ```
 
 The same holds where the annotation is a parameter default or a nested field:
@@ -1152,22 +1169,21 @@ def hire(person: FirstPerson | SecondPerson = {"name": "Alice", "age": 30, "nick
 team: Team = {"lead": {"name": "Alice", "age": 30, "nickname": "Ali"}}
 ```
 
-Once the `TypedDict` behind an alias is visible, a `dict(...)` call is validated against it even
-when another arm of the union already accepts the call. That is a pre-existing bug in the
-constructor path rather than something expansion introduces: the same union written without an alias
-behaves identically on `main`, and the dictionary-literal path gets it right. Expansion only makes
-it reachable through an alias.
+Constructor inference currently ignores compatible non-`TypedDict` union members. This also occurs
+without aliases; expansion only exposes the existing limitation:
 
 ```py
-# TODO: the `dict[str, str]` arm accepts this call, so none of these should be emitted.
+# TODO: The `dict[str, str]` fallback should accept this constructor without errors.
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
 # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
 # error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 accepted_by_fallback: PersonOrId | dict[str, str] = dict(other="x")
+
+# TODO: This should reveal `dict[str, str]`, not `Person`.
 reveal_type(accepted_by_fallback)  # revealed: Person
 ```
 
-It applies wherever the union supplies the type context, not just in an assignment:
+The same limitation applies to arguments, return values, and nested `TypedDict` fields:
 
 ```py
 class Roster(TypedDict):
@@ -1175,50 +1191,88 @@ class Roster(TypedDict):
 
 def takes_fallback(value: PersonOrId | dict[str, str]) -> None: ...
 
-# TODO: none of these should be emitted, here or in the two cases below.
+# TODO: The `dict[str, str]` fallback should accept this argument without errors.
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
 # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
 # error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 takes_fallback(dict(other="x"))
 
 def returns_fallback() -> PersonOrId | dict[str, str]:
+    # TODO: The `dict[str, str]` fallback should accept this return without errors.
     # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
     # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
     # error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
     return dict(other="x")
 
+# TODO: The `dict[str, str]` fallback should accept this nested value without errors.
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
 # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
 # error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 nested_fallback: Roster = {"lead": dict(other="x")}
 ```
 
-A wider arm fares no better:
+Broader fallback types are also ignored:
 
 ```py
 from typing import Any, Mapping
 
-# TODO: neither of these should be emitted.
+# TODO: The `Any` fallback should accept this constructor without errors.
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
 # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
 # error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 any_fallback: PersonOrId | Any = dict(other="x")
+
+# TODO: The `Mapping[str, str]` fallback should accept this constructor without errors.
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
 # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
 # error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 mapping_fallback: PersonOrId | Mapping[str, str] = dict(other="x")
 ```
 
-With no arm to fall back to, validating against the `TypedDict` is correct:
+A constructor with an invalid key is correctly validated when no union member provides a compatible
+dictionary fallback, whether the alias appears directly or in a larger union:
 
 ```py
 # error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
 # error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
 # error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
 no_fallback: PersonOrId = dict(other="x")
+
+# error: [missing-typed-dict-key] "Missing required key 'name' in TypedDict `Person` constructor"
+# error: [missing-typed-dict-key] "Missing required key 'age' in TypedDict `Person` constructor"
+# error: [invalid-key] "Unknown key "other" for TypedDict `Person`"
+invalid_constructor: PersonOrId | str = dict(other="x")
 ```
 
-## `TypedDict` behind a pre-PEP-695 type alias
+## Overload selection with an aliased `TypedDict`
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+A dictionary literal selects the matching overload when its `TypedDict` type is nested inside a
+union-valued alias:
+
+```py
+from typing import TypedDict, assert_type, overload
+
+class Payload(TypedDict):
+    required: int
+
+type PayloadOrInt = Payload | int
+
+@overload
+def select(value: PayloadOrInt | str) -> str: ...
+@overload
+def select(value: float) -> bytes: ...
+def select(value: object) -> object:
+    return str(value)
+
+assert_type(select({"required": 1}), str)
+```
+
+## `TypedDict` behind a `TypeAliasType` alias on Python 3.11
 
 ```toml
 [environment]
@@ -1240,9 +1294,23 @@ PersonOrId = TypeAliasType("PersonOrId", Person | int)
 
 union_alias_in_union: PersonOrId | str = {"name": "Alice", "age": 30}
 reveal_type(union_alias_in_union)  # revealed: Person
+```
 
+Dictionary constructors use the same aliased `TypedDict` context:
+
+```py
+constructed: PersonOrId | str = dict(name="Alice", age=30)
+reveal_type(constructed)  # revealed: Person
+```
+
+Both dictionary literals and constructors reject unknown keys:
+
+```py
 # error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
 unknown_key: PersonOrId | str = {"name": "Alice", "age": 30, "nickname": "Ali"}
+
+# error: [invalid-key] "Unknown key "nickname" for TypedDict `Person`"
+invalid_constructor: PersonOrId | str = dict(name="Alice", age=30, nickname="Ali")
 ```
 
 ## Type ignore compatibility issues

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2542,8 +2542,9 @@ impl<'db> Type<'db> {
     /// If the type is a union (or a type alias that resolves to a union), filters union elements
     /// based on the provided predicate.
     ///
-    /// Elements that are themselves aliases are expanded first: filtering is a set operation, so
-    /// it has to see an element's members rather than its name.
+    /// Aliases among the elements are expanded first. An element may itself be an alias for a
+    /// union, which is otherwise left unexpanded so diagnostics can name it, but filtering is a
+    /// set operation and has to see the members rather than the name.
     ///
     /// Otherwise, returns the type unchanged.
     fn filter_union(
@@ -2555,37 +2556,17 @@ impl<'db> Type<'db> {
         let Type::Union(union) = self.resolve_type_alias(db) else {
             return self;
         };
-
-        if !union.has_aliases(db) {
-            return union.filter(db, f);
-        }
-
-        match union.expand_aliases(db, env) {
-            Type::Union(expanded) => expanded.filter(db, f),
-            // Expanding collapsed the union to a single type, leaving nothing to filter between,
-            // so apply the predicate to it directly.
-            expanded => {
-                if f(&expanded) {
-                    expanded
-                } else {
-                    Type::Never
-                }
+        let union = if union.has_aliases(db) {
+            match union.expand_aliases(db, env) {
+                Type::Union(expanded) => expanded,
+                // Expanding collapsed the union to a single type, leaving nothing to filter
+                // between, so apply the predicate to it directly.
+                expanded => return if f(&expanded) { expanded } else { Type::Never },
             }
-        }
-    }
-
-    /// If the type is a union (or a type alias that resolves to one) with elements that are
-    /// themselves aliases, expands those elements into the union.
-    ///
-    /// Otherwise, returns the type unchanged.
-    ///
-    /// Alias elements are otherwise left unexpanded so diagnostics can name them, which hides
-    /// their members from anything inspecting the union.
-    fn expand_union_aliases(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        match self.resolve_type_alias(db) {
-            Type::Union(union) if union.has_aliases(db) => union.expand_aliases(db, env),
-            _ => self,
-        }
+        } else {
+            union
+        };
+        union.filter(db, f)
     }
 
     /// If the type is a union, removes union elements that are disjoint from `target`.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2551,37 +2551,24 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Like [`Type::filter_union`], but also expands elements that are themselves aliases for a
-    /// union.
+    /// If the type is a union (or a type alias that resolves to one) with elements that are
+    /// themselves aliases, expands those elements into the union.
     ///
-    /// Such an element is normally left unexpanded so diagnostics can name it, which hides its
-    /// members from the predicate. Use this when the predicate asks what *shape* an element has —
-    /// whether it is a callable or a `TypedDict` — since an alias standing in for a union of those
-    /// has no shape of its own and would be rejected on its name alone.
+    /// Otherwise, returns the type unchanged.
     ///
-    /// Prefer plain [`Type::filter_union`] when the predicate asks whether an element mentions an
-    /// unsolved typevar. Expanding there exposes typevars that inference is still in the middle of
-    /// binding, and the elements holding them get filtered away before they can be solved.
-    fn filter_union_expanding_aliases(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        mut f: impl FnMut(&Type<'db>) -> bool,
-    ) -> Type<'db> {
-        let Type::Union(union) = self.resolve_type_alias(db) else {
-            return self;
-        };
-        let union = if union.has_aliases(db) {
-            match union.expand_aliases(db, env) {
-                Type::Union(expanded) => expanded,
-                // Expanding collapsed the union to a single type, leaving nothing to filter
-                // between, so apply the predicate to it directly.
-                expanded => return if f(&expanded) { expanded } else { Type::Never },
-            }
-        } else {
-            union
-        };
-        union.filter(db, f)
+    /// An alias element is normally left unexpanded so diagnostics can name it, which hides its
+    /// members from anything inspecting the union. Expand before asking what *shape* the elements
+    /// have — whether one is a callable, a `TypedDict` — since an alias standing in for a union of
+    /// those has no shape of its own and would be judged on its name alone.
+    ///
+    /// Do not expand before asking whether an element mentions an unsolved typevar. That exposes
+    /// typevars inference is still in the middle of binding, and the elements holding them get
+    /// discarded before they can be solved.
+    fn expand_union_aliases(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
+        match self.resolve_type_alias(db) {
+            Type::Union(union) if union.has_aliases(db) => union.expand_aliases(db, env),
+            _ => self,
+        }
     }
 
     /// If the type is a union, removes union elements that are disjoint from `target`.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2542,12 +2542,35 @@ impl<'db> Type<'db> {
     /// If the type is a union (or a type alias that resolves to a union), filters union elements
     /// based on the provided predicate.
     ///
+    /// Elements that are themselves aliases are expanded first: filtering is a set operation, so
+    /// it has to see an element's members rather than its name.
+    ///
     /// Otherwise, returns the type unchanged.
-    fn filter_union(self, db: &'db dyn Db, f: impl FnMut(&Type<'db>) -> bool) -> Type<'db> {
-        if let Type::Union(union) = self.resolve_type_alias(db) {
-            union.filter(db, f)
-        } else {
-            self
+    fn filter_union(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        mut f: impl FnMut(&Type<'db>) -> bool,
+    ) -> Type<'db> {
+        let Type::Union(union) = self.resolve_type_alias(db) else {
+            return self;
+        };
+
+        if !union.has_aliases(db) {
+            return union.filter(db, f);
+        }
+
+        match union.expand_aliases(db, env) {
+            Type::Union(expanded) => expanded.filter(db, f),
+            // Expanding collapsed the union to a single type, leaving nothing to filter between,
+            // so apply the predicate to it directly.
+            expanded => {
+                if f(&expanded) {
+                    expanded
+                } else {
+                    Type::Never
+                }
+            }
         }
     }
 
@@ -2576,7 +2599,7 @@ impl<'db> Type<'db> {
         inferable: TypeVarSet<'db>,
     ) -> Type<'db> {
         let constraints = ConstraintSetBuilder::new();
-        self.filter_union(db, |elem| {
+        self.filter_union(db, env, |elem| {
             !elem
                 .when_disjoint_from(db, env, target, &constraints, inferable)
                 .is_always_satisfied(db, env)
@@ -3577,7 +3600,7 @@ impl<'db> Type<'db> {
         Place::Defined(DefinedPlace {
             ty: declaration
                 .ty
-                .filter_union(db, |ty| ty.may_be_data_descriptor(db, env)),
+                .filter_union(db, env, |ty| ty.may_be_data_descriptor(db, env)),
             definedness: if all_arms_are_possible_data_descriptors {
                 declaration.definedness
             } else {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2542,12 +2542,27 @@ impl<'db> Type<'db> {
     /// If the type is a union (or a type alias that resolves to a union), filters union elements
     /// based on the provided predicate.
     ///
-    /// Aliases among the elements are expanded first. An element may itself be an alias for a
-    /// union, which is otherwise left unexpanded so diagnostics can name it, but filtering is a
-    /// set operation and has to see the members rather than the name.
-    ///
     /// Otherwise, returns the type unchanged.
-    fn filter_union(
+    fn filter_union(self, db: &'db dyn Db, f: impl FnMut(&Type<'db>) -> bool) -> Type<'db> {
+        if let Type::Union(union) = self.resolve_type_alias(db) {
+            union.filter(db, f)
+        } else {
+            self
+        }
+    }
+
+    /// Like [`Type::filter_union`], but also expands elements that are themselves aliases for a
+    /// union.
+    ///
+    /// Such an element is normally left unexpanded so diagnostics can name it, which hides its
+    /// members from the predicate. Use this when the predicate asks what *shape* an element has —
+    /// whether it is a callable or a `TypedDict` — since an alias standing in for a union of those
+    /// has no shape of its own and would be rejected on its name alone.
+    ///
+    /// Prefer plain [`Type::filter_union`] when the predicate asks whether an element mentions an
+    /// unsolved typevar. Expanding there exposes typevars that inference is still in the middle of
+    /// binding, and the elements holding them get filtered away before they can be solved.
+    fn filter_union_expanding_aliases(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -2580,7 +2595,7 @@ impl<'db> Type<'db> {
         inferable: TypeVarSet<'db>,
     ) -> Type<'db> {
         let constraints = ConstraintSetBuilder::new();
-        self.filter_union(db, env, |elem| {
+        self.filter_union(db, |elem| {
             !elem
                 .when_disjoint_from(db, env, target, &constraints, inferable)
                 .is_always_satisfied(db, env)
@@ -3581,7 +3596,7 @@ impl<'db> Type<'db> {
         Place::Defined(DefinedPlace {
             ty: declaration
                 .ty
-                .filter_union(db, env, |ty| ty.may_be_data_descriptor(db, env)),
+                .filter_union(db, |ty| ty.may_be_data_descriptor(db, env)),
             definedness: if all_arms_are_possible_data_descriptors {
                 declaration.definedness
             } else {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2542,13 +2542,31 @@ impl<'db> Type<'db> {
     /// If the type is a union (or a type alias that resolves to a union), filters union elements
     /// based on the provided predicate.
     ///
+    /// Aliases among the elements are expanded first. An element may itself be an alias for a
+    /// union, which is otherwise left unexpanded so diagnostics can name it, but filtering is a
+    /// set operation and has to see the members rather than the name.
+    ///
     /// Otherwise, returns the type unchanged.
-    fn filter_union(self, db: &'db dyn Db, f: impl FnMut(&Type<'db>) -> bool) -> Type<'db> {
-        if let Type::Union(union) = self.resolve_type_alias(db) {
-            union.filter(db, f)
+    fn filter_union(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        mut f: impl FnMut(&Type<'db>) -> bool,
+    ) -> Type<'db> {
+        let Type::Union(union) = self.resolve_type_alias(db) else {
+            return self;
+        };
+        let union = if union.has_aliases(db) {
+            match union.expand_aliases(db, env) {
+                Type::Union(expanded) => expanded,
+                // Expanding collapsed the union to a single type, leaving nothing to filter
+                // between, so apply the predicate to it directly.
+                expanded => return if f(&expanded) { expanded } else { Type::Never },
+            }
         } else {
-            self
-        }
+            union
+        };
+        union.filter(db, f)
     }
 
     /// If the type is a union, removes union elements that are disjoint from `target`.
@@ -2562,7 +2580,7 @@ impl<'db> Type<'db> {
         inferable: TypeVarSet<'db>,
     ) -> Type<'db> {
         let constraints = ConstraintSetBuilder::new();
-        self.filter_union(db, |elem| {
+        self.filter_union(db, env, |elem| {
             !elem
                 .when_disjoint_from(db, env, target, &constraints, inferable)
                 .is_always_satisfied(db, env)
@@ -3563,7 +3581,7 @@ impl<'db> Type<'db> {
         Place::Defined(DefinedPlace {
             ty: declaration
                 .ty
-                .filter_union(db, |ty| ty.may_be_data_descriptor(db, env)),
+                .filter_union(db, env, |ty| ty.may_be_data_descriptor(db, env)),
             definedness: if all_arms_are_possible_data_descriptors {
                 declaration.definedness
             } else {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2556,14 +2556,8 @@ impl<'db> Type<'db> {
     ///
     /// Otherwise, returns the type unchanged.
     ///
-    /// An alias element is normally left unexpanded so diagnostics can name it, which hides its
-    /// members from anything inspecting the union. Expand before asking what *shape* the elements
-    /// have — whether one is a callable, a `TypedDict` — since an alias standing in for a union of
-    /// those has no shape of its own and would be judged on its name alone.
-    ///
-    /// Do not expand before asking whether an element mentions an unsolved typevar. That exposes
-    /// typevars inference is still in the middle of binding, and the elements holding them get
-    /// discarded before they can be solved.
+    /// Alias elements are otherwise left unexpanded so diagnostics can name them, which hides
+    /// their members from anything inspecting the union.
     fn expand_union_aliases(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         match self.resolve_type_alias(db) {
             Type::Union(union) if union.has_aliases(db) => union.expand_aliases(db, env),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3568,20 +3568,14 @@ impl<'db> Type<'db> {
         else {
             return dynamic_instance_fallback;
         };
-        let all_arms_are_possible_data_descriptors = declaration
-            .ty
-            .resolve_type_alias(db)
-            .as_union()
-            .is_none_or(|union| {
-                union
-                    .elements(db)
-                    .iter()
-                    .all(|ty| ty.may_be_data_descriptor(db, env))
-            });
+        let mut all_arms_are_possible_data_descriptors = true;
+        let descriptor_ty = declaration.ty.filter_union(db, env, |ty| {
+            let is_possible_data_descriptor = ty.may_be_data_descriptor(db, env);
+            all_arms_are_possible_data_descriptors &= is_possible_data_descriptor;
+            is_possible_data_descriptor
+        });
         Place::Defined(DefinedPlace {
-            ty: declaration
-                .ty
-                .filter_union(db, env, |ty| ty.may_be_data_descriptor(db, env)),
+            ty: descriptor_ty,
             definedness: if all_arms_are_possible_data_descriptors {
                 declaration.definedness
             } else {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5804,7 +5804,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let preferred_type_mappings = return_with_tcx
             .and_then(|(return_ty, tcx)| {
                 if !tcx
-                    .filter_union(db, self.env, |ty| ty.may_prefer_declared_type(db, self.env))
+                    .filter_union(db, |ty| ty.may_prefer_declared_type(db, self.env))
                     .may_prefer_declared_type(db, self.env)
                 {
                     return None;
@@ -5864,7 +5864,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                                 binding.bound_typevar,
                                 binding.solution,
                             )
-                            .filter_union(db, self.env, |ty| {
+                            .filter_union(db, |ty| {
                                 if ty.has_unspecialized_type_var(db, self.env) {
                                     partially_specialized_declared_type.insert(identity);
                                     return false;
@@ -5879,8 +5879,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         // deeply contains non-inferable typevars. Such types (e.g.,
                         // `T@h | list[T@h]` from an outer generic scope) don't provide
                         // useful concrete information and would cause over-expansion.
-                        let concrete_content = inferred_ty
-                            .filter_union(db, self.env, |ty| !ty.has_typevar(db, self.env));
+                        let concrete_content =
+                            inferred_ty.filter_union(db, |ty| !ty.has_typevar(db, self.env));
                         if concrete_content.is_never() && inferred_ty.has_typevar(db, self.env) {
                             continue;
                         }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5804,7 +5804,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let preferred_type_mappings = return_with_tcx
             .and_then(|(return_ty, tcx)| {
                 if !tcx
-                    .filter_union(db, |ty| ty.may_prefer_declared_type(db, self.env))
+                    .filter_union(db, self.env, |ty| ty.may_prefer_declared_type(db, self.env))
                     .may_prefer_declared_type(db, self.env)
                 {
                     return None;
@@ -5864,7 +5864,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                                 binding.bound_typevar,
                                 binding.solution,
                             )
-                            .filter_union(db, |ty| {
+                            .filter_union(db, self.env, |ty| {
                                 if ty.has_unspecialized_type_var(db, self.env) {
                                     partially_specialized_declared_type.insert(identity);
                                     return false;
@@ -5879,8 +5879,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         // deeply contains non-inferable typevars. Such types (e.g.,
                         // `T@h | list[T@h]` from an outer generic scope) don't provide
                         // useful concrete information and would cause over-expansion.
-                        let concrete_content =
-                            inferred_ty.filter_union(db, |ty| !ty.has_typevar(db, self.env));
+                        let concrete_content = inferred_ty
+                            .filter_union(db, self.env, |ty| !ty.has_typevar(db, self.env));
                         if concrete_content.is_never() && inferred_ty.has_typevar(db, self.env) {
                             continue;
                         }

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -412,7 +412,7 @@ impl<'db> ConstructorBinding<'db> {
                         .copied()
                         .map(|mapped_ty| {
                             let without_unknown =
-                                mapped_ty.filter_union(db, |element| !element.is_unknown());
+                                mapped_ty.filter_union(db, env, |element| !element.is_unknown());
                             let mapped_ty = if without_unknown.is_never() {
                                 mapped_ty
                             } else {

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -412,7 +412,7 @@ impl<'db> ConstructorBinding<'db> {
                         .copied()
                         .map(|mapped_ty| {
                             let without_unknown =
-                                mapped_ty.filter_union(db, env, |element| !element.is_unknown());
+                                mapped_ty.filter_union(db, |element| !element.is_unknown());
                             let mapped_ty = if without_unknown.is_never() {
                                 mapped_ty
                             } else {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1470,7 +1470,7 @@ pub(crate) fn is_invalid_typed_dict_literal<'db>(
     source: AnyNodeRef<'_>,
 ) -> bool {
     target_ty
-        .filter_union(db, env, Type::is_typed_dict)
+        .filter_union_expanding_aliases(db, env, Type::is_typed_dict)
         .as_typed_dict()
         .is_some()
         && matches!(source, AnyNodeRef::ExprDict(_))

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1470,7 +1470,8 @@ pub(crate) fn is_invalid_typed_dict_literal<'db>(
     source: AnyNodeRef<'_>,
 ) -> bool {
     target_ty
-        .filter_union_expanding_aliases(db, env, Type::is_typed_dict)
+        .expand_union_aliases(db, env)
+        .filter_union(db, Type::is_typed_dict)
         .as_typed_dict()
         .is_some()
         && matches!(source, AnyNodeRef::ExprDict(_))

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1470,8 +1470,7 @@ pub(crate) fn is_invalid_typed_dict_literal<'db>(
     source: AnyNodeRef<'_>,
 ) -> bool {
     target_ty
-        .expand_union_aliases(db, env)
-        .filter_union(db, Type::is_typed_dict)
+        .filter_union(db, env, Type::is_typed_dict)
         .as_typed_dict()
         .is_some()
         && matches!(source, AnyNodeRef::ExprDict(_))

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1463,13 +1463,14 @@ pub(super) fn report_slice_step_size_zero(context: &InferContext, node: AnyNodeR
 
 // We avoid emitting invalid assignment diagnostic for literal assignments to a `TypedDict`, as
 // they can only occur if we already failed to validate the dict (and emitted some diagnostic).
-pub(crate) fn is_invalid_typed_dict_literal(
-    db: &dyn Db,
-    target_ty: Type,
+pub(crate) fn is_invalid_typed_dict_literal<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    target_ty: Type<'db>,
     source: AnyNodeRef<'_>,
 ) -> bool {
     target_ty
-        .filter_union(db, Type::is_typed_dict)
+        .filter_union(db, env, Type::is_typed_dict)
         .as_typed_dict()
         .is_some()
         && matches!(source, AnyNodeRef::ExprDict(_))
@@ -1640,7 +1641,12 @@ pub(super) fn report_invalid_assignment<'db>(
     };
 
     if let Some(value_node) = value_node
-        && is_invalid_typed_dict_literal(db, target_ty, value_node.into())
+        && is_invalid_typed_dict_literal(
+            db,
+            context.program_environment(),
+            target_ty,
+            value_node.into(),
+        )
     {
         return;
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7076,8 +7076,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }) {
             if let Some(typed_dict) = annotation.as_typed_dict() {
                 // If there is a single typed dict annotation, infer against it directly. Expanding
-                // first means a union whose arms all alias the same `TypedDict` arrives here as
-                // that `TypedDict`, rather than falling out of both branches unvalidated.
+                // first means a union whose arms all alias the same `TypedDict` reaches this
+                // branch rather than neither.
                 if let Some(ty) =
                     self.infer_typed_dict_expression(dict, typed_dict, &mut item_types)
                 {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6412,7 +6412,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Some(tcx) = tcx.annotation
             && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
                 .resolve_type_alias(db)
-                .filter_union(db, |ty| ty.as_literal_value().is_some())
+                .filter_union(db, env, |ty| ty.as_literal_value().is_some())
             && ty.is_assignable_to(db, env, literal_tcx)
         {
             ty = Type::LiteralValue(literal.to_unpromotable());
@@ -6541,7 +6541,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for binding in solution {
                 let inferred_ty = binding
                     .solution
-                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
+                    .filter_union(db, env, |ty| !ty.has_unspecialized_type_var(db, env));
                 if inferred_ty.has_unspecialized_type_var(db, env) {
                     continue;
                 }
@@ -7324,11 +7324,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .zip(specialization.types(self.db()))
                 {
                     let inferred_ty = inferred_ty
-                        .filter_union(db, |ty| {
+                        .filter_union(db, env, |ty| {
                             !ty.as_typevar()
                                 .is_some_and(|tv| tv.is_inferable(self.db(), inferable))
                         })
-                        .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
+                        .filter_union(db, env, |ty| !ty.has_unspecialized_type_var(db, env));
                     if inferred_ty.has_unspecialized_type_var(db, env) {
                         continue;
                     }
@@ -7378,8 +7378,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // Avoid inferring a preferred type based on partially specialized
                                 // type context from an outer generic call. If the type context is
                                 // a union, we try to keep any concrete elements.
-                                let inferred_ty = inferred_ty
-                                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
+                                let inferred_ty = inferred_ty.filter_union(db, env, |ty| {
+                                    !ty.has_unspecialized_type_var(db, env)
+                                });
                                 if inferred_ty.has_unspecialized_type_var(db, env) {
                                     continue;
                                 }
@@ -8359,8 +8360,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // in the union/intersection.
         let callable_tcx = if let Some(tcx) = tcx.annotation
             && let Some(callable) = tcx
-                .expand_union_aliases(db, env)
-                .filter_union(db, Type::is_callable_type)
+                .filter_union(db, env, Type::is_callable_type)
                 .as_callable()
         {
             match callable.signatures(self.db()).overloads.as_slice() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7080,13 +7080,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 {
                     return ty;
                 }
-            } else if let Type::Union(union) = annotation {
-                // An element may itself be an alias for a union, which is left unexpanded so
-                // diagnostics can name it. Expand so the members are visible here.
-                let union = match union.expand_aliases(db, env) {
-                    Type::Union(expanded) => expanded,
-                    _ => union,
-                };
+            } else if let Type::Union(union) = annotation.expand_union_aliases(db, env) {
                 let union_elements = union.elements(self.db());
                 let mut typed_dicts = Vec::new();
                 let mut has_dict_compatible_fallback = false;
@@ -8362,7 +8356,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // in the union/intersection.
         let callable_tcx = if let Some(tcx) = tcx.annotation
             && let Some(callable) = tcx
-                .filter_union_expanding_aliases(db, env, Type::is_callable_type)
+                .expand_union_aliases(db, env)
+                .filter_union(db, Type::is_callable_type)
                 .as_callable()
         {
             match callable.signatures(self.db()).overloads.as_slice() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7069,18 +7069,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut item_types = FxHashMap::default();
 
         // Validate `TypedDict` dictionary literal assignments.
-        if let Some(annotation) = tcx
-            .annotation
-            .map(|annotation| annotation.resolve_type_alias(db))
-        {
+        if let Some(annotation) = tcx.annotation.map(|annotation| {
+            annotation
+                .resolve_type_alias(db)
+                .expand_union_aliases(db, env)
+        }) {
             if let Some(typed_dict) = annotation.as_typed_dict() {
-                // If there is a single typed dict annotation, infer against it directly.
+                // If there is a single typed dict annotation, infer against it directly. Expanding
+                // first means a union whose arms all alias the same `TypedDict` arrives here as
+                // that `TypedDict`, rather than falling out of both branches unvalidated.
                 if let Some(ty) =
                     self.infer_typed_dict_expression(dict, typed_dict, &mut item_types)
                 {
                     return ty;
                 }
-            } else if let Type::Union(union) = annotation.expand_union_aliases(db, env) {
+            } else if let Type::Union(union) = annotation {
                 let union_elements = union.elements(self.db());
                 let mut typed_dicts = Vec::new();
                 let mut has_dict_compatible_fallback = false;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7069,11 +7069,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut item_types = FxHashMap::default();
 
         // Validate `TypedDict` dictionary literal assignments.
-        if let Some(annotation) = tcx.annotation.map(|annotation| {
-            annotation
-                .resolve_type_alias(db)
-                .expand_union_aliases(db, env)
-        }) {
+        if let Some(annotation) =
+            tcx.annotation
+                .map(|annotation| match annotation.resolve_type_alias(db) {
+                    Type::Union(union) if union.has_aliases(db) => union.expand_aliases(db, env),
+                    annotation => annotation,
+                })
+        {
             if let Some(typed_dict) = annotation.as_typed_dict() {
                 // If there is a single typed dict annotation, infer against it directly. Expanding
                 // first means a union whose arms all alias the same `TypedDict` reaches this

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6412,7 +6412,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Some(tcx) = tcx.annotation
             && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
                 .resolve_type_alias(db)
-                .filter_union(db, env, |ty| ty.as_literal_value().is_some())
+                .filter_union(db, |ty| ty.as_literal_value().is_some())
             && ty.is_assignable_to(db, env, literal_tcx)
         {
             ty = Type::LiteralValue(literal.to_unpromotable());
@@ -6541,7 +6541,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for binding in solution {
                 let inferred_ty = binding
                     .solution
-                    .filter_union(db, env, |ty| !ty.has_unspecialized_type_var(db, env));
+                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
                 if inferred_ty.has_unspecialized_type_var(db, env) {
                     continue;
                 }
@@ -7327,11 +7327,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .zip(specialization.types(self.db()))
                 {
                     let inferred_ty = inferred_ty
-                        .filter_union(db, env, |ty| {
+                        .filter_union(db, |ty| {
                             !ty.as_typevar()
                                 .is_some_and(|tv| tv.is_inferable(self.db(), inferable))
                         })
-                        .filter_union(db, env, |ty| !ty.has_unspecialized_type_var(db, env));
+                        .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
                     if inferred_ty.has_unspecialized_type_var(db, env) {
                         continue;
                     }
@@ -7381,9 +7381,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // Avoid inferring a preferred type based on partially specialized
                                 // type context from an outer generic call. If the type context is
                                 // a union, we try to keep any concrete elements.
-                                let inferred_ty = inferred_ty.filter_union(db, env, |ty| {
-                                    !ty.has_unspecialized_type_var(db, env)
-                                });
+                                let inferred_ty = inferred_ty
+                                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
                                 if inferred_ty.has_unspecialized_type_var(db, env) {
                                     continue;
                                 }
@@ -8363,7 +8362,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // in the union/intersection.
         let callable_tcx = if let Some(tcx) = tcx.annotation
             && let Some(callable) = tcx
-                .filter_union(db, env, Type::is_callable_type)
+                .filter_union_expanding_aliases(db, env, Type::is_callable_type)
                 .as_callable()
         {
             match callable.signatures(self.db()).overloads.as_slice() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6412,7 +6412,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Some(tcx) = tcx.annotation
             && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
                 .resolve_type_alias(db)
-                .filter_union(db, |ty| ty.as_literal_value().is_some())
+                .filter_union(db, env, |ty| ty.as_literal_value().is_some())
             && ty.is_assignable_to(db, env, literal_tcx)
         {
             ty = Type::LiteralValue(literal.to_unpromotable());
@@ -6541,7 +6541,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for binding in solution {
                 let inferred_ty = binding
                     .solution
-                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
+                    .filter_union(db, env, |ty| !ty.has_unspecialized_type_var(db, env));
                 if inferred_ty.has_unspecialized_type_var(db, env) {
                     continue;
                 }
@@ -7081,6 +7081,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return ty;
                 }
             } else if let Type::Union(union) = annotation {
+                // An element may itself be an alias for a union, which is left unexpanded so
+                // diagnostics can name it. Expand so the members are visible here.
+                let union = match union.expand_aliases(db, env) {
+                    Type::Union(expanded) => expanded,
+                    _ => union,
+                };
                 let union_elements = union.elements(self.db());
                 let mut typed_dicts = Vec::new();
                 let mut has_dict_compatible_fallback = false;
@@ -7321,11 +7327,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .zip(specialization.types(self.db()))
                 {
                     let inferred_ty = inferred_ty
-                        .filter_union(db, |ty| {
+                        .filter_union(db, env, |ty| {
                             !ty.as_typevar()
                                 .is_some_and(|tv| tv.is_inferable(self.db(), inferable))
                         })
-                        .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
+                        .filter_union(db, env, |ty| !ty.has_unspecialized_type_var(db, env));
                     if inferred_ty.has_unspecialized_type_var(db, env) {
                         continue;
                     }
@@ -7375,8 +7381,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // Avoid inferring a preferred type based on partially specialized
                                 // type context from an outer generic call. If the type context is
                                 // a union, we try to keep any concrete elements.
-                                let inferred_ty = inferred_ty
-                                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, env));
+                                let inferred_ty = inferred_ty.filter_union(db, env, |ty| {
+                                    !ty.has_unspecialized_type_var(db, env)
+                                });
                                 if inferred_ty.has_unspecialized_type_var(db, env) {
                                     continue;
                                 }
@@ -8355,7 +8362,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // TODO: We could perform multi-inference here if there are multiple `Callable` annotations
         // in the union/intersection.
         let callable_tcx = if let Some(tcx) = tcx.annotation
-            && let Some(callable) = tcx.filter_union(db, Type::is_callable_type).as_callable()
+            && let Some(callable) = tcx
+                .filter_union(db, env, Type::is_callable_type)
+                .as_callable()
         {
             match callable.signatures(self.db()).overloads.as_slice() {
                 [signature] => Some(signature),

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -26,7 +26,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // then validate and return the TypedDict type. This also covers `dict(**src)` when `src`
         // is `TypedDict`-shaped.
         if let Some(tcx) = call_expression_tcx.annotation
-            && let Some(typed_dict) = tcx.filter_union(db, Type::is_typed_dict).as_typed_dict()
+            && let Some(typed_dict) = tcx
+                .filter_union(db, self.program_environment(), Type::is_typed_dict)
+                .as_typed_dict()
         {
             // Only speculate the `**kwargs` applicability check. Assignability handles inputs that
             // are already valid for the target, including gradual and bottom types. The additional

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -26,10 +26,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // then validate and return the TypedDict type. This also covers `dict(**src)` when `src`
         // is `TypedDict`-shaped.
         if let Some(tcx) = call_expression_tcx.annotation
-            && let Some(typed_dict) = tcx
-                .expand_union_aliases(db, self.program_environment())
+            && let annotation = tcx.expand_union_aliases(db, self.program_environment())
+            && let Some(typed_dict) = annotation
                 .filter_union(db, Type::is_typed_dict)
                 .as_typed_dict()
+            && !self.dict_call_matches_union_fallback(func, arguments, collection_expr, annotation)
         {
             // Only speculate the `**kwargs` applicability check. Assignability handles inputs that
             // are already valid for the target, including gradual and bottom types. The additional
@@ -114,5 +115,46 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             &mut infer_elt_ty,
             call_expression_tcx,
         )
+    }
+
+    /// Whether some non-`TypedDict` arm of `annotation` already accepts this `dict(...)` call.
+    ///
+    /// Finding a `TypedDict` among the arms is not on its own a reason to validate the call as
+    /// one. `Config | int | dict[str, int]` accepts `dict(other=1)` through its `dict[str, int]`
+    /// arm, and committing to `Config` would report key errors for a call the annotation allows.
+    ///
+    /// Inferring against the arm rather than testing the arm's shape mirrors what dictionary
+    /// literals do, and reuses whatever `dict(...)` would ordinarily infer: passing a
+    /// non-`TypedDict` type context here cannot re-enter the fast path.
+    fn dict_call_matches_union_fallback(
+        &mut self,
+        func: &ast::Expr,
+        arguments: &ast::Arguments,
+        collection_expr: Option<ast::ExprRef<'_>>,
+        annotation: Type<'db>,
+    ) -> bool {
+        let db = self.db();
+        let env = self.program_environment();
+
+        let Type::Union(union) = annotation else {
+            return false;
+        };
+
+        union.elements(db).iter().any(|element| {
+            let element = element.resolve_type_alias(db);
+            if element.is_typed_dict() {
+                return false;
+            }
+
+            let mut speculative_builder = self.speculate_without_diagnostics();
+            speculative_builder
+                .infer_keyword_only_dict_call(
+                    func,
+                    arguments,
+                    collection_expr,
+                    TypeContext::new(Some(element)),
+                )
+                .is_some_and(|ty| ty.is_assignable_to(db, env, element))
+        })
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -119,13 +119,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
     /// Whether some non-`TypedDict` arm of `annotation` already accepts this `dict(...)` call.
     ///
-    /// Finding a `TypedDict` among the arms is not on its own a reason to validate the call as
-    /// one. `Config | int | dict[str, int]` accepts `dict(other=1)` through its `dict[str, int]`
-    /// arm, and committing to `Config` would report key errors for a call the annotation allows.
+    /// `Config | int | dict[str, int]` accepts `dict(other=1)` through its `dict[str, int]` arm,
+    /// so committing to `Config` would report key errors for a call the annotation allows.
     ///
-    /// Inferring against the arm rather than testing the arm's shape mirrors what dictionary
-    /// literals do, and reuses whatever `dict(...)` would ordinarily infer: passing a
-    /// non-`TypedDict` type context here cannot re-enter the fast path.
+    /// A non-`TypedDict` type context cannot re-enter the fast path, so the recursion terminates.
     fn dict_call_matches_union_fallback(
         &mut self,
         func: &ast::Expr,

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -27,7 +27,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // is `TypedDict`-shaped.
         if let Some(tcx) = call_expression_tcx.annotation
             && let Some(typed_dict) = tcx
-                .filter_union_expanding_aliases(db, self.program_environment(), Type::is_typed_dict)
+                .expand_union_aliases(db, self.program_environment())
+                .filter_union(db, Type::is_typed_dict)
                 .as_typed_dict()
         {
             // Only speculate the `**kwargs` applicability check. Assignability handles inputs that

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -22,15 +22,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return None;
         }
 
+        let annotation = call_expression_tcx
+            .annotation
+            .map(|annotation| annotation.expand_union_aliases(db, self.program_environment()));
+
         // Fast-path dict(...) in TypedDict context: infer keyword values against fields,
         // then validate and return the TypedDict type. This also covers `dict(**src)` when `src`
         // is `TypedDict`-shaped.
-        if let Some(tcx) = call_expression_tcx.annotation
-            && let annotation = tcx.expand_union_aliases(db, self.program_environment())
+        if let Some(annotation) = annotation
             && let Some(typed_dict) = annotation
                 .filter_union(db, Type::is_typed_dict)
                 .as_typed_dict()
-            && !self.dict_call_matches_union_fallback(func, arguments, collection_expr, annotation)
+            && !self.has_dict_compatible_fallback(func, arguments, collection_expr, annotation)
         {
             // Only speculate the `**kwargs` applicability check. Assignability handles inputs that
             // are already valid for the target, including gradual and bottom types. The additional
@@ -123,7 +126,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// so committing to the `TypedDict` would report key errors for a call the annotation allows.
     ///
     /// A non-`TypedDict` type context cannot re-enter the fast path, so the recursion terminates.
-    fn dict_call_matches_union_fallback(
+    fn has_dict_compatible_fallback(
         &mut self,
         func: &ast::Expr,
         arguments: &ast::Arguments,

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -119,8 +119,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
     /// Whether some non-`TypedDict` arm of `annotation` already accepts this `dict(...)` call.
     ///
-    /// `Config | int | dict[str, int]` accepts `dict(other=1)` through its `dict[str, int]` arm,
-    /// so committing to `Config` would report key errors for a call the annotation allows.
+    /// A union of a `TypedDict` and `dict[str, int]` accepts `dict(other=1)` through the latter,
+    /// so committing to the `TypedDict` would report key errors for a call the annotation allows.
     ///
     /// A non-`TypedDict` type context cannot re-enter the fast path, so the recursion terminates.
     fn dict_call_matches_union_fallback(

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -27,7 +27,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // is `TypedDict`-shaped.
         if let Some(tcx) = call_expression_tcx.annotation
             && let Some(typed_dict) = tcx
-                .filter_union(db, self.program_environment(), Type::is_typed_dict)
+                .filter_union_expanding_aliases(db, self.program_environment(), Type::is_typed_dict)
                 .as_typed_dict()
         {
             // Only speculate the `**kwargs` applicability check. Assignability handles inputs that

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -22,18 +22,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return None;
         }
 
-        let annotation = call_expression_tcx
-            .annotation
-            .map(|annotation| annotation.expand_union_aliases(db, self.program_environment()));
-
         // Fast-path dict(...) in TypedDict context: infer keyword values against fields,
         // then validate and return the TypedDict type. This also covers `dict(**src)` when `src`
         // is `TypedDict`-shaped.
-        if let Some(annotation) = annotation
-            && let Some(typed_dict) = annotation
-                .filter_union(db, Type::is_typed_dict)
+        if let Some(tcx) = call_expression_tcx.annotation
+            && let Some(typed_dict) = tcx
+                .filter_union(db, self.program_environment(), Type::is_typed_dict)
                 .as_typed_dict()
-            && !self.has_dict_compatible_fallback(func, arguments, collection_expr, annotation)
         {
             // Only speculate the `**kwargs` applicability check. Assignability handles inputs that
             // are already valid for the target, including gradual and bottom types. The additional
@@ -118,43 +113,5 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             &mut infer_elt_ty,
             call_expression_tcx,
         )
-    }
-
-    /// Whether some non-`TypedDict` arm of `annotation` already accepts this `dict(...)` call.
-    ///
-    /// A union of a `TypedDict` and `dict[str, int]` accepts `dict(other=1)` through the latter,
-    /// so committing to the `TypedDict` would report key errors for a call the annotation allows.
-    ///
-    /// A non-`TypedDict` type context cannot re-enter the fast path, so the recursion terminates.
-    fn has_dict_compatible_fallback(
-        &mut self,
-        func: &ast::Expr,
-        arguments: &ast::Arguments,
-        collection_expr: Option<ast::ExprRef<'_>>,
-        annotation: Type<'db>,
-    ) -> bool {
-        let db = self.db();
-        let env = self.program_environment();
-
-        let Type::Union(union) = annotation else {
-            return false;
-        };
-
-        union.elements(db).iter().any(|element| {
-            let element = element.resolve_type_alias(db);
-            if element.is_typed_dict() {
-                return false;
-            }
-
-            let mut speculative_builder = self.speculate_without_diagnostics();
-            speculative_builder
-                .infer_keyword_only_dict_call(
-                    func,
-                    arguments,
-                    collection_expr,
-                    TypeContext::new(Some(element)),
-                )
-                .is_some_and(|ty| ty.is_assignable_to(db, env, element))
-        })
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1058,7 +1058,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 // Avoid duplicate diagnostics: invalid TypedDict literals already emit specific errors.
                 let suppress_invalid_default =
-                    is_invalid_typed_dict_literal(db, declared_ty, default_expr.into());
+                    is_invalid_typed_dict_literal(db, env, declared_ty, default_expr.into());
                 if !default_ty.is_assignable_to(db, env, declared_ty)
                     && !suppress_invalid_default
                     && !((self.in_stub()

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -28,7 +28,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .iter()
                     .any(|element| matches!(element.resolve_type_alias(db), Type::TypeForm(_))) =>
             {
-                Some(target.filter_union(db, |element| {
+                Some(target.filter_union(db, env, |element| {
                     !matches!(element.resolve_type_alias(db), Type::TypeForm(_))
                 }))
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -28,7 +28,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .iter()
                     .any(|element| matches!(element.resolve_type_alias(db), Type::TypeForm(_))) =>
             {
-                Some(target.filter_union(db, env, |element| {
+                Some(target.filter_union(db, |element| {
                     !matches!(element.resolve_type_alias(db), Type::TypeForm(_))
                 }))
             }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1533,7 +1533,7 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
             return true;
         }
 
-        if diagnostic::is_invalid_typed_dict_literal(db, item.declared_ty, self.value_node) {
+        if diagnostic::is_invalid_typed_dict_literal(db, env, item.declared_ty, self.value_node) {
             return false;
         }
 


### PR DESCRIPTION
## Summary

A union-valued type alias nested inside another union stayed unexpanded, hiding a TypedDict or callable from inference. Fixed by expanding aliases before shape checks.

## Test Plan

Added mdtest.
