### PR TITLE
[ty] Stabilize guarded implicit-attribute presence

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -369,9 +369,9 @@ T = f()
 
 ## Guarded instance attributes when the base is checked first
 
-A guarded bound-method initializer remains valid, while another initializer still reports an
-attribute that is missing from the base class. This reproduces
-<https://github.com/astral-sh/ty/issues/4076>.
+A guarded bound-method initializer remains valid, including when its receiver is explicitly
+annotated, while another initializer still reports an attribute that is missing from the base class.
+This reproduces <https://github.com/astral-sh/ty/issues/4076>.
 
 `base.py`:
 
@@ -386,18 +386,27 @@ class Base:
             self.missing
         if not hasattr(self, "z"):
             self.z = self.y  # error: [unresolved-attribute]
+
+class Annotated:
+    def __init__(self: "Annotated"):
+        if not hasattr(self, "value"):
+            self.value = self.__str__
+            self.missing  # error: [unresolved-attribute]
 ```
 
 `child.py`:
 
 ```py
-from base import Base
+from base import Annotated, Base
 
 class Child(Base):
     x = Base.__str__
 
     def z(self): ...
     def y(self): ...
+
+class AnnotatedChild(Annotated):
+    value = Annotated.__str__
 ```
 
 ## Guarded instance attributes when the subclass is checked first
@@ -407,13 +416,16 @@ Checking the subclass first preserves the valid initializer and the missing-attr
 `child.py`:
 
 ```py
-from base import Base
+from base import Annotated, Base
 
 class Child(Base):
     x = Base.__str__
 
     def z(self): ...
     def y(self): ...
+
+class AnnotatedChild(Annotated):
+    value = Annotated.__str__
 ```
 
 `base.py`:
@@ -429,16 +441,25 @@ class Base:
             self.missing
         if not hasattr(self, "z"):
             self.z = self.y  # error: [unresolved-attribute]
+
+class Annotated:
+    def __init__(self: "Annotated"):
+        if not hasattr(self, "value"):
+            self.value = self.__str__
+            self.missing  # error: [unresolved-attribute]
 ```
 
 ## Nested and compound attribute guards when the base is checked first
 
 An unrelated condition can appear outside an attribute guard, inside it, or on either side of a
-compound condition without making a guarded initializer invalid.
+compound condition without making a guarded initializer invalid. Previous narrowing of the receiver
+must also preserve real diagnostics in the guarded branch.
 
 `base.py`:
 
 ```py
+class Marker: ...
+
 class Base:
     def __init__(self, enabled: bool):
         if enabled:
@@ -451,18 +472,33 @@ class Base:
             self.leading = self.__str__
         if not hasattr(self, "trailing") and enabled:
             self.trailing = self.__str__
+        if self is not None:
+            if not hasattr(self, "nonnull"):
+                self.nonnull = self.__str__
+                self.nonnull_missing  # error: [unresolved-attribute]
+        if not hasattr(self, "other"):
+            if not hasattr(self, "unrelated"):
+                self.unrelated = self.__str__
+                self.unrelated_missing  # error: [unresolved-attribute]
+        if isinstance(self, Marker):
+            if not hasattr(self, "narrowed"):
+                self.narrowed = self.__str__
+                self.narrowed_missing  # error: [unresolved-attribute]
 ```
 
 `child.py`:
 
 ```py
-from base import Base
+from base import Base, Marker
 
-class Child(Base):
+class Child(Base, Marker):
     outer = Base.__str__
     inner = Base.__str__
     leading = Base.__str__
     trailing = Base.__str__
+    nonnull = Base.__str__
+    unrelated = Base.__str__
+    narrowed = Base.__str__
 ```
 
 ## Nested and compound attribute guards when the subclass is checked first
