### PR TITLE
[ty] Fix specialization of generic TypedDict aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -881,12 +881,12 @@ help: A subclass of `Empty` could validly add a new field of an arbitrary type, 
 
 ## Generic `TypedDict` field conflicts in overload diagnostics
 
-A generic `TypedDict` relation can be unsatisfiable without being the `never` terminal. The
-resulting overload diagnostic should still explain which field introduced the conflicting
-constraints.
+A generic `TypedDict` relation can be unsatisfiable without being the `never` terminal. Capturing
+its type variable from an enclosing function keeps the overload non-generic while retaining the
+conflicting constraints. The resulting diagnostic should explain which field introduced them.
 
 ```py
-from typing import Generic, Self, TypeVar, TypedDict, overload
+from typing import Generic, TypeVar, TypedDict, overload
 
 T = TypeVar("T")
 
@@ -898,38 +898,39 @@ class Fixed(TypedDict):
     first: int
     second: str
 
-class OverloadedSelf:
+def outer(value: T) -> None:
     @overload
-    def method(self, value: Fixed) -> None: ...  # snapshot: invalid-overload
+    def inner(value: Fixed) -> None: ...  # snapshot: invalid-overload
     @overload
-    def method(self, value: str) -> None: ...
-    def method(self, value: Pair[Self] | str) -> None: ...
+    def inner(value: str) -> None: ...
+    def inner(value: Pair[T] | str) -> None: ...
 ```
 
 ```snapshot
 error[invalid-overload]: Implementation does not accept all arguments of this overload
   --> src/mdtest_snippet.py:15:9
    |
-15 |     def method(self, value: Fixed) -> None: ...  # snapshot: invalid-overload
-   |         ^^^^^^
+15 |     def inner(value: Fixed) -> None: ...  # snapshot: invalid-overload
+   |         ^^^^^
 16 |     @overload
-17 |     def method(self, value: str) -> None: ...
-18 |     def method(self, value: Pair[Self] | str) -> None: ...
-   |         ------ Implementation defined here
-info: Implementation signature `(self, value: Pair[Self@method] | str) -> None` is not assignable to overload signature `(self, value: Fixed) -> None`
-info: parameter `value` has an incompatible type: `Fixed` is not assignable to `Pair[Self@method] | str`
-info: └── type `Fixed` is not assignable to any element of the union `Pair[Self@method] | str`
-info:     ├── field "second" on TypedDict `Fixed` has type `str` which is not assignable to type `Self@method` expected by TypedDict `Pair`
+17 |     def inner(value: str) -> None: ...
+18 |     def inner(value: Pair[T] | str) -> None: ...
+   |         ----- Implementation defined here
+info: Implementation signature `(value: Pair[T@outer] | str) -> None` is not assignable to overload signature `(value: Fixed) -> None`
+info: parameter `value` has an incompatible type: `Fixed` is not assignable to `Pair[T@outer] | str`
+info: └── type `Fixed` is not assignable to any element of the union `Pair[T@outer] | str`
+info:     ├── field "second" on TypedDict `Fixed` has type `str` which is not assignable to type `T@outer` expected by TypedDict `Pair`
 info:     └── ... omitted 1 union element without additional context
 ```
 
 ## Stop checking callable parameters after incompatible generic constraints
 
 Once earlier parameters produce an unsatisfiable nonterminal constraint set, continuing to a later
