### PR TITLE
[ty] Update ecosystem-analyzer and mypy-primer pins

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -44,7 +44,7 @@ env:
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
   # TODO: Update the mypy-primer revision in scripts/setup_primer_project.py
   # and regenerate its lockfile when updating ecosystem-analyzer.
-  ECOSYSTEM_ANALYZER_COMMIT: 2b409ad30445f16b863919e0799b438c6b04c645
+  ECOSYSTEM_ANALYZER_COMMIT: a602846d9c13d7c6d7268dff728442f68c47d923
 
 jobs:
   build-ty:

--- a/.github/workflows/ty-ecosystem-report.yaml
+++ b/.github/workflows/ty-ecosystem-report.yaml
@@ -20,7 +20,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
-  ECOSYSTEM_ANALYZER_COMMIT: 2b409ad30445f16b863919e0799b438c6b04c645
+  ECOSYSTEM_ANALYZER_COMMIT: a602846d9c13d7c6d7268dff728442f68c47d923
 
 jobs:
   ty-ecosystem-report:

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -14,7 +14,7 @@
 # [tool.uv.sources]
 # # Keep this revision and the script's lockfile in sync with ecosystem-analyzer's
 # # mypy-primer pin so memory reports and ecosystem jobs use the same project definitions.
-# mypy-primer = { git = "https://github.com/hauntsaninja/mypy_primer", rev = "6d6eebd8d37c9b8931381e79aa99808d9378c988" }
+# mypy-primer = { git = "https://github.com/hauntsaninja/mypy_primer", rev = "db37f8a384c45c02fc52544fd819f979d66e174a" }
 # ///
 
 """Clone a mypy-primer project and set up a virtualenv with its dependencies installed.

--- a/scripts/setup_primer_project.py.lock
+++ b/scripts/setup_primer_project.py.lock
@@ -7,9 +7,9 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [manifest]
-requirements = [{ name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=6d6eebd8d37c9b8931381e79aa99808d9378c988" }]
+requirements = [{ name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=db37f8a384c45c02fc52544fd819f979d66e174a" }]
 
 [[package]]
 name = "mypy-primer"
 version = "0.1.0"
-source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=6d6eebd8d37c9b8931381e79aa99808d9378c988#6d6eebd8d37c9b8931381e79aa99808d9378c988" }
+source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=db37f8a384c45c02fc52544fd819f979d66e174a#db37f8a384c45c02fc52544fd819f979d66e174a" }


### PR DESCRIPTION
Update both ecosystem-analyzer workflow pins to include https://github.com/astral-sh/ecosystem-analyzer/pull/160, which incorporates https://github.com/hauntsaninja/mypy_primer/pull/258 and fixes AutoSplit dependency installation.

Keep the primer reproduction script and its lockfile synchronized with the analyzer's mypy-primer revision.
