### PR TITLE
[ty] Stabilize inherited implicit-attribute cycles

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -229,6 +229,10 @@ c_instance = C()
 reveal_type(c_instance.x)  # revealed: int | str
 reveal_type(c_instance.y)  # revealed: int
 reveal_type(c_instance.z)  # revealed: int
+
+def accepts_int(value: int) -> None: ...
+
+accepts_int(c_instance.x)  # error: [invalid-argument-type]
 ```
 
 #### Singleton promotion happens after unioning implicit assignments
@@ -1250,6 +1254,36 @@ class Child(Parent):
 reveal_type(Child.value)  # revealed: Before | After
 ```
 
+#### Inherited class variables preserve their public type
+
+An inferred superclass default constrains classmethod assignments without exposing its literal type.
+
+```py
+class Parent:
+    value = 1
+
+class Child(Parent):
+    @classmethod
+    def update(cls) -> None:
+        cls.value = str(cls.value)  # error: [invalid-assignment]
+
+reveal_type(Child.value)  # revealed: int
+```
+
+#### Self-referential class variables without an independent value
+
+An ordinary self-referential classmethod assignment retains its recursive type when no independent
+class attribute exists.
+
+```py
+class Example:
+    @classmethod
+    def update(cls) -> None:
+        cls.value = cls.value
+
+reveal_type(Example.value)  # revealed: Divergent
+```
+
 ### Instance variables with class-level default values
 
 These are instance attributes, but the fact that we can see that they have a binding (not a
@@ -1285,6 +1319,71 @@ C.variable_with_class_default1 = "overwritten on class"
 
 reveal_type(C.variable_with_class_default1)  # revealed: Literal["overwritten on class"]
 reveal_type(c_instance.variable_with_class_default1)  # revealed: Literal["value set on instance"]
+```
+
+#### Class-level defaults do not hide invalid instance values
+
+An unannotated default on the same class must not hide a later incompatible instance assignment or
+suppress diagnostics for operations that can receive the assigned value.
+
+```py
+class Parser:
+    token = ""
+
+    def reset(self) -> None:
+        self.token = None  # error: [invalid-assignment]
+
+    def parse(self) -> None:
+        self.token = self.token[1:-1]  # error: [not-subscriptable]
+
+reveal_type(Parser().token)  # revealed: str | None | Unknown
+```
+
+#### Inherited class-level defaults do not hide invalid instance values
+
+An inherited default also cannot erase an incompatible instance value from later recursive reads.
+
+```py
+class Base:
+    token = ""
+
+class Parser(Base):
+    def reset(self) -> None:
+        self.token = None  # error: [invalid-assignment]
+
+    def parse(self) -> None:
+        self.token = self.token[1:-1]  # error: [not-subscriptable]
+
+reveal_type(Parser().token)  # revealed: str | None
+```
+
+Values introduced by destructuring, loop targets, and context managers must remain visible too.
+
+```py
+from contextlib import nullcontext
+
+class UnpackedParser(Base):
+    def reset(self) -> None:
+        (self.token,) = (None,)  # error: [invalid-assignment]
+
+    def parse(self) -> None:
+        self.token = self.token[1:-1]  # error: [not-subscriptable]
+
+class LoopParser(Base):
+    def reset(self) -> None:
+        for self.token in [None]:  # error: [invalid-assignment]
+            pass
+
+    def parse(self) -> None:
+        self.token = self.token[1:-1]  # error: [not-subscriptable]
+
+class ContextParser(Base):
+    def reset(self) -> None:
+        with nullcontext(None) as self.token:  # error: [invalid-assignment]
+            pass
+
+    def parse(self) -> None:
+        self.token = self.token[1:-1]  # error: [not-subscriptable]
 ```
 
 #### Augmented assignments to overriding class-level defaults
@@ -1332,6 +1431,50 @@ class C:
 reveal_type(C().a)  # revealed: int
 reveal_type(C().b)  # revealed: int
 reveal_type(C().c)  # revealed: int
+```
+
+#### Inherited annotated descriptors are bound before self-referential assignments
+
+An inherited descriptor's annotation constrains assignments without changing the bound value read
+before an assignment.
+
+```py
+class Descriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> str:
+        return "value"
+
+class Base:
+    value: Descriptor = Descriptor()
+
+class Child(Base):
+    def update(self) -> None:
+        self.value = self.value + "b"  # error: [invalid-assignment]
+
+    def get_value(self) -> str:
+        return self.value
+
+reveal_type(Child().value)  # revealed: str
+```
+
+#### Inherited descriptors are bound before self-referential class assignments
+
+Reading an inherited descriptor through a class invokes `__get__` with `None` before a classmethod
+stores its updated value.
+
+```py
+class Descriptor:
+    def __get__(self, instance: None, owner: type) -> str:
+        return "value"
+
+class Base:
+    value = Descriptor()
+
+class Child(Base):
+    @classmethod
+    def update(cls) -> None:
+        cls.value = cls.value + "b"
+
+reveal_type(Child.value)  # revealed: str
 ```
 
 ### Inheritance of class/instance attributes
@@ -1455,6 +1598,26 @@ reveal_type(Derived().pure_overwritten_in_subclass_method)  # revealed: str
 reveal_type(Derived.undeclared)  # revealed: str
 reveal_type(Derived().undeclared)  # revealed: str
 reveal_type(Derived().pure_undeclared)  # revealed: str
+```
+
+### Explicit subclass annotations override inferred inherited attributes
+
+A subclass's explicit instance-attribute annotation takes precedence over an inferred superclass
+attribute, even when its initializer reads the inherited value.
+
+```py
+class Parent:
+    def __init__(self, value: str) -> None:
+        self.extras = {value}
+
+class Child(Parent):
+    def __init__(self, value: str) -> None:
+        super().__init__(value)
+        self.extras: tuple[str, ...] = tuple(self.extras)
+
+def record(child: Child, values: dict[Child, tuple[str, ...]]) -> None:
+    reveal_type(child.extras)  # revealed: tuple[str, ...]
+    values[child] = child.extras
 ```
 
 ## Allow replacing ordinary methods with compatible functions
@@ -4762,6 +4925,31 @@ class C:
         return t
 
 reveal_type(C().x)  # revealed: int
+```
+
+### Decorated methods on generic classes preserve instance binding
+
+An identity-decorated method on a generic class must see other instance methods as bound, and
+subclasses must be able to override those methods normally.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+def callback[F](function: F) -> F:
+    return function
+
+class Base[T]:
+    def update(self) -> None: ...
+    @callback
+    def run(self) -> None:
+        reveal_type(self.update)  # revealed: bound method Self@run.update() -> None
+        self.update()
+
+class Child(Base[int]):
+    def update(self) -> None: ...
 ```
 
 ### Attributes defined in methods with unknown decorators

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -385,6 +385,193 @@ class Cached:
 reveal_type(Cached().metadata)  # revealed: int
 ```
 
+## Inherited instance attributes when the base is checked first
+
+A self-referential instance assignment preserves the inherited attribute type when the base file is
+checked first.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+`base.py`:
+
+```py
+class Base:
+    values = ["a"]
+
+class Parent(Base):
+    def __init__(self):
+        if self.values:
+            self.values = [*self.values]
+
+    def get_values(self) -> list[str]:
+        return self.values
+```
+
+`child.py`:
+
+```py
+from base import Parent
+
+class Child(Parent):
+    def __init__(self):
+        self.values = self.values + ["b"]
+```
+
+## Inherited instance attributes when the subclass is checked first
+
+Reversing the file order must preserve the same inherited attribute type.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+`child.py`:
+
+```py
+from base import Parent
+
+class Child(Parent):
+    def __init__(self):
+        self.values = self.values + ["b"]
+```
+
+`base.py`:
+
+```py
+class Base:
+    values = ["a"]
+
+class Parent(Base):
+    def __init__(self):
+        if self.values:
+            self.values = [*self.values]
+
+    def get_values(self) -> list[str]:
+        return self.values
+```
+
+## Inherited instance initializers when the base is checked first
+
+An independently initialized superclass instance attribute remains available to receiver aliases.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self):
+        self.values = ["a"]
+
+class Parent(Base):
+    def __init__(self):
+        super().__init__()
+        if self.values:
+            receiver = self
+            self.values = [*receiver.values]
+
+    def get_values(self) -> list[str]:
+        return self.values
+```
+
+`child.py`:
+
+```py
+from base import Parent
+
+class Child(Parent):
+    def __init__(self):
+        super().__init__()
+        receiver = self
+        self.values = receiver.values + ["b"]
+```
+
+## Inherited instance initializers when the subclass is checked first
+
+Reversing file order preserves an independently initialized superclass instance attribute.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+`child.py`:
+
+```py
+from base import Parent
+
+class Child(Parent):
+    def __init__(self):
+        super().__init__()
+        receiver = self
+        self.values = receiver.values + ["b"]
+```
+
+`base.py`:
+
+```py
+class Base:
+    def __init__(self):
+        self.values = ["a"]
+
+class Parent(Base):
+    def __init__(self):
+        super().__init__()
+        if self.values:
+            receiver = self
+            self.values = [*receiver.values]
+
+    def get_values(self) -> list[str]:
+        return self.values
+```
+
+## Inherited attributes remain stable across assignment forms
+
+Inherited attribute inference does not depend on how an assignment accesses or binds the previous
+value.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+class Base:
+    values = ["a"]
+
+class Child(Base):
+    def aliased(self) -> None:
+        first = self.values
+        second = first
+        self.values = second + ["b"]
+
+    def augmented_alias(self) -> None:
+        previous = self.values
+        previous += ["b"]
+        self.values = previous
+
+    def named_alias(self) -> None:
+        (previous := self.values)
+        self.values = previous + ["b"]
+
+    def unpacked(self) -> None:
+        (self.values,) = (self.values + ["b"],)
+
+    def loop_target(self) -> None:
+        for self.values in [self.values + ["b"]]:
+            pass
+
+    def get_values(self) -> list[str]:
+        return self.values
+```
+
 ## Decorator defined on a base class with constrained typevars, accessed from a subclass with decorated generic parameters
 
 This example was minimized from

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -34,8 +34,7 @@ use ty_python_core::definition::docstring_from_body;
 use ty_python_core::platform::PythonPlatform;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
