### PR TITLE
Fix `InvalidInstruction` on windows CPUs that do not support `POPCNT`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,9 @@ lsp-server = { version = "0.10.0" }
 lsp-types = { package = "gen-lsp-types", version = "0.11.0", features = ["url"] }
 matchit = { version = "0.9.0" }
 memchr = { version = "2.7.1" }
-# Keep v2 until the Rust wrapper includes the fix for older Windows CPUs.
+# mimalloc v3.3.2 crashes on Windows CPUs that do not support POPCNT.
+# Fixed in mimalloc v3.4.0: https://github.com/microsoft/mimalloc/issues/1291
+# Keep v2 until the Rust crate includes the fix:
 # https://github.com/purpleprotocol/mimalloc_rust/pull/169
 mimalloc = { version = "0.1.52", features = ["v2"] }
 natord = { version = "1.0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,7 @@ matchit = { version = "0.9.0" }
 memchr = { version = "2.7.1" }
 # mimalloc v3.3.2 crashes on Windows CPUs that do not support POPCNT.
 # Fixed in mimalloc v3.4.0: https://github.com/microsoft/mimalloc/issues/1291
-# Keep v2 until the Rust crate includes the fix:
-# https://github.com/purpleprotocol/mimalloc_rust/pull/169
+# Keep v2 until an updated Rust crate includes the fix.
 mimalloc = { version = "0.1.52", features = ["v2"] }
 natord = { version = "1.0.9" }
 notify = { version = "8.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,9 @@ lsp-server = { version = "0.10.0" }
 lsp-types = { package = "gen-lsp-types", version = "0.11.0", features = ["url"] }
 matchit = { version = "0.9.0" }
 memchr = { version = "2.7.1" }
-mimalloc = { version = "0.1.52" }
+# Keep v2 until the Rust wrapper includes the fix for older Windows CPUs.
+# https://github.com/purpleprotocol/mimalloc_rust/pull/169
+mimalloc = { version = "0.1.52", features = ["v2"] }
 natord = { version = "1.0.9" }
 notify = { version = "8.0.0" }
 ordermap = { version = "1.0.0" }


### PR DESCRIPTION
## Summary

Restore mimalloc v2 because v3.3.2 can crash on Windows CPUs that do not support `POPCNT`. 
Fixes astral-sh/ruff-vscode#1148.