-parameter must not replace the diagnostic context that explains the original incompatibility.
+parameter must not replace the diagnostic context that explains the original incompatibility. The
+type variable belongs to the enclosing function, so the overload itself remains non-generic.
 
 ```py
-from typing import Generic, Self, TypeVar, TypedDict, overload
+from typing import Generic, TypeVar, TypedDict, overload
 
 T = TypeVar("T")
 
@@ -941,28 +942,28 @@ class Fixed(TypedDict):
     first: int
     second: str
 
-class OverloadedSelf:
+def outer(value: T) -> None:
     @overload
-    def method(self, value: Fixed, later: int) -> None: ...  # snapshot: invalid-overload
+    def inner(value: Fixed, later: int) -> None: ...  # snapshot: invalid-overload
     @overload
-    def method(self, value: str, later: str) -> None: ...
-    def method(self, value: Pair[Self] | str, later: str) -> None: ...
+    def inner(value: str, later: str) -> None: ...
+    def inner(value: Pair[T] | str, later: str) -> None: ...
 ```
 
 ```snapshot
 error[invalid-overload]: Implementation does not accept all arguments of this overload
   --> src/mdtest_snippet.py:15:9
    |
-15 |     def method(self, value: Fixed, later: int) -> None: ...  # snapshot: invalid-overload
-   |         ^^^^^^
+15 |     def inner(value: Fixed, later: int) -> None: ...  # snapshot: invalid-overload
+   |         ^^^^^
 16 |     @overload
-17 |     def method(self, value: str, later: str) -> None: ...
-18 |     def method(self, value: Pair[Self] | str, later: str) -> None: ...
-   |         ------ Implementation defined here
-info: Implementation signature `(self, value: Pair[Self@method] | str, later: str) -> None` is not assignable to overload signature `(self, value: Fixed, later: int) -> None`
-info: parameter `value` has an incompatible type: `Fixed` is not assignable to `Pair[Self@method] | str`
-info: └── type `Fixed` is not assignable to any element of the union `Pair[Self@method] | str`
-info:     ├── field "second" on TypedDict `Fixed` has type `str` which is not assignable to type `Self@method` expected by TypedDict `Pair`
+17 |     def inner(value: str, later: str) -> None: ...
+18 |     def inner(value: Pair[T] | str, later: str) -> None: ...
+   |         ----- Implementation defined here
+info: Implementation signature `(value: Pair[T@outer] | str, later: str) -> None` is not assignable to overload signature `(value: Fixed, later: int) -> None`
+info: parameter `value` has an incompatible type: `Fixed` is not assignable to `Pair[T@outer] | str`
+info: └── type `Fixed` is not assignable to any element of the union `Pair[T@outer] | str`
+info:     ├── field "second" on TypedDict `Fixed` has type `str` which is not assignable to type `T@outer` expected by TypedDict `Pair`
 info:     └── ... omitted 1 union element without additional context
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -170,6 +170,27 @@ def pick(x: object) -> str | bool:
 reveal_type(pick([1]))  # revealed: bool
 ```
 
+## Inferring generic typed-dictionary parameters
+
+A type variable that appears only inside a typed dictionary still makes the function generic, so
+specialized typed dictionaries can be passed to it.
+
+```py
+from typing import Generic, TypeVar, TypedDict
+
+T = TypeVar("T")
+
+class Item(TypedDict, Generic[T]):
+    value: T
+
+def accept(value: Item[T]) -> None: ...
+
+item: Item[int] = {"value": 1}
+
+reveal_type(accept)  # revealed: def accept[T](value: Item[T]) -> None
+accept(item)
+```
+
 ## Inferring a class-object parameter through a generic factory
 
 A factory can infer its type arguments from a specialized subclass of its class-object parameter.

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -632,6 +632,73 @@ class Derived2(GenericBaseAlias[int]):
     pass
 ```
 
+### Generic typed dictionaries in aliases
+
+First, define a generic typed dictionary whose field uses a legacy type variable:
+
+```py
+from typing import Generic, TypeVar, TypedDict
+
+T = TypeVar("T")
+
+class Item(TypedDict, Generic[T]):
+    value: T
+```
+
+An implicit union alias remains generic when its only type variable appears in the typed dictionary,
+and specialization preserves the dictionary's field type:
+
+```py
+OptionalItem = Item[T] | None
+
+def _(item: OptionalItem[int]):
+    reveal_type(item)  # revealed: Item[int] | None
+
+    if item is not None:
+        reveal_type(item["value"])  # revealed: int
+```
+
+Without an explicit type argument, the alias uses the type variable's default specialization:
+
+```py
+def _(item: OptionalItem):
+    reveal_type(item)  # revealed: Item[Unknown] | None
+```
+
+The type variable is also discovered when the typed dictionary is nested inside a container:
+
+```py
+Items = list[Item[T]]
+
+def _(items: Items[str]):
+    reveal_type(items)  # revealed: list[Item[str]]
+    reveal_type(items[0]["value"])  # revealed: str
+```
+
+### Type-variable order in generic typed-dictionary aliases
+
+Type variables that appear inside a typed dictionary are collected in the same order as variables in
+other union members:
+
+```py
+from typing import Generic, TypeVar, TypedDict
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Item(TypedDict, Generic[T]):
+    value: T
+
+TypedDictFirst = Item[T] | list[U]
+TypedDictLast = list[U] | Item[T]
+Repeated = Item[T] | list[T]
+
+def _(first: TypedDictFirst[int, str], last: TypedDictLast[str, int], repeated: Repeated[int]):
+    reveal_type(first)  # revealed: Item[int] | list[str]
+    reveal_type(last)  # revealed: list[str] | Item[int]
+    reveal_type(repeated)  # revealed: Item[int] | list[int]
+```
+
 ### Imported aliases
 
 Generic implicit type aliases can be imported from other modules and specialized:
@@ -662,6 +729,45 @@ def _(
     reveal_type(list_of_ints2)  # revealed: list[int]
     reveal_type(list_of_str)  # revealed: list[str]
     reveal_type(list_of_str_or_none)  # revealed: list[str] | None
+```
+
+### Imported tagged typed-dictionary aliases
+
+A stub can define a generic tagged union containing a typed dictionary and expose a concrete
+specialization through a function signature:
+
+`events.pyi`:
+
+```pyi
+from typing import Generic, Literal, TypeVar, TypedDict, Union
+
+T = TypeVar("T")
+
+class ObjectEvent(TypedDict, Generic[T]):
+    type: Literal["ADDED"]
+    object: T
+
+class BookmarkEvent(TypedDict):
+    type: Literal["BOOKMARK"]
+    object: object
+
+DecodedEvent = Union[ObjectEvent[T], BookmarkEvent, None]
+
+def get_event() -> DecodedEvent[int]: ...
+```
+
+After excluding the other union members, Python code sees the concrete typed-dictionary field type:
+
+`main.py`:
+
+```py
+from events import get_event
+
+event = get_event()
+if event is not None and event["type"] != "BOOKMARK":
+    reveal_type(event)  # revealed: ObjectEvent[int]
+    reveal_type(event["object"])  # revealed: int
+    event["object"].bit_length()
 ```
 
 ### In stringified annotations
