### PR TITLE
[ty] Avoid bypassing solver during literal promotion

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -637,6 +637,36 @@ reveal_type(i("a"))  # revealed: list[str]
 reveal_type(i(1))  # revealed: list[Literal[1]]
 ```
 
+## Promotion respects inferred upper bounds
+
+Promotion must not select a solution that violates its inferred upper bound.
+
+```py
+from typing import Callable
+
+def f[T](value: T, upper: Callable[[T], None]) -> list[T]:
+    return [value]
+
+def _(upper: Callable[[int], None]):
+    # error: [invalid-argument-type]
+    reveal_type(f("x", upper))  # revealed: list[str | int]
+```
+
+This also applies when multiple inheritance contributes both static and gradual specializations:
+
+```py
+from typing import Any
+
+class Base[T]: ...
+class Specialized(Base[str]): ...
+class Mixed(Specialized, Base[Any]): ...
+
+def g[T](values: list[T], base: Base[T]) -> list[T]:
+    return values
+
+g([1], Mixed())  # error: [invalid-argument-type]
+```
+
 ## Literal annotations from declaration are respected
 
 Literal types that are explicitly annotated when declared will not be promoted, even if they are

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5974,8 +5974,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 return None;
             }
 
-            let lower = bounds.lower?;
-            let promoted = lower.promote(db, self.env);
+            // The promotion override must not select an unsatisfiable solution.
+            let Ok(Some(solution)) = PathBounds::default_solve(db, self.env, constraints, bounds)
+            else {
+                return None;
+            };
+            let promoted = solution.promote(db, self.env);
 
             // If the TypeVar has an upper bound, only use the promoted type if it
             // still satisfies the bound.
@@ -5990,8 +5994,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         let mut choose = |typevar: BoundTypeVarInstance<'db>, bounds: Option<&PathBound<'db>>| {
             let bounds = bounds?;
-            if let Some(lower) = bounds.lower
-                && let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(db))
+            let lower = bounds.lower?;
+
+            if let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(db))
                 && lower.is_assignable_to(db, self.env, preferred_ty)
             {
                 return Some(preferred_ty);


### PR DESCRIPTION
Literal promotion currently bypasses the constraint solver validation pass, allowing unsatisfiable results to be inferred, e.g.,
```py
from typing import Callable

def f[T](value: T, upper: Callable[[T], None]) -> list[T]:
    return [value]

def _(upper: Callable[[int], None]):
    # error[invalid-argument-type]
    reveal_type(f("x", upper))  # revealed: list[str]
``` 

Notice that the chosen solution of `str` does not satisfy the upper bound of `int`. It is possible to construct examples where the diagnostics are currently avoided entirely:
```py
class Base[T]: ...
class Specialized(Base[str]): ...
class Unspecialized(Base): ...
class Mixed(Specialized, Unspecialized): ...

def f[T](values: list[T], base: Base[T]) -> list[T]: ...

f([1], Mixed())
```