### PR TITLE
[ty] Propagate narrowing through statically known branches

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -512,13 +512,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let node_with_kind = node.to_kind(self.module);
 
         let scope = Scope::new(parent, node_with_kind, children_start..children_start);
-        let is_class_scope = scope.kind().is_class();
+        let scope_kind = scope.kind();
         self.exception_context_stack_manager.enter_nested_scope();
 
         let file_scope_id = self.scopes.push(scope);
         self.place_tables.push(PlaceTableBuilder::default());
         self.use_def_maps
-            .push(Box::new(UseDefMapBuilder::new(is_class_scope)));
+            .push(Box::new(UseDefMapBuilder::new(scope_kind)));
         let ast_id_scope = self.ast_ids.push(AstIdsBuilder::default());
 
         let scope_id = ScopeId::new(self.db, self.file, file_scope_id);

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3008,7 +3008,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         };
 
         let (predicate, narrowing_id) = self.record_expression_narrowing_constraint(if_expr);
-        let reachability_constraint = self.record_reachability_constraint(predicate);
+        let reachability_constraint = self.record_reachability_constraint_id(narrowing_id);
         let included_path = self.flow_snapshot();
 
         self.flow_restore(filtered_out);
@@ -3278,7 +3278,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             self.flow_snapshot()
         };
         let (predicate, predicate_id) = self.record_expression_narrowing_constraint(test);
-        let reachability_constraint = self.record_reachability_constraint(predicate);
+        let reachability_constraint = self.record_reachability_constraint_id(predicate_id);
         let in_type_checking_block = self.in_type_checking_block;
         self.current_use_def_map_mut()
             .record_range_reachability(body.range(), in_type_checking_block);
@@ -3876,8 +3876,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         self.flow_snapshot()
                     };
                     let negated_predicate = predicate.negated();
-                    self.record_narrowing_constraint(negated_predicate);
-                    self.record_reachability_constraint(negated_predicate);
+                    let predicate_id = self.record_narrowing_constraint(negated_predicate);
+                    self.record_reachability_constraint_id(predicate_id);
                     if let Some(msg) = msg {
                         self.visit_expr(msg);
                     }
@@ -3887,8 +3887,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.flow_restore(truthy);
                 }
 
-                self.record_narrowing_constraint(predicate);
-                self.record_reachability_constraint(predicate);
+                let predicate_id = self.record_narrowing_constraint(predicate);
+                self.record_reachability_constraint_id(predicate_id);
             }
 
             ast::Stmt::Assign(node) => {
@@ -4040,7 +4040,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let (mut last_predicate, mut last_narrowing_id) =
                     self.record_expression_narrowing_constraint(&node.test);
                 let mut last_reachability_constraint =
-                    self.record_reachability_constraint(last_predicate);
+                    self.record_reachability_constraint_id(last_narrowing_id);
 
                 let is_outer_block_in_type_checking = self.in_type_checking_block;
 
@@ -4098,7 +4098,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             self.record_expression_narrowing_constraint(elif_test);
 
                         last_reachability_constraint =
-                            self.record_reachability_constraint(last_predicate);
+                            self.record_reachability_constraint_id(last_narrowing_id);
 
                         Some(next_falsy)
                     } else {
@@ -4177,7 +4177,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.flow_restore(truthy);
                 }
                 let (predicate, predicate_id) = self.record_expression_narrowing_constraint(test);
-                self.record_reachability_constraint(predicate);
+                self.record_reachability_constraint_id(predicate_id);
 
                 let outer_loop = self.push_loop();
                 self.visit_body(body);
@@ -4538,46 +4538,36 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         );
                     previous_pattern = Some(match_pattern_predicate);
                     let reachability_constraint =
-                        self.record_reachability_constraint(match_predicate);
+                        self.record_reachability_constraint_id(match_narrowing_id);
 
+                    // For a pattern `P` and guard `G`, the case body is reached through `P && G`,
+                    // while the next case is reached through `!P || (P && !G)`. Save `P && !G`
+                    // separately so it can be merged with the pattern-failure state after the body.
                     let match_success_guard_failure = case.guard.as_ref().map(|guard| {
-                        let guard_expr = self.add_standalone_expression(guard);
-                        // We could also add the guard expression as a reachability constraint, but
-                        // it seems unlikely that both the case predicate as well as the guard are
-                        // statically known conditions, so we currently don't model that.
-                        self.record_ambiguous_reachability();
                         self.visit_expr(guard);
                         let condition_flow_snapshot = self.flow_snapshot_for_condition(guard);
-                        let predicate = PredicateOrLiteral::Predicate(Predicate {
-                            node: PredicateNode::Expression(guard_expr),
-                            is_positive: true,
-                        });
-                        // Use the same predicate ID for the successful and failed checks.
-                        let guard_predicate_id = self.add_predicate(predicate);
-                        let possibly_narrowed = self.compute_possibly_narrowed_places(&predicate);
-                        let truthy =
-                            if let Some(snapshots) = condition_flow_snapshot.into_branches() {
-                                self.flow_restore(snapshots.falsy);
-                                snapshots.truthy
-                            } else {
-                                self.flow_snapshot()
-                            };
-                        self.current_use_def_map_mut()
-                            .record_negated_narrowing_constraint_for_places(
-                                guard_predicate_id,
-                                &possibly_narrowed,
-                            );
-                        self.current_use_def_map_mut()
-                            .record_exception_checkpoint_binding_change();
+                        let falsy = if let Some(snapshots) = condition_flow_snapshot.into_branches()
+                        {
+                            self.flow_restore(snapshots.truthy);
+                            snapshots.falsy
+                        } else {
+                            self.flow_snapshot()
+                        };
+
+                        let (guard_predicate, guard_predicate_id) =
+                            self.record_expression_narrowing_constraint(guard);
+                        let guard_reachability_constraint =
+                            self.record_reachability_constraint_id(guard_predicate_id);
+                        let guard_success = self.flow_snapshot();
+
+                        self.flow_restore(falsy);
+                        self.record_negated_narrowing_constraint(
+                            guard_predicate,
+                            guard_predicate_id,
+                        );
+                        self.record_negated_reachability_constraint(guard_reachability_constraint);
                         let match_success_guard_failure = self.flow_snapshot();
-                        self.flow_restore(truthy);
-                        self.current_use_def_map_mut()
-                            .record_narrowing_constraint_for_places(
-                                guard_predicate_id,
-                                &possibly_narrowed,
-                            );
-                        self.current_use_def_map_mut()
-                            .record_exception_checkpoint_binding_change();
+                        self.flow_restore(guard_success);
                         match_success_guard_failure
                     });
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4151,11 +4151,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     node_index: _,
                 },
             ) => {
-                let preserve_loop_narrowing = self.in_function_scope();
-                let enclosing_reachability_narrowing = self
-                    .current_use_def_map_mut()
-                    .replace_reachability_narrowing(preserve_loop_narrowing);
-
                 // Pre-walk the loop to collect all the bound places, then create a loop header
                 // definition for each bound place. See `struct LoopHeader` for more on this. Loop
                 // header definitions store the ID of a reserved `LoopHeader` that we populate
@@ -4233,9 +4228,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 for break_state in this_loop.break_states {
                     self.flow_merge(break_state);
                 }
-
-                self.current_use_def_map_mut()
-                    .replace_reachability_narrowing(enclosing_reachability_narrowing);
             }
             ast::Stmt::With(ast::StmtWith {
                 items,
@@ -4339,11 +4331,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ) => {
                 debug_assert_eq!(&self.current_assignments, &[]);
 
-                let preserve_loop_narrowing = self.in_function_scope();
-                let enclosing_reachability_narrowing = self
-                    .current_use_def_map_mut()
-                    .replace_reachability_narrowing(preserve_loop_narrowing);
-
                 let iter_expr = self.add_standalone_expression(iter);
                 self.visit_expr(iter);
                 let iteration_can_raise = *is_async || !Self::iteration_is_known_safe(iter);
@@ -4442,9 +4429,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 for break_state in this_loop.break_states {
                     self.flow_merge(break_state);
                 }
-
-                self.current_use_def_map_mut()
-                    .replace_reachability_narrowing(enclosing_reachability_narrowing);
             }
             ast::Stmt::Match(ast::StmtMatch {
                 subject,
@@ -5124,23 +5108,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             .narrowing_constraints
                             .add_atom(predicate_id);
 
-                        if self.in_function_scope() {
-                            let reachability_constraint = self
-                                .current_reachability_constraints_mut()
-                                .add_atom(predicate_id);
-                            self.current_use_def_map_mut()
-                                .record_non_terminal_call_constraints(
-                                    reachability_constraint,
-                                    narrowing_constraint,
-                                );
-                        } else {
-                            // In non-function scopes, we only record a narrowing constraint
-                            // (not a reachability constraint). Recording reachability for
-                            // calls in module scope is simply too expensive, and it's not
-                            // too important of a use case.
-                            self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
-                        }
+                        let reachability_constraint = self
+                            .current_reachability_constraints_mut()
+                            .add_atom(predicate_id);
+                        self.current_use_def_map_mut()
+                            .record_non_terminal_call_constraints(
+                                reachability_constraint,
+                                narrowing_constraint,
+                            );
                     }
                 }
             }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2163,6 +2163,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     ..
                 }) => Some(*n != 0),
                 ast::Expr::EllipsisLiteral(_) => Some(true),