@@ -1972,6 +2078,26 @@ def _(
     reveal_type(recursive_dict2)  # revealed: dict[str, Divergent]
     reveal_type(recursive_dict3)  # revealed: dict[Divergent, int]
     reveal_type(recursive_dict4)  # revealed: dict[Divergent, int]
+```
+
+### Recursive typed-dictionary fields in generic aliases
+
+A recursive field on a non-generic typed dictionary does not make an unrelated enclosing generic
+alias recursive:
+
+```py
+from typing import TypeVar, TypedDict
+
+T = TypeVar("T")
+RecursiveList = list["RecursiveList | None"]
+
+class Payload(TypedDict):
+    value: RecursiveList
+
+ListOrPayload = list[T] | Payload
+
+def _(value: ListOrPayload[int]):
+    reveal_type(value)  # revealed: list[int] | Payload
 ```
 
 ### Self-referential generic implicit type aliases

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8159,6 +8159,14 @@ impl<'db> Type<'db> {
                 instance.find_legacy_typevars_impl(db, env, binding_context, typevars, visitor);
             }
 
+            Type::TypedDict(TypedDictType::Class(class)) => {
+                class.find_legacy_typevars_impl(db, env, binding_context, typevars, visitor);
+            }
+
+            // Synthesized schemas can contain type variables, but their internal narrowing and
+            // update constraints inherit those variables from an existing generic context.
+            Type::TypedDict(TypedDictType::Synthesized(_)) => {}
+
             Type::NewTypeInstance(_) => {
                 // A newtype can never be constructed from an unspecialized generic class, so it is
                 // impossible that we could ever find any legacy typevars in a newtype instance or
@@ -8307,8 +8315,7 @@ impl<'db> Type<'db> {
             | Type::ClassLiteral(_)
             | Type::LiteralValue(_)
             | Type::BoundSuper(_)
-            | Type::SpecialForm(_)
-            | Type::TypedDict(_) => {}
+            | Type::SpecialForm(_) => {}
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1440,7 +1440,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // instead of two. So until we properly support these, specialize all remaining type
         // variables with a `@Todo` type (since we don't know which of the type arguments
         // belongs to the remaining type variables).
-        if any_over_type(db, env, value_ty, true, |ty| ty.is_divergent()) {
+        //
+        // A lazily inferred class member can contain its own unrelated recursive type, so only
+        // inspect the alias structure and generic arguments when checking whether it is recursive.
+        if any_over_type(db, env, value_ty, false, |ty| ty.is_divergent()) {
             let value_ty = value_ty.apply_specialization(
                 db,
                 generic_context.specialize(


### PR DESCRIPTION
Legacy generic aliases and functions failed to discover type variables that appeared only inside a generic `TypedDict`. Alias specialization could also incorrectly classify an alias as recursive when a `TypedDict` member contained an unrelated recursive field. Together, these bugs prevented valid imported tagged-union aliases from specializing and produced false-positive diagnostics.

Collect legacy type variables from class-based `TypedDict` definitions, and restrict recursive-alias detection to the alias structure and its generic arguments. Update existing overload fixtures to preserve their diagnostic coverage now that `Self` inside a `TypedDict` is correctly discovered.

Closes astral-sh/ty#4255.

## Test plan

- Generic `TypedDict` aliases in unions and containers, including specialized fields, default specialization, type-variable ordering, and repeated variables.
- Imported tagged-union aliases from stubs, including discriminator narrowing and concrete field access.
- Recursive `TypedDict` fields that do not make their containing alias recursive.
- Generic functions whose type variable appears only in a `TypedDict` parameter.
- Existing overload diagnostic-context scenarios after correcting nested `Self` discovery.