-    BindingWithConstraintsIterator, DeclarationsIterator, FileScopeId, attribute_scopes,
-    semantic_index,
+    BindingWithConstraintsIterator, FileScopeId, attribute_scopes, semantic_index,
 };
 pub use ty_site_packages::{
     PythonEnvironment, PythonVersionFileSource, PythonVersionSource, PythonVersionWithSource,
@@ -143,29 +142,6 @@ pub(crate) fn attribute_assignments<'db, 's>(
         let member = place_table.member_id_by_instance_attribute_name(name)?;
         let use_def = index.use_def_map(function_scope_id);
         Some((use_def.reachable_member_bindings(member), function_scope_id))
-    })
-}
-
-/// Returns all attribute declarations (and their method scope IDs) with a symbol name matching
-/// the one given for a specific class body scope.
-///
-/// Only call this when doing type inference on the same file as `class_body_scope`, otherwise it
-/// introduces a direct dependency on that file's AST.
-pub(crate) fn attribute_declarations<'db, 's>(
-    db: &'db dyn Db,
-    class_body_scope: ScopeId<'db>,
-    name: &'s str,
-) -> impl Iterator<Item = (DeclarationsIterator<'db, 'db>, FileScopeId)> + use<'s, 'db> {
-    let index = semantic_index(db, class_body_scope.program_file(db));
-
-    attribute_scopes(db, class_body_scope).filter_map(|function_scope_id| {
-        let place_table = index.place_table(function_scope_id);
-        let member = place_table.member_id_by_instance_attribute_name(name)?;
-        let use_def = index.use_def_map(function_scope_id);
-        Some((
-            use_def.reachable_member_declarations(member),
-            function_scope_id,
-        ))
     })
 }
 

