### PR TITLE
[ty] Respect instance dictionary storage for slotted classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/class/slots.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/slots.md
@@ -885,19 +885,53 @@ class CustomSetter:
 CustomSetter().shared = 1
 ```
 
-## Instance dictionaries and inherited annotations
+## Instance dictionaries require dictionary storage
 
-Typeshed declares `__dict__` on `object`. As an intentional limitation, the attribute therefore
-remains available through ordinary attribute lookup even when accessing it would raise an
-`AttributeError` at runtime.
+A slotted instance without dictionary storage does not expose `__dict__`, even though typeshed
+declares the attribute on `object`. The class itself still has its own namespace.
 
 ```py
 class Slotted:
     __slots__ = ("value",)
 
-reveal_type(Slotted().__dict__)  # revealed: dict[str, Any]
+Slotted().__dict__  # error: [unresolved-attribute]
 reveal_type(Slotted.__dict__)  # revealed: dict[str, Any]
 ```
+
+A slotted dataclass also omits the instance dictionary.
+
+```py
+from dataclasses import dataclass
+
+@dataclass(slots=True)
+class SlottedDataclass:
+    value: int
+
+SlottedDataclass(1).__dict__  # error: [unresolved-attribute]
+```
+
+An explicit dictionary slot restores access to the instance dictionary.
+
+```py
+class WithDictionary:
+    __slots__ = ("value", "__dict__")
+
+reveal_type(WithDictionary().__dict__)  # revealed: dict[str, Any]
+```
+
+An ordinary base class can also provide inherited dictionary storage.
+
+```py
+class OrdinaryBase:
+    pass
+
+class InheritedDictionary(OrdinaryBase):
+    __slots__ = ("value",)
+
+reveal_type(InheritedDictionary().__dict__)  # revealed: dict[str, Any]
+```
+
+## Guarded instance dictionary access
 
 An unslotted subclass can introduce an instance dictionary, so methods on a slotted base may access
 the dictionary after checking whether it exists.
@@ -917,6 +951,33 @@ class OrdinaryChild(SlottedBase):
     pass
 
 reveal_type(OrdinaryChild().__dict__)  # revealed: dict[str, Any]
+```
+
+A positive `hasattr` check can also establish that a value annotated with the slotted base is
+actually an instance of a subclass with a dictionary.
+
+```py
+def attributes(instance: SlottedBase) -> dict[str, Any]:
+    if hasattr(instance, "__dict__"):
+        reveal_type(instance.__dict__)  # revealed: dict[str, Any]
+        return instance.__dict__
+    return {}
+```
+
+## Virtual instance dictionaries
+
+A custom attribute getter can expose a virtual dictionary without providing dictionary-backed
+attribute storage.
+
+```py
+class VirtualDictionary:
+    __slots__ = ()
+
+    def __getattr__(self, name: str) -> int:
+        return 1
+
+reveal_type(VirtualDictionary().__dict__)  # revealed: int
+VirtualDictionary().extra = 1  # error: [unresolved-attribute]
 ```
 
 ## Weak-reference slots create descriptors

--- a/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
@@ -98,3 +98,25 @@ def f(x: object):
         # error: [unresolved-attribute] "Object of type `<Protocol with members '__qualname__'>` has no attribute `foo`"
         reveal_type(x.foo)  # revealed: Unknown
 ```
+
+Not every object has an instance dictionary, despite the broad `object.__dict__` annotation in
+typeshed. Checking for `__dict__` therefore preserves the corresponding protocol constraint.
+
+```py
+def has_dictionary(value: object) -> None:
+    if hasattr(value, "__dict__"):
+        reveal_type(value)  # revealed: <Protocol with members '__dict__'>
+```
+
+A final slotted class cannot gain an instance dictionary through a subclass, so the positive branch
+is unreachable.
+
+```py
+@final
+class FinalSlotted:
+    __slots__ = ()
+
+def no_dictionary(value: FinalSlotted) -> None:
+    if hasattr(value, "__dict__"):
+        reveal_type(value)  # revealed: Never
+```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
@@ -108,6 +108,22 @@ def has_dictionary(value: object) -> None:
         reveal_type(value)  # revealed: <Protocol with members '__dict__'>
 ```
 
+A protocol can be implemented by classes with or without instance dictionaries, so checking for
+`__dict__` preserves both possibilities.
+
+```py
+from typing import Protocol
+
+class HasValue(Protocol):
+    value: int
+
+def protocol_dictionary(value: HasValue) -> None:
+    if hasattr(value, "__dict__"):
+        reveal_type(value)  # revealed: HasValue & <Protocol with members '__dict__'>
+    else:
+        reveal_type(value)  # revealed: HasValue & ~<Protocol with members '__dict__'>
+```
+
 A final slotted class cannot gain an instance dictionary through a subclass, so the positive branch
 is unreachable.
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3696,8 +3696,28 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         key: MemberLookupKey<'db>,
+        receiver: Type<'db>,
     ) -> PlaceAndQualifiers<'db> {
         let ty = key.ty(db);