@@ -472,18 +508,23 @@ Checking the subclass first must preserve the same nested and compound guarded i
 `child.py`:
 
 ```py
-from base import Base
+from base import Base, Marker
 
-class Child(Base):
+class Child(Base, Marker):
     outer = Base.__str__
     inner = Base.__str__
     leading = Base.__str__
     trailing = Base.__str__
+    nonnull = Base.__str__
+    unrelated = Base.__str__
+    narrowed = Base.__str__
 ```
 
 `base.py`:
 
 ```py
+class Marker: ...
+
 class Base:
     def __init__(self, enabled: bool):
         if enabled:
@@ -496,6 +537,18 @@ class Base:
             self.leading = self.__str__
         if not hasattr(self, "trailing") and enabled:
             self.trailing = self.__str__
+        if self is not None:
+            if not hasattr(self, "nonnull"):
+                self.nonnull = self.__str__
+                self.nonnull_missing  # error: [unresolved-attribute]
+        if not hasattr(self, "other"):
+            if not hasattr(self, "unrelated"):
+                self.unrelated = self.__str__
+                self.unrelated_missing  # error: [unresolved-attribute]
+        if isinstance(self, Marker):
+            if not hasattr(self, "narrowed"):
+                self.narrowed = self.__str__
+                self.narrowed_missing  # error: [unresolved-attribute]
 ```
 
 ## Unreachable and deleted class attributes do not prevent guarded initialization

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -431,6 +431,105 @@ class Base:
             self.z = self.y  # error: [unresolved-attribute]
 ```
 
+## Nested and compound attribute guards when the base is checked first
+
+An unrelated condition can appear outside an attribute guard, inside it, or on either side of a
+compound condition without making a guarded initializer invalid.
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self, enabled: bool):
+        if enabled:
+            if not hasattr(self, "outer"):
+                self.outer = self.__str__
+        if not hasattr(self, "inner"):
+            if enabled:
+                self.inner = self.__str__
+        if enabled and not hasattr(self, "leading"):
+            self.leading = self.__str__
+        if not hasattr(self, "trailing") and enabled:
+            self.trailing = self.__str__
+```
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    outer = Base.__str__
+    inner = Base.__str__
+    leading = Base.__str__
+    trailing = Base.__str__
+```
+
+## Nested and compound attribute guards when the subclass is checked first
+
+Checking the subclass first must preserve the same nested and compound guarded initializers.
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    outer = Base.__str__
+    inner = Base.__str__
+    leading = Base.__str__
+    trailing = Base.__str__
+```
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self, enabled: bool):
+        if enabled:
+            if not hasattr(self, "outer"):
+                self.outer = self.__str__
+        if not hasattr(self, "inner"):
+            if enabled:
+                self.inner = self.__str__
+        if enabled and not hasattr(self, "leading"):
+            self.leading = self.__str__
+        if not hasattr(self, "trailing") and enabled:
+            self.trailing = self.__str__
+```
+
+## Unreachable and deleted class attributes do not prevent guarded initialization
+
+A class attribute that was never assigned or was deleted cannot make a later instance initializer
+unreachable.
+
+`base.py`:
+
+```py
+class Base:
+    if False:
+        unreachable = 1
+
+    deleted = 1
+    del deleted
+
+    def __init__(self):
+        if not hasattr(self, "unreachable"):
+            self.unreachable = self.__str__
+        if not hasattr(self, "deleted"):
+            self.deleted = self.__str__
+```
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    unreachable = Base.__str__
+    deleted = Base.__str__
+```
+
 ## Guarded instance attributes after a call when the base is checked first
 
 A call before a guarded initializer must not make its validity or later diagnostics depend on file

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -367,6 +367,181 @@ min(Y)  # error: [invalid-argument-type]
 T = f()
 ```
 
+## Guarded instance attributes when the base is checked first
+
+A guarded bound-method initializer remains valid, while another initializer still reports an
+attribute that is missing from the base class. This reproduces
+<https://github.com/astral-sh/ty/issues/4076>.
+
+`base.py`:
+
+```py
+class Base:
+    existing = 1
+
+    def __init__(self):
+        if not hasattr(self, "x"):
+            self.x = self.__str__
+        if not hasattr(self, "existing"):
+            self.missing
+        if not hasattr(self, "z"):
+            self.z = self.y  # error: [unresolved-attribute]
+```
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+
+    def z(self): ...
+    def y(self): ...
+```
+
+## Guarded instance attributes when the subclass is checked first
+
+Checking the subclass first preserves the valid initializer and the missing-attribute diagnostic.
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+
+    def z(self): ...
+    def y(self): ...
+```
+
+`base.py`:
+
+```py
+class Base:
+    existing = 1
+
+    def __init__(self):
+        if not hasattr(self, "x"):
+            self.x = self.__str__
+        if not hasattr(self, "existing"):
+            self.missing
+        if not hasattr(self, "z"):
+            self.z = self.y  # error: [unresolved-attribute]
+```
+
+## Guarded instance attributes after a call when the base is checked first
+
+A call before a guarded initializer must not make its validity or later diagnostics depend on file
+order.
+
+`base.py`:
+
+```py
+def prepare() -> None: ...
+
+class Base:
+    def __init__(self):
+        if not hasattr(self, "x"):
+            prepare()
+            self.x = self.__str__
+            self.missing  # error: [unresolved-attribute]
+```
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+```
+
+## Guarded instance attributes after a call when the subclass is checked first
+
+Checking the subclass first must preserve the same guarded assignment and genuine missing-attribute
+diagnostic after the intervening call.
+
+`child.py`:
+
+```py
+from base import Base
+
+class Child(Base):
+    x = Base.__str__
+```
+
+`base.py`:
+
+```py
+def prepare() -> None: ...
+
+class Base:
+    def __init__(self):
+        if not hasattr(self, "x"):
+            prepare()
+            self.x = self.__str__
+            self.missing  # error: [unresolved-attribute]
+```
+
+## Non-returning initializers do not define instance attributes
+
+An assignment whose initializer never returns cannot make its target attribute present.
+
+```py
+from typing import NoReturn
+
+def fail() -> NoReturn:
+    raise RuntimeError
+
+class C:
+    def initialize(self):
+        if not hasattr(self, "x"):
+            self.x = fail()  # error: [invalid-assignment]
+
+C().x  # error: [unresolved-attribute]
+```
+
+## Assignments in the opposite guard branch do not initialize an attribute
+
+Assigning an existing attribute when `hasattr` succeeds does not initialize it in the opposite
+branch. That branch remains unreachable and cannot create another instance attribute. Existing
+inherited class attributes also retain their usual narrowing.
+
+```py
+class Base:
+    inherited = 1
+
+class C(Base):
+    def __init__(self):
+        self.x = 1
+
+    def update(self):
+        if not hasattr(self, "inherited"):
+            self.missing
+        if hasattr(self, "x"):
+            self.x = 2
+        else:
+            self.y = self.missing
+
+C().y  # error: [unresolved-attribute]
+```
+
+## Contradictory attribute guards do not initialize an attribute
+
+An impossible inner `hasattr` branch cannot create an instance attribute.
+
+```py
+class C:
+    def initialize(self):
+        if hasattr(self, "x"):
+            if not hasattr(self, "x"):
+                self.x = self.missing
+
+C().x  # error: [unresolved-attribute]
+```
+
 ## Lazy cached property behind `hasattr`
 
 This pattern used to panic with "too many cycle iterations".

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -185,13 +185,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: BoundMethodType<'db>,
         target: BoundMethodType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // A bound method is a typically a subtype of itself. However, we must explicitly verify