--- a/crates/ty_python_semantic/src/types/class/implicit_attributes.rs
+++ b/crates/ty_python_semantic/src/types/class/implicit_attributes.rs
@@ -2,12 +2,11 @@
 
 use super::{MethodDecorator, static_literal::StaticClassLiteral};
 use crate::{
-    Db, ProgramEnvironment, TypeQualifiers, attribute_assignments, attribute_declarations,
+    Db, ProgramEnvironment, TypeQualifiers,
     place::{Place, Provenance},
     reachability::binding_reachability,
     types::{
-        ClassBase, ClassLiteral, KnownClass, Truthiness, Type, TypeContext, UnionBuilder,
-        definition_expression_type,
+        ClassBase, ClassLiteral, Type, TypeContext, UnionBuilder,
         function::{FunctionDecorators, is_implicit_classmethod, is_implicit_staticmethod},
         infer::{function_known_decorator_flags, infer_unpack_types},
         infer_expression_type, inferred_declaration,
@@ -20,7 +19,7 @@ use ty_python_core::{
     attribute_scopes,
     definition::{Definition, DefinitionKind, DefinitionState, TargetKind},
     place_table,
-    scope::{Scope, ScopeId},
+    scope::ScopeId,
     semantic_index, use_def_map,
 };
 
@@ -75,12 +74,13 @@ impl<'db> StaticClassLiteral<'db> {
             target_method_decorator,
         );
 
-        if !implicit_attribute_has_declaration(db, attribute)
+        let facts = implicit_attribute_facts(db, attribute);
+        if facts.declarations.is_empty()
             && let Some(incoming) = self.independent_attribute_value(db, attribute)
         {
             let env = ProgramEnvironment::from_scope(class_body_scope);
             let mut incoming_values = UnionBuilder::new(db, &env).add(incoming);
-            for &definition in implicit_attribute_assignment_definitions(db, attribute) {
+            for &definition in &facts.bindings {
                 if let Some(ty) = independent_attribute_assignment_type(db, attribute, definition) {
                     incoming_values.add_in_place(ty);
                 }
@@ -195,11 +195,10 @@ impl<'db> StaticClassLiteral<'db> {
         attribute: ImplicitAttributeName<'db>,
     ) -> ImplicitAttribute<'db> {
         let class_body_scope = attribute.class_body_scope(db);
-        let name = attribute.name(db).as_str();
-        let target_method_decorator = attribute.target_method_decorator(db);
         let program_file = class_body_scope.program_file(db);
         let python_file = program_file.python_file(db);
         let env = &ProgramEnvironment::from_file(program_file);
+        let facts = implicit_attribute_facts(db, attribute);
 
         // If we do not see any declarations of an attribute, neither in the class body nor in
         // any method, we build a union of the raw types inferred from all bindings of that
@@ -213,186 +212,66 @@ impl<'db> StaticClassLiteral<'db> {
 
         let module = parsed_module(db, python_file).load(db);
         let index = semantic_index(db, program_file);
-        let class_map = use_def_map(db, class_body_scope);
-        let class_table = place_table(db, class_body_scope);
-        let is_valid_scope = |method_scope: &Scope| {
-            let Some(method_def) = method_scope.node().as_function() else {
-                return true;
+
+        for &declaration in &facts.declarations {
+            let DefinitionKind::AnnotatedAssignment(assignment) = declaration.kind(db) else {
+                continue;
             };
 
-            // Check the decorators directly on the AST node to determine if this method
-            // is a classmethod or staticmethod. This is more reliable than checking the
-            // final evaluated type, which may be wrapped by other decorators like @cache.
-            let function_node = method_def.node(&module);
-            let definition = index.expect_single_definition(method_def);
+            // We found an annotated assignment of one of the following forms (using 'self' in these
+            // examples, but we support arbitrary names for the first parameters of methods):
+            //
+            //     self.name: <annotation>
+            //     self.name: <annotation> = …
 
-            let mut is_classmethod = false;
-            let mut is_staticmethod = false;
+            let Some(annotation) = inferred_declaration(db, declaration).declared() else {
+                continue;
+            };
+            let annotation = Place::declared(annotation.inner)
+                .with_definition(declaration)
+                .with_qualifiers(
+                    annotation.qualifiers | TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE,
+                );
 
-            for decorator in &function_node.decorator_list {
-                let decorator_ty =
-                    definition_expression_type(db, definition, &decorator.expression);
-                if let Type::ClassLiteral(class) = decorator_ty {
-                    match class.known(db) {
-                        Some(KnownClass::Classmethod) => is_classmethod = true,
-                        Some(KnownClass::Staticmethod) => is_staticmethod = true,
-                        _ => {}
-                    }
+            if let Some(all_qualifiers) = annotation.is_bare_final() {
+                if let Some(value) = assignment.value(&module) {
+                    // If we see an annotated assignment with a bare `Final` as in
+                    // `self.SOME_CONSTANT: Final = 1`, infer the type from the value
+                    // on the right-hand side.
+
+                    let inferred_ty =
+                        infer_expression_type(db, index.expression(value), TypeContext::default());
+                    return ImplicitAttribute {
+                        member: Member {
+                            inner: Place::bound(inferred_ty)
+                                .with_definition(declaration)
+                                .with_qualifiers(all_qualifiers),
+                        },
+                        augmented_bindings: None,
+                    };
                 }
-            }
 
-            // Also check for implicit classmethods/staticmethods based on method name
-            let method_name = function_node.name.as_str();
-            if is_implicit_classmethod(method_name) {
-                is_classmethod = true;
-            }
-            if is_implicit_staticmethod(method_name) {
-                is_staticmethod = true;
-            }
-
-            match target_method_decorator {
-                MethodDecorator::None => !is_classmethod && !is_staticmethod,
-                MethodDecorator::ClassMethod => is_classmethod,
-                MethodDecorator::StaticMethod => is_staticmethod,
-            }
-        };
-
-        // First check declarations
-        for (attribute_declarations, method_scope_id) in
-            attribute_declarations(db, class_body_scope, name)
-        {
-            let method_scope = index.scope(method_scope_id);
-            if !is_valid_scope(method_scope) {
+                // If there is no right-hand side, just record that we saw a `Final` qualifier
+                qualifiers |= all_qualifiers;
                 continue;
             }
 
-            for attribute_declaration in attribute_declarations {
-                let DefinitionState::Defined(declaration) = attribute_declaration.declaration
-                else {
-                    continue;
-                };
-
-                let DefinitionKind::AnnotatedAssignment(assignment) = declaration.kind(db) else {
-                    continue;
-                };
-
-                // We found an annotated assignment of one of the following forms (using 'self' in these
-                // examples, but we support arbitrary names for the first parameters of methods):
-                //
-                //     self.name: <annotation>
-                //     self.name: <annotation> = …
-
-                let Some(annotation) = inferred_declaration(db, declaration).declared() else {
-                    continue;
-                };
-                let annotation = Place::declared(annotation.inner)
-                    .with_definition(declaration)
-                    .with_qualifiers(
-                        annotation.qualifiers | TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE,
-                    );
-
-                if let Some(all_qualifiers) = annotation.is_bare_final() {
-                    if let Some(value) = assignment.value(&module) {
-                        // If we see an annotated assignment with a bare `Final` as in
-                        // `self.SOME_CONSTANT: Final = 1`, infer the type from the value
-                        // on the right-hand side.
-
-                        let inferred_ty = infer_expression_type(
-                            db,
-                            index.expression(value),
-                            TypeContext::default(),
-                        );
-                        return ImplicitAttribute {
-                            member: Member {
-                                inner: Place::bound(inferred_ty)
-                                    .with_definition(declaration)
-                                    .with_qualifiers(all_qualifiers),
-                            },
-                            augmented_bindings: None,
-                        };
-                    }
-
-                    // If there is no right-hand side, just record that we saw a `Final` qualifier
-                    qualifiers |= all_qualifiers;
-                    continue;
-                }
-
-                return ImplicitAttribute {
-                    member: Member { inner: annotation },
-                    augmented_bindings: None,
-                };
-            }
+            return ImplicitAttribute {
+                member: Member { inner: annotation },
+                augmented_bindings: None,
+            };
         }
 
-        for (attribute_assignments, attribute_binding_scope_id) in
-            attribute_assignments(db, class_body_scope, name)
-        {
-            let binding_scope = index.scope(attribute_binding_scope_id);
-            if !is_valid_scope(binding_scope) {
+        for &binding in &facts.bindings {
+            if matches!(binding.kind(db), DefinitionKind::AugmentedAssignment(_)) {
+                augmented_bindings.push(binding);
                 continue;
             }
 
-            let scope_for_reachability_analysis = {
-                if binding_scope.node().as_function().is_some() {
-                    binding_scope
-                } else if binding_scope.is_eager() {
-                    let mut eager_scope_parent = binding_scope;
-                    while eager_scope_parent.is_eager()
-                        && let Some(parent) = eager_scope_parent.parent()
-                    {
-                        eager_scope_parent = index.scope(parent);
-                    }
-                    eager_scope_parent
-                } else {
-                    binding_scope
-                }
-            };
-
-            // The attribute assignment inherits the reachability of the method which contains it
-            let is_method_reachable =
-                if let Some(method_def) = scope_for_reachability_analysis.node().as_function() {
-                    let method = index.expect_single_definition(method_def);
-                    let method_place = class_table
-                        .symbol_id(&method_def.node(&module).name)
-                        .unwrap();
-                    class_map
-                        .reachable_symbol_bindings(method_place)
-                        .find_map(|bind| {
-                            (bind.binding.is_defined_and(|def| def == method))
-                                .then(|| binding_reachability(db, class_map, &bind))
-                        })
-                        .unwrap_or(Truthiness::AlwaysFalse)
-                } else {
-                    Truthiness::AlwaysFalse
-                };
-            if is_method_reachable.is_always_false() {
-                continue;
-            }
-
-            for attribute_assignment in attribute_assignments {
-                if let DefinitionState::Undefined = attribute_assignment.binding {
-                    continue;
-                }
-
-                let DefinitionState::Defined(binding) = attribute_assignment.binding else {
-                    continue;
-                };
-
-                if matches!(binding.kind(db), DefinitionKind::AugmentedAssignment(_)) {
-                    augmented_bindings.push(binding);
-                    continue;
-                }
-
-                if !is_method_reachable.is_always_false() {
-                    is_attribute_bound = true;
-                }
-
-                let inferred_ty = implicit_attribute_binding_type(db, binding);
-
-                if let Some(inferred_ty) = inferred_ty {
-                    provenance = provenance.or(Provenance::SingleDefinition(binding));
-                    union_of_inferred_types = union_of_inferred_types.add(inferred_ty);
-                }
+            is_attribute_bound = true;
+            if let Some(inferred_ty) = implicit_attribute_binding_type(db, binding) {
+                provenance = provenance.or(Provenance::SingleDefinition(binding));
+                union_of_inferred_types = union_of_inferred_types.add(inferred_ty);
             }
         }
 
@@ -455,70 +334,37 @@ struct ImplicitAttributeName<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for ImplicitAttributeName<'_> {}
 
-/// Returns whether a matching method explicitly declares this attribute.
-///
-/// Local declarations take precedence over inherited values used for cycle recovery.
-#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-fn implicit_attribute_has_declaration<'db>(
-    db: &'db dyn Db,
-    attribute: ImplicitAttributeName<'db>,
-) -> bool {
-    let class_body_scope = attribute.class_body_scope(db);
-    let index = semantic_index(db, class_body_scope.program_file(db));
-
-    attribute_declarations(db, class_body_scope, attribute.name(db).as_str()).any(
-        |(mut declarations, method_scope_id)| {
-            let method_scope = index.scope(method_scope_id);
-            if let Some(method_def) = method_scope.node().as_function() {
-                let definition = index.expect_single_definition(method_def);
-                let decorators = function_known_decorator_flags(db, definition);
-                let method_name = definition.name(db);
-                let is_classmethod = decorators.contains(FunctionDecorators::CLASSMETHOD)
-                    || method_name.as_deref().is_some_and(is_implicit_classmethod);
-                let is_staticmethod = decorators.contains(FunctionDecorators::STATICMETHOD)
-                    || method_name.as_deref().is_some_and(is_implicit_staticmethod);
-
-                let is_valid_scope = match attribute.target_method_decorator(db) {
-                    MethodDecorator::None => !is_classmethod && !is_staticmethod,
-                    MethodDecorator::ClassMethod => is_classmethod,
-                    MethodDecorator::StaticMethod => is_staticmethod,
-                };
-                if !is_valid_scope {
-                    return false;
-                }
-            }
-
-            declarations.any(|declaration| {
-                matches!(
-                    declaration.declaration,
-                    DefinitionState::Defined(definition)
-                        if matches!(definition.kind(db), DefinitionKind::AnnotatedAssignment(_))
-                )
-            })
-        },
-    )
+/// Definitions from methods whose receivers can establish this attribute.
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+struct ImplicitAttributeFacts<'db> {
+    declarations: Box<[Definition<'db>]>,
+    bindings: Box<[Definition<'db>]>,
 }
 
-/// Return independently inferrable assignments in matching, reachable methods.
+/// Collect declarations and reachable bindings once for ordinary inference and cycle recovery.
 ///
-/// Keeping the definitions in an owner-local query prevents lookups from depending directly on
-/// another file's syntax tree.
-#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-fn implicit_attribute_assignment_definitions<'db>(
+/// Keeping this shared scan owner-local avoids dependencies on another file's syntax tree and
+/// ensures that both inference paths apply the same decorator and method-reachability rules.
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+fn implicit_attribute_facts<'db>(
     db: &'db dyn Db,
     attribute: ImplicitAttributeName<'db>,
-) -> Box<[Definition<'db>]> {
+) -> ImplicitAttributeFacts<'db> {
     let class_body_scope = attribute.class_body_scope(db);
     let program_file = class_body_scope.program_file(db);
-    let module = parsed_module(db, program_file.python_file(db)).load(db);
     let index = semantic_index(db, program_file);
     let class_map = use_def_map(db, class_body_scope);
     let class_table = place_table(db, class_body_scope);
-    let mut definitions = Vec::new();
+    let mut declarations = Vec::new();
+    let mut bindings = Vec::new();
 
-    for (assignments, method_scope_id) in
-        attribute_assignments(db, class_body_scope, attribute.name(db).as_str())
-    {
+    for method_scope_id in attribute_scopes(db, class_body_scope) {
+        let method_table = index.place_table(method_scope_id);
+        let Some(member) =
+            method_table.member_id_by_instance_attribute_name(attribute.name(db).as_str())
+        else {
+            continue;
+        };
         let mut method_scope = index.scope(method_scope_id);
         while method_scope.is_eager()
             && let Some(parent) = method_scope.parent()
@@ -529,12 +375,14 @@ fn implicit_attribute_assignment_definitions<'db>(
             continue;
         };
         let method = index.expect_single_definition(method_def);
+        let Some(method_name) = method.name(db) else {
+            continue;
+        };
         let decorators = function_known_decorator_flags(db, method);
-        let method_name = method.name(db);
         let is_classmethod = decorators.contains(FunctionDecorators::CLASSMETHOD)
-            || method_name.as_deref().is_some_and(is_implicit_classmethod);
+            || is_implicit_classmethod(&method_name);
         let is_staticmethod = decorators.contains(FunctionDecorators::STATICMETHOD)
-            || method_name.as_deref().is_some_and(is_implicit_staticmethod);
+            || is_implicit_staticmethod(&method_name);
         let is_valid_scope = match attribute.target_method_decorator(db) {
             MethodDecorator::None => !is_classmethod && !is_staticmethod,
             MethodDecorator::ClassMethod => is_classmethod,
@@ -544,7 +392,18 @@ fn implicit_attribute_assignment_definitions<'db>(
             continue;
         }
 
-        let Some(method_place) = class_table.symbol_id(&method_def.node(&module).name) else {
+        let method_map = index.use_def_map(method_scope_id);
+        declarations.extend(method_map.reachable_member_declarations(member).filter_map(
+            |declaration| {
+                let DefinitionState::Defined(definition) = declaration.declaration else {
+                    return None;
+                };
+                matches!(definition.kind(db), DefinitionKind::AnnotatedAssignment(_))
+                    .then_some(definition)
+            },
+        ));
+
+        let Some(method_place) = class_table.symbol_id(&method_name) else {
             continue;
         };
         if !class_map
@@ -559,22 +418,20 @@ fn implicit_attribute_assignment_definitions<'db>(
             continue;
         }
 
-        for assignment in assignments {
-            if let DefinitionState::Defined(definition) = assignment.binding
-                && matches!(
-                    definition.kind(db),
-                    DefinitionKind::Assignment(_)
-                        | DefinitionKind::For(_)
-                        | DefinitionKind::WithItem(_)
-                        | DefinitionKind::Comprehension(_)
-                )
-            {
-                definitions.push(definition);
-            }
-        }
+        bindings.extend(
+            method_map
+                .reachable_member_bindings(member)
+                .filter_map(|binding| match binding.binding {
+                    DefinitionState::Defined(definition) => Some(definition),
+                    DefinitionState::Undefined | DefinitionState::Deleted => None,
+                }),
+        );
     }
 
-    definitions.into_boxed_slice()
+    ImplicitAttributeFacts {
+        declarations: declarations.into_boxed_slice(),
+        bindings: bindings.into_boxed_slice(),
+    }
 }
 
 /// Infer one assignment without allowing a recursive read to establish its own value.

--- a/crates/ty_python_semantic/src/types/class/implicit_attributes.rs
+++ b/crates/ty_python_semantic/src/types/class/implicit_attributes.rs
@@ -6,11 +6,12 @@ use crate::{
     place::{Place, Provenance},
     reachability::binding_reachability,
     types::{
-        KnownClass, Truthiness, Type, TypeContext, UnionBuilder, definition_expression_type,
-        function::{is_implicit_classmethod, is_implicit_staticmethod},
-        infer::infer_unpack_types,
+        ClassBase, ClassLiteral, KnownClass, Truthiness, Type, TypeContext, UnionBuilder,
+        definition_expression_type,
+        function::{FunctionDecorators, is_implicit_classmethod, is_implicit_staticmethod},
+        infer::{function_known_decorator_flags, infer_unpack_types},
         infer_expression_type, inferred_declaration,
-        member::Member,
+        member::{Member, class_member},
     },
 };
 use ruff_db::parsed::parsed_module;
@@ -67,15 +68,108 @@ impl<'db> StaticClassLiteral<'db> {
             };
         };
 
-        Self::implicit_attribute_inner(
+        let attribute = ImplicitAttributeName::new(
             db,
-            ImplicitAttributeName::new(
-                db,
-                class_body_scope,
-                &names[name_index],
-                target_method_decorator,
-            ),
-        )
+            class_body_scope,
+            &names[name_index],
+            target_method_decorator,
+        );
+
+        if !implicit_attribute_has_declaration(db, attribute)
+            && let Some(incoming) = self.independent_attribute_value(db, attribute)
+        {
+            let env = ProgramEnvironment::from_scope(class_body_scope);
+            let mut incoming_values = UnionBuilder::new(db, &env).add(incoming);
+            for &definition in implicit_attribute_assignment_definitions(db, attribute) {
+                if let Some(ty) = independent_attribute_assignment_type(db, attribute, definition) {
+                    incoming_values.add_in_place(ty);
+                }
+            }
+
+            Self::implicit_attribute_anchored(db, attribute, incoming_values.build())
+        } else {
+            Self::implicit_attribute_inner(db, attribute)
+        }
+    }
+
+    /// Find an attribute value independently established by a proper superclass.
+    ///
+    /// Inspecting class namespaces never invokes their implicit classmethod lookup. Instance
+    /// attributes from superclasses are resolved recursively, always moving toward a strictly
+    /// earlier class in the inheritance hierarchy. A default defined by the current class is not
+    /// an independent root: using it for cycle recovery could hide other assignments in that class.
+    #[salsa::tracked(
+        returns(copy),
+        cycle_initial=|_, _, _, _| None,
+        heap_size=ruff_memory_usage::heap_size,
+    )]
+    fn independent_attribute_value(
+        self,
+        db: &'db dyn Db,
+        attribute: ImplicitAttributeName<'db>,
+    ) -> Option<Type<'db>> {
+        let name = attribute.name(db).as_str();
+        let target_method_decorator = attribute.target_method_decorator(db);
+        let env = ProgramEnvironment::from_scope(self.body_scope(db));
+
+        for superclass in self.iter_mro(db, None).skip(1) {
+            let ClassBase::Class(superclass) = superclass else {
+                continue;
+            };
+            let (literal, specialization) = superclass.class_literal_and_specialization(db);
+            let ClassLiteral::Static(literal) = literal else {
+                continue;
+            };
+
+            let member = class_member(db, literal.body_scope(db), name)
+                .map_type(|ty| ty.apply_optional_specialization(db, specialization));
+            if member.inner.place.is_definitely_bound()
+                && let Ok(ty) = member.inner.into_lookup_result(db, &env)
+                && let ty = ty.inner_type()
+                && ty.is_definitely_non_data_descriptor(db, &env)
+            {
+                let receiver_class = self.identity_specialization(db);
+                let instance = (target_method_decorator == MethodDecorator::None)
+                    .then(|| Type::instance(db, &env, receiver_class));
+                return Some(
+                    ty.try_call_dunder_get(db, &env, instance, Type::from(receiver_class))
+                        .unwrap_or_else(|error| Some(error.fallback()))
+                        .map_or(ty, |result| result.return_type),
+                );
+            }
+
+            let implicit = literal.implicit_attribute_bindings(db, name, target_method_decorator);
+            if implicit.member.inner.place.is_definitely_bound()
+                && let Some(ty) = implicit.member.ignore_possibly_undefined()
+                && !ty.is_divergent()
+            {
+                return Some(ty.apply_optional_specialization(db, specialization));
+            }
+        }
+
+        None
+    }
+
+    #[salsa::tracked(
+        returns(copy),
+        cycle_result=|_, _, _, incoming| ImplicitAttribute {
+            member: Member {
+                inner: Place::bound(incoming)
+                    .with_qualifiers(TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE),
+            },
+            augmented_bindings: None,
+        },
+        heap_size=ruff_memory_usage::heap_size,
+    )]
+    fn implicit_attribute_anchored(
+        db: &'db dyn Db,
+        attribute: ImplicitAttributeName<'db>,
+        incoming: Type<'db>,
+    ) -> ImplicitAttribute<'db> {
+        // Independent inherited and local values identify this query and provide an immediate
+        // cycle result without discarding assignments that widen the attribute's inferred type.
+        let _ = incoming;
+        Self::implicit_attribute_impl(db, attribute)
     }
 
     #[salsa::tracked(
@@ -361,7 +455,150 @@ struct ImplicitAttributeName<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for ImplicitAttributeName<'_> {}
 
+/// Returns whether a matching method explicitly declares this attribute.
+///
+/// Local declarations take precedence over inherited values used for cycle recovery.
+#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+fn implicit_attribute_has_declaration<'db>(
+    db: &'db dyn Db,
+    attribute: ImplicitAttributeName<'db>,
+) -> bool {
+    let class_body_scope = attribute.class_body_scope(db);
+    let index = semantic_index(db, class_body_scope.program_file(db));
+
+    attribute_declarations(db, class_body_scope, attribute.name(db).as_str()).any(
+        |(mut declarations, method_scope_id)| {
+            let method_scope = index.scope(method_scope_id);
+            if let Some(method_def) = method_scope.node().as_function() {
+                let definition = index.expect_single_definition(method_def);
+                let decorators = function_known_decorator_flags(db, definition);
+                let method_name = definition.name(db);
+                let is_classmethod = decorators.contains(FunctionDecorators::CLASSMETHOD)
+                    || method_name.as_deref().is_some_and(is_implicit_classmethod);
+                let is_staticmethod = decorators.contains(FunctionDecorators::STATICMETHOD)
+                    || method_name.as_deref().is_some_and(is_implicit_staticmethod);
+
+                let is_valid_scope = match attribute.target_method_decorator(db) {
+                    MethodDecorator::None => !is_classmethod && !is_staticmethod,
+                    MethodDecorator::ClassMethod => is_classmethod,
+                    MethodDecorator::StaticMethod => is_staticmethod,
+                };
+                if !is_valid_scope {
+                    return false;
+                }
+            }
+
+            declarations.any(|declaration| {
+                matches!(
+                    declaration.declaration,
+                    DefinitionState::Defined(definition)
+                        if matches!(definition.kind(db), DefinitionKind::AnnotatedAssignment(_))
+                )
+            })
+        },
+    )
+}
+
+/// Return independently inferrable assignments in matching, reachable methods.
+///
+/// Keeping the definitions in an owner-local query prevents lookups from depending directly on
+/// another file's syntax tree.
+#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
+fn implicit_attribute_assignment_definitions<'db>(
+    db: &'db dyn Db,
+    attribute: ImplicitAttributeName<'db>,
+) -> Box<[Definition<'db>]> {
+    let class_body_scope = attribute.class_body_scope(db);
+    let program_file = class_body_scope.program_file(db);
+    let module = parsed_module(db, program_file.python_file(db)).load(db);
+    let index = semantic_index(db, program_file);
+    let class_map = use_def_map(db, class_body_scope);
+    let class_table = place_table(db, class_body_scope);
+    let mut definitions = Vec::new();
+
+    for (assignments, method_scope_id) in
+        attribute_assignments(db, class_body_scope, attribute.name(db).as_str())
+    {
+        let mut method_scope = index.scope(method_scope_id);
+        while method_scope.is_eager()
+            && let Some(parent) = method_scope.parent()
+        {
+            method_scope = index.scope(parent);
+        }
+        let Some(method_def) = method_scope.node().as_function() else {
+            continue;
+        };
+        let method = index.expect_single_definition(method_def);
+        let decorators = function_known_decorator_flags(db, method);
+        let method_name = method.name(db);
+        let is_classmethod = decorators.contains(FunctionDecorators::CLASSMETHOD)
+            || method_name.as_deref().is_some_and(is_implicit_classmethod);
+        let is_staticmethod = decorators.contains(FunctionDecorators::STATICMETHOD)
+            || method_name.as_deref().is_some_and(is_implicit_staticmethod);
+        let is_valid_scope = match attribute.target_method_decorator(db) {
+            MethodDecorator::None => !is_classmethod && !is_staticmethod,
+            MethodDecorator::ClassMethod => is_classmethod,
+            MethodDecorator::StaticMethod => is_staticmethod,
+        };
+        if !is_valid_scope {
+            continue;
+        }
+
+        let Some(method_place) = class_table.symbol_id(&method_def.node(&module).name) else {
+            continue;
+        };
+        if !class_map
+            .reachable_symbol_bindings(method_place)
+            .any(|binding| {
+                binding
+                    .binding
+                    .is_defined_and(|definition| definition == method)
+                    && !binding_reachability(db, class_map, &binding).is_always_false()
+            })
+        {
+            continue;
+        }
+
+        for assignment in assignments {
+            if let DefinitionState::Defined(definition) = assignment.binding
+                && matches!(
+                    definition.kind(db),
+                    DefinitionKind::Assignment(_)
+                        | DefinitionKind::For(_)
+                        | DefinitionKind::WithItem(_)
+                        | DefinitionKind::Comprehension(_)
+                )
+            {
+                definitions.push(definition);
+            }
+        }
+    }
+
+    definitions.into_boxed_slice()
+}
+
+/// Infer one assignment without allowing a recursive read to establish its own value.
+///
+/// A cycle involving this exact definition contributes no independent value. Other assignments
+/// remain available, so an inherited default cannot hide a local assignment such as `None`.
+#[salsa::tracked(
+    returns(copy),
+    cycle_result=|_, _, _, _| None,
+    heap_size=ruff_memory_usage::heap_size,
+)]
+fn independent_attribute_assignment_type<'db>(
+    db: &'db dyn Db,
+    attribute: ImplicitAttributeName<'db>,
+    definition: Definition<'db>,
+) -> Option<Type<'db>> {
+    let _ = attribute;
+    implicit_attribute_binding_type(db, definition)
+}
+
 /// Infer the value written by an attribute definition, including unpacked and iteration targets.
