### PR TITLE
[ty] Distinguish TypeVarTuple arguments from uninhabited runtime tuples

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -3841,6 +3841,19 @@ instance.non_existing = 2  # error: [invalid-assignment] "Cannot assign to unres
 instance.existing = 2  # error: [invalid-assignment] "Cannot assign to attribute `existing` on type `Frozen` whose `__setattr__` method returns `Never`/`NoReturn`"
 ```
 
+An uninhabited tuple return type also means the assignment cannot complete.
+
+```py
+class FrozenByUninhabitedTuple:
+    existing: int = 1
+
+    def __setattr__(self, name: str, value: object) -> tuple[Never]:
+        raise AttributeError("Attributes cannot be modified")
+
+# error: [invalid-assignment]
+FrozenByUninhabitedTuple().existing = 2
+```
+
 ### `__setattr__` on `object`
 
 `object` has a custom `__setattr__` implementation, but we still emit an error if a non-existing

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -29,6 +29,35 @@ p = partial(f, b="hello")
 reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello") -> bool]
 ```
 
+### Uninhabited parameter bound positionally
+
+An uninhabited positional parameter remains present in the reduced signature, even when its type is
+not represented directly as `Never`.
+
+```py
+from functools import partial
+from typing import Any
+from typing_extensions import Never
+
+def f(first: tuple[Never], second: int) -> None: ...
+def bind(value: Any) -> None:
+    reveal_type(partial(f, value))  # revealed: partial[(first: tuple[Never], second: int) -> None]
+```
+
+### Uninhabited parameter bound by keyword
+
+An uninhabited keyword-bound parameter becomes keyword-only but does not acquire a default.
+
+```py
+from functools import partial
+from typing import Any
+from typing_extensions import Never
+
+def f(first: tuple[Never], second: int) -> None: ...
+def bind(value: Any) -> None:
+    reveal_type(partial(f, first=value))  # revealed: partial[(*, first: tuple[Never], second: int) -> None]
+```
+
 ### Leading parameter bound by keyword
 
 Binding a positional-or-keyword parameter by keyword makes it defaulted and keyword-only in the

--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/membership_test.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/membership_test.md
@@ -151,17 +151,29 @@ from typing_extensions import Never, NotRequired, TypedDict
 class Closed(TypedDict, closed=True):
     present: int
     impossible: NotRequired[Never]
+    impossible_tuple: NotRequired[tuple[Never]]
 
 class ClosedByExtraItems(TypedDict, extra_items=Never):
     present: int
 
-def closed_membership(closed: Closed, closed_by_extra_items: ClosedByExtraItems) -> None:
+class ClosedByUninhabitedTuple(TypedDict, extra_items=tuple[Never]):
+    present: int
+
+def closed_membership(
+    closed: Closed,
+    closed_by_extra_items: ClosedByExtraItems,
+    closed_by_uninhabited_tuple: ClosedByUninhabitedTuple,
+) -> None:
     reveal_type("missing" in closed)  # revealed: Literal[False]
     reveal_type("missing" not in closed)  # revealed: Literal[True]
     reveal_type("impossible" in closed)  # revealed: Literal[False]
     reveal_type("impossible" not in closed)  # revealed: Literal[True]
+    reveal_type("impossible_tuple" in closed)  # revealed: Literal[False]
+    reveal_type("impossible_tuple" not in closed)  # revealed: Literal[True]
     reveal_type("missing" in closed_by_extra_items)  # revealed: Literal[False]
     reveal_type("missing" not in closed_by_extra_items)  # revealed: Literal[True]
+    reveal_type("missing" in closed_by_uninhabited_tuple)  # revealed: Literal[False]
+    reveal_type("missing" not in closed_by_uninhabited_tuple)  # revealed: Literal[True]
 ```
 
 ## Undeclared keys in open `TypedDict`s

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -1900,6 +1900,36 @@ def _(source: tuple[bool, bool]):
     target: tuple[int, int] = source
 ```
 
+## Invariant variadic generic classes
+
+The invariance hint also explains incompatible specializations of a class parameterized by a type
+variable tuple.
+
+```py
+class Box[*Ts]:
+    values: tuple[*Ts]
+
+def accepts(value: Box[int]) -> None: ...
+def check(value: Box[bool]) -> None:
+    accepts(value)  # snapshot
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `accepts` is incorrect
+ --> src/mdtest_snippet.py:6:13
+  |
+6 |     accepts(value)  # snapshot
+  |             ^^^^^ Expected `Box[int]`, found `Box[bool]`
+info: the first tuple element is not compatible: `int` is not assignable to `bool`
+info: Function defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+4 | def accepts(value: Box[int]) -> None: ...
+  |     ^^^^^^^ --------------- Parameter declared here
+info: `Box` is invariant in its type parameter
+info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
+```
+
 ## Error context in other scenarios
 
 ### In `invalid-return-type` diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -1099,3 +1099,29 @@ def returns_recursive_alias(value: Any) -> GrowingAlias[int]:
 def returns_recursive_alias_with_any(value: Any) -> GrowingAliasWithAny[int]:
     return value
 ```
+
+## Regression test: `unsound-return-statement` + callable type aliases
+
+A generic decorator factory cannot return a callback transformer that only supports one concrete
+return type. Comparing two specializations of the same callable alias must not reuse one
+specialization's cached expansion for the other.
+
+```toml
+[environment]
+python-version = "3.12"
+
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from collections.abc import Callable
+
+type Callback[T] = Callable[[], T]
+
+def decorator_factory[T]() -> Callable[[Callback[T]], Callback[T]]:
+    def wrapper(callback: Callback[int]) -> Callback[int]:
+        return lambda: 1
+
+    return wrapper  # error: [unsound-return-statement]
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -422,6 +422,41 @@ def _(i: int, s: str) -> None:
     reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
+### Constructor inference with `Never` arguments
+
+A legacy variadic generic retains all constructor argument positions when one argument is `Never`.
+
+```py
+from typing import Generic, Never, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Factory(Generic[*Ts]):
+    def __init__(self, *args: *Ts) -> None: ...
+
+def check(value: Never) -> None:
+    reveal_type(Factory(1, value))  # revealed: Factory[int, Never]
+    reveal_type(Factory(value, 1))  # revealed: Factory[Never, int]
+```
+
+### Inherited variadic constructors
+
+A legacy variadic subclass can use its base class's constructor without treating their type variable
+tuples as incompatible.
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Base(Generic[*Ts]):
+    def __init__(self, *args: *Ts) -> None: ...
+
+class Child(Base[*Ts], Generic[*Ts]): ...
+
+Child(1, "hello")
+```
+
 ### Unspecified type arguments
 
 When a generic class parameterized by a type variable tuple is used without any type parameters and
@@ -465,6 +500,31 @@ class WithDefault(Generic[*Ts]):
 
 reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
 reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
+```
+
+### Default type arguments containing `Never`
+
+A legacy variadic parameter retains a required `Never` element in its unpacked default.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Generic, Never, TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, Never]])
+OneNever = TypeVarTuple("OneNever", default=Unpack[tuple[Never]])
+QuotedNever = TypeVarTuple("QuotedNever", default=Unpack["tuple[int, Never]"])
+
+class WithNeverDefault(Generic[*Ts]): ...
+class WithOneNeverDefault(Generic[*OneNever]): ...
+class WithQuotedNeverDefault(Generic[*QuotedNever]): ...
+
+reveal_type(WithNeverDefault())  # revealed: WithNeverDefault[int, Never]
+reveal_type(WithOneNeverDefault())  # revealed: WithOneNeverDefault[Never]
+reveal_type(WithQuotedNeverDefault())  # revealed: WithQuotedNeverDefault[int, Never]
 ```
 
 ### Backported default type arguments

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -115,6 +115,65 @@ def _(value: Container) -> None:
     expected: Kind[int, Any] = value
 ```
 
+### Unpacked specializations containing `Never`
+
+Unpacking a sequence of type arguments preserves a required `Never` element even though a runtime
+tuple with the same elements would be uninhabited.
+
+```py
+from typing import Callable, Never, Unpack
+
+class Container[*Ts]: ...
+
+def check(
+    first: Container[*tuple[int, Never]],
+    second: Container[*tuple[Never, int]],
+    one_element: Container[*tuple[Never]],
+    quoted: Container[Unpack["tuple[int, Never]"]],
+    callback: Callable[[*tuple[int, Never]], None],
+) -> None:
+    reveal_type(first)  # revealed: Container[int, Never]
+    reveal_type(second)  # revealed: Container[Never, int]
+    reveal_type(one_element)  # revealed: Container[Never]
+    reveal_type(quoted)  # revealed: Container[int, Never]
+    reveal_type(callback)  # revealed: (*tuple[int, Never]) -> None
+
+def unpacked(*args: *tuple[int, Never]) -> None: ...
+
+reveal_type(unpacked)  # revealed: def unpacked(*args: tuple[int, Never]) -> None
+```
+
+### Inconsistent inherited specializations
+
+An empty variadic argument sequence is a concrete specialization, so it conflicts with a nonempty
+specialization of the same base regardless of their order.
+
+```py
+class Base[*Ts]: ...
+class Empty(Base[()]): ...
+class Nonempty(Base[int]): ...
+
+# error: [invalid-generic-class]
+class EmptyFirst(Empty, Nonempty): ...
+
+# error: [invalid-generic-class]
+class EmptySecond(Nonempty, Empty): ...
+```
+
+A dynamically typed element does not erase the concrete length of a variadic specialization.
+
+```py
+from typing import Any
+
+class Dynamic(Base[Any]): ...
+
+# error: [invalid-generic-class]
+class DynamicFirst(Dynamic, Empty): ...
+
+# error: [invalid-generic-class]
+class DynamicSecond(Empty, Dynamic): ...
+```
+
 ### `TypeVarTuple` with `ParamSpec`
 
 ```py
@@ -173,6 +232,44 @@ indirect: Variadic[str] = inferred
 direct: Variadic[str] = Variadic(1)
 ```
 
+### Constructor inference with `Never` arguments
+
+A `Never` constructor argument does not erase the other arguments or its position in the inferred
+variadic specialization.
+
+```py
+from typing import Never
+
+class Factory[*Ts]:
+    def __init__(self, *args: *Ts) -> None: ...
+
+def check(value: Never) -> None:
+    reveal_type(Factory(1, value))  # revealed: Factory[Literal[1], Never]
+    reveal_type(Factory(value, 1))  # revealed: Factory[Never, Literal[1]]
+    reveal_type(Factory(1, value, "x"))  # revealed: Factory[Literal[1], Never, Literal["x"]]
+```
+
+### Inherited variadic constructors and `Self`
+
+A variadic subclass can use its base class's constructor and `Self`-typed methods without losing the
+connection between their type variable tuples.
+
+```py
+from typing import Self
+
+class Base[*Ts]:
+    def __init__(self, *args: *Ts) -> None: ...
+    def identity(self) -> Self:
+        return self
+
+class Child[*Ts](Base[*Ts]): ...
+
+Child(1, "hello")
+
+def check(value: Child[int, str]) -> None:
+    reveal_type(value.identity())  # revealed: Child[int, str]
+```
+
 ### Unspecified type arguments
 
 An unsubscripted variadic generic behaves as if it used an unknown-length tuple of `Any` arguments.
@@ -206,6 +303,26 @@ reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
 reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
 ```
 
+### Default type arguments containing `Never`
+
+A defaulted variadic parameter preserves its complete argument sequence when a required element is
+`Never`.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Never
+
+class WithNeverDefault[*Ts = *tuple[int, Never]]: ...
+class WithOneNeverDefault[*Ts = *tuple[Never]]: ...
+
+reveal_type(WithNeverDefault())  # revealed: WithNeverDefault[int, Never]
+reveal_type(WithOneNeverDefault())  # revealed: WithOneNeverDefault[Never]
+```
+
 ### Gradual specializations
 
 A type variable tuple remains assignable to an explicitly gradual specialization of its generic
@@ -220,6 +337,45 @@ class Array[*Ts]:
 ```
 
 ## Functions
+
+### Generic class arguments containing `Never`
+
+Inference from a generic class preserves each variadic type argument, including `Never` arguments
+and fixed type parameters beside the variadic pack.
+
+```py
+from typing import Never
+
+class Container[*Ts]:
+    values: tuple[*Ts]
+
+def identity[*Ts](value: Container[*Ts]) -> Container[*Ts]:
+    return value
+
+def first[T, *Ts](value: Container[T, *Ts]) -> T:
+    raise NotImplementedError
+
+def check(value: Container[int, Never]) -> None:
+    reveal_type(identity(value))  # revealed: Container[int, Never]
+    reveal_type(first(value))  # revealed: int
+```
+
+### Argument lengths containing `Never`
+
+A type variable tuple inferred from a generic argument still determines the required number of
+variadic arguments when one of its elements is `Never`.
+
+```py
+from typing import Never
+
+class Container[*Ts]: ...
+
+def use[*Ts](value: Container[*Ts], *args: *Ts) -> None: ...
+def check(value: Container[int, Never]) -> None:
+    use(value)  # error: [invalid-argument-type]
+    use(value, 1)  # error: [invalid-argument-type]
+    use(value, 1, "wrong", "extra")  # error: [invalid-argument-type]
+```
 
 ### Multiple type variable tuples
 
@@ -640,6 +796,78 @@ reveal_type(simple(variadic2))  # revealed: tuple[Unknown, ...]
 reveal_type(simple(keyword_only))  # revealed: tuple[Unknown, ...]
 ```
 
+### Callable inference with `Never` arguments
+
+Callable parameter lists are sequences of argument types, so a `Never` parameter does not erase the
+other parameters when inferring a variadic specialization.
+
+```py
+from typing import Callable, Never
+
+class Container[*Ts]: ...
+
+def infer_callable[*Ts](callback: Callable[[*Ts], None]) -> Container[*Ts]:
+    raise NotImplementedError
+
+def callback(first: int, second: Never) -> None: ...
+
+reveal_type(infer_callable(callback))  # revealed: Container[int, Never]
+```
+
+A fixed suffix following the variadic pack is not part of the inferred pack.
+
+```py
+def infer_mixed_callable[*Ts](callback: Callable[[int, *Ts, str], None]) -> Container[*Ts]:
+    raise NotImplementedError
+
+def mixed_callback(first: int, middle: Never, last: str) -> None: ...
+
+reveal_type(infer_mixed_callable(mixed_callback))  # revealed: Container[Never]
+```
+
+Extra optional keyword arguments do not interfere with inference from positional parameters.
+
+```py
+def keyword_callback(first: int, second: Never, **kwargs: int) -> None: ...
+
+reveal_type(infer_callable(keyword_callback))  # revealed: Container[int, Never]
+```
+
+### Protocol inference with `Never` arguments
+
+A structural protocol preserves each inferred positional argument, including `Never`, when its
+method is implemented by a concrete class.
+
+```py
+from typing import Never, Protocol
+
+class Container[*Ts]: ...
+
+class Runner[*Ts](Protocol):
+    def run(self, *args: *Ts) -> None: ...
+
+def infer_runner[*Ts](runner: Runner[*Ts]) -> Container[*Ts]:
+    raise NotImplementedError
+
+class Concrete:
+    def run(self, first: int, second: Never) -> None: ...
+
+reveal_type(infer_runner(Concrete()))  # revealed: Container[int, Never]
+```
+
+The same specialization remains visible through an invariant wrapper.
+
+```py
+class Wrapper[T]:
+    value: T
+
+def infer_wrapped[*Ts](wrapper: Wrapper[Runner[*Ts]]) -> Container[*Ts]:
+    raise NotImplementedError
+
+def check(wrapper: Wrapper[Runner[int, Never]]) -> None:
+    reveal_type(infer_wrapped(wrapper))  # revealed: Container[int, Never]
+```
+
 ### Callable inference through invariant and contravariant wrappers
 
 An unpacked `TypeVarTuple` keeps its precise inferred parameter types when a callable or callable
@@ -778,6 +1006,25 @@ reveal_type(infer_return_middle(fixed_middle))  # revealed: tuple[str]
 reveal_type(infer_return_middle(mixed_middle))  # revealed: tuple[str, ...]
 ```
 
+### Callable return inference with `Never` arguments
+
+A callable returning a variadic generic preserves the full specialized argument sequence, including
+required `Never` elements.
+
+```py
+from typing import Callable, Never
+
+class Container[*Ts]: ...
+
+def infer_return[*Ts](callback: Callable[[], Container[*Ts]]) -> Container[*Ts]:
+    raise NotImplementedError
+
+def callback() -> Container[int, Never]:
+    raise NotImplementedError
+
+reveal_type(infer_return(callback))  # revealed: Container[int, Never]
+```
+
 ### Callable inference with sub-call checking
 
 This usage pattern is similar to how `ParamSpec` can be used to accept a callable and its arguments
@@ -829,6 +1076,59 @@ def forward_mixed[*Ts](
     accept_mixed_forwarded(callback, args)
 ```
 
+### Callable inference with optional parameters
+
+When a callback's parameters have default values, it can be invoked without forwarding any
+arguments. The inferred type variable tuple must not treat those optional parameters as required.
+
+```py
+from functools import partial
+from typing import Callable
+
+def invoke[*Ts](callback: Callable[[*Ts], None], *args: *Ts) -> None: ...
+def optional(value: int = 1) -> None: ...
+def positional_only(value: int = 1, /) -> None: ...
+def multiple(first: int = 1, second: str = "") -> None: ...
+
+invoke(optional)
+invoke(positional_only)
+invoke(multiple)
+```
+
+The same signature rules apply to callable objects, bound methods, and partially applied functions.
+
+```py
+class Callback:
+    def __call__(self, value: int = 1) -> None: ...
+    def method(self, value: int = 1) -> None: ...
+
+def required(first: int, second: str = "") -> None: ...
+
+invoke(Callback())
+invoke(Callback().method)
+invoke(partial(required, 1))
+```
+
+### Protocol inference with optional parameters
+
+A structural protocol can be specialized with an empty type variable tuple when its implementation
+has only optional method parameters. Forwarding an empty argument sequence must remain valid.
+
+```py
+from typing import Protocol
+
+class Runner[*Ts](Protocol):
+    def run(self, *args: *Ts) -> None: ...
+
+def invoke[*Ts](runner: Runner[*Ts], *args: *Ts) -> None: ...
+
+class OptionalRunner:
+    def run(self, value: int = 0) -> None: ...
+
+empty: Runner[()] = OptionalRunner()
+invoke(OptionalRunner())
+```
+
 ### Callable inference through nested callable parameters
 
 Nested callable parameters make the pack covariant, but inference currently loses its fixed length.
@@ -855,8 +1155,8 @@ def check(value: int, other: str) -> None:
 
 ### Starred variadic tuple normalization
 
-A fixed provided tuple containing `Never` keeps its shape during tuple-level constraint inference.
-Its `Never` element must not be discarded or replaced by an unknown-length tuple.
+A variadic argument sequence containing `Never` keeps its shape during constraint inference. The
+resulting runtime tuple is uninhabited but retains its shape for display.
 
 ```py
 from typing import Never
@@ -869,6 +1169,8 @@ def collect_prefixed[*Ts](*args: *tuple[int, *Ts]) -> tuple[*Ts]:
 
 def check_never(value: Never) -> None:
     reveal_type(collect(value))  # revealed: tuple[Never]
+
+def check_prefixed_never(value: Never) -> None:
     reveal_type(collect_prefixed(1, value))  # revealed: tuple[Never]
 ```
 
@@ -1319,6 +1621,24 @@ type Padded[T] = Container[T, Never]
 
 def _(value: Padded[int]) -> None:
     reveal_type(value)  # revealed: Container[int, Never]
+```
+
+### Union aliases containing variadic specializations
+
+A generic union must retain a concrete alternative that is not redundant for every specialization of
+its variadic parameter.
+
+```py
+class Container[*Ts]:
+    value: tuple[*Ts]
+
+type Unioned[*Ts] = Container[*Ts] | Container[int]
+
+def check(value: Unioned[()]) -> None:
+    reveal_type(value)  # revealed: Container[()] | Container[int]
+
+def accepts(value: Container[int]) -> Unioned[()]:
+    return value
 ```
 
 ### Unpacked tuple type arguments

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -1247,6 +1247,36 @@ def finite_alias_union(x: NonRecursiveId[NestedNoneAlias], condition: bool):
     reveal_type(x if condition else 1)  # revealed: None | Literal[1]
 ```
 