+                ast::Expr::Lambda(_) | ast::Expr::Generator(_) => Some(true),
                 ast::Expr::NoneLiteral(_) => Some(false),
                 ast::Expr::UnaryOp(ast::ExprUnaryOp {
                     op: ast::UnaryOp::Not,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4150,6 +4150,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     node_index: _,
                 },
             ) => {
+                let preserve_loop_narrowing = self.in_function_scope();
+                let enclosing_reachability_narrowing = self
+                    .current_use_def_map_mut()
+                    .replace_reachability_narrowing(preserve_loop_narrowing);
+
                 // Pre-walk the loop to collect all the bound places, then create a loop header
                 // definition for each bound place. See `struct LoopHeader` for more on this. Loop
                 // header definitions store the ID of a reserved `LoopHeader` that we populate
@@ -4227,6 +4232,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 for break_state in this_loop.break_states {
                     self.flow_merge(break_state);
                 }
+
+                self.current_use_def_map_mut()
+                    .replace_reachability_narrowing(enclosing_reachability_narrowing);
             }
             ast::Stmt::With(ast::StmtWith {
                 items,
@@ -4330,6 +4338,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ) => {
                 debug_assert_eq!(&self.current_assignments, &[]);
 
+                let preserve_loop_narrowing = self.in_function_scope();
+                let enclosing_reachability_narrowing = self
+                    .current_use_def_map_mut()
+                    .replace_reachability_narrowing(preserve_loop_narrowing);
+
                 let iter_expr = self.add_standalone_expression(iter);
                 self.visit_expr(iter);
                 let iteration_can_raise = *is_async || !Self::iteration_is_known_safe(iter);
@@ -4428,6 +4441,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 for break_state in this_loop.break_states {
                     self.flow_merge(break_state);
                 }
+
+                self.current_use_def_map_mut()
+                    .replace_reachability_narrowing(enclosing_reachability_narrowing);
             }
             ast::Stmt::Match(ast::StmtMatch {
                 subject,

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -34,7 +34,7 @@ use symbol::ScopedSymbolId;
 pub use use_def::{
     ApplicableConstraints, BindingWithConstraints, BindingWithConstraintsIterator,
     DeclarationWithConstraint, DeclarationsIterator, LiveBinding, LoopHeaderId, NarrowingEvaluator,
-    ScopedDefinitionId, UseDefMap,
+    PredicateNarrowingTargets, ScopedDefinitionId, UseDefMap,
 };
 use use_def::{EnclosingSnapshotKey, ScopedEnclosingSnapshotId};
 

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -266,6 +266,29 @@ impl NarrowingConstraintsBuilder {
         }
     }
 
+    /// Adds a constraint that selects between two formulas based on `predicate`.
+    pub(crate) fn add_conditional(
+        &mut self,
+        predicate: ScopedPredicateId,
+        if_true: ScopedNarrowingConstraint,
+        if_false: ScopedNarrowingConstraint,
+    ) -> ScopedNarrowingConstraint {
+        let node = InteriorNode {
+            atom: predicate,
+            if_true,
+            if_uncertain: ALWAYS_FALSE,
+            if_false,
+        };
+        if let Some(cached) = self.interior_cache.get(&node) {
+            return *cached;
+        }
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return ALWAYS_TRUE;
+        }
+
+        self.add_interior(node)
+    }
+
     pub(crate) fn add_or_constraint(
         &mut self,
         a: ScopedNarrowingConstraint,

--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -263,6 +263,13 @@ impl ReachabilityConstraintsBuilder {
             return root;
         }
 
+        let root_node = self.interiors[root];
+        if let (Some(if_true), Some(if_false)) =
+            (terminal(root_node.if_true), terminal(root_node.if_false))
+        {
+            return narrowing_constraints.add_conditional(root_node.atom, if_true, if_false);
+        }
+
         let mut converted = FxHashMap::default();
         let mut actions = vec![Action::Visit(root)];
 

--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -7,6 +7,7 @@ use std::cmp::Ordering;
 use ruff_index::{Idx, IndexVec};
 use rustc_hash::FxHashMap;
 
+use crate::narrowing_constraints::{NarrowingConstraintsBuilder, ScopedNarrowingConstraint};
 use crate::predicate::ScopedPredicateId;
 use crate::rank::{RankBitBox, RankBitBoxVec};
 
@@ -229,6 +230,68 @@ impl ReachabilityConstraintsBuilder {
             self.mark_used(node.if_ambiguous);
             self.mark_used(node.if_false);
         }
+    }
+
+    /// Converts a reachability formula into a narrowing gate.
+    ///
+    /// An ambiguous reachability leaf cannot exclude a control-flow path, so its
+    /// narrowing gate is `ALWAYS_TRUE`, preserving any existing narrowing.
+    /// Interior ambiguous branches are omitted because narrowing follows the
+    /// runtime-true or runtime-false path of each predicate.
+    pub(crate) fn narrowing_gate(
+        &self,
+        root: ScopedReachabilityConstraintId,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+    ) -> ScopedNarrowingConstraint {
+        enum Action {
+            Visit(ScopedReachabilityConstraintId),
+            Finish(ScopedReachabilityConstraintId),
+        }
+
+        let terminal = |id| match id {
+            ScopedReachabilityConstraintId::ALWAYS_TRUE
+            | ScopedReachabilityConstraintId::AMBIGUOUS => {
+                Some(ScopedNarrowingConstraint::ALWAYS_TRUE)
+            }
+            ScopedReachabilityConstraintId::ALWAYS_FALSE => {
+                Some(ScopedNarrowingConstraint::ALWAYS_FALSE)
+            }
+            _ => None,
+        };
+
+        if let Some(root) = terminal(root) {
+            return root;
+        }
+
+        let mut converted = FxHashMap::default();
+        let mut actions = vec![Action::Visit(root)];
+
+        while let Some(action) = actions.pop() {
+            match action {
+                Action::Visit(id) => {
+                    if terminal(id).is_some() || converted.contains_key(&id) {
+                        continue;
+                    }
+
+                    let node = self.interiors[id];
+                    actions.push(Action::Finish(id));
+                    actions.push(Action::Visit(node.if_false));
+                    actions.push(Action::Visit(node.if_true));
+                }
+                Action::Finish(id) => {
+                    let node = self.interiors[id];
+                    let if_true =
+                        terminal(node.if_true).unwrap_or_else(|| converted[&node.if_true]);
+                    let if_false =
+                        terminal(node.if_false).unwrap_or_else(|| converted[&node.if_false]);
+                    let result =
+                        narrowing_constraints.add_conditional(node.atom, if_true, if_false);
+                    converted.insert(id, result);
+                }
+            }
+        }
+
+        converted[&root]
     }
 
     /// Implements the ordering that determines which level a TDD node appears at.

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -613,55 +613,20 @@ struct ConstraintTables<'db> {
 /// Reachability gates can contain predicates that are unrelated to the place being narrowed.
 /// Keeping the conservative targets computed while building the semantic index lets type
 /// inference skip constructing those predicates' full narrowing maps.
-///
-/// Scope-wide control-flow gates apply to every place that existed when they were recorded. At
-/// most two leading entries use the otherwise-reserved `ALWAYS_TRUE` predicate to retain the
-/// highest covered symbol and member IDs without adding fields to every cached constraint table.
 #[derive(Debug, Default, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub struct PredicateNarrowingTargets(Box<[(ScopedPredicateId, ScopedPlaceId)]>);
 
 impl PredicateNarrowingTargets {
-    fn from_entries(
-        mut entries: Vec<(ScopedPredicateId, ScopedPlaceId)>,
-        scope_wide_targets: ScopeWideNarrowingTargets,
-    ) -> Self {
+    fn from_entries(mut entries: Vec<(ScopedPredicateId, ScopedPlaceId)>) -> Self {
         entries.sort_unstable_by_key(|&(predicate, place)| (place, predicate));
         entries.dedup();
-
-        let mut marker_count = 0;
-        if scope_wide_targets.symbols > 0 {
-            entries.push((
-                ScopedPredicateId::ALWAYS_TRUE,
-                ScopedPlaceId::Symbol(ScopedSymbolId::new(scope_wide_targets.symbols - 1)),
-            ));
-            marker_count += 1;
-        }
-        if scope_wide_targets.members > 0 {
-            entries.push((
-                ScopedPredicateId::ALWAYS_TRUE,
-                ScopedPlaceId::Member(ScopedMemberId::new(scope_wide_targets.members - 1)),
-            ));
-            marker_count += 1;
-        }
-        entries.rotate_right(marker_count);
 
         Self(entries.into_boxed_slice())
     }
 
-    fn place_specific_entries(&self) -> &[(ScopedPredicateId, ScopedPlaceId)] {
-        let marker_count = self
-            .0
-            .iter()
-            .take(2)
-            .take_while(|(predicate, _)| *predicate == ScopedPredicateId::ALWAYS_TRUE)
-            .count();
-
-        &self.0[marker_count..]
-    }
-
     /// Returns whether `predicate` may narrow `place`.
     pub fn contains(&self, predicate: ScopedPredicateId, place: ScopedPlaceId) -> bool {
-        self.place_specific_entries()
+        self.0
             .binary_search_by_key(&(place, predicate), |&(predicate, place)| {
                 (place, predicate)
             })
@@ -670,30 +635,10 @@ impl PredicateNarrowingTargets {
 
     /// Returns whether any predicate may narrow `place`.
     pub fn contains_place(&self, place: ScopedPlaceId) -> bool {
-        self.place_specific_entries()
+        self.0
             .binary_search_by_key(&place, |&(_, target)| target)
             .is_ok()
     }
-
-    /// Returns whether a scope-wide control-flow gate can affect `place`.
-    pub fn contains_scope_wide_control_flow(&self, place: ScopedPlaceId) -> bool {
-        self.0
-            .iter()
-            .take(2)
-            .take_while(|(predicate, _)| *predicate == ScopedPredicateId::ALWAYS_TRUE)
-            .any(|&(_, last_place)| match (place, last_place) {
-                (ScopedPlaceId::Symbol(place), ScopedPlaceId::Symbol(last)) => place <= last,
-                (ScopedPlaceId::Member(place), ScopedPlaceId::Member(last)) => place <= last,
-                _ => false,
-            })
-    }
-}
-
-/// Number of places covered by at least one scope-wide narrowing gate.
-#[derive(Clone, Copy, Debug, Default)]
-struct ScopeWideNarrowingTargets {
-    symbols: usize,
-    members: usize,
 }
 
 /// Fields that are empty in most use-def maps.
@@ -1848,9 +1793,6 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Predicate-place pairs for which a narrowing constraint was recorded.
     predicate_narrowing_targets: Vec<(ScopedPredicateId, ScopedPlaceId)>,
 
-    /// Places that existed when a control-flow gate was applied to the entire scope.
-    scope_wide_narrowing_targets: ScopeWideNarrowingTargets,
-
     /// Builder of reachability constraints.
     pub(super) reachability_constraints: ReachabilityConstraintsBuilder,
 
@@ -1914,9 +1856,6 @@ pub(super) struct UseDefMapBuilder<'db> {
     is_class_scope: bool,
 
     /// Whether reachability predicates should also preserve narrowing across branches.
-    ///
-    /// This is disabled inside module- and class-scope loops, where loop-carried forward
-    /// references can otherwise introduce cycles through their narrowing predicates.
     reachability_narrowing_enabled: bool,
 }
 
@@ -1926,7 +1865,6 @@ impl<'db> UseDefMapBuilder<'db> {
             all_definitions: IndexVec::from_iter([DefinitionEntry::Undefined]),
             predicates: PredicatesBuilder::default(),
             predicate_narrowing_targets: Vec::new(),
-            scope_wide_narrowing_targets: ScopeWideNarrowingTargets::default(),
             reachability_constraints: ReachabilityConstraintsBuilder::default(),
             narrowing_constraints: NarrowingConstraintsBuilder::default(),
             bindings_by_use: IndexVec::new(),
@@ -1949,11 +1887,6 @@ impl<'db> UseDefMapBuilder<'db> {
                 ScopeKind::Module | ScopeKind::Class | ScopeKind::Function | ScopeKind::Lambda
             ),
         }
-    }
-
-    /// Sets whether reachability also creates narrowing gates, returning the previous setting.
-    pub(super) fn replace_reachability_narrowing(&mut self, enabled: bool) -> bool {
-        std::mem::replace(&mut self.reachability_narrowing_enabled, enabled)
     }
 
     pub(super) fn reserve_loop_header(&mut self) -> LoopHeaderId {
@@ -2374,41 +2307,6 @@ impl<'db> UseDefMapBuilder<'db> {
                 &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             );
-        }
-    }
-
-    /// Records a narrowing constraint for all places in the current scope.
-    ///
-    /// This is used to gate narrowing by `IsNonTerminalCall` constraints: when a branch contains
-    /// a call to a `NoReturn` function, all narrowing in that branch should be conditional
-    /// on the call actually returning `Never`.
-    pub(super) fn record_narrowing_constraint_for_all_places(
-        &mut self,
-        constraint: ScopedNarrowingConstraint,
-    ) {
-        self.checkpoint_state.record_call_gate();
-        self.scope_wide_narrowing_targets.symbols = self
-            .scope_wide_narrowing_targets
-            .symbols
-            .max(self.symbol_states.len());
-        self.scope_wide_narrowing_targets.members = self
-            .scope_wide_narrowing_targets
-            .members
-            .max(self.member_states.len());
-
-        let pending = self.pending_reachability.current;
-        for state in self
-            .symbol_states
-            .iter_mut()
-            .chain(self.member_states.iter_mut())
-        {
-            let state = self.pending_reachability.materialize(
-                state,
-                pending,
-                &mut self.narrowing_constraints,
-                &mut self.reachability_constraints,
-            );
-            state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
         }
     }
 
@@ -3038,10 +2936,8 @@ impl<'db> UseDefMapBuilder<'db> {
             })
         });
         let predicates = self.predicates.build();