+///
+/// Ordinary inference and inherited cycle recovery share these projections so that independently
+/// written values cannot disappear merely because they were introduced by a `for` or `with`.
 fn implicit_attribute_binding_type<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
@@ -467,12 +704,22 @@ pub(super) fn implicit_attribute_names<'db>(
     let mut names = Vec::new();
 
     for function_scope_id in attribute_scopes(db, class_body_scope) {
-        names.extend(
-            index
-                .place_table(function_scope_id)
-                .members()
-                .filter_map(|member| member.as_instance_attribute().map(Name::new)),
-        );
+        let place_table = index.place_table(function_scope_id);
+        let use_def = index.use_def_map(function_scope_id);
+        names.extend(place_table.members().filter_map(|member| {
+            let name = member.as_instance_attribute()?;
+            let member_id = place_table.member_id_by_instance_attribute_name(name)?;
+            let has_binding = use_def
+                .reachable_member_bindings(member_id)
+                .any(|binding| matches!(binding.binding, DefinitionState::Defined(_)));
+            (has_binding
+                || use_def
+                    .reachable_member_declarations(member_id)
+                    .any(|declaration| {
+                        matches!(declaration.declaration, DefinitionState::Defined(_))
+                    }))
+            .then(|| Name::new(name))
+        }));
     }
 
     names.sort_unstable();


