### PR TITLE
[`flake8-comprehensions`] Document `map`/generator exception behavior (`C417`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -41,9 +41,35 @@ use crate::{FixAvailability, Violation};
 /// (x + 1 for x in iterable)
 /// ```
 ///
+/// ## Known problems
+/// A `map` object and a generator expression are not interchangeable when the
+/// mapped expression raises. Once an exception propagates out of a generator,
+/// the generator is closed, so every later `next()` call raises
+/// `StopIteration`. A `map` object is not closed, so iteration can resume after
+/// the error:
+///
+/// ```python
+/// values = ["0", "x", "2"]
+///
+/// m = map(lambda v: int(v), values)
+/// next(m)  # 0
+/// next(m)  # raises ValueError
+/// next(m)  # 2
+///
+/// g = (int(v) for v in values)
+/// next(g)  # 0
+/// next(g)  # raises ValueError
+/// next(g)  # raises StopIteration
+/// ```
+///
+/// Ruff cannot tell whether a caller relies on this difference, so the
+/// diagnostic is still reported in such cases.
+///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe, as it may occasionally drop comments
 /// when rewriting the call. In most cases, though, comments will be preserved.
+/// The fix is also unsafe because it can change how errors propagate out of the
+/// resulting iterator, as described under "Known problems" above.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.74")]
 pub(crate) struct UnnecessaryMap {


### PR DESCRIPTION
## Summary

Documents that `map` objects and generator expressions are not interchangeable
when the mapped expression raises, which is a known source of false positives
for `unnecessary-map` (`C417`).

Once an exception propagates out of a generator, the generator is closed and
every later `next()` call raises `StopIteration`. A `map` object has no frame to
close, so a caller that handles the exception can keep iterating. Code that
relies on this - for example, collecting every element that converts
successfully and reporting all failures at the end, rather than stopping at the
first one - behaves differently after `C417`'s fix is applied.

As discussed in the issue, there isn't a good way for Ruff to detect this
situation and suppress the diagnostic, so this adds a `## Known problems`
section describing the difference and notes it under `## Fix safety` as an
additional reason the fix is unsafe.

Docs-only; no behavior change.

Closes #27304

## Test Plan

`cargo dev generate-all`, plus `cargo nextest run -p ruff_linter -p ruff_dev`
and `cargo clippy -p ruff_linter --all-targets -- -D warnings` to confirm the
doc comment still builds and no generated artifact is stale.
