### PR TITLE
Compare stacked PRs against the preceding layer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -799,7 +799,8 @@ jobs:
           cargo build --profile=profiling --bin=ty
           mv target/profiling/ty ty-new
 
-          MERGE_BASE="$(git merge-base "$GITHUB_SHA" "origin/$GITHUB_BASE_REF")"
+          # The first parent contains any preceding layers in a stacked pull request.
+          MERGE_BASE="$(git rev-parse "${GITHUB_SHA}^1")"
           git checkout -b old_commit "$MERGE_BASE"
           echo "old commit (merge base)"
           git rev-list --format=%s --max-count=1 old_commit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
     name: "Determine changes"
     runs-on: ubuntu-latest
     outputs:
+      comparison_base: ${{ steps.merge_base.outputs.sha }}
       # Flag that is raised when any code that affects parser is changed
       parser: ${{ steps.check_parser.outputs.changed }}
       # Flag that is raised when any code that affects linter is changed
@@ -67,7 +68,12 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
-          sha=$(git merge-base HEAD "origin/${BASE_REF}")
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            # The first parent contains any preceding layers in a stacked pull request.
+            sha="$(git rev-parse "${GITHUB_SHA}^1")"
+          else
+            sha="$(git merge-base HEAD "origin/${BASE_REF}")"
+          fi
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
 
       - name: Check if release build inputs changed
@@ -659,7 +665,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ needs.determine_changes.outputs.comparison_base }}
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -791,6 +797,7 @@ jobs:
       - name: Fuzz
         env:
           FORCE_COLOR: 1
+          MERGE_BASE: ${{ needs.determine_changes.outputs.comparison_base }}
           # Line-tables-only debug info: faster builds, backtraces still work.
           CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
         run: |
@@ -799,8 +806,6 @@ jobs:
           cargo build --profile=profiling --bin=ty
           mv target/profiling/ty ty-new
 
-          # The first parent contains any preceding layers in a stacked pull request.
-          MERGE_BASE="$(git rev-parse "${GITHUB_SHA}^1")"
           git checkout -b old_commit "$MERGE_BASE"
           echo "old commit (merge base)"
           git rev-list --format=%s --max-count=1 old_commit

--- a/.github/workflows/memory_report.yaml
+++ b/.github/workflows/memory_report.yaml
@@ -88,7 +88,8 @@ jobs:
             cargo build --bin ty --profile profiling
             mv target/profiling/ty ty-new
 
-            MERGE_BASE="$(git merge-base "$GITHUB_SHA" "origin/$GITHUB_BASE_REF")"
+            # The first parent contains any preceding layers in a stacked pull request.
+            MERGE_BASE="$(git rev-parse "${GITHUB_SHA}^1")"
             git checkout -b old_commit "$MERGE_BASE"
             echo "old commit (merge base)"
             git rev-list --format=%s --max-count=1 old_commit

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -78,7 +78,8 @@ jobs:
             # Faster to do this separately than to use `fetch-depth: 0` with `actions/checkout`
             git fetch --no-tags --filter=blob:none --unshallow origin
 
-            MERGE_BASE="$(git merge-base "${GITHUB_SHA}" "origin/${GITHUB_BASE_REF}")"
+            # The first parent contains any preceding layers in a stacked pull request.
+            MERGE_BASE="$(git rev-parse "${GITHUB_SHA}^1")"
             echo "${MERGE_BASE}" > merge-base.txt
             echo "Merge base: ${MERGE_BASE}"
             echo "PR commit: ${GITHUB_SHA}"
@@ -209,6 +210,7 @@ jobs:
         id: generate-reports
         env:
           REF_NAME: ${{ github.ref_name }}
+          BASE_REF_NAME: ${{ github.event.pull_request.base.ref }}
         run: |
           # Merge shard diagnostics
           jq -s '{ outputs: [.[].outputs[]] }' diagnostics-base-*.json > diagnostics-base.json
@@ -222,7 +224,7 @@ jobs:
             generate-diff \
             diagnostics-base.json \
             diagnostics-PR.json \
-            --old-name "main (merge base)" \
+            --old-name "${BASE_REF_NAME} (merge base)" \
             --new-name "$REF_NAME" \
             --output-html dist/diff.html
 
@@ -232,7 +234,7 @@ jobs:
             diagnostics-base.json \
             diagnostics-PR.json \
             --fail-on-new-abnormal-exits \
-            --old-name "main (merge base)" \
+            --old-name "${BASE_REF_NAME} (merge base)" \
             --new-name "$REF_NAME" \
             --output diff-statistics.md
           DIFF_STATISTICS_EXIT_CODE=$?
@@ -242,7 +244,7 @@ jobs:
             generate-timing-diff \
             diagnostics-base.json \
             diagnostics-PR.json \
-            --old-name "main (merge base)" \
+            --old-name "${BASE_REF_NAME} (merge base)" \
             --new-name "$REF_NAME" \
             --output-html dist/timing.html
 

--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -87,7 +87,8 @@ jobs:
             cargo build --bin ty
             mv target/debug/ty ty-new
 
-            MERGE_BASE="$(git merge-base "$GITHUB_SHA" "origin/$GITHUB_BASE_REF")"
+            # The first parent contains any preceding layers in a stacked pull request.
+            MERGE_BASE="$(git rev-parse "${GITHUB_SHA}^1")"
             git checkout -b old_commit "$MERGE_BASE"
             echo "old commit (merge base)"
             git rev-list --format=%s --max-count=1 old_commit


### PR DESCRIPTION
## Summary

Previously, our ecosystem, typing-conformance, memory, and fuzzing comparisons calculated their baseline with `git merge-base "$GITHUB_SHA" "origin/$GITHUB_BASE_REF"`. For GitHub's native stacked pull requests, this compares every layer against the stack base instead of the immediately preceding pull request.

We now use the first parent of GitHub's synthetic merge commit, `git rev-parse "${GITHUB_SHA}^1"`, as the comparison baseline, selecting the preceding merged layer for native stacks. CI reuses this baseline for change detection, Ruff's ecosystem comparison, and ty fuzzing; push and manually dispatched workflows retain their previous merge-base behavior. Ecosystem reports also label the comparison with the actual base branch instead of hardcoding `main`.

For ordinary pull requests, the compared revisions do not change: the first parent is the same base-branch commit previously selected by `git merge-base`. Pull requests targeting branches other than `main` retain the same comparison but receive an accurate report label, and the baseline remains pinned to the exact revision GitHub merged even if the base branch changes afterward.

On #27749, this reduced the ecosystem diff from `89 added / 676 removed / 8 changed` to `10 added / 0 removed / 0 changed`; conformance also stopped repeating improvements from the parent pull request.
