### PR TITLE
[ty] Accept enum members for lax Pydantic string and integer fields

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -789,6 +789,50 @@ LaxFieldModel(value=StringEnum.VALUE)
 LaxFieldModel(value=IntegerEnum.VALUE)
 ```
 
+### Enum values for integer fields
+
+In lax mode, Pydantic accepts enum members as integers by using their underlying values.
+
+```py
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+class IntegerEnum(Enum):
+    VALUE = 1
+
+class LaxModel(BaseModel):
+    value: int
+
+LaxModel(value=IntegerEnum.VALUE)
+```
+
+Strict models and fields reject ordinary enum members because they are not integers.
+
+```py
+class StrictModel(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    value: int
+
+class StrictFieldModel(BaseModel):
+    value: int = Field(strict=True)
+
+StrictModel(value=IntegerEnum.VALUE)  # error: [invalid-argument-type]
+StrictFieldModel(value=IntegerEnum.VALUE)  # error: [invalid-argument-type]
+```
+
+A field that opts out of model-wide strict mode accepts enum members again.
+
+```py
+class LaxFieldModel(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    value: int = Field(strict=False)
+
+LaxFieldModel(value=IntegerEnum.VALUE)
+```
+
 ### Changing a specific field
 
 Strict mode can also be activated for a specific field only:

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -738,6 +738,57 @@ JsonValueModel(value=SomethingElse())  # error: [invalid-argument-type]
 JsonValueModel(value={"outer": [1, {"inner": SomethingElse()}]})
 ```
 
+### Enum values for string fields
+
+In lax mode, Pydantic converts enum members to strings regardless of the member's underlying value.
+
+```py
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+class StringEnum(Enum):
+    VALUE = "value"
+
+class IntegerEnum(Enum):
+    VALUE = 1
+
+class LaxModel(BaseModel):
+    value: str
+
+LaxModel(value=StringEnum.VALUE)
+LaxModel(value=IntegerEnum.VALUE)
+```
+
+Strict models and fields reject ordinary enum members because they are not strings.
+
+```py
+class StrictModel(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    value: str
+
+class StrictFieldModel(BaseModel):
+    value: str = Field(strict=True)
+
+StrictModel(value=StringEnum.VALUE)  # error: [invalid-argument-type]
+StrictModel(value=IntegerEnum.VALUE)  # error: [invalid-argument-type]
+StrictFieldModel(value=StringEnum.VALUE)  # error: [invalid-argument-type]
+StrictFieldModel(value=IntegerEnum.VALUE)  # error: [invalid-argument-type]
+```
+
+A field that opts out of model-wide strict mode accepts enum members again.
+
+```py
+class LaxFieldModel(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    value: str = Field(strict=False)
+
+LaxFieldModel(value=StringEnum.VALUE)
+LaxFieldModel(value=IntegerEnum.VALUE)
+```
+
 ### Changing a specific field
 
 Strict mode can also be activated for a specific field only:

--- a/crates/ty_vendored/ty_extensions/pydantic.pyi
+++ b/crates/ty_vendored/ty_extensions/pydantic.pyi
@@ -23,7 +23,7 @@ type LaxDate = bytes | date | datetime | float | int | str | Decimal
 type LaxDatetime = bytes | date | datetime | float | int | str | Decimal
 type LaxDecimal = float | int | str | Decimal
 type LaxFloat = bool | bytes | float | int | str | Decimal
-type LaxInt = bool | bytes | float | int | str | Decimal
+type LaxInt = bool | bytes | float | int | str | Decimal | Enum
 type LaxIPv4Address = bytes | int | str | IPv4Address | IPv4Interface
 type LaxIPv4Interface = (
     bytes | int | str | tuple[object, object] | IPv4Address | IPv4Interface

--- a/crates/ty_vendored/ty_extensions/pydantic.pyi
+++ b/crates/ty_vendored/ty_extensions/pydantic.pyi
@@ -3,6 +3,7 @@
 
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from enum import Enum
 from ipaddress import (
     IPv4Address,
     IPv4Interface,
@@ -36,7 +37,7 @@ type LaxIPv6Network = bytes | int | str | IPv6Address | IPv6Interface | IPv6Netw
 type LaxPath = str | Path
 type LaxStrPattern = str | Pattern[str]
 type LaxBytesPattern = bytes | Pattern[bytes]
-type LaxStr = bytearray | bytes | str
+type LaxStr = bytearray | bytes | str | Enum
 type LaxTime = bytes | float | int | str | time | Decimal
 type LaxTimedelta = bytes | float | int | str | timedelta | Decimal
 type LaxUUID = str | UUID


### PR DESCRIPTION
## Summary

Previously, we rejected enum members passed to Pydantic string and integer fields, even though Pydantic accepts them in lax mode:

```python
from enum import Enum

from pydantic import BaseModel


class Color(Enum):
    RED = "red"


class Number(Enum):
    SEVEN = 7


class Model(BaseModel):
    name: str
    count: int


Model(name=Color.RED, count=Number.SEVEN)
Model(name=Number.SEVEN, count=Number.SEVEN)
```

We now include `Enum` in the accepted input types for both lax string and integer fields. Strict models and strict fields continue to reject ordinary enum members, while fields that opt out of model-wide strictness accept them.

Closes https://github.com/astral-sh/ty/issues/4259.
