### PR TITLE
[ty] Widen function-like callables in inferred generic specializations

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1544,7 +1544,7 @@ fn attrs(criterion: &mut Criterion) {
             max_dep_date: TY_ECOSYSTEM_PIN,
             python_version: SupportedPythonVersion::Py311,
         },
-        104,
+        105,
     );
 
     bench_project(&benchmark, criterion);

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -393,6 +393,31 @@ reveal_type(p(2))  # revealed: tuple[int, int]
 reveal_type(p(2)[1])  # revealed: int
 ```
 
+A function bound to the generic parameter must not prevent another callable object from being passed
+to the remaining parameter:
+
+```py
+def default() -> None: ...
+
+class CallableObject:
+    def __call__(self) -> None: ...
+
+partial(pair, default)(CallableObject())
+```
+
+An explicit function bound must still preserve the attributes it guarantees:
+
+```py
+from types import FunctionType
+
+FunctionT = TypeVar("FunctionT", bound=FunctionType)
+
+def choose(first: FunctionT, second: FunctionT) -> FunctionT:
+    return second
+
+reveal_type(partial(choose, default)(default).__name__)  # revealed: str
+```
+
 ### Generic functions preserve defaults for no-longer-inferable type params
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -25,10 +25,12 @@ x = [a, b]
 reveal_type(x)  # revealed: list[(_: int) -> int]
 ```
 
-The inferred `Callable` type is function-like, i.e. we can still access attributes like `__name__`:
+The original function retains its function-specific attributes, but the inferred callable element
+does not: other callable objects could later be stored in the list.
 
 ```py
-reveal_type(x[0].__name__)  # revealed: str
+reveal_type(a.__name__)  # revealed: str
+x[0].__name__  # error: [unresolved-attribute]
 ```
 
 ## Mixed list
@@ -62,6 +64,7 @@ reveal_type(z)  # revealed: list[Sequence[int | str | None]]
 
 xx: list[None] = reveal_type([None])  # revealed: list[None]
 reveal_type(xx)  # revealed: list[None]
+reveal_type([xx])  # revealed: list[list[None]]
 
 yy = reveal_type([None])  # revealed: list[None | Unknown]
 reveal_type(yy)  # revealed: list[None | Unknown]

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -82,6 +82,74 @@ reveal_type(f)  # revealed: def f(_: int) -> int
 reveal_type(promote(f))  # revealed: list[(_: int) -> int]
 ```
 
+## Function values are promoted in invariant generic classes
+
+An invariant generic class initialized with a function should also accept other callable objects
+with the same signature, including callable protocols and concrete callable instances.
+
+```py
+from typing import Protocol
+
+class Box[T]:
+    value: T
+
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+    def set(self, value: T) -> None:
+        self.value = value
+
+class Callback(Protocol):
+    def __call__(self) -> None: ...
+
+class CallableObject:
+    def __call__(self) -> None: ...
+
+def default() -> None: ...
+def callback() -> Callback:
+    return default
+
+inferred_box = Box(default)
+inferred_box.set(callback())
+inferred_box.set(CallableObject())
+```
+
+Callable objects do not necessarily provide the attributes of a function.
+
+```py
+inferred_box.value.__name__  # error: [unresolved-attribute]
+```
+
+An explicit `FunctionType` bound must accept other real functions while preserving their guaranteed
+attributes.
+
+```py
+from types import FunctionType
+
+class FunctionBox[T: FunctionType]:
+    value: T
+
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+def another_default() -> None: ...
+
+function_box = FunctionBox(default)
+function_box.value = another_default
+reveal_type(function_box.value.__name__)  # revealed: str
+```
+
+Context variables infer their type arguments through overloaded `__new__` methods, rather than
+`__init__`, but must apply the same promotion.
+
+```py
+from contextvars import ContextVar
+
+context_callback = ContextVar("callback", default=default)
+context_callback.set(callback())
+context_callback.set(CallableObject())
+```
+
 ## Invariant collection literals are promoted
 
 The elements of invariant collection literals, i.e. lists, dictionaries, and sets, are promoted:
@@ -90,6 +158,30 @@ The elements of invariant collection literals, i.e. lists, dictionaries, and set
 reveal_type([1, 2, 3])  # revealed: list[int]
 reveal_type({"a": 1, "b": 2, "c": 3})  # revealed: dict[str, int]
 reveal_type({"a", "b", "c"})  # revealed: set[str]
+```
+
+Function values are promoted to ordinary callables in each invariant collection. Lambda expressions
+are already callable types and must undergo the same promotion.
+
+```py
+from collections.abc import Callable
+
+def callback() -> None: ...
+def accept_list(callbacks: list[Callable[[], None]]) -> None: ...
+def accept_dict(callbacks: dict[str, Callable[[], None]]) -> None: ...
+def accept_set(callbacks: set[Callable[[], None]]) -> None: ...
+
+list_callbacks = [callback]
+accept_list(list_callbacks)
+
+dict_callbacks = {"callback": callback}
+accept_dict(dict_callbacks)
+
+lambda_callbacks = {"callback": lambda: None}
+accept_dict(lambda_callbacks)
+
+set_callbacks = {callback}
+accept_set(set_callbacks)
 ```
 
 Covariant collection literals are not promoted:
@@ -650,6 +742,21 @@ def f[T](value: T, upper: Callable[[T], None]) -> list[T]:
 def _(upper: Callable[[int], None]):
     # error: [invalid-argument-type]
     reveal_type(f("x", upper))  # revealed: list[str | int]
+```
+
+An inferred function-only upper bound must also prevent promotion from discarding function
+attributes:
+
+```py
+from types import FunctionType
+
+def callback() -> None: ...
+def another_callback() -> None: ...
+def accept_function(value: FunctionType) -> None: ...
+
+callbacks = f(callback, accept_function)
+callbacks.append(another_callback)
+reveal_type(callbacks[0].__name__)  # revealed: str
 ```
 
 This also applies when multiple inheritance contributes both static and gradual specializations:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -449,8 +449,10 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
                 materialization_kind: MaterializationKind::Bottom,
                 ..
             } => &self.bottom_specialization_materialization,
-            TypeMapping::Promote(PromotionMode::On, _) => &self.promotion,
-            TypeMapping::Promote(PromotionMode::Off, _) => &self.skip_promotion,
+            TypeMapping::Promote(PromotionMode::On, _)
+            | TypeMapping::PromoteSingletons(PromotionMode::On) => &self.promotion,
+            TypeMapping::Promote(PromotionMode::Off, _)
+            | TypeMapping::PromoteSingletons(PromotionMode::Off) => &self.skip_promotion,
             _ => &self.default,
         };
         type_transformer
@@ -2647,12 +2649,34 @@ impl<'db> Type<'db> {
     ///
     /// Note that this function tries to promote literals to a more user-friendly form than their
     /// fallback instance type. For example, `def _() -> int` is promoted to `Callable[[], int]`,
-    /// as opposed to `FunctionType`.
+    /// as opposed to `FunctionType`, while preserving its function attributes and descriptor
+    /// behavior.
     pub(crate) fn promote(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         self.apply_type_mapping(
             db,
             env,
-            &TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular),
+            &TypeMapping::Promote(PromotionMode::On, PromotionPolicy::LITERALS),
+            TypeContext::default(),
+        )
+    }
+
+    /// Promote an inferred generic argument without retaining function-only guarantees.
+    ///
+    /// An inferred generic argument can describe other callable objects with the same signature,
+    /// such as values later stored in a mutable generic or arguments passed to a partially applied
+    /// function. It must not promise function-only attributes or descriptor behavior.
+    pub(crate) fn promote_for_generic_specialization(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Type<'db> {
+        self.apply_type_mapping(
+            db,
+            env,
+            &TypeMapping::Promote(
+                PromotionMode::On,
+                PromotionPolicy::LITERALS | PromotionPolicy::FUNCTION_LIKE_CALLABLES,
+            ),
             TypeContext::default(),
         )
     }
@@ -2668,14 +2692,13 @@ impl<'db> Type<'db> {
 
     /// Promote class literals to the class objects represented by `type[...]`.
     ///
-    /// This is intentionally separate from regular promotion. Applying it during collection
-    /// inference would lose useful precision for local and module-level collections of class
-    /// objects.
+    /// Keep class-literal promotion separate from collection inference, where it would lose useful
+    /// precision for local and module-level collections of class objects.
     fn promote_class_literals(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         self.apply_type_mapping(
             db,
             env,
-            &TypeMapping::Promote(PromotionMode::On, PromotionKind::ClassLiteralsOnly),
+            &TypeMapping::Promote(PromotionMode::On, PromotionPolicy::CLASS_LITERALS),
             TypeContext::default(),
         )
     }
@@ -2692,7 +2715,7 @@ impl<'db> Type<'db> {
         self.apply_type_mapping(
             db,
             env,
-            &TypeMapping::Promote(PromotionMode::On, PromotionKind::SingletonsOnly),
+            &TypeMapping::PromoteSingletons(PromotionMode::On),
             TypeContext::default(),
         )
     }
@@ -7643,19 +7666,15 @@ impl<'db> Type<'db> {
 
         // Recursive singleton promotion only recurses into `NominalInstance` types (tuples
         // and specialized generics). For all other types, return early.
-        if matches!(
-            type_mapping,
-            TypeMapping::Promote(_, PromotionKind::SingletonsOnly)
-        ) && !matches!(self, Type::NominalInstance(_))
+        if matches!(type_mapping, TypeMapping::PromoteSingletons(_))
+            && !matches!(self, Type::NominalInstance(_))
         {
             return self;
         }
 
         if let Type::ClassLiteral(class) = self
-            && matches!(
-                type_mapping,
-                TypeMapping::Promote(PromotionMode::On, PromotionKind::ClassLiteralsOnly)
-            )
+            && let TypeMapping::Promote(PromotionMode::On, policy) = type_mapping
+            && policy.contains(PromotionPolicy::CLASS_LITERALS)
         {
             return SubclassOfType::from(db, visitor.env, class.default_specialization(db));
         }
@@ -7672,14 +7691,21 @@ impl<'db> Type<'db> {
                 match type_mapping {
                     // Promote the types within the signature before promoting the signature to its
                     // callable form.
-                    TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => {
-                        Type::FunctionLiteral(function.apply_type_mapping_impl(
-                            db,
-                            type_mapping,
-                            tcx,
-                            visitor,
-                        ))
-                        .promote_impl(db, visitor.env)
+                    TypeMapping::Promote(PromotionMode::On, policy)
+                        if policy.contains(PromotionPolicy::LITERALS) =>
+                    {
+                        let callable = function
+                            .apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                            .into_callable_type(db);
+                        Type::Callable(
+                            if policy.contains(PromotionPolicy::FUNCTION_LIKE_CALLABLES)
+                                && callable.is_function_like(db)
+                            {
+                                callable.into_regular(db)
+                            } else {
+                                callable
+                            },
+                        )
                     }
                     _ => Type::FunctionLiteral(function.apply_type_mapping_impl(
                         db,
@@ -7700,35 +7726,21 @@ impl<'db> Type<'db> {
                     .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             )),
 
-            Type::NominalInstance(instance)
-                if matches!(
-                    type_mapping,
-                    TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular)
-                ) =>
-            {
-                match instance.known_class(db) {
-                    Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db, visitor.env),
-                    Some(KnownClass::Float) => KnownUnion::Float.to_type(db, visitor.env),
-                    _ => instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                }
-            }
-
-            Type::NominalInstance(instance)
-                if matches!(
-                    type_mapping,
-                    TypeMapping::Promote(PromotionMode::On, PromotionKind::SingletonsOnly)
-                ) =>
-            {
-                if instance.is_singleton(db) {
+            Type::NominalInstance(instance) => match type_mapping {
+                TypeMapping::PromoteSingletons(PromotionMode::On) if instance.is_singleton(db) => {
                     self.promote_singletons_impl(db, visitor.env)
-                } else {
-                    instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                 }
-            }
-
-            Type::NominalInstance(instance) => {
-                instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-            }
+                TypeMapping::Promote(PromotionMode::On, policy)
+                    if policy.contains(PromotionPolicy::LITERALS) =>
+                {
+                    match instance.known_class(db) {
+                        Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db, visitor.env),
+                        Some(KnownClass::Float) => KnownUnion::Float.to_type(db, visitor.env),
+                        _ => instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    }
+                }
+                _ => instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            },
 
             Type::NewTypeInstance(newtype) => visitor.visit(db, self, type_mapping, || {
                 Type::NewTypeInstance(newtype.map_base_class_type(db, |class_type| {
@@ -7770,7 +7782,15 @@ impl<'db> Type<'db> {
             }
 
             Type::Callable(callable) => visitor.visit(db, self, type_mapping, || {
-                Type::Callable(callable.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                let callable = callable.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                if let TypeMapping::Promote(PromotionMode::On, policy) = type_mapping
+                    && policy.contains(PromotionPolicy::FUNCTION_LIKE_CALLABLES)
+                    && callable.is_function_like(db)
+                {
+                    Type::Callable(callable.into_regular(db))
+                } else {
+                    Type::Callable(callable)
+                }
             }),
 
             Type::GenericAlias(generic) => {
@@ -7802,11 +7822,11 @@ impl<'db> Type<'db> {
                         visitor,
                     ));
                 }
-                // Regular promotion should remove negative contributions from intersections,
-                // so we don't preserve them here when regular promotion is enabled.
+                // Literal promotion removes negative contributions from intersections.
                 if !matches!(
                     type_mapping,
-                    TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular)
+                    TypeMapping::Promote(PromotionMode::On, policy)
+                        if policy.contains(PromotionPolicy::LITERALS)
                 ) {
                     for negative in intersection.negative(db) {
                         builder.add_negative_in_place(negative.apply_type_mapping_impl(
@@ -7947,12 +7967,13 @@ impl<'db> Type<'db> {
                 | TypeMapping::EagerExpansion
                 | TypeMapping::RescopeReturnCallables(_)
                 | TypeMapping::Promote(PromotionMode::Off, _)
-                | TypeMapping::Promote(
-                    PromotionMode::On,
-                    PromotionKind::ClassLiteralsOnly | PromotionKind::SingletonsOnly,
-                ) => self,
-                TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => {
-                    self.promote_impl(db, visitor.env)
+                | TypeMapping::PromoteSingletons(_) => self,
+                TypeMapping::Promote(PromotionMode::On, policy) => {
+                    if policy.contains(PromotionPolicy::LITERALS) {
+                        self.promote_impl(db, visitor.env)
+                    } else {
+                        self
+                    }
                 }
             },
 
@@ -7964,6 +7985,7 @@ impl<'db> Type<'db> {
                 | TypeMapping::BindSelf(..)
                 | TypeMapping::ReplaceSelf { .. }
                 | TypeMapping::Promote(..)
+                | TypeMapping::PromoteSingletons(_)
                 | TypeMapping::ReplaceParameterDefaults
                 | TypeMapping::EagerExpansion
                 | TypeMapping::RescopeReturnCallables(_) => self,
@@ -9004,16 +9026,20 @@ impl PromotionMode {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, get_size2::GetSize)]
-pub enum PromotionKind {
-    /// Default promotion behaviour: recurse into nested types
-    Regular,
-    /// Promote class literals recursively without promoting other literal types.
-    ClassLiteralsOnly,
-    /// Singleton-only promotion recursively descends through nominal instances
-    /// without recursing into unions or non-nominal types.
-    SingletonsOnly,
+bitflags! {
+    /// Controls which kinds of types are widened by a promotion mapping.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub struct PromotionPolicy: u8 {
+        /// Promote literal values and their associated inferred fallback types.
+        const LITERALS = 1 << 0;
+        /// Promote class literals to their corresponding `type[...]` forms.
+        const CLASS_LITERALS = 1 << 1;
+        /// Widen function-like callables to ordinary callable types.
+        const FUNCTION_LIKE_CALLABLES = 1 << 2;
+    }
 }
+
+impl get_size2::GetSize for PromotionPolicy {}
 
 /// Returns the [`ClassLiteral`] that "owns" a `Self` typevar (i.e., the class from its upper bound).
 fn self_typevar_owner_class_literal<'db>(
@@ -9128,9 +9154,12 @@ pub enum TypeMapping<'a, 'db> {
         specialization: ApplySpecialization<'a, 'db>,
         materialization_kind: MaterializationKind,
     },
-    /// Replaces any literal types with their corresponding promoted type form (e.g. `Literal["string"]`
-    /// to `str`, or `def _() -> int` to `Callable[[], int]`).
-    Promote(PromotionMode, PromotionKind),
+    /// Applies the selected promotion policies, such as replacing `Literal["string"]` with `str` or
+    /// converting `def _() -> int` to `Callable[[], int]`.
+    Promote(PromotionMode, PromotionPolicy),
+    /// Promotes singleton instances to unions with `Unknown`, descending only through nominal
+    /// instances rather than arbitrary nested types.
+    PromoteSingletons(PromotionMode),
     /// Binds a legacy typevar with the generic context (class, function, type alias) that it is
     /// being used in.
     BindLegacyTypevars(BindingContext<'db>),
@@ -9197,6 +9226,7 @@ impl<'db> TypeMapping<'_, 'db> {
                 )
             }
             TypeMapping::Promote(..)
+            | TypeMapping::PromoteSingletons(_)
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::Materialize(_)
             | TypeMapping::ReplaceParameterDefaults
@@ -9240,7 +9270,8 @@ impl<'db> TypeMapping<'_, 'db> {
                 specialization: *specialization,
                 materialization_kind: materialization_kind.flip(),
             },
-            TypeMapping::Promote(mode, kind) => TypeMapping::Promote(mode.flip(), *kind),
+            TypeMapping::Promote(mode, policy) => TypeMapping::Promote(mode.flip(), *policy),
+            TypeMapping::PromoteSingletons(mode) => TypeMapping::PromoteSingletons(mode.flip()),
             TypeMapping::ApplySpecialization(_)
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::FreshenBoundTypeVars { .. }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -6001,13 +6001,33 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             else {
                 return None;
             };
-            let promoted = solution.promote(db, self.env);
+            let promoted = solution.promote_for_generic_specialization(db, self.env);
 
             // If the TypeVar has an upper bound, only use the promoted type if it
             // still satisfies the bound.
-            if let Some(TypeVarBoundOrConstraints::UpperBound(bound)) = bound_or_constraints {
-                if !promoted.is_assignable_to(db, self.env, bound) {
-                    return None;
+            if let Some(TypeVarBoundOrConstraints::UpperBound(bound)) = bound_or_constraints
+                && !promoted.is_assignable_to(db, self.env, bound)
+            {
+                let ordinary = solution.promote(db, self.env);
+                return ordinary
+                    .is_assignable_to(db, self.env, bound)
+                    .then_some(ordinary);
+            }
+
+            // Widening a function-like callable beyond ordinary promotion can violate an inferred
+            // upper bound.
+            if bounds.has_upper() && promoted != solution {
+                let ordinary = solution.promote(db, self.env);
+                if promoted != ordinary {
+                    let mut promoted_bounds = bounds.clone();
+                    promoted_bounds.lower = Some(promoted);
+
+                    if !matches!(
+                        PathBounds::default_solve(db, self.env, constraints, &promoted_bounds),
+                        Ok(Some(validated)) if validated == promoted
+                    ) {
+                        return Some(ordinary);
+                    }
                 }
             }
 

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -418,7 +418,7 @@ impl<'db> ConstructorBinding<'db> {
                             } else {
                                 without_unknown
                             };
-                            mapped_ty.promote(db, env)
+                            mapped_ty.promote_for_generic_specialization(db, env)
                         })
                         .collect();
                     Specialization::new(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7600,13 +7600,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         db,
                         env,
                         key_ty.identity(self.db()),
-                        unpacked_key_ty.promote(db, env),
+                        unpacked_key_ty.promote_for_generic_specialization(db, env),
                     );
                     tuple_size_promotion_constraints.record_unpromotable_type(
                         db,
                         env,
                         value_ty.identity(self.db()),
-                        unpacked_value_ty.promote(db, env),
+                        unpacked_value_ty.promote_for_generic_specialization(db, env),
                     );
 
                     builder.infer(Type::TypeVar(key_ty), unpacked_key_ty).ok()?;
@@ -7660,7 +7660,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // A covariant context is an upper bound, so promotion must not widen an otherwise
                 // compatible element beyond that bound. In particular, promoting an exact float
                 // introduces `int`, which is not assignable to an exact-float context.
-                let promoted_elt_ty = inferred_elt_ty.promote(db, env);
+                let promoted_elt_ty = inferred_elt_ty.promote_for_generic_specialization(db, env);
                 let inferred_elt_ty = if let Some(elt_tcx) = elt_tcx
                     && elt_tcx_variance[&elt_ty_identity].is_covariant()
                     && promoted_elt_ty != inferred_elt_ty
@@ -7704,7 +7704,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // Constraints learned from later collection uses follow the same promotion
                         // policy as literal elements: promote element literal types in invariant
                         // position unless an explicit annotation made them unpromotable.
-                        lower.promote(db, env)
+                        lower.promote_for_generic_specialization(db, env)
                     } else {
                         lower
                     };

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -7,7 +7,7 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, CallableType,
         ClassType, GenericContext, InferenceFlags, InvalidTypeExpressionError, KnownClass,
-        PromotionKind, PromotionMode, StringLiteralType, Type, TypeAliasType, TypeContext,
+        PromotionMode, PromotionPolicy, StringLiteralType, Type, TypeAliasType, TypeContext,
         TypeMapping, TypeVarNonce, TypeVarVariance, UnionBuilder,
         class::NamedTupleSpec,
         constraints::{OwnedConstraintSet, TypeVarSolution},
@@ -439,6 +439,7 @@ impl<'db> KnownInstanceType<'db> {
                 TypeMapping::ApplySpecialization(_)
                 | TypeMapping::ApplySpecializationWithMaterialization { .. }
                 | TypeMapping::Promote(..)
+                | TypeMapping::PromoteSingletons(_)
                 | TypeMapping::FreshenBoundTypeVars { .. }
                 | TypeMapping::BindSelf(..)
                 | TypeMapping::ReplaceSelf { .. }
@@ -470,7 +471,9 @@ impl<'db> KnownInstanceType<'db> {
                 ))
             }
             KnownInstanceType::Range { .. } => match type_mapping {
-                TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => {
+                TypeMapping::Promote(PromotionMode::On, policy)
+                    if policy.contains(PromotionPolicy::LITERALS) =>
+                {
                     self.instance_fallback(db, visitor.env)
                 }
                 _ => Type::KnownInstance(self),

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1689,9 +1689,22 @@ impl<'db> Signature<'db> {
         }
 
         Some(inference.specialization_with(db, |typevar, inferred| {
-            promoted_typevars
-                .contains(&typevar.identity(db))
-                .then(|| inferred.map_or(Type::TypeVar(typevar), |ty| ty.promote(db, env)))
+            promoted_typevars.contains(&typevar.identity(db)).then(|| {
+                inferred.map_or(Type::TypeVar(typevar), |inferred| {
+                    let promoted = inferred.promote_for_generic_specialization(db, env);
+                    match typevar.typevar(db).bound_or_constraints(db, env) {
+                        Some(TypeVarBoundOrConstraints::Constraints(_)) => {
+                            inferred.promote(db, env)
+                        }
+                        Some(TypeVarBoundOrConstraints::UpperBound(bound))
+                            if !promoted.is_assignable_to(db, env, bound) =>
+                        {
+                            inferred.promote(db, env)
+                        }
+                        _ => promoted,
+                    }
+                })
+            })
         }))
     }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1316,6 +1316,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                 }
             }
             TypeMapping::Promote(..)
+            | TypeMapping::PromoteSingletons(_)
             | TypeMapping::ReplaceParameterDefaults
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::EagerExpansion


### PR DESCRIPTION
Functions inferred as generic type arguments kept ty's internal function-like marker. As a result, invariant collections appeared to have the expected callable signature while still rejecting regular `Callable` specializations, callback protocols, and other callable objects. This affected dictionaries of callbacks, `ContextVar.set`, generic containers, and partially applied generic functions.

Promote inferred generic arguments to regular callable types consistently across mutable collections, constructors, and partial applications. Values read from inferred collections no longer promise function-only attributes such as `__name__`; direct functions and explicitly function-bounded type variables retain those guarantees.

Use composable promotion policies for literals, class literals, and function-like callables. Keep singleton promotion as a separate nominal-only mapping because its traversal cannot safely compose with ordinary promotion.

Fixes astral-sh/ty#3697.
Fixes astral-sh/ty#4257.

## Test plan

- Lists, dictionaries, and sets containing named functions or lambdas match their corresponding callable collection types.
- Inferred generic containers and `ContextVar` accept callback protocols and concrete callable objects without exposing unsupported function-only attributes.
- Partially applied generic functions accept compatible callable objects, while declared and inferred function bounds preserve function attributes.
- Direct functions retain their attributes, and explicitly typed nested `list[None]` remains unchanged under singleton promotion.