+### Non-recursive callable aliases with distinct specializations
+
+Expanding two specializations of the same callable alias must apply each specialization separately.
+Reusing the first expansion would incorrectly make callbacks with different return types or
+parameter types equivalent.
+
+```py
+from collections.abc import Callable
+
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+
+type Producer[T] = Callable[[], T]
+type Consumer[T] = Callable[[T], None]
+
+static_assert(not is_assignable_to(Producer[int], Producer[str]))
+static_assert(not is_subtype_of(Producer[int], Producer[str]))
+static_assert(not is_equivalent_to(Producer[int], Producer[str]))
+
+static_assert(is_subtype_of(Producer[bool], Producer[int]))
+static_assert(not is_subtype_of(Producer[int], Producer[bool]))
+
+static_assert(not is_equivalent_to(Consumer[int], Consumer[str]))
+static_assert(is_subtype_of(Consumer[int], Consumer[bool]))
+static_assert(not is_subtype_of(Consumer[bool], Consumer[int]))
+
+def incompatible_producer(value: Producer[int]) -> Producer[str]:
+    return value  # error: [invalid-return-type]
+```
+
 ### Non-recursive generic union aliases
 
 Avoiding relation checks while a potentially recursive alias body is rebuilt must not prevent

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -1001,20 +1001,211 @@ type WrappedRight[T] = tuple[Box[Box[WrappedRight[list[T]]]]]
 static_assert(not is_subtype_of(WrappedLeft[int], WrappedRight[int]))
 ```
 
+### Inhabited recursive generic aliases with tuple alternatives
+
+A recursive tuple alternative does not make an alias uninhabited when another union alternative
+contains values.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[Recursive[T]] | int
+
+def accepts_recursive(value: Recursive[int]) -> None:
+    reveal_type(value)  # revealed: tuple[Recursive[int]] | int
+
+static_assert(not is_equivalent_to(Recursive[int], Never))
+```
+
+### Inhabited recursive generic aliases with growing specializations
+
+The alias definition must also be recognized when its specialization grows on each recursive
+reference.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Growing[T] = tuple[Growing[list[T]]] | int
+
+def accepts_growing(value: Growing[int]) -> None:
+    reveal_type(value)  # revealed: tuple[Growing[list[int]]] | int
+
+static_assert(not is_equivalent_to(Growing[int], Never))
+```
+
+The recursive reference must not hide an element whose specialization determines whether the alias
+has any inhabitants.
+
+```py
+type ParameterDependent[T] = tuple[ParameterDependent[list[T]], T] | T
+
+static_assert(is_equivalent_to(ParameterDependent[Never], Never))
+static_assert(not is_equivalent_to(ParameterDependent[int], Never))
+```
+
+That specialization-dependent inhabitance must also determine whether a homogeneous tuple has only
+its empty value.
+
+```py
+type ParameterSequence[T] = tuple[ParameterDependent[T], ...]
+
+static_assert(is_equivalent_to(ParameterSequence[Never], tuple[()]))
+static_assert(not is_equivalent_to(ParameterSequence[int], tuple[()]))
+```
+
+### Mutually recursive generic aliases with tuple alternatives
+
+The same reasoning applies when two aliases refer to one another.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Left[T] = tuple[Right[T]] | int
+type Right[T] = tuple[Left[T]] | str
+
+def accepts_mutually_recursive(value: Left[int]) -> None:
+    reveal_type(value)  # revealed: tuple[Right[int]] | int
+
+static_assert(not is_equivalent_to(Left[int], Never))
+```
+
+### Homogeneous recursive generic tuple aliases
+
+A homogeneous tuple can always be empty, even when its element type refers back to the same alias.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[Recursive[T], ...]
+
+def accepts_recursive(value: Recursive[int]) -> None:
+    reveal_type(value)  # revealed: tuple[Recursive[int], ...]
+
+static_assert(not is_equivalent_to(Recursive[int], Never))
+```
+
+An actually uninhabited recursive element must still normalize a homogeneous tuple to its empty
+tuple value.
+
+```py
+type Empty[T] = tuple[Empty[list[T]], Never]
+type EmptySequence[T] = tuple[Empty[T], ...]
+
+static_assert(is_equivalent_to(EmptySequence[int], tuple[()]))
+```
+
+The same recursion is safe when each reference introduces a more deeply nested specialization.
+
+```py
+type Growing[T] = tuple[Growing[list[T]], ...]
+
+static_assert(not is_equivalent_to(Growing[int], Never))
+```
+
+### Homogeneous recursive generic aliases nested inside tuples
+
+An extra tuple between a homogeneous element and its recursive alias must not hide the recursive
+definition when each specialization grows.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[tuple[Recursive[list[T]]], ...]
+
+def accepts_recursive(value: Recursive[int]) -> None: ...
+
+static_assert(not is_equivalent_to(Recursive[int], Never))
+```
+
+The same recursive definition can also be hidden behind a non-recursive generic alias.
+
+```py
+type Box[T] = tuple[T]
+type Wrapped[T] = tuple[Box[Wrapped[list[T]]], ...] | T
+
+static_assert(not is_equivalent_to(Wrapped[Never], Never))
+```
+
+### Homogeneous recursive generic aliases nested inside unions
+
+A union inside the homogeneous element must preserve the same recursive definition identity, even
+when another alternative specializes to `Never`.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[Recursive[list[T]] | T, ...]
+
+def accepts_recursive(value: Recursive[int]) -> None: ...
+
+static_assert(not is_equivalent_to(Recursive[int], Never))
+static_assert(not is_equivalent_to(Recursive[Never], Never))
+```
+
+### Recursive variadic generic aliases
+
+Recursive aliases can preserve a variable number of type arguments while retaining an inhabited
+union alternative.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[*Ts] = tuple[Recursive[*Ts]] | int
+
+def accepts_recursive(value: Recursive[int, str]) -> None:
+    reveal_type(value)  # revealed: tuple[Recursive[int, str]] | int
+
+static_assert(not is_equivalent_to(Recursive[int, str], Never))
+```
+
+### Growing recursive aliases with uninhabited elements
+
+A recursively growing specialization does not prevent another required tuple element from proving
+that the alias is uninhabited.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Empty[T] = tuple[Empty[list[T]], Never]
+
+static_assert(is_equivalent_to(Empty[int], Never))
+```
+
 ### Non-recursive nested generic aliases
 
 A repeated use of the same generic alias can be a finite alias application instead of recursion.
 
 ```py
-from typing import Literal
+from typing import Literal, Never
 
 from ty_extensions import static_assert
-from ty_extensions._internal import is_subtype_of
+from ty_extensions._internal import is_equivalent_to, is_subtype_of
 
 type NonRecursiveId[T] = T
 
 static_assert(is_subtype_of(NonRecursiveId[NonRecursiveId[int]], int))
 static_assert(not is_subtype_of(NonRecursiveId[NonRecursiveId[int]], str))
+
+type NonRecursiveTuple[T] = tuple[T]
+
+static_assert(is_equivalent_to(NonRecursiveTuple[NonRecursiveTuple[Never]], Never))
+static_assert(is_equivalent_to(NonRecursiveTuple[NonRecursiveTuple[NonRecursiveTuple[Never]]], Never))
 
 truth: NonRecursiveId[NonRecursiveId[Literal[True]]] = True
 static_assert(truth)
@@ -1054,6 +1245,21 @@ type NestedNoneAlias = NonRecursiveId[NoneAlias]
 
 def finite_alias_union(x: NonRecursiveId[NestedNoneAlias], condition: bool):
     reveal_type(x if condition else 1)  # revealed: None | Literal[1]
+```
+
+### Non-recursive generic union aliases
+
+Avoiding relation checks while a potentially recursive alias body is rebuilt must not prevent
+ordinary, non-recursive generic aliases from exposing their simplified values.
+
+```py
+class Parent: ...
+class Child(Parent): ...
+
+type Alias[T] = T | Parent
+
+def reveal_alias(value: Alias[Child]) -> None:
+    reveal_type(value)  # revealed: Parent
 ```
 
 ### Generic self-recursive aliases with deeper specializations
@@ -1106,6 +1312,22 @@ def stable_wrapped(x: StableWrapped[int], y: StableWrapped[str]):
     x = y
     # error: [invalid-assignment] "Object of type `StableWrapped[int]` is not assignable to `StableWrapped[str]`"
     y = x
+```
+
+### Materializations of recursive homogeneous tuple aliases
+
+Top and bottom materializations must preserve the empty tuple that inhabits a recursively defined
+homogeneous tuple, even when its specialization grows at each recursive reference.
+
+```py
+from typing import Any, Never
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[Recursive[list[T]], ...] | T
+
+static_assert(not is_equivalent_to(Top[Recursive[Any]], Never))
+static_assert(not is_equivalent_to(Bottom[Recursive[Any]], Never))
 ```
 
 ### Subtyping of materializations of cyclic aliases

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -353,6 +353,59 @@ reveal_type(f12(1))  # revealed: ((int, /) -> bool) | None
 reveal_type(f13(1))  # revealed: ((bool, /) -> Invariant[int]) | None
 ```
 
+## Variadic constructor promotion follows parameter variance
+
+Variadic type parameters follow the same promotion rules as ordinary type parameters. Covariant and
+bivariant arguments retain their literal types, while invariant and contravariant arguments are
+promoted.
+
+```py
+from typing import Literal
+
+class Bivariant[*Ts]:
+    def __init__(self, *values: *Ts) -> None: ...
+
+class Covariant[*Ts]:
+    def __init__(self, *values: *Ts) -> None: ...
+    def get(self) -> tuple[*Ts]:
+        raise NotImplementedError
+
+class Contravariant[*Ts]:
+    def __init__(self, *values: *Ts) -> None: ...
+    def put(self, *values: *Ts) -> None: ...
+
+class Invariant[*Ts]:
+    values: tuple[*Ts]
+
+    def __init__(self, *values: *Ts) -> None: ...
+
+reveal_type(Bivariant(1))  # revealed: Bivariant[Literal[1]]
+reveal_type(Covariant(1))  # revealed: Covariant[Literal[1]]
+reveal_type(Contravariant(1))  # revealed: Contravariant[int]
+reveal_type(Invariant(1))  # revealed: Invariant[int]
+
+precise: Covariant[Literal[1]] = Covariant(1)
+```
+
+Explicitly declared legacy variance follows the same rules.
+
+```py
+from typing import Generic
+from typing_extensions import TypeVarTuple
+
+Ts_co = TypeVarTuple("Ts_co", covariant=True)
+Ts_invariant = TypeVarTuple("Ts_invariant")
+
+class LegacyCovariant(Generic[*Ts_co]):
+    def __init__(self, *values: *Ts_co) -> None: ...
+
+class LegacyInvariant(Generic[*Ts_invariant]):
+    def __init__(self, *values: *Ts_invariant) -> None: ...
+
+reveal_type(LegacyCovariant(1))  # revealed: LegacyCovariant[Literal[1]]
+reveal_type(LegacyInvariant(1))  # revealed: LegacyInvariant[int]
+```
+
 ## Promotion is recursive
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -171,6 +171,29 @@ class TupleSubclass(tuple[int, str]): ...
 static_assert(is_subtype_of(TupleSubclass, IntFromZeroSubscript))
 ```
 
+## Indexing a tuple with an uninhabited homogeneous portion
+
+If a variable-length portion has an uninhabited element type, it contributes no elements. Indexing
+therefore sees only the fixed prefix and suffix.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Never
+
+def read(empty: tuple[tuple[Never], ...], fixed: tuple[int, *tuple[tuple[Never], ...], str]) -> None:
+    reveal_type(empty)  # revealed: tuple[()]
+    empty[0]  # error: [index-out-of-bounds]
+
+    reveal_type(fixed)  # revealed: tuple[int, str]
+    reveal_type(fixed[0])  # revealed: int
+    reveal_type(fixed[1])  # revealed: str
+    fixed[2]  # error: [index-out-of-bounds]
+```
+
 ## Slices
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -359,7 +359,7 @@ from ty_extensions._internal import is_equivalent_to
 from typing_extensions import Never, Union
 
 static_assert(is_equivalent_to(type, type[object]))
-static_assert(is_equivalent_to(tuple[Never, ...], tuple[()]))
+static_assert(is_equivalent_to(tuple[int, Never], Never))
 static_assert(is_equivalent_to(int | str, Union[int, str]))
 
 static_assert(not is_equivalent_to(int, str))

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
@@ -171,19 +171,18 @@ x: list[Never] = []
 
 ## Tuples involving `Never`
 
-A type like `tuple[int, Never]` remains distinct from `Never`. A tuple annotation can describe
-user-defined subclasses, so its element types remain part of the type:
+A type like `tuple[int, Never]` has no inhabitants, and so it is equivalent to `Never`:
 
 ```py
 from ty_extensions import static_assert
 from ty_extensions._internal import is_equivalent_to
 from typing_extensions import Never
 
-static_assert(not is_equivalent_to(tuple[int, Never], Never))
+static_assert(is_equivalent_to(tuple[int, Never], Never))
 ```
 
-The homogeneous tuple type `tuple[Never, ...]` is also distinct from `Never`: it is inhabited by the
-empty tuple.
+Note that this is not the case for the homogenous tuple type `tuple[Never, ...]` though, because
+that type is inhabited by the empty tuple:
 
 ```py
 static_assert(not is_equivalent_to(tuple[Never, ...], Never))

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -227,18 +227,17 @@ static_assert(not is_singleton(tuple[None]))
 python-version = "3.11"
 ```
 
-The `Never` type contains no inhabitants, but a tuple annotation can also describe user-defined
-subclasses. A tuple type containing `Never` as a mandatory element therefore retains its shape
-instead of simplifying to `Never`.
+The `Never` type contains no inhabitants, so a tuple type that contains `Never` as a mandatory
+element also contains no inhabitants.
 
 ```py
 from typing import Never
 from ty_extensions import static_assert
 from ty_extensions._internal import is_equivalent_to
 
-static_assert(not is_equivalent_to(tuple[Never], Never))
-static_assert(not is_equivalent_to(tuple[int, Never], Never))
-static_assert(not is_equivalent_to(tuple[Never, *tuple[int, ...]], Never))
+static_assert(is_equivalent_to(tuple[Never], Never))
+static_assert(is_equivalent_to(tuple[int, Never], Never))
+static_assert(is_equivalent_to(tuple[Never, *tuple[int, ...]], Never))
 ```
 
 Tuple expressions also preserve their element types when an element has type `Never`.
@@ -261,6 +260,16 @@ static_assert(is_equivalent_to(tuple[Never, ...], tuple[()]))
 static_assert(is_equivalent_to(tuple[int, *tuple[Never, ...]], tuple[int]))
 static_assert(is_equivalent_to(tuple[int, *tuple[Never, ...], int], tuple[int, int]))
 static_assert(is_equivalent_to(tuple[*tuple[Never, ...], int], tuple[int]))
+```
+
+An element type that is only equivalent to `Never`, such as an uninhabited tuple, also forces the
+variable-length portion to be empty.
+
+```py
+static_assert(is_equivalent_to(tuple[tuple[Never], ...], tuple[()]))
+static_assert(is_equivalent_to(tuple[int, *tuple[tuple[Never], ...]], tuple[int]))
+static_assert(is_equivalent_to(tuple[int, *tuple[tuple[Never], ...], str], tuple[int, str]))
+static_assert(is_equivalent_to(tuple[*tuple[tuple[Never], ...], int], tuple[int]))
 ```
 
 ## Homogeneous non-empty tuples

