### PR TITLE
[`ruff`] Add `ctypes.LittleEndianStructure` and others alike to existing exception (`RUF012`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
@@ -176,7 +176,7 @@ class U(ctypes.Union):
         ("b", BES),
     ]
 
-class LEU(ctypes.BigEndianUnion):
+class LEU(ctypes.LittleEndianUnion):
     test = [""]
     _fields_ = [
         ("a", LES),

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
@@ -150,3 +150,42 @@ class S(ctypes.Structure):
         ("propagation", ctypes.c_uint64),
         ("userns_fd", ctypes.c_uint64),
     ]
+
+class LES(ctypes.LittleEndianStructure):
+    test = [""]
+    _fields_ = [
+        ("attr_set", ctypes.c_uint64),
+        ("attr_clr", ctypes.c_uint64),
+        ("propagation", ctypes.c_uint64),
+        ("userns_fd", ctypes.c_uint64),
+    ]
+
+class BES(ctypes.BigEndianStructure):
+    test = [""]
+    _fields_ = [
+        ("attr_set", ctypes.c_uint64),
+        ("attr_clr", ctypes.c_uint64),
+        ("propagation", ctypes.c_uint64),
+        ("userns_fd", ctypes.c_uint64),
+    ]
+
+class U(ctypes.Union):
+    test = [""]
+    _fields_ = [
+        ("a", LES),
+        ("b", BES),
+    ]
+
+class LEU(ctypes.BigEndianUnion):
+    test = [""]
+    _fields_ = [
+        ("a", LES),
+        ("b", BES),
+    ]
+
+class BEU(ctypes.BigEndianUnion):
+    test = [""]
+    _fields_ = [
+        ("a", LES),
+        ("b", BES),
+    ]

--- a/crates/ruff_linter/src/rules/ruff/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/helpers.rs
@@ -252,7 +252,15 @@ pub(super) fn is_ctypes_structure_fields(
 ) -> bool {
     let is_ctypes_structure =
         analyze::class::any_qualified_base_class(class_def, semantic, |qualified_name| {
-            matches!(qualified_name.segments(), ["ctypes", "Structure"])
+            matches!(
+                qualified_name.segments(),
+                ["ctypes", "Structure"]
+                    | ["ctypes", "BigEndianStructure"]
+                    | ["ctypes", "LittleEndianStructure"]
+                    | ["ctypes", "Union"]
+                    | ["ctypes", "BigEndianUnion"]
+                    | ["ctypes", "LitleEndianUnion"]
+            )
         });
 
     let is_fields = matches!(

--- a/crates/ruff_linter/src/rules/ruff/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/helpers.rs
@@ -254,12 +254,15 @@ pub(super) fn is_ctypes_structure_fields(
         analyze::class::any_qualified_base_class(class_def, semantic, |qualified_name| {
             matches!(
                 qualified_name.segments(),
-                ["ctypes", "Structure"]
-                    | ["ctypes", "BigEndianStructure"]
-                    | ["ctypes", "LittleEndianStructure"]
-                    | ["ctypes", "Union"]
-                    | ["ctypes", "BigEndianUnion"]
-                    | ["ctypes", "LitleEndianUnion"]
+                [
+                    "ctypes",
+                    "Structure"
+                        | "BigEndianStructure"
+                        | "LittleEndianStructure"
+                        | "Union"
+                        | "BigEndianUnion"
+                        | "LittleEndianUnion"
+                ]
             )
         });
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF012_RUF012.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF012_RUF012.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
+assertion_line: 133
 ---
 RUF012 Mutable default value for class attribute
   --> RUF012.py:9:34
@@ -137,5 +138,60 @@ RUF012 Mutable default value for class attribute
     |            ^^^^
 147 |     _fields_ = [
 148 |         ("attr_set", ctypes.c_uint64),
+    |
+help: Consider initializing in `__init__` or annotating with `typing.ClassVar`
+
+RUF012 Mutable default value for class attribute
+   --> RUF012.py:155:12
+    |
+154 | class LES(ctypes.LittleEndianStructure):
+155 |     test = [""]
+    |            ^^^^
+156 |     _fields_ = [
+157 |         ("attr_set", ctypes.c_uint64),
+    |
+help: Consider initializing in `__init__` or annotating with `typing.ClassVar`
+
+RUF012 Mutable default value for class attribute
+   --> RUF012.py:164:12
+    |
+163 | class BES(ctypes.BigEndianStructure):
+164 |     test = [""]
+    |            ^^^^
+165 |     _fields_ = [
+166 |         ("attr_set", ctypes.c_uint64),
+    |
+help: Consider initializing in `__init__` or annotating with `typing.ClassVar`
+
+RUF012 Mutable default value for class attribute
+   --> RUF012.py:173:12
+    |
+172 | class U(ctypes.Union):
+173 |     test = [""]
+    |            ^^^^
+174 |     _fields_ = [
+175 |         ("a", LES),
+    |
+help: Consider initializing in `__init__` or annotating with `typing.ClassVar`
+
+RUF012 Mutable default value for class attribute
+   --> RUF012.py:180:12
+    |
+179 | class LEU(ctypes.BigEndianUnion):
+180 |     test = [""]
+    |            ^^^^
+181 |     _fields_ = [
+182 |         ("a", LES),
+    |
+help: Consider initializing in `__init__` or annotating with `typing.ClassVar`
+
+RUF012 Mutable default value for class attribute
+   --> RUF012.py:187:12
+    |
+186 | class BEU(ctypes.BigEndianUnion):
+187 |     test = [""]
+    |            ^^^^
+188 |     _fields_ = [
+189 |         ("a", LES),
     |
 help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF012_RUF012.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF012_RUF012.py.snap
@@ -177,7 +177,7 @@ help: Consider initializing in `__init__` or annotating with `typing.ClassVar`
 RUF012 Mutable default value for class attribute
    --> RUF012.py:180:12
     |
-179 | class LEU(ctypes.BigEndianUnion):
+179 | class LEU(ctypes.LittleEndianUnion):
 180 |     test = [""]
     |            ^^^^
 181 |     _fields_ = [


### PR DESCRIPTION
## Summary

#22559 Added an exception to the _fields_ Class Variable not needing an annotation. 

I have the same issue as what the fix is supposed to fix for certain variants of ctypes.Structure.

## Test Plan

I extended the ruff012.py file with extra base types and then I added the extra base types to the helper.rs function that detected the original case. Then I updated the snapshot, as the output is what I now expect.
