### PR TITLE
[ty] Collect legacy typevars in TypedDict members

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4165,6 +4165,28 @@ class BadMerge(L[int], R[str]): ...
 class BadMergeGeneric[T](L[int], R[T]): ...
 ```
 
+### Generic `TypedDict` in a generic type alias
+
+A generic `TypedDict` used as a member of a generic type alias must substitute the alias type
+argument into the `TypedDict`. This requires the alias to collect the legacy type variables that the
+`TypedDict` member holds.
+
+```py
+from typing import Generic, TypeVar, TypedDict, Union
+
+T = TypeVar("T")
+
+class Obj(TypedDict, Generic[T]):
+    value: T
+
+Alias = Union[Obj[T], None]
+
+def f(x: Alias[int]) -> None:
+    if x is not None:
+        reveal_type(x)  # revealed: Obj[int]
+        reveal_type(x["value"])  # revealed: int
+```
+
 ## Recursive `TypedDict`
 
 `TypedDict`s can also be recursive, allowing for nested structures:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8250,8 +8250,11 @@ impl<'db> Type<'db> {
             | Type::ClassLiteral(_)
             | Type::LiteralValue(_)
             | Type::BoundSuper(_)
-            | Type::SpecialForm(_)
-            | Type::TypedDict(_) => {}
+            | Type::SpecialForm(_) => {}
+
+            Type::TypedDict(typed_dict) => visitor.visit(db, self, || {
+                typed_dict.find_legacy_typevars_impl(db, env, binding_context, typevars, visitor);
+            }),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -18,9 +18,11 @@ use super::diagnostic::{
 };
 use super::infer::{TypeExpressionFlags, infer_deferred_types};
 use super::{
-    ApplyTypeMappingVisitor, ErrorContext, IntersectionType, Type, TypeMapping, TypeQualifiers,
-    UnionBuilder, definition_expression_annotation, definition_expression_type, visitor,
+    ApplyTypeMappingVisitor, BoundTypeVarInstance, ErrorContext, FindLegacyTypeVarsVisitor,
+    IntersectionType, Type, TypeMapping, TypeQualifiers, UnionBuilder,
+    definition_expression_annotation, definition_expression_type, visitor,
 };
+use crate::FxOrderSet;
 use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
@@ -584,6 +586,50 @@ impl<'db> TypedDictType<'db> {
                 synthesized.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             ),
         }
+    }
+
+    pub(crate) fn find_legacy_typevars_impl(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        binding_context: Option<Definition<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
+        visitor: &FindLegacyTypeVarsVisitor<'db>,
+    ) {
+        // `Self` in a `TypedDict` member is bound by the enclosing class scope. It is not a free
+        // legacy typevar that the surrounding alias, function, or base-class list introduces.
+        // Collecting it would turn `Self` into an inference variable of that context. For example,
+        // an overload implementation signature with a parameter type `Pair[Self]` would then treat
+        // `Self` as free and wrongly accept the overload. Gather the members' typevars separately
+        // and drop `Self`, which is never a free typevar here. This matches the other ways `Self`
+        // reaches a signature (a bare `Self` annotation, or a `Self` argument of a generic class),
+        // none of which add `Self` to the collected generic context.
+        let mut members = FxOrderSet::default();
+        match self {
+            Self::Class(defining_class) => {
+                defining_class.find_legacy_typevars_impl(
+                    db,
+                    env,
+                    binding_context,
+                    &mut members,
+                    visitor,
+                );
+            }
+            Self::Synthesized(synthesized) => {
+                synthesized.find_legacy_typevars_impl(
+                    db,
+                    env,
+                    binding_context,
+                    &mut members,
+                    visitor,
+                );
+            }
+        }
+        typevars.extend(
+            members
+                .into_iter()
+                .filter(|bound_typevar| !bound_typevar.typevar(db).is_self(db)),
+        );
     }
 
     pub(crate) fn from_schema_items(db: &'db dyn Db, items: TypedDictSchema<'db>) -> Self {
@@ -3024,6 +3070,25 @@ impl<'db> SynthesizedTypedDictType<'db> {
         match self.kind(db) {
             SynthesizedTypedDictKind::Schema => Self::schema(db, items, openness),
             SynthesizedTypedDictKind::Patch => Self::patch(db, items, openness),
+        }
+    }
+
+    fn find_legacy_typevars_impl(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        binding_context: Option<Definition<'db>>,
+        typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
+        visitor: &FindLegacyTypeVarsVisitor<'db>,
+    ) {
+        for field in self.items(db).values() {
+            field.declared_ty.find_legacy_typevars_impl(
+                db,
+                env,
+                binding_context,
+                typevars,
+                visitor,
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

A generic `TypedDict` used inside a generic type alias did not report its type variables, so subscripting the alias (e.g. `Alias[int]`) left `T` unsubstituted — leaking `T` and raising a false error. This makes typevar collection recurse into `TypedDict` members so the substitution applies.

## Test plan

Added an mdtest covering a generic `TypedDict` in a generic alias (checks `Alias[int]` resolves correctly, no error); ran the typed_dict, generics, and type_alias mdtest groups — all pass.

astral-sh/ty#4255