### PR TITLE
Fix s390x stacker assembly in release builds

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -411,6 +411,7 @@ jobs:
           - target: s390x-unknown-linux-gnu
             arch: s390x
             manylinux: 2_17
+            maturin_docker_options: -e CFLAGS_s390x_unknown_linux_gnu=-march=z10
           - target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
             manylinux: 2_17


### PR DESCRIPTION
## Summary

Pass the s390x architecture flag to release builds so that stacker builds successfully

## Test Plan

Testing: Focused repository hooks passed.
