### PR TITLE
[ty] Reduce notebook version logging to debug

### DIFF
--- a/crates/ty_server/src/session/index.rs
+++ b/crates/ty_server/src/session/index.rs
@@ -109,8 +109,8 @@ impl Index {
                 )
             });
 
-        tracing::info!(
-            "version: {}, new_version: {}",
+        tracing::debug!(
+            "Updating notebook document from version {} to version {}",
             notebook.version(),
             new_version
         );


### PR DESCRIPTION
## Summary

Reduce notebook document version logging from info to debug and clarify the version transition.

## Test Plan

Testing: Crate compilation and repository hooks passed.
