### PR TITLE
Offer display-only fixes and mark safe fixes preferred

### DIFF
--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -15,7 +15,7 @@ use crate::{
     session::DocumentQuery,
 };
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic};
-use ruff_diagnostics::{Edit, Fix};
+use ruff_diagnostics::{Applicability, Edit, Fix};
 use ruff_linter::{
     Locator, SuppressionKind,
     directives::{Flags, extract_directives},
@@ -397,6 +397,10 @@ fn to_lsp_diagnostic(
 
     let data = (fix.is_some() || noqa_edit.is_some())
         .then(|| {
+            let mut title = suggestion.unwrap_or(name).to_string();
+            if fix.is_some_and(|fix| fix.applicability() == Applicability::DisplayOnly) {
+                title.push_str(" (review required)");
+            }
             let edits = fix
                 .into_iter()
                 .flat_map(Fix::edits)
@@ -410,7 +414,7 @@ fn to_lsp_diagnostic(
                 new_text: noqa_edit.into_content().unwrap_or_default().into_string(),
             });
             serde_json::to_value(AssociatedDiagnosticData {
-                title: suggestion.unwrap_or(name).to_string(),
+                title,
                 noqa_edit,
                 edits,
                 code: code.clone(),

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -15,7 +15,7 @@ use crate::{
     session::DocumentQuery,
 };
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic};
-use ruff_diagnostics::{Applicability, Edit, Fix};
+use ruff_diagnostics::{Edit, Fix};
 use ruff_linter::{
     Locator, SuppressionKind,
     directives::{Flags, extract_directives},
@@ -372,7 +372,6 @@ fn to_lsp_diagnostic(
     let name = diagnostic.name();
     let fix = diagnostic.fix();
     let suggestion = diagnostic.first_help_text();
-    let fix = fix.and_then(|fix| fix.applies(Applicability::Unsafe).then_some(fix));
 
     let (severity, code) = if let Some(code) = diagnostic.secondary_code() {
         let severity = severity(code);

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -399,7 +399,7 @@ fn to_lsp_diagnostic(
         .then(|| {
             let mut title = suggestion.unwrap_or(name).to_string();
             if fix.is_some_and(|fix| fix.applicability() == Applicability::DisplayOnly) {
-                title.push_str(" (review required)");
+                title.push_str(" (suggestion)");
             }
             let edits = fix
                 .into_iter()

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -47,6 +47,8 @@ pub(crate) struct AssociatedDiagnosticData {
     code: String,
     /// Possible edit to add a suppression comment which will disable this diagnostic.
     noqa_edit: Option<lsp_types::TextEdit>,
+    /// Whether this fix corresponds to a preferred action that can be used by auto fix commands.
+    is_preferred: Option<bool>,
 }
 
 /// Describes a fix for `fixed_diagnostic` that may have quick fix
@@ -64,6 +66,8 @@ pub(crate) struct DiagnosticFix {
     pub(crate) edits: Vec<lsp_types::TextEdit>,
     /// Possible edit to add a suppression comment which will disable this diagnostic.
     pub(crate) noqa_edit: Option<lsp_types::TextEdit>,
+    /// Whether this fix corresponds to a preferred action that can be used by auto fix commands.
+    pub(crate) is_preferred: Option<bool>,
 }
 
 /// A series of diagnostics across a single text document or an arbitrary number of notebook cells.
@@ -306,6 +310,7 @@ pub(crate) fn fixes_for_diagnostics(
                 title: associated_data.title,
                 noqa_edit: associated_data.noqa_edit,
                 edits: associated_data.edits,
+                is_preferred: associated_data.is_preferred,
             }))
         })
         .filter_map(crate::Result::transpose)
@@ -418,6 +423,7 @@ fn to_lsp_diagnostic(
                 noqa_edit,
                 edits,
                 code: code.clone(),
+                is_preferred: fix.map(|fix| fix.applicability().is_safe()),
             })
             .ok()
         })

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -268,8 +268,7 @@ impl Server {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum SupportedCodeAction {
     /// Maps to the `quickfix` code action kind. Quick fix code actions are shown under
-    /// their respective diagnostics. Quick fixes are only created where the fix applicability is
-    /// at least [`ruff_diagnostics::Applicability::Unsafe`].
+    /// their respective diagnostics, including display-only fixes that require manual review.
     QuickFix,
     /// Maps to the `source.fixAll` and `source.fixAll.ruff` code action kinds.
     /// This is a source action that applies all safe fixes to the currently open document.

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -152,6 +152,7 @@ fn quick_fix(
                 data: Some(
                     serde_json::to_value(document_uri).expect("document uri should serialize"),
                 ),
+                is_preferred: fix.is_preferred,
                 ..Default::default()
             }))
         })

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -135,6 +135,7 @@ extend-select = ["F401"]
             "tags": []
           }
         ],