--- a/crates/ty_python_semantic/resources/mdtest/type_form.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_form.md
@@ -229,6 +229,14 @@ def accept_gradual_and_bottom(dynamic: Any, bottom: Never) -> None:
     bottom_form: TypeForm[str] = bottom
 ```
 
+Other uninhabited types are also assignable to a `TypeForm` without reinterpreting the expression as
+a type.
+
+```py
+def accept_uninhabited_tuple(value: tuple[Never]) -> None:
+    form: TypeForm[str] = value
+```
+
 ## Union contexts
 
 If a union contains both `TypeForm` and non-`TypeForm` arms, ordinary expression inference should

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -839,9 +839,9 @@ from typing_extensions import Any, Never, Sequence
 from ty_extensions import static_assert
 from ty_extensions._internal import is_assignable_to
 
-# The bottom materialization of `tuple[Any]` is `tuple[Never]`. Both
-# `tuple[int]` and `tuple[()]` are disjoint from `tuple[Never]`, so they are
-# assignable to `~tuple[Any]`.
+# The bottom materialization of `tuple[Any]` is `tuple[Never]`,
+# which simplifies to `Never`, so `tuple[int]` and `tuple[()]` are
+# both assignable to `~tuple[Any]`
 static_assert(is_assignable_to(tuple[int], ~tuple[Any]))
 static_assert(is_assignable_to(tuple[()], ~tuple[Any]))
 
@@ -990,6 +990,31 @@ static_assert(is_assignable_to(Any & int, Never))
 static_assert(is_assignable_to(Unknown & int, Never))
 static_assert(not is_assignable_to(Any | int, Never))
 static_assert(not is_assignable_to(Unknown | int, Never))
+```
+
+### Assignability to uninhabited tuples
+
+A tuple with a required `Never` element is equivalent to `Never`. Gradual types, bottom aliases, and
+classes that inherit from `Any` therefore retain their normal assignability to the bottom type.
+
+```py
+from typing import Any, Never
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_assignable_to
+
+type Bottom = Never
+
+class DynamicBase(Any): ...
+
+static_assert(is_assignable_to(Any, tuple[Never]))
+static_assert(is_assignable_to(Unknown, tuple[Never]))
+static_assert(is_assignable_to(Bottom, tuple[Never]))
+static_assert(is_assignable_to(DynamicBase, tuple[Never]))
+static_assert(not is_assignable_to(int, tuple[Never]))
+static_assert(not is_assignable_to(Any | int, tuple[Never]))
+
+def bounded[T: Never](value: T) -> tuple[Never]:
+    return value
 ```
 
 ## Callable

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -257,6 +257,60 @@ static_assert(not is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[int, ...
 static_assert(is_disjoint_from(tuple[int, int], tuple[None, ...]))  # error: [static-assert-error]
 ```
 
+## Tuple types containing `Never`
+
+A tuple with a required `Never` element has no inhabitants. It is equivalent to `Never` and is
+therefore disjoint from every type, including itself. Ordinary tuples with incompatible element
+types remain disjoint as well.
+
+```py
+from typing_extensions import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from, is_equivalent_to, is_subtype_of
+
+static_assert(is_equivalent_to(tuple[Never], Never))
+static_assert(is_disjoint_from(tuple[Never], tuple[Never]))
+static_assert(is_subtype_of(tuple[Never], tuple[int]))
+static_assert(is_subtype_of(tuple[Never], tuple[str]))
+static_assert(is_disjoint_from(tuple[Never], tuple[int]))
+static_assert(is_disjoint_from(tuple[int], tuple[str]))
+static_assert(is_disjoint_from(tuple[int, Never], tuple[int, str]))
+static_assert(is_disjoint_from(tuple[int, Never], tuple[str, Never]))
+static_assert(is_disjoint_from(tuple[Never], tuple[Never, int]))
+```
+
+A variable-length tuple whose element type is uninhabited can only have zero such elements. It is
+therefore disjoint from every tuple with a required element, but not from the empty tuple.
+
+```py
+static_assert(not is_disjoint_from(tuple[tuple[Never], ...], tuple[()]))
+static_assert(is_disjoint_from(tuple[tuple[Never], ...], tuple[int]))
+```
+
+Subclasses of uninhabited tuple types are similarly disjoint from themselves and every other type.
+
+```py
+class UninhabitedTupleSubclass(tuple[int, Never]): ...
+class IndirectUninhabitedTupleSubclass(UninhabitedTupleSubclass): ...
+
+static_assert(is_disjoint_from(UninhabitedTupleSubclass, UninhabitedTupleSubclass))
+static_assert(is_disjoint_from(IndirectUninhabitedTupleSubclass, int))
+```
+
+A generic tuple subclass can be empty for one specialization and inhabited for another, even though
+both specializations have the same class origin.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class GenericTupleSubclass(tuple[T], Generic[T]): ...
+
+static_assert(is_disjoint_from(GenericTupleSubclass[Never], GenericTupleSubclass[Never]))
+static_assert(not is_disjoint_from(GenericTupleSubclass[int], GenericTupleSubclass[int]))
+```
+
 ## Unions
 
 A union is disjoint from another type when none of its alternatives overlap that type.
@@ -1464,4 +1518,49 @@ static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericF
 static_assert(not is_disjoint_from(TypeOf[GenericFinalClass], type[GenericFinalClass[int]]))
 static_assert(not is_disjoint_from(TypeOf[GenericFinalClass[int]], type[GenericFinalClass[int]]))
 static_assert(is_disjoint_from(TypeOf[GenericFinalClass[str]], type[GenericFinalClass[int]]))
+```
+
+## Variadic generic arguments containing `Never`
+
+A variadic generic specialization can be inhabited even when one of its type arguments is `Never`. A
+writable attribute makes the type variable tuple invariant, so specializations with incompatible
+type arguments are still disjoint.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
+
+# Although `tuple` is covariant, the mutable attribute makes `Container` invariant.
+class Container[*Ts]:
+    values: tuple[*Ts]
+
+static_assert(not is_disjoint_from(Container[int, Never], Container[int, Never]))
+static_assert(not is_disjoint_from(Container[int, Never], Container[int, Any]))
+
+static_assert(not is_subtype_of(Container[Never, Never], Container[int, Never]))
+static_assert(not is_subtype_of(Container[Never, Never], Container[str, Never]))
+static_assert(is_disjoint_from(Container[int, Never], Container[str, Never]))
+
+static_assert(is_disjoint_from(Container[int, Never], Container[int, Never, Never]))
+static_assert(is_disjoint_from(Container[int, Never], Container[Never, int]))
+```
+
+If the type variable tuple appears only in covariant positions, as in a `tuple[*Ts]` return type, it
+is covariant. In that case, `CovariantContainer[Never, Never]` is a common subtype, so the two
+specializations are not disjoint.
+
+```py
+class CovariantContainer[*Ts]:
+    def values(self) -> tuple[*Ts]:
+        raise NotImplementedError
+
+static_assert(is_subtype_of(CovariantContainer[Never, Never], CovariantContainer[int, Never]))
+static_assert(is_subtype_of(CovariantContainer[Never, Never], CovariantContainer[str, Never]))
+static_assert(not is_disjoint_from(CovariantContainer[int, Never], CovariantContainer[str, Never]))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -557,6 +557,20 @@ static_assert(not is_subtype_of(int, ~Literal[3]))
 static_assert(not is_subtype_of(Literal[1], int & ~Literal[1]))
 ```
 
+## Complements of uninhabited tuples
+
+The complement of an uninhabited tuple contains every object, just like the complement of `Never`.
+
+```pyi
+from typing_extensions import Any, Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to, is_subtype_of
+
+static_assert(is_equivalent_to(~tuple[Never, int], object))
+static_assert(is_subtype_of(Any, ~tuple[Never, int]))
+static_assert(is_subtype_of(object, ~tuple[Never, int]))
+```
+
 ## Intersections with non-fully-static negated elements
 
 A type can be a _subtype_ of an intersection containing negated elements only if the _top_
@@ -1445,9 +1459,14 @@ type Bottom = Never
 
 def rejects_keywords(*args: *tuple[*tuple[int, ...], int], **kwargs: Bottom) -> None: ...
 def rejects_named_keyword(*args: *tuple[*tuple[int, ...], int], a: Never = cast(Never, 0)) -> None: ...
+def rejects_impossible_keywords(
+    *args: *tuple[*tuple[int, ...], int],
+    **kwargs: tuple[Never],
+) -> None: ...
 
 static_assert(is_subtype_of(OccupiesKeyword, RegularCallableTypeOf[rejects_keywords]))
 static_assert(is_subtype_of(OccupiesKeyword, RegularCallableTypeOf[rejects_named_keyword]))
+static_assert(is_subtype_of(OccupiesKeyword, RegularCallableTypeOf[rejects_impossible_keywords]))
 ```
 
 Equivalent empty or fixed-length unpacked parameters are compatible, but cannot be reused for

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -294,13 +294,13 @@ from ty_extensions import Bottom, Top, static_assert
 from ty_extensions._internal import Unknown, is_equivalent_to
 
 static_assert(is_equivalent_to(Top[tuple[Any, int]], tuple[object, int]))
-static_assert(is_equivalent_to(Bottom[tuple[Any, int]], tuple[Never, int]))
+static_assert(is_equivalent_to(Bottom[tuple[Any, int]], Never))
 
 static_assert(is_equivalent_to(Top[tuple[Unknown, int]], tuple[object, int]))
-static_assert(is_equivalent_to(Bottom[tuple[Unknown, int]], tuple[Never, int]))
+static_assert(is_equivalent_to(Bottom[tuple[Unknown, int]], Never))
 
 static_assert(is_equivalent_to(Top[tuple[Any, int, Unknown]], tuple[object, int, object]))
-static_assert(is_equivalent_to(Bottom[tuple[Any, int, Unknown]], tuple[Never, int, Never]))
+static_assert(is_equivalent_to(Bottom[tuple[Any, int, Unknown]], Never))
 ```
 
 Except for when the tuple itself is in a contravariant position, then all positions in the tuple
@@ -469,9 +469,9 @@ from ty_extensions._internal import Unknown, is_equivalent_to
 static_assert(is_equivalent_to(Top[~Any], object))
 static_assert(is_equivalent_to(Bottom[~Any], Never))
 
-# tuple[Any, int] is in a contravariant position, so its top
-# materialization negates the tuple's bottom materialization.
-static_assert(is_equivalent_to(Top[~tuple[Any, int]], ~tuple[Never, int]))
+# tuple[Any, int] is in a contravariant position, so the
+# top materialization is Never and the negation of it
+static_assert(is_equivalent_to(Top[~tuple[Any, int]], object))
 static_assert(is_equivalent_to(Bottom[~tuple[Any, int]], ~tuple[object, int]))
 ```
 
@@ -681,6 +681,52 @@ def covariant(top: Top[CovariantCallable], bottom: Bottom[CovariantCallable]) ->
 def contravariant(top: Top[ContravariantCallable], bottom: Bottom[ContravariantCallable]) -> None:
     reveal_type(top)  # revealed: (GenericContravariant[object], /) -> None
     reveal_type(bottom)  # revealed: (GenericContravariant[Never], /) -> None
+```
+
+## Variadic generic arguments containing `Never`
+
+Materialization acts on every variadic type argument, even when another required argument is
+`Never`. Covariant arguments preserve the surrounding variance and contravariant arguments flip it.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, Never
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+class Covariant[*Ts]:
+    def get(self) -> tuple[*Ts]:
+        raise NotImplementedError
+
+class Contravariant[*Ts]:
+    def put(self, value: tuple[*Ts]) -> None: ...
+
+class Invariant[*Ts]:
+    values: tuple[*Ts]
+
+static_assert(is_equivalent_to(Top[Covariant[Any, Never]], Covariant[object, Never]))
+static_assert(is_equivalent_to(Bottom[Covariant[Any, Never]], Covariant[Never, Never]))
+static_assert(is_equivalent_to(Top[Contravariant[Any, Never]], Contravariant[Never, Never]))
+static_assert(is_equivalent_to(Bottom[Contravariant[Any, Never]], Contravariant[object, Never]))
+
+def check(top: Top[Invariant[Any, Never]], bottom: Bottom[Invariant[Any, Never]]) -> None:
+    reveal_type(top)  # revealed: Top[Invariant[Any, Never]]
+    reveal_type(bottom)  # revealed: Bottom[Invariant[Any, Never]]
+```
+
+An unbounded sequence of `Never` elements can only contain zero elements, so materializing an
+unbounded gradual pack normalizes it to an empty sequence.
+
+```py
+static_assert(is_equivalent_to(Bottom[Covariant[*tuple[Any, ...]]], Covariant[()]))
+static_assert(is_equivalent_to(Top[Contravariant[*tuple[Any, ...]]], Contravariant[()]))
+
+def normalized(value: Bottom[Covariant[*tuple[Any, ...]]]) -> Covariant[()]:
+    return value
 ```
 
 ## Bounded generic type parameters

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/tuples_containing_never.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/tuples_containing_never.md
@@ -1,25 +1,56 @@
 # Tuples containing `Never`
 
-A heterogeneous `tuple[…]` type that contains `Never` remains distinct from `Never`. Tuple types
-include user-defined subclasses, so their element types must not be discarded solely because an
-ordinary tuple with those elements cannot be constructed.
+A heterogeneous `tuple[…]` type that contains `Never` as a type argument is equivalent to `Never`,
+but retains its shape for display. One way to think about this is the following: in order to
+construct a tuple, you need to have an object of every element type. But since there is no object of
+type `Never`, you cannot construct the tuple. Such a tuple type is therefore uninhabited and
+equivalent to `Never`.
+
+In the language of algebraic data types, a tuple type is a product type and `Never` acts like the
+zero element in multiplication, similar to how a Cartesian product with the empty set is the empty
+set.
 
 ```py
 from ty_extensions import static_assert
 from ty_extensions._internal import is_equivalent_to
 from typing_extensions import Never, NoReturn
 
-static_assert(not is_equivalent_to(Never, tuple[Never]))
-static_assert(not is_equivalent_to(Never, tuple[Never, int]))
-static_assert(not is_equivalent_to(Never, tuple[int, Never]))
-static_assert(not is_equivalent_to(Never, tuple[int, Never, str]))
-static_assert(not is_equivalent_to(Never, tuple[int, tuple[str, Never]]))
-static_assert(not is_equivalent_to(Never, tuple[tuple[str, Never], int]))
+static_assert(is_equivalent_to(Never, tuple[Never]))
+static_assert(is_equivalent_to(Never, tuple[Never, int]))
+static_assert(is_equivalent_to(Never, tuple[int, Never]))
+static_assert(is_equivalent_to(Never, tuple[int, Never, str]))
+static_assert(is_equivalent_to(Never, tuple[int, tuple[str, Never]]))
+static_assert(is_equivalent_to(Never, tuple[tuple[str, Never], int]))
 
-def _(x: tuple[Never], y: tuple[int, Never], z: tuple[Never, int]):
+def one_element(x: tuple[Never]) -> None:
     reveal_type(x)  # revealed: tuple[Never]
+
+def never_last(y: tuple[int, Never]) -> None:
     reveal_type(y)  # revealed: tuple[int, Never]
+
+def never_first(z: tuple[Never, int]) -> None:
     reveal_type(z)  # revealed: tuple[Never, int]
+```
+
+A type alias cannot make an uninhabited tuple element inhabitable.
+
+```py
+from typing_extensions import TypeAlias
+
+Bottom: TypeAlias = Never
+
+static_assert(is_equivalent_to(Never, tuple[Bottom]))
+static_assert(is_equivalent_to(Never, tuple[int, tuple[Bottom]]))
+```
+
+A subclass of an uninhabited tuple type is also uninhabited, including through indirect inheritance.
+
+```py
+class UninhabitedTupleSubclass(tuple[int, Never]): ...
+class IndirectUninhabitedTupleSubclass(UninhabitedTupleSubclass): ...
+
+static_assert(is_equivalent_to(UninhabitedTupleSubclass, Never))
+static_assert(is_equivalent_to(IndirectUninhabitedTupleSubclass, Never))
 ```
 
 The empty `tuple` is *not* equivalent to `Never`!
@@ -28,13 +59,13 @@ The empty `tuple` is *not* equivalent to `Never`!
 static_assert(not is_equivalent_to(Never, tuple[()]))
 ```
 
-`NoReturn` is just a different spelling of `Never`, so these tuple types also retain their shape:
+`NoReturn` is just a different spelling of `Never`, so the same is true for `NoReturn`:
 
 ```py
-static_assert(not is_equivalent_to(NoReturn, tuple[NoReturn]))
-static_assert(not is_equivalent_to(NoReturn, tuple[NoReturn, int]))
-static_assert(not is_equivalent_to(NoReturn, tuple[int, NoReturn]))
-static_assert(not is_equivalent_to(NoReturn, tuple[int, NoReturn, str]))
-static_assert(not is_equivalent_to(NoReturn, tuple[int, tuple[str, NoReturn]]))
-static_assert(not is_equivalent_to(NoReturn, tuple[tuple[str, NoReturn], int]))
+static_assert(is_equivalent_to(NoReturn, tuple[NoReturn]))
+static_assert(is_equivalent_to(NoReturn, tuple[NoReturn, int]))
+static_assert(is_equivalent_to(NoReturn, tuple[int, NoReturn]))
+static_assert(is_equivalent_to(NoReturn, tuple[int, NoReturn, str]))
+static_assert(is_equivalent_to(NoReturn, tuple[int, tuple[str, NoReturn]]))
+static_assert(is_equivalent_to(NoReturn, tuple[tuple[str, NoReturn], int]))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -7146,10 +7146,14 @@ type Bottom = Never
 class AliasedExtra(TypedDict, extra_items=Bottom):
     x: int
 
+class UninhabitedTupleExtra(TypedDict, extra_items=tuple[Never]):
+    x: int
+
 static_assert(is_equivalent_to(Extra, Closed))
 static_assert(is_subtype_of(Extra, Closed))
 static_assert(is_subtype_of(Closed, Extra))
 static_assert(is_equivalent_to(AliasedExtra, Closed))
+static_assert(is_equivalent_to(UninhabitedTupleExtra, Closed))
 ```
 
 ### Empty closed TypedDict truthiness
@@ -7162,6 +7166,7 @@ from typing_extensions import Never, NotRequired, TypedDict
 
 class Empty(TypedDict, closed=True): ...
 class EmptyByNever(TypedDict, extra_items=Never): ...
+class EmptyByUninhabitedTuple(TypedDict, extra_items=tuple[Never]): ...
 
 class OptionalClosed(TypedDict, closed=True):
     value: NotRequired[int]
@@ -7169,19 +7174,26 @@ class OptionalClosed(TypedDict, closed=True):
 class ImpossibleOptionalClosed(TypedDict, closed=True):
     value: NotRequired[Never]
 
+class ImpossibleTupleOptionalClosed(TypedDict, closed=True):
+    value: NotRequired[tuple[Never]]
+
 class EmptyOpen(TypedDict): ...
 
 def _(
     empty: Empty,
     empty_by_never: EmptyByNever,
+    empty_by_uninhabited_tuple: EmptyByUninhabitedTuple,
     optional_closed: OptionalClosed,
     impossible_optional_closed: ImpossibleOptionalClosed,
+    impossible_tuple_optional_closed: ImpossibleTupleOptionalClosed,
     empty_open: EmptyOpen,
 ) -> None:
     reveal_type(bool(empty))  # revealed: Literal[False]
     reveal_type(bool(empty_by_never))  # revealed: Literal[False]
+    reveal_type(bool(empty_by_uninhabited_tuple))  # revealed: Literal[False]
     reveal_type(bool(optional_closed))  # revealed: bool
     reveal_type(bool(impossible_optional_closed))  # revealed: Literal[False]
+    reveal_type(bool(impossible_tuple_optional_closed))  # revealed: Literal[False]
     reveal_type(bool(empty_open))  # revealed: bool
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -393,9 +393,8 @@ def gradual_aliases(
     reveal_type(nested_last)  # revealed: Covariant[NestedGradualAlias]
 ```
 
-Matching top materializations do not establish that gradual tuple arguments have the same shape. A
-bounded generic must preserve which tuple position contains the gradual element, including in its
-bottom materialization.
+Matching materialization endpoints do not establish that gradual tuple arguments have the same
+shape. A bounded generic must preserve which tuple position contains the gradual element.
 
 ```py
 from ty_extensions import Bottom, Top, static_assert
@@ -409,7 +408,7 @@ class C[T: tuple[int, int]]:
         raise NotImplementedError
 
 static_assert(is_equivalent_to(Top[C[L]], Top[C[R]]))
-static_assert(not is_equivalent_to(Bottom[C[L]], Bottom[C[R]]))
+static_assert(is_equivalent_to(Bottom[C[L]], Bottom[C[R]]))
 static_assert(not is_equivalent_to(C[L], C[R]))
 static_assert(not is_equivalent_to(C[L] | C[R], C[L]))
 static_assert(not is_equivalent_to(C[R] | C[L], C[R]))

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -503,7 +503,9 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     // the current pattern will have to match. We return `AlwaysTrue` here, since the call to
     // `analyze_single_pattern_predicate_kind` below would return `Ambiguous` in this case.
     let next_narrowed_subject_ty = type_narrowed_by_pattern(db, predicate, narrowed_subject_ty);
-    if !narrowed_subject_ty.is_never() && next_narrowed_subject_ty.is_never() {
+    if !narrowed_subject_ty.is_uninhabited(db, &env)
+        && next_narrowed_subject_ty.is_uninhabited(db, &env)
+    {
         return Truthiness::AlwaysTrue;
     }
 
@@ -1518,7 +1520,7 @@ fn analyze_non_terminal_call<'db>(
     let mut any_overload_is_generic = false;
 
     for overload in overloads_iterator {
-        let returns_never = overload.return_ty.is_equivalent_to(db, &env, Type::Never);
+        let returns_never = overload.return_ty.is_uninhabited(db, &env);
         no_overloads_return_never &= !returns_never;
         all_overloads_return_never &= returns_never;
         any_overload_is_generic |= overload.return_ty.has_typevar(db, &env);
@@ -1530,7 +1532,7 @@ fn analyze_non_terminal_call<'db>(
         Truthiness::AlwaysFalse
     } else {
         let call_expr_ty = infer_same_file_expression_type(db, call_expr, TypeContext::default());
-        if call_expr_ty.is_equivalent_to(db, &env, Type::Never) {
+        if call_expr_ty.is_uninhabited(db, &env) {
             Truthiness::AlwaysFalse
         } else {
             Truthiness::AlwaysTrue

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2546,7 +2546,11 @@ impl<'db> Type<'db> {
 
             Type::NominalInstance(instance) if instance.is_object() => Type::Never,
 
-            Type::NominalInstance(instance) if instance.tuple_spec(db, env).is_some() => {
+            Type::NominalInstance(instance)
+                if instance
+                    .tuple_spec(db, env)
+                    .is_some_and(|tuple| tuple.fixed_elements().any(Type::may_be_uninhabited)) =>
+            {
                 IntersectionBuilder::new(db, env)
                     .add_negative(*self)
                     .build()

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -503,9 +503,12 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
     /// guards must remain shared so recursive aliases still terminate.
     fn for_new_mapping_root(&self) -> Self {
         let materialization_equivalence = OnceCell::new();
-        let was_empty =
-            materialization_equivalence.set(Rc::clone(self.materialization_equivalence()));
-        debug_assert!(was_empty.is_ok());
+        // Preserve an active equivalence guard, but do not allocate one just to specialize an
+        // ordinary alias that never compares materialized types.
+        if let Some(visitor) = self.materialization_equivalence.get() {
+            let was_empty = materialization_equivalence.set(Rc::clone(visitor));
+            debug_assert!(was_empty.is_ok());
+        }
 
         let alias_expansion = OnceCell::new();
         if let Some(visitor) = self.alias_expansion.get() {
@@ -1758,8 +1761,24 @@ impl<'db> Type<'db> {
     /// its tuple shape is preserved for display. Type aliases do not change inhabitance. Variadic
     /// type argument packs are not runtime tuples, so their `Never` elements remain meaningful.
     pub(crate) fn is_uninhabited(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
-        self.may_be_uninhabited()
-            && (*self == Type::Never || self.is_equivalent_to(db, env, Type::Never))
+        if *self == Type::Never {
+            return true;
+        }
+
+        if !self.may_be_uninhabited() {
+            return false;
+        }
+
+        if let Type::NominalInstance(instance) = self
+            && (instance.is_typevartuple_pack(db)
+                || instance
+                    .tuple_spec(db, env)
+                    .is_none_or(|tuple| !tuple.fixed_elements().any(Type::may_be_uninhabited)))
+        {
+            return false;
+        }
+
+        self.is_equivalent_to(db, env, Type::Never)
     }
 
     /// Avoid relation checks for type variants that always have at least one possible value.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -492,7 +492,14 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
             .visit_type(db, Type::TypeAlias(alias), expand)
     }
 
-    fn for_new_materialization_root(&self) -> Self {
+    /// Starts an independent type mapping without losing the surrounding recursion guards.
+    ///
+    /// Transformation caches are keyed by the input type, not the mapping being applied. Different
+    /// alias specializations or materialization roots therefore need separate caches: otherwise,
+    /// specializing the same `Callable[[], T]` body first with `int` and then with `str` would
+    /// incorrectly reuse the `Callable[[], int]` result for both. Alias-expansion and equivalence
+    /// guards must remain shared so recursive aliases still terminate.
+    fn for_new_mapping_root(&self) -> Self {
         let materialization_equivalence = OnceCell::new();
         let was_empty =
             materialization_equivalence.set(Rc::clone(self.materialization_equivalence()));

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -389,9 +389,11 @@ fn definition_expression_annotation<'db>(
 
 struct ApplyTypeMappingTag;
 struct ApplyMaterializationEquivalence;
+struct ExpandTypeAlias;
 
 type MaterializationEquivalenceVisitor<'db> =
     Rc<CycleDetector<'db, ApplyMaterializationEquivalence, (Type<'db>, Type<'db>), bool, 1>>;
+type TypeAliasExpansionVisitor<'db> = Rc<TypeTransformer<'db, ExpandTypeAlias>>;
 
 /// A [`TypeTransformer`] that is used in `apply_type_mapping` methods.
 ///
@@ -408,6 +410,7 @@ pub(crate) struct ApplyTypeMappingVisitor<'env, 'db> {
     promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     skip_promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
+    alias_expansion: OnceCell<TypeAliasExpansionVisitor<'db>>,
 }
 
 impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
@@ -422,6 +425,7 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
             promotion: OnceCell::default(),
             skip_promotion: OnceCell::default(),
             materialization_equivalence: OnceCell::default(),
+            alias_expansion: OnceCell::default(),
         }
     }
 
@@ -469,14 +473,40 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
             })
     }
 
+    fn is_uninhabited(&self, db: &'db dyn Db, ty: Type<'db>) -> bool {
+        ty == Type::Never || ty.is_equivalent_to_with_materialization_visitor(db, Type::Never, self)
+    }
+
+    /// Keep alias recursion visible through wrappers such as tuples, unions, and materialization.
+    ///
+    /// The transformer identifies recursive aliases by their definition, so growing
+    /// specializations encounter the same active visit even when their concrete types differ.
+    fn expand_alias(
+        &self,
+        db: &'db dyn Db,
+        alias: TypeAliasType<'db>,
+        expand: impl FnOnce() -> Type<'db>,
+    ) -> Type<'db> {
+        self.alias_expansion
+            .get_or_init(|| Rc::new(TypeTransformer::default()))
+            .visit_type(db, Type::TypeAlias(alias), expand)
+    }
+
     fn for_new_materialization_root(&self) -> Self {
         let materialization_equivalence = OnceCell::new();
         let was_empty =
             materialization_equivalence.set(Rc::clone(self.materialization_equivalence()));
         debug_assert!(was_empty.is_ok());
 
+        let alias_expansion = OnceCell::new();
+        if let Some(visitor) = self.alias_expansion.get() {
+            let was_empty = alias_expansion.set(Rc::clone(visitor));
+            debug_assert!(was_empty.is_ok());
+        }
+
         Self {
             materialization_equivalence,
+            alias_expansion,
             ..Self::new(self.env)
         }
     }
@@ -1713,15 +1743,13 @@ impl<'db> Type<'db> {
         )
     }
 
-    pub(crate) const fn is_never(&self) -> bool {
-        matches!(
-            self,
-            Type::Never
-                | Type::Divergent(DivergentType {
-                    materialization: Some(MaterializationKind::Bottom),
-                    ..
-                })
-        )
+    /// Returns whether this type has no inhabitants.
+    ///
+    /// A runtime tuple with a required uninhabited element is equivalent to `Never` even though
+    /// its tuple shape is preserved for display. Type aliases do not change inhabitance. Variadic
+    /// type argument packs are not runtime tuples, so their `Never` elements remain meaningful.
+    pub(crate) fn is_uninhabited(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
+        *self == Type::Never || self.is_equivalent_to(db, env, Type::Never)
     }
 
     /// Returns `true` if this type contains a `Self` type variable.
@@ -2505,7 +2533,6 @@ impl<'db> Type<'db> {
             | Type::TypeVar(_)
             | Type::TypedDict(_)
             | Type::NewTypeInstance(_)
-            | Type::NominalInstance(_)
             | Type::ProtocolInstance(_)
             | Type::ModuleLiteral(_)
             | Type::ClassLiteral(_)
@@ -2524,11 +2551,12 @@ impl<'db> Type<'db> {
                 NegativeIntersectionElements::Single(*self),
             )),
 
-            Type::Union(_) | Type::Intersection(_) | Type::EnumComplement(_) => {
-                IntersectionBuilder::new(db, env)
-                    .add_negative(*self)
-                    .build()
-            }
+            Type::NominalInstance(_)
+            | Type::Union(_)
+            | Type::Intersection(_)
+            | Type::EnumComplement(_) => IntersectionBuilder::new(db, env)
+                .add_negative(*self)
+                .build(),
         }
     }
 
@@ -7873,9 +7901,23 @@ impl<'db> Type<'db> {
                 property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             ),
 
-            Type::Union(union) => union.map_leave_aliases(db, visitor.env, |element| {
-                element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-            }),
+            Type::Union(union) => {
+                let transform = |element: &Type<'db>| {
+                    element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                };
+                if matches!(
+                    type_mapping,
+                    TypeMapping::ApplySpecialization(ApplySpecialization::TypeAlias(_))
+                        | TypeMapping::ApplySpecializationWithMaterialization {
+                            specialization: ApplySpecialization::TypeAlias(_),
+                            ..
+                        }
+                ) {
+                    union.map_leave_aliases_during_cycle_recovery(db, visitor.env, transform)
+                } else {
+                    union.map_leave_aliases(db, visitor.env, transform)
+                }
+            }
             Type::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db, visitor.env);
                 for positive in intersection.positive(db) {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -474,7 +474,9 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
     }
 
     fn is_uninhabited(&self, db: &'db dyn Db, ty: Type<'db>) -> bool {
-        ty == Type::Never || ty.is_equivalent_to_with_materialization_visitor(db, Type::Never, self)
+        ty.may_be_uninhabited()
+            && (ty == Type::Never
+                || ty.is_equivalent_to_with_materialization_visitor(db, Type::Never, self))
     }
 
     /// Keep alias recursion visible through wrappers such as tuples, unions, and materialization.
@@ -1756,7 +1758,24 @@ impl<'db> Type<'db> {
     /// its tuple shape is preserved for display. Type aliases do not change inhabitance. Variadic
     /// type argument packs are not runtime tuples, so their `Never` elements remain meaningful.
     pub(crate) fn is_uninhabited(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
-        *self == Type::Never || self.is_equivalent_to(db, env, Type::Never)
+        self.may_be_uninhabited()
+            && (*self == Type::Never || self.is_equivalent_to(db, env, Type::Never))
+    }
+
+    /// Avoid relation checks for type variants that always have at least one possible value.
+    const fn may_be_uninhabited(&self) -> bool {
+        matches!(
+            self,
+            Type::Never
+                | Type::Divergent(_)
+                | Type::NominalInstance(_)
+                | Type::SubclassOf(_)
+                | Type::Union(_)
+                | Type::Intersection(_)
+                | Type::EnumComplement(_)
+                | Type::TypeVar(_)
+                | Type::TypeAlias(_)
+        )
     }
 
     /// Returns `true` if this type contains a `Self` type variable.
@@ -2527,6 +2546,12 @@ impl<'db> Type<'db> {
 
             Type::NominalInstance(instance) if instance.is_object() => Type::Never,
 
+            Type::NominalInstance(instance) if instance.tuple_spec(db, env).is_some() => {
+                IntersectionBuilder::new(db, env)
+                    .add_negative(*self)
+                    .build()
+            }
+
             Type::AlwaysTruthy
             | Type::AlwaysFalsy
             | Type::KnownBoundMethod(_)
@@ -2552,18 +2577,18 @@ impl<'db> Type<'db> {
             | Type::Callable(_)
             | Type::WrapperDescriptor(_)
             | Type::TypeAlias(_)
+            | Type::NominalInstance(_)
             | Type::BoundMethod(_) => Type::Intersection(IntersectionType::new(
                 db,
                 FxOrderSet::default(),
                 NegativeIntersectionElements::Single(*self),
             )),
 
-            Type::NominalInstance(_)
-            | Type::Union(_)
-            | Type::Intersection(_)
-            | Type::EnumComplement(_) => IntersectionBuilder::new(db, env)
-                .add_negative(*self)
-                .build(),
+            Type::Union(_) | Type::Intersection(_) | Type::EnumComplement(_) => {
+                IntersectionBuilder::new(db, env)
+                    .add_negative(*self)
+                    .build()
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -680,8 +680,8 @@ pub(super) fn property_setter_returns_never<'db>(
     property_ty.as_property_instance().is_some_and(|property| {
         property.setter(db).is_some_and(|setter| {
             match setter.try_call(db, env, &CallArguments::positional([object_ty, value_ty])) {
-                Ok(result) => result.return_type(db, env).is_never(),
-                Err(error) => error.return_type(db, env).is_never(),
+                Ok(result) => result.return_type(db, env).is_uninhabited(db, env),
+                Err(error) => error.return_type(db, env).is_uninhabited(db, env),
             }
         })
     })

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -238,7 +238,10 @@ impl<'db> Type<'db> {
                 if td.items(db).values().any(TypedDictField::is_required) {
                     Truthiness::AlwaysTrue
                 } else if td.openness(db).is_closed()
-                    && td.items(db).values().all(|field| !field.may_be_present(db))
+                    && td
+                        .items(db)
+                        .values()
+                        .all(|field| !field.may_be_present(db, env))
                 {
                     Truthiness::AlwaysFalse
                 } else {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5905,8 +5905,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         // useful concrete information and would cause over-expansion.
                         let concrete_content = inferred_ty
                             .filter_union(db, self.env, |ty| !ty.has_typevar(db, self.env));
-                        if concrete_content.is_uninhabited(db, self.env)
-                            && inferred_ty.has_typevar(db, self.env)
+                        if concrete_content == Type::Never && inferred_ty.has_typevar(db, self.env)
                         {
                             continue;
                         }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -400,6 +400,7 @@ impl<'db> CallableItem<'db> {
                 env,
                 binding.partial_signature_applications(
                     db,
+                    env,
                     partial_overload,
                     bound_call_arguments,
                 )?,
@@ -1777,11 +1778,13 @@ impl<'db> Bindings<'db> {
                                 {
                                     // `property.__delete__` returns `None` for ordinary deleters,
                                     // but preserving `Never` keeps non-returning deleters divergent.
-                                    overload.set_return_type(if return_ty.is_never() {
-                                        return_ty
-                                    } else {
-                                        Type::none(db, env)
-                                    });
+                                    overload.set_return_type(
+                                        if return_ty.is_uninhabited(db, env) {
+                                            return_ty
+                                        } else {
+                                            Type::none(db, env)
+                                        },
+                                    );
                                 } else {
                                     overload.errors.push(BindingError::InternalCallError(
                                         "calling the deleter failed",
@@ -1820,11 +1823,13 @@ impl<'db> Bindings<'db> {
                                 {
                                     // `property.__delete__` returns `None` for ordinary deleters,
                                     // but preserving `Never` keeps non-returning deleters divergent.
-                                    overload.set_return_type(if return_ty.is_never() {
-                                        return_ty
-                                    } else {
-                                        Type::none(db, env)
-                                    });
+                                    overload.set_return_type(
+                                        if return_ty.is_uninhabited(db, env) {
+                                            return_ty
+                                        } else {
+                                            Type::none(db, env)
+                                        },
+                                    );
                                 } else {
                                     overload.errors.push(BindingError::InternalCallError(
                                         "calling the deleter failed",
@@ -3534,6 +3539,7 @@ impl<'db> CallableBinding<'db> {
     fn partial_signature_applications<'a>(
         &self,
         db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
         partial_overload: &mut Binding<'db>,
         bound_call_arguments: &CallArguments<'a, 'db>,
     ) -> Option<SmallVec<[PartialSignatureApplication<'db>; 1]>> {
@@ -3573,7 +3579,7 @@ impl<'db> CallableBinding<'db> {
             .into_iter()
             .filter_map(|index| {
                 self.overloads().get(index).map(|overload| {
-                    overload.partial_signature_application(db, signature_arguments.as_ref())
+                    overload.partial_signature_application(db, env, signature_arguments.as_ref())
                 })
             })
             .collect();
@@ -5899,7 +5905,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         // useful concrete information and would cause over-expansion.
                         let concrete_content = inferred_ty
                             .filter_union(db, self.env, |ty| !ty.has_typevar(db, self.env));
-                        if concrete_content.is_never() && inferred_ty.has_typevar(db, self.env) {
+                        if concrete_content.is_uninhabited(db, self.env)
+                            && inferred_ty.has_typevar(db, self.env)
+                        {
                             continue;
                         }
 
@@ -6263,7 +6271,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             && provided
                 .variable()
                 .homogeneous_type()
-                .is_some_and(|element| !element.resolve_type_alias(db).is_never())
+                .is_some_and(|element| !element.is_uninhabited(db, self.env))
         {
             // Expose required boundaries without discarding fixed values the splat already has.
             let target_length = TupleLength::Variable(
@@ -6284,7 +6292,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         }
 
         Some((
-            Type::tuple(TupleType::new(db, self.env, &actual)),
+            Type::tuple(TupleType::new(db, self.env, &actual)).into_typevartuple_pack(db),
             argument_indices,
         ))
     }
@@ -7264,7 +7272,7 @@ impl<'db> Binding<'db> {
                 let return_ty = bindings.return_type(db, env);
                 // `property.__set__` returns `None` for ordinary setters, but preserving `Never`
                 // keeps non-returning setters divergent.
-                self.set_return_type(if return_ty.is_never() {
+                self.set_return_type(if return_ty.is_uninhabited(db, env) {
                     return_ty
                 } else {
                     Type::none(db, env)
@@ -7945,7 +7953,7 @@ impl<'db> Binding<'db> {
 
         Some(if !can_synthesize_signature {
             imprecise_return_type
-        } else if new_return_type.is_never() {
+        } else if new_return_type == Type::Never {
             failed_synthesis_return_type
         } else {
             new_return_type
@@ -7976,7 +7984,12 @@ impl<'db> Binding<'db> {
     }
 
     /// Collects the parameter-level effects of a `functools.partial(...)` application.
-    fn partial_application(&self, arguments: &CallArguments<'_, 'db>) -> PartialApplication<'db> {
+    fn partial_application(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        arguments: &CallArguments<'_, 'db>,
+    ) -> PartialApplication<'db> {
         let parameters = self.signature.parameters().as_slice();
         let mut partial_application = PartialApplication::new(parameters.len());
 
@@ -7989,7 +8002,7 @@ impl<'db> Binding<'db> {
                         let parameter_index = matched_parameter.index;
                         let parameter = &parameters[parameter_index];
                         if parameter.is_positional()
-                            && parameter.annotated_type() != Type::Never
+                            && !parameter.annotated_type().is_uninhabited(db, env)
                             && !parameter.is_variadic()
                             && !parameter.is_keyword_variadic()
                         {
@@ -8014,7 +8027,7 @@ impl<'db> Binding<'db> {
 
                         partial_application.bind_by_keyword(
                             parameter_index,
-                            (parameter.annotated_type() != Type::Never).then(|| {
+                            (!parameter.annotated_type().is_uninhabited(db, env)).then(|| {
                                 matched_parameter.argument_type.unwrap_or_else(|| {
                                     argument_ty.get_default().unwrap_or_else(Type::unknown)
                                 })
@@ -8032,11 +8045,12 @@ impl<'db> Binding<'db> {
     fn partial_signature_application(
         &self,
         db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
         arguments: &CallArguments<'_, 'db>,
     ) -> PartialSignatureApplication<'db> {
         PartialSignatureApplication::new(
             self.signature.clone(),
-            self.partial_application(arguments),
+            self.partial_application(db, env, arguments),
             self.inference,
             self.unspecialized_return_type(db),
         )

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -413,7 +413,7 @@ impl<'db> ConstructorBinding<'db> {
                         .map(|mapped_ty| {
                             let without_unknown =
                                 mapped_ty.filter_union(db, env, |element| !element.is_unknown());
-                            let mapped_ty = if without_unknown.is_uninhabited(db, env) {
+                            let mapped_ty = if without_unknown == Type::Never {
                                 mapped_ty
                             } else {
                                 without_unknown

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -413,7 +413,7 @@ impl<'db> ConstructorBinding<'db> {
                         .map(|mapped_ty| {
                             let without_unknown =
                                 mapped_ty.filter_union(db, env, |element| !element.is_unknown());
-                            let mapped_ty = if without_unknown.is_never() {
+                            let mapped_ty = if without_unknown.is_uninhabited(db, env) {
                                 mapped_ty
                             } else {
                                 without_unknown

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -128,6 +128,8 @@ bitflags::bitflags! {
         const HAS_CUSTOM_GETATTRIBUTE = 1 << 2;
         /// An unknown base may provide an attribute-interception method.
         const HAS_DYNAMIC_GETATTRIBUTE = 1 << 3;
+        /// The class is, or inherits from, `tuple`.
+        const TUPLE_SUBCLASS = 1 << 4;
     }
 }
 
@@ -622,7 +624,7 @@ impl<'db> ClassLiteral<'db> {
         match self {
             Self::Static(literal) => literal.instance_flags(db),
             Self::DynamicTypedDict(_) => ClassInstanceFlags::TYPED_DICT,
-            Self::DynamicNamedTuple(_) => ClassInstanceFlags::empty(),
+            Self::DynamicNamedTuple(_) => ClassInstanceFlags::TUPLE_SUBCLASS,
             Self::Dynamic(literal) if literal.explicit_bases(db).is_empty() => {
                 ClassInstanceFlags::empty()
             }
@@ -630,11 +632,19 @@ impl<'db> ClassLiteral<'db> {
                 ClassInstanceFlags::empty()
             }
             Self::Dynamic(_) | Self::DynamicEnum(_) => {
-                if self.iter_mro(db).any(ClassBase::is_explicit_any_base) {
-                    ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY
-                } else {
-                    ClassInstanceFlags::empty()
+                let mut flags = ClassInstanceFlags::empty();
+                for base in self.iter_mro(db) {
+                    if base.is_explicit_any_base() {
+                        flags.insert(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY);
+                    }
+                    if base
+                        .into_class()
+                        .is_some_and(|class| class.known(db) == Some(KnownClass::Tuple))
+                    {
+                        flags.insert(ClassInstanceFlags::TUPLE_SUBCLASS);
+                    }
                 }
+                flags
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -927,25 +927,34 @@ impl<'db> StaticClassLiteral<'db> {
                         flags.insert(ClassInstanceFlags::HAS_DYNAMIC_GETATTRIBUTE);
                     }
                     ClassBase::TypedDict(_) => flags.insert(ClassInstanceFlags::TYPED_DICT),
-                    ClassBase::Class(class)
+                    ClassBase::Class(class) => {
+                        if class.known(db) == Some(KnownClass::Tuple) {
+                            flags.insert(ClassInstanceFlags::TUPLE_SUBCLASS);
+                        }
                         if class
                             .static_class_literal(db)
-                            .is_none_or(|(class, _)| class.has_own_custom_getattribute(db)) =>
-                    {
-                        flags.insert(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE);
+                            .is_none_or(|(class, _)| class.has_own_custom_getattribute(db))
+                        {
+                            flags.insert(ClassInstanceFlags::HAS_CUSTOM_GETATTRIBUTE);
+                        }
                     }
-                    ClassBase::Class(_) | ClassBase::Generic | ClassBase::Protocol => {}
+                    ClassBase::Generic | ClassBase::Protocol => {}
                 }
             }
             flags
         }
 
         let mut flags = if let Some(known) = self.known(db) {
-            if known.is_typed_dict_subclass() {
-                ClassInstanceFlags::TYPED_DICT
-            } else {
-                ClassInstanceFlags::empty()
-            }
+            let mut flags = ClassInstanceFlags::empty();
+            flags.set(
+                ClassInstanceFlags::TYPED_DICT,
+                known.is_typed_dict_subclass(),
+            );
+            flags.set(
+                ClassInstanceFlags::TUPLE_SUBCLASS,
+                known.is_tuple_subclass(),
+            );
+            flags
         } else if self.has_explicit_bases(db) {
             return instance_flags_inner(db, self);
         } else {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -4005,7 +4005,7 @@ impl<'db> PathBounds<'db> {
         let restricted = path_bound.restrict_gradual_solution(db, env, solution);
 
         // An empty gradual range makes the constraint path unsatisfiable.
-        if restricted.is_never() && !solution.is_never() {
+        if restricted == Type::Never && solution != Type::Never {
             return Err(());
         }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -4757,7 +4757,7 @@ impl ConstraintAssignment {
                 );
             }
 
-            if lower.is_uninhabited(db, env) && upper.is_object() {
+            if upper.is_object() && lower.is_uninhabited(db, env) {
                 return write!(
                     f,
                     "({} {} *)",
@@ -5006,7 +5006,7 @@ impl SequentMap {
         let constraint_data = storage.constraint_data(constraint);
         let lower = constraint_data.bounds.materialized_lower();
         let upper = constraint_data.bounds.materialized_upper();
-        if lower.is_uninhabited(db, env) && upper.is_object() {
+        if upper.is_object() && lower.is_uninhabited(db, env) {
             self.add_single_tautology(constraint);
             return;
         }
@@ -5275,8 +5275,8 @@ impl SequentMap {
 
             // (CL ≤ C ≤ pivot) ∧ (pivot ≤ B ≤ BU) → (CL ≤ C ≤ B)
             (constrained_lower, Some(constrained_upper), Some(bound_lower), _)
-                if !constrained_upper.is_uninhabited(db, env)
-                    && !constrained_upper.is_object()
+                if !constrained_upper.is_object()
+                    && !constrained_upper.is_uninhabited(db, env)
                     && storage.cached_is_constraint_set_subtype_of(
                         db,
                         env,
@@ -5289,8 +5289,8 @@ impl SequentMap {
 
             // (pivot ≤ C ≤ CU) ∧ (BL ≤ B ≤ pivot) → (B ≤ C ≤ CU)
             (Some(constrained_lower), constrained_upper, _, Some(bound_upper))
-                if !constrained_lower.is_uninhabited(db, env)
-                    && !constrained_lower.is_object()
+                if !constrained_lower.is_object()
+                    && !constrained_lower.is_uninhabited(db, env)
                     && storage.cached_is_constraint_set_subtype_of(
                         db,
                         env,
@@ -5637,9 +5637,9 @@ impl SequentMap {
                     //   - Contravariant + S is B's upper bound (B ≤ S): G[S] ≤ G[B] → weaker. Emit.
                     //   - Other combinations tighten rather than weaken. Skip.
                     let should_weaken_upper = !constrained_upper.is_type_var()
-                        && !constrained_upper.is_uninhabited(db, env)
                         && !constrained_upper.is_object()
                         && !constrained_upper.is_dynamic()
+                        && !constrained_upper.is_uninhabited(db, env)
                         && match constrained_upper.variance_of(db, env, nested_typevar.identity(db))
                         {
                             TypeVarVariance::Bivariant => false,
@@ -5679,9 +5679,9 @@ impl SequentMap {
 
                     // Ditto for the lower bound.
                     let should_weaken_lower = !constrained_lower.is_type_var()
-                        && !constrained_lower.is_uninhabited(db, env)
                         && !constrained_lower.is_object()
                         && !constrained_lower.is_dynamic()
+                        && !constrained_lower.is_uninhabited(db, env)
                         && match constrained_lower.variance_of(db, env, nested_typevar.identity(db))
                         {
                             TypeVarVariance::Bivariant => false,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -444,9 +444,13 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         env: &ProgramEnvironment<'db>,
         builder: &'c ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
-        lower: Option<Type<'db>>,
-        upper: Option<Type<'db>>,
+        mut lower: Option<Type<'db>>,
+        mut upper: Option<Type<'db>>,
     ) -> Self {
+        if typevar.is_typevartuple(db) {
+            lower = lower.map(|bound| bound.into_typevartuple_pack(db));
+            upper = upper.map(|bound| bound.into_typevartuple_pack(db));
+        }
         let mut storage = builder.storage.borrow_mut();
         let (node, source_order) =
             Constraint::new_node_with_bounds(db, env, &mut storage, typevar, lower, upper);
@@ -1985,12 +1989,12 @@ impl<'db> UpperBound<'db> {
         self.clauses.len() == 1 && self.clauses.contains(&Type::Never)
     }
 
-    fn add_clause(&mut self, clause: Type<'db>) {
+    fn add_clause(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, clause: Type<'db>) {
         if self.is_never() {
             return;
         }
 
-        if clause.is_never() {
+        if clause.is_uninhabited(db, env) {
             self.clauses.clear();
             self.clauses.insert(Type::Never);
             return;
@@ -2545,10 +2549,10 @@ impl ConstraintId {
         };
         let mut merged_upper = UpperBound::none();
         if let Some(upper) = self_constraint.bounds.upper {
-            merged_upper.add_clause(upper);
+            merged_upper.add_clause(db, env, upper);
         }
         if let Some(upper) = other_constraint.bounds.upper {
-            merged_upper.add_clause(upper);
+            merged_upper.add_clause(db, env, upper);
         }
         let effective_lower = lower.unwrap_or(Type::Never);
 
@@ -3490,7 +3494,7 @@ impl<'db> ConstraintBoundsBuilder<'db> {
 
     fn add_upper(&mut self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, ty: Type<'db>) {
         self.classify_evidence(db, env, ty);
-        self.upper.add_clause(ty);
+        self.upper.add_clause(db, env, ty);
     }
 
     fn finish(
@@ -4753,7 +4757,7 @@ impl ConstraintAssignment {
                 );
             }
 
-            if lower.is_never() && upper.is_object() {
+            if lower.is_uninhabited(db, env) && upper.is_object() {
                 return write!(
                     f,
                     "({} {} *)",
@@ -4764,7 +4768,7 @@ impl ConstraintAssignment {
 
             f.write_str(range_prefix)?;
             f.write_str("(")?;
-            if !lower.is_never() {
+            if !lower.is_uninhabited(db, env) {
                 write!(f, "{} ≤ ", lower.display(db, env))?;
             }
             typevar.identity(db).display(db).fmt(f)?;
@@ -5002,7 +5006,7 @@ impl SequentMap {
         let constraint_data = storage.constraint_data(constraint);
         let lower = constraint_data.bounds.materialized_lower();
         let upper = constraint_data.bounds.materialized_upper();
-        if lower.is_never() && upper.is_object() {
+        if lower.is_uninhabited(db, env) && upper.is_object() {
             self.add_single_tautology(constraint);
             return;
         }
@@ -5045,7 +5049,7 @@ impl SequentMap {
         // Skip trivial cases where the assignability check won't produce useful results.
         if !constraint_data.bounds.has_lower()
             || !constraint_data.bounds.has_upper()
-            || lower.is_never()
+            || lower == Type::Never
             || upper.is_object()
         {
             return;
@@ -5271,7 +5275,7 @@ impl SequentMap {
 
             // (CL ≤ C ≤ pivot) ∧ (pivot ≤ B ≤ BU) → (CL ≤ C ≤ B)
             (constrained_lower, Some(constrained_upper), Some(bound_lower), _)
-                if !constrained_upper.is_never()
+                if !constrained_upper.is_uninhabited(db, env)
                     && !constrained_upper.is_object()
                     && storage.cached_is_constraint_set_subtype_of(
                         db,
@@ -5285,7 +5289,7 @@ impl SequentMap {
 
             // (pivot ≤ C ≤ CU) ∧ (BL ≤ B ≤ pivot) → (B ≤ C ≤ CU)
             (Some(constrained_lower), constrained_upper, _, Some(bound_upper))
-                if !constrained_lower.is_never()
+                if !constrained_lower.is_uninhabited(db, env)
                     && !constrained_lower.is_object()
                     && storage.cached_is_constraint_set_subtype_of(
                         db,
@@ -5305,7 +5309,7 @@ impl SequentMap {
         // explicit bounds that are equivalent to missing lower/upper bounds, so a derived
         // `T ≤ U ≤ object` can satisfy a later query for `T ≤ U` without requiring a separate
         // materialized-default implication.
-        let mut constrained_lower = new_lower.filter(|lower| !lower.is_never());
+        let mut constrained_lower = new_lower.filter(|lower| !lower.is_uninhabited(db, env));
         let mut constrained_upper = new_upper.filter(|upper| !upper.is_object());
 
         // The transitive rule above gives us an intended post-condition
@@ -5351,9 +5355,7 @@ impl SequentMap {
             constrained_upper = None;
         }
 
-        if !(constrained_lower.is_none_or(|ty| ty.is_never())
-            && constrained_upper.is_none_or(|ty| ty.is_object()))
-        {
+        if !(constrained_lower.is_none() && constrained_upper.is_none_or(|ty| ty.is_object())) {
             post_constraints.push(ConstraintId::new_with_bounds(
                 db,
                 env,
@@ -5462,13 +5464,13 @@ impl SequentMap {
                     // Contravariance flips direction: lower bound on T substitutes into upper
                     // bound. A ≤ B → G[B] ≤ G[A], so (l_B ≤ T) gives G[T] ≤ G[l_B].
                     (TypeVarVariance::Contravariant, Some(bound_lower), _)
-                        if !bound_lower.is_never() =>
+                        if !bound_lower.is_uninhabited(db, env) =>
                     {
                         bound_data.bounds.lower
                     }
                     // Invariance requires equality: only substitute if l_B = u_B.
                     (TypeVarVariance::Invariant, Some(bound_lower), Some(bound_upper))
-                        if bound_lower == bound_upper && !bound_lower.is_never() =>
+                        if bound_lower == bound_upper && !bound_lower.is_uninhabited(db, env) =>
                     {
                         bound_data.bounds.lower
                     }
@@ -5522,7 +5524,7 @@ impl SequentMap {
                     // Covariance preserves direction: lower bound on T substitutes into lower
                     // bound. A ≤ B → G[A] ≤ G[B], so (l_B ≤ T) gives G[l_B] ≤ G[T].
                     (TypeVarVariance::Covariant, Some(bound_lower), _)
-                        if !bound_lower.is_never() =>
+                        if !bound_lower.is_uninhabited(db, env) =>
                     {
                         bound_data.bounds.lower
                     }
@@ -5535,7 +5537,7 @@ impl SequentMap {
                     }
                     // Invariance requires equality: only substitute if l_B = u_B.
                     (TypeVarVariance::Invariant, Some(bound_lower), Some(bound_upper))
-                        if bound_lower == bound_upper && !bound_lower.is_never() =>
+                        if bound_lower == bound_upper && !bound_lower.is_uninhabited(db, env) =>
                     {
                         bound_data.bounds.lower
                     }
@@ -5635,7 +5637,7 @@ impl SequentMap {
                     //   - Contravariant + S is B's upper bound (B ≤ S): G[S] ≤ G[B] → weaker. Emit.
                     //   - Other combinations tighten rather than weaken. Skip.
                     let should_weaken_upper = !constrained_upper.is_type_var()
-                        && !constrained_upper.is_never()
+                        && !constrained_upper.is_uninhabited(db, env)
                         && !constrained_upper.is_object()
                         && !constrained_upper.is_dynamic()
                         && match constrained_upper.variance_of(db, env, nested_typevar.identity(db))
@@ -5645,7 +5647,7 @@ impl SequentMap {
                             TypeVarVariance::Contravariant => is_upper_bound,
                             TypeVarVariance::Invariant => {
                                 bound_data.bounds.lower == bound_data.bounds.upper
-                                    && !bound_lower.is_never()
+                                    && !bound_lower.is_uninhabited(db, env)
                             }
                         };
                     if should_weaken_upper {
@@ -5677,7 +5679,7 @@ impl SequentMap {
 
                     // Ditto for the lower bound.
                     let should_weaken_lower = !constrained_lower.is_type_var()
-                        && !constrained_lower.is_never()
+                        && !constrained_lower.is_uninhabited(db, env)
                         && !constrained_lower.is_object()
                         && !constrained_lower.is_dynamic()
                         && match constrained_lower.variance_of(db, env, nested_typevar.identity(db))
@@ -5687,7 +5689,7 @@ impl SequentMap {
                             TypeVarVariance::Contravariant => !is_upper_bound,
                             TypeVarVariance::Invariant => {
                                 bound_data.bounds.lower == bound_data.bounds.upper
-                                    && !bound_lower.is_never()
+                                    && !bound_lower.is_uninhabited(db, env)
                             }
                         };
                     if should_weaken_lower {
@@ -5774,7 +5776,8 @@ impl SequentMap {
                         // Avoid preserving explicit bounds that are equivalent to missing
                         // lower/upper bounds; direct constraints still retain their explicit
                         // bound presence.
-                        let mut constrained_lower = right_lower.filter(|lower| !lower.is_never());
+                        let mut constrained_lower =
+                            right_lower.filter(|lower| !lower.is_uninhabited(db, env));
                         let mut constrained_upper = right_upper.filter(|upper| !upper.is_object());
 
                         if let Some(Type::TypeVar(lower_bound_typevar)) = right_lower
@@ -5805,7 +5808,7 @@ impl SequentMap {
                             constrained_upper = None;
                         }
 
-                        if !(constrained_lower.unwrap_or(Type::Never).is_never()
+                        if !(constrained_lower.is_none()
                             && constrained_upper.unwrap_or(Type::object()).is_object())
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
@@ -7313,13 +7316,18 @@ mod tests {
         let env = db.program_environment();
         let int = known_instance(db, KnownClass::Int);
 
-        let mut upper = UpperBound::from_clause(int);
-        upper.add_clause(Type::Never);
-        assert_eq!(upper.clauses, FxOrderSet::from_iter([Type::Never]));
-        assert_eq!(upper.materialize_exact(db, &env), Type::Never);
+        for never in [
+            Type::Never,
+            Type::heterogeneous_tuple(db, &env, [Type::Never]),
+        ] {
+            let mut upper = UpperBound::from_clause(int);
+            upper.add_clause(db, &env, never);
+            assert_eq!(upper.clauses, FxOrderSet::from_iter([Type::Never]));
+            assert_eq!(upper.materialize_exact(db, &env), Type::Never);
 
-        upper.add_clause(int);
-        assert_eq!(upper.clauses, FxOrderSet::from_iter([Type::Never]));
+            upper.add_clause(db, &env, int);
+            assert_eq!(upper.clauses, FxOrderSet::from_iter([Type::Never]));
+        }
     }
 
     #[test]
@@ -7346,7 +7354,7 @@ mod tests {
         ] {
             let mut upper = UpperBound::none();
             for clause in clauses {
-                upper.add_clause(clause);
+                upper.add_clause(db, &env, clause);
             }
 
             assert_eq!(upper.clauses.len(), 2);
@@ -7381,7 +7389,7 @@ mod tests {
         for clauses in [[int_or_str, int_or_bytes], [int_or_bytes, int_or_str]] {
             let mut upper = UpperBound::none();
             for clause in clauses {
-                upper.add_clause(clause);
+                upper.add_clause(db, &env, clause);
             }
 
             assert_eq!(upper.materialize_exact(db, &env), int);
@@ -7397,7 +7405,7 @@ mod tests {
         let int = known_instance(db, KnownClass::Int);
         let u = Type::TypeVar(create_typevar(db, "U"));
         let mut upper = UpperBound::from_clause(u);
-        upper.add_clause(int);
+        upper.add_clause(db, &env, int);
 
         assert!(
             upper

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -386,15 +386,17 @@ where
     /// Visits `item`, returning it in `Err` if another active item has the same identity.
     ///
     /// The caller must convert `Err(item)` into an operation-specific conservative result. An
-    /// exact recursive reentry uses the detector's configured fallback and is returned as `Ok`.
+    /// exact recursive reentry uses `cycle_fallback`, when provided, or the detector's configured
+    /// fallback otherwise, and is returned as `Ok`.
     #[inline]
     pub(super) fn try_visit(
         &self,
         db: &'db dyn Db,
         item: T,
+        cycle_fallback: Option<R>,
         compute: impl FnOnce() -> R,
     ) -> Result<R, T> {
-        match self.begin_visit(db, item) {
+        match self.begin_visit_with_cycle_fallback(db, item, cycle_fallback) {
             CycleDetectorVisit::Ready(result) => Ok(result),
             CycleDetectorVisit::Cycle(item) => Err(item),
             CycleDetectorVisit::Pending(item) => {
@@ -405,13 +407,24 @@ where
     }
 
     fn begin_visit(&self, db: &'db dyn Db, item: T) -> CycleDetectorVisit<T, R> {
+        self.begin_visit_with_cycle_fallback(db, item, None)
+    }
+
+    fn begin_visit_with_cycle_fallback(
+        &self,
+        db: &'db dyn Db,
+        item: T,
+        cycle_fallback: Option<R>,
+    ) -> CycleDetectorVisit<T, R> {
         if let Some(result) = self.cache.borrow().get(&item) {
             return CycleDetectorVisit::Ready(result.clone());
         }
 
         let seen = self.seen.borrow();
         if seen.iter().any(|active| active.item == item) {
-            return CycleDetectorVisit::Ready(self.fallback.clone());
+            return CycleDetectorVisit::Ready(
+                cycle_fallback.unwrap_or_else(|| self.fallback.clone()),
+            );
         }
 
         let mut candidates = seen
@@ -842,6 +855,21 @@ class RecursivePropertySetter[T](Protocol):
         assert_eq!(
             detector.visit(db, 1, || detector.visit(db, 1, || 20) + 10),
             10
+        );
+    }
+
+    #[test]
+    fn exact_cycle_can_override_the_default_fallback() {
+        let db = setup_db();
+        let db = &db;
+        let detector = Detector::new(1);
+
+        assert_eq!(
+            detector.try_visit(db, 1, None, || {
+                assert_eq!(detector.try_visit(db, 1, Some(0), || 2), Ok(0));
+                3
+            }),
+            Ok(3)
         );
     }
 

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -249,7 +249,7 @@ impl<'db> PartitionedEnumComparison<'db> {
                     }
                 })
                 .build();
-            if !excluded.is_never() {
+            if excluded != Type::Never {
                 return ComparisonResult::CanNarrow(
                     IntersectionBuilder::new(db, &env)
                         .add_positive(narrowed)

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2568,7 +2568,7 @@ impl KnownFunction {
                     return;
                 };
                 let env = context.program_environment();
-                if actual_ty.is_equivalent_to(db, env, Type::Never) {
+                if actual_ty.is_uninhabited(db, env) {
                     return;
                 }
                 if let Some(builder) = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1261,9 +1261,11 @@ impl<'db> Specialization<'db> {
         tuple_inner: Option<TupleType<'db>>,
     ) -> Self {
         let mut types = types.into();
-        for (typevar, ty) in generic_context.variables(db).zip(types.iter_mut()) {
-            if typevar.is_typevartuple(db) {
-                *ty = ty.into_typevartuple_pack(db);
+        if tuple_inner.is_none() && types.iter().copied().any(Type::is_exact_tuple_instance) {
+            for (typevar, ty) in generic_context.variables(db).zip(types.iter_mut()) {
+                if typevar.is_typevartuple(db) {
+                    *ty = ty.into_typevartuple_pack(db);
+                }
             }
         }
         Self::new_internal(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1202,7 +1202,7 @@ impl<'db> GenericContext<'db> {
 ///
 /// TODO: Handle nested specializations better, with actual parent links to the specialization of
 /// the lexically containing context.
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, constructor=new_internal, heap_size=ruff_memory_usage::heap_size)]
 pub struct Specialization<'db> {
     #[returns(copy)]
     pub(crate) generic_context: GenericContext<'db>,
@@ -1252,6 +1252,29 @@ pub(super) fn walk_specialization_types<'db, V: TypeVisitor<'db> + ?Sized>(
 }
 
 impl<'db> Specialization<'db> {
+    /// Interns a specialization after distinguishing variadic argument packs from runtime tuples.
+    pub(crate) fn new(
+        db: &'db dyn Db,
+        generic_context: GenericContext<'db>,
+        types: impl Into<Box<[Type<'db>]>>,
+        materialization_kind: Option<MaterializationKind>,
+        tuple_inner: Option<TupleType<'db>>,
+    ) -> Self {
+        let mut types = types.into();
+        for (typevar, ty) in generic_context.variables(db).zip(types.iter_mut()) {
+            if typevar.is_typevartuple(db) {
+                *ty = ty.into_typevartuple_pack(db);
+            }
+        }
+        Self::new_internal(
+            db,
+            generic_context,
+            types,
+            materialization_kind,
+            tuple_inner,
+        )
+    }
+
     /// Merge cycle iterations that differ only by gradual `Unknown` type arguments.
     ///
     /// Known argument mismatches are not merged because doing so would be unsound for invariant
@@ -2829,9 +2852,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     fn insert_hash_map_type_mapping(
         &mut self,
         bound_typevar: BoundTypeVarInstance<'db>,
-        ty: Type<'db>,
+        mut ty: Type<'db>,
     ) {
         let db = self.db;
+        if bound_typevar.is_typevartuple(db) {
+            ty = ty.into_typevartuple_pack(db);
+        }
         let identity = bound_typevar.identity(db);
         match self.types.entry(identity) {
             Entry::Occupied(mut entry) => {
@@ -2866,9 +2892,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         let unioned = TupleSpecBuilder::from(existing_tuple.as_ref())
                             .union(db, self.env, &new_tuple)
                             .build();
-                        *accumulator = UnionAccumulator::new(Type::tuple(TupleType::new(
-                            db, self.env, &unioned,
-                        )));
+                        *accumulator = UnionAccumulator::new(
+                            Type::tuple(TupleType::new(db, self.env, &unioned))
+                                .into_typevartuple_pack(db),
+                        );
                     }
                     _ => {
                         entry.get_mut().add(db, self.env, ty);
@@ -3492,7 +3519,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
                 let remaining_actual =
                     actual_union.filter(db, |ty| !ty.is_subtype_of(db, self.env, formal));
-                if remaining_actual.is_never() {
+                if remaining_actual.is_uninhabited(db, self.env) {
                     return Ok(());
                 }
                 // Infer through the TypeVar arm so its bound or constraints are still enforced.
@@ -3528,7 +3555,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // ```
                 //
                 // without specializing `T` to `None`.
-                if !actual.is_never() {
+                if !actual.is_uninhabited(db, self.env) {
                     let assignable_elements = union_formal.elements(db).iter().filter(|ty| {
                         actual
                             .when_subtype_of(db, self.env, **ty, self.constraints, self.inferable)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3519,7 +3519,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
                 let remaining_actual =
                     actual_union.filter(db, |ty| !ty.is_subtype_of(db, self.env, formal));
-                if remaining_actual.is_uninhabited(db, self.env) {
+                if remaining_actual == Type::Never {
                     return Ok(());
                 }
                 // Infer through the TypeVar arm so its bound or constraints are still enforced.
@@ -3555,7 +3555,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // ```
                 //
                 // without specializing `T` to `None`.
-                if !actual.is_uninhabited(db, self.env) {
+                if actual != Type::Never {
                     let assignable_elements = union_formal.elements(db).iter().filter(|ty| {
                         actual
                             .when_subtype_of(db, self.env, **ty, self.constraints, self.inferable)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2846,8 +2846,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         property_ty.as_property_instance().is_some_and(|property| {
             property.deleter(db).is_some_and(|deleter| {
                 match deleter.try_call(db, env, &CallArguments::positional([object_ty])) {
-                    Ok(result) => result.return_type(db, env).is_never(),
-                    Err(err) => err.return_type(db, env).is_never(),
+                    Ok(result) => result.return_type(db, env).is_uninhabited(db, env),
+                    Err(err) => err.return_type(db, env).is_uninhabited(db, env),
                 }
             })
         })
@@ -2995,8 +2995,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     frozen_dataclass_dispatch,
                     Some(FrozenDataclassDispatch::FrozenField)
                 ) || match &delattr_dunder_call_result {
-                    Ok(result) => result.return_type(db, env).is_never(),
-                    Err(err) => err.return_type(db, env).is_some_and(|ty| ty.is_never()),
+                    Ok(result) => result.return_type(db, env).is_uninhabited(db, env),
+                    Err(err) => err
+                        .return_type(db, env)
+                        .is_some_and(|ty| ty.is_uninhabited(db, env)),
                 };
                 if returns_never {
                     if emit_diagnostics
@@ -3075,12 +3077,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     // `Never` supports arbitrary operations only because there can be no runtime
                     // value to mutate; it is not a concrete descriptor with a terminal deleter.
-                    let deleter_returns_never = !attr_ty.is_never()
+                    let deleter_returns_never = !attr_ty.is_uninhabited(db, env)
                         && match &delete_dunder_call_result {
-                            Ok(bindings) => bindings.return_type(db, env).is_never(),
-                            Err(error) => {
-                                error.return_type(db, env).is_some_and(|ty| ty.is_never())
-                            }
+                            Ok(bindings) => bindings.return_type(db, env).is_uninhabited(db, env),
+                            Err(error) => error
+                                .return_type(db, env)
+                                .is_some_and(|ty| ty.is_uninhabited(db, env)),
                         };
                     if deleter_returns_never
                         || self.property_deleter_returns_never(attr_ty, object_ty)

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -405,8 +405,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             frozen_dataclass_dispatch,
             Some(FrozenDataclassDispatch::FrozenField)
         ) || match &setattr_result {
-            Ok(bindings) => bindings.return_type(db, env).is_never(),
-            Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
+            Ok(bindings) => bindings.return_type(db, env).is_uninhabited(db, env),
+            Err(error) => error
+                .return_type(db, env)
+                .is_some_and(|ty| ty.is_uninhabited(db, env)),
         };
 
         // We could also model this more precisely by synthesizing a `__setattr__`overload set
@@ -557,8 +559,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 let (setattr_result, value_ty) =
                     self.infer_and_try_call_setattr(object_ty, emit_diagnostics);
                 let setattr_returns_never = match &setattr_result {
-                    Ok(bindings) => bindings.return_type(db, env).is_never(),
-                    Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
+                    Ok(bindings) => bindings.return_type(db, env).is_uninhabited(db, env),
+                    Err(error) => error
+                        .return_type(db, env)
+                        .is_some_and(|ty| ty.is_uninhabited(db, env)),
                 };
                 if setattr_returns_never {
                     if emit_diagnostics {
@@ -706,10 +710,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         );
         // `Never` supports arbitrary operations only because there can be no runtime value to
         // mutate; it is not a concrete descriptor with a terminal setter.
-        let setter_returns_never = !descriptor_ty.is_never()
+        let setter_returns_never = !descriptor_ty.is_uninhabited(db, env)
             && match &setter_result {
-                Ok(bindings) => bindings.return_type(db, env).is_never(),
-                Err(error) => error.return_type(db, env).is_never(),
+                Ok(bindings) => bindings.return_type(db, env).is_uninhabited(db, env),
+                Err(error) => error.return_type(db, env).is_uninhabited(db, env),
             };
         if setter_returns_never
             || property_setter_returns_never(db, env, descriptor_ty, object_ty, value_ty)

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -40,7 +40,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let value_ty = self
             .speculate_without_diagnostics()
             .infer_maybe_standalone_expression(expression, TypeContext::default());
-        if matches!(value_ty.resolve_type_alias(db), Type::Never)
+        if value_ty.is_uninhabited(db, env)
             || self.contains_type_form_value(expression, value_ty)
             || non_type_form_fallback
                 .is_some_and(|alternative| value_ty.is_assignable_to(db, env, alternative))

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -221,6 +221,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let annotation = self.infer_extra_items_kwarg(&kw.value);
                         extra_items = Some(TypedDictOpenness::extra(
                             db,
+                            env,
                             annotation.inner_type(),
                             annotation.qualifiers().contains(TypeQualifiers::READ_ONLY),
                         ));

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -1070,7 +1070,7 @@ fn infer_membership_test_comparison<'db>(
         && let Some(typed_dict) = right.as_typed_dict()
     {
         let truthiness = typed_dict
-            .key_membership_truthiness(db, key.value(db))
+            .key_membership_truthiness(db, env, key.value(db))
             .negate_if(op.is_not_in());
         return Ok(Type::from_truthiness(db, env, truthiness));
     }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -103,6 +103,16 @@ impl<'db> Type<'db> {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(tuple)))
     }
 
+    /// Marks a tuple-shaped type as a generic argument sequence instead of a runtime value.
+    pub(crate) fn into_typevartuple_pack(self, db: &'db dyn Db) -> Self {
+        match self {
+            Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(tuple))) => {
+                Type::tuple(tuple.into_typevartuple_pack(db))
+            }
+            _ => self,
+        }
+    }
+
     pub fn homogeneous_tuple(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -307,6 +317,18 @@ impl<'db> NominalInstanceType<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Cow<'db, TupleSpec<'db>>> {
+        #[salsa::tracked(
+            returns(copy),
+            cycle_initial = |_, _, _| false,
+            heap_size = ruff_memory_usage::heap_size
+        )]
+        fn is_tuple_subclass<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
+            class
+                .iter_mro(db)
+                .filter_map(ClassBase::into_class)
+                .any(|base| base.known(db) == Some(KnownClass::Tuple))
+        }
+
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
             NominalInstanceInner::SysVersionInfo => {
@@ -315,10 +337,16 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::Object => None,
             NominalInstanceInner::NonTuple(class) => {
                 let class = class.class(db);
-                // Avoid an expensive MRO traversal for common stdlib classes.
-                if class
-                    .known(db)
-                    .is_some_and(|known_class| !known_class.is_tuple_subclass())
+                let class_literal = class.class_literal(db);
+                let known_class = class_literal.known(db);
+                // Known non-tuple classes and user-defined classes without explicit bases cannot
+                // have a tuple ancestor. Cache the answer by class origin for all other classes.
+                if known_class.is_some_and(|known_class| !known_class.is_tuple_subclass())
+                    || known_class.is_none()
+                        && class_literal
+                            .as_static()
+                            .is_some_and(|class| !class.has_explicit_bases(db))
+                    || !is_tuple_subclass(db, class_literal)
                 {
                     return None;
                 }
@@ -353,6 +381,14 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => false,
             NominalInstanceInner::NonTuple(class) => class.class(db).is_generic(),
         }
+    }
+
+    /// Returns whether this instance represents an internal `TypeVarTuple` argument pack.
+    pub(super) fn is_typevartuple_pack(self, db: &'db dyn Db) -> bool {
+        matches!(
+            self.0,
+            NominalInstanceInner::ExactTuple(tuple) if tuple.is_typevartuple_pack(db)
+        )
     }
 
     /// If this type is an *exact* tuple type (*not* a subclass of `tuple`), returns the

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -14,6 +14,7 @@ use super::{
     MaterializationKind, SubclassOfType, Type, TypeAliasType, TypeVarVariance,
 };
 use crate::place::PlaceAndQualifiers;
+use crate::types::class::ClassInstanceFlags;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
 };
@@ -317,18 +318,6 @@ impl<'db> NominalInstanceType<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Cow<'db, TupleSpec<'db>>> {
-        #[salsa::tracked(
-            returns(copy),
-            cycle_initial = |_, _, _| false,
-            heap_size = ruff_memory_usage::heap_size
-        )]
-        fn is_tuple_subclass<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
-            class
-                .iter_mro(db)
-                .filter_map(ClassBase::into_class)
-                .any(|base| base.known(db) == Some(KnownClass::Tuple))
-        }
-
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
             NominalInstanceInner::SysVersionInfo => {
@@ -340,13 +329,16 @@ impl<'db> NominalInstanceType<'db> {
                 let class_literal = class.class_literal(db);
                 let known_class = class_literal.known(db);
                 // Known non-tuple classes and user-defined classes without explicit bases cannot
-                // have a tuple ancestor. Cache the answer by class origin for all other classes.
+                // have a tuple ancestor. Other classes already cache this property with their
+                // remaining instance flags.
                 if known_class.is_some_and(|known_class| !known_class.is_tuple_subclass())
                     || known_class.is_none()
                         && class_literal
                             .as_static()
                             .is_some_and(|class| !class.has_explicit_bases(db))
-                    || !is_tuple_subclass(db, class_literal)
+                    || !class_literal
+                        .instance_flags(db)
+                        .contains(ClassInstanceFlags::TUPLE_SUBCLASS)
                 {
                     return None;
                 }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -104,6 +104,14 @@ impl<'db> Type<'db> {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(tuple)))
     }
 
+    /// Whether this type uses the exact-tuple representation that can become an argument pack.
+    pub(super) const fn is_exact_tuple_instance(self) -> bool {
+        matches!(
+            self,
+            Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(_)))
+        )
+    }
+
     /// Marks a tuple-shaped type as a generic argument sequence instead of a runtime value.
     pub(crate) fn into_typevartuple_pack(self, db: &'db dyn Db) -> Self {
         match self {

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -936,8 +936,7 @@ fn try_sequence_pattern_binding_fallthrough_type<'db>(
                         env,
                         &PatternPredicateKind::Sequence(kind.clone()),
                         bound,
-                    )
-                    .is_never()
+                    ) == Type::Never
                 }) =>
         {
             Type::Never
@@ -1035,7 +1034,7 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
         if remaining == element {
             return Ok(Some(subject_ty));
         }
-        if remaining.is_never() {
+        if remaining.is_uninhabited(db, env) {
             continue;
         }
 
@@ -1232,7 +1231,10 @@ fn build_definite_sequence_pattern_type<'db>(
         .map(element_type)
         .collect::<Option<_>>()?;
 
-    if element_types.iter().any(Type::is_never) {
+    if element_types
+        .iter()
+        .any(|element| element.is_uninhabited(db, env))
+    {
         Some(Type::Never)
     } else {
         Some(exact_sequence_pattern_type(

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -1034,7 +1034,7 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
         if remaining == element {
             return Ok(Some(subject_ty));
         }
-        if remaining.is_uninhabited(db, env) {
+        if remaining == Type::Never {
             continue;
         }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -430,7 +430,7 @@ pub(crate) fn pattern_success_types<'db>(
             .into_iter()
             .map(|(place, binding)| (place, binding.ty(db, &env)))
             .collect(),
-        missing_binding_ty: if result.matched_subject_ty.is_never() {
+        missing_binding_ty: if result.matched_subject_ty.is_uninhabited(db, &env) {
             Type::Never
         } else {
             Type::unknown()
@@ -734,11 +734,11 @@ impl<'db> Conjunctions<'db> {
         if self
             .conjuncts
             .iter()
-            .any(|conjunct| conjunct.ty().is_never())
+            .any(|conjunct| conjunct.ty() == Type::Never)
             || other
                 .conjuncts
                 .iter()
-                .any(|conjunct| conjunct.ty().is_never())
+                .any(|conjunct| conjunct.ty() == Type::Never)
         {
             return Self::singleton(Type::Never);
         }
@@ -1912,7 +1912,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     },
                     |pattern| self.analyze_successful_pattern(pattern, subject_ty),
                 );
-                if !result.matched_subject_ty.is_never()
+                if !result.matched_subject_ty.is_uninhabited(db, &self.env)
                     && let Some(place) = name
                         .as_ref()
                         .and_then(|name| self.places().symbol_id(name.as_str()))
@@ -2455,7 +2455,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> Option<(Type<'db>, Vec<ClassPatternArgument<'db>>)> {
         let narrowed_subject_ty =
             self.filter_class_pattern_subject_type(context.class, context.class_ty, subject_ty);
-        if narrowed_subject_ty.is_never() {
+        if narrowed_subject_ty.is_uninhabited(self.db, &self.env) {
             return None;
         }
         let arguments = self.class_pattern_arguments_for_arm(
@@ -2503,7 +2503,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     .zip(arguments)
                 {
                     let child_ty = analyzer.matched_subject_type(pattern, argument.ty);
-                    if child_ty.is_never() {
+                    if child_ty.is_uninhabited(analyzer.db, &self.env) {
                         return None;
                     }
                     if argument.source == PatternValueSource::Subject {
@@ -2560,7 +2560,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     .zip(arguments)
                 {
                     let mut child = analyzer.analyze_successful_pattern(pattern, argument.ty);
-                    if child.matched_subject_ty.is_never() {
+                    if child
+                        .matched_subject_ty
+                        .is_uninhabited(analyzer.db, &self.env)
+                    {
                         return None;
                     }
                     if argument.source != PatternValueSource::Subject {
@@ -2591,7 +2594,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             let key_ty = key_ty.resolve_type_alias(db);
             let typed_dict_key_ty = typed_dict.key_type(db, &self.env);
             let policy = self.comparison_soundness_policy();
-            if typed_dict_key_ty.is_never()
+            if typed_dict_key_ty.is_uninhabited(db, &self.env)
                 || equality_truthiness(db, &self.env, typed_dict_key_ty, key_ty, policy)
                     == Truthiness::AlwaysFalse
             {
@@ -2690,7 +2693,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let db = self.db;
         let narrowed_subject_ty =
             self.intersect_types(subject_ty, mapping_pattern_type(db, &self.env));
-        if narrowed_subject_ty.is_never() {
+        if narrowed_subject_ty == Type::Never {
             return None;
         }
         let value_types = key_types
@@ -2715,7 +2718,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 for (entry, value_ty) in kind.entries.iter().zip(value_types) {
                     if analyzer
                         .matched_subject_type(&entry.pattern, value_ty)
-                        .is_never()
+                        .is_uninhabited(analyzer.db, &self.env)
                     {
                         return None;
                     }
@@ -2740,7 +2743,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 let mut bindings = BTreeMap::new();
                 for (entry, value_ty) in kind.entries.iter().zip(value_types) {
                     let mut child = analyzer.analyze_successful_pattern(&entry.pattern, value_ty);
-                    if child.matched_subject_ty.is_never() {
+                    if child
+                        .matched_subject_ty
+                        .is_uninhabited(analyzer.db, &analyzer.env)
+                    {
                         return None;
                     }
                     Self::demote_subject_bindings(&mut child.bindings);
@@ -2798,7 +2804,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 let mut persistent_element_types = Vec::with_capacity(kind.patterns.len());
                 for (pattern, element_ty) in kind.patterns.iter().zip(element_types) {
                     let child = analyzer.analyze_successful_pattern(pattern, element_ty);
-                    if child.matched_subject_ty.is_never() {
+                    if child.matched_subject_ty.is_uninhabited(db, &self.env) {
                         return None;
                     }
                     // Use the mutation-safe type so an exact tuple does not retain stale facts
@@ -2847,7 +2853,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 let mut binding_element_types = Vec::with_capacity(kind.patterns.len());
                 for (pattern, element_ty) in kind.patterns.iter().zip(element_types) {
                     let mut child = analyzer.analyze_successful_pattern(pattern, element_ty);
-                    if child.matched_subject_ty.is_never() {
+                    if child.matched_subject_ty.is_uninhabited(db, &self.env) {
                         return None;
                     }
                     matched_element_types.push(child.matched_subject_ty);
@@ -2973,7 +2979,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> Option<(Type<'db>, Vec<Type<'db>>)> {
         let db = self.db;
         let narrowed_subject_ty = self.intersect_types(subject_ty, sequence_ty);
-        if narrowed_subject_ty.is_never() {
+        if narrowed_subject_ty == Type::Never {
             return None;
         }
 
@@ -3055,7 +3061,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
             for binding in arm_bindings.values_mut() {
                 let subject_ty = binding.subject_ty(db, &self.env);
-                if !subject_ty.is_never() {
+                if !subject_ty.is_uninhabited(db, &self.env) {
                     binding.restore_subject(self.preserve_original_subject_type(
                         original_subject_ty,
                         subject_ty,
@@ -3681,7 +3687,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         element,
                         rhs_identity_ty,
                     );
-                    builder.add(if runtime_overlap.is_never() {
+                    builder.add(if runtime_overlap == Type::Never {
                         element
                     } else {
                         runtime_overlap
@@ -4046,7 +4052,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             } else {
                 let requires_key = |td: TypedDictType<'db>| -> bool {
-                    td.key_membership_truthiness(db, key).is_always_true()
+                    td.key_membership_truthiness(db, &self.env, key)
+                        .is_always_true()
                 };
 
                 let resolved_rhs_type = rhs_type.resolve_type_alias(db);
@@ -4418,7 +4425,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let subject_ty = infer_same_file_expression_type(db, subject, TypeContext::default());
         let definitely_matched =
             definite_match_pattern_type_for_subject(db, &self.env, pattern, subject_ty);
-        if definitely_matched.is_never() {
+        if definitely_matched.is_uninhabited(db, &self.env) {
             return None;
         }
 
@@ -4581,7 +4588,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if NarrowingConstraint::intersection(subject_ty)
             .merge_constraint_and(constraint.clone())
             .evaluate_constraint_type(db, &self.env)
-            .is_never()
+            .is_uninhabited(db, &self.env)
         {
             return PatternNarrowingResult::Impossible;
         }
@@ -4831,7 +4838,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }),
             Type::TypedDict(typed_dict)
                 if typed_dict
-                    .key_membership_truthiness(db, key)
+                    .key_membership_truthiness(db, &self.env, key)
                     .is_always_false() =>
             {
                 Type::Never

--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -117,10 +117,10 @@ mod stable {
         }
     );
 
-    // `T` is not disjoint from itself, unless `T` is `Never`.
+    // `T` is not disjoint from itself, unless `T` is uninhabited.
     type_property_test!(
         disjoint_from_is_irreflexive, db, env,
-        forall types t. t.is_disjoint_from(db, env, t) => t.is_never()
+        forall types t. t.is_disjoint_from(db, env, t) => t.is_uninhabited(db, env)
     );
 
     // `S` is disjoint from `T` implies that `T` is disjoint from `S`.
@@ -129,10 +129,10 @@ mod stable {
         forall types s, t. s.is_disjoint_from(db, env, t) == t.is_disjoint_from(db, env, s)
     );
 
-    // `S <: T` implies that `S` is not disjoint from `T`, unless `S` is `Never`.
+    // `S <: T` implies that `S` is not disjoint from `T`, unless `S` is uninhabited.
     type_property_test!(
         subtype_of_implies_not_disjoint_from, db, env,
-        forall types s, t. s.is_subtype_of(db, env, t) => !s.is_disjoint_from(db, env, t) || s.is_never()
+        forall types s, t. s.is_subtype_of(db, env, t) => !s.is_disjoint_from(db, env, t) || s.is_uninhabited(db, env)
     );
 
     // `S <: T` implies that `S` can be assigned to `T`.

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2612,8 +2612,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
         if match &setattr_result {
-            Ok(bindings) => bindings.return_type(db, env).is_never(),
-            Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
+            Ok(bindings) => bindings.return_type(db, env).is_uninhabited(db, env),
+            Err(error) => error
+                .return_type(db, env)
+                .is_some_and(|ty| ty.is_uninhabited(db, env)),
         } {
             return self.never();
         }
@@ -3413,7 +3415,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             else {
                 return self.never();
             };
-            if !callable_has_only_non_never_returns(db, method) {
+            if !callable_has_only_non_never_returns(db, env, method) {
                 return self.never();
             }
 
@@ -3424,7 +3426,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             };
 
             callables.iter().when_all(db, self.constraints, |callable| {
-                if !callable_has_only_non_never_returns(db, *callable) {
+                if !callable_has_only_non_never_returns(db, env, *callable) {
                     return self.never();
                 }
 
@@ -3719,15 +3721,19 @@ fn protocol_apply_self_with_receiver<'db>(
 ///
 /// Return-type disjointness is a pragmatic approximation for method members: a callable returning
 /// `Never` could satisfy otherwise-incompatible signatures, so it must not establish disjointness.
-fn callable_has_only_non_never_returns<'db>(db: &'db dyn Db, callable: CallableType<'db>) -> bool {
+fn callable_has_only_non_never_returns<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    callable: CallableType<'db>,
+) -> bool {
     let mut signatures = callable.signatures(db).iter();
     let Some(first) = signatures.next() else {
         // An empty signature previously produced `Unknown`, which cannot establish disjointness.
         return false;
     };
 
-    !first.return_ty.resolve_type_alias(db).is_never()
-        && signatures.all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
+    !first.return_ty.is_uninhabited(db, env)
+        && signatures.all(|signature| !signature.return_ty.is_uninhabited(db, env))
 }
 
 /// Protocol compatibility can only succeed if every required member is present.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1454,23 +1454,35 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // It is a subtype of all other types.
             (Type::Never, _) => self.always(),
 
+            // Dynamic types are assignable to and from every type, including empty tuples.
+            // A later match arm also handles this case, but handling assignability here first
+            // is an important optimisation, as it avoids inspecting the other type's class
+            // hierarchy in simple/common cases.
+            (Type::Dynamic(_), _) | (_, Type::Dynamic(_)) if self.relation.is_assignability() => {
+                self.always()
+            }
+
             // Tuple instances and tuple subclasses with an uninhabited required element behave
             // as `Never`. Internal TypeVarTuple argument packs instead remain structural.
-            (Type::NominalInstance(instance), other)
-                if !other
+            (Type::NominalInstance(source), target)
+                if !target
                     .as_nominal_instance()
-                    .is_some_and(|other| other.is_typevartuple_pack(db))
-                    && self.is_uninhabited_nominal_instance(db, instance) =>
+                    .is_some_and(|target| target.is_typevartuple_pack(db))
+                    && self.is_uninhabited_nominal_instance(db, source) =>
             {
                 self.always()
             }
-            (other, Type::NominalInstance(instance))
-                if !other
-                    .as_nominal_instance()
-                    .is_some_and(|other| other.is_typevartuple_pack(db))
-                    && self.is_uninhabited_nominal_instance(db, instance) =>
+
+            // A definitely inhabited non-dynamic source cannot be a subtype of an empty
+            // target. Uninhabited nominal sources were already checked in the branch immediately
+            // above; ordinary class relations and explicit-`Any` handling settle the remaining
+            // nominal cases.
+            (source, Type::NominalInstance(target))
+                if source.may_be_uninhabited()
+                    && !source.is_nominal_instance()
+                    && self.is_uninhabited_nominal_instance(db, target) =>
             {
-                self.check_type_pair(db, other, Type::Never)
+                self.check_type_pair(db, source, Type::Never)
             }
 
             (Type::TypeVar(source_typevar), Type::TypeVar(target_typevar))

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1254,10 +1254,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     ) -> bool {
         !instance.is_typevartuple_pack(db)
             && instance.tuple_spec(db, self.env).is_some_and(|tuple| {
-                self.with_recursion_guard(db, Type::NominalInstance(instance), Type::Never, || {
-                    self.check_tuple_spec_is_uninhabited(db, tuple.as_ref())
-                })
-                .is_always_satisfied(db, self.env)
+                tuple.fixed_elements().any(Type::may_be_uninhabited)
+                    && self
+                        .with_recursion_guard(
+                            db,
+                            Type::NominalInstance(instance),
+                            Type::Never,
+                            || self.check_tuple_spec_is_uninhabited(db, tuple.as_ref()),
+                        )
+                        .is_always_satisfied(db, self.env)
             })
     }
 
@@ -2836,19 +2841,34 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         left: Type<'db>,
         right: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        // `Never` is a subtype of every type, so equivalence to it only requires checking the
+        // opposite direction. Avoid constructing a second materialization root for this common
+        // inhabitance check.
+        if left == Type::Never {
+            let materialization_visitor = self.materialization_visitor.for_new_mapping_root();
+            return self
+                .as_relation_checker(&materialization_visitor)
+                .check_type_pair(db, right, left);
+        }
+
         // Recursive materialization fallbacks depend on the comparison root, so each directional
         // pass needs fresh materialization caches. Nested equivalence checks still share the
         // materialization-equivalence recursion guard to avoid re-entering the same comparison.
         let left_to_right_materialization_visitor =
             self.materialization_visitor.for_new_mapping_root();
-        self.as_relation_checker(&left_to_right_materialization_visitor)
-            .check_type_pair(db, left, right)
-            .and(db, self.constraints, || {
-                let right_to_left_materialization_visitor =
-                    self.materialization_visitor.for_new_mapping_root();
-                self.as_relation_checker(&right_to_left_materialization_visitor)
-                    .check_type_pair(db, right, left)
-            })
+        let left_to_right = self
+            .as_relation_checker(&left_to_right_materialization_visitor)
+            .check_type_pair(db, left, right);
+        if right == Type::Never {
+            return left_to_right;
+        }
+
+        left_to_right.and(db, self.constraints, || {
+            let right_to_left_materialization_visitor =
+                self.materialization_visitor.for_new_mapping_root();
+            self.as_relation_checker(&right_to_left_materialization_visitor)
+                .check_type_pair(db, right, left)
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -19,8 +19,8 @@ use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
-    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    MemberLookupPolicy, NominalInstanceType, PropertyInstanceType, ProtocolInstanceType,
+    SubclassOfInner, SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -1220,6 +1220,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             .try_visit(
                 db,
                 (source, target, self.relation, self.typevar_evaluation),
+                (target == Type::Never).then(|| self.never()),
                 work,
             )
             .unwrap_or_else(|item| self.recursive_type_pair_fallback(item.0, item.1))
@@ -1238,6 +1239,26 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         // The correct choice here is a logical value that is "neither true nor false", and expressing this requires the introduction of 3-valued logic.
         // Discussion: https://github.com/astral-sh/ty/issues/4050
         self.never()
+    }
+
+    /// A nominal tuple instance is uninhabited when its tuple specification has an empty element.
+    ///
+    /// Keep this check inside nominal-instance match arms: discovering a tuple subclass can
+    /// require walking its MRO, and most type pairs never need that work. Argument packs share
+    /// the tuple representation but describe type sequences, so their elements do not determine
+    /// runtime inhabitance.
+    fn is_uninhabited_nominal_instance(
+        &self,
+        db: &'db dyn Db,
+        instance: NominalInstanceType<'db>,
+    ) -> bool {
+        !instance.is_typevartuple_pack(db)
+            && instance.tuple_spec(db, self.env).is_some_and(|tuple| {
+                self.with_recursion_guard(db, Type::NominalInstance(instance), Type::Never, || {
+                    self.check_tuple_spec_is_uninhabited(db, tuple.as_ref())
+                })
+                .is_always_satisfied(db, self.env)
+            })
     }
 
     /// Is `target` a metaclass instance (a nominal instance of a subclass of `builtins.type`)?
@@ -1428,6 +1449,25 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // It is a subtype of all other types.
             (Type::Never, _) => self.always(),
 
+            // Tuple instances and tuple subclasses with an uninhabited required element behave
+            // as `Never`. Internal TypeVarTuple argument packs instead remain structural.
+            (Type::NominalInstance(instance), other)
+                if !other
+                    .as_nominal_instance()
+                    .is_some_and(|other| other.is_typevartuple_pack(db))
+                    && self.is_uninhabited_nominal_instance(db, instance) =>
+            {
+                self.always()
+            }
+            (other, Type::NominalInstance(instance))
+                if !other
+                    .as_nominal_instance()
+                    .is_some_and(|other| other.is_typevartuple_pack(db))
+                    && self.is_uninhabited_nominal_instance(db, instance) =>
+            {
+                self.check_type_pair(db, other, Type::Never)
+            }
+
             (Type::TypeVar(source_typevar), Type::TypeVar(target_typevar))
                 if source_typevar.is_same_typevar_as(db, target_typevar) =>
             {
@@ -1451,13 +1491,21 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (Type::TypeAlias(source_alias), _) => {
                 self.with_recursion_guard(db, source, target, || {
-                    self.check_type_pair(db, source_alias.value_type(db), target)
+                    self.check_type_pair(
+                        db,
+                        source_alias.value_type_with_visitor(db, self.materialization_visitor),
+                        target,
+                    )
                 })
             }
 
             (_, Type::TypeAlias(target_alias)) => {
                 self.with_recursion_guard(db, source, target, || {
-                    self.check_type_pair(db, source, target_alias.value_type(db))
+                    self.check_type_pair(
+                        db,
+                        source,
+                        target_alias.value_type_with_visitor(db, self.materialization_visitor),
+                    )
                 })
             }
 
@@ -2678,7 +2726,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         })
     }
 
-    fn as_equivalence_checker(&self) -> EquivalenceChecker<'_, 'c, 'db> {
+    pub(super) fn as_equivalence_checker(&self) -> EquivalenceChecker<'_, 'c, 'db> {
         EquivalenceChecker {
             env: self.env,
             constraints: self.constraints,
@@ -2998,18 +3046,42 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         match (left, right) {
             (Type::Never, _) | (_, Type::Never) => self.always(),
 
+            // An uninhabited runtime tuple or tuple subclass has no common values with another
+            // runtime type. TypeVarTuple argument packs are type sequences, not runtime values.
+            (Type::NominalInstance(instance), other)
+                if !other
+                    .as_nominal_instance()
+                    .is_some_and(|other| other.is_typevartuple_pack(db))
+                    && self
+                        .as_relation_checker(TypeRelation::Redundancy { pure: true })
+                        .is_uninhabited_nominal_instance(db, instance) =>
+            {
+                self.always()
+            }
+            (other, Type::NominalInstance(instance))
+                if !other
+                    .as_nominal_instance()
+                    .is_some_and(|other| other.is_typevartuple_pack(db))
+                    && self
+                        .as_relation_checker(TypeRelation::Redundancy { pure: true })
+                        .is_uninhabited_nominal_instance(db, instance) =>
+            {
+                self.always()
+            }
+
             (Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => self.never(),
             (Type::Divergent(_), _) | (_, Type::Divergent(_)) => self.never(),
 
             (Type::TypeAlias(alias), _) => nontrivial_check(self, || {
-                let left_alias_ty = alias.value_type(db);
+                let left_alias_ty = alias.value_type_with_visitor(db, self.materialization_visitor);
                 self.with_recursion_guard(db, left, right, || {
                     self.check_type_pair(db, left_alias_ty, right)
                 })
             }),
 
             (_, Type::TypeAlias(alias)) => nontrivial_check(self, || {
-                let right_alias_ty = alias.value_type(db);
+                let right_alias_ty =
+                    alias.value_type_with_visitor(db, self.materialization_visitor);
                 self.with_recursion_guard(db, left, right, || {
                     self.check_type_pair(db, left, right_alias_ty)
                 })

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2840,12 +2840,12 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         // pass needs fresh materialization caches. Nested equivalence checks still share the
         // materialization-equivalence recursion guard to avoid re-entering the same comparison.
         let left_to_right_materialization_visitor =
-            self.materialization_visitor.for_new_materialization_root();
+            self.materialization_visitor.for_new_mapping_root();
         self.as_relation_checker(&left_to_right_materialization_visitor)
             .check_type_pair(db, left, right)
             .and(db, self.constraints, || {
                 let right_to_left_materialization_visitor =
-                    self.materialization_visitor.for_new_materialization_root();
+                    self.materialization_visitor.for_new_mapping_root();
                 self.as_relation_checker(&right_to_left_materialization_visitor)
                     .check_type_pair(db, right, left)
             })

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -922,7 +922,7 @@ impl<'db> IntersectionType<'db> {
         let non_union_elements = elements.clone().filter(|element| !element.is_union());
         let initial = Self::from_elements(db, env, non_union_elements);
         let insert_candidate = |candidates: &mut Vec<Type<'db>>, new_ty: Type<'db>| -> Option<()> {
-            if new_ty.is_uninhabited(db, env)
+            if new_ty == Type::Never
                 || candidates
                     .iter()
                     .any(|old| new_ty.is_redundant_with(db, env, *old))

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -193,6 +193,26 @@ impl<'db> UnionType<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
+    ) -> Type<'db> {
+        self.map_leave_aliases_impl(db, env, false, transform_fn)
+    }
+
+    /// Rebuild a potentially recursive alias body without starting independent relation checks.
+    pub(crate) fn map_leave_aliases_during_cycle_recovery(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
+    ) -> Type<'db> {
+        self.map_leave_aliases_impl(db, env, true, transform_fn)
+    }
+
+    fn map_leave_aliases_impl(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        cycle_recovery: bool,
         mut transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
     ) -> Type<'db> {
         let elements = self.elements(db);
@@ -200,7 +220,9 @@ impl<'db> UnionType<'db> {
         while let Some((i, ty)) = iter.next() {
             let new_ty = transform_fn(ty);
             if &new_ty != ty {
-                let mut builder = UnionBuilder::new(db, env).unpack_aliases(false);
+                let mut builder = UnionBuilder::new(db, env)
+                    .unpack_aliases(false)
+                    .cycle_recovery(cycle_recovery);
                 for prev in &elements[..i] {
                     builder.add_in_place(*prev);
                 }
@@ -900,7 +922,7 @@ impl<'db> IntersectionType<'db> {
         let non_union_elements = elements.clone().filter(|element| !element.is_union());
         let initial = Self::from_elements(db, env, non_union_elements);
         let insert_candidate = |candidates: &mut Vec<Type<'db>>, new_ty: Type<'db>| -> Option<()> {
-            if new_ty.is_never()
+            if new_ty.is_uninhabited(db, env)
                 || candidates
                     .iter()
                     .any(|old| new_ty.is_redundant_with(db, env, *old))

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1517,7 +1517,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
         }
 
         // `T & Never` -> `Never`
-        if new_positive.is_never() {
+        if new_positive.is_uninhabited(db, env) {
             *self = Self::default();
             self.positive.insert(Type::Never);
             return;
@@ -1779,8 +1779,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     self.add_positive(db, env, *neg);
                 }
             }
-            Type::Never => {
-                // Adding ~Never to an intersection is a no-op.
+            ty if ty.is_uninhabited(db, env) => {
+                // Adding the complement of an uninhabited type is a no-op.
             }
             Type::NominalInstance(instance) if instance.is_object() => {
                 // Adding ~object to an intersection results in Never.
@@ -1969,7 +1969,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
         {
             let speculative =
                 expand_intersection_typevars_and_newtypes(db, env, &self.positive, &self.negative);
-            if speculative.is_never() {
+            if speculative.is_uninhabited(db, env) {
                 return Type::Never;
             }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1331,7 +1331,9 @@ impl<'db> Signature<'db> {
                 && bound_signature
                     .variance_of(db, env, typevar.identity(db))
                     .is_covariant()
-                && bounds.lower.is_some_and(|lower| !lower.is_never())
+                && bounds
+                    .lower
+                    .is_some_and(|lower| !lower.is_uninhabited(db, env))
                 && let Ok(Some(solution)) = PathBounds::default_solve(db, env, &constraints, bounds)
             {
                 return Some(solution);
@@ -2543,13 +2545,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         match target_parameters.keyword_by_name(name) {
                             Some((_, parameter)) => {
                                 !parameter.is_keyword_only()
-                                    || parameter.annotated_type().resolve_type_alias(db).is_never()
+                                    || parameter.annotated_type().is_uninhabited(db, self.env)
                             }
                             None => {
                                 target_parameters
                                     .keyword_variadic()
                                     .is_none_or(|(_, parameter)| {
-                                        parameter.annotated_type().resolve_type_alias(db).is_never()
+                                        parameter.annotated_type().is_uninhabited(db, self.env)
                                     })
                             }
                         }
@@ -3911,7 +3913,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                             captured_source_parameters()
                                                 .map(Parameter::annotated_type),
                                         )
-                                    };
+                                    }
+                                    .into_typevartuple_pack(db);
 
                                 reuse_current_source = source_parameter_count == 0;
                                 for _ in 1..source_parameter_count {

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -185,9 +185,9 @@ fn divergent_type() {
     assert!(!top_div.has_dynamic(db, &env));
     assert!(!bottom_div.has_dynamic(db, &env));
     assert!(top_div.is_object());
-    assert!(!top_div.is_never());
+    assert!(!top_div.is_uninhabited(db, &env));
     assert!(!bottom_div.is_object());
-    assert!(bottom_div.is_never());
+    assert!(bottom_div.is_uninhabited(db, &env));
     assert_eq!(top_div.negate(db, &env), bottom_div);
     assert_eq!(bottom_div.negate(db, &env), top_div);
     assert_eq!(

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -10,8 +10,7 @@
 //!
 //! The description of which elements can appear in a `tuple` is called a [`TupleSpec`]. Other
 //! things besides `tuple` instances can be described by a tuple spec — for instance, the targets
-//! of an unpacking assignment. A `tuple` specialization can include `Never` as a fixed-length
-//! element because a user-defined tuple subclass can inhabit that type.
+//! of an unpacking assignment or the arguments of a `TypeVarTuple`.
 
 use crate::{Program, ProgramEnvironment};
 use std::cmp::Ordering;
@@ -125,6 +124,13 @@ impl TupleLength {
     }
 }
 
+/// Whether a tuple specification describes runtime values or variadic type arguments.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
+pub enum TupleRole {
+    RuntimeValue,
+    TypeVarTuplePack,
+}
+
 #[salsa::interned(debug, constructor=new_internal, heap_size=ruff_memory_usage::heap_size)]
 pub struct TupleType<'db> {
     #[returns(copy)]
@@ -132,6 +138,11 @@ pub struct TupleType<'db> {
 
     #[returns(ref)]
     pub(crate) tuple: TupleSpec<'db>,
+
+    /// Argument packs describe type sequences, not runtime tuples, so `Never` does not make them
+    /// uninhabited. Intern the role to keep packs distinct from otherwise identical runtime tuples.
+    #[returns(copy)]
+    pub(crate) role: TupleRole,
 }
 
 pub(super) fn walk_tuple_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
@@ -174,20 +185,30 @@ impl<'db> TupleType<'db> {
         env: &ProgramEnvironment<'db>,
         spec: &TupleSpec<'db>,
     ) -> Self {
-        // If the variable-length portion is Never, it can only be instantiated with zero elements.
-        // That means this isn't a variable-length tuple after all!
+        Self::new_with_visitor(db, spec, &ApplyTypeMappingVisitor::new(env))
+    }
+
+    fn new_with_visitor(
+        db: &'db dyn Db,
+        spec: &TupleSpec<'db>,
+        visitor: &ApplyTypeMappingVisitor<'_, 'db>,
+    ) -> Self {
+        let env = visitor.env;
+        // If the variable-length portion is uninhabited, it can only be instantiated with zero
+        // elements. That means this isn't a variable-length tuple after all!
         if let TupleSpec::Variable(tuple) = spec
-            && matches!(tuple.variable(), VariableSegment::Homogeneous(Type::Never))
+            && let VariableSegment::Homogeneous(element) = tuple.variable()
+            && visitor.is_uninhabited(db, element)
         {
             let tuple = TupleSpec::Fixed(FixedLengthTuple::from_elements(
                 tuple
                     .iter_prefix_elements()
                     .chain(tuple.iter_suffix_elements()),
             ));
-            return TupleType::new_internal(db, env.program(db), tuple);
+            return TupleType::new_internal(db, env.program(db), tuple, TupleRole::RuntimeValue);
         }
 
-        TupleType::new_internal(db, env.program(db), spec)
+        TupleType::new_internal(db, env.program(db), spec, TupleRole::RuntimeValue)
     }
 
     pub(crate) fn empty(db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Self {
@@ -195,6 +216,7 @@ impl<'db> TupleType<'db> {
             db,
             env.program(db),
             TupleSpec::from(FixedLengthTuple::empty()),
+            TupleRole::RuntimeValue,
         )
     }
 
@@ -241,13 +263,10 @@ impl<'db> TupleType<'db> {
         env: &ProgramEnvironment<'db>,
         element: Type<'db>,
     ) -> Self {
-        match element {
-            Type::Never => TupleType::empty(db, env),
-            _ => TupleType::new_internal(db, env.program(db), TupleSpec::homogeneous(element)),
-        }
+        Self::new(db, env, &TupleSpec::homogeneous(element))
     }
 
-    /// Packs a `TypeVarTuple` into the tuple value used for generic specialization relations.
+    /// Represents a symbolic `TypeVarTuple` as an argument pack rather than a runtime tuple.
     pub(crate) fn unpacked_typevartuple(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -258,7 +277,26 @@ impl<'db> TupleType<'db> {
             db,
             env.program(db),
             VariableLengthTuple::mixed([], VariableSegment::TypeVarTuple(typevar), []),
+            TupleRole::TypeVarTuplePack,
         )
+    }
+
+    pub(crate) fn is_typevartuple_pack(self, db: &'db dyn Db) -> bool {
+        self.role(db) == TupleRole::TypeVarTuplePack
+    }
+
+    /// Gives this tuple specification the distinct identity of a generic argument pack.
+    pub(crate) fn into_typevartuple_pack(self, db: &'db dyn Db) -> Self {
+        if self.is_typevartuple_pack(db) {
+            self
+        } else {
+            Self::new_internal(
+                db,
+                self.program(db),
+                self.tuple(db),
+                TupleRole::TypeVarTuplePack,
+            )
+        }
     }
 
     // N.B. If this method is not Salsa-tracked, we take 10 minutes to check
@@ -293,6 +331,7 @@ impl<'db> TupleType<'db> {
             env.program(db),
             self.tuple(db)
                 .recursive_type_normalized_impl(db, env, div, nested)?,
+            self.role(db),
         ))
     }
 
@@ -303,13 +342,18 @@ impl<'db> TupleType<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'_, 'db>,
     ) -> Self {
-        TupleType::new(
+        let mapped = TupleType::new_with_visitor(
             db,
-            visitor.env,
             &self
                 .tuple(db)
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-        )
+            visitor,
+        );
+        if self.is_typevartuple_pack(db) {
+            mapped.into_typevartuple_pack(db)
+        } else {
+            mapped
+        }
     }
 
     pub(crate) fn find_legacy_typevars_impl(
@@ -326,6 +370,34 @@ impl<'db> TupleType<'db> {
 }
 
 impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
+    /// A runtime tuple or tuple subclass is uninhabited if any required element is uninhabited.
+    ///
+    /// Reuse this relation checker's visitors for the element comparisons: a recursive alias
+    /// such as `type Empty[T] = tuple[Empty[list[T]], Never]` must encounter the existing
+    /// recursion guard instead of starting an independent equivalence check for each element.
+    pub(super) fn check_tuple_spec_is_uninhabited(
+        &self,
+        db: &'db dyn Db,
+        tuple: &TupleSpec<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let check_element = |element| {
+            self.as_equivalence_checker()
+                .check_type_pair(db, element, Type::Never)
+        };
+
+        match tuple {
+            Tuple::Fixed(tuple) => {
+                tuple
+                    .iter_all_elements()
+                    .when_any(db, self.constraints, check_element)
+            }
+            Tuple::Variable(tuple) => tuple
+                .iter_prefix_elements()
+                .chain(tuple.iter_suffix_elements())
+                .when_any(db, self.constraints, check_element),
+        }
+    }
+
     pub(super) fn check_tuple_type_pair(
         &self,
         db: &'db dyn Db,
@@ -429,7 +501,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
                 match target.variable() {
                     VariableSegment::TypeVarTuple(typevartuple) => {
-                        let packed = Type::heterogeneous_tuple(db, self.env, source_iter.copied());
+                        let packed = Type::heterogeneous_tuple(db, self.env, source_iter.copied())
+                            .into_typevartuple_pack(db);
                         result.and(db, self.constraints, || {
                             self.check_type_pair(db, packed, Type::TypeVar(typevartuple))
                         })
@@ -577,7 +650,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             source.variable(),
                             source_suffix[..source_suffix_start].iter().copied(),
                         ),
-                    ));
+                    ))
+                    .into_typevartuple_pack(db);
                     return boundary_constraints.and(db, self.constraints, || {
                         self.check_type_pair(db, packed, Type::TypeVar(typevartuple))
                     });

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -185,7 +185,16 @@ impl<'db> TupleType<'db> {
         env: &ProgramEnvironment<'db>,
         spec: &TupleSpec<'db>,
     ) -> Self {
-        Self::new_with_visitor(db, spec, &ApplyTypeMappingVisitor::new(env))
+        // Fixed tuples and definitely inhabited variable segments cannot normalize to a shorter
+        // tuple, so they do not need to construct a transformation visitor.
+        if let TupleSpec::Variable(tuple) = spec
+            && let VariableSegment::Homogeneous(element) = tuple.variable()
+            && element.may_be_uninhabited()
+        {
+            Self::new_with_visitor(db, spec, &ApplyTypeMappingVisitor::new(env))
+        } else {
+            Self::new_internal(db, env.program(db), spec, TupleRole::RuntimeValue)
+        }
     }
 
     fn new_with_visitor(

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -380,9 +380,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         tuple: &TupleSpec<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let check_element = |element| {
-            self.as_equivalence_checker()
-                .check_type_pair(db, element, Type::Never)
+        let check_element = |element: Type<'db>| {
+            if element == Type::Never {
+                self.always()
+            } else if element.may_be_uninhabited() {
+                self.as_equivalence_checker()
+                    .check_type_pair(db, element, Type::Never)
+            } else {
+                self.never()
+            }
         };
 
         match tuple {

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -283,6 +283,22 @@ fn apply_type_alias_specialization<'db>(
     };
 
     let env = ProgramEnvironment::from_program(generic_context.program(db));
+    apply_type_alias_specialization_with_visitor(
+        db,
+        ty,
+        generic_context,
+        specialization,
+        &ApplyTypeMappingVisitor::new(&env),
+    )
+}
+
+fn apply_type_alias_specialization_with_visitor<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    generic_context: GenericContext<'db>,
+    specialization: Option<Specialization<'db>>,
+    visitor: &ApplyTypeMappingVisitor<'_, 'db>,
+) -> Type<'db> {
     let specialization =
         specialization.unwrap_or_else(|| generic_context.default_specialization(db, None));
     let type_mapping = match specialization.materialization_kind(db) {
@@ -293,12 +309,7 @@ fn apply_type_alias_specialization<'db>(
         },
     };
 
-    ty.apply_type_mapping_impl(
-        db,
-        &type_mapping,
-        TypeContext::default(),
-        &ApplyTypeMappingVisitor::new(&env),
-    )
+    ty.apply_type_mapping_impl(db, &type_mapping, TypeContext::default(), visitor)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
@@ -393,6 +404,36 @@ impl<'db> TypeAliasType<'db> {
             TypeAliasType::PEP695(type_alias) => type_alias.raw_value_type(db),
             TypeAliasType::ManualPEP695(type_alias) => type_alias.raw_value_type(db),
         }
+    }
+
+    /// Expand this alias while retaining the caller's active transformation and recursion state.
+    ///
+    /// Tuple normalization can ask whether a recursive alias is inhabited during specialization;
+    /// creating a fresh visitor at that boundary would hide the active recursive definition.
+    pub(super) fn value_type_with_visitor(
+        self,
+        db: &'db dyn Db,
+        visitor: &ApplyTypeMappingVisitor<'_, 'db>,
+    ) -> Type<'db> {
+        visitor.expand_alias(db, self, || {
+            let value = self.raw_value_type(db);
+            let specialized = self
+                .generic_context(db)
+                .map(|generic_context| {
+                    apply_type_alias_specialization_with_visitor(
+                        db,
+                        value,
+                        generic_context,
+                        self.specialization(db),
+                        visitor,
+                    )
+                })
+                .unwrap_or(value);
+
+            self.materialization_kind(db)
+                .map(|kind| specialized.materialize(db, kind, visitor))
+                .unwrap_or(specialized)
+        })
     }
 
     /// Returns the alias without an applied specialization or pending materialization.

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -416,6 +416,7 @@ impl<'db> TypeAliasType<'db> {
         visitor: &ApplyTypeMappingVisitor<'_, 'db>,
     ) -> Type<'db> {
         visitor.expand_alias(db, self, || {
+            let specialization_visitor = visitor.for_new_mapping_root();
             let value = self.raw_value_type(db);
             let specialized = self
                 .generic_context(db)
@@ -425,13 +426,13 @@ impl<'db> TypeAliasType<'db> {
                         value,
                         generic_context,
                         self.specialization(db),
-                        visitor,
+                        &specialization_visitor,
                     )
                 })
                 .unwrap_or(value);
 
             self.materialization_kind(db)
-                .map(|kind| specialized.materialize(db, kind, visitor))
+                .map(|kind| specialized.materialize(db, kind, &specialization_visitor))
                 .unwrap_or(specialized)
         })
     }

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -416,10 +416,16 @@ impl<'db> TypeAliasType<'db> {
         visitor: &ApplyTypeMappingVisitor<'_, 'db>,
     ) -> Type<'db> {
         visitor.expand_alias(db, self, || {
-            let specialization_visitor = visitor.for_new_mapping_root();
             let value = self.raw_value_type(db);
-            let specialized = self
-                .generic_context(db)
+            let generic_context = self.generic_context(db);
+            let materialization_kind = self.materialization_kind(db);
+
+            if generic_context.is_none() && materialization_kind.is_none() {
+                return value;
+            }
+
+            let specialization_visitor = visitor.for_new_mapping_root();
+            let specialized = generic_context
                 .map(|generic_context| {
                     apply_type_alias_specialization_with_visitor(
                         db,
@@ -431,7 +437,7 @@ impl<'db> TypeAliasType<'db> {
                 })
                 .unwrap_or(value);
 
-            self.materialization_kind(db)
+            materialization_kind
                 .map(|kind| specialized.materialize(db, kind, &specialization_visitor))
                 .unwrap_or(specialized)
         })

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -77,8 +77,13 @@ impl<'db> TypedDictOpenness<'db> {
     /// class ByExtraItems(TypedDict, extra_items=Never): ...
     /// class ByClosed(TypedDict, closed=True): ...
     /// ```
-    pub(crate) fn extra(db: &'db dyn Db, declared_ty: Type<'db>, is_read_only: bool) -> Self {
-        if declared_ty.resolve_type_alias(db).is_never() {
+    pub(crate) fn extra(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        declared_ty: Type<'db>,
+        is_read_only: bool,
+    ) -> Self {
+        if declared_ty.is_uninhabited(db, env) {
             Self::Closed
         } else {
             Self::Extra(TypedDictExtraItems {
@@ -134,6 +139,7 @@ impl<'db> TypedDictOpenness<'db> {
             Self::ImplicitlyOpen | Self::Closed => self,
             Self::Extra(extra_items) => Self::extra(
                 db,
+                visitor.env,
                 extra_items
                     .declared_ty
                     .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -160,7 +166,7 @@ impl<'db> TypedDictOpenness<'db> {
                 } else {
                     declared_ty.unwrap_or(div)
                 };
-                Some(Self::extra(db, declared_ty, extra_items.is_read_only))
+                Some(Self::extra(db, env, declared_ty, extra_items.is_read_only))
             }
         }
     }
@@ -278,6 +284,7 @@ impl<'db> TypedDictType<'db> {
                             .map_type(|ty| ty.apply_optional_specialization(db, specialization));
                     return TypedDictOpenness::extra(
                         db,
+                        &env,
                         annotation.inner_type(),
                         annotation.qualifiers().contains(TypeQualifiers::READ_ONLY),
                     );
@@ -354,7 +361,7 @@ impl<'db> TypedDictType<'db> {
 
         self.items(db)
             .iter()
-            .filter(|(_, field)| field.may_be_present(db))
+            .filter(|(_, field)| field.may_be_present(db, env))
             .fold(UnionBuilder::new(db, env), |builder, (name, _)| {
                 builder.add(Type::string_literal(db, name))
             })
@@ -365,10 +372,15 @@ impl<'db> TypedDictType<'db> {
     ///
     /// An undeclared key can still exist in an implicitly open `TypedDict` or one with explicit
     /// extra items. An optional field with an uninhabited value type can never be present.
-    pub(crate) fn key_membership_truthiness(self, db: &'db dyn Db, key: &str) -> Truthiness {
+    pub(crate) fn key_membership_truthiness(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        key: &str,
+    ) -> Truthiness {
         match self.items(db).get(key) {
             Some(field) if field.is_required() => Truthiness::AlwaysTrue,
-            Some(field) if field.may_be_present(db) => Truthiness::Ambiguous,
+            Some(field) if field.may_be_present(db, env) => Truthiness::Ambiguous,
             Some(_) => Truthiness::AlwaysFalse,
             None if self.openness(db).is_closed() => Truthiness::AlwaysFalse,
             None => Truthiness::Ambiguous,
@@ -1396,6 +1408,7 @@ pub(super) fn deferred_functional_typed_dict_openness<'db>(
         let deferred_inference = infer_deferred_types(db, definition);
         return TypedDictOpenness::extra(
             db,
+            &env,
             deferred_inference.expression_type(&extra_items.value),
             deferred_inference
                 .qualifiers(&extra_items.value)
@@ -1711,6 +1724,7 @@ fn intersect_unpacked_typed_dict_openness<'db>(
     } else {
         TypedDictOpenness::extra(
             db,
+            env,
             IntersectionType::from_elements(db, env, explicit_value_types),
             true,
         )
@@ -1749,11 +1763,11 @@ fn union_unpacked_typed_dict_openness<'db>(
     }
 
     if has_implicitly_open && has_explicit_extra_items {
-        TypedDictOpenness::extra(db, Type::object(), true)
+        TypedDictOpenness::extra(db, env, Type::object(), true)
     } else if has_implicitly_open {
         TypedDictOpenness::ImplicitlyOpen
     } else if has_explicit_extra_items {
-        TypedDictOpenness::extra(db, value_types.build(), true)
+        TypedDictOpenness::extra(db, env, value_types.build(), true)
     } else {
         TypedDictOpenness::Closed
     }
@@ -2027,9 +2041,13 @@ pub(super) fn infer_unpacked_keyword_types<'db>(
         .collect()
 }
 
-fn unpacked_keyword_is_gradual<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+fn unpacked_keyword_is_gradual<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+) -> bool {
     match ty.resolve_type_alias(db) {
-        ty if ty.is_never() || ty.is_dynamic() => true,
+        ty if ty.is_uninhabited(db, env) || ty.is_dynamic() => true,
         Type::Union(union) => union
             .elements(db)
             .iter()
@@ -2123,7 +2141,7 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
         return;
     }
 
-    if unpacked_keyword_is_gradual(db, unpacked_type) {
+    if unpacked_keyword_is_gradual(db, env, unpacked_type) {
         provided_keys.extend(typed_dict.items(db).keys().cloned());
     } else if let Some(unpacked_keys) =
         extract_unpacked_typed_dict_keys_from_value_type(db, env, unpacked_type)
@@ -2855,7 +2873,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
 
     // Never and Dynamic types are special: they can have any keys, so we skip validation and mark
     // all target keys as provided.
-    if unpacked_keyword_is_gradual(db, unpacked_type) {
+    if unpacked_keyword_is_gradual(db, env, unpacked_type) {
         shadowed_keys.extend(items.keys().cloned());
         for key_name in items.keys() {
             guaranteed_keys.entry(key_name.clone()).or_insert(None);
@@ -2915,7 +2933,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
                 context,
                 typed_dict,
                 &BTreeMap::new(),
-                TypedDictOpenness::extra(db, value_ty, true),
+                TypedDictOpenness::extra(db, env, value_ty, true),
                 nodes,
                 shadowed_keys,
             );
@@ -3103,8 +3121,8 @@ impl<'db> TypedDictField<'db> {
     }
 
     /// Returns `false` for optional fields whose declared type is uninhabited.
-    pub(crate) fn may_be_present(&self, db: &'db dyn Db) -> bool {
-        self.is_required() || !self.declared_ty.resolve_type_alias(db).is_never()
+    pub(crate) fn may_be_present(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
+        self.is_required() || !self.declared_ty.is_uninhabited(db, env)
     }
 
     pub(crate) const fn first_declaration(&self) -> Option<Definition<'db>> {

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1299,7 +1299,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                         let env = visitor.env;
                         // Materialization uses a different mapping mode. Reuse of the outer
                         // visitor can incorrectly hit a cache entry from specialization.
-                        let materialization_visitor = visitor.for_new_materialization_root();
+                        let materialization_visitor = visitor.for_new_mapping_root();
                         let materialized =
                             mapped.materialize(db, *materialization_kind, &materialization_visitor);
 


### PR DESCRIPTION
## Motivation

#27580 preserved `Never` elements in `TypeVarTuple` specializations by changing how tuple types containing `Never` behave. That fixed examples such as `Container[int, Never]`, but it also made the type algebra inconsistent: a runtime `tuple[int, Never]` cannot have any inhabitants, so it must be equivalent to `Never` and disjoint from every type, including itself.

The distinction is that these two superficially similar type sequences describe different things:

```py
from typing import Never

class Container[*Ts]: ...

# This generic specialization can have inhabitants: `Never` is a type argument.
value: Container[int, Never]

# This runtime tuple cannot have inhabitants: its second value would have to inhabit `Never`.
impossible: tuple[int, Never]
```

The implementation needs to preserve the complete variadic argument sequence without giving an impossible runtime tuple nonempty semantics or discarding its useful annotation shape.

## Implementation

The central change is to make the existing `TupleType` representation explicitly distinguish its two roles. A new interned `TupleRole` records whether the tuple specification describes a runtime tuple value or a `TypeVarTuple` argument pack. Interning the role means that otherwise identical element sequences are distinct when their meanings differ: a runtime `tuple[int, Never]` is an impossible product of runtime values, whereas the argument pack `[int, Never]` is a perfectly meaningful sequence of type arguments. Both roles still use the existing tuple specification, generic specialization, and constraint representations.

Argument packs are marked at the boundaries where variadic generic arguments and `TypeVarTuple` constraints are constructed. Once marked, they retain their full shape throughout inference and relation checking, including the position of every `Never` element, their fixed length, and any fixed prefix or suffix. This allows constructors, generic functions, callable signatures, structural protocols, variadic defaults, and nested generic aliases to infer the same specialization without introducing a second representation that each subsystem must separately preserve.

Runtime tuples take the opposite semantic path. Their stored element sequence is retained so annotations, displays, unpacking, and tuple subclasses remain precise, but a runtime tuple with an uninhabited required element is recognized as semantically equivalent to `Never`. The relation checker applies this rule to both exact tuple instances and subclasses, while explicitly excluding argument packs. Consequently, an impossible tuple is a subtype of every type and disjoint from every type, including itself; assignability to such a tuple delegates to the existing rules for assignability to `Never`, preserving the established behavior of `Any`, aliases, and bounded type variables.

Variable-length tuples need a related but different normalization. A homogeneous segment with an uninhabited element type cannot contribute even one value, but it can still contribute zero values. The implementation therefore removes that variable segment and preserves any fixed prefix and suffix, so `tuple[Never, ...]` becomes `tuple[()]` and `tuple[int, *tuple[Never, ...], str]` becomes `tuple[int, str]`.

Because semantic emptiness is no longer synonymous with the literal `Type::Never` variant, the change also audits operations that depend on whether a type has inhabitants. Constraint bounds, intersections and complements, narrowing, reachability, typed-dictionary fields, callable binding, and related operations now use semantic inhabitance checks where correctness depends on emptiness. Cheap direct comparisons with `Type::Never` are retained only where the check is genuinely a representation-level fast path.

Checking tuple inhabitance can expand recursive type aliases, including aliases hidden behind additional tuple or union wrappers and aliases whose specialization grows on each recursive reference. Alias expansion now remains inside the existing transformation visitor and identifies active recursion by alias definition rather than by the fully specialized type. The same visitor is preserved across materialization, and recursive union rebuilding avoids starting independent relation checks while an alias body is being reconstructed. This keeps recursive aliases terminating without sacrificing precision for ordinary non-recursive aliases.

Finally, recognizing impossible tuple subclasses must not repeatedly traverse the inheritance hierarchy of unrelated classes. Known non-tuple classes and ordinary user-defined classes without explicit bases are rejected immediately; other classes use a Salsa-cached tuple-subclass query keyed by the unspecialized class origin. The actual tuple specification is still retrieved from the specialized class, so one specialization can be uninhabited while another remains inhabited.

## Alternatives considered

One alternative was to retain the behavior introduced by #27580 and preserve `Never` elements by treating runtime tuples that contain them as ordinary, inhabited tuple types. This superficially fixes variadic argument display and inference because the tuple representation no longer loses element positions, but it conflates a sequence of type arguments with a product of runtime values. There cannot be an object of type `Never`, so there cannot be an instance of `tuple[int, Never]` or any subclass that requires such an element. Treating those types as inhabited contradicts their relationship with the bottom type, produces inconsistent subtype and disjointness results, and causes the stable property tests to find counterexamples. Repairing individual relation checks without restoring the underlying semantic distinction only moves the inconsistency between operations.

Another alternative was to introduce an independent `TupleSpec`-based variadic argument representation, a dedicated `GenericArgument` variant, or a parallel sidecar containing the preserved argument sequence. `TupleSpec` can naturally store `Never` elements, so this initially appears to model variadic packs directly. In practice, however, the existing solver, specialization machinery, callable inference, protocol matching, alias substitution, constructor inference, materialization, and diagnostics already exchange tuple-shaped types. Maintaining a second representation therefore requires every one of those paths to carry, synchronize, and consult the extra information. At its largest, the experimental implementation had already reached **3,227 changed lines across 38 files: 2,527 additions and 700 deletions**. Even at that size, independent reviews were still finding bugs: unpacked annotations and defaults lost `Never` elements, callable and structural-protocol inference dropped argument shape, materialization ignored hidden pack elements, and inherited constructors produced spurious errors. Sidecars also added storage to inference structures even for code that never uses `TypeVarTuple`. Recording the role directly in the existing interned tuple type preserves the distinction everywhere the established machinery already transports tuple-shaped types.

## Test plan

The stable property tests were run with `QUICKCHECK_TESTS=100000`, meaning **100,000 generated cases for each of the 24 properties**.

The PR also adds extensive mdtests because the distinction between runtime tuples and variadic argument packs crosses many independently implemented, user-visible paths. Separate regressions cover both PEP 695 and legacy `TypeVarTuple` declarations, explicit arguments and defaults, constructors, generic functions, callable and structural-protocol inference, optional callback parameters, variance and promotion, materialization, generic union aliases, tuple subclasses, disjointness, and several forms of recursive alias. Earlier implementations passed existing tests while failing in particular combinations of these features, so the larger mdtest suite protects the individual integration points that broad algebraic property tests do not exercise.
