### PR TITLE
[ty] Preserve source protocol members and classify finite aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -6192,6 +6192,111 @@ def infer[T](outer: T, recursive: C[int]) -> None:
     accept(outer, recursive)
 ```
 
+### Nested protocol source members with finite targets
+
+A source specialization can contain its own protocol even when the target has no recursive
+requirements. This must not activate a recursive matching shortcut or discard the source member.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_constraint_set_assignable_to
+
+class Consumer[T](Protocol):
+    def consume(self, value: T | int) -> None: ...
+
+static_assert(is_constraint_set_assignable_to(Consumer[Consumer[int]], Consumer[int]))
+```
+
+### Recursive members in the source specialization
+
+A protocol member can contain the same protocol in the source specialization but remain finite in
+the target specialization. Its structural requirements must still contribute all valid solutions,
+even when nominal inheritance alone would infer a narrower type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Consumer[T](Protocol):
+    def consume(self, value: T | int) -> None: ...
+    @property
+    def child(self) -> Consumer[T]: ...
+
+def extract[T](consumer: Consumer[T]) -> T:
+    raise NotImplementedError
+
+def check(value: Consumer[Consumer[int]]) -> None:
+    reveal_type(extract(value))  # revealed: Consumer[int] | int
+```
+
+### Repeated applications of a nonrecursive alias
+
+Nested applications of the same finite alias do not create an alias cycle. Their protocol
+requirement must still contribute its type-variable constraints.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+from ty_extensions._internal import is_constraint_set_assignable_to
+
+type Identity[T] = T
+
+class Recursive[T](Protocol):
+    @property
+    def value(self) -> Identity[Identity[T]]: ...
+    @property
+    def child(self) -> Recursive[T]: ...
+
+def inspect[T]() -> None:
+    constraints = is_constraint_set_assignable_to(Recursive[int], Recursive[T])
+    reveal_type(constraints.solutions_for(T, inferable=tuple[T]))  # revealed: tuple[Solution[T=int]]
+```
+
+### Growing aliases in recursive protocol requirements
+
+A recursive alias can change its specialization every time its definition is expanded. Finite
+protocol matching must detect the repeated alias definition instead of following the growing
+specializations indefinitely.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+type GrowingAlias[T] = T | GrowingAlias[list[T]]
+
+class Recursive[T](Protocol):
+    def consume(self, value: T) -> None: ...
+    def growing(self) -> GrowingAlias[T]: ...
+    def child(self) -> Recursive[T]: ...
+
+def check(value: Recursive[int]) -> None:
+    rejected: Recursive[str] = value  # error: [invalid-assignment]
+```
+
 ### Recursive legacy generic protocol
 
 ```py

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -17,6 +17,7 @@ use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
 };