### PR DESCRIPTION
## Summary

Previously, an implicit attribute reassigned from its inherited value could recover to different recursive types depending on which class or file we checked first. This produced unstable `unsound-return-statement` diagnostics in Meson:

```python
class Base:
    values = ["a"]


class Parent(Base):
    def __init__(self):
        if self.values:
            self.values = [*self.values]

    def get_values(self) -> list[str]:
        return self.values


class Child(Parent):
    def __init__(self):
        self.values = self.values + ["b"]
```

We now recover inherited attribute cycles using values established independently on a proper superclass. Independent assignments on the current class also contribute to the recovered type, so an inherited default cannot hide an incompatible assignment or suppress a genuine unsafe-use diagnostic:

```python
class Base:
    token = ""


class Parser(Base):
    def reset(self) -> None:
        self.token = None  # invalid-assignment

    def parse(self) -> None:
        self.token = self.token[1:-1]  # not-subscriptable
```

Explicit subclass declarations, inherited descriptors, classmethods, and normal assignment inference retain their existing precedence.

## Scope

This fixes cycles involving one implicitly inferred attribute with an independently established inherited value. It does not resolve mutually dependent attributes. For example:

```python
class Base:
    token = ""


class Parser(Base):
    def reset(self) -> None:
        self.other = None
        self.token = self.other  # invalid-assignment

    def update(self) -> None:
        self.other = self.token

    def parse(self) -> None:
        self.token = self.token[1:-1]  # Missing: not-subscriptable
```

Here, recovering the missing diagnostic requires propagating `None` through a cycle involving both `token` and `other`; this PR intentionally does not introduce a general fixed-point solver for those dependencies.

Rootless attribute cycles, arbitrary cross-class receiver or call graphs, and other recursive-inference scenarios also remain out of scope. The broader experiment in https://github.com/astral-sh/ruff/pull/27736 contains additional examples and regression coverage. The related guarded-`hasattr` cycle is addressed independently in https://github.com/astral-sh/ruff/pull/27788.

Closes https://github.com/astral-sh/ty/issues/4221.