-        // the subtyping of the underlying function signatures (since they might be specialized
-        // differently), and of the bound self parameter (taking care that parameters, including a
-        // bound self parameter, are contravariant.)
+        // The receiver exposed by `__self__` is an already-captured value, so it is covariant.
+        // However, `Self` can also appear in the remaining parameters, where binding the
+        // receiver must still preserve ordinary callable contravariance.
         self.check_function_pair(db, source.function(db), target.function(db))
             .and(db, self.constraints, || {
-                self.check_type_pair(db, target.self_instance(db), source.self_instance(db))
+                self.check_type_pair(db, source.self_instance(db), target.self_instance(db))
+            })
+            .and(db, self.constraints, || {
+                self.check_callable_signature_pair(
+                    db,
+                    source.bound_signatures(db),
+                    target.bound_signatures(db),
+                )
             })
     }
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -11,15 +11,14 @@ use crate::types::typed_dict::{TypedDictFieldBuilder, TypedDictSchema, TypedDict
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    Parameter, Parameters, Signature, SpecialFormType, StringLiteralType, SubclassOfInner,
-    SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
-    callable_pattern_type, class_pattern_positional_sources,
-    definite_match_pattern_type_for_subject, exact_sequence_pattern_type, infer_expression_types,
-    mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
-    singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
+    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
+    class_pattern_positional_sources, definite_match_pattern_type_for_subject,
+    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
+    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use crate::{Db, ProgramEnvironment};
-use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
@@ -29,9 +28,7 @@ use ty_python_core::predicate::{
     SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{
-    ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index, use_def_map,
-};
+use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
 
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::name::Name;
@@ -149,45 +146,6 @@ fn all_narrowing_constraints_for_expression<'db>(
     ExpressionNarrowingConstraints {
         positive: NarrowingConstraintsBuilder::new(db, &env, &module, predicate, true).finish(),
         negative: NarrowingConstraintsBuilder::new(db, &env, &module, predicate, false).finish(),
-    }
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-enum AttributePresence {
-    Present,
-    Absent,
-    Indeterminate,
-}
-
-/// Checks attribute presence without allowing a guarded initializer to prove its own absence.
-///
-/// ```python
-/// if not hasattr(self, "value"):
-///     self.value = self.__str__
-/// ```
-///
-/// A cyclic presence check recovers to `Indeterminate`, independently of file order. Including the
-/// predicate in the query identity prevents recovery from affecting unrelated `hasattr` checks.
-#[salsa::tracked(
-    returns(copy),
-    cycle_result=|_, _, _, _, _| AttributePresence::Indeterminate,
-    heap_size=ruff_memory_usage::heap_size,
-)]
-fn negative_hasattr_presence_proof<'db>(
-    db: &'db dyn Db,
-    predicate: Expression<'db>,
-    receiver: Type<'db>,
-    attribute: StringLiteralType<'db>,
-) -> AttributePresence {
-    let env = ProgramEnvironment::from_file(predicate.program_file(db));
-    if receiver
-        .member(db, &env, attribute.value(db))
-        .place
-        .is_definitely_bound()
-    {
-        AttributePresence::Present
-    } else {
-        AttributePresence::Absent
     }
 }
 
