### PR TITLE
[ty] Avoid enabling semantic features from Markdown tests

### DIFF
--- a/crates/ty_python_semantic/src/pull_types.rs
+++ b/crates/ty_python_semantic/src/pull_types.rs
@@ -3,7 +3,7 @@
 //! This is used in the "corpus" and (indirectly) the "mdtest" integration tests for this crate.
 //! (Mdtest uses the `pull_types` function via the `ty_test` crate.)
 
-use crate::{Db, HasType, SemanticModel};
+use super::{Db, HasType, SemanticModel};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::{
     self as ast, visitor::source_order, visitor::source_order::SourceOrderVisitor,

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -7,14 +7,19 @@ use ruff_db::vendored::VendoredFileSystem;
 
 use ty_python_core::program::ProgramSettings;
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
-use ty_python_semantic::pull_types::pull_types;
 use ty_python_semantic::{
-    AnalysisSettings, Db as _, PythonVersionWithSource, check_file_unwrap, default_lint_registry,
+    AnalysisSettings, Db, HasType, PythonVersionWithSource, SemanticModel, check_file_unwrap,
+    default_lint_registry,
 };
 
 use ruff_db::diagnostic::Diagnostic;
 use test_case::test_case;
 use ty_python_core::{Db as _, ProgramFile, TestProgramDb};
+
+#[path = "../src/pull_types.rs"]
+pub mod pull_types;
+
+use pull_types::pull_types;
 
 fn get_cargo_workspace_root() -> anyhow::Result<&'static SystemPath> {
     SystemPath::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/ty_python_semantic/tests/mdtest.rs
+++ b/crates/ty_python_semantic/tests/mdtest.rs
@@ -1,5 +1,9 @@
 use anyhow::anyhow;
 use camino::Utf8Path;
+use ty_python_semantic::{Db, HasType, SemanticModel};
+
+#[path = "../src/pull_types.rs"]
+pub mod pull_types;
 
 thread_local! {
     // Restrict each fixture's Rayon work to one thread so concurrent tests do not compete for the
@@ -72,6 +76,7 @@ fn run(
                 short_title,
                 test_name,
                 options,
+                pull_types::pull_types,
             )
         })
     })?;

--- a/crates/ty_test/Cargo.toml
+++ b/crates/ty_test/Cargo.toml
@@ -15,14 +15,14 @@ doctest = false
 
 [dependencies]
 mdtest = { workspace = true }
-ruff_db = { workspace = true, features = ["os", "testing"] }
+ruff_db = { workspace = true, features = ["os", "serde", "testing"] }
 ruff_diagnostics = { workspace = true }
 ruff_notebook = { workspace = true }
-ruff_python_ast = { workspace = true }
+ruff_python_ast = { workspace = true, features = ["serde"] }
 ruff_source_file = { workspace = true }
 ty_module_resolver = { workspace = true }
-ty_python_semantic = { workspace = true, features = ["serde", "testing"] }
-ty_python_core = { workspace = true }
+ty_python_semantic = { workspace = true }
+ty_python_core = { workspace = true, features = ["serde", "testing"] }
 ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/ty_test/src/config.rs
+++ b/crates/ty_test/src/config.rs
@@ -104,7 +104,25 @@ struct ScriptTool {
     ty: Option<ScriptOptions>,
 }
 
-pub(crate) type Rules = BTreeMap<String, Level>;
+pub(crate) type Rules = BTreeMap<String, RuleLevel>;
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum RuleLevel {
+    Ignore,
+    Warn,
+    Error,
+}
+
+impl From<RuleLevel> for Level {
+    fn from(level: RuleLevel) -> Self {
+        match level {
+            RuleLevel::Ignore => Self::Ignore,
+            RuleLevel::Warn => Self::Warn,
+            RuleLevel::Error => Self::Error,
+        }
+    }
+}
 
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -199,4 +217,50 @@ pub(crate) struct Project {
     ///
     /// Example: `dependencies = ["pydantic==2.12.2"]`
     dependencies: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MarkdownTestConfig;
+    use ty_python_semantic::lint::Level;
+
+    #[test]
+    fn rule_levels_deserialize_without_semantic_serde() {
+        let configuration = toml::from_str::<MarkdownTestConfig>(
+            r#"
+            [rules]
+            disabled = "ignore"
+            warning = "warn"
+            failure = "error"
+            "#,
+        )
+        .expect("valid rule levels");
+        let rules = configuration.rules.expect("configured rules");
+
+        assert_eq!(
+            rules.get("disabled").copied().map(Level::from),
+            Some(Level::Ignore)
+        );
+        assert_eq!(
+            rules.get("warning").copied().map(Level::from),
+            Some(Level::Warn)
+        );
+        assert_eq!(
+            rules.get("failure").copied().map(Level::from),
+            Some(Level::Error)
+        );
+    }
+
+    #[test]
+    fn unknown_rule_levels_are_rejected() {
+        assert!(
+            toml::from_str::<MarkdownTestConfig>(
+                r#"
+                [rules]
+                invalid = "information"
+                "#,
+            )
+            .is_err()
+        );
+    }
 }

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -17,7 +17,7 @@ use tempfile::TempDir;
 use ty_module_resolver::ModuleGlobSetBuilder;
 use ty_python_core::program::ProgramSettings;
 use ty_python_core::{Db as _, ProgramFile, TestProgramDb};