+use crate::types::cyclic::{ActiveRecursionDetector, TypeIdentity};
 use crate::types::enums::is_single_member_enum;
 use crate::types::generics::walk_specialization;
 use crate::types::protocol_class::{
@@ -703,8 +704,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         let source_interface = source_protocol.interface(db);
         let target_interface = protocol.interface(db);
-        let source_non_recursive =
-            non_recursive_protocol_interface(db, source_interface.base(), identity_protocol, ty);
         let target_non_recursive = non_recursive_protocol_interface(
             db,
             target_interface.base(),
@@ -712,19 +711,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             Type::ProtocolInstance(protocol),
         );
 
-        if source_non_recursive == source_interface.base()
-            && target_non_recursive == target_interface.base()
-        {
+        if target_non_recursive == target_interface.base() {
             return None;
         }
 
+        // Filter requirements, not evidence: a target-finite member can contain the same protocol
+        // in the source specialization and must remain available for comparison.
         Some(self.check_protocol_interface_pair(
             db,
             ty,
-            ProtocolInterfaceView::new(
-                source_non_recursive,
-                source_interface.materialization_kind(),
-            ),
+            source_interface,
             ProtocolInterfaceView::new(
                 target_non_recursive,
                 target_interface.materialization_kind(),
@@ -802,6 +798,7 @@ fn non_recursive_protocol_interface<'db>(
         origin: ClassLiteral<'db>,
         found: Cell<bool>,
         recursion_guard: TypeCollector<'db>,
+        active_aliases: ActiveRecursionDetector<TypeIdentity<'db>>,
     }
 
     impl<'db> TypeVisitor<'db> for ProtocolReferenceFinder<'_, 'db> {
@@ -814,7 +811,11 @@ fn non_recursive_protocol_interface<'db>(
         }
 
         fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
-            self.visit_type(db, type_alias.value_type(db));
+            self.active_aliases.visit(
+                &Type::TypeAlias(type_alias).to_type_identity(db),
+                || self.found.set(true),
+                || self.visit_type(db, type_alias.value_type(db)),
+            );
         }
 
         fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
@@ -844,6 +845,7 @@ fn non_recursive_protocol_interface<'db>(
             origin: protocol.class_literal(db),
             found: Cell::new(false),
             recursion_guard: TypeCollector::default(),
+            active_aliases: ActiveRecursionDetector::default(),
         };
         walk_protocol_instance_member(db, member, receiver_ty, &visitor);
         !visitor.found.get()

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -15,7 +15,7 @@ use crate::types::attribute_write::{
 use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::overrides::{VariableKind, effective_superclass_variable_kind};
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
-use crate::types::visitor::any_over_type;
+use crate::types::visitor::any_over_type_expanding_aliases;
 use crate::types::{TypeContext, UpcastPolicy};
 use crate::{
     Db, FxOrderSet,
@@ -1803,7 +1803,7 @@ enum StructuralMemberPriority {
     Simple,
     /// A non-recursive callable member with multiple overloads.
     FiniteOverload,
-    /// A member that may recurse through a protocol or type alias, or whose finiteness is unknown.
+    /// A member that contains a protocol or recursive alias, or whose finiteness is unknown.
     Recursive,
 }
 
@@ -1908,16 +1908,16 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
 
     /// Returns the priority for structurally comparing this member.
     ///
-    /// Simple finite members are cheapest, followed by finite overloads. Recursive and
-    /// alias-containing members are compared last because they can expand the same interface again.
+    /// Simple finite members are cheapest, followed by finite overloads. Recursive members and
+    /// aliases that contain a protocol or are themselves recursive are compared last.
     fn structural_member_priority(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> StructuralMemberPriority {
         let is_recursive_type = |ty| {
-            any_over_type(db, env, ty, false, |nested| {
-                matches!(nested, Type::ProtocolInstance(_) | Type::TypeAlias(_))
+            any_over_type_expanding_aliases(db, env, ty, |nested| {
+                matches!(nested, Type::ProtocolInstance(_))
             })
         };
 

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -15,7 +15,7 @@ use crate::types::{
     bound_super::walk_bound_super_type,
     callable::walk_callable_type,
     class::walk_generic_alias,
-    cyclic::ActiveRecursionDetector,
+    cyclic::{ActiveRecursionDetector, TypeIdentity},
     function::{FunctionType, walk_function_type},
     generics::walk_specialization_types,
     instance::{walk_nominal_instance_type, walk_protocol_instance_type},
@@ -652,6 +652,37 @@ pub(super) fn any_over_type<'db>(
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
     any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query)
+}
+
+/// Searches through type aliases without forcing other lazily inferred type attributes.
+///
+/// Revisiting a recursive alias counts as a match because its specialization can grow on each
+/// visit. Distinct specializations of a nonrecursive alias remain separate, so nested uses such as
+/// `Identity[Identity[int]]` are still considered finite.
+pub(super) fn any_over_type_expanding_aliases<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+    query: impl Fn(Type<'db>) -> bool,
+) -> bool {
+    fn search<'db>(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        ty: Type<'db>,
+        query: &impl Fn(Type<'db>) -> bool,
+        active_aliases: &ActiveRecursionDetector<TypeIdentity<'db>>,
+    ) -> bool {
+        any_over_type(db, env, ty, false, |nested| {
+            query(nested)
+                || matches!(nested, Type::TypeAlias(alias) if active_aliases.visit(
+                    &Type::TypeAlias(alias).to_type_identity(db),
+                    || true,
+                    || search(db, env, alias.value_type(db), query, active_aliases),
+                ))
+        })
+    }
+
+    search(db, env, ty, &query, &ActiveRecursionDetector::default())
 }
 
 /// Recurse into a type and calls the passed-in closure on every nested type


### PR DESCRIPTION
This is the first prerequisite for fixing the performance issues in astral-sh/ty#4269. It makes ty's existing shortcut for comparing recursive protocols more accurate, without adding the later performance optimizations.

## Keep the methods needed for comparison

A recursive protocol can send the type checker back through the same requirements repeatedly. To avoid that, ty can first compare the requirements that do not refer back to the protocol. The problem was that it removed recursive-looking members from *both* types being compared. A member of the actual type can mention the protocol even when the corresponding requirement does not, so removing it loses information needed to decide whether the types are compatible.

For example:

```python
from __future__ import annotations

from typing import Protocol

class Consumer[T](Protocol):
    def consume(self, value: T | int) -> None: ...

    @property
    def child(self) -> Consumer[T]: ...

def extract[T](consumer: Consumer[T]) -> T:
    raise NotImplementedError

def check(value: Consumer[Consumer[int]]) -> None:
    reveal_type(extract(value))
    # Before: Consumer[int]
    # After:  Consumer[int] | int
```

Here, the actual `consume` method accepts `Consumer[int] | int`. Its annotation mentions `Consumer`, so the old shortcut could discard the method and infer only `Consumer[int]` from the class's type arguments. Keeping the method available preserves the additional `int` possibility.

This PR filters only the requirements of the expected protocol, while keeping every member of the actual type available to satisfy those requirements. It also uses ordinary matching when the expected protocol has no recursive requirements, even if the actual type contains a nested use of the same protocol.

## Distinguish repeated aliases from recursion

ty tries to compare simple protocol members before members that can lead back into another protocol comparison. Previously, any type alias caused a member to be put in the potentially recursive group, even when the alias was just another name for `int`.

The new traversal follows alias definitions before making that decision. Reusing an ordinary alias does not itself create a cycle:

```python
type Identity[T] = T

# This expands completely to int.
type Example = Identity[Identity[int]]
```

But an actually recursive alias can keep changing its type arguments as it expands:

```python
type Growing[T] = T | Growing[list[T]]

# Growing[int] leads to Growing[list[int]], then
# Growing[list[list[int]]], and so on.
```

For a recursive alias, the traversal stops when it reaches a definition it is already expanding, even if the type arguments have changed. Ordinary alias applications remain distinct, so nested uses such as `Identity[Identity[int]]` are still recognized as non-recursive. ty can answer this question without expanding the rest of a protocol's members.

## Test plan

The added protocol mdtests cover:

- A non-recursive expected protocol whose actual type contains a nested use of that protocol.
- Recursive protocol members that contribute the full `Consumer[int] | int` inference shown above.
- Nested applications of a non-recursive generic alias that must still contribute to type inference.
- A recursive alias whose type arguments grow, checking that comparison terminates and still rejects an incompatible assignment.
