### PR TITLE
[ty] Pack class literal metadata into bitflags

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -12,7 +12,7 @@ pub(super) use self::named_tuple::{
 };
 use self::static_literal::{AugmentedBindings, ImplicitAttribute};
 pub(crate) use self::static_literal::{
-    ExpandedClassBaseEntry, FrozenDataclassDispatch, StaticClassLiteral,
+    ExpandedClassBaseEntry, FrozenDataclassDispatch, StaticClassLiteral, StaticClassLiteralFlags,
     expanded_class_base_entries,
 };
 pub(super) use self::typed_dict::{
@@ -164,8 +164,10 @@ impl<'db> CodeGeneratorKind<'db> {
     fn from_static_class(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> Option<Self> {
         if class.dataclass_params(db).is_none()
             && class.known(db).is_none()
-            && !class.has_explicit_bases(db)
-            && !class.has_explicit_metaclass(db)
+            && !class.flags(db).intersects(
+                StaticClassLiteralFlags::HAS_EXPLICIT_BASES
+                    | StaticClassLiteralFlags::HAS_EXPLICIT_METACLASS,
+            )
         {
             return None;
         }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -71,6 +71,27 @@ use ty_python_core::{
     use_def_map,
 };
 
+bitflags::bitflags! {
+    /// Metadata inferred from a class definition and its decorators.
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    pub struct StaticClassLiteralFlags: u8 {
+        /// The class is decorated with `@typing.type_check_only`.
+        const TYPE_CHECK_ONLY = 1 << 0;
+        /// The class is decorated with `@functools.total_ordering`.
+        const TOTAL_ORDERING = 1 << 1;
+        /// The class has at least one decorator.
+        const HAS_DECORATORS = 1 << 2;
+        /// The class has PEP 695 type parameters.
+        const HAS_TYPE_PARAMS = 1 << 3;
+        /// The class has at least one explicit base class.
+        const HAS_EXPLICIT_BASES = 1 << 4;
+        /// The class has an explicit `metaclass` keyword argument.
+        const HAS_EXPLICIT_METACLASS = 1 << 5;
+    }
+}
+
+impl get_size2::GetSize for StaticClassLiteralFlags {}
+
 /// Representation of a class definition statement in the AST: either a non-generic class, or a
 /// generic class that has not been specialized.
 ///
@@ -93,32 +114,12 @@ pub struct StaticClassLiteral<'db> {
     pub(crate) deprecated: Option<DeprecatedInstance<'db>>,
 
     #[returns(copy)]
-    pub(crate) type_check_only: bool,
-
-    #[returns(copy)]
     pub(crate) dataclass_params: Option<DataclassParams<'db>>,
     #[returns(copy)]
     pub(crate) dataclass_transformer_params: Option<DataclassTransformerParams<'db>>,
 
-    /// Whether this class is decorated with `@functools.total_ordering`
     #[returns(copy)]
-    pub(crate) total_ordering: bool,
-
-    /// Whether this class has any decorators.
-    #[returns(copy)]
-    pub(crate) has_decorators: bool,
-
-    /// Whether this class has PEP 695 type parameters.
-    #[returns(copy)]
-    pub(crate) has_type_params: bool,
-
-    /// Whether this class has any explicit base classes.
-    #[returns(copy)]
-    pub(crate) has_explicit_bases: bool,
-
-    /// Whether this class has an explicit `metaclass` keyword argument.
-    #[returns(copy)]
-    pub(crate) has_explicit_metaclass: bool,
+    pub(crate) flags: StaticClassLiteralFlags,
 }
 
 // The Salsa heap is tracked separately.
@@ -218,6 +219,42 @@ struct OwnClassFields<'db> {
 
 #[salsa::tracked]
 impl<'db> StaticClassLiteral<'db> {
+    /// Returns whether this class is decorated with `@typing.type_check_only`.
+    pub(crate) fn type_check_only(self, db: &'db dyn Db) -> bool {
+        self.flags(db)
+            .contains(StaticClassLiteralFlags::TYPE_CHECK_ONLY)
+    }
+
+    /// Returns whether this class is decorated with `@functools.total_ordering`.
+    pub(crate) fn total_ordering(self, db: &'db dyn Db) -> bool {
+        self.flags(db)
+            .contains(StaticClassLiteralFlags::TOTAL_ORDERING)
+    }
+
+    /// Returns whether this class has any decorators.
+    pub(crate) fn has_decorators(self, db: &'db dyn Db) -> bool {
+        self.flags(db)
+            .contains(StaticClassLiteralFlags::HAS_DECORATORS)
+    }
+
+    /// Returns whether this class has PEP 695 type parameters.
+    pub(crate) fn has_type_params(self, db: &'db dyn Db) -> bool {
+        self.flags(db)
+            .contains(StaticClassLiteralFlags::HAS_TYPE_PARAMS)
+    }
+
+    /// Returns whether this class has any explicit base classes.
+    pub(crate) fn has_explicit_bases(self, db: &'db dyn Db) -> bool {
+        self.flags(db)
+            .contains(StaticClassLiteralFlags::HAS_EXPLICIT_BASES)
+    }
+
+    /// Returns whether this class has an explicit `metaclass` keyword argument.
+    pub(crate) fn has_explicit_metaclass(self, db: &'db dyn Db) -> bool {
+        self.flags(db)
+            .contains(StaticClassLiteralFlags::HAS_EXPLICIT_METACLASS)
+    }
+
     /// Return `true` if this class represents `known_class`
     pub(crate) fn is_known(self, db: &'db dyn Db, known_class: KnownClass) -> bool {
         self.known(db) == Some(known_class)
@@ -272,14 +309,9 @@ impl<'db> StaticClassLiteral<'db> {
             self.body_scope(db),
             self.known(db),
             self.deprecated(db),
-            self.type_check_only(db),
             dataclass_params,
             self.dataclass_transformer_params(db),
-            self.total_ordering(db),
-            self.has_decorators(db),
-            self.has_type_params(db),
-            self.has_explicit_bases(db),
-            self.has_explicit_metaclass(db),
+            self.flags(db),
         )
     }
 
@@ -1318,7 +1350,10 @@ impl<'db> StaticClassLiteral<'db> {
             Ok((candidate.metaclass.into(), transform_info))
         }
 
-        if !self.has_explicit_bases(db) && !self.has_explicit_metaclass(db) {
+        if !self.flags(db).intersects(
+            StaticClassLiteralFlags::HAS_EXPLICIT_BASES
+                | StaticClassLiteralFlags::HAS_EXPLICIT_METACLASS,
+        ) {
             let env = ProgramEnvironment::from_scope(self.body_scope(db));
             return Ok((KnownClass::Type.to_class_literal(db, &env), None));
         }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -294,6 +294,35 @@ pub(super) fn class_defines_property<'db>(
     false
 }
 
+bitflags::bitflags! {
+    /// Properties of an enum class and its canonical members.
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    pub struct EnumClassLiteralFlags: u8 {
+        /// The canonical member and alias sets are known exactly.
+        const ALIASES_ARE_KNOWN = 1 << 0;
+
+        /// The canonical members exhaust the runtime values of this enum class.
+        ///
+        /// `Flag` classes and transforming metaclasses can create runtime members beyond those
+        /// declared in the class body, so their declared members are not a closed value set.
+        const MEMBERS_ARE_EXHAUSTIVE = 1 << 1;
+    }
+}
+
+impl EnumClassLiteralFlags {
+    /// Returns whether the canonical member and alias sets are known exactly.
+    pub(super) const fn aliases_are_known(self) -> bool {
+        self.contains(Self::ALIASES_ARE_KNOWN)
+    }
+
+    /// Returns whether the canonical members exhaust the enum's possible runtime values.
+    pub(super) const fn members_are_exhaustive(self) -> bool {
+        self.contains(Self::MEMBERS_ARE_EXHAUSTIVE)
+    }
+}
+
+impl get_size2::GetSize for EnumClassLiteralFlags {}
+
 /// An enum class literal with its canonical members, value types, and aliases.
 ///
 /// This keeps the enum-specific information used by enum literals and enum complements alongside
@@ -306,15 +335,8 @@ pub struct EnumClassLiteral<'db> {
     pub(crate) members: Box<[(Name, Type<'db>)]>,
     #[returns(ref)]
     pub(crate) aliases: Box<[(Name, Name)]>,
-    /// Whether the canonical member and alias sets are known exactly.
     #[returns(copy)]
-    pub(super) aliases_are_known: bool,
-    /// Whether the canonical members exhaust the runtime values of this enum class.
-    ///
-    /// `Flag` classes and transforming metaclasses can create runtime members beyond those
-    /// declared in the class body, so their declared members are not a closed value set.
-    #[returns(copy)]
-    pub(crate) members_are_exhaustive: bool,
+    pub(super) flags: EnumClassLiteralFlags,
 }
 
 // The Salsa heap is tracked separately.
@@ -348,24 +370,41 @@ fn enum_class_literal<'db>(
         .map(|(alias, member)| (alias.clone(), member.clone()))
         .collect();
     aliases.sort_unstable();
-    let members_are_exhaustive = !metadata.value_construction.metaclass_may_transform_values
-        && !Type::ClassLiteral(class).is_subtype_of(
-            db,
-            &env,
-            KnownClass::Flag.to_subclass_of(db, &env),
-        );
+    let mut flags = EnumClassLiteralFlags::empty();
+    flags.set(
+        EnumClassLiteralFlags::ALIASES_ARE_KNOWN,
+        metadata.aliases_are_known,
+    );
+    flags.set(
+        EnumClassLiteralFlags::MEMBERS_ARE_EXHAUSTIVE,
+        !metadata.value_construction.metaclass_may_transform_values
+            && !Type::ClassLiteral(class).is_subtype_of(
+                db,
+                &env,
+                KnownClass::Flag.to_subclass_of(db, &env),
+            ),
+    );
 
     Some(EnumClassLiteral::new(
         db,
         class,
         members,
         aliases.into_boxed_slice(),
-        metadata.aliases_are_known,
-        members_are_exhaustive,
+        flags,
     ))
 }
 
 impl<'db> EnumClassLiteral<'db> {
+    /// Returns whether the canonical member and alias sets are known exactly.
+    pub(super) fn aliases_are_known(self, db: &'db dyn Db) -> bool {
+        self.flags(db).aliases_are_known()
+    }
+
+    /// Returns whether the canonical members exhaust the runtime values of this enum class.
+    pub(crate) fn members_are_exhaustive(self, db: &'db dyn Db) -> bool {
+        self.flags(db).members_are_exhaustive()
+    }
+
     pub(crate) fn member_count(self, db: &'db dyn Db) -> usize {
         self.members(db).len()
     }

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -7,7 +7,7 @@ use ty_python_core::Truthiness;
 use crate::types::literal::IntLiteralType;
 use crate::types::{
     EnumClassLiteral, EnumComplementType, EnumLiteralType, IntersectionBuilder, IntersectionType,
-    LiteralValueType, LiteralValueTypeKind, Type, UnionBuilder,
+    LiteralValueType, LiteralValueTypeKind, Type, UnionBuilder, enums::EnumClassLiteralFlags,
 };
 use crate::{Db, FxOrderMap, FxOrderSet, ProgramEnvironment};
 
@@ -1070,7 +1070,7 @@ impl<'db> EnumValueSet<'db> {
             }
         }
 
-        if !self.is_closed(profile.members_are_exhaustive) {
+        if !self.is_closed(profile.flags.members_are_exhaustive()) {
             projection.unknown_domains.insert(key_domain);
         }
         Some(())
@@ -1098,7 +1098,8 @@ impl<'db> EnumValueSet<'db> {
                 Self::insert_member(&mut included, name, promotable);
             }
         }
-        if included.len() == self.member_count(db) && self.is_closed(profile.members_are_exhaustive)
+        if included.len() == self.member_count(db)
+            && self.is_closed(profile.flags.members_are_exhaustive())
         {
             return Ok(Some(self.clone()));
         }
@@ -1109,7 +1110,7 @@ impl<'db> EnumValueSet<'db> {
 
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 struct EnumClassKeyProfile<'db> {
-    members_are_exhaustive: bool,
+    flags: EnumClassLiteralFlags,
     semantics: Option<KnownComparisonSemantics>,
     members: Box<[(Name, Option<LiteralValueTypeKind<'db>>)]>,
 }
@@ -1144,7 +1145,7 @@ fn enum_class_key_profile<'db>(
         })
         .collect();
     EnumClassKeyProfile {
-        members_are_exhaustive: enum_class.members_are_exhaustive(db),
+        flags: enum_class.flags(db),
         semantics,
         members,
     }
@@ -1176,7 +1177,7 @@ fn same_enum_comparison_profile<'db>(
     let profile = enum_class_key_profile(db, enum_class, operator);
     let (comparison_keys, members_compare_by_identity) = match profile.semantics {
         None => (None, false),
-        Some(KnownComparisonSemantics::Object) if !enum_class.aliases_are_known(db) => {
+        Some(KnownComparisonSemantics::Object) if !profile.flags.aliases_are_known() => {
             (Some(SameEnumComparisonKeys::UnknownOrRepeated), true)
         }
         Some(KnownComparisonSemantics::Object) => (Some(SameEnumComparisonKeys::Distinct), true),
@@ -1202,7 +1203,7 @@ fn same_enum_comparison_profile<'db>(
         Some(_) => (Some(SameEnumComparisonKeys::UnknownOrRepeated), false),
     };
     SameEnumComparisonProfile {
-        members_are_exhaustive: profile.members_are_exhaustive,
+        members_are_exhaustive: profile.flags.members_are_exhaustive(),
         members_compare_by_identity,
         comparison_keys,
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -6,6 +6,7 @@ use crate::types::{
     SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext, TypedDictModule,
     call::CallError,
     callable::CallableFunctionProvenance,
+    class::StaticClassLiteralFlags,
     function::KnownFunction,
     infer::{
         TypeInferenceBuilder,
@@ -126,24 +127,36 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut decorators_to_apply = Vec::with_capacity(decorator_types_and_nodes.len());
         let mut metadata_applies_to_original_class = true;
         let mut deprecated = None;
-        let mut type_check_only = false;
         let mut dataclass_params = None;
         let mut dataclass_transformer_params = None;
-        let mut total_ordering = false;
-        let has_explicit_bases = class_node
-            .arguments
-            .as_deref()
-            .is_some_and(|arguments| !arguments.args.is_empty());
-        let has_explicit_metaclass = class_node
-            .arguments
-            .as_deref()
-            .is_some_and(|arguments| arguments.find_keyword("metaclass").is_some());
-        let infer_original_class_ty = |deprecated,
-                                       type_check_only,
-                                       dataclass_params,
-                                       dataclass_transformer_params,
-                                       total_ordering| {
-            match (maybe_known_class, &*name.id) {
+        let mut class_flags = StaticClassLiteralFlags::empty();
+        class_flags.set(
+            StaticClassLiteralFlags::HAS_DECORATORS,
+            !class_node.decorator_list.is_empty(),
+        );
+        class_flags.set(
+            StaticClassLiteralFlags::HAS_TYPE_PARAMS,
+            class_node.type_params.is_some(),
+        );
+        class_flags.set(
+            StaticClassLiteralFlags::HAS_EXPLICIT_BASES,
+            class_node
+                .arguments
+                .as_deref()
+                .is_some_and(|arguments| !arguments.args.is_empty()),
+        );
+        class_flags.set(
+            StaticClassLiteralFlags::HAS_EXPLICIT_METACLASS,
+            class_node
+                .arguments
+                .as_deref()
+                .is_some_and(|arguments| arguments.find_keyword("metaclass").is_some()),
+        );
+        let infer_original_class_ty =
+            |deprecated, dataclass_params, dataclass_transformer_params, class_flags| match (
+                maybe_known_class,
+                &*name.id,
+            ) {
                 (None, "NamedTuple") if in_typing_module() => {
                     Type::SpecialForm(SpecialFormType::NamedTuple)
                 }
@@ -157,17 +170,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     body_scope,
                     maybe_known_class,
                     deprecated,
-                    type_check_only,
                     dataclass_params,
                     dataclass_transformer_params,
-                    total_ordering,
-                    !class_node.decorator_list.is_empty(),
-                    class_node.type_params.is_some(),
-                    has_explicit_bases,
-                    has_explicit_metaclass,
+                    class_flags,
                 )),
-            }
-        };
+            };
         let decorator_call_ty = |decorator: &ast::Decorator| match &decorator.expression {
             ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
             _ => None,
@@ -196,7 +203,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .as_function_literal()
                 .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
             {
-                total_ordering = true;
+                class_flags.insert(StaticClassLiteralFlags::TOTAL_ORDERING);
                 continue;
             }
 
@@ -226,7 +233,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .as_function_literal()
                 .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
             {
-                type_check_only = true;
+                class_flags.insert(StaticClassLiteralFlags::TYPE_CHECK_ONLY);
                 continue;
             }
 
@@ -275,10 +282,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             let original_class_ty = infer_original_class_ty(
                 deprecated,
-                type_check_only,
                 dataclass_params,
                 dataclass_transformer_params,
-                total_ordering,
+                class_flags,
             );
             let decorator_result = apply_class_decorator(db, env, decorator_ty, original_class_ty);
             let decorated_ty = match &decorator_result {
@@ -308,10 +314,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let mut inferred_ty = infer_original_class_ty(
             deprecated,
-            type_check_only,
             dataclass_params,
             dataclass_transformer_params,
-            total_ordering,
+            class_flags,
         );
 
         let original_class_ty = inferred_ty;


### PR DESCRIPTION
## Summary

- Replace the separate boolean metadata fields on `StaticClassLiteral` and `EnumClassLiteral` with compact `u8` bitflags.
- Preserve the existing boolean accessor APIs and add named helpers for enum alias and member-exhaustiveness flags.
- Avoid repeated Salsa field lookups when checking related static-class flags and reuse enum flags across cached comparison profiles.