-use ty_python_semantic::lint::{LintRegistry, RuleSelection};
+use ty_python_semantic::lint::{Level, LintRegistry, RuleSelection};
 use ty_python_semantic::{
     AnalysisSettings, Db as SemanticDb, PythonVersionWithSource, check_file_unwrap,
     default_lint_registry,
@@ -349,13 +349,14 @@ fn mdtest_rule_selection(rules: Option<&Rules>, required_rule: Option<&str>) -> 
     }
 
     if let Some(rules) = rules {
-        let set_lint_level =
-            |selection: &mut RuleSelection, lint, level| match Severity::try_from(level) {
-                Ok(severity) => {
-                    selection.enable(lint, severity, ty_python_semantic::lint::LintSource::File);
-                }
-                Err(()) => selection.disable(lint),
-            };
+        let set_lint_level = |selection: &mut RuleSelection, lint, level| match Severity::try_from(
+            Level::from(level),
+        ) {
+            Ok(severity) => {
+                selection.enable(lint, severity, ty_python_semantic::lint::LintSource::File);
+            }
+            Err(()) => selection.disable(lint),
+        };
 
         // If "all" key is present, use it's value as the default for all rules.
         if let Some(level) = rules.get("all") {

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -23,7 +23,6 @@ use ty_module_resolver::{
 use ty_python_core::TestProgramDb as _;
 use ty_python_core::platform::PythonPlatform;
 use ty_python_core::program::{FallibleStrategy, ProgramSettings};
-use ty_python_semantic::pull_types::pull_types;
 use ty_python_semantic::types::UNDEFINED_REVEAL;
 use ty_python_semantic::{
     Db as _, PythonEnvironment, PythonVersionSource, PythonVersionWithSource, SysPrefixPathOrigin,
@@ -48,6 +47,7 @@ pub fn run(
     short_title: &str,
     test_name: &str,
     options: RunOptions,
+    pull_types: fn(&dyn ty_python_semantic::Db, ty_python_core::ProgramFile<'_>),
 ) -> anyhow::Result<()> {
     let mut db = db::Db::setup();
     let fixture_paths = FixturePaths {
@@ -74,6 +74,7 @@ pub fn run(
                 assertion,
                 output_format,
                 options,
+                pull_types,
             )
         },
     )
@@ -93,6 +94,7 @@ fn run_test(
     assertion: &mut String,
     output_format: OutputFormat,
     options: RunOptions,
+    pull_types: fn(&dyn ty_python_semantic::Db, ty_python_core::ProgramFile<'_>),
 ) -> Result<(TestOutcome, Vec<MarkdownEdit>), Failures> {
     let FixturePaths {
         absolute: absolute_fixture_path,


### PR DESCRIPTION
## Summary

Previously, ty_test enabled the serde and testing features on ty_python_semantic through its development-dependency cycle. As a result, running the semantic Markdown tests compiled the semantic crate with a different feature set from an ordinary cargo check.

Keep the existing type-pulling visitor in the semantic package and pass it into the Markdown test runner as a callback. Deserialize test rule levels locally, and request the necessary serialization and testing support directly from the database, AST, and core dependencies instead of enabling those features on the semantic crate.

The existing semantic testing feature and its public type-pulling API remain available, and both the Markdown and corpus integration targets retain their existing commands and behavior. This removes semantic feature amplification only: the package-level development-dependency cycle, separate build/test compilation units, and any genuinely required transitive dependency feature differences remain.