### PR TITLE
Use pinned forms for `uvx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI.
 Invoke Ruff directly with [`uvx`](https://docs.astral.sh/uv/):
 
 ```shell
-uvx ruff check   # Lint all files in the current directory.
-uvx ruff format  # Format all files in the current directory.
+uvx ruff@0.16.3 check   # Lint all files in the current directory.
+uvx ruff@0.16.3 format  # Format all files in the current directory.
 ```
 
 Or install Ruff with `uv` (recommended), `pip`, or `pipx`:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,8 +5,8 @@ Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI.
 Ruff can be invoked directly with [`uvx`](https://docs.astral.sh/uv/):
 
 ```shell
-uvx ruff check   # Lint all files in the current directory.
-uvx ruff format  # Format all files in the current directory.
+uvx ruff@0.16.3 check   # Lint all files in the current directory.
+uvx ruff@0.16.3 format  # Format all files in the current directory.
 ```
 
 Or installed with `uv` (recommended), `pip`, or `pipx`:

--- a/playground/README.md
+++ b/playground/README.md
@@ -12,7 +12,7 @@ module.
 To run the datastore, which is based
 on [Workers KV](https://developers.cloudflare.com/workers/runtime-apis/kv/),
 install the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/),
-then run `npx wrangler dev --local` from the `./playground/api` directory. Note that the datastore
+then run `npx wrangler@4.118.0 dev --local` from the `./playground/api` directory. Note that the datastore
 is
 only required to generate shareable URLs for code snippets. The development datastore does not
 require Cloudflare authentication or login, but in turn only persists data locally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ version_files = [
     "pyproject.toml",
     # Might become unneeded once Markdown formatting is stabilized.
     "docs/formatter.md",
+    "docs/installation.md",
     "docs/integrations.md",
     "docs/tutorial.md",
     "crates/ruff/Cargo.toml",

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -1,8 +1,8 @@
 """
 Run typing conformance tests and compare results between two ty versions.
 
-By default, this script will use `uv` to run the latest version of ty
-as the new version with `uvx ty@latest`. This requires `uv` to be installed
+By default, this script will use `uv` to run ty 0.0.72
+as the new version with `uvx ty@0.0.72`. This requires `uv` to be installed
 and available in the system PATH.
 
 If CONFORMANCE_SUITE_COMMIT is set, the hash will be used to create
@@ -10,7 +10,7 @@ links to the corresponding line in the conformance repository for each
 diagnostic. Otherwise, it will default to `main'.
 
 Examples:
-    # Compare an older version of ty to latest
+    # Compare an older version of ty to the default version
     %(prog)s --old-ty uvx ty@0.0.1a35
 
     # Compare two specific ty versions
@@ -1019,8 +1019,8 @@ def parse_args():
     parser.add_argument(
         "--new-ty",
         nargs="+",
-        default=["uvx", "ty@latest"],
-        help="Command to run new version of ty (default: uvx ty@latest)",
+        default=["uvx", "ty@0.0.72"],
+        help="Command to run new version of ty (default: uvx ty@0.0.72)",
     )
 
     parser.add_argument(

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -1,9 +1,9 @@
 """
 Run typing conformance tests and compare results between two ty versions.
 
-By default, this script will use `uv` to run ty 0.0.72
-as the new version with `uvx ty@0.0.72`. This requires `uv` to be installed
-and available in the system PATH.
+ty versions can be supplied as `uvx ty` or `uvx ty@version`
+for a specific version. This requires `uv` to be installed
+and available on the system PATH.
 
 If CONFORMANCE_SUITE_COMMIT is set, the hash will be used to create
 links to the corresponding line in the conformance repository for each
@@ -1019,8 +1019,8 @@ def parse_args():
     parser.add_argument(
         "--new-ty",
         nargs="+",
-        default=["uvx", "ty@0.0.72"],
-        help="Command to run new version of ty (default: uvx ty@0.0.72)",
+        help="Command to run new version of ty",
+        required=True,
     )
 
     parser.add_argument(

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -10,9 +10,6 @@ links to the corresponding line in the conformance repository for each
 diagnostic. Otherwise, it will default to `main'.
 
 Examples:
-    # Compare an older version of ty to the default version
-    %(prog)s --old-ty uvx ty@0.0.1a35
-
     # Compare two specific ty versions
     %(prog)s --old-ty uvx ty@0.0.1a35 --new-ty uvx ty@0.0.7
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Makes us always use `uvx pkg@...`, i.e. the version pinned form, to ensure that we never implicitly resolve a latest version.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

NFC.

<!-- How was it tested? -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>