### PR TITLE
[ty] Fix overload argument expansion with unpacked positional arguments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -264,6 +264,109 @@ def _(a: A, bc: B | C, cd: C | D):
     reveal_type(f(*(a, cd)))  # revealed: Unknown
 ```
 
+### Expanding a keyword argument after unpacking into a variadic parameter
+
+Valid unpacked positional arguments must not prevent expansion of an unrelated union-typed keyword
+argument. The positional arguments may come from an empty tuple, a fixed-length tuple, a
+variable-length tuple, or a list.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f(*values: str, kind: int) -> int: ...
+@overload
+def f(*values: str, kind: None) -> str: ...
+```
+
+Expanding `kind` matches one overload when its value is an `int` and the other when its value is
+`None`, independently of how the positional arguments are provided. An incompatible positional
+argument must still fail to match either overload.
+
+```py
+from overloaded import f
+
+def _(one: tuple[str], many: tuple[str, ...], items: list[str], kind: int | None) -> None:
+    reveal_type(f("a", kind=kind))  # revealed: int | str
+    reveal_type(f(*(), kind=kind))  # revealed: int | str
+    reveal_type(f(*one, kind=kind))  # revealed: int | str
+    reveal_type(f(*many, kind=kind))  # revealed: int | str
+    reveal_type(f(*items, kind=kind))  # revealed: int | str
+
+def _(invalid: tuple[int], kind: int | None) -> None:
+    # error: [no-matching-overload]
+    reveal_type(f(*invalid, kind=kind))  # revealed: Unknown
+```
+
+### Expanding a keyword argument with an unpacked variadic annotation
+
+An unpacked variadic annotation can specify a different expected type for each positional argument.
+Unpacked arguments must be checked against their corresponding element types while an unrelated
+union-typed keyword argument is expanded.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f(*values: *tuple[str, int], kind: int) -> int: ...
+@overload
+def f(*values: *tuple[str, int], kind: None) -> str: ...
+@overload
+def suffix[T: str, *Parts](*values: *tuple[*Parts, T], kind: int) -> int: ...
+@overload
+def suffix[T: str, *Parts](*values: *tuple[*Parts, T], kind: None) -> str: ...
+```
+
+Both directly supplied arguments and an unpacked tuple satisfy the heterogeneous annotation. A
+generic variadic prefix also permits expansion when the fixed suffix has a compatible type.
+
+```py
+from overloaded import f, suffix
+
+def _(values: tuple[str, int], kind: int | None) -> None:
+    reveal_type(f("a", 1, kind=kind))  # revealed: int | str
+    reveal_type(f(*values, kind=kind))  # revealed: int | str
+
+def _(pair: tuple[int, str], kind: int | None) -> None:
+    reveal_type(suffix(*pair, kind=kind))  # revealed: int | str
+```
+
+### Expanding a keyword argument after unpacking into positional parameters
+
+Expanding a union-typed keyword argument must also work when a fixed-length tuple supplies ordinary
+positional parameters with different types instead of a variadic parameter.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f(value: str, count: int, *, kind: int) -> int: ...
+@overload
+def f(value: str, count: int, *, kind: None) -> str: ...
+```
+
+Both the direct positional arguments and the unpacked tuple select the same overloads after `kind`
+is expanded.
+
+```py
+from overloaded import f
+
+def _(values: tuple[str, int], kind: int | None) -> None:
+    reveal_type(f("a", 1, kind=kind))  # revealed: int | str
+    reveal_type(f(*values, kind=kind))  # revealed: int | str
+```
+
 ### Generics (legacy)
 
 `overloaded.pyi`:
@@ -755,7 +858,7 @@ class Foo:
 from overloaded import A, B, C, Foo, f
 from typing_extensions import Any, reveal_type
 
-def _(ab: A | B, a: int | Any):
+def _(ab: A | B, a: int | Any, invalid: tuple[C]):
     reveal_type(f(a1=a, a2=a, a3=a))  # revealed: C
     reveal_type(f(A(), a1=a, a2=a, a3=a))  # revealed: A
     reveal_type(f(B(), a1=a, a2=a, a3=a))  # revealed: B
@@ -800,6 +903,25 @@ def _(ab: A | B, a: int | Any):
             a28=a,
             a29=a,
             a30=a,
+        )
+    )
+
+    # An incompatible element in a definitely nonempty splat must also prevent expansion of the
+    # nine union-typed keyword arguments.
+    reveal_type(
+        # error: [no-matching-overload]
+        # revealed: Unknown
+        f(
+            *invalid,
+            a1=a,
+            a2=a,
+            a3=a,
+            a4=a,
+            a5=a,
+            a6=a,
+            a7=a,
+            a8=a,
+            a9=a,
         )
     )
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3814,13 +3814,31 @@ impl<'db> CallableBinding<'db> {
             if is_expandable_type(db, env, argument_type) {
                 continue;
             }
-            let mut is_argument_assignable_to_any_overload = false;
-            'overload: for overload in &self.overloads {
-                for matched_parameter in &overload.argument_matches[argument_index].parameters {
-                    let parameter_type =
-                        overload.signature.parameters()[matched_parameter.index].annotated_type();
-                    let argument_type = argument_types.get_for_declared_type(parameter_type);
-                    if argument_type
+            let is_argument_assignable_to_any_overload = self.overloads.iter().any(|overload| {
+                let matched_parameters = &overload.argument_matches[argument_index].parameters;
+                if matched_parameters.is_empty() {
+                    return matches!(argument, Argument::Variadic)
+                        && argument_type.iterate(db, env).len().minimum() == 0;
+                }
+
+                // A starred argument contributes its individual element types, not the type of
+                // the iterable itself, and each element must match its corresponding parameter.
+                matched_parameters.iter().all(|matched_parameter| {
+                    let parameter = &overload.signature.parameters()[matched_parameter.index];
+                    if parameter.has_starred_annotation()
+                        && matched_parameter.expected_type.is_none()
+                    {
+                        return true;
+                    }
+
+                    let parameter_type = matched_parameter
+                        .expected_type
+                        .unwrap_or_else(|| parameter.annotated_type());
+                    let argument_type = matched_parameter
+                        .argument_type
+                        .unwrap_or_else(|| argument_types.get_for_declared_type(parameter_type));
+
+                    argument_type
                         .when_assignable_to(
                             db,
                             env,
@@ -3829,12 +3847,8 @@ impl<'db> CallableBinding<'db> {
                             overload.inferable_typevars,
                         )
                         .is_always_satisfied(db, env)
-                    {
-                        is_argument_assignable_to_any_overload = true;
-                        break 'overload;
-                    }
-                }
-            }
+                })
+            });
             if !is_argument_assignable_to_any_overload {
                 tracing::debug!(
                     "Argument at {argument_index} (`{}`) is not assignable to any of the \


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4258.

The overload-expansion optimization compared an unpacked iterable against an individual parameter's type, causing valid calls with `*args` to be rejected before an unrelated union-typed argument could be expanded.

- Check each unpacked element against its actual matched parameter instead of comparing the entire iterable.
- Treat empty unpacking as imposing no positional constraint.
- Preserve existing behavior for unresolved variadic generics and retain early pruning for incompatible arguments.

## Test plan

Added overload-resolution mdtests covering empty unpacking, fixed-length and variable-length tuples, lists, invalid unpacked elements, heterogeneous positional parameters, unpacked tuple annotations, unresolved variadic generic prefixes, and early pruning of invalid nonempty unpacking.
