### PR TITLE
Fix broken link to Python docs

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -46,7 +46,7 @@ use ruff_python_ast::PythonVersion;
 /// - `target-version`
 ///
 /// ## References
-/// - [Python documentation: `str.strip`](https://docs.python.org/3/library/stdtypes.html?highlight=strip#str.strip)
+/// - [Python documentation: `str.strip`](https://docs.python.org/3/library/stdtypes.html#str.strip)
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.242")]
 pub(crate) struct BadStrStripCall {

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -38,7 +38,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// ```
 ///
 /// ## References
-/// - [Python documentation: `set.discard()`](https://docs.python.org/3/library/stdtypes.html?highlight=list#frozenset.discard)
+/// - [Python documentation: `set.discard()`](https://docs.python.org/3/library/stdtypes.html#set.discard)
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "0.12.0")]
 pub(crate) struct CheckAndRemoveFromSet {

--- a/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
@@ -41,8 +41,8 @@ use crate::rules::refurb::helpers::generate_method_call;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: Mutable Sequence Types](https://docs.python.org/3/library/stdtypes.html?highlight=list#mutable-sequence-types)
-/// - [Python documentation: `dict.clear()`](https://docs.python.org/3/library/stdtypes.html?highlight=list#dict.clear)
+/// - [Python documentation: Mutable Sequence Types](https://docs.python.org/3/library/stdtypes.html#typesseq-mutable)
+/// - [Python documentation: `dict.clear()`](https://docs.python.org/3/library/stdtypes.html#dict.clear)
 #[derive(ViolationMetadata)]
 #[violation_metadata(preview_since = "v0.0.287")]
 pub(crate) struct DeleteFullSlice;

--- a/crates/ruff_linter/src/rules/refurb/rules/if_expr_min_max.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/if_expr_min_max.rs
@@ -36,8 +36,8 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// This rule's fix is marked as safe, unless the expression contains comments.
 ///
 /// ## References
-/// - [Python documentation: `min`](https://docs.python.org/3.11/library/functions.html#min)
-/// - [Python documentation: `max`](https://docs.python.org/3.11/library/functions.html#max)
+/// - [Python documentation: `min`](https://docs.python.org/3/library/functions.html#min)
+/// - [Python documentation: `max`](https://docs.python.org/3/library/functions.html#max)
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "0.5.0")]
 pub(crate) struct IfExprMinMax {

--- a/crates/ruff_linter/src/rules/ruff/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/helpers.rs
@@ -227,7 +227,7 @@ pub(super) fn has_default_copy_semantics(
 /// Returns `true` if the given function is an instantiation of a class that implements the
 /// descriptor protocol.
 ///
-/// See: <https://docs.python.org/3.10/reference/datamodel.html#descriptors>
+/// See: <https://docs.python.org/3/reference/datamodel.html#descriptors>
 pub(super) fn is_descriptor_class(func: &Expr, semantic: &SemanticModel) -> bool {
     semantic.lookup_attribute(func).is_some_and(|id| {
         let BindingKind::ClassDefinition(scope_id) = semantic.binding(id).kind else {

--- a/crates/ruff_linter/src/rules/ruff/rules/falsy_dict_get_fallback.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/falsy_dict_get_fallback.rs
@@ -38,7 +38,7 @@ use crate::{Applicability, Fix, FixAvailability, Violation};
 /// shown in the [documentation], `dict.get` takes two positional-only arguments, so invalid cases
 /// are identified by the presence of more than two arguments or any keyword arguments.
 ///
-/// [documentation]: https://docs.python.org/3.13/library/stdtypes.html#dict.get
+/// [documentation]: https://docs.python.org/3/library/stdtypes.html#dict.get
 #[derive(ViolationMetadata)]
 #[violation_metadata(preview_since = "0.8.5")]
 pub(crate) struct FalsyDictGetFallback;

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1593,7 +1593,7 @@ impl<'src> Parser<'src> {
     ///
     /// If the parser isn't positioned at a `String` token.
     ///
-    /// See: <https://docs.python.org/3.13/reference/lexical_analysis.html#string-and-bytes-literals>
+    /// See: <https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals>
     fn parse_string_or_byte_literal(&mut self) -> StringType {
         let range = self.current_token_range();
         let flags = self.tokens.current_flags().as_any_string_flags();

--- a/crates/ruff_python_stdlib/src/identifiers.rs
+++ b/crates/ruff_python_stdlib/src/identifiers.rs
@@ -46,7 +46,7 @@ fn is_identifier_continuation(c: char) -> bool {
 /// identifier is defined in a class definition, it will be mangled prior to
 /// code generation.
 ///
-/// See: <https://docs.python.org/3.5/reference/expressions.html#private-name-mangling>.
+/// See: <https://docs.python.org/3/reference/expressions.html#private-name-mangling>.
 pub fn is_mangled_private(id: &str) -> bool {
     id.starts_with("__") && !id.ends_with("__")
 }

--- a/crates/ruff_python_stdlib/src/identifiers.rs
+++ b/crates/ruff_python_stdlib/src/identifiers.rs
@@ -46,7 +46,7 @@ fn is_identifier_continuation(c: char) -> bool {
 /// identifier is defined in a class definition, it will be mangled prior to
 /// code generation.
 ///
-/// See: <https://docs.python.org/3.5/reference/expressions.html?highlight=mangling#index-5>.
+/// See: <https://docs.python.org/3.5/reference/expressions.html#private-name-mangling>.
 pub fn is_mangled_private(id: &str) -> bool {
     id.starts_with("__") && !id.ends_with("__")
 }


### PR DESCRIPTION
Fixed a link to `frozen.discard` in the Python docs this was a valid link in older Python docs but has been broken.

While I was there I noticed a few other uncanonical links so replaced them with more canonical versions and removed some links to specific Python versions that are unnecessary.