-        let predicate_narrowing_targets = PredicateNarrowingTargets::from_entries(
-            self.predicate_narrowing_targets,
-            self.scope_wide_narrowing_targets,
-        );
+        let predicate_narrowing_targets =
+            PredicateNarrowingTargets::from_entries(self.predicate_narrowing_targets);
         let reachability_constraints = self.reachability_constraints.build();
         let narrowing_constraints = self.narrowing_constraints.build();
         let constraint_tables = (!reachability_constraints.used_interiors().is_empty()

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1915,10 +1915,13 @@ pub(super) struct UseDefMapBuilder<'db> {
 
     /// Is this a class scope?
     is_class_scope: bool,
+
+    /// Whether reachability predicates should also preserve narrowing across branches.
+    is_function_scope: bool,
 }
 
 impl<'db> UseDefMapBuilder<'db> {
-    pub(super) fn new(is_class_scope: bool) -> Self {
+    pub(super) fn new(scope_kind: ScopeKind) -> Self {
         Self {
             all_definitions: IndexVec::from_iter([DefinitionEntry::Undefined]),
             predicates: PredicatesBuilder::default(),
@@ -1940,7 +1943,8 @@ impl<'db> UseDefMapBuilder<'db> {
             reachable_symbol_definitions: IndexVec::new(),
             enclosing_snapshots: EnclosingSnapshots::default(),
             loop_headers: IndexVec::new(),
-            is_class_scope,
+            is_class_scope: scope_kind.is_class(),
+            is_function_scope: matches!(scope_kind, ScopeKind::Function | ScopeKind::Lambda),
         }
     }
 
@@ -2408,9 +2412,12 @@ impl<'db> UseDefMapBuilder<'db> {
         self.checkpoint_flow = self
             .reachability_constraints
             .add_and_constraint(self.checkpoint_flow, reachability_constraint);
-        let narrowing_constraint = self
-            .reachability_constraints
-            .narrowing_gate(reachability_constraint, &mut self.narrowing_constraints);
+        let narrowing_constraint = if self.is_function_scope {
+            self.reachability_constraints
+                .narrowing_gate(reachability_constraint, &mut self.narrowing_constraints)
+        } else {
+            ScopedNarrowingConstraint::ALWAYS_TRUE
+        };
         self.record_reachability_constraint_impl(reachability_constraint, narrowing_constraint);
     }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1917,7 +1917,10 @@ pub(super) struct UseDefMapBuilder<'db> {
     is_class_scope: bool,
 
     /// Whether reachability predicates should also preserve narrowing across branches.
-    is_function_scope: bool,
+    ///
+    /// This is disabled inside module- and class-scope loops, where loop-carried forward
+    /// references can otherwise introduce cycles through their narrowing predicates.
+    reachability_narrowing_enabled: bool,
 }
 
 impl<'db> UseDefMapBuilder<'db> {
@@ -1944,8 +1947,16 @@ impl<'db> UseDefMapBuilder<'db> {
             enclosing_snapshots: EnclosingSnapshots::default(),
             loop_headers: IndexVec::new(),
             is_class_scope: scope_kind.is_class(),
-            is_function_scope: matches!(scope_kind, ScopeKind::Function | ScopeKind::Lambda),
+            reachability_narrowing_enabled: matches!(
+                scope_kind,
+                ScopeKind::Module | ScopeKind::Class | ScopeKind::Function | ScopeKind::Lambda
+            ),
         }
+    }
+
+    /// Sets whether reachability also creates narrowing gates, returning the previous setting.
+    pub(super) fn replace_reachability_narrowing(&mut self, enabled: bool) -> bool {
+        std::mem::replace(&mut self.reachability_narrowing_enabled, enabled)
     }
 
     pub(super) fn reserve_loop_header(&mut self) -> LoopHeaderId {
@@ -2412,7 +2423,7 @@ impl<'db> UseDefMapBuilder<'db> {
         self.checkpoint_flow = self
             .reachability_constraints
             .add_and_constraint(self.checkpoint_flow, reachability_constraint);
-        let narrowing_constraint = if self.is_function_scope {
+        let narrowing_constraint = if self.reachability_narrowing_enabled {
             self.reachability_constraints
                 .narrowing_gate(reachability_constraint, &mut self.narrowing_constraints)
         } else {

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -603,8 +603,41 @@ enum InternedEnclosingSnapshotId {
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 struct ConstraintTables<'db> {
     predicates: Predicates<'db>,
+    predicate_narrowing_targets: PredicateNarrowingTargets,
     reachability_constraints: ReachabilityConstraints,
     narrowing_constraints: NarrowingConstraints,
+}
+
+/// Predicate-place pairs for which type narrowing may produce a constraint.
+///
+/// Reachability gates can contain predicates that are unrelated to the place being narrowed.
+/// Keeping the conservative targets computed while building the semantic index lets type
+/// inference skip constructing those predicates' full narrowing maps.
+#[derive(Debug, Default, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+pub struct PredicateNarrowingTargets(Box<[(ScopedPredicateId, ScopedPlaceId)]>);
+
+impl PredicateNarrowingTargets {
+    fn from_entries(mut entries: Vec<(ScopedPredicateId, ScopedPlaceId)>) -> Self {
+        entries.sort_unstable_by_key(|&(predicate, place)| (place, predicate));
+        entries.dedup();
+        Self(entries.into_boxed_slice())
+    }
+
+    /// Returns whether `predicate` may narrow `place`.
+    pub fn contains(&self, predicate: ScopedPredicateId, place: ScopedPlaceId) -> bool {
+        self.0
+            .binary_search_by_key(&(place, predicate), |&(predicate, place)| {
+                (place, predicate)
+            })
+            .is_ok()
+    }
+
+    /// Returns whether any predicate may narrow `place`.
+    pub fn contains_place(&self, place: ScopedPlaceId) -> bool {
+        self.0
+            .binary_search_by_key(&place, |&(_, target)| target)
+            .is_ok()
+    }
 }
 
 /// Fields that are empty in most use-def maps.
@@ -635,6 +668,7 @@ struct UseDefMapExtra {
 static EMPTY_CONSTRAINT_TABLES: LazyLock<ConstraintTables<'static>> =
     LazyLock::new(|| ConstraintTables {
         predicates: IndexVec::new().into(),
+        predicate_narrowing_targets: PredicateNarrowingTargets::default(),
         reachability_constraints: ReachabilityConstraintsBuilder::default().build(),
         narrowing_constraints: NarrowingConstraintsBuilder::default().build(),
     });
@@ -1289,6 +1323,10 @@ impl<'map, 'db> NarrowingEvaluator<'map, 'db> {
         &self.constraint_tables.predicates
     }
 
+    pub fn predicate_narrowing_targets(&self) -> &'map PredicateNarrowingTargets {
+        &self.constraint_tables.predicate_narrowing_targets
+    }
+
     pub fn narrowing_constraints(&self) -> &'map NarrowingConstraints {
         &self.constraint_tables.narrowing_constraints
     }
@@ -1751,6 +1789,9 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Builder of predicates.
     predicates: PredicatesBuilder<'db>,
 
+    /// Predicate-place pairs for which a narrowing constraint was recorded.
+    predicate_narrowing_targets: Vec<(ScopedPredicateId, ScopedPlaceId)>,
+
     /// Builder of reachability constraints.
     pub(super) reachability_constraints: ReachabilityConstraintsBuilder,
 
@@ -1819,6 +1860,7 @@ impl<'db> UseDefMapBuilder<'db> {
         Self {
             all_definitions: IndexVec::from_iter([DefinitionEntry::Undefined]),
             predicates: PredicatesBuilder::default(),
+            predicate_narrowing_targets: Vec::new(),
             reachability_constraints: ReachabilityConstraintsBuilder::default(),
             narrowing_constraints: NarrowingConstraintsBuilder::default(),
             bindings_by_use: IndexVec::new(),
@@ -1988,6 +2030,9 @@ impl<'db> UseDefMapBuilder<'db> {
             return;
         }
 
+        self.predicate_narrowing_targets
+            .extend(places.iter().map(|place| (predicate, *place)));
+
         let atom = self.narrowing_constraints.add_atom(predicate);
         self.record_narrowing_constraint_node_for_places(atom, places);
     }
@@ -2005,6 +2050,8 @@ impl<'db> UseDefMapBuilder<'db> {
         {
             return;
         }
+
+        self.predicate_narrowing_targets.push((predicate, place));
 
         let constraint = self.narrowing_constraints.add_atom(predicate);
         let pending = self.pending_reachability.current;
@@ -2035,6 +2082,8 @@ impl<'db> UseDefMapBuilder<'db> {
         {
             return;
         }
+
+        self.predicate_narrowing_targets.push((predicate, place));
 
         let constraint = self.narrowing_constraints.add_atom(predicate);
         let pending = self.pending_reachability.current;
@@ -2067,6 +2116,9 @@ impl<'db> UseDefMapBuilder<'db> {
         {
             return;
         }
+
+        self.predicate_narrowing_targets
+            .extend(places.iter().map(|place| (predicate, *place)));
 
         let negated = self.narrowing_constraints.add_negated_atom(predicate);
         self.record_narrowing_constraint_node_for_places(negated, places);
@@ -2900,6 +2952,8 @@ impl<'db> UseDefMapBuilder<'db> {
             })
         });
         let predicates = self.predicates.build();
+        let predicate_narrowing_targets =
+            PredicateNarrowingTargets::from_entries(self.predicate_narrowing_targets);
         let reachability_constraints = self.reachability_constraints.build();
         let narrowing_constraints = self.narrowing_constraints.build();
         let constraint_tables = (!reachability_constraints.used_interiors().is_empty()
@@ -2907,6 +2961,7 @@ impl<'db> UseDefMapBuilder<'db> {
         .then(|| {
             Box::new(ConstraintTables {
                 predicates,
+                predicate_narrowing_targets,
                 reachability_constraints,
                 narrowing_constraints,
             })

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -649,15 +649,12 @@ impl PredicateNarrowingTargets {
     }
 
     fn place_specific_entries(&self) -> &[(ScopedPredicateId, ScopedPlaceId)] {
-        let marker_count = usize::from(
-            self.0
-                .first()
-                .is_some_and(|&(predicate, _)| predicate == ScopedPredicateId::ALWAYS_TRUE),
-        ) + usize::from(
-            self.0
-                .get(1)
-                .is_some_and(|&(predicate, _)| predicate == ScopedPredicateId::ALWAYS_TRUE),
-        );
+        let marker_count = self
+            .0
+            .iter()
+            .take(2)
+            .take_while(|(predicate, _)| *predicate == ScopedPredicateId::ALWAYS_TRUE)
+            .count();
 
         &self.0[marker_count..]
     }
@@ -2183,7 +2180,9 @@ impl<'db> UseDefMapBuilder<'db> {
     /// Records a negated narrowing constraint for only the specified places.
     ///
     /// The positive and negative constraints use the same predicate ID. This lets `P or not P`
-    /// simplify to `ALWAYS_TRUE`, so narrowing cancels out after a complete `if`/`else`.
+    /// simplify to `ALWAYS_TRUE`, so narrowing cancels out after a complete `if`/`else`. The
+    /// predicate's possible targets are independent of its polarity and were already recorded
+    /// with the positive constraint.
     pub(super) fn record_negated_narrowing_constraint_for_places(
         &mut self,
         predicate: ScopedPredicateId,
@@ -2194,9 +2193,6 @@ impl<'db> UseDefMapBuilder<'db> {
         {
             return;
         }
-
-        self.predicate_narrowing_targets
-            .extend(places.iter().map(|place| (predicate, *place)));
 
         let negated = self.narrowing_constraints.add_negated_atom(predicate);
         self.record_narrowing_constraint_node_for_places(negated, places);

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -613,19 +613,58 @@ struct ConstraintTables<'db> {
 /// Reachability gates can contain predicates that are unrelated to the place being narrowed.
 /// Keeping the conservative targets computed while building the semantic index lets type
 /// inference skip constructing those predicates' full narrowing maps.
+///
+/// Scope-wide control-flow gates apply to every place that existed when they were recorded. At
+/// most two leading entries use the otherwise-reserved `ALWAYS_TRUE` predicate to retain the
+/// highest covered symbol and member IDs without adding fields to every cached constraint table.
 #[derive(Debug, Default, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub struct PredicateNarrowingTargets(Box<[(ScopedPredicateId, ScopedPlaceId)]>);
 
 impl PredicateNarrowingTargets {
-    fn from_entries(mut entries: Vec<(ScopedPredicateId, ScopedPlaceId)>) -> Self {
+    fn from_entries(
+        mut entries: Vec<(ScopedPredicateId, ScopedPlaceId)>,
+        scope_wide_targets: ScopeWideNarrowingTargets,
+    ) -> Self {
         entries.sort_unstable_by_key(|&(predicate, place)| (place, predicate));
         entries.dedup();
+
+        let mut marker_count = 0;
+        if scope_wide_targets.symbols > 0 {
+            entries.push((
+                ScopedPredicateId::ALWAYS_TRUE,
+                ScopedPlaceId::Symbol(ScopedSymbolId::new(scope_wide_targets.symbols - 1)),
+            ));
+            marker_count += 1;
+        }
+        if scope_wide_targets.members > 0 {
+            entries.push((
+                ScopedPredicateId::ALWAYS_TRUE,
+                ScopedPlaceId::Member(ScopedMemberId::new(scope_wide_targets.members - 1)),
+            ));
+            marker_count += 1;
+        }
+        entries.rotate_right(marker_count);
+
         Self(entries.into_boxed_slice())
+    }
+
+    fn place_specific_entries(&self) -> &[(ScopedPredicateId, ScopedPlaceId)] {
+        let marker_count = usize::from(
+            self.0
+                .first()
+                .is_some_and(|&(predicate, _)| predicate == ScopedPredicateId::ALWAYS_TRUE),
+        ) + usize::from(
+            self.0
+                .get(1)
+                .is_some_and(|&(predicate, _)| predicate == ScopedPredicateId::ALWAYS_TRUE),
+        );
+
+        &self.0[marker_count..]
     }
 
     /// Returns whether `predicate` may narrow `place`.
     pub fn contains(&self, predicate: ScopedPredicateId, place: ScopedPlaceId) -> bool {
-        self.0
+        self.place_specific_entries()
             .binary_search_by_key(&(place, predicate), |&(predicate, place)| {
                 (place, predicate)
             })
@@ -634,10 +673,30 @@ impl PredicateNarrowingTargets {
 
     /// Returns whether any predicate may narrow `place`.
     pub fn contains_place(&self, place: ScopedPlaceId) -> bool {
-        self.0
+        self.place_specific_entries()
             .binary_search_by_key(&place, |&(_, target)| target)
             .is_ok()
     }
+
+    /// Returns whether a scope-wide control-flow gate can affect `place`.
+    pub fn contains_scope_wide_control_flow(&self, place: ScopedPlaceId) -> bool {
+        self.0
+            .iter()
+            .take(2)
+            .take_while(|(predicate, _)| *predicate == ScopedPredicateId::ALWAYS_TRUE)
+            .any(|&(_, last_place)| match (place, last_place) {
+                (ScopedPlaceId::Symbol(place), ScopedPlaceId::Symbol(last)) => place <= last,
+                (ScopedPlaceId::Member(place), ScopedPlaceId::Member(last)) => place <= last,
+                _ => false,
+            })
+    }
+}
+
+/// Number of places covered by at least one scope-wide narrowing gate.
+#[derive(Clone, Copy, Debug, Default)]
+struct ScopeWideNarrowingTargets {
+    symbols: usize,
+    members: usize,
 }
 
 /// Fields that are empty in most use-def maps.
@@ -1792,6 +1851,9 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Predicate-place pairs for which a narrowing constraint was recorded.
     predicate_narrowing_targets: Vec<(ScopedPredicateId, ScopedPlaceId)>,
 
+    /// Places that existed when a control-flow gate was applied to the entire scope.
+    scope_wide_narrowing_targets: ScopeWideNarrowingTargets,
+
     /// Builder of reachability constraints.
     pub(super) reachability_constraints: ReachabilityConstraintsBuilder,
 
@@ -1861,6 +1923,7 @@ impl<'db> UseDefMapBuilder<'db> {
             all_definitions: IndexVec::from_iter([DefinitionEntry::Undefined]),
             predicates: PredicatesBuilder::default(),
             predicate_narrowing_targets: Vec::new(),
+            scope_wide_narrowing_targets: ScopeWideNarrowingTargets::default(),
             reachability_constraints: ReachabilityConstraintsBuilder::default(),
             narrowing_constraints: NarrowingConstraintsBuilder::default(),
             bindings_by_use: IndexVec::new(),
@@ -2313,6 +2376,15 @@ impl<'db> UseDefMapBuilder<'db> {
         constraint: ScopedNarrowingConstraint,
     ) {
         self.checkpoint_state.record_call_gate();
+        self.scope_wide_narrowing_targets.symbols = self
+            .scope_wide_narrowing_targets
+            .symbols
+            .max(self.symbol_states.len());
+        self.scope_wide_narrowing_targets.members = self
+            .scope_wide_narrowing_targets
+            .members
+            .max(self.member_states.len());
+
         let pending = self.pending_reachability.current;
         for state in self
             .symbol_states
@@ -2952,8 +3024,10 @@ impl<'db> UseDefMapBuilder<'db> {
             })
         });
         let predicates = self.predicates.build();
-        let predicate_narrowing_targets =
-            PredicateNarrowingTargets::from_entries(self.predicate_narrowing_targets);
+        let predicate_narrowing_targets = PredicateNarrowingTargets::from_entries(
+            self.predicate_narrowing_targets,
+            self.scope_wide_narrowing_targets,
+        );
         let reachability_constraints = self.reachability_constraints.build();
         let narrowing_constraints = self.narrowing_constraints.build();
         let constraint_tables = (!reachability_constraints.used_interiors().is_empty()

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1379,7 +1379,7 @@ struct PendingReachabilityConstraint {
     narrowing_constraint: ScopedNarrowingConstraint,
 }
 
-/// An append-only tree of scope-wide reachability constraints and call narrowing gates.
+/// An append-only tree of scope-wide reachability constraints and narrowing gates.
 ///
 /// Each [`PendingPlaceState`] remembers the last node applied for each constraint kind, so
 /// snapshots can share place states and defer applying subsequent constraints until needed.
@@ -1520,8 +1520,8 @@ impl PendingReachability {
 
     /// Returns the place state needed to resolve a use.
     ///
-    /// A call's narrowing gate is only needed if the place is later changed or merged, so it is
-    /// not materialized here.
+    /// Pending narrowing gates are only needed to preserve path correlations across a later place
+    /// change or merge, so they are not materialized here.
     fn materialize_ref_at_use<'a>(
         &self,
         pending: &'a mut PendingPlaceState,
@@ -1556,7 +1556,7 @@ impl PendingReachability {
         constraint
     }
 
-    /// Combines the call narrowing gates after `ancestor` through `target` into one constraint.
+    /// Combines the narrowing gates after `ancestor` through `target` into one constraint.
     ///
     /// `ancestor` must be an ancestor of `target`.
     fn narrowing_constraint_between(
@@ -1682,7 +1682,7 @@ impl PendingReachability {
                     continue;
                 }
 
-                // Preserve call gates that precede the branch, then merge gates introduced on the
+                // Preserve gates that precede the branch, then merge gates introduced on the
                 // individual branch paths. If either path has no gate, the merged gate simplifies
                 // to `ALWAYS_TRUE` and can be discarded.
                 self.materialize_narrowing(current, branch_ancestor, narrowing_constraints);
@@ -1903,12 +1903,6 @@ impl<'db> UseDefMapBuilder<'db> {
     pub(super) fn exception_checkpoint_key(&self) -> ExceptionCheckpointKey {
         self.checkpoint_state
             .key((!self.reachability_constraints.is_saturated()).then_some(self.checkpoint_flow))
-    }
-
-    /// Invalidates checkpoint reuse for narrowing that has no corresponding reachability predicate.
-    /// Match guards use this because their success and failure are not modeled in reachability.
-    pub(super) fn record_exception_checkpoint_binding_change(&mut self) {
-        self.checkpoint_state.record_binding_change();
     }
 
     pub(super) fn record_binding(
@@ -2285,18 +2279,18 @@ impl<'db> UseDefMapBuilder<'db> {
 
     pub(super) fn record_reachability_constraint(
         &mut self,
-        constraint: ScopedReachabilityConstraintId,
+        reachability_constraint: ScopedReachabilityConstraintId,
     ) {
         self.checkpoint_flow = self
             .reachability_constraints
-            .add_and_constraint(self.checkpoint_flow, constraint);
-        self.record_reachability_constraint_impl(
-            constraint,
-            ScopedNarrowingConstraint::ALWAYS_TRUE,
-        );
+            .add_and_constraint(self.checkpoint_flow, reachability_constraint);
+        let narrowing_constraint = self
+            .reachability_constraints
+            .narrowing_gate(reachability_constraint, &mut self.narrowing_constraints);
+        self.record_reachability_constraint_impl(reachability_constraint, narrowing_constraint);
     }
 
-    /// Records a call's reachability predicate and its corresponding narrowing gate together.
+    /// Records a reachability predicate and its corresponding narrowing gate together.
     ///
     /// Reachability is materialized when a place is used, while the narrowing gate remains pending
     /// until that place is changed or merged.
@@ -2784,8 +2778,8 @@ impl<'db> UseDefMapBuilder<'db> {
             .iter_mut()
             .chain(self.member_states.iter_mut())
         {
-            // No later state change can require the correlation represented by pending call
-            // narrowing gates, so only reachability needs to be finalized here.
+            // No later place change or merge can require the path correlation represented by
+            // pending narrowing gates, so only reachability needs to be finalized here.
             self.pending_reachability.materialize_reachability(
                 state,
                 pending,

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -184,6 +184,61 @@ class Record(TypedDict):
     value: int
 ```
 
+### Deferred forward references in nested non-function loops
+
+A loop-carried forward reference keeps its declared type when the module-level loop is nested inside
+a conditional.
+
+```py
+from __future__ import annotations
+from typing import Never, TypedDict, overload
+
+@overload
+def inspect(value: str) -> Never: ...
+@overload
+def inspect(value: object) -> int: ...
+def inspect(value: object) -> int:
+    return 1
+
+if bool(input()) and bool(input()):
+    for _ in range(2):
+        record: ModuleRecord
+        record = {"value": 1}
+        inspect(record)
+        reveal_type(record)  # revealed: ModuleRecord
+
+class ModuleRecord(TypedDict):
+    value: int
+```
+
+A statically known outer branch also preserves the loop-carried declaration.
+
+```py
+if 1 + 1 == 2:
+    for _ in range(2):
+        record: StaticModuleRecord
+        record = {"value": 1}
+        inspect(record)
+        reveal_type(record)  # revealed: StaticModuleRecord
+
+class StaticModuleRecord(TypedDict):
+    value: int
+```
+
+The same holds for a forward reference carried by a class-body `while` loop.
+
+```py
+class Container:
+    while bool(input()):
+        record: ClassRecord
+        record = {"value": 1}
+        inspect(record)
+        reveal_type(record)  # revealed: ClassRecord
+
+class ClassRecord(TypedDict):
+    value: int
+```
+
 ### Deferred forward references on Python 3.14
 
 Annotations are deferred by default in Python 3.14 and later.

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -157,6 +157,33 @@ class Record(TypedDict):
     value: int
 ```
 
+### Deferred forward references in overloaded calls
+
+Selecting an overload must not recursively infer a loop-carried forward reference before its
+declared `TypedDict` is available.
+
+```py
+from __future__ import annotations
+from typing import Never, TypedDict, overload
+
+@overload
+def inspect(value: str) -> Never: ...
+@overload
+def inspect(value: object) -> int: ...
+def inspect(value: object) -> int:
+    return 1
+
+for _ in range(2):
+    record: Record
+    record = {"value": 1}
+    inspect(record)
+    reveal_type(record)  # revealed: Record
+    record["missing"]  # error: [invalid-key]
+
+class Record(TypedDict):
+    value: int
+```
+
 ### Deferred forward references on Python 3.14
 
 Annotations are deferred by default in Python 3.14 and later.

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -225,15 +225,16 @@ class StaticModuleRecord(TypedDict):
     value: int
 ```
 
-The same holds for a forward reference carried by a class-body `while` loop.
+TODO: In class-body `while` loops, eager collection cycle recovery loses the declared `TypedDict`
+context.
 
 ```py
 class Container:
     while bool(input()):
-        record: ClassRecord
+        record: ClassRecord  # error: [invalid-declaration]
         record = {"value": 1}
         inspect(record)
-        reveal_type(record)  # revealed: ClassRecord
+        reveal_type(record)  # revealed: dict[str, int]
 
 class ClassRecord(TypedDict):
     value: int

--- a/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -137,7 +137,7 @@ def _(flag: bool):
 
 def _(flag: bool, possibly_falsy_int: int, possibly_falsy_str: str):
     (flag and (x := possibly_falsy_int)) or (x := possibly_falsy_str)
-    reveal_type(x)  # revealed: int | str
+    reveal_type(x)  # revealed: (int & ~AlwaysFalsy) | str
 
 def _(flag: bool):
     (flag or (x := 0)) and (x := 2)

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -1,5 +1,27 @@
 # Cycles
 
+## Recursive lambda in a loop condition
+
+A lambda is always truthy. Determining whether the final assignment is reachable must not require
+inferring the lambda's return type, which depends on that same assignment.
+
+```py
+(f := lambda: f)
+while lambda: f:
+    pass
+f = 0
+```
+
+## Recursive lambda in a conditional
+
+The same cycle can arise when a conditional filters the bindings visible to a recursive lambda.
+
+```py
+f = lambda: f
+if not (lambda: f):
+    f = 0
+```
+
 ## Function signature
 
 Deferred annotations can result in cycles in resolving a function signature:

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -66,6 +66,17 @@ for from_count in range(count):
 reveal_type(from_count)  # revealed: int
 ```
 
+Narrowing established by a non-empty loop remains available after the loop.
+
+```py
+def narrowing_after_non_empty_range(value: int | None) -> None:
+    for _ in range(1):
+        if value is None:
+            return
+
+    reveal_type(value)  # revealed: int
+```
+
 The emptiness refinement is independent of the order in which range values are assigned:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1940,7 +1940,7 @@ for _ in range(1_000_000):
         break
     node = node.next
 reveal_type(node)  # revealed: Node
-reveal_type(node.next)  # revealed: None | Node
+reveal_type(node.next)  # revealed: Node | None
 ```
 
 ### Nested collection cycles do not panic

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1929,7 +1929,7 @@ for _ in range(1_000_000):
         break
     node = node.next
 reveal_type(node)  # revealed: Node
-reveal_type(node.next)  # revealed: Node | None
+reveal_type(node.next)  # revealed: None | Node
 ```
 
 ### Nested collection cycles do not panic

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -77,6 +77,38 @@ def narrowing_after_non_empty_range(value: int | None) -> None:
     reveal_type(value)  # revealed: int
 ```
 
+This narrowing is not yet preserved for module- and class-scope loops. We currently avoid combining
+reachability and narrowing in these loops because doing so can introduce cycles through deferred
+annotations.
+
+```py
+def get_value() -> int | None:
+    return None
+
+module_value = get_value()
+
+for _ in range(1):
+    if module_value is None:
+        raise RuntimeError
+
+# TODO: This should be `int`, since the loop always runs.
+reveal_type(module_value)  # revealed: int | None
+```
+
+The same limitation applies to a loop in a class body.
+
+```py
+class Example:
+    value = get_value()
+
+    for _ in range(1):
+        if value is None:
+            raise RuntimeError
+
+    # TODO: This should be `int`, since the loop always runs.
+    reveal_type(value)  # revealed: int | None
+```
+
 The emptiness refinement is independent of the order in which range values are assigned:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -77,9 +77,7 @@ def narrowing_after_non_empty_range(value: int | None) -> None:
     reveal_type(value)  # revealed: int
 ```
 
-This narrowing is not yet preserved for module- and class-scope loops. We currently avoid combining
-reachability and narrowing in these loops because doing so can introduce cycles through deferred
-annotations.
+The same narrowing is preserved at module scope.
 
 ```py
 def get_value() -> int | None:
@@ -91,11 +89,10 @@ for _ in range(1):
     if module_value is None:
         raise RuntimeError
 
-# TODO: This should be `int`, since the loop always runs.
-reveal_type(module_value)  # revealed: int | None
+reveal_type(module_value)  # revealed: int
 ```
 
-The same limitation applies to a loop in a class body.
+It also works in a class body.
 
 ```py
 class Example:
@@ -105,8 +102,7 @@ class Example:
         if value is None:
             raise RuntimeError
 
-    # TODO: This should be `int`, since the loop always runs.
-    reveal_type(value)  # revealed: int | None
+    reveal_type(value)  # revealed: int
 ```
 
 The emptiness refinement is independent of the order in which range values are assigned:
@@ -1972,7 +1968,7 @@ for _ in range(1_000_000):
         break
     node = node.next
 reveal_type(node)  # revealed: Node
-reveal_type(node.next)  # revealed: Node | None
+reveal_type(node.next)  # revealed: None | Node
 ```
 
 ### Nested collection cycles do not panic

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -3852,7 +3852,7 @@ def _(x: Literal["foo", b"bar"] | int):
             pass
         case b"bar" if reveal_type(x):  # revealed: Literal[b"bar"]
             pass
-        case _ if reveal_type(x):  # revealed: Literal["foo", b"bar"] | int
+        case _ if reveal_type(x):  # revealed: int & ~Literal[42]
             pass
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -297,10 +297,10 @@ def _(val: int | str | None):
     reveal_type(val)  # revealed: int
 ```
 
-## Narrowing through always-true branches
+## Narrowing through statically known branches
 
-When a terminal (`return`) is inside an always-true branch, narrowing propagates through because the
-else-branch is unreachable and contributes `Never` to the union.
+When a terminal (`return`) is inside the reachable branch of a statically known condition, narrowing
+propagates through because the unreachable branch contributes `Never` to the union.
 
 ```py
 def _(x: int | None):
@@ -312,27 +312,89 @@ def _(x: int | None):
 ```
 
 ```py
+from typing import Final
+
 def _(x: int | None):
     if 1 + 1 == 2:
         if x is None:
             return
         reveal_type(x)  # revealed: int
 
-    # TODO: should be `int` (the else-branch of `1 + 1 == 2` is unreachable)
+    reveal_type(x)  # revealed: int
+
+def _(x: int | None):
+    if 1 + 1 != 2:
+        pass
+    else:
+        if x is None:
+            return
+        reveal_type(x)  # revealed: int
+
+    reveal_type(x)  # revealed: int
+
+def _(x: int | None, flag: bool):
+    if 1 + 1 == 2 or flag:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: int
+
+def _(x: int | None, flag: bool):
+    if 1 + 1 != 2 and flag:
+        pass
+    else:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: int
+
+def _(x: int | None, flag: bool):
+    if flag:
+        if x is None:
+            return
+
+    # An ambiguous condition must not make its other branch unreachable.
     reveal_type(x)  # revealed: int | None
+
+needs_inference: Final = True
+
+def _(x: int | None):
+    if needs_inference:
+        if x is None:
+            return
+        reveal_type(x)  # revealed: int
+
+    reveal_type(x)  # revealed: int
 ```
 
 This also works when the always-true condition is nested inside a narrowing branch:
 
 ```py
+from typing import Literal
+
 def _(x: int | None):
     if x is None:
         if 1 + 1 == 2:
             return
 
-    # TODO: should be `int` (the inner always-true branch makes the outer
-    # if-branch terminal)
-    reveal_type(x)  # revealed: int | None
+    reveal_type(x)  # revealed: int
+
+def _(x: int | None):
+    if x is None:
+        if needs_inference:
+            return
+
+    reveal_type(x)  # revealed: int
+
+def always_true(value: object) -> Literal[True]:
+    return True
+
+def _(x: int | None):
+    if x is None:
+        if always_true(x):
+            return
+
+    reveal_type(x)  # revealed: int
 ```
 
 ## Narrowing from `assert` should not affect reassigned variables

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -397,6 +397,36 @@ def _(x: int | None):
     reveal_type(x)  # revealed: int
 ```
 
+## Statically known branches inside module and class loops
+
+Narrowing also propagates through a statically known branch inside a module-level loop.
+
+```py
+def get_value() -> int | None:
+    return None
+
+while bool(input()):
+    value = get_value()
+    if 1 + 1 == 2:
+        if value is None:
+            raise RuntimeError
+
+    reveal_type(value)  # revealed: int
+```
+
+The same condition narrows a value inside a class-body loop.
+
+```py
+class Example:
+    while bool(input()):
+        value = get_value()
+        if 1 + 1 == 2:
+            if value is None:
+                raise RuntimeError
+
+        reveal_type(value)  # revealed: int
+```
+
 ## Narrowing from `assert` should not affect reassigned variables
 
 When a variable is reassigned after an `assert`, the narrowing from the assert should not apply to

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -1,5 +1,17 @@
 # Narrowing For Truthiness Checks (`if x` or `if not x`)
 
+## Generator expressions
+
+A generator object is truthy even when it yields no values.
+
+```py
+def narrow(value: int | None) -> None:
+    if (value for _ in ()):
+        if value is None:
+            return
+    reveal_type(value)  # revealed: int
+```
+
 ## Value Literals
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -774,6 +774,18 @@ def f(flag: bool):
         flag and (x := 38),
         flag and (x := 36),
         flag and (x := 36),
+        flag and (x := 39),
+        flag and (x := 40),
+        flag and (x := 41),
+        flag and (x := 42),
+        flag and (x := 43),
+        flag and (x := 44),
+        flag and (x := 45),
+        flag and (x := 46),
+        flag and (x := 47),
+        flag and (x := 48),
+        flag and (x := 49),
+        flag and (x := 50),
     )
 
     # Normally this `nonlocal` write would make us infer `int` for `y`, but now we ignore it.

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -1104,6 +1104,55 @@ class Example:
     reveal_type(continuing_value)  # revealed: Never
 ```
 
+### Generic calls in module and class scopes
+
+A generic call is terminal when its argument specializes the return type to `Never`.
+
+```py
+from typing import NoReturn, TypeVar, cast
+
+T = TypeVar("T")
+
+def identity(argument: T) -> T:
+    return argument
+
+def stop() -> NoReturn:
+    raise RuntimeError
+
+module_value = 1
+
+if bool(input()):
+    module_value = "unreachable"
+    identity(stop())
+
+reveal_type(module_value)  # revealed: Literal[1]
+```
+
+Generic specialization also works when its terminal argument is not a simple call.
+
+```py
+cast_value = 1
+
+if bool(input()):
+    cast_value = "unreachable"
+    identity(cast(NoReturn, None))
+
+reveal_type(cast_value)  # revealed: Literal[1]
+```
+
+The same terminal call also narrows bindings in a class body.
+
+```py
+class Example:
+    value = 1
+
+    if bool(input()):
+        value = "unreachable"
+        identity(stop())
+
+    reveal_type(value)  # revealed: Literal[1]
+```
+
 ### Overloads in module scope
 
 When only one overload returns `Never`, select the matching overload before deciding whether its
@@ -1131,6 +1180,19 @@ if flag:
 reveal_type(value)  # revealed: Literal[1]
 ```
 
+A local argument that requires inference must still select its terminal overload.
+
+```py
+local_argument: int = int(input())
+local_value = 1
+
+if bool(input()):
+    local_value = "unreachable"
+    stop_if_int(local_argument)
+
+reveal_type(local_value)  # revealed: Literal[1]
+```
+
 The overload that returns normally must not remove its branch.
 
 ```py
@@ -1142,6 +1204,33 @@ if other_flag:
     stop_if_int("safe")
 
 reveal_type(continuing_value)  # revealed: Literal[1, "reachable"]
+```
+
+### Calls with no applicable bound overloads
+
+A bound method with no applicable overloads is invalid, but its call can still return at runtime. It
+must not hide bindings from its branch or subsequent diagnostics.
+
+```py
+from __future__ import annotations
+from typing import overload
+
+class Example:
+    @overload
+    def method(self: str) -> None: ...
+    @overload
+    def method(self: bytes) -> None: ...
+    def method(self: Example | str | bytes) -> None:
+        pass
+
+value = 1
+
+if bool(input()):
+    value = "reachable"
+    Example().method()  # error: [no-matching-overload]
+
+reveal_type(value)  # revealed: Literal[1, "reachable"]
+value.bit_count()  # error: [unresolved-attribute]
 ```
 
 ### Possibly unresolved diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -1104,6 +1104,50 @@ class Example:
     reveal_type(continuing_value)  # revealed: Never
 ```
 
+### Statically known branches in module and class scopes
+
+A terminal call in the reachable branch of a statically known condition removes its module-level
+binding, even though the condition does not directly narrow that binding.
+
+```py
+from typing import NoReturn
+
+def stop() -> NoReturn:
+    raise RuntimeError
+
+flag: bool = bool(input())
+module_value = 1
+
+if flag:
+    module_value = "unreachable"
+
+    if 1 + 1 == 2:
+        stop()
+    else:
+        pass
+
+reveal_type(module_value)  # revealed: Literal[1]
+module_value.bit_count()
+```
+
+The same statically known condition also removes the unreachable binding from a class body.
+
+```py
+class Example:
+    value = 1
+
+    if flag:
+        value = "unreachable"
+
+        if 1 + 1 == 2:
+            stop()
+        else:
+            pass
+
+    reveal_type(value)  # revealed: Literal[1]
+    value.bit_count()
+```
+
 ### Generic calls in module and class scopes
 
 A generic call is terminal when its argument specializes the return type to `Never`.

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -1022,6 +1022,128 @@ def g(x: int | None):
     reveal_type(x)  # revealed: int
 ```
 
+### Module scope
+
+A terminal call at module scope removes a binding from its branch even when the branch condition
+does not narrow that binding.
+
+```py
+from typing import NoReturn
+
+def stop() -> NoReturn:
+    raise RuntimeError
+
+def continue_normally() -> None:
+    pass
+
+flag: bool = bool(input())
+value = 1
+
+if flag:
+    value = "unreachable"
+    stop()
+
+reveal_type(value)  # revealed: Literal[1]
+```
+
+A call that returns normally must retain the binding from its branch.
+
+```py
+continuing_value = 1
+other_flag: bool = bool(input())
+
+if other_flag:
+    continuing_value = "reachable"
+    continue_normally()
+
+reveal_type(continuing_value)  # revealed: Literal[1, "reachable"]
+```
+
+An unconditional terminal call eliminates the remaining bindings.
+
+```py
+stop()
+reveal_type(continuing_value)  # revealed: Never
+```
+
+### Class scope
+
+Terminal and non-terminal calls have the same effect on class-body bindings as they do on
+module-level bindings.
+
+```py
+from typing import NoReturn
+
+def stop() -> NoReturn:
+    raise RuntimeError
+
+def continue_normally() -> None:
+    pass
+
+flag: bool = bool(input())
+other_flag: bool = bool(input())
+
+class Example:
+    value = 1
+
+    if flag:
+        value = "unreachable"
+        stop()
+
+    reveal_type(value)  # revealed: Literal[1]
+
+    continuing_value = 1
+
+    if other_flag:
+        continuing_value = "reachable"
+        continue_normally()
+
+    reveal_type(continuing_value)  # revealed: Literal[1, "reachable"]
+
+    stop()
+    reveal_type(continuing_value)  # revealed: Never
+```
+
+### Overloads in module scope
+
+When only one overload returns `Never`, select the matching overload before deciding whether its
+branch terminates.
+
+```py
+from typing import NoReturn, overload
+
+@overload
+def stop_if_int(argument: int) -> NoReturn: ...
+@overload
+def stop_if_int(argument: str) -> int: ...
+def stop_if_int(argument: int | str) -> int:
+    if isinstance(argument, int):
+        raise RuntimeError
+    return 1
+
+flag: bool = bool(input())
+value = 1
+
+if flag:
+    value = "unreachable"
+    stop_if_int(1)
+
+reveal_type(value)  # revealed: Literal[1]
+```
+
+The overload that returns normally must not remove its branch.
+
+```py
+other_flag: bool = bool(input())
+continuing_value = 1
+
+if other_flag:
+    continuing_value = "reachable"
+    stop_if_int("safe")
+
+reveal_type(continuing_value)  # revealed: Literal[1, "reachable"]
+```
+
 ### Possibly unresolved diagnostics
 
 If the codepath on which a variable is not defined eventually returns `Never`, use of the variable

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1506,7 +1506,7 @@ fn loop_header_reachability_impl<'db>(
 ) -> LoopHeaderReachability<'db> {
     // This cutoff was chosen by benchmarking real isort to keep loop analysis
     // overhead minimal while preserving diagnostics.
-    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
+    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 4096;
 
     let DefinitionKind::LoopHeader(loop_header_definition) = definition.kind(db) else {
         unreachable!("`loop_header_reachability` called with non-loop-header definition");

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1506,7 +1506,7 @@ fn loop_header_reachability_impl<'db>(
 ) -> LoopHeaderReachability<'db> {
     // This cutoff was chosen by benchmarking real isort to keep loop analysis
     // overhead minimal while preserving diagnostics.
-    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 4096;
+    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
 
     let DefinitionKind::LoopHeader(loop_header_definition) = definition.kind(db) else {
         unreachable!("`loop_header_reachability` called with non-loop-header definition");

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -865,8 +865,13 @@ pub(crate) fn narrow_type_by_constraint<'db>(
 
     // Reachability gates can mention predicates that do not narrow this place. Evaluating those
     // predicates cannot change its type and can introduce cycles through unrelated expressions.
+    // Scope-wide control-flow gates are an exception: a call returning `Never` can eliminate a
+    // binding even when no ordinary predicate narrows its place.
     let predicate_narrowing_targets = evaluator.predicate_narrowing_targets();
-    if !predicate_narrowing_targets.contains_place(place) {
+    let has_place_specific_narrowing = predicate_narrowing_targets.contains_place(place);
+    if !has_place_specific_narrowing
+        && !predicate_narrowing_targets.contains_scope_wide_control_flow(place)
+    {
         return base_ty;
     }
 
@@ -878,6 +883,15 @@ pub(crate) fn narrow_type_by_constraint<'db>(
         Some(predicate_narrowing_targets),
         place,
     );
+    if !has_place_specific_narrowing {
+        return if projector.project_control_flow_only(id) == ProjectedNarrowingNodeId::ALWAYS_FALSE
+        {
+            Type::Never
+        } else {
+            base_ty
+        };
+    }
+
     let projected_root = projector.project(id);
     let mut context = ProjectedNarrowingContext {
         db,
@@ -1110,6 +1124,12 @@ struct NarrowingProjector<'a, 'db> {
     graph: ProjectedNarrowingGraph<'db>,
 }
 
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum NarrowingProjectionMode {
+    Full,
+    ControlFlowOnly,
+}
+
 impl<'a, 'db> NarrowingProjector<'a, 'db> {
     /// Creates a projector for narrowing `place`.
     fn new(
@@ -1161,6 +1181,22 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 
     /// Projects one constraint node into the graph for this place.
     fn project(&mut self, root: ScopedNarrowingConstraint) -> ProjectedNarrowingNodeId {
+        self.project_with_mode(root, NarrowingProjectionMode::Full)
+    }
+
+    /// Resolves control-flow gates without inferring unrelated expression predicates.
+    fn project_control_flow_only(
+        &mut self,
+        root: ScopedNarrowingConstraint,
+    ) -> ProjectedNarrowingNodeId {
+        self.project_with_mode(root, NarrowingProjectionMode::ControlFlowOnly)
+    }
+
+    fn project_with_mode(
+        &mut self,
+        root: ScopedNarrowingConstraint,
+        mode: NarrowingProjectionMode,
+    ) -> ProjectedNarrowingNodeId {
         type Id = ScopedNarrowingConstraint;
         enum Action {
             Visit(Id),
@@ -1182,13 +1218,27 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 
                     let node = self.constraints.get_interior_node(id);
                     let predicate = self.predicates[node.atom];
-
-                    if matches!(
+                    let is_control_flow_gate = matches!(
                         predicate.node,
                         PredicateNode::IsNonTerminalCall(_)
                             | PredicateNode::ContextManagerSuppresses { .. }
                             | PredicateNode::FinallyNormalPathImpossible { .. }
-                    ) {
+                    );
+
+                    if mode == NarrowingProjectionMode::ControlFlowOnly
+                        && (node.if_uncertain == ScopedNarrowingConstraint::ALWAYS_TRUE
+                            || (!is_control_flow_gate
+                                && (node.if_true == ScopedNarrowingConstraint::ALWAYS_TRUE
+                                    || node.if_false == ScopedNarrowingConstraint::ALWAYS_TRUE)))
+                    {
+                        // One surviving branch is enough, so do not infer a call on another
+                        // branch merely to confirm that the binding remains possible.
+                        self.project_cache
+                            .insert(id, ProjectedNarrowingNodeId::ALWAYS_TRUE);
+                        continue;
+                    }
+
+                    if is_control_flow_gate {
                         actions.push(Action::AnalyzeNonTerminal(id));
                         actions.push(Action::Visit(node.if_uncertain));
                     } else {
@@ -1201,7 +1251,21 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                 Action::AnalyzeNonTerminal(id) => {
                     let node = self.constraints.get_interior_node(id);
                     let predicate = self.predicates[node.atom];
-                    let branch = match analyze_single(db, self.env, &predicate) {
+                    let truthiness = if mode == NarrowingProjectionMode::ControlFlowOnly
+                        && let PredicateNode::IsNonTerminalCall(CallableAndCallExpr {
+                            callable,
+                            call_expr,
+                            is_await,
+                        }) = predicate.node
+                    {
+                        analyze_non_terminal_call_without_generic_arguments(
+                            db, callable, call_expr, is_await,
+                        )
+                        .negate_if(!predicate.is_positive)
+                    } else {
+                        analyze_single(db, self.env, &predicate)
+                    };
+                    let branch = match truthiness {
                         Truthiness::AlwaysTrue => node.if_true,
                         Truthiness::AlwaysFalse => node.if_false,
                         Truthiness::Ambiguous => {
@@ -1226,9 +1290,14 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let if_true = self.projected_node(node.if_true);
                     let if_uncertain = self.projected_node(node.if_uncertain);
                     let if_false = self.projected_node(node.if_false);
-                    let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom);
 
-                    let projected = if pos_constraint.is_none() && neg_constraint.is_none() {
+                    let projected = if mode == NarrowingProjectionMode::ControlFlowOnly {
+                        // This predicate cannot narrow the requested place. Preserve both of its
+                        // possible branches without inferring an unrelated expression, which can
+                        // otherwise introduce a cycle through a deferred annotation.
+                        let either = self.graph.or(if_true, if_false);
+                        self.graph.or(either, if_uncertain)
+                    } else if let (None, None) = self.predicate_constraints(node.atom) {
                         // This node represents `if_uncertain || (P && if_true) || (!P && if_false)`.
                         // Since the predicate `P` cannot narrow this place, remove it while retaining only branches that `P` can take.
                         // Including a statically unreachable branch could erase narrowing from the reachable branch.
@@ -1567,6 +1636,49 @@ fn analyze_non_terminal_call<'db>(
         } else {
             Truthiness::AlwaysTrue
         }
+    }
+}
+
+/// Resolves terminal calls without inferring arguments solely for a generic return type.
+///
+/// Inferring a generic call expression can depend on the same binding whose control-flow gate is
+/// being evaluated. Treat generic calls as non-terminal unless an overload explicitly returns
+/// `Never`; overload selection remains necessary when some, but not all, overloads are terminal.
+fn analyze_non_terminal_call_without_generic_arguments<'db>(
+    db: &'db dyn Db,
+    callable: Expression<'db>,
+    call_expr: Expression<'db>,
+    is_await: bool,
+) -> Truthiness {
+    let env = ProgramEnvironment::from_scope(callable.scope(db));
+    let ty = infer_same_file_expression_type(db, callable, TypeContext::default());
+
+    if matches!(ty, Type::Dynamic(_)) {
+        return Truthiness::AlwaysTrue;
+    }
+
+    let Some(callable_ty) = ty
+        .try_upcast_to_callable(db, &env)
+        .and_then(CallableTypes::exactly_one)
+    else {
+        return Truthiness::AlwaysTrue;
+    };
+
+    let mut any_overload_returns_never = false;
+    let mut all_overloads_return_never = true;
+
+    for overload in &callable_ty.signatures(db).overloads {
+        let returns_never = overload.return_ty.is_equivalent_to(db, &env, Type::Never);
+        any_overload_returns_never |= returns_never;
+        all_overloads_return_never &= returns_never;
+    }
+
+    if all_overloads_return_never {
+        Truthiness::AlwaysFalse
+    } else if any_overload_returns_never {
+        analyze_non_terminal_call(db, callable, call_expr, is_await)
+    } else {
+        Truthiness::AlwaysTrue
     }
 }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1206,8 +1206,17 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom);
 
                     let projected = if pos_constraint.is_none() && neg_constraint.is_none() {
-                        let either = self.graph.or(if_true, if_false);
-                        self.graph.or(either, if_uncertain)
+                        // This node represents `if_uncertain || (P && if_true) || (!P && if_false)`.
+                        // Since the predicate `P` cannot narrow this place, remove it while retaining only branches that `P` can take.
+                        // Including a statically unreachable branch could erase narrowing from the reachable branch.
+                        match analyze_single(self.db, &self.predicates[node.atom]) {
+                            Truthiness::AlwaysTrue => self.graph.or(if_true, if_uncertain),
+                            Truthiness::AlwaysFalse => self.graph.or(if_false, if_uncertain),
+                            Truthiness::Ambiguous => {
+                                let either = self.graph.or(if_true, if_false);
+                                self.graph.or(either, if_uncertain)
+                            }
+                        }
                     } else {
                         self.graph.add_node(ProjectedNarrowingNode {
                             atom: node.atom,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -865,13 +865,10 @@ pub(crate) fn narrow_type_by_constraint<'db>(
 
     // Reachability gates can mention predicates that do not narrow this place. Evaluating those
     // predicates cannot change its type and can introduce cycles through unrelated expressions.
-    // Scope-wide control-flow gates are an exception: a call returning `Never` can eliminate a
-    // binding even when no ordinary predicate narrows its place.
+    // Terminal calls are also recorded as reachability constraints, so bindings eliminated by
+    // those calls are handled by reachability analysis even when no predicate narrows this place.
     let predicate_narrowing_targets = evaluator.predicate_narrowing_targets();
-    let has_place_specific_narrowing = predicate_narrowing_targets.contains_place(place);
-    if !has_place_specific_narrowing
-        && !predicate_narrowing_targets.contains_scope_wide_control_flow(place)
-    {
+    if !predicate_narrowing_targets.contains_place(place) {
         return base_ty;
     }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -880,7 +880,7 @@ pub(crate) fn narrow_type_by_constraint<'db>(
         env,
         evaluator.narrowing_constraints(),
         evaluator.predicates(),
-        has_place_specific_narrowing.then_some(predicate_narrowing_targets),
+        predicate_narrowing_targets,
         place,
     );
     let projected_root = projector.project(id);
@@ -1115,7 +1115,7 @@ struct NarrowingProjector<'a, 'db> {
     env: &'a ProgramEnvironment<'db>,
     constraints: &'a NarrowingConstraints,
     predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
-    predicate_narrowing_targets: Option<&'a PredicateNarrowingTargets>,
+    predicate_narrowing_targets: &'a PredicateNarrowingTargets,
     place: ScopedPlaceId,
     project_cache: FxHashMap<ScopedNarrowingConstraint, ProjectedNarrowingNodeId>,
     graph: ProjectedNarrowingGraph<'db>,
@@ -1128,7 +1128,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         env: &'a ProgramEnvironment<'db>,
         constraints: &'a NarrowingConstraints,
         predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
-        predicate_narrowing_targets: Option<&'a PredicateNarrowingTargets>,
+        predicate_narrowing_targets: &'a PredicateNarrowingTargets,
         place: ScopedPlaceId,
     ) -> Self {
         Self {
@@ -1156,9 +1156,9 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             return cached.clone();
         }
 
-        let constraints = if self
+        let constraints = if !self
             .predicate_narrowing_targets
-            .is_some_and(|targets| !targets.contains(predicate_id, self.place))
+            .contains(predicate_id, self.place)
         {
             (None, None)
         } else {
@@ -1241,23 +1241,15 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom);
 
                     let projected = if pos_constraint.is_none() && neg_constraint.is_none() {
-                        if self.predicate_narrowing_targets.is_none() {
-                            // Scope-wide call gates can eliminate this binding even though no
-                            // ordinary predicate narrows it. Preserve both branches without
-                            // inferring an unrelated predicate's truthiness.
-                            let either = self.graph.or(if_true, if_false);
-                            self.graph.or(either, if_uncertain)
-                        } else {
-                            // This node represents `if_uncertain || (P && if_true) || (!P && if_false)`.
-                            // Since the predicate `P` cannot narrow this place, remove it while retaining only branches that `P` can take.
-                            // Including a statically unreachable branch could erase narrowing from the reachable branch.
-                            match analyze_single(self.db, self.env, &self.predicates[node.atom]) {
-                                Truthiness::AlwaysTrue => self.graph.or(if_true, if_uncertain),
-                                Truthiness::AlwaysFalse => self.graph.or(if_false, if_uncertain),
-                                Truthiness::Ambiguous => {
-                                    let either = self.graph.or(if_true, if_false);
-                                    self.graph.or(either, if_uncertain)
-                                }
+                        // This node represents `if_uncertain || (P && if_true) || (!P && if_false)`.
+                        // Since the predicate `P` cannot narrow this place, remove it while retaining only branches that `P` can take.
+                        // Including a statically unreachable branch could erase narrowing from the reachable branch.
+                        match analyze_single(self.db, self.env, &self.predicates[node.atom]) {
+                            Truthiness::AlwaysTrue => self.graph.or(if_true, if_uncertain),
+                            Truthiness::AlwaysFalse => self.graph.or(if_false, if_uncertain),
+                            Truthiness::Ambiguous => {
+                                let either = self.graph.or(if_true, if_false);
+                                self.graph.or(either, if_uncertain)
                             }
                         }
                     } else {
@@ -2039,12 +2031,13 @@ class TargetB:
                 let constraints = NarrowingConstraints::from_test_nodes(nodes);
                 let x = index.place_table(function_scope).symbol_id("x").unwrap();
                 let env = db.program_environment();
+                let evaluator = use_def.narrowing_evaluator(ScopedNarrowingConstraint::ALWAYS_TRUE);
                 let mut projector = NarrowingProjector::new(
                     &db,
                     &env,
                     &constraints,
                     &predicates,
-                    None,
+                    evaluator.predicate_narrowing_targets(),
                     ScopedPlaceId::Symbol(x),
                 );
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -880,19 +880,16 @@ pub(crate) fn narrow_type_by_constraint<'db>(
         env,
         evaluator.narrowing_constraints(),
         evaluator.predicates(),
-        Some(predicate_narrowing_targets),
+        has_place_specific_narrowing.then_some(predicate_narrowing_targets),
         place,
     );
-    if !has_place_specific_narrowing {
-        return if projector.project_control_flow_only(id) == ProjectedNarrowingNodeId::ALWAYS_FALSE
-        {
-            Type::Never
-        } else {
-            base_ty
-        };
+    let projected_root = projector.project(id);
+    match projected_root {
+        ProjectedNarrowingNodeId::ALWAYS_TRUE => return base_ty,
+        ProjectedNarrowingNodeId::ALWAYS_FALSE => return Type::Never,
+        _ => {}
     }
 
-    let projected_root = projector.project(id);
     let mut context = ProjectedNarrowingContext {
         db,
         env,
@@ -1124,12 +1121,6 @@ struct NarrowingProjector<'a, 'db> {
     graph: ProjectedNarrowingGraph<'db>,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum NarrowingProjectionMode {
-    Full,
-    ControlFlowOnly,
-}
-
 impl<'a, 'db> NarrowingProjector<'a, 'db> {
     /// Creates a projector for narrowing `place`.
     fn new(
@@ -1181,22 +1172,6 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 
     /// Projects one constraint node into the graph for this place.
     fn project(&mut self, root: ScopedNarrowingConstraint) -> ProjectedNarrowingNodeId {
-        self.project_with_mode(root, NarrowingProjectionMode::Full)
-    }
-
-    /// Resolves control-flow gates without inferring unrelated expression predicates.
-    fn project_control_flow_only(
-        &mut self,
-        root: ScopedNarrowingConstraint,
-    ) -> ProjectedNarrowingNodeId {
-        self.project_with_mode(root, NarrowingProjectionMode::ControlFlowOnly)
-    }
-
-    fn project_with_mode(
-        &mut self,
-        root: ScopedNarrowingConstraint,
-        mode: NarrowingProjectionMode,
-    ) -> ProjectedNarrowingNodeId {
         type Id = ScopedNarrowingConstraint;
         enum Action {
             Visit(Id),
@@ -1225,19 +1200,6 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             | PredicateNode::FinallyNormalPathImpossible { .. }
                     );
 
-                    if mode == NarrowingProjectionMode::ControlFlowOnly
-                        && (node.if_uncertain == ScopedNarrowingConstraint::ALWAYS_TRUE
-                            || (!is_control_flow_gate
-                                && (node.if_true == ScopedNarrowingConstraint::ALWAYS_TRUE
-                                    || node.if_false == ScopedNarrowingConstraint::ALWAYS_TRUE)))
-                    {
-                        // One surviving branch is enough, so do not infer a call on another
-                        // branch merely to confirm that the binding remains possible.
-                        self.project_cache
-                            .insert(id, ProjectedNarrowingNodeId::ALWAYS_TRUE);
-                        continue;
-                    }
-
                     if is_control_flow_gate {
                         actions.push(Action::AnalyzeNonTerminal(id));
                         actions.push(Action::Visit(node.if_uncertain));
@@ -1251,21 +1213,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                 Action::AnalyzeNonTerminal(id) => {
                     let node = self.constraints.get_interior_node(id);
                     let predicate = self.predicates[node.atom];
-                    let truthiness = if mode == NarrowingProjectionMode::ControlFlowOnly
-                        && let PredicateNode::IsNonTerminalCall(CallableAndCallExpr {
-                            callable,
-                            call_expr,
-                            is_await,
-                        }) = predicate.node
-                    {
-                        analyze_non_terminal_call_without_generic_arguments(
-                            db, callable, call_expr, is_await,
-                        )
-                        .negate_if(!predicate.is_positive)
-                    } else {
-                        analyze_single(db, self.env, &predicate)
-                    };
-                    let branch = match truthiness {
+                    let branch = match analyze_single(db, self.env, &predicate) {
                         Truthiness::AlwaysTrue => node.if_true,
                         Truthiness::AlwaysFalse => node.if_false,
                         Truthiness::Ambiguous => {
@@ -1290,23 +1238,26 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let if_true = self.projected_node(node.if_true);
                     let if_uncertain = self.projected_node(node.if_uncertain);
                     let if_false = self.projected_node(node.if_false);
+                    let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom);
 
-                    let projected = if mode == NarrowingProjectionMode::ControlFlowOnly {
-                        // This predicate cannot narrow the requested place. Preserve both of its
-                        // possible branches without inferring an unrelated expression, which can
-                        // otherwise introduce a cycle through a deferred annotation.
-                        let either = self.graph.or(if_true, if_false);
-                        self.graph.or(either, if_uncertain)
-                    } else if let (None, None) = self.predicate_constraints(node.atom) {
-                        // This node represents `if_uncertain || (P && if_true) || (!P && if_false)`.
-                        // Since the predicate `P` cannot narrow this place, remove it while retaining only branches that `P` can take.
-                        // Including a statically unreachable branch could erase narrowing from the reachable branch.
-                        match analyze_single(self.db, self.env, &self.predicates[node.atom]) {
-                            Truthiness::AlwaysTrue => self.graph.or(if_true, if_uncertain),
-                            Truthiness::AlwaysFalse => self.graph.or(if_false, if_uncertain),
-                            Truthiness::Ambiguous => {
-                                let either = self.graph.or(if_true, if_false);
-                                self.graph.or(either, if_uncertain)
+                    let projected = if pos_constraint.is_none() && neg_constraint.is_none() {
+                        if self.predicate_narrowing_targets.is_none() {
+                            // Scope-wide call gates can eliminate this binding even though no
+                            // ordinary predicate narrows it. Preserve both branches without
+                            // inferring an unrelated predicate's truthiness.
+                            let either = self.graph.or(if_true, if_false);
+                            self.graph.or(either, if_uncertain)
+                        } else {
+                            // This node represents `if_uncertain || (P && if_true) || (!P && if_false)`.
+                            // Since the predicate `P` cannot narrow this place, remove it while retaining only branches that `P` can take.
+                            // Including a statically unreachable branch could erase narrowing from the reachable branch.
+                            match analyze_single(self.db, self.env, &self.predicates[node.atom]) {
+                                Truthiness::AlwaysTrue => self.graph.or(if_true, if_uncertain),
+                                Truthiness::AlwaysFalse => self.graph.or(if_false, if_uncertain),
+                                Truthiness::Ambiguous => {
+                                    let either = self.graph.or(if_true, if_false);
+                                    self.graph.or(either, if_uncertain)
+                                }
                             }
                         }
                     } else {
@@ -1636,49 +1587,6 @@ fn analyze_non_terminal_call<'db>(
         } else {
             Truthiness::AlwaysTrue
         }
-    }
-}
-
-/// Resolves terminal calls without inferring arguments solely for a generic return type.
-///
-/// Inferring a generic call expression can depend on the same binding whose control-flow gate is
-/// being evaluated. Treat generic calls as non-terminal unless an overload explicitly returns
-/// `Never`; overload selection remains necessary when some, but not all, overloads are terminal.
-fn analyze_non_terminal_call_without_generic_arguments<'db>(
-    db: &'db dyn Db,
-    callable: Expression<'db>,
-    call_expr: Expression<'db>,
-    is_await: bool,
-) -> Truthiness {
-    let env = ProgramEnvironment::from_scope(callable.scope(db));
-    let ty = infer_same_file_expression_type(db, callable, TypeContext::default());
-
-    if matches!(ty, Type::Dynamic(_)) {
-        return Truthiness::AlwaysTrue;
-    }
-
-    let Some(callable_ty) = ty
-        .try_upcast_to_callable(db, &env)
-        .and_then(CallableTypes::exactly_one)
-    else {
-        return Truthiness::AlwaysTrue;
-    };
-
-    let mut any_overload_returns_never = false;
-    let mut all_overloads_return_never = true;
-
-    for overload in &callable_ty.signatures(db).overloads {
-        let returns_never = overload.return_ty.is_equivalent_to(db, &env, Type::Never);
-        any_overload_returns_never |= returns_never;
-        all_overloads_return_never &= returns_never;
-    }
-
-    if all_overloads_return_never {
-        Truthiness::AlwaysFalse
-    } else if any_overload_returns_never {
-        analyze_non_terminal_call(db, callable, call_expr, is_await)
-    } else {
-        Truthiness::AlwaysTrue
     }
 }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1151,19 +1151,20 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         Option<NarrowingConstraint<'db>>,
         Option<NarrowingConstraint<'db>>,
     ) {
+        if !self
+            .predicate_narrowing_targets
+            .contains(predicate_id, self.place)
+        {
+            return (None, None);
+        }
+
         let db = self.db;
         if let Some(cached) = self.graph.predicate_constraints_cache.get(&predicate_id) {
             return cached.clone();
         }
 
-        let constraints = if !self
-            .predicate_narrowing_targets
-            .contains(predicate_id, self.place)
-        {
-            (None, None)
-        } else {
-            infer_narrowing_constraints(db, self.predicates[predicate_id], self.place)
-        };
+        let constraints =
+            infer_narrowing_constraints(db, self.predicates[predicate_id], self.place);
         self.graph
             .predicate_constraints_cache
             .insert(predicate_id, constraints.clone());

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -216,7 +216,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use ty_python_core::{
     BindingWithConstraints, DeclarationWithConstraint, DeclarationsIterator, EvaluationMode,
-    FileScopeId, ScopedDefinitionId, SemanticIndex, Truthiness, UseDefMap,
+    FileScopeId, NarrowingEvaluator, PredicateNarrowingTargets, ScopedDefinitionId, SemanticIndex,
+    Truthiness, UseDefMap,
     definition::DefinitionState,
     expression::Expression,
     narrowing_constraints::{NarrowingConstraints, ScopedNarrowingConstraint},
@@ -851,19 +852,32 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
 pub(crate) fn narrow_type_by_constraint<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
-    constraints: &NarrowingConstraints,
-    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-    id: ScopedNarrowingConstraint,
+    evaluator: &NarrowingEvaluator<'_, 'db>,
     base_ty: Type<'db>,
     place: ScopedPlaceId,
 ) -> Type<'db> {
+    let id = evaluator.constraint();
     match id {
         ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
         ScopedNarrowingConstraint::ALWAYS_FALSE => return Type::Never,
         _ => {}
     }
 
-    let mut projector = NarrowingProjector::new(db, env, constraints, predicates, place);
+    // Reachability gates can mention predicates that do not narrow this place. Evaluating those
+    // predicates cannot change its type and can introduce cycles through unrelated expressions.
+    let predicate_narrowing_targets = evaluator.predicate_narrowing_targets();
+    if !predicate_narrowing_targets.contains_place(place) {
+        return base_ty;
+    }
+
+    let mut projector = NarrowingProjector::new(
+        db,
+        env,
+        evaluator.narrowing_constraints(),
+        evaluator.predicates(),
+        Some(predicate_narrowing_targets),
+        place,
+    );
     let projected_root = projector.project(id);
     let mut context = ProjectedNarrowingContext {
         db,
@@ -1090,6 +1104,7 @@ struct NarrowingProjector<'a, 'db> {
     env: &'a ProgramEnvironment<'db>,
     constraints: &'a NarrowingConstraints,
     predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    predicate_narrowing_targets: Option<&'a PredicateNarrowingTargets>,
     place: ScopedPlaceId,
     project_cache: FxHashMap<ScopedNarrowingConstraint, ProjectedNarrowingNodeId>,
     graph: ProjectedNarrowingGraph<'db>,
@@ -1102,6 +1117,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         env: &'a ProgramEnvironment<'db>,
         constraints: &'a NarrowingConstraints,
         predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
+        predicate_narrowing_targets: Option<&'a PredicateNarrowingTargets>,
         place: ScopedPlaceId,
     ) -> Self {
         Self {
@@ -1109,6 +1125,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             env,
             constraints,
             predicates,
+            predicate_narrowing_targets,
             place,
             project_cache: FxHashMap::default(),
             graph: ProjectedNarrowingGraph::default(),
@@ -1128,8 +1145,14 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             return cached.clone();
         }
 
-        let constraints =
-            infer_narrowing_constraints(db, self.predicates[predicate_id], self.place);
+        let constraints = if self
+            .predicate_narrowing_targets
+            .is_some_and(|targets| !targets.contains(predicate_id, self.place))
+        {
+            (None, None)
+        } else {
+            infer_narrowing_constraints(db, self.predicates[predicate_id], self.place)
+        };
         self.graph
             .predicate_constraints_cache
             .insert(predicate_id, constraints.clone());
@@ -1209,7 +1232,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                         // This node represents `if_uncertain || (P && if_true) || (!P && if_false)`.
                         // Since the predicate `P` cannot narrow this place, remove it while retaining only branches that `P` can take.
                         // Including a statically unreachable branch could erase narrowing from the reachable branch.
-                        match analyze_single(self.db, &self.predicates[node.atom]) {
+                        match analyze_single(self.db, self.env, &self.predicates[node.atom]) {
                             Truthiness::AlwaysTrue => self.graph.or(if_true, if_uncertain),
                             Truthiness::AlwaysFalse => self.graph.or(if_false, if_uncertain),
                             Truthiness::Ambiguous => {
@@ -2001,6 +2024,7 @@ class TargetB:
                     &env,
                     &constraints,
                     &predicates,
+                    None,
                     ScopedPlaceId::Symbol(x),
                 );
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2571,7 +2571,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         nested_bindings_kind: &NestedBindingsDefinitionKind,
         definition: Definition<'db>,
     ) {
-        const MAX_EXACT_NESTED_BINDING_REACHABILITY_NODES: usize = 2048;
+        const MAX_EXACT_NESTED_BINDING_REACHABILITY_NODES: usize = 4096;
 
         let db = self.db();
         let scope_id = definition.file_scope(db);

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -744,6 +744,50 @@ class Form(Ui):
     Ok(())
 }
 
+#[test]
+fn loop_reachability_remains_precise_after_many_module_calls() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    let calls = "noop()\n".repeat(MANY_NON_TERMINAL_CALLS);
+    let source = format!(
+        r#"from typing_extensions import reveal_type
+def noop() -> None: ...
+{calls}flag = False
+value = 1
+for _ in range(2):
+    reveal_type(value)
+    if flag:
+        value = 'abc'
+"#
+    );
+    db.write_file("/src/main.py", &source)?;
+
+    assert_revealed_type(&db, "/src/main.py", "Literal[1]");
+
+    Ok(())
+}
+
+#[test]
+fn nested_binding_remains_precise_after_many_module_calls() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    let calls = "noop()\n".repeat(MANY_NON_TERMINAL_CALLS);
+    let source = format!(
+        r#"def noop() -> None: ...
+{calls}value = 1
+values = [(value := 'abc') for _ in range(2)]
+value.bit_count()
+"#
+    );
+    db.write_file("/src/main.py", &source)?;
+
+    assert_file_diagnostics(
+        &db,
+        "/src/main.py",
+        &["Object of type `str` has no attribute `bit_count`"],
+    );
+
+    Ok(())
+}
+
 // Incremental inference tests
 #[track_caller]
 fn first_public_binding<'db>(db: &'db TestDb, file: File, name: &str) -> Definition<'db> {

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -745,28 +745,6 @@ class Form(Ui):
 }
 
 #[test]
-fn loop_reachability_remains_precise_after_many_module_calls() -> anyhow::Result<()> {
-    let mut db = setup_db();
-    let calls = "noop()\n".repeat(MANY_NON_TERMINAL_CALLS);
-    let source = format!(
-        r#"from typing_extensions import reveal_type
-def noop() -> None: ...
-{calls}flag = False
-value = 1
-for _ in range(2):
-    reveal_type(value)
-    if flag:
-        value = 'abc'
-"#
-    );
-    db.write_file("/src/main.py", &source)?;
-
-    assert_revealed_type(&db, "/src/main.py", "Literal[1]");
-
-    Ok(())
-}
-
-#[test]
 fn nested_binding_remains_precise_after_many_module_calls() -> anyhow::Result<()> {
     let mut db = setup_db();
     let calls = "noop()\n".repeat(MANY_NON_TERMINAL_CALLS);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -116,7 +116,11 @@ pub(crate) fn infer_narrowing_constraints<'db>(
     }
 }
 
-#[salsa::tracked(returns(as_ref), heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(as_ref),
+    cycle_initial=|_, _, _| None,
+    heap_size=ruff_memory_usage::heap_size,
+)]
 fn all_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
     pattern: PatternPredicate<'db>,
@@ -149,7 +153,11 @@ fn all_narrowing_constraints_for_expression<'db>(
     }
 }
 
-#[salsa::tracked(returns(as_ref), heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(as_ref),
+    cycle_initial=|_, _, _| None,
+    heap_size=ruff_memory_usage::heap_size,
+)]
 fn all_negative_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
     pattern: PatternPredicate<'db>,
@@ -162,7 +170,11 @@ fn all_negative_narrowing_constraints_for_pattern<'db>(
         .finish()
 }
 
-#[salsa::tracked(returns(as_ref), heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(as_ref),
+    cycle_initial=|_, _, _, _| None,
+    heap_size=ruff_memory_usage::heap_size,
+)]
 fn all_narrowing_constraints_for_subject_element_pattern<'db>(
     db: &'db dyn Db,
     pattern: PatternPredicate<'db>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -5305,14 +5305,6 @@ impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
         base_type: Type<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        narrow_type_by_constraint(
-            db,
-            env,
-            self.narrowing_constraints(),
-            self.predicates(),
-            self.constraint(),
-            base_type,
-            place,
-        )
+        narrow_type_by_constraint(db, env, self, base_type, place)
     }
 }


### PR DESCRIPTION
## Summary

Previously, narrowing was lost after a statically known branch because the unreachable control-flow path still contributed its original type:

```python
def narrow(value: int | None) -> None:
    if 1 + 1 == 2:
        if value is None:
            return

    reveal_type(value)  # Previously: int | None; now: int
```

We now gate narrowing constraints with their corresponding reachability conditions and reuse predicate identities across both analyses. This allows narrowing to propagate through constant conditions, short-circuit expressions, match guards, and statically non-empty `range()` loops while preserving ambiguous branches.

Statement-level calls now participate in normal reachability analysis in every scope, replacing the separate scope-wide narrowing machinery for module- and class-level calls. As a result, the improved narrowing also works inside module- and class-level loops, while preserving terminal-call analysis, overload selection, and loop-carried forward references.

Because these calls now contribute to reachability graphs, we raise the nested-binding cutoff from 2,048 to 4,096 to preserve precision in call-heavy scopes. The loop-reachability and loop-inference cutoffs remain unchanged to protect performance on loop-heavy projects such as isort and parso.

We also track the places each predicate can narrow, avoiding unnecessary constraint inference and preventing unrelated reachability gates from introducing cycles through deferred annotations. Lambda and generator conditions are resolved without inferring their bodies, avoiding recursive-callable inference cycles.

This also fixes exhaustive nested checks where proving that an outer branch terminates depends on narrowing a separate inner value, preventing spurious `assert_never` errors.

Based on @mtshiba's work in #27207 and #23201.

Closes https://github.com/astral-sh/ty/issues/4240.
