### PR TITLE
[ty] Improve ecosystem report summaries

### DIFF
--- a/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
+++ b/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
@@ -17,9 +17,9 @@ Start each investigation from fresh artifacts. Do not trust retained memories, p
 
 ## Collect Exact-Run Metadata
 
-If a primary agent supplied an existing run-metadata manifest, verify that its run ID and attempt match the frozen report and that it contains each assigned project. Reuse the manifest without modifying it.
+If the primary agent supplied an immutable `TY_ECOSYSTEM_RUN_METADATA` manifest, verify that its run ID and attempt match the frozen report and that it contains each assigned project. All subagents reuse the same read-only manifest; never modify it or generate another shared manifest.
 
-Otherwise, run the bundled helper with the Actions run ID or URL, matching attempt, and every affected mypy-primer project name:
+Otherwise, run the bundled helper once with the Actions run ID or URL, matching attempt, and every affected mypy-primer project name:
 
 ```bash
 scripts/collect_ty_ecosystem_run_metadata.py \
@@ -34,9 +34,9 @@ The current workflow splits compilation into `Build ty (base)` and `Build ty (pr
 
 ## Prepare ty
 
-If a primary agent supplied freshly copied base and PR profiling binaries plus the PR ecosystem config, preserve their absolute paths as `TY_ECOSYSTEM_BASE_BINARY` and `TY_ECOSYSTEM_PR_BINARY`, verify they exist, and reuse them. Do not rebuild those binaries, switch shared Ruff refs, or overwrite the shared artifacts. An agent may build an exact-revision debug binary on demand to identify an ambiguous internal type, using an isolated worktree if necessary; the profiling binaries remain the behavioral oracle.
+If a primary agent supplied freshly copied base and PR profiling binaries plus the PR ecosystem config, preserve their absolute paths as `TY_ECOSYSTEM_BASE_BINARY` and `TY_ECOSYSTEM_PR_BINARY`, verify they exist, and reuse them. Do not rebuild those binaries, switch shared Ruff refs, or overwrite the shared artifacts. If an exact-revision debug binary is needed to identify an ambiguous internal type, request it from the primary agent; the profiling binaries remain the behavioral oracle.
 
-Otherwise, require a clean working tree, copy `.github/ty-ecosystem.toml` from the PR revision, and build ty on the manifest's merge base and PR revision:
+Otherwise, require a clean working tree, remember its original ref, and build both exact revisions before assigning any subagent work. Reuse the checkout's existing Cargo target directory, copy the profiling binaries and PR ecosystem config to `target/ty-ecosystem-bins`, and restore the original ref when finished:
 
 Fetch the PR revision explicitly because pull-request runs usually use a synthetic GitHub merge commit that a normal clone does not contain:
 
@@ -44,23 +44,30 @@ Fetch the PR revision explicitly because pull-request runs usually use a synthet
 set -euo pipefail
 
 test -z "$(git status --short)" || { git status --short; exit 1; }
-git fetch origin <pr-revision>
+original_ref="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
+git fetch https://github.com/astral-sh/ruff.git <pr-revision>
 mkdir -p target/ty-ecosystem-bins
+trap 'git checkout "$original_ref"' EXIT
+
+artifact_dir="$PWD/target/ty-ecosystem-bins"
+build_target_dir="${CARGO_TARGET_DIR:-target}"
 export CARGO_PROFILE_PROFILING_DEBUG=line-tables-only
 
-git checkout <merge-base>
+git checkout --detach <merge-base>
 cargo build --package ty --profile profiling
-cp target/profiling/ty target/ty-ecosystem-bins/ty-base
+cp "$build_target_dir/profiling/ty" "$artifact_dir/ty-base"
 
-git checkout <pr-revision>
-cp .github/ty-ecosystem.toml target/ty-ecosystem-bins/ty-ecosystem.toml
+git checkout --detach <pr-revision>
+cp .github/ty-ecosystem.toml "$artifact_dir/ty-ecosystem.toml"
 cargo build --package ty --profile profiling
-cp target/profiling/ty target/ty-ecosystem-bins/ty-pr
+cp "$build_target_dir/profiling/ty" "$artifact_dir/ty-pr"
 ```
+
+After restoring the original ref, inspect vendored definitions and Rust implementations with `git -C <ruff-checkout> show <exact-revision>:<repository-relative-path>`, selecting the merge-base or PR revision from the immutable manifest. Never assume working-tree files match either analyzed binary or switch the shared checkout's ref.
 
 ## Reproduce
 
-Create a unique temporary directory for each project and use its absolute path. Read its Python version and the pinned mypy-primer revision from the manifest. Obtain the project revision from the `/blob/<commit>/` component of the original diagnostic's source permalink, and check that links for the same project agree. If no diagnostic permalink exists, inspect the matching diagnostics shard or Actions logs; if the exact revision cannot be recovered, explicitly report that limitation. Then bypass the adjacent script lockfile:
+Create a unique temporary directory for each project and use its absolute path. Read its Python version and the pinned mypy-primer revision from the shared manifest. Obtain the project revision from the `/blob/<commit>/` component of the original diagnostic's source permalink, and check that links for the same project agree. If no diagnostic permalink exists, inspect the matching diagnostics shard or Actions logs; if the exact revision cannot be recovered, explicitly report that limitation. Then bypass the adjacent script lockfile:
 
 ```bash
 uv run \
@@ -73,7 +80,7 @@ uv run \
   --exclude-newer <EXCLUDE_NEWER>
 ```
 
-Use the ecosystem config as user-level configuration, matching CI without replacing project-level config discovery, and re-export `XDG_CONFIG_HOME` in each new shell. If a primary agent supplied `TY_ECOSYSTEM_CONFIG_HOME`, reuse its installed config without modifying it; otherwise, install the copied config locally. Read the project's `strict` or `non-strict` label from the frozen detailed report, or its `strict_settings` value from the matching diagnostics shard. Preserve that mode when running either binary:
+Use the ecosystem config as user-level configuration, matching CI without replacing project-level config discovery, and re-export `XDG_CONFIG_HOME` and `RUST_BACKTRACE=1` in each new shell. If a primary agent supplied `TY_ECOSYSTEM_CONFIG_HOME`, reuse its installed config without modifying it; otherwise, install the copied config locally. Read the project's `strict` or `non-strict` label from the frozen detailed report, or its `strict_settings` value from the matching diagnostics shard. Preserve that mode when running either binary:
 
 ```bash
 if [[ -n "${TY_ECOSYSTEM_CONFIG_HOME:-}" ]]; then
@@ -85,6 +92,7 @@ else
   cp "$PWD/target/ty-ecosystem-bins/ty-ecosystem.toml" "$XDG_CONFIG_HOME/ty/ty.toml"
 fi
 unset TY_CONFIG_FILE
+export RUST_BACKTRACE=1
 
 project_dir="<absolute-temporary-directory>"
 ty_base="${TY_ECOSYSTEM_BASE_BINARY:-$PWD/target/ty-ecosystem-bins/ty-base}"
@@ -116,16 +124,18 @@ pr_exit_status=0
 run_ecosystem_ty || pr_exit_status=$?
 ```
 
-Confirm the detailed report's difference exactly, including duplicate diagnostics and both exit statuses. Ordinary diagnostics can produce exit status 1; do not mistake that for a failed reproduction.
+Confirm the detailed report's difference exactly, including duplicate diagnostics and both exit statuses. When reproducing an intermittent severe failure, repeat each side using its reported run count. Ordinary diagnostics can produce exit status 1; do not mistake that for a failed reproduction. For panics, identify the stable fingerprint by comparing the Rust panic site or decisive causal frame and panic payload; ignore checked Python-file paths and incidental backtrace differences.
 
 ## Minimize
 
-Reduce the reproduced project toward a self-contained single-file reproducer with minimal code and dependencies. A reduction is trivial only when the difference already occurs in one self-contained file and can be preserved solely by deleting obviously unrelated code. Multiple files, imports or dependencies, inlining, replacing language constructs, ambiguous types such as `@Todo`, or an uncertain cause make a reduction nontrivial. Before attempting any nontrivial reduction, read and follow [references/advanced-minimization.md](references/advanced-minimization.md). If in doubt, treat the reduction as nontrivial.
+The target is a fully minimized, provenance-preserving reproducer: preferably one self-contained file, with no avoidable third-party or standard-library imports and no unnecessary definitions, annotations, branches, or advanced language features. Retain a third-party import only if identified ty behavior depends on that library's identity or third-party search-path classification.
 
-Matching diagnostics or displayed types do not establish a shared cause. When the output is ambiguous, identify the original and minimized triggers using exact-revision debug output, a targeted `reveal_type`, or the producing Rust call site.
+Before minimizing any ecosystem change, read and follow [references/advanced-minimization.md](references/advanced-minimization.md). Exhaust its complete reduction loop, including third-party dependency and standard-library inlining, and retain an import only after verifying that neither removing it nor inlining its definitions preserves the underlying behavior.
 
-Record the original source permalink, accepted reductions, both binaries' results, and any causal fingerprint. If source provenance or a matching cause cannot be established, return the original project excerpt explicitly marked as unminimized.
+Matching diagnostics or displayed types do not establish a shared cause. When the output is ambiguous, identify and compare the original and minimized triggers using exact-revision debug output, a targeted `reveal_type`, or the producing Rust call site from the matching analyzed revision.
+
+A minimization is complete only when a verified reduction chain connects the reproducer to the original ecosystem entry and an exhaustive pass finds no further reduction. If a genuine external blocker prevents completion, report the blocker and identify the minimization as incomplete; an original source excerpt is not a successfully minimized result.
 
 ## Return
 
-Provide the original permalinked report entry, exact base and PR behavior, minimal code, full diagnostic messages and error codes, and the manifest/commands needed to reproduce it. When called from the summary workflow, return import-audit and reduction notes separately from report-ready Markdown.
+Provide the original permalinked report entry, exact base and PR behavior, minimal code, full diagnostic messages and error codes or the panic fingerprint, and the manifest/commands needed to reproduce it. When called from the summary workflow, return import-audit and reduction notes separately from report-ready Markdown.

--- a/.agents/skills/minimizing-ty-ecosystem-changes/references/advanced-minimization.md
+++ b/.agents/skills/minimizing-ty-ecosystem-changes/references/advanced-minimization.md
@@ -4,7 +4,7 @@ Use this reference after the reported difference reproduces against the copied b
 
 ## Target
 
-Prefer a single-file reproducer with no third-party imports, few definitions, and the least complex typing or language features that still demonstrate the difference. Keep special modules such as `typing`, `abc`, `enum`, `types`, and `typing_extensions` only when removing them changes the behavior.
+Prefer a single-file reproducer with no avoidable third-party imports, few definitions, and the least complex typing or language features that still demonstrate the difference. Keep special modules such as `typing`, `abc`, `enum`, `types`, and `typing_extensions` only when neither removing them nor inlining their definitions preserves the behavior; retain a third-party import only after identifying ty behavior that depends on that library's identity or third-party search-path classification.
 
 ## Reduction Loop
 
@@ -13,16 +13,16 @@ Work systematically from the reproduced project. NEVER skip ahead to an explanat
 1. Delete unrelated files.
 2. Remove imports, definitions, decorators, annotations, statements, and branches.
 3. Inline first-party definitions into the reproducer.
-4. For each required third-party dependency, copy the entire installed dependency into the source tree as first-party code, including every package directory and module it provides. Do this before attempting to minimize any part of the dependency. Adjust imports, verify that the difference still reproduces with the complete copy, and only then begin deleting files or definitions from it. Never start by copying only apparently relevant files or definitions. If cloning a dependency is unavoidable, use the exact installed revision or version and copy the complete dependency into the source tree before reducing it.
-5. Inline the relevant standard-library definitions from `crates/ty_vendored`, which is ty's source of truth for stdlib types.
+4. For each required third-party dependency, copy the entire installed dependency into the source tree as first-party code, including every package directory and module it provides. Do this before attempting to minimize any part of the dependency. Adjust imports, verify that the difference still reproduces with the complete copy, and only then begin deleting files or definitions from it. If the complete copy changes the behavior because ty special-cases that library or distinguishes first-party from third-party search paths, identify the relevant ty implementation at the matching analyzed Ruff revision before retaining the original import. Never start by copying only apparently relevant files or definitions. If cloning a dependency is unavoidable, use the exact installed revision or version and copy the complete dependency into the source tree before reducing it.
+5. Inline the relevant standard-library definitions from the analyzed revision of `crates/ty_vendored`, using `git -C <ruff-checkout> show <exact-revision>:crates/ty_vendored/<path>`; compare the merge-base and PR definitions when they differ.
 6. Replace complex constructs with simpler equivalents, such as removing a walrus expression or replacing a protocol when the difference survives.
 
 Repeat the full loop until an exhaustive pass through every stage finds no further reduction that preserves the difference. Do not stop merely because the likely cause is understood or the reproducer is already small.
 
 ## Final Audit
 
-Attempt to remove every remaining import and inline every remaining third-party definition. Record why any surviving import is essential. Keep these notes as working evidence; the caller decides whether they belong in its final artifact.
+Attempt to remove every remaining import and inline its definitions, including remaining third-party and standard-library definitions. Retain an import only after verifying that neither removal nor inlining preserves the underlying behavior. For a third-party import, additionally verify that its module identity or third-party search-path classification is essential and identify the relevant ty implementation. Convenience, familiar APIs, matching class names, or preserving the diagnostic's module spelling do not justify keeping an import. Record why any surviving import is essential and, for a third-party import, where ty implements the relevant behavior. Keep these notes as working evidence; the caller decides whether they belong in its final artifact.
 
-Verify that the recorded reduction chain connects the final reproducer to the original ecosystem entry and, when diagnostic output is ambiguous, preserves the original causal fingerprint. If either check fails, return the original project excerpt as unminimized instead of substituting an unrelated example.
+Verify that the recorded reduction chain connects the final reproducer to the original ecosystem entry and, when diagnostic output is ambiguous, preserves the original causal fingerprint. If a required check fails, continue investigating; if a genuine external blocker prevents completion, report the blocker and mark the minimization as incomplete instead of presenting an unrelated example or original excerpt as a minimized result.
 
 Delete transient project and dependency copies after the investigation.

--- a/.agents/skills/summarise-ecosystem-results/SKILL.md
+++ b/.agents/skills/summarise-ecosystem-results/SKILL.md
@@ -7,9 +7,11 @@ description: Use when a user says "summarise ecosystem results", "summarize this
 
 ## Priorities
 
-1. Reproduce every retained behavior with the exact environment used by the Actions run.
-2. Lead the report with new or meaningfully changed project failures, including intermittent severe failures, then cover stable diagnostic changes and clear minimized examples.
-3. Keep execution, audit, and traceability bookkeeping out of the report.
+1. Reproduce every retained source-attributable behavior with the exact environment used by the Actions run.
+2. For every distinct source-attributable behavior change, produce the smallest provenance-preserving reproducer obtainable through the complete advanced-minimization workflow.
+3. Eliminate every third-party import unless identified ty behavior depends on that library's identity or third-party search-path classification, and eliminate every unnecessary standard-library import. Retain an import only after verifying that neither removing it nor inlining its definitions preserves the underlying behavior.
+4. Lead the report with new or meaningfully changed project failures, including intermittent severe failures, then cover stable diagnostic changes and fully minimized examples.
+5. Keep execution, audit, and traceability bookkeeping out of the report.
 
 ## Deliverable
 
@@ -23,16 +25,26 @@ If summarising an ecosystem report is the only thing you're asked to do in a Cod
 
 - Focus on new or meaningfully changed behavior relative to the merge base. Evaluate individual diagnostics and failure outcomes, not a project's overall flaky or persistent status.
 - Omit flaky diagnostic changes, unchanged failures, and frequency fluctuations that leave the observed outcomes unchanged.
-- Report new or changed panics, crashes, overflows, and timeouts, including merge-base and PR run frequencies when intermittent behavior is involved.
+- Report new, fixed, or meaningfully changed panics, crashes, overflows, and timeouts, including merge-base and PR run frequencies when intermittent behavior is involved.
 
 ## Workflow
 
-1. **Freeze the evidence.** Preserve any report URL or ecosystem-results comment explicitly supplied by the user before identifying the PR. For PR-only input, find its ecosystem-results comment and linked detailed report. Capture the matching Actions run and attempt as described in [references/evidence-acquisition.md](references/evidence-acquisition.md); never replace a supplied report with the PR's current report. Ignore later comment edits, PR updates, and workflow runs. Use the frozen detailed report as the authoritative change list and the comment for orientation when available.
-2. **Identify changed outcomes.** Check the detailed report for new, fixed, or changed project failures, panics, overflows, timeouts, abnormal exits, and diagnostic changes, applying the reporting policy to each entry and outcome.
-3. **Reproduce from scratch.** Ignore retained memories and previous local artifacts. Load the `minimizing-ty-ecosystem-changes` skill, use its metadata helper and exact-run workflow, and reproduce each report entry before explaining or minimizing it. Reproduce intermittent severe failure changes with the reported run counts.
-4. **Minimize with provenance.** Include a standalone reproducer only when a verified reduction chain connects it to a cited ecosystem entry and preserves the same underlying trigger. If either cannot be verified, retain the original source excerpt and identify it as unminimized.
+1. **Freeze the evidence.** Preserve any report URL or ecosystem-results comment explicitly supplied by the user before identifying the PR. For PR-only input, find its ecosystem-results comment and linked detailed report. Capture the matching Actions run and attempt as described in [references/evidence-acquisition.md](references/evidence-acquisition.md); never replace a supplied report with the PR's current report. Recover exact-run metadata promptly, then prepare both exact-revision profiling binaries and the shared configuration before assigning subagent work. Ignore later comment edits, PR updates, and workflow runs. Prefer the selected attempt's validated `full-report/diff.json` as the authoritative structured change inventory, retain its matching frozen HTML report, and use the comment for orientation when available. Fall back to the frozen HTML report if the JSON report is unavailable.
+2. **Identify changed outcomes.** Inspect the structured diff for added, removed, and modified projects; stable diagnostic additions, removals, and rewrites; project failures; and intermittent exit-status changes. Preserve diagnostic levels, duplicate occurrences, source permalinks, project strictness, panic evidence, and observed run frequencies. Exclude flaky diagnostics and frequency-only noise without excluding stable diagnostics or changed severe failures from flaky projects. Use the matching HTML report for visual context, or as the primary evidence when structured JSON cannot be obtained safely.
+3. **Reproduce from scratch.** Ignore retained memories and previous local artifacts. Load the `minimizing-ty-ecosystem-changes` skill, collect exact-run metadata once, and reproduce every retained, source-attributable diagnostic or panic before explaining or minimizing it. Reproduce intermittent severe failure changes with the reported merge-base and PR run counts. Verify retained outcomes without recoverable source against their captured statuses, stderr, panic evidence, and run frequencies.
+4. **Minimize to completion with provenance.** For each distinct source-attributable behavior change, follow the complete advanced-minimization workflow until an exhaustive pass finds no further reduction. Derive the reproducer from a cited ecosystem entry through a verified reduction chain; never replace that entry with an independently invented example demonstrating superficially similar behavior. Before accepting a reproducer, attempt to remove every import, inline every third-party definition, and inline relevant standard-library definitions. Retain a third-party import only when identified ty behavior depends on that library's identity or third-party search-path classification and neither removing the import nor inlining its definitions preserves the underlying behavior. If a genuine external blocker prevents completion, report that blocker to the user and identify the task as incomplete. Do not silently substitute an unminimized excerpt or present a partially minimized report as finished.
 5. **Group by cause.** Group entries only when the same base-to-PR behavior, underlying trigger, explanation, and reproducer account for every entry. Identical diagnostic text or displayed `@Todo` types do not establish equivalence.
 6. **Find existing ty issues.** When a diagnostic change exposes a pre-existing shortcoming in ty, search the `astral-sh/ty` issue tracker for the precise underlying behavior. Link matching issues directly from the relevant report section; do not mistake incorrect or incomplete third-party annotations for ty shortcomings.
-7. **Write and verify.** Fill the report template, record each affected project's strict or non-strict analysis mode, and include both strict-analysis flags in the comparison method when applicable. Check every change number, link, diagnostic, reproducer's source provenance, and causal fingerprint when required, then run `uv run --only-group dev --locked prek run --files PR_<number>_ECOSYSTEM_SUMMARY.md`. Present the Markdown file as the finished product.
+7. **Write and verify.** Fill the report template and verify that every source-attributable behavior change has a fully minimized, provenance-preserving reproducer. Check every change number, link, diagnostic, retained import, reproducer's source provenance, and causal fingerprint when required. Verify that every retained third-party import is essential to identified ty behavior that depends on that library's identity or third-party search-path classification, that no avoidable standard-library import remains, and that no source-attributable section contains an unminimized excerpt. Then run `uv run --only-group dev --locked prek run --files PR_<number>_ECOSYSTEM_SUMMARY.md`. Present the Markdown file as the finished product only after these checks pass.
 
-When parallelizing reproduction or minimization, read [references/subagent-handoff.md](references/subagent-handoff.md). Otherwise, keep batches small and work through them sequentially.
+## Parallel execution
+
+This skill explicitly requests subagents when the report contains multiple affected projects or independently investigable entries.
+
+Once the exact-run metadata, both profiling binaries, and shared configuration are ready, spawn as many subagents as the available concurrency budget and independent work allow, reserving one slot for the primary agent. Keep available slots occupied by assigning further work as subagents finish.
+
+Assign disjoint projects or explicit report entries. Apparent similarity may guide scheduling, but does not establish causal equivalence. Follow all existing requirements for exhaustive reproduction, verified reduction chains, exhaustive minimization, and grouping by verified cause.
+
+The primary agent owns the frozen evidence, shared profiling binaries, configuration, coordination, and final report. Follow [references/subagent-handoff.md](references/subagent-handoff.md) for handoff and shared-artifact requirements.
+
+If multiple independent assignments exist but no subagents are spawned, record the specific reason.

--- a/.agents/skills/summarise-ecosystem-results/references/evidence-acquisition.md
+++ b/.agents/skills/summarise-ecosystem-results/references/evidence-acquisition.md
@@ -7,6 +7,8 @@ If no comment matching an explicitly supplied report remains, continue with the 
 Create a unique snapshot directory, save the matching comment when available and the selected attempt's effective job graph, and inspect the run's available artifacts:
 
 ```bash
+set -euo pipefail
+
 snapshot_dir="$(mktemp -d "${TMPDIR:-/tmp}/ty-ecosystem-report.XXXXXX")"
 ecosystem_comment_id="<matching-comment-id-or-empty>"
 if [[ -n "$ecosystem_comment_id" ]]; then
@@ -14,18 +16,40 @@ if [[ -n "$ecosystem_comment_id" ]]; then
 fi
 gh run view <actions-run> --repo astral-sh/ruff --attempt <actions-attempt> \
   --json attempt,headSha,jobs,startedAt,updatedAt,url > "$snapshot_dir/run.json"
-gh api "repos/astral-sh/ruff/actions/runs/<actions-run>/artifacts" > "$snapshot_dir/artifacts.json"
+gh api --paginate --slurp \
+  "repos/astral-sh/ruff/actions/runs/<actions-run>/artifacts?per_page=100" |
+  jq '{artifacts: [.[].artifacts[]]}' > "$snapshot_dir/artifacts.json"
+printf 'TY_ECOSYSTEM_SNAPSHOT_DIR=%s\n' "$snapshot_dir"
 ```
 
-`gh run download` cannot select an attempt, and a newer rerun can replace an older attempt's artifacts without changing Ruff's revisions. Before downloading, verify that `full-report` was created during the selected attempt's report-generation job and that each diagnostics shard was created during its matching successful shard job. Use the effective job graph, not the attempt start time: partial reruns legitimately inherit successful jobs and artifacts from earlier attempts.
+`gh run download` cannot select an attempt, and a newer rerun can replace an older attempt's artifacts without changing Ruff's revisions. Before downloading, verify that `full-report` was created during the selected attempt's report-generation job and that each diagnostics shard was created during its matching successful shard job. Use the effective job graph, not the attempt start time: partial reruns legitimately inherit successful jobs and artifacts from earlier attempts. Preserve each validated artifact's immutable ID; never re-resolve its mutable name during download.
 
-Download only artifacts that pass these checks; use the shard glob only when every matching artifact belongs to the selected job graph:
+Download the validated report and each available, validated shard directly by artifact ID:
 
 ```bash
-gh run download <actions-run> --repo astral-sh/ruff --name full-report --dir "$snapshot_dir/full-report"
-gh run download <actions-run> --repo astral-sh/ruff --pattern 'diagnostics-shard-*' --dir "$snapshot_dir/shards"
+download_validated_artifact() {
+  local artifact_id="$1"
+  local destination="$2"
+
+  mkdir -p "$destination"
+  gh api "repos/astral-sh/ruff/actions/artifacts/$artifact_id/zip" \
+    > "$snapshot_dir/artifact-$artifact_id.zip"
+  unzip -q "$snapshot_dir/artifact-$artifact_id.zip" -d "$destination"
+}
+
+download_validated_artifact <validated-full-report-id> "$snapshot_dir/full-report"
+download_validated_artifact <validated-shard-id> \
+  "$snapshot_dir/shards/diagnostics-shard-<number>"
 ```
 
-Record the selected Actions attempt and pass it to `scripts/collect_ty_ecosystem_run_metadata.py` with `--attempt <actions-attempt>`. Verify that the frozen report's Ruff base and PR revisions agree with the resulting manifest, then use the saved report, shards, run, attempt, and matching comment when available throughout the investigation.
+When the selected deployed HTML report was available, compare it byte-for-byte with the downloaded artifact's `diff.html` before trusting the adjacent JSON. Record the selected Actions attempt and pass it to `scripts/collect_ty_ecosystem_run_metadata.py` with `--attempt <actions-attempt>` once for all projects requiring reproduction. Verify that the frozen HTML report's Ruff base and PR revisions agree with the resulting immutable manifest, then use the saved report, shards, run, attempt, and matching comment when available throughout the investigation.
 
-If the selected report's artifacts were replaced or are unavailable, use its frozen deployed report and explicitly describe any unavailable shards or resulting verification limitations. Never silently substitute artifacts produced by an unrelated reporting attempt.
+## Prefer the Exact Attempt's Structured Diff
+
+When the validated `full-report` artifact contains `diff.json`, use `$snapshot_dir/full-report/diff.json` as the authoritative structured change inventory and the adjacent `diff.html` as its human-readable counterpart. The JSON contains no Ruff revisions, Actions run ID, or attempt number: its provenance comes from the verified artifact and its matching HTML report, not from its contents or a coincidentally matching PR revision.
+
+The deployment also exposes a sibling `diff.json` next to the detailed HTML report. Use a deployed JSON file only when it was frozen from the same immutable deployment as the selected HTML report and that deployment can be tied to the selected Actions run and attempt. A current PR deployment, a later artifact, or matching Ruff commits alone cannot establish this provenance.
+
+Inspect the structured report and the schema or diff-generation code at the exact ecosystem-analyzer revision; do not assume JSON field names or classifications remain stable across revisions. Record each affected project's strict or non-strict analysis mode and include both strict-analysis flags in the comparison method when applicable.
+
+If the selected attempt's JSON report or artifacts are unavailable or replaced, or its artifact HTML differs from the frozen deployed report, use the frozen HTML report, disclose unavailable shards and resulting verification limitations, and never substitute another attempt's artifacts.

--- a/.agents/skills/summarise-ecosystem-results/references/subagent-handoff.md
+++ b/.agents/skills/summarise-ecosystem-results/references/subagent-handoff.md
@@ -1,29 +1,39 @@
 # Subagent Handoff
 
-Use this reference only when parallelizing reproduction and minimization.
+Use this reference whenever the summary skill delegates reproduction or minimization.
 
 ## Primary-Agent Responsibilities
 
-Prepare the frozen evidence snapshot, copied base binary, PR binary, PR ecosystem config, and one run-metadata manifest covering every affected project. Record the binaries' absolute paths as `TY_ECOSYSTEM_BASE_BINARY` and `TY_ECOSYSTEM_PR_BINARY`. Choose an absolute `TY_ECOSYSTEM_CONFIG_HOME` and install the copied config once at `$TY_ECOSYSTEM_CONFIG_HOME/ty/ty.toml`. Treat the snapshot, binaries, manifest, copied config, and installed configuration as read-only shared inputs. Batch related entries without creating more assignments than can run concurrently.
+Freeze the exact report, Actions run, and attempt. Run `scripts/collect_ty_ecosystem_run_metadata.py` once for all projects with retained source-attributable diagnostics or new, fixed, or meaningfully changed reproducible failure outcomes, then build and copy both exact-revision profiling binaries before assigning any subagent work.
+
+Publish the immutable `TY_ECOSYSTEM_RUN_METADATA`, `TY_ECOSYSTEM_BASE_BINARY`, and `TY_ECOSYSTEM_PR_BINARY` absolute paths. Install the copied PR ecosystem config once at `$TY_ECOSYSTEM_CONFIG_HOME/ty/ty.toml` and publish the absolute `TY_ECOSYSTEM_CONFIG_HOME` path. Treat the snapshot, optional structured JSON, binaries, metadata, copied config, and installed configuration as read-only shared inputs.
+
+If a subagent requests an exact-revision debug binary, only the primary agent may build it. Pause every active worker and wait for acknowledgment, verify the shared checkout is clean, remember its original ref, then build and copy the requested binary. Always restore the original ref before resuming workers, even if the build fails; publish the binary's immutable path only after a successful build and restoration. The profiling binaries remain the behavioral oracle.
+
+Subagents must not regenerate shared manifests, rebuild shared profiling binaries, switch shared Ruff refs, rewrite shared configuration, or overwrite another agent's working files.
 
 ## Assignment Checklist
 
 Give each subagent:
 
 - The PR and detailed report links, plus the ecosystem comment link when available.
-- The paths to the frozen detailed report and available diagnostics shards, plus the frozen comment path when available and the selected Actions run and attempt; use these captured inputs instead of refetching live evidence.
-- The exact report entries assigned to it.
-- The copied-config and metadata-manifest paths, plus the shared `TY_ECOSYSTEM_BASE_BINARY`, `TY_ECOSYSTEM_PR_BINARY`, and `TY_ECOSYSTEM_CONFIG_HOME` values.
-- The instruction to follow the `minimizing-ty-ecosystem-changes` skill using a unique temporary directory.
-- The instruction to preserve a verified reduction chain and underlying trigger, or return the original source explicitly marked as unminimized.
-- Permission to build an exact-revision debug binary on demand for causal inspection, using an isolated worktree if necessary and retaining the profiling binaries as the behavioral oracle.
-- The instruction not to rebuild profiling binaries, regenerate the supplied manifest, rewrite the installed configuration, switch shared Ruff refs, overwrite shared artifacts, trust previous local reproductions, or substitute current dependency metadata.
+- The paths to the frozen HTML report, optional matching structured JSON, and available diagnostics shards, plus the frozen comment path when available and the selected Actions run and attempt; use these captured inputs instead of refetching live evidence.
+- The exact assigned entries from the structured JSON when available, or from the frozen HTML report otherwise; distinguish source-attributable changes from outcomes without recoverable source, and provide the reported merge-base and PR run counts for intermittent severe failures.
+- The immutable `TY_ECOSYSTEM_RUN_METADATA`, `TY_ECOSYSTEM_BASE_BINARY`, `TY_ECOSYSTEM_PR_BINARY`, and `TY_ECOSYSTEM_CONFIG_HOME` absolute paths.
+- For assignments requiring reproduction, the instruction to use the `minimizing-ty-ecosystem-changes` skill with the shared manifest, copied profiling binaries, installed configuration, and a unique temporary directory; never generate another manifest.
+- For source-attributable assignments, the instruction to produce a fully minimized, provenance-preserving reproducer by exhausting the complete advanced-minimization workflow, including third-party dependency inlining, standard-library inlining, and an audit of every remaining import.
+- The instruction to inspect vendored definitions and Rust implementations with `git -C <ruff-checkout> show <exact-revision>:<repository-relative-path>`, using the analyzed revisions from the immutable manifest rather than the restored working tree.
+- The instruction that an independently invented analogue does not satisfy a source-attributable assignment, and that a partially minimized example or an original source excerpt never satisfies any minimization assignment. If a genuine external blocker prevents minimization, return the blocker and mark the assignment as incomplete.
+- For outcomes without recoverable source evidence, the instruction to verify and report the captured outcomes, stderr, panic evidence, and run frequencies without requiring a source reproducer or minimized code.
+- The instruction to request any exact-revision debug binary from the primary agent instead of building one or switching shared Ruff refs.
+- The instruction to stop all checkout-dependent work and subprocesses when the primary agent requests a pause, acknowledge only after they have stopped, and remain paused until explicitly resumed, even if the debug build fails.
+- The instruction not to rebuild profiling binaries, regenerate published metadata, rewrite the installed configuration, switch shared Ruff refs, overwrite shared artifacts, trust previous local reproductions, or substitute current dependency metadata.
 
 ## Required Return
 
 Request:
 
-- Report-ready GitHub-flavored Markdown describing the exact base-versus-PR behavior and minimized code.
-- Separate working notes covering the original source permalink, reproduction, accepted reductions, both binaries' results, any necessary causal fingerprint, and the import audit.
+- For source-attributable assignments, report-ready GitHub-flavored Markdown describing the exact base-versus-PR behavior and minimized code, plus separate working notes covering the original source permalink, reproduction, accepted reductions, both binaries' results, per-side run counts for intermittent severe failures, any necessary causal fingerprint, and the import audit.
+- For outcomes without recoverable source evidence, report-ready GitHub-flavored Markdown describing the verified project outcomes, relevant stderr, panic evidence, and run frequencies.
 
 If a later entry has exactly the same behavior change and cause as an already minimized entry, the subagent may classify it as a duplicate instead of repeating the full minimization, but it must explain the match.

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -220,13 +220,16 @@ jobs:
 
           mkdir dist
 
+          # Upload a structured JSON report alongside the HTML report to make
+          # ecosystem changes easier for agents to analyze.
           ecosystem-analyzer \
             generate-diff \
             diagnostics-base.json \
             diagnostics-PR.json \
             --old-name "${BASE_REF_NAME} (merge base)" \
             --new-name "$REF_NAME" \
-            --output-html dist/diff.html
+            --output-html dist/diff.html \
+            --output-json dist/diff.json
 
           set +e
           ecosystem-analyzer \
@@ -254,8 +257,8 @@ jobs:
 
           echo "diff_statistics_exit_code=$DIFF_STATISTICS_EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-      # NOTE: astral-bot deploys both HTML files in this artifact and uses the
-      # deployed URLs for the report links in its PR comment.
+      # NOTE: astral-bot deploys every file in this artifact and uses the
+      # deployed HTML URLs for the report links in its PR comment.
       # Make sure to update the bot if you rename the artifact.
       - name: "Upload full report"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

- Generate and deploy a structured `diff.json` alongside the existing HTML ecosystem report so agents can analyze diagnostic and failure changes without parsing presentation markup.
- Freeze evidence to the exact GitHub Actions run and attempt, validate artifacts against the effective job graph, download them by immutable ID, and retain an HTML fallback for older reports.
- Explicitly delegate independent ecosystem investigations to subagents once shared exact-revision binaries, configuration, and run metadata are ready.
- Require exhaustive, provenance-preserving minimization with verified causal fingerprints, exact project settings, intermittent run counts, and removal of avoidable third-party and standard-library imports.
- Keep shared checkouts safe during profiling and debug builds, and inspect Ruff source at the exact analyzed revisions after restoring the original ref.

## Why

The existing ecosystem-summary workflow can investigate projects sequentially and stop at partially minimized or causally unrelated examples. Structured reports and coordinated delegation reduce repeated work, while stricter verification produces smaller and more trustworthy reproductions.