### PR TITLE
[`flake8-bugbear`] Use the actual method name in the `B005` message

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -46,12 +46,15 @@ use crate::checkers::ast::Checker;
 /// - [Python documentation: `str.strip`](https://docs.python.org/3/library/stdtypes.html#str.strip)
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.106")]
-pub(crate) struct StripWithMultiCharacters;
+pub(crate) struct StripWithMultiCharacters {
+    method: String,
+}
 
 impl Violation for StripWithMultiCharacters {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "Using `.strip()` with multi-character strings is misleading".to_string()
+        let StripWithMultiCharacters { method } = self;
+        format!("Using `.{method}()` with multi-character strings is misleading")
     }
 }
 
@@ -74,6 +77,11 @@ pub(crate) fn strip_with_multi_characters(
     };
 
     if value.chars().count() > 1 && !value.chars().all_unique() {
-        checker.report_diagnostic(StripWithMultiCharacters, expr.range());
+        checker.report_diagnostic(
+            StripWithMultiCharacters {
+                method: attr.to_string(),
+            },
+            expr.range(),
+        );
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B005_B005.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B005_B005.py.snap
@@ -23,7 +23,7 @@ B005 Using `.strip()` with multi-character strings is misleading
 9 | s.lstrip("we")  # no warning
   |
 
-B005 Using `.strip()` with multi-character strings is misleading
+B005 Using `.lstrip()` with multi-character strings is misleading
   --> B005.py:10:1
    |
  8 | s.lstrip(s)  # no warning
@@ -34,7 +34,7 @@ B005 Using `.strip()` with multi-character strings is misleading
 12 | s.lstrip("\n\t ")  # no warning
    |
 
-B005 Using `.strip()` with multi-character strings is misleading
+B005 Using `.lstrip()` with multi-character strings is misleading
   --> B005.py:13:1
    |
 11 | s.lstrip("e")  # no warning
@@ -45,7 +45,7 @@ B005 Using `.strip()` with multi-character strings is misleading
 15 | s.rstrip("we")  # warning
    |
 
-B005 Using `.strip()` with multi-character strings is misleading
+B005 Using `.rstrip()` with multi-character strings is misleading
   --> B005.py:16:1
    |
 14 | s.rstrip(s)  # no warning
@@ -56,7 +56,7 @@ B005 Using `.strip()` with multi-character strings is misleading
 18 | s.rstrip("\n\t ")  # no warning
    |
 
-B005 Using `.strip()` with multi-character strings is misleading
+B005 Using `.rstrip()` with multi-character strings is misleading
   --> B005.py:19:1
    |
 17 | s.rstrip("e")  # no warning


### PR DESCRIPTION
## Summary

B005's message hardcodes `.strip()`, so `s.lstrip(...)` / `s.rstrip(...)` get flagged as "Using `.strip()` with multi-character strings is misleading" — the wrong method name. I thread the matched method (`strip`/`lstrip`/`rstrip`) through the violation struct and format it into the message.

Message-only change; the diagnostic range is untouched.

Fixes #27085.

## Test Plan

The existing `B005.py` fixture already exercises `lstrip`/`rstrip`, so the snapshot update is the whole visible effect: the four `lstrip`/`rstrip` diagnostics now name the right method, and the genuine `.strip()` cases are unchanged.

`cargo test -p ruff_linter --lib flake8_bugbear::tests::rules` fails on the B005 snapshot before the change and passes after `cargo insta accept`.

---
AI-assist disclosure (per the AI policy): I used Claude to help write the Rust and regenerate the snapshot; the diff and this description are mine and I've verified the change.
