### PR TITLE
[ty] Preserve callable return types when narrowed to FunctionType

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -1111,7 +1111,7 @@ static_assert(is_assignable_to(TypeOf[f], Callable[..., Any]))
 reveal_type(f.__get__)
 static_assert(is_assignable_to(TypeOf[f.__get__], Callable[..., Any]))
 
-# revealed: def __call__(self, *args: Any, **kwargs: Any) -> Any
+# revealed: def __call__(self, *args: Any, **kwargs: Any) -> object
 reveal_type(types.FunctionType.__call__)
 static_assert(is_assignable_to(TypeOf[types.FunctionType.__call__], Callable[..., Any]))
 
@@ -1172,7 +1172,7 @@ def _(
     # revealed: Overload[(instance: None, owner: type, /) -> Unknown, (instance: object, owner: type | None = None, /) -> Unknown]
     reveal_type(c)
 
-    # revealed: (self, *args: Any, **kwargs: Any) -> Any
+    # revealed: (self, *args: Any, **kwargs: Any) -> object
     reveal_type(d)
 
     # revealed: (obj: type) -> None
@@ -1201,6 +1201,35 @@ def _(
 
     # revealed: (prefix: str | tuple[str, ...], start: SupportsIndex | None = None, end: SupportsIndex | None = None, /) -> bool
     reveal_type(l)
+```
+
+## Calls to `types.FunctionType`
+
+A function with an unknown signature accepts arbitrary arguments, but its return type is `object`,
+not `Any`. It therefore cannot satisfy a callable that promises a more specific return type.
+
+```py
+from types import FunctionType
+from typing import Callable
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to
+
+def check(function: FunctionType) -> None:
+    reveal_type(function())  # revealed: object
+    reveal_type(function.__call__())  # revealed: object
+
+static_assert(is_assignable_to(FunctionType, Callable[..., object]))
+static_assert(not is_assignable_to(FunctionType, Callable[..., str]))
+```
+
+Narrowing a callable to `FunctionType` exposes function-only attributes without introducing `Any`
+into the callable's return type. See [ty#1495](https://github.com/astral-sh/ty/issues/1495).
+
+```py
+def check_narrowed_callable(function: Callable[[], int]) -> None:
+    if isinstance(function, FunctionType):
+        reveal_type(function.__name__)  # revealed: str
+        reveal_type(function())  # revealed: int
 ```
 
 [functions and methods]: https://docs.python.org/3/howto/descriptor.html#functions-and-methods

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2133,10 +2133,12 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
 
     /// Returns the access that a candidate value must provide for this member.
     ///
-    /// A module-level callable can satisfy an ordinary or static method through direct member
+    /// A callback protocol's `__call__` method describes call syntax and is fully checked through
+    /// instance access, regardless of whether it is an ordinary, static, or class method. A
+    /// module-level callable can also satisfy an ordinary or static method through direct member
     /// access. A class object can likewise satisfy a class, static, or ordinary instance method;
-    /// special instance methods instead use special-method lookup through the meta-type. Neither
-    /// case needs a separate class-side check for the same member.
+    /// special instance methods instead use special-method lookup through the meta-type. None of
+    /// these cases needs a separate class-side check for the same member.
     fn implementation_access(
         &self,
         db: &'db dyn Db,
@@ -2145,16 +2147,17 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         mode: ProtocolMemberAccessMode,
     ) -> ProtocolMemberAccess<'db> {
         if mode == ProtocolMemberAccessMode::Class
-            && (matches!(
-                (ty, self.data.kind),
-                (
-                    Type::ModuleLiteral(_),
-                    ProtocolMemberKind::Method(
-                        _,
-                        ProtocolMethodKind::Instance | ProtocolMethodKind::Static
+            && ((self.is_method() && (self.name == "__call__" || is_class_object_type(ty)))
+                || matches!(
+                    (ty, self.data.kind),
+                    (
+                        Type::ModuleLiteral(_),
+                        ProtocolMemberKind::Method(
+                            _,
+                            ProtocolMethodKind::Instance | ProtocolMethodKind::Static
+                        )
                     )
-                )
-            ) || (is_class_object_type(ty) && self.is_method()))
+                ))
         {
             ProtocolMemberAccess::NONE
         } else {

--- a/crates/ty_vendored/typeshed_patches/0008-functiontype-call-object.patch
+++ b/crates/ty_vendored/typeshed_patches/0008-functiontype-call-object.patch
@@ -1,0 +1,6 @@
+--- a/stdlib/types.pyi
++++ b/stdlib/types.pyi
+@@ -143,2 +143,2 @@ class FunctionType:
+-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
++    def __call__(self, *args: Any, **kwargs: Any) -> object:
+         """Call self as a function."""

--- a/crates/ty_vendored/vendor/typeshed/stdlib/types.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/types.pyi
@@ -140,7 +140,7 @@ class FunctionType:
             closure: tuple[CellType, ...] | None = None,
         ) -> Self: ...
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+    def __call__(self, *args: Any, **kwargs: Any) -> object:
         """Call self as a function."""
 
     @overload


### PR DESCRIPTION
Narrowing a precisely typed callable with `isinstance(value, FunctionType)` exposes function-specific attributes, but calling the narrowed value previously polluted its return type with `Any` from `FunctionType.__call__`. Patch typeshed so `FunctionType.__call__` returns `object`, preserving the callable's original return type while safely representing functions with unknown signatures.

Keep the change in both the vendored typeshed stub and the persistent typeshed patch. Also adjust callback-protocol matching so ordinary, static, and class `__call__` implementations are checked against actual call behavior without an unnecessary class-side check.

Related: <https://github.com/astral-sh/ty/issues/1495>

## Test plan

- Cover direct and explicit `FunctionType.__call__` invocations and callable assignability for `object` versus more specific return types.
- Cover narrowing `Callable[[], int]` with `isinstance(..., FunctionType)`, confirming that function-only attributes remain available and calls still return `int`.
- Preserve existing coverage for static and class callback protocols.
