### PR TITLE
[ty] Add executable discovery to the server command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4670,6 +4670,7 @@ dependencies = [
  "ty_python_core",
  "ty_python_semantic",
  "ty_server",
+ "ty_site_packages",
  "ty_static",
  "wild",
 ]

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -25,6 +25,7 @@ ty_combine = { workspace = true }
 ty_project = { workspace = true, features = ["zstd", "junit"] }
 ty_python_semantic = { workspace = true, features = ["serde"] }
 ty_server = { workspace = true }
+ty_site_packages = { workspace = true }
 ty_static = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -35,7 +35,7 @@ pub(crate) enum Command {
     Check(CheckCommand),
 
     /// Start the language server
-    Server,
+    Server(ServerCommand),
 
     /// Display ty's version
     Version {
@@ -308,6 +308,17 @@ impl CheckCommand {
         // Merge with options passed in via --config
         options.combine(self.config.into_options().unwrap_or_default())
     }
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct ServerCommand {
+    /// Print the absolute path to the ty executable to use for the current folder.
+    ///
+    /// Discover the Python environment for the current working directory, preferring a virtual
+    /// environment over system Python. Print the path to ty if it is installed there.
+    /// Exit with status 0 if ty is found, 1 if discovery fails, or 2 on an unexpected error.
+    #[arg(long, hide = true)]
+    pub(crate) find_executable: bool,
 }
 
 /// A list of rules to enable or disable with a given severity.

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -314,9 +314,9 @@ impl CheckCommand {
 pub(crate) struct ServerCommand {
     /// Print the absolute path to the ty executable to use for the current folder.
     ///
-    /// Discover the project from the current working directory, then find its Python environment
-    /// using the normal environment-discovery order. Project configuration is used to locate the
-    /// root, but `environment.python` is ignored. Print the path to ty if it is installed there.
+    /// Discover the project from the current working directory. Use `environment.python` if it
+    /// is configured; otherwise, discover the Python environment in the normal order.
+    /// Print the path to ty if it is installed there.
     /// If project discovery fails, use the current working directory as the discovery root.
     /// Exit with status 0 if ty is found, 1 if discovery fails, or 2 on an unexpected error.
     #[arg(long, hide = true)]

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -314,8 +314,10 @@ impl CheckCommand {
 pub(crate) struct ServerCommand {
     /// Print the absolute path to the ty executable to use for the current folder.
     ///
-    /// Discover the Python environment for the current working directory, preferring a virtual
-    /// environment over system Python. Print the path to ty if it is installed there.
+    /// Discover the project from the current working directory, then find its Python environment
+    /// using the normal environment-discovery order. Project configuration is used to locate the
+    /// root, but `environment.python` is ignored. Print the path to ty if it is installed there.
+    /// If project discovery fails, use the current working directory as the discovery root.
     /// Exit with status 0 if ty is found, 1 if discovery fails, or 2 on an unexpected error.
     #[arg(long, hide = true)]
     pub(crate) find_executable: bool,

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -3,6 +3,7 @@ mod logging;
 mod printer;
 mod python_version;
 mod rule;
+mod server;
 mod version;
 
 use std::io::{BufWriter, Write};
@@ -29,7 +30,6 @@ use ty_project::watch::ProjectWatcher;
 use ty_project::{CollectReporter, Db, watch};
 use ty_project::{ProjectDatabase, ProjectMetadata};
 use ty_python_semantic::{fix_all_diagnostics, suppress_all_diagnostics};
-use ty_server::run_server;
 use ty_static::EnvVars;
 
 use crate::args::{CheckCommand, Command, ExplainCommand, HelpFormat, TerminalColor};
@@ -47,8 +47,8 @@ pub fn run() -> anyhow::Result<ExitStatus> {
     let args = Cli::parse_from(args);
 
     match args.command {
-        Command::Server => run_server().map(|()| ExitStatus::Success),
         Command::Check(check_args) => run_check(check_args),
+        Command::Server(server_args) => server::run(&server_args),
         Command::Version { output_format } => version(output_format).map(|()| ExitStatus::Success),
         Command::GenerateShellCompletion { shell } => {
             use std::io::stdout;
@@ -102,16 +102,7 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
     tracing::debug!("Version: {}", version::version());
 
     // The base path to which all CLI arguments are relative to.
-    let cwd = {
-        let cwd = std::env::current_dir().context("Failed to get the current working directory")?;
-        SystemPathBuf::from_path_buf(cwd).map_err(|path| {
-            anyhow!(
-                "The current working directory `{}` contains non-Unicode characters. \
-                ty only supports Unicode paths.",
-                path.display()
-            )
-        })?
-    };
+    let cwd = current_directory()?;
 
     let project_path = args
         .project
@@ -248,13 +239,13 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
 
 #[derive(Copy, Clone)]
 pub enum ExitStatus {
-    /// Checking was successful and there were no errors.
+    /// The command completed successfully.
     Success = 0,
 
-    /// Checking was successful but there were errors.
+    /// Checking was successful but there were errors, or executable discovery found no match.
     Failure = 1,
 
-    /// Checking failed due to an invocation error (e.g. the current directory no longer exists, incorrect CLI arguments, ...)
+    /// The command failed due to an invocation error (e.g. the current directory no longer exists, incorrect CLI arguments, ...)
     Error = 2,
 
     /// Internal ty error (panic, or any other error that isn't due to the user using the
@@ -705,6 +696,17 @@ enum MainLoopMessage {
     },
     ApplyChanges(Vec<watch::ChangeEvent>),
     Exit,
+}
+
+fn current_directory() -> Result<SystemPathBuf> {
+    let cwd = std::env::current_dir().context("Failed to get the current working directory")?;
+    SystemPathBuf::from_path_buf(cwd).map_err(|path| {
+        anyhow!(
+            "The current working directory `{}` contains non-Unicode characters. \
+             ty only supports Unicode paths.",
+            path.display()
+        )
+    })
 }
 
 fn set_colored_override(color: Option<TerminalColor>) {

--- a/crates/ty/src/server.rs
+++ b/crates/ty/src/server.rs
@@ -32,15 +32,19 @@ fn find_executable() -> Result<ExitStatus> {
     let cwd = current_directory()?;
     let system = OsSystem::new(&cwd);
 
-    let project_root = match ProjectMetadata::discover(&cwd, &system) {
-        Ok(project) => project.root().to_path_buf(),
+    let environment = match ProjectMetadata::discover(&cwd, &system) {
+        Ok(project) => match project.to_merged_options().python_environment(&system) {
+            Ok(None) => PythonEnvironment::discover(Some(project.root()), &system)
+                .map_err(anyhow::Error::from),
+            configured => configured,
+        },
         Err(error) => {
             tracing::debug!("Failed to discover a project, falling back to `{cwd}`: {error}");
-            cwd.clone()
+            PythonEnvironment::discover(Some(&cwd), &system).map_err(anyhow::Error::from)
         }
     };
 
-    let environment = match PythonEnvironment::discover(Some(&project_root), &system) {
+    let environment = match environment {
         Ok(Some(environment)) => environment,
         Ok(None) => return Ok(ExitStatus::Failure),
         Err(error) => {

--- a/crates/ty/src/server.rs
+++ b/crates/ty/src/server.rs
@@ -5,6 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use anyhow::Result;
 use ruff_db::system::OsSystem;
+use ty_project::ProjectMetadata;
 use ty_site_packages::PythonEnvironment;
 
 use crate::args::{ServerCommand, TerminalColor};
@@ -31,7 +32,15 @@ fn find_executable() -> Result<ExitStatus> {
     let cwd = current_directory()?;
     let system = OsSystem::new(&cwd);
 
-    let environment = match PythonEnvironment::discover(Some(&cwd), &system) {
+    let project_root = match ProjectMetadata::discover(&cwd, &system) {
+        Ok(project) => project.root().to_path_buf(),
+        Err(error) => {
+            tracing::debug!("Failed to discover a project, falling back to `{cwd}`: {error}");
+            cwd.clone()
+        }
+    };
+
+    let environment = match PythonEnvironment::discover(Some(&project_root), &system) {
         Ok(Some(environment)) => environment,
         Ok(None) => return Ok(ExitStatus::Failure),
         Err(error) => {

--- a/crates/ty/src/server.rs
+++ b/crates/ty/src/server.rs
@@ -1,0 +1,67 @@
+use std::fs;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use anyhow::Result;
+use ruff_db::system::OsSystem;
+use ty_site_packages::PythonEnvironment;
+
+use crate::args::{ServerCommand, TerminalColor};
+use crate::logging::{VerbosityLevel, setup_tracing};
+use crate::printer::Printer;
+use crate::{ExitStatus, current_directory};
+
+/// Unix execute-permission bits for the file owner, group, and others.
+#[cfg(unix)]
+const EXECUTE_BITS: u32 = 0o111;
+
+pub(crate) fn run(args: &ServerCommand) -> Result<ExitStatus> {
+    if args.find_executable {
+        return find_executable();
+    }
+    ty_server::run_server()?;
+    Ok(ExitStatus::Success)
+}
+
+fn find_executable() -> Result<ExitStatus> {
+    let verbosity = VerbosityLevel::Quiet;
+    let printer = Printer::new(verbosity, true);
+    let _guard = setup_tracing(verbosity, TerminalColor::default())?;
+    let cwd = current_directory()?;
+    let system = OsSystem::new(&cwd);
+
+    let environment = match PythonEnvironment::discover(Some(&cwd), &system) {
+        Ok(Some(environment)) => environment,
+        Ok(None) => return Ok(ExitStatus::Failure),
+        Err(error) => {
+            tracing::debug!("Failed to discover a Python environment: {error}");
+            return Ok(ExitStatus::Failure);
+        }
+    };
+
+    let candidate = environment.sys_prefix().join(if cfg!(windows) {
+        "Scripts/ty.exe"
+    } else {
+        "bin/ty"
+    });
+
+    let Ok(metadata) = fs::metadata(candidate.as_std_path()).inspect_err(|error| {
+        tracing::debug!("Failed to read file metadata for `{candidate}`: {error}");
+    }) else {
+        return Ok(ExitStatus::Failure);
+    };
+
+    if !metadata.is_file() {
+        return Ok(ExitStatus::Failure);
+    }
+
+    #[cfg(unix)]
+    if metadata.permissions().mode() & EXECUTE_BITS == 0 {
+        return Ok(ExitStatus::Failure);
+    }
+
+    writeln!(printer.stream_for_requested_summary().lock(), "{candidate}")?;
+
+    Ok(ExitStatus::Success)
+}

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -7,6 +7,7 @@ mod python_environment;
 mod rule;
 mod rule_selection;
 mod scripts;
+mod server;
 mod uv_workspace;
 
 use anyhow::Context as _;
@@ -982,8 +983,12 @@ impl CliTest {
     }
 
     pub(crate) fn command(&self) -> Command {
+        self.command_with_subcommand("check")
+    }
+
+    fn command_with_subcommand(&self, subcommand: &str) -> Command {
         let mut command = Command::new(&self.ty_binary_path);
-        command.current_dir(&self.project_dir).arg("check");
+        command.current_dir(&self.project_dir).arg(subcommand);
 
         // Unset all environment variables because they can affect test behavior.
         command.env_clear();

--- a/crates/ty/tests/cli/server.rs
+++ b/crates/ty/tests/cli/server.rs
@@ -1,0 +1,185 @@
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::Context as _;
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::CliTest;
+
+#[test]
+fn find_uses_cwd_and_ignores_configuration() -> anyhow::Result<()> {
+    let case = CliTest::new()?.with_filter(r"/Scripts/ty\b", "/bin/ty");
+    venv_with_ty(&case, "project with spaces/.venv")?;
+    let project = case.root().join("project with spaces");
+    // We could consider respecting `tool.ty.environment.python` in the future. For now,
+    // executable discovery does not read project configuration.
+    case.write_file(
+        project.join("ty.toml"),
+        "[environment]\npython = 'missing configured environment'\n",
+    )?;
+
+    assert_cmd_snapshot!(find_command(&case).current_dir(&project), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    <temp_dir>/project with spaces/.venv/bin/ty
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn find_does_not_fall_back_to_path_or_own_executable() -> anyhow::Result<()> {
+    let case = CliTest::new()?;
+    let own_ty = venv_with_ty(&case, "own environment")?;
+    let case = case.with_ty_at(&own_ty)?;
+    let path = own_ty.parent().context("ty must have a parent")?;
+
+    assert_cmd_snapshot!(find_command(&case).env("PATH", path), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn find_rejects_wrong_layout() -> anyhow::Result<()> {
+    let case = CliTest::with_file(".venv/pyvenv.cfg", "home = .\n")?;
+    let other_layout = if cfg!(windows) {
+        "bin/ty"
+    } else {
+        "Scripts/ty.exe"
+    };
+    write_executable(&case, Path::new(".venv").join(other_layout))?;
+
+    assert_cmd_snapshot!(find_command(&case), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn find_rejects_directory() -> anyhow::Result<()> {
+    let case = CliTest::with_file(".venv/pyvenv.cfg", "home = .\n")?;
+    fs::create_dir_all(case.root().join(ty_path(".venv")))?;
+
+    assert_cmd_snapshot!(find_command(&case), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn find_follows_symlinks() -> anyhow::Result<()> {
+    let case = CliTest::with_file(".venv/pyvenv.cfg", "home = .\n")?;
+    let target = write_executable(&case, "target with spaces")?;
+    case.write_symlink(&target, ty_path(".venv"))?;
+
+    assert_cmd_snapshot!(find_command(&case), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    <temp_dir>/.venv/bin/ty
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn find_rejects_non_executable_file() -> anyhow::Result<()> {
+    let case = CliTest::new()?;
+    let candidate = venv_with_ty(&case, ".venv")?;
+    fs::set_permissions(&candidate, fs::Permissions::from_mode(0o644))?;
+
+    assert_cmd_snapshot!(find_command(&case), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn find_rejects_broken_symlink() -> anyhow::Result<()> {
+    let case = CliTest::with_file(".venv/pyvenv.cfg", "home = .\n")?;
+    case.write_symlink("missing", ty_path(".venv"))?;
+
+    assert_cmd_snapshot!(find_command(&case), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn find_returns_no_match_on_discovery_error() -> anyhow::Result<()> {
+    let case = CliTest::new()?;
+
+    assert_cmd_snapshot!(find_command(&case).env("VIRTUAL_ENV", "missing"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+fn find_command(case: &CliTest) -> Command {
+    let mut command = case.command_with_subcommand("server");
+    command.arg("--find-executable");
+    command
+}
+
+fn venv_with_ty(case: &CliTest, prefix: &str) -> anyhow::Result<PathBuf> {
+    case.write_file(Path::new(prefix).join("pyvenv.cfg"), "home = .\n")?;
+    write_executable(case, ty_path(prefix))
+}
+
+fn ty_path(prefix: impl AsRef<Path>) -> PathBuf {
+    prefix.as_ref().join(if cfg!(windows) {
+        "Scripts/ty.exe"
+    } else {
+        "bin/ty"
+    })
+}
+
+fn write_executable(case: &CliTest, path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
+    let path = case.root().join(path);
+    case.write_file(&path, "")?;
+    #[cfg(unix)]
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755))?;
+    Ok(path)
+}

--- a/crates/ty/tests/cli/server.rs
+++ b/crates/ty/tests/cli/server.rs
@@ -15,17 +15,95 @@ fn find_uses_discovered_project_root() -> anyhow::Result<()> {
     venv_with_ty(&case, "project with spaces/.venv")?;
     venv_with_ty(&case, "project with spaces/src/.venv")?;
     let project = case.root().join("project with spaces");
-    // Configuration identifies the project root, but does not select the executable's environment.
-    case.write_file(
-        project.join("ty.toml"),
-        "[environment]\npython = 'missing configured environment'\n",
-    )?;
+    case.write_file(project.join("ty.toml"), "")?;
 
     assert_cmd_snapshot!(find_command(&case).current_dir(project.join("src")), @"
     success: true
     exit_code: 0
     ----- stdout -----
     <temp_dir>/project with spaces/.venv/bin/ty
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn find_uses_configured_environment() -> anyhow::Result<()> {
+    let case = CliTest::new()?.with_filter(r"/Scripts/ty\b", "/bin/ty");
+    venv_with_ty(&case, "project with spaces/configured environment")?;
+    venv_with_ty(&case, "project with spaces/.venv")?;
+    let project = case.root().join("project with spaces");
+    fs::create_dir(project.join("src"))?;
+    case.write_file(
+        project.join("pyproject.toml"),
+        "[tool.ty.environment]\npython = 'configured environment'\n",
+    )?;
+
+    assert_cmd_snapshot!(find_command(&case)
+        .current_dir(project.join("src"))
+        .env("VIRTUAL_ENV", project.join(".venv")), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    <temp_dir>/project with spaces/configured environment/bin/ty
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn find_uses_configured_interpreter() -> anyhow::Result<()> {
+    let case = CliTest::new()?.with_filter(r"/Scripts/ty\b", "/bin/ty");
+    venv_with_ty(&case, "configured environment")?;
+    let interpreter = if cfg!(windows) {
+        "configured environment/Scripts/python.exe"
+    } else {
+        "configured environment/bin/python3"
+    };
+    write_executable(&case, interpreter)?;
+    case.write_file(
+        "ty.toml",
+        &format!("[environment]\npython = '{interpreter}'\n"),
+    )?;
+
+    assert_cmd_snapshot!(find_command(&case), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    <temp_dir>/configured environment/bin/ty
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn find_does_not_fall_back_from_configured_environment() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "ty.toml",
+        "[environment]\npython = 'configured environment'\n",
+    )?;
+    venv_with_ty(&case, ".venv")?;
+
+    assert_cmd_snapshot!(find_command(&case), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    case.write_file("configured environment/pyvenv.cfg", "home = .\n")?;
+
+    assert_cmd_snapshot!(find_command(&case), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
 
     ----- stderr -----
     ");

--- a/crates/ty/tests/cli/server.rs
+++ b/crates/ty/tests/cli/server.rs
@@ -10,22 +10,40 @@ use insta_cmd::assert_cmd_snapshot;
 use crate::CliTest;
 
 #[test]
-fn find_uses_cwd_and_ignores_configuration() -> anyhow::Result<()> {
+fn find_uses_discovered_project_root() -> anyhow::Result<()> {
     let case = CliTest::new()?.with_filter(r"/Scripts/ty\b", "/bin/ty");
     venv_with_ty(&case, "project with spaces/.venv")?;
+    venv_with_ty(&case, "project with spaces/src/.venv")?;
     let project = case.root().join("project with spaces");
-    // We could consider respecting `tool.ty.environment.python` in the future. For now,
-    // executable discovery does not read project configuration.
+    // Configuration identifies the project root, but does not select the executable's environment.
     case.write_file(
         project.join("ty.toml"),
         "[environment]\npython = 'missing configured environment'\n",
     )?;
 
-    assert_cmd_snapshot!(find_command(&case).current_dir(&project), @"
+    assert_cmd_snapshot!(find_command(&case).current_dir(project.join("src")), @"
     success: true
     exit_code: 0
     ----- stdout -----
     <temp_dir>/project with spaces/.venv/bin/ty
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn find_uses_cwd_when_project_discovery_fails() -> anyhow::Result<()> {
+    let case = CliTest::with_file("pyproject.toml", "not valid TOML [")?
+        .with_filter(r"/Scripts/ty\b", "/bin/ty");
+    venv_with_ty(&case, "src/.venv")?;
+
+    assert_cmd_snapshot!(find_command(&case).current_dir(case.root().join("src")), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    <temp_dir>/src/.venv/bin/ty
 
     ----- stderr -----
     ");
@@ -143,7 +161,7 @@ fn find_rejects_broken_symlink() -> anyhow::Result<()> {
 }
 
 #[test]
-fn find_returns_no_match_on_discovery_error() -> anyhow::Result<()> {
+fn find_returns_no_match_on_python_environment_error() -> anyhow::Result<()> {
     let case = CliTest::new()?;
 
     assert_cmd_snapshot!(find_command(&case).env("VIRTUAL_ENV", "missing"), @"

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -392,7 +392,7 @@ impl ProjectMetadata {
         Ok(metadata)
     }
 
-    pub(crate) fn root(&self) -> &SystemPath {
+    pub fn root(&self) -> &SystemPath {
         &self.root
     }
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use ty_combine::Combine;
 use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, ProgramSettings};
+use ty_python_semantic::PythonEnvironment;
 use ty_static::EnvVars;
 
 use crate::Db;
@@ -581,6 +582,15 @@ impl MergedOptions<'_> {
             vendored,
             strategy,
         )
+    }
+
+    /// Resolve the configured Python environment. Return `None` if no path was configured.
+    pub fn python_environment(
+        &self,
+        system: &dyn System,
+    ) -> anyhow::Result<Option<PythonEnvironment>> {
+        self.options
+            .python_environment(self.metadata.root(), system)
     }
 
     pub fn to_settings<Strategy: MisconfigurationStrategy>(

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -207,27 +207,11 @@ impl Options {
                 default
             });
 
-        let python_environment = if let Some(python_path) = environment.python.as_ref() {
-            let origin = match python_path.source() {
-                ValueSource::Cli => SysPrefixPathOrigin::PythonCliFlag,
-                ValueSource::File(path) => {
-                    SysPrefixPathOrigin::ConfigFileSetting(path.clone(), python_path.range())
-                }
-                ValueSource::ScriptMetadata(_) => SysPrefixPathOrigin::ScriptMetadataSetting,
-                ValueSource::Editor => SysPrefixPathOrigin::Editor,
-                ValueSource::UvWorkspace => SysPrefixPathOrigin::UvWorkspace,
-            };
-
-            PythonEnvironment::new(
-                python_path.absolute(context.configuration_root(), system),
-                origin,
-                system,
-            )
-            .map_err(anyhow::Error::from)
-            .map(Some)
-        } else {
-            PythonEnvironment::discover(context.project_root(), system)
-                .context("Failed to discover local Python environment")
+        let python_environment = match self.python_environment(context.configuration_root(), system)
+        {
+            Ok(None) => PythonEnvironment::discover(context.project_root(), system)
+                .context("Failed to discover local Python environment"),
+            configured => configured,
         };
 
         // If in safe-mode, fallback to None if this fails instead of erroring.
@@ -321,6 +305,36 @@ impl Options {
             },
             diagnostics,
         ))
+    }
+
+    /// Resolve the configured Python environment. Return `None` if no path was configured.
+    pub(crate) fn python_environment(
+        &self,
+        configuration_root: &SystemPath,
+        system: &dyn System,
+    ) -> anyhow::Result<Option<PythonEnvironment>> {
+        let environment = self.environment.or_default();
+        let Some(python_path) = environment.python.as_ref() else {
+            return Ok(None);
+        };
+
+        let origin = match python_path.source() {
+            ValueSource::Cli => SysPrefixPathOrigin::PythonCliFlag,
+            ValueSource::File(path) => {
+                SysPrefixPathOrigin::ConfigFileSetting(path.clone(), python_path.range())
+            }
+            ValueSource::ScriptMetadata(_) => SysPrefixPathOrigin::ScriptMetadataSetting,
+            ValueSource::Editor => SysPrefixPathOrigin::Editor,
+            ValueSource::UvWorkspace => SysPrefixPathOrigin::UvWorkspace,
+        };
+
+        PythonEnvironment::new(
+            python_path.absolute(configuration_root, system),
+            origin,
+            system,
+        )
+        .map_err(anyhow::Error::from)
+        .map(Some)
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -368,6 +368,14 @@ impl PythonEnvironment {
         }
     }
 
+    /// Returns the canonical, absolute `sys.prefix` of this environment.
+    pub fn sys_prefix(&self) -> &SysPrefixPath {
+        match self {
+            Self::Virtual(env) => &env.root_path,
+            Self::System(env) => env.path.sys_prefix(),
+        }
+    }
+
     /// Returns the Python version that was used to create this environment
     /// (will only be available for virtual environments that specify
     /// the metadata in their `pyvenv.cfg` files).
@@ -2441,6 +2449,7 @@ mod tests {
                 .expect("Expected environment construction to succeed");
 
             let expect_virtual_env = self.virtual_env.is_some();
+            assert_eq!(env.sys_prefix().as_std_path(), env_path.as_std_path());
             match &env {
                 PythonEnvironment::Virtual(venv) if expect_virtual_env => {
                     self.assert_virtual_environment(venv, &env_path);


### PR DESCRIPTION
## Summary

Add hidden `ty server --find-executable` for editor integrations to locate ty in the automatically discovered Python environment without starting the language server.


The basic idea here is to allow an LSP to discover the ty binary in the same environment that ty will use to type check the project. This seems like a reasonable default. 

I plan to use this in ty's VS Code extension when the Python Environment and Python extensions are not available or if no environment is selected. Then, use ty to discover the Python environment. This, mostly, gives us:

* Finding ty in a local `.venv` folder
* Finding ty in a user installation
* Finding ty in a system installation


Now, it does a little more than just checking for `<cwd>/.venv/`. The command applies ty's project discovery (search for the closest `ty.toml` or `pyproject.toml` with a `tool.ty` section), and then reads the `environment.python` setting. 

I think the basic idea of searching ty in the same environment as ty uses for type checking seems reasonable to me. But this also does a fair bit of work, and maybe too much? Should the command skip reading the setting? Should the command always search the environment from the current working directory? Should we defer this altogether until users ask for it? 

I'm still leaning towards that this is valuable, but I don't feel strongly.

VS Code change https://github.com/astral-sh/ty-vscode/pull/522

## Test Plan

Testing: CLI and environment tests, Clippy, formatting, generated-file checks, and pinned hooks pass.
