### PR TITLE
[ty] Preserve TypeAliasType runtime origin

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -23,6 +23,32 @@ def f() -> None:
     reveal_type(x)  # revealed: int | str
 ```
 
+## Runtime classes
+
+On Python 3.12, aliases defined by a `type` statement or the `typing.TypeAliasType` constructor are
+instances of the standard-library class, while aliases created with
+`typing_extensions.TypeAliasType` are instances of the distinct backport class.
+
+```py
+from typing import TypeAliasType as StdlibTypeAliasType
+from typing_extensions import TypeAliasType as ExtensionsTypeAliasType
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_subtype_of
+
+type StatementAlias = int
+StdlibAlias = StdlibTypeAliasType("StdlibAlias", int)
+ExtensionsAlias = ExtensionsTypeAliasType("ExtensionsAlias", int)
+
+static_assert(is_subtype_of(TypeOf[StatementAlias], StdlibTypeAliasType))
+static_assert(not is_subtype_of(TypeOf[StatementAlias], ExtensionsTypeAliasType))
+
+static_assert(is_subtype_of(TypeOf[StdlibAlias], StdlibTypeAliasType))
+static_assert(not is_subtype_of(TypeOf[StdlibAlias], ExtensionsTypeAliasType))
+
+static_assert(is_subtype_of(TypeOf[ExtensionsAlias], ExtensionsTypeAliasType))
+static_assert(not is_subtype_of(TypeOf[ExtensionsAlias], StdlibTypeAliasType))
+```
+
 ## Type aliases in `type[...]`
 
 ```py
@@ -203,7 +229,8 @@ def _(flag: bool):
 
 ```py
 type ListOrSet[T] = list[T] | set[T]
-reveal_type(ListOrSet.__type_params__)  # revealed: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]
+# revealed: tuple[typing.TypeVar | typing_extensions.TypeVar | typing.ParamSpec | typing_extensions.ParamSpec | typing.TypeVarTuple | typing_extensions.TypeVarTuple, ...]
+reveal_type(ListOrSet.__type_params__)
 type Tuple1[T] = tuple[T]
 
 def _(cond: bool):

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -113,7 +113,6 @@ pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
 };
 pub use special_form::SpecialFormType;
-pub(crate) use special_form::TypedDictModule;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
@@ -493,6 +492,61 @@ pub(crate) struct FindLegacyTypeVars;
 /// A [`CycleDetector`] that is used in `visit_specialization` methods.
 type SpecializationVisitor<'db> = CycleDetector<'db, VisitSpecialization, Type<'db>, (), 3>;
 struct VisitSpecialization;
+
+/// The standard-library `typing` module or its `typing_extensions` backport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
+pub enum TypingModule {
+    /// The standard-library `typing` module.
+    Typing,
+    /// The `typing_extensions` backport.
+    TypingExtensions,
+}
+
+impl TypingModule {
+    /// Return the module for a `TypedDict` special form, including a union of the special forms
+    /// exported by `typing` and `typing_extensions`.
+    fn from_typed_dict_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        match ty {
+            Type::SpecialForm(SpecialFormType::TypedDict(module)) => Some(module),
+            Type::Union(union) => {
+                let mut elements = union.elements(db).iter();
+                let Type::SpecialForm(SpecialFormType::TypedDict(module)) = elements.next()? else {
+                    return None;
+                };
+                elements.try_fold(*module, |module, element| {
+                    let Type::SpecialForm(SpecialFormType::TypedDict(element_module)) = element
+                    else {
+                        return None;
+                    };
+                    // `typing_extensions.TypedDict` always offers strictly more functionality than `typing.TypedDict`.
+                    // If any element is from `typing`, we therefore infer that the type is a `typing.TypedDict`,
+                    // since an operation on a union is only valid if the operation is valid on all elements in the
+                    // union.
+                    Some(match (module, element_module) {
+                        (Self::TypingExtensions, Self::TypingExtensions) => Self::TypingExtensions,
+                        _ => Self::Typing,
+                    })
+                })
+            }
+            _ => None,
+        }
+    }
+
+    const fn from_type_alias_class(class: KnownClass) -> Option<Self> {
+        match class {
+            KnownClass::TypeAliasType => Some(Self::Typing),
+            KnownClass::ExtensionsTypeAliasType => Some(Self::TypingExtensions),
+            _ => None,
+        }
+    }
+
+    const fn type_alias_class(self) -> KnownClass {
+        match self {
+            Self::Typing => KnownClass::TypeAliasType,
+            Self::TypingExtensions => KnownClass::ExtensionsTypeAliasType,
+        }
+    }
+}
 
 /// Whether a type represents the upper or lower bound of a gradual type.
 ///
@@ -6017,7 +6071,7 @@ impl<'db> Type<'db> {
                 )
             }
 
-            KnownClass::TypeAliasType => {
+            KnownClass::TypeAliasType | KnownClass::ExtensionsTypeAliasType => {
                 // ```py
                 // def __new__(
                 //     cls,