+        "isPreferred": true,
         "edit": {
           "changes": {
             "file://<temp_dir>/ruff.toml": [

--- a/crates/ruff_server/tests/e2e/diagnostics.rs
+++ b/crates/ruff_server/tests/e2e/diagnostics.rs
@@ -57,6 +57,7 @@ fn uses_human_readable_names_in_preview() -> Result<()> {
                 }
               }
             ],
+            "is_preferred": true,
             "noqa_edit": {
               "newText": "  # ruff: ignore[unused-import]\n",
               "range": {
@@ -138,6 +139,7 @@ extend-select = ["F401"]
                 }
               }
             ],
+            "is_preferred": true,
             "noqa_edit": null,
             "title": "Replace rule code with `unused-import`"
           }

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
@@ -40,6 +40,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: I002\n",
           "range": {
@@ -78,6 +79,7 @@ expression: diagnostics
       "data": {
         "code": "RUF900",
         "edits": [],
+        "is_preferred": null,
         "noqa_edit": {
           "newText": "  # noqa: RUF900\n",
           "range": {
@@ -130,6 +132,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: RUF901\n",
           "range": {
@@ -182,6 +185,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": false,
         "noqa_edit": {
           "newText": "  # noqa: RUF902\n",
           "range": {
@@ -234,6 +238,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": false,
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {
@@ -272,6 +277,7 @@ expression: diagnostics
       "data": {
         "code": "RUF950",
         "edits": [],
+        "is_preferred": null,
         "noqa_edit": {
           "newText": "  # noqa: RUF950\n",
           "range": {
@@ -327,6 +333,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: I001\n",
           "range": {
@@ -381,6 +388,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -437,6 +445,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -489,6 +498,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -541,6 +551,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: F541\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
@@ -247,7 +247,7 @@ expression: diagnostics
             }
           }
         },
-        "title": "stable-test-rule-display-only-fix (review required)"
+        "title": "stable-test-rule-display-only-fix (suggestion)"
       }
     },
     {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
@@ -247,7 +247,7 @@ expression: diagnostics
             }
           }
         },
-        "title": "stable-test-rule-display-only-fix"
+        "title": "stable-test-rule-display-only-fix (review required)"
       }
     },
     {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
@@ -219,7 +219,21 @@ expression: diagnostics
       "tags": [],
       "data": {
         "code": "RUF903",
-        "edits": [],
+        "edits": [
+          {
+            "newText": "# fix from stable-test-rule-display-only-fix\n",
+            "range": {
+              "end": {
+                "character": 0,
+                "line": 0
+              },
+              "start": {
+                "character": 0,
+                "line": 0
+              }
+            }
+          }
+        ],
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
@@ -219,7 +219,21 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
       "tags": [],
       "data": {
         "code": "RUF903",
-        "edits": [],
+        "edits": [
+          {
+            "newText": "# fix from stable-test-rule-display-only-fix\n",
+            "range": {
+              "end": {
+                "character": 0,
+                "line": 0
+              },
+              "start": {
+                "character": 0,
+                "line": 0
+              }
+            }
+          }
+        ],
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
@@ -40,6 +40,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: I002\n",
           "range": {
@@ -78,6 +79,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
       "data": {
         "code": "RUF900",
         "edits": [],
+        "is_preferred": null,
         "noqa_edit": {
           "newText": "  # noqa: RUF900\n",
           "range": {
@@ -130,6 +132,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: RUF901\n",
           "range": {
@@ -182,6 +185,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": false,
         "noqa_edit": {
           "newText": "  # noqa: RUF902\n",
           "range": {
@@ -234,6 +238,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": false,
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {
@@ -272,6 +277,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
       "data": {
         "code": "RUF950",
         "edits": [],
+        "is_preferred": null,
         "noqa_edit": {
           "newText": "  # noqa: RUF950\n",
           "range": {
@@ -327,6 +333,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: I001\n",
           "range": {
@@ -381,6 +388,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -437,6 +445,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -489,6 +498,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -541,6 +551,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: F541\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
@@ -247,7 +247,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         },
-        "title": "stable-test-rule-display-only-fix"
+        "title": "stable-test-rule-display-only-fix (review required)"
       }
     },
     {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
@@ -247,7 +247,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         },
-        "title": "stable-test-rule-display-only-fix (review required)"
+        "title": "stable-test-rule-display-only-fix (suggestion)"
       }
     },
     {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
@@ -40,6 +40,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: I002\n",
           "range": {
@@ -78,6 +79,7 @@ expression: diagnostics
       "data": {
         "code": "RUF900",
         "edits": [],
+        "is_preferred": null,
         "noqa_edit": {
           "newText": "  # noqa: RUF900\n",
           "range": {
@@ -130,6 +132,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: RUF901\n",
           "range": {
@@ -182,6 +185,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": false,
         "noqa_edit": {
           "newText": "  # noqa: RUF902\n",
           "range": {
@@ -234,6 +238,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": false,
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {
@@ -272,6 +277,7 @@ expression: diagnostics
       "data": {
         "code": "RUF950",
         "edits": [],
+        "is_preferred": null,
         "noqa_edit": {
           "newText": "  # noqa: RUF950\n",
           "range": {
@@ -327,6 +333,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: I001\n",
           "range": {
@@ -381,6 +388,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -437,6 +445,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -489,6 +498,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -541,6 +551,7 @@ expression: diagnostics
             }
           }
         ],
+        "is_preferred": true,
         "noqa_edit": {
           "newText": "  # noqa: F541\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
@@ -247,7 +247,7 @@ expression: diagnostics
             }
           }
         },
-        "title": "stable-test-rule-display-only-fix (review required)"
+        "title": "stable-test-rule-display-only-fix (suggestion)"
       }
     },
     {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
@@ -247,7 +247,7 @@ expression: diagnostics
             }
           }
         },
-        "title": "stable-test-rule-display-only-fix"
+        "title": "stable-test-rule-display-only-fix (review required)"
       }
     },
     {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
@@ -219,7 +219,21 @@ expression: diagnostics
       "tags": [],
       "data": {
         "code": "RUF903",
-        "edits": [],
+        "edits": [
+          {
+            "newText": "# fix from stable-test-rule-display-only-fix\n",
+            "range": {
+              "end": {
+                "character": 0,
+                "line": 0
+              },
+              "start": {
+                "character": 0,
+                "line": 0
+              }
+            }
+          }
+        ],
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/workspace.rs
+++ b/crates/ruff_server/tests/e2e/workspace.rs
@@ -81,6 +81,7 @@ ignore = ["F401"]
                 }
               }
             ],
+            "is_preferred": true,
             "noqa_edit": {
               "newText": "  # noqa: F401\n",
               "range": {


### PR DESCRIPTION
Summary
--

I thought this was the case before (https://github.com/astral-sh/ruff/issues/18686#issuecomment-2977459714), but apparently that only applied to `ruff-lsp`, which I was somehow still using at the time. This change exposes display-only fixes in the native server, like in `ruff-lsp` and the [playground].

We append `(suggestion)` to the fix title for display-only fixes in an effort to distinguish them from the more reliable safe and unsafe fixes.

To further differentiate these from safe fixes, this PR also sets the `isPreferred` property to `true` for safe fixes. This means such fixes can be applied automatically with the "Auto Fix" command (distinct from the "Quick Fix" command, which always opens a menu), should sort first, and get a slightly different lightbulb icon, at least in VS Code.

Before landing on this, I tried adding a [request for confirmation](https://code.visualstudio.com/api/references/vscode-api#WorkspaceEditEntryMetadata) to the fix, but the UI for this seems really annoying in VS Code. It opens this separate panel, and you have to click the check box and also click Apply:

<img width="597" height="236" alt="image" src="https://github.com/user-attachments/assets/53c97e14-1f5d-49e7-8e6c-73d6c5552eb2" />

That seemed to go a bit farther than we need, especially relative to the code change required and after I vetted our display-only fixes. Most of them are only a bit less safe than our unsafe fixes. We don't have any that seem obviously disastrous. Related to the scope of the code change, this functionality may also not be available in some clients, at least according to Codex. However, one cool thing about this approach is that we could pass down rule-specific information about why the fix needs confirmation. That would obviously increase the scope even more but was an interesting finding.

These changes align pretty well with what rust-analyzer does. Its applicability levels are a bit different from ours, but it marks `MachineApplicable` fixes as preferred, `MaybeIncorrect` fixes as not preferred, and `HasPlaceholders` suggestions don't have quick fixes. The main difference is that our `DisplayOnly` fixes seem considerably safer than [`HasPlaceholders`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint_defs/enum.Applicability.html#variant.HasPlaceholders), so we can still set non-preferred fixes on them.

Test Plan
--

Updated existing snapshots and manual testing in VS Code. The quick fix list previously only offered
"Disable for this line" but now also offers the display-only fix:

<img width="528" height="349" alt="image" src="https://github.com/user-attachments/assets/adc9503d-446e-4360-a112-64df918bc1c4" />

I also tested the `Ruff: Fix all auto-fixable problems` and `Fix all` commands. These still don't apply display-only fixes. Only inline quick fixes include display-only fixes.

[playground]: https://play.ruff.rs/487aa90c-7809-4405-b9c5-ef9c5b8cf9c7