+
+        // `object.__dict__` is a typeshed approximation: a concrete slotted instance without
+        // dictionary storage does not inherit that attribute at runtime. Keep normal lookup for
+        // `Self` and other type variables because their subclasses can introduce a dictionary.
+        let key = if key.name(db) == "__dict__"
+            && let Type::NominalInstance(instance) = receiver
+            && let Some((class, _)) = instance.class(db, env).static_class_literal(db)
+            && class.lacks_instance_storage(db, "__dict__")
+        {
+            MemberLookupKey::new(
+                db,
+                key.program(db),
+                ty,
+                key.name(db).as_str(),
+                key.policy(db) | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            )
+        } else {
+            key
+        };
 
         if let Type::TypeVar(_) = ty {
             if let Some(class) = ty.nominal_class(db, env) {
@@ -4675,7 +4695,8 @@ impl<'db> Type<'db> {
         fallback: MemberLookupResult<'db>,
         policy: InstanceFallbackShadowsNonDataDescriptor,
     ) -> MemberLookupResult<'db> {
-        let meta_attr_plain = Self::instance_lookup_class_member_with_policy(db, env, key);
+        let meta_attr_plain =
+            Self::instance_lookup_class_member_with_policy(db, env, key, receiver);
         let meta_attr_ty = meta_attr_plain.place.ignore_possibly_undefined();
         // Preserve the receiver's type variables and all its narrowed class constraints.
         let owner = receiver.to_meta_type(db, env);

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1401,10 +1401,12 @@ impl<'db> ProtocolInstanceType<'db> {
         ) -> bool {
             let interface = protocol.interface(db);
 
-            // Hashability is not preserved by inheritance: subclasses can replace
-            // `object.__hash__` with `None`. A protocol that explicitly requires `__hash__`
-            // therefore does not describe every object, despite `object` defining that method.
-            if interface.includes_member(db, "__hash__") {
+            // Neither hashability nor instance-dictionary storage is guaranteed for every object.
+            // Subclasses can replace `object.__hash__` with `None`, while slotted instances can
+            // omit the `__dict__` that typeshed broadly declares on `object`.
+            if interface.includes_member(db, "__hash__")
+                || interface.includes_member(db, "__dict__")
+            {
                 return false;
             }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -495,7 +495,10 @@ impl<'db> ProtocolInterfaceView<'db> {
         self.interface.includes_member(db, name)
     }
 
-    /// Includes inherited `object` members except `__hash__`, which subclasses can disable.
+    /// Includes inherited `object` members that are guaranteed for every instance.
+    ///
+    /// Subclasses can disable `__hash__`, and slotted instances can omit the `__dict__` that
+    /// typeshed declares on `object`.
     fn includes_member_or_object_fallback(
         self,
         db: &'db dyn Db,
@@ -503,7 +506,7 @@ impl<'db> ProtocolInterfaceView<'db> {
         name: &str,
     ) -> bool {
         self.includes_member(db, name)
-            || name != "__hash__"
+            || !matches!(name, "__hash__" | "__dict__")
                 && object_member_names(db, self.interface.program(db)).contains(name)
                 && matches!(
                     Type::object().member(db, env, name).place,
@@ -3485,7 +3488,9 @@ fn non_object_protocol_member_count<'db>(
 ) -> usize {
     let inherited_member_count = object_member_names(db, interface.program(db))
         .iter()
-        .filter(|name| name.as_str() != "__hash__" && interface.includes_member(db, name))
+        .filter(|name| {
+            !matches!(name.as_str(), "__hash__" | "__dict__") && interface.includes_member(db, name)
+        })
         .count();
     interface.member_count(db) - inherited_member_count
 }


### PR DESCRIPTION
## Summary

Previously, we exposed the typeshed `object.__dict__` annotation even for slotted instances without an instance dictionary.

```python
class Slotted:
    __slots__ = ("value",)


Slotted().__dict__  # error: [unresolved-attribute]
```

We now check the actual receiver's instance layout before considering the inherited annotation. Explicit and inherited instance dictionaries, custom attribute getters, and subclass-polymorphic `Self` keep their existing behavior.

Protocols requiring `__dict__` are no longer treated as equivalent to `object`, so positive `hasattr` checks preserve dictionary evidence and final slotted classes narrow the positive branch to `Never`.

Follow-up to #27730.
