### PR TITLE
[ty] Preserve explicit globals after conditional rebinding

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -299,6 +299,36 @@ def factory():
         reveal_type(x)  # revealed: Literal[1]
 ```
 
+An explicit module-level binding remains visible when the enclosing function only conditionally
+rebinds that global:
+
+```py
+value = 0
+
+def conditional_global_factory(flag: bool):
+    global value
+    if flag:
+        value = "updated"
+
+    class Nested:
+        reveal_type(value)  # revealed: Literal["updated", 0]
+```
+
+A module-level declaration also remains visible when the enclosing function only conditionally binds
+that global:
+
+```py
+declared_value: int
+
+def conditional_declared_global_factory(flag: bool):
+    global declared_value
+    if flag:
+        declared_value = 1
+
+    class Nested:
+        reveal_type(declared_value)  # revealed: int
+```
+
 If the rebinding is conditional, an unbound enclosing snapshot continues to the implicit global:
 
 ```py
@@ -321,6 +351,22 @@ def conditional_builtin_factory(flag: bool):
 
     class C:
         reveal_type(len)  # revealed: Literal[1] | (def len(obj: Sized, /) -> int)
+```
+
+## Comprehension after global rebinding
+
+A comprehension is also an eager nested scope, so it should see both the original module-level
+binding and a conditional global rebinding:
+
+```py
+value = 0
+
+def factory(flag: bool):
+    global value
+    if flag:
+        value = "updated"
+
+    [reveal_type(value) for _ in [0]]  # revealed: Literal["updated", 0]
 ```
 
 ## References to variables before they are defined within a class scope are considered global

--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -314,6 +314,23 @@ def conditional_global_factory(flag: bool):
         reveal_type(value)  # revealed: Literal["updated", 0]
 ```
 
+If the condition is known to be false, the nested class should see only the original module-level
+binding and should not report an unresolved reference:
+
+```py
+from typing import Literal
+
+known_false_value = 0
+
+def known_false_global_factory(flag: Literal[False]):
+    global known_false_value
+    if flag:
+        known_false_value = "updated"
+
+    class Nested:
+        reveal_type(known_false_value)  # revealed: Literal[0]
+```
+
 A module-level declaration also remains visible when the enclosing function only conditionally binds
 that global:
 

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -248,7 +248,23 @@ impl<'db> Iterator for PlaceLoadResolution<'db, '_> {
                         bindings,
                         enclosing_scope,
                     } = snapshot;
-                    self.next_node = Some(PlaceLoadResolutionNode::ImplicitGlobalSource);
+                    let global_place_table = self.context.index.place_table(FileScopeId::global());
+                    let has_explicit_global = self
+                        .loaded_symbol_name()
+                        .and_then(|name| global_place_table.symbol_id(name))
+                        .is_some_and(|symbol_id| {
+                            let symbol = global_place_table.symbol(symbol_id);
+                            symbol.is_bound() || symbol.is_declared()
+                        });
+
+                    // Nested global assignments create synthetic module bindings even when the
+                    // module never defines the name itself. Do not let those bindings hide an
+                    // implicit global or builtin when the forwarded assignment did not run.
+                    self.next_node = Some(if has_explicit_global {
+                        PlaceLoadResolutionNode::ExplicitGlobalSource(PlaceLoadSourceRole::Ordinary)
+                    } else {
+                        PlaceLoadResolutionNode::ImplicitGlobalSource
+                    });
 
                     let source = self.constraints.source(
                         PlaceLoadSourceKind::Bindings(bindings),


### PR DESCRIPTION
A nested class or comprehension inside a function could infer only the conditionally reassigned value of a `global`, dropping its existing module-level value. This let ty accept code that could fail at runtime, and could cause false-positive `possibly-unresolved-reference` errors.

Resolve forwarded global snapshots against real module-level bindings and declarations before falling back to implicit globals or builtins. Exclude synthetic bindings from nested `global` assignments so existing implicit-global and builtin behavior is preserved.

Closes https://github.com/astral-sh/ty/issues/4273.

## Test plan

Added scope mdtests covering:

- A nested class reading a global with an existing module-level binding after conditional reassignment.
- A nested class reading a global that has only a module-level type declaration.
- An eager comprehension reading a conditionally reassigned global.

Existing neighboring mdtests also cover fallback to implicit globals and builtins.
