### PR TITLE
fix(flake8-executable): don't flag `#!` comments after code as shebangs

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_executable/EXE001_4.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_executable/EXE001_4.py
@@ -1,0 +1,4 @@
+# `#!` inside a function body is an ordinary comment, not a shebang.
+def f():
+    #! regular comment
+    return 1

--- a/crates/ruff_linter/src/rules/flake8_executable/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/mod.rs
@@ -17,6 +17,7 @@ mod tests {
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_1.py"))]
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_2.py"))]
     #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_3.py"))]
+    #[test_case(Rule::ShebangNotExecutable, Path::new("EXE001_4.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_1.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_2.py"))]
     #[test_case(Rule::ShebangMissingExecutableFile, Path::new("EXE002_3.py"))]

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use ruff_python_trivia::CommentRanges;
+use ruff_python_trivia::{CommentRanges, is_python_whitespace};
 pub(crate) use shebang_leading_whitespace::*;
 pub(crate) use shebang_missing_executable_file::*;
 pub(crate) use shebang_missing_python::*;
@@ -28,15 +28,25 @@ pub(crate) fn from_tokens(
     for range in comment_ranges {
         let comment = locator.slice(range);
         if let Some(shebang) = ShebangDirective::try_extract(comment) {
-            has_any_shebang = true;
+            // A `#!` comment is only a shebang when only whitespace precedes it
+            // in the file. A `#!` that appears after code is an ordinary comment
+            // and should not trigger executable/python-presence rules.
+            let preceded_by_only_whitespace = locator
+                .up_to(range.start())
+                .chars()
+                .all(|c| is_python_whitespace(c) || matches!(c, '\r' | '\n'));
 
-            shebang_missing_python(range, &shebang, context);
+            if preceded_by_only_whitespace {
+                has_any_shebang = true;
 
-            if context.is_rule_enabled(Rule::ShebangNotExecutable) {
-                shebang_not_executable(path, range, context);
+                shebang_missing_python(range, &shebang, context);
+
+                if context.is_rule_enabled(Rule::ShebangNotExecutable) {
+                    shebang_not_executable(path, range, context);
+                }
+
+                shebang_leading_whitespace(context, range, locator);
             }
-
-            shebang_leading_whitespace(context, range, locator);
 
             shebang_not_first_line(range, locator, context);
         }

--- a/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE001_4.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_executable/snapshots/ruff_linter__rules__flake8_executable__tests__EXE001_4.py.snap
@@ -1,0 +1,3 @@
+---
+source: crates/ruff_linter/src/rules/flake8_executable/mod.rs
+---


### PR DESCRIPTION
Ran into a false positive today — EXE001 was firing on a `#! regular comment` inside a function body, claiming "shebang is present but file is not executable." Same issue affects EXE003 and EXE004.

The root cause is in `from_tokens`: it iterates over every comment range and calls `ShebangDirective::try_extract` on each one, then unconditionally applies all shebang rules to any match. A `#!` comment inside a function is obviously not a shebang, but nothing was filtering it out.

The fix adds a quick check before running EXE001/EXE003/EXE004: only apply those rules if everything before the `#!` comment in the file is whitespace. If there's any real code before it, skip those three rules — the comment can't be a shebang. EXE005 is left as-is since it's specifically meant to catch legitimate shebangs that ended up on the wrong line.

Added `EXE001_4.py` as a regression fixture and a snapshot asserting no diagnostics.

Fixes #27028