@@ -4316,44 +4274,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let [first_arg, second_arg] = &*expr_call.arguments.args else {
                     return None;
                 };
-                let first_arg_place = PlaceExpr::try_from_expr(first_arg)?;
+                let first_arg = PlaceExpr::try_from_expr(first_arg)?;
                 let function = function_type.known(db)?;
-                let place = self.expect_place(&first_arg_place);
+                let place = self.expect_place(&first_arg);
 
                 if function == KnownFunction::HasAttr {
-                    let attribute = inference.expression_type(second_arg).as_string_literal()?;
-                    let attr = attribute.value(db);
+                    let attr = inference
+                        .expression_type(second_arg)
+                        .as_string_literal()?
+                        .value(db);
 
                     if !is_identifier(attr) {
-                        return None;
-                    }
-
-                    let places = self.places();
-                    let receiver = inference.expression_type(first_arg);
-                    if !is_positive
-                        && let Some(member) = places.member_id_by_instance_attribute_name(attr)
-                        && places.place(member).is_bound()
-                        && places
-                            .parents(places.place(member))
-                            .any(|parent| parent == place)
-                        && matches!(receiver, Type::TypeVar(typevar) if typevar.typevar(db).is_self(db))
-                        && let PredicateNode::Expression(predicate) = self.predicate
-                        && let Some(receiver_name) = first_arg.as_name_expr()
-                        && {
-                            let use_def = use_def_map(db, self.scope());
-                            let use_id =
-                                receiver_name.scoped_use_id(db, predicate.program_file(db));
-                            // An earlier narrowing of this receiver can already establish that
-                            // the attribute exists, making the negative guard unreachable.
-                            use_def.bindings_at_use(use_id).all(|binding| {
-                                binding.narrowing_constraint.constraint().is_terminal()
-                            })
-                        }
-                        && negative_hasattr_presence_proof(db, predicate, receiver, attribute)
-                            == AttributePresence::Indeterminate
-                    {
-                        // An implicit attribute cannot establish its own absence when proving its
-                        // presence requires inferring the initializer narrowed by this predicate.
                         return None;
                     }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -19,6 +19,7 @@ use crate::types::{
     singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use crate::{Db, ProgramEnvironment};
+use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
@@ -27,9 +28,10 @@ use ty_python_core::predicate::{
     PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
     SubjectElementPatternPredicate,
 };
-use ty_python_core::reachability_constraints::ScopedReachabilityConstraintId;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
+use ty_python_core::{
+    ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index, use_def_map,
+};
 
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::name::Name;
@@ -3235,72 +3237,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         place_table(db, self.scope())
     }
 
-    /// Returns whether every reachable assignment to this member depends on the current guard.
-    fn predicate_initializes_member(&self, member: ScopedPlaceId) -> bool {
-        let db = self.db;
-        let scope = self.scope();
-        let index = semantic_index(db, scope.program_file(db));
-        let use_def = index.use_def_map(scope.file_scope_id(db));
-        let constraints = use_def.reachability_constraints();
-        let predicates = use_def.predicates();
-        let is_terminal = |constraint| {
-            matches!(
-                constraint,
-                ScopedReachabilityConstraintId::ALWAYS_TRUE
-                    | ScopedReachabilityConstraintId::AMBIGUOUS
-                    | ScopedReachabilityConstraintId::ALWAYS_FALSE
-            )
-        };
-
-        let mut initialized_by_predicate = false;
-        for binding in use_def.reachable_bindings(member) {
-            if binding.binding.definition().is_none() {
-                continue;
-            }
-
-            let mut constraint = binding.reachability_constraint;
-            while !is_terminal(constraint) {
-                let node = constraints.get_interior_node(constraint);
-                let predicate = predicates[node.atom()];
-
-                if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                    // A non-terminal-call predicate cannot evaluate to ambiguous.
-                    if !predicate.is_positive
-                        || node.if_false() != ScopedReachabilityConstraintId::ALWAYS_FALSE
-                    {
-                        return false;
-                    }
-                    constraint = node.if_true();
-                    continue;
-                }
-
-                let opposing_branch = if self.is_positive == predicate.is_positive {
-                    node.if_false()
-                } else {
-                    node.if_true()
-                };
-
-                if predicate.node != self.predicate
-                    || opposing_branch != ScopedReachabilityConstraintId::ALWAYS_FALSE
-                    || ![node.if_true(), node.if_ambiguous(), node.if_false()]
-                        .into_iter()
-                        .all(is_terminal)
-                {
-                    return false;
-                }
-
-                initialized_by_predicate = true;
-                break;
-            }
-
-            if constraint == ScopedReachabilityConstraintId::ALWAYS_TRUE {
-                return false;
-            }
-        }
-
-        initialized_by_predicate
-    }
-
     fn scope(&self) -> ScopeId<'db> {
         let db = self.db;
         match self.predicate {
@@ -4402,23 +4338,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                             .any(|parent| parent == place)
                         && matches!(receiver, Type::TypeVar(typevar) if typevar.typevar(db).is_self(db))
                         && let PredicateNode::Expression(predicate) = self.predicate
-                        && !matches!(
-                            predicate.node_ref(db).node(self.module),
-                            ast::Expr::BoolOp(_)
-                        )
-                        && self.predicate_initializes_member(member.into())
-                        && !receiver.nominal_class(db, &self.env).is_some_and(|class| {
-                            class
-                                .iter_mro(db)
-                                .filter_map(ClassBase::into_class)
-                                .filter_map(|base| base.static_class_literal(db))
-                                .any(|(base, _)| {
-                                    let places = place_table(db, base.body_scope(db));
-                                    places
-                                        .symbol_id(attr)
-                                        .is_some_and(|symbol| places.symbol(symbol).is_bound())
-                                })
-                        })
+                        && let Some(receiver_name) = first_arg.as_name_expr()
+                        && {
+                            let use_def = use_def_map(db, self.scope());
+                            let use_id =
+                                receiver_name.scoped_use_id(db, predicate.program_file(db));
+                            // An earlier narrowing of this receiver can already establish that
+                            // the attribute exists, making the negative guard unreachable.
+                            use_def.bindings_at_use(use_id).all(|binding| {
+                                binding.narrowing_constraint.constraint().is_terminal()
+                            })
+                        }
                         && negative_hasattr_presence_proof(db, predicate, receiver, attribute)
                             == AttributePresence::Indeterminate
                     {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -11,12 +11,12 @@ use crate::types::typed_dict::{TypedDictFieldBuilder, TypedDictSchema, TypedDict
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
-    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
-    class_pattern_positional_sources, definite_match_pattern_type_for_subject,
-    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    Parameter, Parameters, Signature, SpecialFormType, StringLiteralType, SubclassOfInner,
+    SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
+    callable_pattern_type, class_pattern_positional_sources,
+    definite_match_pattern_type_for_subject, exact_sequence_pattern_type, infer_expression_types,
+    mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use crate::{Db, ProgramEnvironment};
 use ty_python_core::expression::Expression;
@@ -27,6 +27,7 @@ use ty_python_core::predicate::{
     PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
     SubjectElementPatternPredicate,
 };
+use ty_python_core::reachability_constraints::ScopedReachabilityConstraintId;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
 
@@ -146,6 +147,45 @@ fn all_narrowing_constraints_for_expression<'db>(
     ExpressionNarrowingConstraints {
         positive: NarrowingConstraintsBuilder::new(db, &env, &module, predicate, true).finish(),
         negative: NarrowingConstraintsBuilder::new(db, &env, &module, predicate, false).finish(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+enum AttributePresence {
+    Present,
+    Absent,
+    Indeterminate,
+}
+
+/// Checks attribute presence without allowing a guarded initializer to prove its own absence.
+///
+/// ```python
+/// if not hasattr(self, "value"):
+///     self.value = self.__str__
+/// ```
+///
+/// A cyclic presence check recovers to `Indeterminate`, independently of file order. Including the
+/// predicate in the query identity prevents recovery from affecting unrelated `hasattr` checks.
+#[salsa::tracked(
+    returns(copy),
+    cycle_result=|_, _, _, _, _| AttributePresence::Indeterminate,
+    heap_size=ruff_memory_usage::heap_size,
+)]
+fn negative_hasattr_presence_proof<'db>(
+    db: &'db dyn Db,
+    predicate: Expression<'db>,
+    receiver: Type<'db>,
+    attribute: StringLiteralType<'db>,
+) -> AttributePresence {
+    let env = ProgramEnvironment::from_file(predicate.program_file(db));
+    if receiver
+        .member(db, &env, attribute.value(db))
+        .place
+        .is_definitely_bound()
+    {
+        AttributePresence::Present
+    } else {
+        AttributePresence::Absent
     }
 }
 
@@ -3195,6 +3235,72 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         place_table(db, self.scope())
     }
 
+    /// Returns whether every reachable assignment to this member depends on the current guard.
+    fn predicate_initializes_member(&self, member: ScopedPlaceId) -> bool {
+        let db = self.db;
+        let scope = self.scope();
+        let index = semantic_index(db, scope.program_file(db));
+        let use_def = index.use_def_map(scope.file_scope_id(db));
+        let constraints = use_def.reachability_constraints();
+        let predicates = use_def.predicates();
+        let is_terminal = |constraint| {
+            matches!(
+                constraint,
+                ScopedReachabilityConstraintId::ALWAYS_TRUE
+                    | ScopedReachabilityConstraintId::AMBIGUOUS
+                    | ScopedReachabilityConstraintId::ALWAYS_FALSE
+            )
+        };
+
+        let mut initialized_by_predicate = false;
+        for binding in use_def.reachable_bindings(member) {
+            if binding.binding.definition().is_none() {
+                continue;
+            }
+
+            let mut constraint = binding.reachability_constraint;
+            while !is_terminal(constraint) {
+                let node = constraints.get_interior_node(constraint);
+                let predicate = predicates[node.atom()];
+
+                if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+                    // A non-terminal-call predicate cannot evaluate to ambiguous.
+                    if !predicate.is_positive
+                        || node.if_false() != ScopedReachabilityConstraintId::ALWAYS_FALSE
+                    {
+                        return false;
+                    }
+                    constraint = node.if_true();
+                    continue;
+                }
+
+                let opposing_branch = if self.is_positive == predicate.is_positive {
+                    node.if_false()
+                } else {
+                    node.if_true()
+                };
+
+                if predicate.node != self.predicate
+                    || opposing_branch != ScopedReachabilityConstraintId::ALWAYS_FALSE
+                    || ![node.if_true(), node.if_ambiguous(), node.if_false()]
+                        .into_iter()
+                        .all(is_terminal)
+                {
+                    return false;
+                }
+
+                initialized_by_predicate = true;
+                break;
+            }
+
+            if constraint == ScopedReachabilityConstraintId::ALWAYS_TRUE {
+                return false;
+            }
+        }
+
+        initialized_by_predicate
+    }
+
     fn scope(&self) -> ScopeId<'db> {
         let db = self.db;
         match self.predicate {
@@ -4274,17 +4380,50 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let [first_arg, second_arg] = &*expr_call.arguments.args else {
                     return None;
                 };
-                let first_arg = PlaceExpr::try_from_expr(first_arg)?;
+                let first_arg_place = PlaceExpr::try_from_expr(first_arg)?;
                 let function = function_type.known(db)?;
-                let place = self.expect_place(&first_arg);
+                let place = self.expect_place(&first_arg_place);
 
                 if function == KnownFunction::HasAttr {
-                    let attr = inference
-                        .expression_type(second_arg)
-                        .as_string_literal()?
-                        .value(db);
+                    let attribute = inference.expression_type(second_arg).as_string_literal()?;
+                    let attr = attribute.value(db);
 
                     if !is_identifier(attr) {
+                        return None;
+                    }
+
+                    let places = self.places();
+                    let receiver = inference.expression_type(first_arg);
+                    if !is_positive
+                        && let Some(member) = places.member_id_by_instance_attribute_name(attr)
+                        && places.place(member).is_bound()
+                        && places
+                            .parents(places.place(member))
+                            .any(|parent| parent == place)
+                        && matches!(receiver, Type::TypeVar(typevar) if typevar.typevar(db).is_self(db))
+                        && let PredicateNode::Expression(predicate) = self.predicate
+                        && !matches!(
+                            predicate.node_ref(db).node(self.module),
+                            ast::Expr::BoolOp(_)
+                        )
+                        && self.predicate_initializes_member(member.into())
+                        && !receiver.nominal_class(db, &self.env).is_some_and(|class| {
+                            class
+                                .iter_mro(db)
+                                .filter_map(ClassBase::into_class)
+                                .filter_map(|base| base.static_class_literal(db))
+                                .any(|(base, _)| {
+                                    let places = place_table(db, base.body_scope(db));
+                                    places
+                                        .symbol_id(attr)
+                                        .is_some_and(|symbol| places.symbol(symbol).is_bound())
+                                })
+                        })
+                        && negative_hasattr_presence_proof(db, predicate, receiver, attribute)
+                            == AttributePresence::Indeterminate
+                    {
+                        // An implicit attribute cannot establish its own absence when proving its
+                        // presence requires inferring the initializer narrowed by this predicate.
                         return None;
                     }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -3730,6 +3730,42 @@ fn callable_has_only_non_never_returns<'db>(db: &'db dyn Db, callable: CallableT
         && signatures.all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
 }
 
+/// Check synthesized protocol members without treating a cyclic implicit attribute as present.
+///
+/// A `Divergent` member is only a provisional cycle value, not proof that the attribute exists.
+#[salsa::tracked(
+    returns(copy),
+    cycle_result=|_, _, _, _, _| false,
+    heap_size=ruff_memory_usage::heap_size,
+)]
+fn synthesized_protocol_members_are_definitely_present<'db>(
+    db: &'db dyn Db,
+    program: Program<'db>,
+    ty: Type<'db>,
+    protocol: ProtocolInstanceType<'db>,
+) -> bool {
+    let env = ProgramEnvironment::from_program(program);
+
+    protocol.interface(db).members(db).all(|member| {
+        ty.member_lookup_with_policy(
+            db,
+            &env,
+            member.name(),
+            MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+        )
+        .place
+        .is_definitely_bound()
+            || matches!(
+                ty.member(db, &env, member.name()).place,
+                Place::Defined(DefinedPlace {
+                    ty,
+                    definedness: Definedness::AlwaysDefined,
+                    ..
+                }) if !ty.is_divergent()
+            )
+    })
+}
+
 /// Protocol compatibility can only succeed if every required member is present.
 ///
 /// Check that necessary condition up front so we can avoid expensive per-member type
