### PR TITLE
[ty] Infer generic protocols from class objects

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -2064,8 +2064,7 @@ class Color(Enum):
 for color in Color:
     reveal_type(color)  # revealed: Color
 
-# TODO: Should be `list[Color]`
-reveal_type(list(Color))  # revealed: list[Unknown]
+reveal_type(list(Color))  # revealed: list[Color]
 ```
 
 ## Methods / non-member attributes

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4418,6 +4418,119 @@ class IntParser:
 parser: Parser = IntParser
 ```
 
+## Generic protocol inference from class attributes
+
+A class object can supply the type argument of a protocol through an ordinary attribute. Passing the
+class itself should infer the same type as passing an instance.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class HasValue[T](Protocol):
+    value: T
+
+class IntValue:
+    value: int = 1
+
+def get_value[T](obj: HasValue[T]) -> T:
+    return obj.value
+
+reveal_type(get_value(IntValue))  # revealed: int
+reveal_type(get_value(IntValue()))  # revealed: int
+
+def _(cls: type[IntValue]) -> None:
+    reveal_type(get_value(cls))  # revealed: int
+```
+
+## Generic protocol inference from class methods
+
+The return type of a class method can determine a protocol's type argument, including when the
+argument is the class object itself.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+T = TypeVar("T")
+
+class Factory(Protocol[T_co]):
+    @classmethod
+    def make(cls) -> T_co: ...
+
+class Concrete:
+    @classmethod
+    def make(cls) -> "Concrete":
+        return cls()
+
+def from_protocol(factory: Factory[T]) -> T:
+    return factory.make()
+
+reveal_type(from_protocol(Concrete))  # revealed: Concrete
+reveal_type(from_protocol(Concrete()))  # revealed: Concrete
+
+bad: Factory[str] = Concrete  # error: [invalid-assignment]
+```
+
+Specialized generic class objects and unions of class objects also contribute their method return
+types to inference.
+
+```py
+class GenericFactory[T]:
+    @classmethod
+    def make(cls) -> T:
+        raise NotImplementedError
+
+reveal_type(from_protocol(GenericFactory[int]))  # revealed: int
+
+def _(cls: type[GenericFactory[int]] | type[GenericFactory[str]]) -> None:
+    reveal_type(from_protocol(cls))  # revealed: int | str
+```
+
+## Generic protocol inference from static methods
+
+A static method on a class object can satisfy either a static-method or an instance-method protocol
+member. Both forms should contribute the method's return type to inference.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class StaticFactory[T](Protocol):
+    @staticmethod
+    def make() -> T: ...
+
+class InstanceFactory[T](Protocol):
+    def make(self) -> T: ...
+
+class IntFactory:
+    @staticmethod
+    def make() -> int:
+        return 1
+
+def from_static[T](factory: StaticFactory[T]) -> T:
+    return factory.make()
+
+def from_instance[T](factory: InstanceFactory[T]) -> T:
+    return factory.make()
+
+reveal_type(from_static(IntFactory))  # revealed: int
+reveal_type(from_instance(IntFactory))  # revealed: int
+```
+
 ## Class objects and `Self`-returning class-method protocol members
 
 When a class object is checked against a class-method protocol member, `Self` in the protocol

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5691,6 +5691,57 @@ class Constructor(Protocol):
 constructor: Constructor = Product
 ```
 
+## Generic constructor callback inference
+
+Passing `type[T]` to a generic callback protocol must preserve the type variable returned by the
+class's constructor.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class Callback[T](Protocol):
+    def __call__(self) -> T: ...
+
+def invoke[T](callback: Callback[T]) -> T:
+    return callback()
+
+def create[T](cls: type[T]) -> T:
+    reveal_type(invoke(cls))  # revealed: T@create
+    return invoke(cls)
+```
+
+## Generic callback inference from other members
+
+A callable protocol can infer a type argument from another member. Comparing only its `__call__`
+signature would miss the class attribute that determines `T` here.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class ConstructorWithValue[T](Protocol):
+    value: T
+
+    def __call__(self) -> object: ...
+
+class Product:
+    value: int = 1
+
+def get_value[T](factory: ConstructorWithValue[T]) -> T:
+    return factory.value
+
+reveal_type(get_value(Product))  # revealed: int
+```
+
 ## Generic protocols and union arguments
 
 When a union is passed to a parameter annotated as a generic protocol, each union element can

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -4073,7 +4073,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 return self.infer_from_constraint_set(when);
             }
 
-            (formal @ Type::ProtocolInstance(_), actual @ Type::TypedDict(_)) => {
+            (
+                formal @ Type::ProtocolInstance(_),
+                actual @ (Type::ClassLiteral(_)
+                | Type::GenericAlias(_)
+                | Type::SubclassOf(_)
+                | Type::TypedDict(_)),
+            ) => {
+                // A class object can itself implement a protocol. Compare its members directly;
+                // converting it to its instance type would infer from a different interface.
                 let when = self.constraint_for_relation(formal, actual, relation_polarity);
                 return self.infer_from_constraint_set(when);
             }


### PR DESCRIPTION
## Summary

Passing a class object to a generic protocol parameter could leave the protocol's type arguments as `Unknown`, even when its attributes or methods supplied enough information to infer them. Ordinary instance arguments and unions already used structural constraints, but individual class objects fell through to inference that only considered `__call__`.

Use the existing structural constraint machinery for class literals, specialized generic classes, and `type[C]` arguments. This preserves the class object's own interface and also fixes `list(EnumClass)` inferring `list[Unknown]`.

Fixes https://github.com/astral-sh/ty/issues/4291

## Test plan

Added mdtests for inference through plain class attributes, class methods, static methods, ordinary-method protocols, specialized generic class objects, and unions of class types. Callback regressions cover preserving `T` when passing `type[T]` and inferring from a data member alongside `__call__`. The tests also retain instance behavior and rejection of an incompatible return type. Updated the enum iteration test to expect the precise member type.

### Ecosystem

The ecosystem report includes a new `invalid-assignment` diagnostic in [Scrapy's telnet test](https://github.com/scrapy/scrapy/blob/488a762d7173922190ea027e0fb6f6d9d3b59880/tests/test_extension_telnet.py#L46), which replaces a zero-argument bound method with `dict`. This PR correctly infers `TelnetConsole` where the result was previously `Unknown`, revealing an orthogonal, pre-existing limitation in ty's instance-method assignment checking. The directly typed assignment is rejected on both the base and PR revisions; the inference change does not introduce that restriction. Compatible class-level method replacement was addressed in [#26158](https://github.com/astral-sh/ruff/pull/26158), while instance-method replacement remains separate work related to [ty#350](https://github.com/astral-sh/ty/issues/350). This is just better type inference exposing an unrelated issue, so we accept it for this PR.

Other ecosystem changes are desirable improved inference.