@@ -6313,6 +6367,7 @@ impl<'db> Type<'db> {
                     | KnownClass::Property
                     | KnownClass::Super
                     | KnownClass::TypeAliasType
+                    | KnownClass::ExtensionsTypeAliasType
                     | KnownClass::Deprecated
             )
         ) {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -45,7 +45,7 @@ use crate::types::tuple::TupleSpec;
 use crate::types::typevar::TypeVarSet;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, CallableTypes, DataclassParams,
-    FindLegacyTypeVarsVisitor, IntersectionType, TypeContext, TypeMapping, TypedDictModule,
+    FindLegacyTypeVarsVisitor, IntersectionType, TypeContext, TypeMapping, TypingModule,
     UnionBuilder, VarianceInferable,
 };
 use crate::{
@@ -3130,7 +3130,7 @@ pub(super) enum ClassMemberResult<'db> {
     /// Found the member or exhausted the MRO.
     Done(CompletedMemberLookup<'db>),
     /// Encountered a `TypedDict` base.
-    TypedDict(TypedDictModule),
+    TypedDict(TypingModule),
 }
 
 pub(super) struct CompletedMemberLookup<'db> {

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -112,6 +112,7 @@ pub enum KnownClass {
     TypeVarTuple,
     ExtensionsTypeVarTuple, // must be distinct from typing.TypeVarTuple, backports new features
     TypeAliasType,
+    ExtensionsTypeAliasType, // may be distinct from typing.TypeAliasType
     NoDefaultType,
     NewType,
     Hashable,
@@ -193,6 +194,7 @@ impl KnownClass {
             | Self::FunctionType
             | Self::VersionInfo
             | Self::TypeAliasType
+            | Self::ExtensionsTypeAliasType
             | Self::TypeVar
             | Self::ExtensionsTypeVar
             | Self::ParamSpec
@@ -373,6 +375,7 @@ impl KnownClass {
             | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
+            | KnownClass::ExtensionsTypeAliasType
             | KnownClass::NoDefaultType
             | KnownClass::NewType
             | KnownClass::Hashable
@@ -487,6 +490,7 @@ impl KnownClass {
             | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
+            | KnownClass::ExtensionsTypeAliasType
             | KnownClass::NoDefaultType
             | KnownClass::NewType
             | KnownClass::Hashable
@@ -602,6 +606,7 @@ impl KnownClass {
             | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
+            | KnownClass::ExtensionsTypeAliasType
             | KnownClass::NoDefaultType
             | KnownClass::NewType
             | KnownClass::Hashable
@@ -724,6 +729,7 @@ impl KnownClass {
             | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::TypeAliasType
+            | Self::ExtensionsTypeAliasType
             | Self::NoDefaultType
             | Self::NewType
             | Self::ChainMap
@@ -849,6 +855,7 @@ impl KnownClass {
             | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
+            | KnownClass::ExtensionsTypeAliasType
             | KnownClass::NoDefaultType
             | KnownClass::NewType
             | KnownClass::Hashable
@@ -946,7 +953,7 @@ impl KnownClass {
             Self::TypeVarTuple => "TypeVarTuple",
             Self::ExtensionsTypeVarTuple => "TypeVarTuple",
             Self::Sentinel => "sentinel",
-            Self::TypeAliasType => "TypeAliasType",
+            Self::TypeAliasType | Self::ExtensionsTypeAliasType => "TypeAliasType",
             Self::NoDefaultType => "_NoDefaultType",
             Self::NewType => "NewType",
             Self::Hashable => "Hashable",
@@ -1374,7 +1381,7 @@ impl KnownClass {
             | Self::ParamSpec
             | Self::Hashable
             | Self::SupportsIndex => KnownModule::Typing,
-            Self::TypeAliasType
+            Self::ExtensionsTypeAliasType
             | Self::ExtensionsTypeVar
             | Self::ExtensionsTypeVarTuple
             | Self::ExtensionsParamSpec
@@ -1383,6 +1390,13 @@ impl KnownClass {
             | Self::Deprecated
             | Self::ExtensionTypedDictFallback
             | Self::NewType => KnownModule::TypingExtensions,
+            Self::TypeAliasType => {
+                if python_version >= PythonVersion::PY312 {
+                    KnownModule::Typing
+                } else {
+                    KnownModule::TypingExtensions
+                }
+            }
             Self::TypeVarTuple => {
                 if python_version >= PythonVersion::PY311 {
                     KnownModule::Typing
@@ -1494,6 +1508,7 @@ impl KnownClass {
             | Self::AsyncGenerator
             | Self::Deprecated
             | Self::TypeAliasType
+            | Self::ExtensionsTypeAliasType
             | Self::TypeVar
             | Self::ExtensionsTypeVar
             | Self::ParamSpec
@@ -1603,7 +1618,7 @@ impl KnownClass {
             "WrapperDescriptorType" => &[Self::WrapperDescriptorType],
             "BuiltinFunctionType" => &[Self::BuiltinFunctionType],
             "NewType" => &[Self::NewType],
-            "TypeAliasType" => &[Self::TypeAliasType],
+            "TypeAliasType" => &[Self::TypeAliasType, Self::ExtensionsTypeAliasType],
             "TypeVar" => &[Self::TypeVar, Self::ExtensionsTypeVar],
             "Iterable" => &[Self::Iterable, Self::TyExtensionsIterable],
             "Iterator" => &[Self::Iterator, Self::TyExtensionsIterator],
@@ -1746,6 +1761,8 @@ impl KnownClass {
             | Self::ExtensionsParamSpec
             | Self::TypeVarTuple
             | Self::ExtensionsTypeVarTuple
+            | Self::TypeAliasType
+            | Self::ExtensionsTypeAliasType
             | Self::Sentinel
             | Self::NamedTupleLike
             | Self::ConstraintSet
@@ -1774,7 +1791,6 @@ impl KnownClass {
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
 
             Self::SpecialForm
-            | Self::TypeAliasType
             | Self::NoDefaultType
             | Self::Hashable
             | Self::SupportsIndex

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -25,7 +25,7 @@ use crate::{
         DataclassParams, GenericAlias, GenericContext, KnownClass, KnownInstanceType,
         MaterializationKind, MemberLookupPolicy, MetaclassCandidate, MetaclassTransformInfo,
         Parameter, Parameters, PropertyInstanceType, Signature, SpecialFormType, StaticMroError,
-        SubclassOfType, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictModule,
+        SubclassOfType, Type, TypeContext, TypeMapping, TypeVarVariance, TypingModule,
         UnionBuilder, UnionType,
         bound_super::BoundSuperType,
         call::{CallError, CallErrorKind},
@@ -961,7 +961,7 @@ impl<'db> StaticClassLiteral<'db> {
 
     /// Return the module defining the `TypedDict` base of this class.
     #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
+    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypingModule> {
         self.iter_mro(db, None)
             .find_map(ClassBase::typed_dict_module)
     }

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -22,8 +22,8 @@ use crate::types::typed_dict::{
 };
 use crate::types::{
     BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral, ClassType, KnownClass,
-    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictModule,
-    TypedDictType, UnionType, determine_upper_bound,
+    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictType,
+    TypingModule, UnionType, determine_upper_bound,
 };
 use crate::{Db, FxIndexMap};
 use ty_python_core::definition::Definition;
@@ -900,7 +900,7 @@ pub struct DynamicTypedDictLiteral<'db> {
     pub(crate) anchor: DynamicTypedDictAnchor<'db>,
 
     #[returns(copy)]
-    pub(crate) typed_dict_module: TypedDictModule,
+    pub(crate) typed_dict_module: TypingModule,
 }
 
 impl get_size2::GetSize for DynamicTypedDictLiteral<'_> {}
@@ -1060,7 +1060,7 @@ pub(in crate::types) fn synthesized_typed_dict_class_member<'db>(
         db,
         env,
         typed_dict,
-        TypedDictModule::Typing,
+        TypingModule::Typing,
         lookup_policy,
         name,
         || Type::TypedDict(typed_dict),
@@ -1070,13 +1070,13 @@ pub(in crate::types) fn synthesized_typed_dict_class_member<'db>(
 pub(super) fn typed_dict_fallback_class_member<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
-    module: TypedDictModule,
+    module: TypingModule,
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
     let fallback = match module {
-        TypedDictModule::Typing => KnownClass::TypedDictFallback,
-        TypedDictModule::TypingExtensions => KnownClass::ExtensionTypedDictFallback,
+        TypingModule::Typing => KnownClass::TypedDictFallback,
+        TypingModule::TypingExtensions => KnownClass::ExtensionTypedDictFallback,
     };
 
     fallback
@@ -1089,7 +1089,7 @@ pub(super) fn typed_dict_class_member<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     class: ClassType<'db>,
-    module: TypedDictModule,
+    module: TypingModule,
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
@@ -1110,7 +1110,7 @@ fn typed_dict_inherited_class_member<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     typed_dict: TypedDictType<'db>,
-    module: TypedDictModule,
+    module: TypingModule,
     lookup_policy: MemberLookupPolicy,
     name: &str,
     new_upper_bound: impl FnOnce() -> Type<'db>,

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -8,7 +8,7 @@ use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, ClassLiteral, ClassType, DivergentType, DynamicType, KnownClass,
     KnownInstanceType, MaterializationKind, SpecialFormType, StaticMroError, Type, TypeContext,
-    TypeMapping, TypedDictModule, todo_type,
+    TypeMapping, TypingModule, todo_type,
 };
 use crate::{Db, DisplaySettings};
 
@@ -37,7 +37,7 @@ pub enum ClassBase<'db> {
     /// but nonetheless appears in the MRO of classes that inherit from `Generic[T]`,
     /// `Protocol[T]`, or bare `Protocol`.
     Generic,
-    TypedDict(TypedDictModule),
+    TypedDict(TypingModule),
 }
 
 impl<'db> ClassBase<'db> {
@@ -91,7 +91,7 @@ impl<'db> ClassBase<'db> {
         self.typed_dict_module().is_some()
     }
 
-    pub(super) const fn typed_dict_module(self) -> Option<TypedDictModule> {
+    pub(super) const fn typed_dict_module(self) -> Option<TypingModule> {
         match self {
             ClassBase::TypedDict(module) => Some(module),
             _ => None,
@@ -104,7 +104,7 @@ impl<'db> ClassBase<'db> {
     /// pseudo-base when detecting duplicate or conflicting bases.
     pub(super) const fn mro_identity(self) -> Self {
         match self {
-            Self::TypedDict(_) => Self::TypedDict(TypedDictModule::Typing),
+            Self::TypedDict(_) => Self::TypedDict(TypingModule::Typing),
             _ => self,
         }
     }
@@ -164,7 +164,7 @@ impl<'db> ClassBase<'db> {
                 }
             }
             Type::Union(union) => {
-                if let Some(module) = TypedDictModule::from_type(db, ty) {
+                if let Some(module) = TypingModule::from_typed_dict_type(db, ty) {
                     return Some(ClassBase::TypedDict(module));
                 }
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -35,7 +35,7 @@ use crate::types::{
     CallableType, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
     KnownUnion, LiteralValueType, LiteralValueTypeKind, MaterializationKind, PropertyInstanceType,
     Protocol, SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType, Type,
-    TypeAliasType, TypeGuardLike, TypedDictModule, TypedDictType, UnionType, WrapperDescriptorKind,
+    TypeAliasType, TypeGuardLike, TypedDictType, TypingModule, UnionType, WrapperDescriptorKind,
     visitor,
 };
 use ty_python_core::ProgramFile;
@@ -1540,7 +1540,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
                 f.with_type(Type::SpecialForm(SpecialFormType::TypedDict(
-                    TypedDictModule::Typing,
+                    TypingModule::Typing,
                 )))
                 .write_str("TypedDict")?;
                 f.write_str(" with items ")?;

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1643,7 +1643,14 @@ fn known_type_form_parameter_index(db: &dyn Db, callable_type: Type<'_>) -> Opti
             Some(KnownFunction::AssertType) => Some(1),
             _ => None,
         },
-        Type::ClassLiteral(class) if class.is_known(db, KnownClass::TypeAliasType) => Some(1),
+        Type::ClassLiteral(class)
+            if matches!(
+                class.known(db),
+                Some(KnownClass::TypeAliasType | KnownClass::ExtensionsTypeAliasType)
+            ) =>
+        {
+            Some(1)
+        }
         _ => None,
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -120,7 +120,7 @@ use crate::types::{
     LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter,
     Parameters, ProgramEnvironment, SentinelInstance, Signature, SpecialFormType, SubclassOfType,
     Type, TypeAliasType, TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints,
-    TypeVarKind, TypeVarVariance, TypedDictModule, UnionAccumulator, UnionBuilder, UnionType,
+    TypeVarKind, TypeVarVariance, TypingModule, UnionAccumulator, UnionBuilder, UnionType,
     any_over_type, binding_type, extract_fixed_length_iterable_element_types,
     infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
@@ -3299,7 +3299,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             namedtuple_kind,
                         )
                     } else if let Some(typed_dict_module) =
-                        TypedDictModule::from_type(self.db(), callable_type)
+                        TypingModule::from_typed_dict_type(self.db(), callable_type)
                     {
                         self.infer_typeddict_call_expression(
                             call_expr,
@@ -3357,8 +3357,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // signalling that we must fall back to normal call inference.
                                 self.infer_builtins_type_call(call_expr, Some(definition))
                             }
-                            Some(KnownClass::TypeAliasType) => {
-                                self.infer_typealiastype_call(target, call_expr, definition)
+                            Some(known_class)
+                                if let Some(typing_module) =
+                                    TypingModule::from_type_alias_class(known_class) =>
+                            {
+                                self.infer_typealiastype_call(
+                                    target,
+                                    call_expr,
+                                    definition,
+                                    typing_module,
+                                )
                             }
                             Some(KnownClass::Sentinel) => self
                                 .infer_sentinel_expression(target, call_expr, definition)
@@ -3626,7 +3634,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.infer_newtype_assignment_deferred(arguments);
                 return;
             }
-            (Some(KnownClass::TypeAliasType), InferenceRegion::Deferred(definition)) => {
+            (
+                Some(KnownClass::TypeAliasType | KnownClass::ExtensionsTypeAliasType),
+                InferenceRegion::Deferred(definition),
+            ) => {
                 self.infer_typealiastype_assignment_deferred(definition, arguments);
                 return;
             }
@@ -3636,7 +3647,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             _ => {}
         }
-        if TypedDictModule::from_type(self.db(), func_ty).is_some() {
+        if TypingModule::from_typed_dict_type(self.db(), func_ty).is_some() {
             self.infer_functional_typeddict_deferred(arguments);
             return;
         }
@@ -3778,6 +3789,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         target: &ast::Expr,
         call_expr: &ast::ExprCall,
         definition: Definition<'db>,
+        typing_module: TypingModule,
     ) -> Type<'db> {
         fn error<'db>(
             context: &InferContext<'db, '_>,
@@ -3849,7 +3861,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         Type::KnownInstance(KnownInstanceType::TypeAliasType(
             TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(
-                db, name, definition, None, None,
+                db,
+                name,
+                definition,
+                typing_module,
+                None,
+                None,
             )),
         ))
     }
@@ -8879,7 +8896,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return ty;
         }
 
-        if let Some(typed_dict_module) = TypedDictModule::from_type(self.db(), callable_type) {
+        if let Some(typed_dict_module) =
+            TypingModule::from_typed_dict_type(self.db(), callable_type)
+        {
             return self.infer_typeddict_call_expression(call_expression, None, typed_dict_module);
         }
 
@@ -9208,7 +9227,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                     }
                 }
-                Some(KnownClass::TypeAliasType) => {
+                Some(KnownClass::TypeAliasType | KnownClass::ExtensionsTypeAliasType) => {
                     if let Some(builder) = self
                         .context
                         .report_lint(&INVALID_TYPE_ALIAS_TYPE, call_expression)

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -3,7 +3,7 @@ use crate::ProgramEnvironment;
 use crate::place::Place;
 use crate::types::{
     CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
-    SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext, TypedDictModule,
+    SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext, TypingModule,
     call::CallError,
     callable::CallableFunctionProvenance,
     function::KnownFunction,
@@ -55,7 +55,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.infer_expression(base, TypeContext::default())
                 };
                 is_typed_dict |= match ty {
-                    ty if TypedDictModule::from_type(self.db(), ty).is_some() => true,
+                    ty if TypingModule::from_typed_dict_type(self.db(), ty).is_some() => true,
                     Type::ClassLiteral(class) => class.is_typed_dict(self.db()),
                     Type::GenericAlias(alias) => alias.is_typed_dict(self.db()),
                     _ => false,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -16,7 +16,7 @@ use crate::{
     types::{
         CallArguments, ClassBase, ClassLiteral, ClassType, DataclassFlags, KnownClass,
         KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters, Signature,
-        SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypedDictModule, binding_type,
+        SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypingModule, binding_type,
         call::Argument,
         class::{
             AbstractMethod, CodeGeneratorKind, Field, FieldKind, MetaclassErrorKind,
@@ -670,7 +670,7 @@ pub(crate) fn check_static_class_definitions<'db>(
     if let Some(args) = class_node.arguments.as_deref() {
         if class_kind == Some(CodeGeneratorKind::TypedDict) {
             let supports_pep_728 = context.in_stub()
-                || class.typed_dict_module(db) == Some(TypedDictModule::TypingExtensions)
+                || class.typed_dict_module(db) == Some(TypingModule::TypingExtensions)
                 || env.python_version(db) >= PythonVersion::PY315;
 
             for keyword in &args.keywords {

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -19,8 +19,8 @@ use crate::types::typed_dict::{
     validate_typed_dict_constructor, validate_typed_dict_dict_literal,
 };
 use crate::types::{
-    ClassType, IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictModule,
-    TypedDictType, any_over_type,
+    ClassType, IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
+    TypingModule, any_over_type,
 };
 use crate::{Db, ProgramEnvironment, TypeQualifiers};
 use ty_python_core::definition::Definition;
@@ -99,7 +99,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         call_expr: &ast::ExprCall,
         definition: Option<Definition<'db>>,
-        typed_dict_module: TypedDictModule,
+        typed_dict_module: TypingModule,
     ) -> Type<'db> {
         let env = self.program_environment();
         let db = self.db();
@@ -173,7 +173,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut closed = false;
         let mut extra_items = None;
         let supports_pep_728 = self.in_stub()
-            || typed_dict_module == TypedDictModule::TypingExtensions
+            || typed_dict_module == TypingModule::TypingExtensions
             || self.program_environment().python_version(db) >= PythonVersion::PY315;
 
         for kw in keywords {

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -319,7 +319,7 @@ impl<'db> KnownInstanceType<'db> {
             Self::TypeAliasType(alias) if alias.specialization(db).is_some() => {
                 KnownClass::GenericAlias
             }
-            Self::TypeAliasType(_) => KnownClass::TypeAliasType,
+            Self::TypeAliasType(alias) => alias.known_class(db),
             Self::Deprecated(_) => KnownClass::Deprecated,
             Self::Field(_) => KnownClass::Field,
             Self::ConstraintSet(_) => KnownClass::ConstraintSet,

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -486,7 +486,7 @@ fn arbitrary_core_type(g: &mut Gen, fully_static: bool) -> Ty {
             Ty::KnownClassInstance(KnownClass::FunctionType),
             Ty::KnownClassInstance(KnownClass::SpecialForm),
             Ty::KnownClassInstance(KnownClass::TypeVar),
-            Ty::KnownClassInstance(KnownClass::TypeAliasType),
+            Ty::KnownClassInstance(KnownClass::ExtensionsTypeAliasType),
             Ty::KnownClassInstance(KnownClass::NoDefaultType),
             Ty::TypingLiteral,
             Ty::UnittestMockLiteral,

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -1,7 +1,7 @@
 //! An enumeration of special forms in the Python type system.
 //! Each of these is considered to inhabit a unique type in our model of the type system.
 
-use super::{ClassType, Type, TypeFormType, class::KnownClass};
+use super::{ClassType, Type, TypeFormType, TypingModule, class::KnownClass};
 use crate::ProgramEnvironment;
 use crate::db::Db;
 use crate::types::IntersectionType;
@@ -110,7 +110,7 @@ pub enum SpecialFormType {
     /// The symbol `typing.TypeGuard` (which can also be found as `typing_extensions.TypeGuard`)
     TypeGuard,
     /// The symbol `typing.TypedDict` or `typing_extensions.TypedDict`.
-    TypedDict(TypedDictModule),
+    TypedDict(TypingModule),
     /// The symbol `typing.TypeIs` (which can also be found as `typing_extensions.TypeIs`)
     TypeIs,
 
@@ -130,48 +130,6 @@ pub enum SpecialFormType {
     /// Typeshed defines this symbol as a class, but this isn't accurate: it's actually a factory function
     /// at runtime. We therefore represent it as a special form internally.
     NamedTuple,
-}
-
-/// The module or modules from which `TypedDict` may have been imported.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
-pub enum TypedDictModule {
-    /// `typing.TypedDict`.
-    Typing,
-    /// `typing_extensions.TypedDict`.
-    TypingExtensions,
-}
-
-impl TypedDictModule {
-    /// Return the module for a `TypedDict` special form, including a union of the special forms
-    /// exported by `typing` and `typing_extensions`.
-    pub(super) fn from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
-        match ty {
-            Type::SpecialForm(SpecialFormType::TypedDict(module)) => Some(module),
-            Type::Union(union) => {
-                let mut elements = union.elements(db).iter();
-                let Type::SpecialForm(SpecialFormType::TypedDict(module)) = elements.next()? else {
-                    return None;
-                };
-                elements.try_fold(*module, |module, element| {
-                    let Type::SpecialForm(SpecialFormType::TypedDict(element_module)) = element
-                    else {
-                        return None;
-                    };
-                    // `typing_extensions.TypedDict` always offers strictly more functionality than `typing.TypedDict`.
-                    // If any element is from `typing`, we therefore infer that the type is a `typing.TypedDict`,
-                    // since an operation on a union is only valid if the operation is valid on all elements in the
-                    // union.
-                    Some(match (module, element_module) {
-                        (TypedDictModule::TypingExtensions, TypedDictModule::TypingExtensions) => {
-                            TypedDictModule::TypingExtensions
-                        }
-                        _ => TypedDictModule::Typing,
-                    })
-                })
-            }
-            _ => None,
-        }
-    }
 }
 
 impl SpecialFormType {
@@ -489,8 +447,8 @@ impl SpecialFormType {
                     SpecialFormTypeBuilder::Unpack => &[Self::Unpack],
                     SpecialFormTypeBuilder::Tuple => &[Self::Tuple],
                     SpecialFormTypeBuilder::TypedDict => &[
-                        Self::TypedDict(TypedDictModule::Typing),
-                        Self::TypedDict(TypedDictModule::TypingExtensions),
+                        Self::TypedDict(TypingModule::Typing),
+                        Self::TypedDict(TypingModule::TypingExtensions),
                     ],
                     SpecialFormTypeBuilder::TypeOf => &[Self::TypeOf],
                     SpecialFormTypeBuilder::List => {
@@ -555,7 +513,7 @@ impl SpecialFormType {
             | Self::Tuple
             | Self::Type
             | Self::Generic
-            | Self::TypedDict(TypedDictModule::Typing)
+            | Self::TypedDict(TypingModule::Typing)
             | Self::TypingCallable => module.is_typing(),
 
             Self::Annotated
@@ -594,7 +552,7 @@ impl SpecialFormType {
                 KnownModule::CollectionsAbc | KnownModule::CollectionsAbcInternal
             ),
 
-            Self::TypedDict(TypedDictModule::TypingExtensions) => module.is_typing_extensions(),
+            Self::TypedDict(TypingModule::TypingExtensions) => module.is_typing_extensions(),
         }
     }
 
@@ -799,8 +757,8 @@ impl SpecialFormType {
                 &[KnownModule::Typing, KnownModule::TypingExtensions]
             }
 
-            SpecialFormType::TypedDict(TypedDictModule::Typing) => &[KnownModule::Typing],
-            SpecialFormType::TypedDict(TypedDictModule::TypingExtensions) => {
+            SpecialFormType::TypedDict(TypingModule::Typing) => &[KnownModule::Typing],
+            SpecialFormType::TypedDict(TypingModule::TypingExtensions) => {
                 &[KnownModule::TypingExtensions]
             }
 

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -4,9 +4,9 @@ use std::fmt::Write;
 use crate::{
     Db, FxOrderSet,
     types::{
-        ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, GenericContext,
+        ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, GenericContext, KnownClass,
         KnownInstanceType, MaterializationKind, Type, TypeContext, TypeMapping, TypeVarVariance,
-        definition_expression_type,
+        TypingModule, definition_expression_type,
         display::qualified_name_components_from_scope,
         generics::{ApplySpecialization, Specialization, bind_typevar},
         variance::VarianceInferable,
@@ -148,6 +148,9 @@ pub struct ManualPEP695TypeAliasType<'db> {
     pub definition: Definition<'db>,
 
     #[returns(copy)]
+    pub(super) typing_module: TypingModule,
+
+    #[returns(copy)]
     pub(super) specialization: Option<Specialization<'db>>,
 
     /// Keeps recursive references stable while their alias body is materialized lazily.
@@ -223,6 +226,7 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
             db,
             self.name(db),
             self.definition(db),
+            self.typing_module(db),
             Some(f(generic_context)),
             self.materialization_kind(db),
         )
@@ -326,6 +330,15 @@ pub(super) fn walk_type_alias_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
 
 #[salsa::tracked]
 impl<'db> TypeAliasType<'db> {
+    pub(super) fn known_class(self, db: &'db dyn Db) -> KnownClass {
+        match self {
+            TypeAliasType::PEP695(_) => KnownClass::TypeAliasType,
+            TypeAliasType::ManualPEP695(type_alias) => {
+                type_alias.typing_module(db).type_alias_class()
+            }
+        }
+    }
+
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db str {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.name(db),
@@ -397,6 +410,7 @@ impl<'db> TypeAliasType<'db> {
                     db,
                     alias.name(db),
                     alias.definition(db),
+                    alias.typing_module(db),
                     None,
                     None,
                 ))
@@ -433,6 +447,7 @@ impl<'db> TypeAliasType<'db> {
                     db,
                     alias.name(db),
                     alias.definition(db),
+                    alias.typing_module(db),
                     alias.specialization(db),
                     materialization_kind,
                 ))


### PR DESCRIPTION
On Python 3.12, aliases declared with `type Alias = int` are instances of `typing.TypeAliasType`, but ty currently infers them as instances of `typing_extensions.TypeAliasType` because both classes share a `KnownClass` variant that resolves to the backport.

- Distinguish the standard-library and backport `TypeAliasType` classes with separate `KnownClass` variants.
- Generalize `TypedDictModule` into a shared `TypingModule` enum and retain the actual constructor origin on manually created aliases through specialization and materialization.
- Update alias construction, runtime-class fallback, TypedDict handling, and IDE argument classification to use the correct module.
- Cover statement-defined aliases and both direct constructors on Python 3.12, and update `__type_params__` inference to reflect the standard-library class.

The fact that we fail to model this precisely right now appears to cause a surprising number of ecosystem diagnostics on bokeh.