@@ -3752,6 +3788,9 @@ pub(super) fn has_all_protocol_members_defined<'db>(
                 && target_interface.members(db).all(|member| {
                     source_interface.includes_member_or_object_fallback(db, env, member.name())
                 })
+        }
+        _ if protocol.class_origin(db).is_none() => {
+            synthesized_protocol_members_are_definitely_present(db, env.program(db), ty, protocol)
         }
         _ => target_interface.members(db).all(|member| {
             matches!(


### PR DESCRIPTION
## Summary

Previously, checking a guarded implicit attribute could produce a different result depending on whether its defining class or a subclass was checked first:

```python
# base.py
class Base:
    def __init__(self):
        if not hasattr(self, "value"):
            self.value = self.__str__


# child.py
from base import Base


class Child(Base):
    value = Base.__str__
```

Inferring `Base.value` can reenter the negative `hasattr` predicate while that predicate is deciding whether the same attribute already exists. Different Salsa cycle heads then either reject the guarded assignment or suppress the branch entirely.

We now resolve this specific presence check through a predicate-keyed query whose cyclic result is indeterminate. Only the exact guarded, self-initializing attribute bypasses negative narrowing when its presence genuinely depends on that cycle; ordinary `hasattr` narrowing, existing class or inherited attributes, and unrelated missing-attribute diagnostics retain their previous behavior.

Closes https://github.com/astral-sh/ty/issues/4076.
