### PR TITLE
Align t-string/bytes mix error with CPython 3.14

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/mixed_tstring_and_bytes_literals.py
+++ b/crates/ruff_python_parser/resources/inline/err/mixed_tstring_and_bytes_literals.py
@@ -1,0 +1,7 @@
+t'first' b'second'
+b'first' t'second'
+t'first' br'second'
+'first' b'second' t'third'
+b'first' 'second' t'third'
+'first' t'second' 'third' b'fourth'
+b'first' t'second' f'third'

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1454,78 +1454,71 @@ impl<'src> Parser<'src> {
                 StringType::Str(_) => {}
             }
         }
+        let has_bytes = byte_literal_count > 0;
+        let has_tstring = tstring_count > 0;
 
-        let all_bytes = byte_literal_count == strings.len();
-        let all_tstrings = tstring_count == strings.len();
-        let is_mixed =
-            (byte_literal_count > 0 && !all_bytes) || (tstring_count > 0 && !all_tstrings);
+        if has_bytes {
+            if byte_literal_count < strings.len() {
+                // TODO(dhruvmanila): This is not an ideal recovery because the parser
+                // replaces the byte literals with an invalid string literal node. Any
+                // downstream tools can extract the raw bytes from the range.
+                //
+                // We could convert the node into a string and mark it as invalid
+                // and would be clever to mark the type which is fewer in quantity.
 
-        // CPython reports the first incompatible pair. A t-string mismatch takes
-        // precedence over a bytes mismatch within that pair.
-        if is_mixed
-            && let Some(message) = strings.windows(2).find_map(|pair| match pair {
-                [StringType::TString(_), StringType::TString(_)]
-                | [StringType::Bytes(_), StringType::Bytes(_)] => None,
-                [StringType::TString(_), _] | [_, StringType::TString(_)] => {
-                    Some("Cannot mix t-string literals with string or bytes literals")
+                // test_err mixed_tstring_and_bytes_literals
+                // t'first' b'second'
+                // b'first' t'second'
+                // t'first' br'second'
+                // 'first' b'second' t'third'
+                // b'first' 'second' t'third'
+                // 'first' t'second' 'third' b'fourth'
+                // b'first' t'second' f'third'
+
+                // test_err mixed_bytes_and_non_bytes_literals
+                // 'first' b'second'
+                // f'first' b'second'
+                // 'first' f'second' b'third'
+                self.report_mixed_string_literal_error(&strings, range);
+            }
+            // Only construct a byte expression if all the literals are bytes
+            // otherwise, we'll try either string, t-string, or f-string. This is to retain
+            // as much information as possible.
+            else {
+                let mut values = Vec::with_capacity(strings.len());
+                for string in strings {
+                    values.push(match string {
+                        StringType::Bytes(value) => value,
+                        _ => unreachable!("Expected `StringType::Bytes`"),
+                    });
                 }
-                [StringType::Bytes(_), _] | [_, StringType::Bytes(_)] => {
-                    Some("Bytes literal cannot be mixed with non-bytes literals")
-                }
-                _ => None,
-            })
-        {
-            // TODO(dhruvmanila): This is not an ideal recovery because the parser
-            // replaces the byte/t-string literals with an invalid string literal
-            // node. Any downstream tools can extract the raw bytes from the range.
-            //
-            // We could convert the node into a string and mark it as invalid
-            // and would be clever to mark the type which is fewer in quantity.
-
-            // test_err mixed_tstring_and_bytes_literals
-            // t'first' b'second'
-            // b'first' t'second'
-            // t'first' br'second'
-            // 'first' b'second' t'third'
-            // b'first' 'second' t'third'
-            // 'first' t'second' 'third' b'fourth'
-            // b'first' t'second' f'third'
-
-            // test_err mixed_bytes_and_non_bytes_literals
-            // 'first' b'second'
-            // f'first' b'second'
-            // 'first' f'second' b'third'
-            self.add_error(ParseErrorType::OtherError(message.to_string()), range);
-        }
-
-        if all_tstrings {
-            let mut values = Vec::with_capacity(strings.len());
-            for string in strings {
-                values.push(match string {
-                    StringType::TString(value) => value,
-                    _ => unreachable!("Expected `StringType::TString`"),
+                return Expr::from(ast::ExprBytesLiteral {
+                    value: ast::BytesLiteralValue::concatenated(values),
+                    range,
+                    node_index: AtomicNodeIndex::NONE,
                 });
             }
-            return Expr::from(ast::ExprTString {
-                value: ast::TStringValue::concatenated(values),
-                range,
-                node_index: AtomicNodeIndex::NONE,
-            });
-        }
-
-        if all_bytes {
-            let mut values = Vec::with_capacity(strings.len());
-            for string in strings {
-                values.push(match string {
-                    StringType::Bytes(value) => value,
-                    _ => unreachable!("Expected `StringType::Bytes`"),
+        } else if has_tstring {
+            if tstring_count < strings.len() {
+                self.report_mixed_string_literal_error(&strings, range);
+            }
+            // Only construct a t-string expression if all the literals are t-strings
+            // otherwise, we'll try either string or f-string. This is to retain
+            // as much information as possible.
+            else {
+                let mut values = Vec::with_capacity(strings.len());
+                for string in strings {
+                    values.push(match string {
+                        StringType::TString(value) => value,
+                        _ => unreachable!("Expected `StringType::TString`"),
+                    });
+                }
+                return Expr::from(ast::ExprTString {
+                    value: ast::TStringValue::concatenated(values),
+                    range,
+                    node_index: AtomicNodeIndex::NONE,
                 });
             }
-            return Expr::from(ast::ExprBytesLiteral {
-                value: ast::BytesLiteralValue::concatenated(values),
-                range,
-                node_index: AtomicNodeIndex::NONE,
-            });
         }
 
         // TODO(dhruvmanila): Parser drops unterminated strings here as well
@@ -1550,7 +1543,7 @@ impl<'src> Parser<'src> {
         // )
         // 2 + 2
 
-        if !has_fstring && tstring_count == 0 {
+        if !has_fstring && !has_tstring {
             let mut values = Vec::with_capacity(strings.len());
             for string in strings {
                 values.push(match string {
@@ -1587,6 +1580,26 @@ impl<'src> Parser<'src> {
             range,
             node_index: AtomicNodeIndex::NONE,
         })
+    }
+
+    fn report_mixed_string_literal_error(&mut self, strings: &[StringType], range: TextRange) {
+        // CPython reports the first incompatible pair. A t-string mismatch takes
+        // precedence over a bytes mismatch within that pair.
+        for pair in strings.windows(2) {
+            let message = match pair {
+                [StringType::TString(_), StringType::TString(_)]
+                | [StringType::Bytes(_), StringType::Bytes(_)] => continue,
+                [StringType::TString(_), _] | [_, StringType::TString(_)] => {
+                    "Cannot mix t-string literals with string or bytes literals"
+                }
+                [StringType::Bytes(_), _] | [_, StringType::Bytes(_)] => {
+                    "Bytes literal cannot be mixed with non-bytes literals"
+                }
+                _ => continue,
+            };
+            self.add_error(ParseErrorType::OtherError(message.to_string()), range);
+            break;
+        }
     }
 
     /// Parses a single string or byte literal.

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1454,74 +1454,78 @@ impl<'src> Parser<'src> {
                 StringType::Str(_) => {}
             }
         }
-        let has_bytes = byte_literal_count > 0;
-        let has_tstring = tstring_count > 0;
 
-        if has_bytes {
-            if byte_literal_count < strings.len() {
-                // TODO(dhruvmanila): This is not an ideal recovery because the parser
-                // replaces the byte literals with an invalid string literal node. Any
-                // downstream tools can extract the raw bytes from the range.
-                //
-                // We could convert the node into a string and mark it as invalid
-                // and would be clever to mark the type which is fewer in quantity.
+        let all_bytes = byte_literal_count == strings.len();
+        let all_tstrings = tstring_count == strings.len();
+        let is_mixed =
+            (byte_literal_count > 0 && !all_bytes) || (tstring_count > 0 && !all_tstrings);
 
-                // test_err mixed_bytes_and_non_bytes_literals
-                // 'first' b'second'
-                // f'first' b'second'
-                // 'first' f'second' b'third'
-                self.add_error(
-                    ParseErrorType::OtherError(
-                        "Bytes literal cannot be mixed with non-bytes literals".to_string(),
-                    ),
-                    range,
-                );
-            }
-            // Only construct a byte expression if all the literals are bytes
-            // otherwise, we'll try either string, t-string, or f-string. This is to retain
-            // as much information as possible.
-            else {
-                let mut values = Vec::with_capacity(strings.len());
-                for string in strings {
-                    values.push(match string {
-                        StringType::Bytes(value) => value,
-                        _ => unreachable!("Expected `StringType::Bytes`"),
-                    });
+        // CPython reports the first incompatible pair. A t-string mismatch takes
+        // precedence over a bytes mismatch within that pair.
+        if is_mixed
+            && let Some(message) = strings.windows(2).find_map(|pair| match pair {
+                [StringType::TString(_), StringType::TString(_)]
+                | [StringType::Bytes(_), StringType::Bytes(_)] => None,
+                [StringType::TString(_), _] | [_, StringType::TString(_)] => {
+                    Some("Cannot mix t-string literals with string or bytes literals")
                 }
-                return Expr::from(ast::ExprBytesLiteral {
-                    value: ast::BytesLiteralValue::concatenated(values),
-                    range,
-                    node_index: AtomicNodeIndex::NONE,
-                });
-            }
+                [StringType::Bytes(_), _] | [_, StringType::Bytes(_)] => {
+                    Some("Bytes literal cannot be mixed with non-bytes literals")
+                }
+                _ => None,
+            })
+        {
+            // TODO(dhruvmanila): This is not an ideal recovery because the parser
+            // replaces the byte/t-string literals with an invalid string literal
+            // node. Any downstream tools can extract the raw bytes from the range.
+            //
+            // We could convert the node into a string and mark it as invalid
+            // and would be clever to mark the type which is fewer in quantity.
+
+            // test_err mixed_tstring_and_bytes_literals
+            // t'first' b'second'
+            // b'first' t'second'
+            // t'first' br'second'
+            // 'first' b'second' t'third'
+            // b'first' 'second' t'third'
+            // 'first' t'second' 'third' b'fourth'
+            // b'first' t'second' f'third'
+
+            // test_err mixed_bytes_and_non_bytes_literals
+            // 'first' b'second'
+            // f'first' b'second'
+            // 'first' f'second' b'third'
+            self.add_error(ParseErrorType::OtherError(message.to_string()), range);
         }
 
-        if has_tstring {
-            if tstring_count < strings.len() {
-                self.add_error(
-                    ParseErrorType::OtherError(
-                        "Cannot mix t-string literals with string or bytes literals".to_string(),
-                    ),
-                    range,
-                );
-            }
-            // Only construct a t-string expression if all the literals are t-strings
-            // otherwise, we'll try either string or f-string. This is to retain
-            // as much information as possible.
-            else {
-                let mut values = Vec::with_capacity(strings.len());
-                for string in strings {
-                    values.push(match string {
-                        StringType::TString(value) => value,
-                        _ => unreachable!("Expected `StringType::TString`"),
-                    });
-                }
-                return Expr::from(ast::ExprTString {
-                    value: ast::TStringValue::concatenated(values),
-                    range,
-                    node_index: AtomicNodeIndex::NONE,
+        if all_tstrings {
+            let mut values = Vec::with_capacity(strings.len());
+            for string in strings {
+                values.push(match string {
+                    StringType::TString(value) => value,
+                    _ => unreachable!("Expected `StringType::TString`"),
                 });
             }
+            return Expr::from(ast::ExprTString {
+                value: ast::TStringValue::concatenated(values),
+                range,
+                node_index: AtomicNodeIndex::NONE,
+            });
+        }
+
+        if all_bytes {
+            let mut values = Vec::with_capacity(strings.len());
+            for string in strings {
+                values.push(match string {
+                    StringType::Bytes(value) => value,
+                    _ => unreachable!("Expected `StringType::Bytes`"),
+                });
+            }
+            return Expr::from(ast::ExprBytesLiteral {
+                value: ast::BytesLiteralValue::concatenated(values),
+                range,
+                node_index: AtomicNodeIndex::NONE,
+            });
         }
 
         // TODO(dhruvmanila): Parser drops unterminated strings here as well
@@ -1546,7 +1550,7 @@ impl<'src> Parser<'src> {
         // )
         // 2 + 2
 
-        if !has_fstring && !has_tstring {
+        if !has_fstring && tstring_count == 0 {
             let mut values = Vec::with_capacity(strings.len());
             for string in strings {
                 values.push(match string {

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@mixed_tstring_and_bytes_literals.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@mixed_tstring_and_bytes_literals.py.snap
@@ -1,0 +1,460 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/mixed_tstring_and_bytes_literals.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        node_index: NodeIndex(None),
+        range: 0..176,
+        body: [
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 0..18,
+                    value: FString(
+                        ExprFString {
+                            node_index: NodeIndex(None),
+                            range: 0..18,
+                            value: FStringValue {
+                                inner: Concatenated(
+                                    [
+                                        Literal(
+                                            StringLiteral {
+                                                range: 0..8,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 9..18,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 19..37,
+                    value: FString(
+                        ExprFString {
+                            node_index: NodeIndex(None),
+                            range: 19..37,
+                            value: FStringValue {
+                                inner: Concatenated(
+                                    [
+                                        Literal(
+                                            StringLiteral {
+                                                range: 19..27,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 28..37,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 38..57,
+                    value: FString(
+                        ExprFString {
+                            node_index: NodeIndex(None),
+                            range: 38..57,
+                            value: FStringValue {
+                                inner: Concatenated(
+                                    [
+                                        Literal(
+                                            StringLiteral {
+                                                range: 38..46,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 47..57,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 58..84,
+                    value: FString(
+                        ExprFString {
+                            node_index: NodeIndex(None),
+                            range: 58..84,
+                            value: FStringValue {
+                                inner: Concatenated(
+                                    [
+                                        Literal(
+                                            StringLiteral {
+                                                range: 58..65,
+                                                node_index: NodeIndex(None),
+                                                value: "first",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 66..75,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 76..84,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 85..111,
+                    value: FString(
+                        ExprFString {
+                            node_index: NodeIndex(None),
+                            range: 85..111,
+                            value: FStringValue {
+                                inner: Concatenated(
+                                    [
+                                        Literal(
+                                            StringLiteral {
+                                                range: 85..93,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 94..102,
+                                                node_index: NodeIndex(None),
+                                                value: "second",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 103..111,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 112..147,
+                    value: FString(
+                        ExprFString {
+                            node_index: NodeIndex(None),
+                            range: 112..147,
+                            value: FStringValue {
+                                inner: Concatenated(
+                                    [
+                                        Literal(
+                                            StringLiteral {
+                                                range: 112..119,
+                                                node_index: NodeIndex(None),
+                                                value: "first",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 120..129,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 130..137,
+                                                node_index: NodeIndex(None),
+                                                value: "third",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 138..147,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 148..175,
+                    value: FString(
+                        ExprFString {
+                            node_index: NodeIndex(None),
+                            range: 148..175,
+                            value: FStringValue {
+                                inner: Concatenated(
+                                    [
+                                        Literal(
+                                            StringLiteral {
+                                                range: 148..156,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        Literal(
+                                            StringLiteral {
+                                                range: 157..166,
+                                                node_index: NodeIndex(None),
+                                                value: "",
+                                                flags: StringLiteralFlags {
+                                                    quote_style: Single,
+                                                    prefix: Empty,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                        FString(
+                                            FString {
+                                                range: 167..175,
+                                                node_index: NodeIndex(None),
+                                                elements: [
+                                                    Literal(
+                                                        InterpolatedStringLiteralElement {
+                                                            range: 169..174,
+                                                            node_index: NodeIndex(None),
+                                                            value: "third",
+                                                        },
+                                                    ),
+                                                ],
+                                                flags: FStringFlags {
+                                                    quote_style: Single,
+                                                    prefix: Regular,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | t'first' b'second'
+  | ^^^^^^^^^^^^^^^^^^ Syntax Error: Cannot mix t-string literals with string or bytes literals
+2 | b'first' t'second'
+3 | t'first' br'second'
+  |
+
+
+  |
+1 | t'first' b'second'
+2 | b'first' t'second'
+  | ^^^^^^^^^^^^^^^^^^ Syntax Error: Cannot mix t-string literals with string or bytes literals
+3 | t'first' br'second'
+4 | 'first' b'second' t'third'
+  |
+
+
+  |
+1 | t'first' b'second'
+2 | b'first' t'second'
+3 | t'first' br'second'
+  | ^^^^^^^^^^^^^^^^^^^ Syntax Error: Cannot mix t-string literals with string or bytes literals
+4 | 'first' b'second' t'third'
+5 | b'first' 'second' t'third'
+  |
+
+
+  |
+2 | b'first' t'second'
+3 | t'first' br'second'
+4 | 'first' b'second' t'third'
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: Bytes literal cannot be mixed with non-bytes literals
+5 | b'first' 'second' t'third'
+6 | 'first' t'second' 'third' b'fourth'
+  |
+
+
+  |
+3 | t'first' br'second'
+4 | 'first' b'second' t'third'
+5 | b'first' 'second' t'third'
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: Bytes literal cannot be mixed with non-bytes literals
+6 | 'first' t'second' 'third' b'fourth'
+7 | b'first' t'second' f'third'
+  |
+
+
+  |
+4 | 'first' b'second' t'third'
+5 | b'first' 'second' t'third'
+6 | 'first' t'second' 'third' b'fourth'
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: Cannot mix t-string literals with string or bytes literals
+7 | b'first' t'second' f'third'
+  |
+
+
+  |
+5 | b'first' 'second' t'third'
+6 | 'first' t'second' 'third' b'fourth'
+7 | b'first' t'second' f'third'
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: Cannot mix t-string literals with string or bytes literals


### PR DESCRIPTION
## Summary

Implicitly concatenating a t-string with a bytes literal (e.g. `t'a' b'b'`) reported the generic bytes-mixing error instead of the t-string specific one, even though that message already existed for this case. With CPython3.14 implementation, in a mismatched pair of adjacent literals containing a t-string, the t-string error is always reported over a bytes error, regardless of order. This does not apply for pairs not containing t-strings.

This behavior can be observed with the following:

### CPython 3.14
```bash
$ python3.14
Python 3.14.7 (main, Aug 10 2026, 07:46:56) [GCC 16.1.1 20260728] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> t'a' b'b'
  File "<python-input-0>", line 1
    t'a' b'b'
    ^^^^^^^^^^^
SyntaxError: cannot mix t-string literals with string or bytes literals
```

### Ruff
```bash
$ cargo run --bin ruff -- check --target-version py314 --no-cache --isolated - <<EOF                                                                        
heredoc> t'a' b'b'
heredoc> EOF
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/ruff check --target-version py314 --no-cache --isolated -`
invalid-syntax: Bytes literal cannot be mixed with non-bytes literals
 --> -:1:1
  |
1 | t'a' b'b'
  | ^^^^^^^^^^^

Found 1 error.
```

This change replaces the check with a pairwise scan over adjacent literals, matching CPython's diagnostics.

## Test Plan

These changes can be tested using the commands found above: both error messages should be equal.
I also added a unit test `inline_err::mixed_tstring_and_bytes_literals.py` to ensure ruff always prefers the t-string error as CPython 3.14 does.

Lastly, I have this script (AI-provided) comparing Ruff's and CPython's outputs with all possible combinations of string, bytes, f-strings and t-strings:
<details>
  <summary>cross-check.py</summary>

```python
import ast
import itertools
import os
import pathlib
import subprocess

RUFF = pathlib.Path(os.environ("RUFF_REPO")) / "/target/debug/ruff"

KINDS = {
    "S": "'{}'",
    "B": "b'{}'",
    "F": "f'{}'",
    "T": "t'{}'",
}


def build_source(combo):
    parts = [KINDS[k].format(chr(ord("a") + i)) for i, k in enumerate(combo)]
    return " ".join(parts)


def cpython_classify(source):
    try:
        ast.parse(source)
        return "ok"
    except SyntaxError as e:
        msg = str(e.msg)
        if "bytes and nonbytes" in msg:
            return "bytes"
        if "t-string" in msg:
            return "tstring"
        return f"other:{msg}"


def ruff_classify(source):
    proc = subprocess.run(
        [RUFF, "check", "--target-version", "py314", "--no-cache", "--isolated", "-"],
        input=source,
        capture_output=True,
        text=True,
    )
    out = proc.stdout + proc.stderr
    has_bytes = "Bytes literal cannot be mixed" in out
    has_tstring = "Cannot mix t-string literals" in out
    if has_bytes and has_tstring:
        return "both!"
    if has_bytes:
        return "bytes"
    if has_tstring:
        return "tstring"
    # Ignore unrelated diagnostics (e.g. B018/B021 lint noise) - we only care
    # about whether the two string-mixing syntax errors are reported correctly.
    return "ok"


def main():
    mismatches = []
    total = 0
    for length in (2, 3, 4, 5):
        for combo in itertools.product("SBFT", repeat=length):
            total += 1
            source = build_source(combo)
            cpy = cpython_classify(source)
            ruf = ruff_classify(source)
            if cpy != ruf:
                mismatches.append((combo, source, cpy, ruf))

    print(f"Checked {total} combinations (lengths 2-4 over S/B/F/T)")
    print(f"Mismatches: {len(mismatches)}")
    for combo, source, cpy, ruf in mismatches:
        print(f"  {''.join(combo):6} {source!r:45} cpython={cpy!r:12} ruff={ruf!r}")


if __name__ == "__main__":
    main()

```
</details>

