### PR TITLE
[ty] Disambiguate same-named types in several diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -333,8 +333,8 @@ except ImportError:
 
 ## Method and constructor descriptions
 
-ty distinguishes the defining class of a method or constructor from a same-named argument type.
-Method owners with no visible ambiguity remain unqualified.
+ty distinguishes the defining class of a bound method, unbound method, or constructor from a
+same-named argument type. Method owners with no visible ambiguity remain unqualified.
 
 `first.py`:
 
@@ -362,12 +362,29 @@ def calls(value: second.Model, other: second.Other) -> None:
     # error: [invalid-argument-type] "Argument to bound method `second.Model.method` is incorrect: Expected `first.Model`, found `Literal[1]`"
     value.method(1)
 
+    # error: [invalid-argument-type] "Argument to function `second.Model.method` is incorrect: Expected `first.Model`, found `Literal[1]`"
+    second.Model.method(value, 1)
+
     # error: [invalid-argument-type] "Argument to `second.Model.__init__` is incorrect: Expected `first.Model`, found `Literal[1]`"
     second.Model(1)
 
     # No competing type named `Other` appears in this diagnostic, so its method owner stays unqualified.
     # error: [invalid-argument-type] "Argument to bound method `Other.method` is incorrect: Expected `Model`, found `Literal[1]`"
     other.method(1)
+```
+
+## Builtin class descriptions
+
+ty distinguishes a builtin class used as a callable from a same-named argument type.
+
+```py
+import builtins
+
+class tuple: ...
+
+def convert(value: tuple) -> None:
+    # error: [invalid-argument-type] "Argument to class `builtins.tuple` is incorrect: Expected `Iterable[Unknown]`, found `mdtest_snippet.tuple`"
+    builtins.tuple(value)
 ```
 
 ## Identifying union members
@@ -393,6 +410,45 @@ import second
 
 def missing_attribute(value: first.Model | second.Model) -> int:
     # error: [unresolved-attribute] "Attribute `present` is not defined on `second.Model` in union `first.Model | second.Model`"
+    return value.present
+```
+
+## Aliased union members
+
+ty distinguishes a union's type alias from a same-named member that does not define an attribute.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+`first.py`:
+
+```py
+class Present:
+    present: int
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+`alias.py`:
+
+```py
+import first
+import second
+
+type Model = first.Present | second.Model
+```
+
+```py
+from alias import Model
+
+def missing_attribute(value: Model) -> int:
+    # error: [unresolved-attribute] "Attribute `present` is not defined on `second.Model` in union `alias.Model`"
     return value.present
 ```
 
@@ -456,8 +512,8 @@ def assign_union_attribute(owner: first.Model | Other, value: second.Model) -> N
 
 ## Subscript assignments
 
-ty distinguishes an incompatible assigned value from a same-named class nested in the subscripted
-object's type.
+ty distinguishes an incompatible assigned value or subscript key from a same-named class nested in
+the subscripted object's type.
 
 `first.py`:
 
@@ -478,6 +534,10 @@ import second
 def assign_value(values: list[first.Model], value: second.Model) -> None:
     # error: [invalid-assignment] "Invalid subscript assignment with key of type `Literal[0]` and value of type `second.Model` on object of type `list[first.Model]`"
     values[0] = value
+
+def assign_key(values: dict[first.Model, int], key: second.Model) -> None:
+    # error: [invalid-assignment] "Invalid subscript assignment with key of type `second.Model` and value of type `Literal[1]` on object of type `dict[first.Model, int]`"
+    values[key] = 1
 ```
 
 ## Type assertions
@@ -508,8 +568,61 @@ import first
 import second
 
 def invalid_assertion(value: second.Model) -> None:
-    # error: [type-assertion-failure] "Type `second.Model` does not match asserted type `first.Model`"
-    assert_type(value, first.Model)
+    assert_type(value, first.Model)  # snapshot: type-assertion-failure
+```
+
+```snapshot
+error[type-assertion-failure]: Argument does not have asserted type `first.Model`
+ --> src/mdtest_snippet.py:7:5
+  |
+7 |     assert_type(value, first.Model)  # snapshot: type-assertion-failure
+  |     ^^^^^^^^^^^^-----^^^^^^^^^^^^^^
+  |                 |
+  |                 Inferred type is `second.Model`
+info: `first.Model` and `second.Model` are not equivalent types
+```
+
+## Unspellable subtype assertions
+
+ty distinguishes same-named classes throughout a type assertion about an unspellable intersection.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+```py
+from typing import assert_type
+
+import first
+import second
+
+def invalid_subtype_assertion(value: first.Model) -> None:
+    if isinstance(value, second.Model):
+        assert_type(value, second.Model)  # snapshot: assert-type-unspellable-subtype
+```
+
+```snapshot
+error[assert-type-unspellable-subtype]: Argument does not have asserted type `second.Model`
+ --> src/mdtest_snippet.py:8:9
+  |
+8 |         assert_type(value, second.Model)  # snapshot: assert-type-unspellable-subtype
+  |         ^^^^^^^^^^^^-----^^^^^^^^^^^^^^^
+  |                     |
+  |                     Inferred type is `first.Model & second.Model`
+info: `first.Model & second.Model` is a subtype of `second.Model`, but they are not equivalent
 ```
 
 ## Incompatible inherited methods
@@ -543,8 +656,7 @@ class Model(first.Model, second.Different): ...
 
 ## Conflicting metaclasses
 
-ty distinguishes a derived class from its same-named base throughout a metaclass-conflict
-diagnostic.
+ty distinguishes same-named classes and metaclasses throughout a metaclass-conflict diagnostic.
 
 `first.py`:
 
@@ -560,4 +672,8 @@ class OtherMeta(type): ...
 
 # error: [conflicting-metaclass] "derived class (`mdtest_snippet.Model`) must be a subclass of the metaclasses of all its bases, but `OtherMeta` (metaclass of `mdtest_snippet.Model`) and `Meta` (metaclass of base class `first.Model`) have no subclass relationship"
 class Model(first.Model, metaclass=OtherMeta): ...
+class Meta(type): ...
+
+# error: [conflicting-metaclass] "derived class (`Other`) must be a subclass of the metaclasses of all its bases, but `mdtest_snippet.Meta` (metaclass of `Other`) and `first.Meta` (metaclass of base class `Model`) have no subclass relationship"
+class Other(first.Model, metaclass=Meta): ...
 ```

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -304,3 +304,260 @@ def get_models_tuple() -> tuple[Model]:
     # error: [invalid-return-type] "Return type does not match returned value: expected `tuple[mdtest_snippet.Model]`, found `tuple[module.Model]`"
     return (Model(),)
 ```
+
+## Callable special forms
+
+ty distinguishes same-named classes nested in the signatures of two callable special forms.
+
+`first.py`:
+
+```py
+from typing import Callable
+
+class StartResponse: ...
+
+Application = Callable[[StartResponse], int]
+```
+
+```py
+from typing import Callable
+
+try:
+    from first import Application, StartResponse
+except ImportError:
+    class StartResponse: ...
+
+    # error: [invalid-assignment] "Object of type `<Callable special-form '(mdtest_snippet.StartResponse, /) -> int'>` is not assignable to `<Callable special-form '(first.StartResponse, /) -> int'>`"
+    Application = Callable[[StartResponse], int]
+```
+
+## Method and constructor descriptions
+
+ty distinguishes the defining class of a method or constructor from a same-named argument type.
+Method owners with no visible ambiguity remain unqualified.
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+import first
+
+class Model:
+    def __init__(self, value: first.Model) -> None: ...
+    def method(self, value: first.Model) -> None: ...
+
+class Other:
+    def method(self, value: first.Model) -> None: ...
+```
+
+```py
+import second
+
+def calls(value: second.Model, other: second.Other) -> None:
+    # error: [invalid-argument-type] "Argument to bound method `second.Model.method` is incorrect: Expected `first.Model`, found `Literal[1]`"
+    value.method(1)
+
+    # error: [invalid-argument-type] "Argument to `second.Model.__init__` is incorrect: Expected `first.Model`, found `Literal[1]`"
+    second.Model(1)
+
+    # No competing type named `Other` appears in this diagnostic, so its method owner stays unqualified.
+    # error: [invalid-argument-type] "Argument to bound method `Other.method` is incorrect: Expected `Model`, found `Literal[1]`"
+    other.method(1)
+```
+
+## Identifying union members
+
+ty uses the same qualification for a union member missing an attribute as for the complete union.
+
+`first.py`:
+
+```py
+class Model:
+    present: int
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+```py
+import first
+import second
+
+def missing_attribute(value: first.Model | second.Model) -> int:
+    # error: [unresolved-attribute] "Attribute `present` is not defined on `second.Model` in union `first.Model | second.Model`"
+    return value.present
+```
+
+## Redefined union members
+
+When distinct union members have the same name in the same module, ty identifies the missing member
+using both its source location and its module name.
+
+`test.py`:
+
+```py
+def coinflip() -> bool:
+    return True
+
+if coinflip():
+    class Model:
+        present: int
+
+else:
+    class Model: ...
+
+# error: [unresolved-attribute] "Attribute `present` is not defined on `test.Model @ src/test.py:9:11` in union `test.Model @ src/test.py:5:11 | test.Model @ src/test.py:9:11`"
+Model().present
+```
+
+## Attribute assignments
+
+For ordinary and union attribute assignments, ty distinguishes the assigned class from a same-named
+class appearing elsewhere in the diagnostic.
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+```py
+import first
+import second
+
+class Owner:
+    item: first.Model
+
+class Other:
+    item: int
+
+def assign_attribute(owner: Owner, value: second.Model) -> None:
+    # error: [invalid-assignment] "Object of type `second.Model` is not assignable to attribute `item` of type `first.Model`"
+    owner.item = value
+
+def assign_union_attribute(owner: first.Model | Other, value: second.Model) -> None:
+    # error: [invalid-assignment] "Object of type `second.Model` is not assignable to attribute `item` on type `first.Model | Other`"
+    owner.item = value
+```
+
+## Subscript assignments
+
+ty distinguishes an incompatible assigned value from a same-named class nested in the subscripted
+object's type.
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+```py
+import first
+import second
+
+def assign_value(values: list[first.Model], value: second.Model) -> None:
+    # error: [invalid-assignment] "Invalid subscript assignment with key of type `Literal[0]` and value of type `second.Model` on object of type `list[first.Model]`"
+    values[0] = value
+```
+
+## Type assertions
+
+ty distinguishes an asserted class from a same-named inferred class.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+```py
+from typing import assert_type
+
+import first
+import second
+
+def invalid_assertion(value: second.Model) -> None:
+    # error: [type-assertion-failure] "Type `second.Model` does not match asserted type `first.Model`"
+    assert_type(value, first.Model)
+```
+
+## Incompatible inherited methods
+
+ty distinguishes a derived class from its same-named base when their inherited methods are
+incompatible.
+
+`first.py`:
+
+```py
+class Model:
+    def method(self, value: int) -> int:
+        return value
+```
+
+`second.py`:
+
+```py
+class Different:
+    def method(self, value: str) -> str:
+        return value
+```
+
+```py
+import first
+import second
+
+# error: [invalid-method-override] "Base classes for class `mdtest_snippet.Model` define method `method` incompatibly: `first.Model.method` is incompatible with `Different.method`"
+class Model(first.Model, second.Different): ...
+```
+
+## Conflicting metaclasses
+
+ty distinguishes a derived class from its same-named base throughout a metaclass-conflict
+diagnostic.
+
+`first.py`:
+
+```py
+class Meta(type): ...
+class Model(metaclass=Meta): ...
+```
+
+```py
+import first
+
+class OtherMeta(type): ...
+
+# error: [conflicting-metaclass] "derived class (`mdtest_snippet.Model`) must be a subclass of the metaclasses of all its bases, but `OtherMeta` (metaclass of `mdtest_snippet.Model`) and `Meta` (metaclass of base class `first.Model`) have no subclass relationship"
+class Model(first.Model, metaclass=OtherMeta): ...
+```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -8293,21 +8293,52 @@ pub(crate) struct CallableDescription<'a> {
 }
 
 impl<'db> CallableDescription<'db> {
+    fn defining_class(db: &'db dyn Db, callable_type: Type<'db>) -> Option<ClassLiteral<'db>> {
+        let function = match callable_type {
+            Type::FunctionLiteral(function) => function,
+            Type::BoundMethod(method) => method.function(db),
+            Type::ClassLiteral(class) => return Some(class),
+            _ => return None,
+        };
+
+        let semantic_index = semantic_index(db, function.program_file(db));
+        let enclosing_scope = semantic_index.scope(function.definition(db).file_scope(db));
+        let class_node = enclosing_scope.node().as_class()?;
+
+        original_class_type(db, semantic_index.expect_single_definition(class_node))
+    }
+
     pub(crate) fn new(
         db: &'db dyn Db,
         callable_type: Type<'db>,
     ) -> Option<CallableDescription<'db>> {
+        Self::new_with_settings(db, callable_type, None)
+    }
+
+    fn new_with_settings(
+        db: &'db dyn Db,
+        callable_type: Type<'db>,
+        settings: Option<&DisplaySettings<'db>>,
+    ) -> Option<CallableDescription<'db>> {
         fn qualified_function_name<'db>(
             db: &'db dyn Db,
             function: FunctionType<'db>,
+            settings: Option<&DisplaySettings<'db>>,
         ) -> Cow<'db, str> {
-            let semantic_index = semantic_index(db, function.program_file(db));
-            let enclosing_scope = semantic_index.scope(function.definition(db).file_scope(db));
-            if let Some(class_node) = enclosing_scope.node().as_class()
-                && let Some(class) =
-                    original_class_type(db, semantic_index.expect_single_definition(class_node))
+            if let Some(class) =
+                CallableDescription::defining_class(db, Type::FunctionLiteral(function))
             {
-                Cow::Owned(format!("{}.{}", class.name(db), function.name(db)))
+                settings
+                    .map(|settings| {
+                        Cow::Owned(format!(
+                            "{}.{}",
+                            class.display_with(db, settings.clone()),
+                            function.name(db)
+                        ))
+                    })
+                    .unwrap_or_else(|| {
+                        Cow::Owned(format!("{}.{}", class.name(db), function.name(db)))
+                    })
             } else {
                 Cow::Borrowed(function.name(db))
             }
@@ -8320,11 +8351,15 @@ impl<'db> CallableDescription<'db> {
                 } else {
                     "function"
                 }),
-                name: qualified_function_name(db, function),
+                name: qualified_function_name(db, function, settings),
             }),
             Type::ClassLiteral(class_type) => Some(CallableDescription {
                 kind: Some("class"),
-                name: Cow::Borrowed(class_type.name(db)),
+                name: settings
+                    .map(|settings| {
+                        Cow::Owned(class_type.display_with(db, settings.clone()).to_string())
+                    })
+                    .unwrap_or_else(|| Cow::Borrowed(class_type.name(db).as_str())),
             }),
             Type::SubclassOf(subclass) if let Some(typevar) = subclass.into_type_var() => {
                 Some(CallableDescription {
@@ -8341,7 +8376,7 @@ impl<'db> CallableDescription<'db> {
                 };
                 CallableDescription {
                     kind,
-                    name: qualified_function_name(db, function),
+                    name: qualified_function_name(db, function, settings),
                 }
             }),
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
@@ -8846,10 +8881,17 @@ impl<'db> BindingError<'db> {
                     return;
                 };
 
-                let display_settings = DisplaySettings::from_possibly_ambiguous_types(
+                let defining_class =
+                    CallableDescription::defining_class(db, callable_ty).map(Type::ClassLiteral);
+                let types = [*provided_ty, *expected_ty]
+                    .into_iter()
+                    .chain(defining_class);
+                let display_settings =
+                    DisplaySettings::from_possibly_ambiguous_types(db, env, types);
+                let qualified_callable_description = CallableDescription::new_with_settings(
                     db,
-                    env,
-                    [provided_ty, expected_ty],
+                    callable_ty,
+                    Some(&display_settings),
                 );
                 let provided_ty_display =
                     provided_ty.display_with(db, env, display_settings.clone());
@@ -8857,7 +8899,9 @@ impl<'db> BindingError<'db> {
 
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Argument{} is incorrect",
-                    callable_description
+                    qualified_callable_description
+                        .as_ref()
+                        .or(callable_description)
                         .map(|description| format!(" to {description}"))
                         .unwrap_or_default()
                 ));

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1763,13 +1763,14 @@ pub(super) fn report_invalid_attribute_assignment(
     // diagnostic being emitted here.
 
     let env = &context.program_environment();
+    let settings = DisplaySettings::from_possibly_ambiguous_types(db, env, [source_ty, target_ty]);
     let Some(mut diag) = report_invalid_assignment_with_message(
         context,
         range,
         format_args!(
             "Object of type `{}` is not assignable to attribute `{attribute_name}` of type `{}`",
-            source_ty.display(db, env),
-            target_ty.display(db, env),
+            source_ty.display_with(db, env, settings.clone()),
+            target_ty.display_with(db, env, settings),
         ),
     ) else {
         return;
@@ -4365,20 +4366,20 @@ pub(super) fn report_incompatible_base_method<'db>(
 
     let (selected_owner, selected_definition, selected_decorator) = selected;
     let (contract_owner, contract_definition, contract_decorator) = contract;
-    let (selected_name, contract_name) = if selected_owner.name(db) == contract_owner.name(db) {
-        (
-            selected_owner.qualified_name(db).to_string(),
-            contract_owner.qualified_name(db).to_string(),
-        )
-    } else {
-        (
-            selected_owner.name(db).to_string(),
-            contract_owner.name(db).to_string(),
-        )
-    };
+    let types = [
+        Type::from(class),
+        Type::from(selected_owner),
+        Type::from(contract_owner),
+    ];
+    let settings =
+        DisplaySettings::from_possibly_ambiguous_types(db, context.program_environment(), types);
+    let class_name = ClassLiteral::Static(class).display_with(db, settings.clone());
+    let selected_name = selected_owner
+        .class_literal(db)
+        .display_with(db, settings.clone());
+    let contract_name = contract_owner.class_literal(db).display_with(db, settings);
     let mut diagnostic = builder.into_diagnostic(format_args!(
-        "Base classes for class `{}` define method `{member}` incompatibly",
-        class.name(db)
+        "Base classes for class `{class_name}` define method `{member}` incompatibly",
     ));
     diagnostic.set_primary_annotation_message(format_args!(
         "`{selected_name}.{member}` is incompatible with `{contract_name}.{member}`"

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -824,7 +824,11 @@ pub(super) fn qualified_name_components_from_scope(
 }
 
 impl<'db> ClassLiteral<'db> {
-    fn display_with(self, db: &'db dyn Db, settings: DisplaySettings<'db>) -> ClassDisplay<'db> {
+    pub(crate) fn display_with(
+        self,
+        db: &'db dyn Db,
+        settings: DisplaySettings<'db>,
+    ) -> ClassDisplay<'db> {
         ClassDisplay {
             db,
             class: self,
@@ -833,7 +837,7 @@ impl<'db> ClassLiteral<'db> {
     }
 }
 
-struct ClassDisplay<'db> {
+pub(crate) struct ClassDisplay<'db> {
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
     settings: DisplaySettings<'db>,
@@ -2244,14 +2248,6 @@ impl TupleSpecialization {
 }
 
 impl<'db> CallableType<'db> {
-    fn display<'a>(
-        &'a self,
-        db: &'db dyn Db,
-        env: &'a ProgramEnvironment<'db>,
-    ) -> DisplayCallableType<'a, 'db> {
-        Self::display_with(self, db, env, DisplaySettings::default())
-    }
-
     fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
@@ -3768,7 +3764,9 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
                 f.with_type(Type::SpecialForm(SpecialFormType::TypingCallable))
                     .write_str("Callable")?;
                 f.write_str(" special-form '")?;
-                callable.display(db, self.env).fmt_detailed(f)?;
+                callable
+                    .display_with(db, self.env, self.settings.clone())
+                    .fmt_detailed(f)?;
                 f.write_str("'>")
             }
             KnownInstanceType::TypeGenericAlias(inner) => {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2518,9 +2518,14 @@ impl KnownFunction {
                     &ASSERT_TYPE_UNSPELLABLE_SUBTYPE
                 };
                 if let Some(builder) = context.report_lint(diagnostic, call_expression) {
+                    let settings = DisplaySettings::from_possibly_ambiguous_types(
+                        db,
+                        env,
+                        [*actual_ty, asserted_ty],
+                    );
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Argument does not have asserted type `{}`",
-                        asserted_ty.display(db, env),
+                        asserted_ty.display_with(db, env, settings.clone()),
                     ));
 
                     diagnostic.annotate(
@@ -2532,28 +2537,28 @@ impl KnownFunction {
                         )
                         .message(format_args!(
                             "Inferred type is `{}`",
-                            actual_ty.display(db, env)
+                            actual_ty.display_with(db, env, settings.clone())
                         )),
                     );
 
                     if actual_ty.is_subtype_of(db, env, asserted_ty) {
                         diagnostic.info(format_args!(
                             "`{inferred_type}` is a subtype of `{asserted_type}`, but they are not equivalent",
-                            asserted_type = asserted_ty.display(db, env),
-                            inferred_type = actual_ty.display(db, env),
+                            asserted_type = asserted_ty.display_with(db, env, settings.clone()),
+                            inferred_type = actual_ty.display_with(db, env, settings.clone()),
                         ));
                     } else {
                         diagnostic.info(format_args!(
                             "`{asserted_type}` and `{inferred_type}` are not equivalent types",
-                            asserted_type = asserted_ty.display(db, env),
-                            inferred_type = actual_ty.display(db, env),
+                            asserted_type = asserted_ty.display_with(db, env, settings.clone()),
+                            inferred_type = actual_ty.display_with(db, env, settings.clone()),
                         ));
                     }
 
                     diagnostic.set_concise_message(format_args!(
                         "Type `{}` does not match asserted type `{}`",
-                        actual_ty.display(db, env),
-                        asserted_ty.display(db, env),
+                        actual_ty.display_with(db, env, settings.clone()),
+                        asserted_ty.display_with(db, env, settings),
                     ));
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -124,7 +124,7 @@ use crate::types::{
     any_over_type, binding_type, extract_fixed_length_iterable_element_types,
     infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
-use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet};
+use crate::{AnalysisSettings, Db, DisplaySettings, FxIndexSet, FxOrderSet};
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
     Definition, DefinitionKind, DefinitionNodeKey, DefinitionState, ExceptHandlerDefinitionKind,
@@ -10449,9 +10449,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             if let Some(builder) =
                                 self.context.report_lint(&UNRESOLVED_ATTRIBUTE, attribute)
                             {
+                                let types = std::iter::once(union_like_type)
+                                    .chain(elements_missing_the_attribute.iter().copied());
+                                let settings =
+                                    DisplaySettings::from_possibly_ambiguous_types(db, env, types);
                                 let missing_types = elements_missing_the_attribute
                                     .iter()
-                                    .map(|ty| format!("`{}`", ty.display(db, env)))
+                                    .map(|ty| {
+                                        format!("`{}`", ty.display_with(db, env, settings.clone()))
+                                    })
                                     .collect::<Vec<_>>()
                                     .join(", ");
 
@@ -10459,7 +10465,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     "Attribute `{attr_name}` is not defined on {} \
                                     in union `{union_like_type}`",
                                     missing_types,
-                                    union_like_type = union_like_type.display(db, env),
+                                    union_like_type =
+                                        union_like_type.display_with(db, env, settings),
                                 ));
                             }
                             return type_when_bound;

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -15,7 +15,9 @@ use crate::types::diagnostic::{
     INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, UNRESOLVED_ATTRIBUTE, report_bad_dunder_set_call,
     report_invalid_attribute_assignment, report_possibly_missing_attribute,
 };
-use crate::types::{CallDunderError, MemberLookupPolicy, Type, TypeContext, TypeQualifiers};
+use crate::types::{
+    CallDunderError, DisplaySettings, MemberLookupPolicy, Type, TypeContext, TypeQualifiers,
+};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Make sure that the attribute assignment `obj.attribute = value` is valid.
@@ -808,11 +810,16 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     .context
                     .report_lint(&INVALID_ASSIGNMENT, self.target)
                 {
+                    let settings = DisplaySettings::from_possibly_ambiguous_types(
+                        db,
+                        env,
+                        [value_ty, object_ty],
+                    );
                     builder.into_diagnostic(format_args!(
                         "Object of type `{}` is not assignable to attribute `{}` on type `{}`",
-                        value_ty.display(db, env),
+                        value_ty.display_with(db, env, settings.clone()),
                         self.attribute,
-                        object_ty.display(db, env),
+                        object_ty.display_with(db, env, settings),
                     ));
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -14,9 +14,10 @@ use crate::{
     diagnostic::format_enumeration,
     place::{DefinedPlace, Place, TypeOrigin, place_from_bindings, place_from_declarations},
     types::{
-        CallArguments, ClassBase, ClassLiteral, ClassType, DataclassFlags, KnownClass,
-        KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters, Signature,
-        SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypingModule, binding_type,
+        CallArguments, ClassBase, ClassLiteral, ClassType, DataclassFlags, DisplaySettings,
+        KnownClass, KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters,
+        Signature, SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypingModule,
+        binding_type,
         call::Argument,
         class::{
             AbstractMethod, CodeGeneratorKind, Field, FieldKind, MetaclassErrorKind,
@@ -649,16 +650,27 @@ pub(crate) fn check_static_class_definitions<'db>(
                 } else if let Some(builder) =
                     context.report_lint(&CONFLICTING_METACLASS, class_node)
                 {
+                    let types = [
+                        Type::from(class),
+                        Type::from(*metaclass1),
+                        Type::from(*metaclass2),
+                        Type::from(*class2),
+                    ];
+                    let settings = DisplaySettings::from_possibly_ambiguous_types(db, env, types);
                     builder.into_diagnostic(format_args!(
                         "The metaclass of a derived class (`{class}`) \
                             must be a subclass of the metaclasses of all its bases, \
                             but `{metaclass_of_class}` (metaclass of `{class}`) \
                             and `{metaclass_of_base}` (metaclass of base class `{base}`) \
                             have no subclass relationship",
-                        class = class.name(db),
-                        metaclass_of_class = metaclass1.name(db),
-                        metaclass_of_base = metaclass2.name(db),
-                        base = class2.name(db),
+                        class = ClassLiteral::Static(class).display_with(db, settings.clone()),
+                        metaclass_of_class = metaclass1
+                            .class_literal(db)
+                            .display_with(db, settings.clone()),
+                        metaclass_of_base = metaclass2
+                            .class_literal(db)
+                            .display_with(db, settings.clone()),
+                        base = ClassLiteral::Static(*class2).display_with(db, settings),
                     ));
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -29,7 +29,7 @@ use crate::types::typed_dict::{
 use crate::types::typevar::TypeVarSet;
 use crate::types::{
     BoundTypeVarInstance, CallArguments, CallDunderError, CallableBinding, CycleDetector,
-    DynamicType, InternedType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
+    DisplaySettings, DynamicType, InternedType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
     MemberLookupPolicy, Parameter, Parameters, SpecialFormType, StaticClassLiteral, Type,
     TypeAliasType, TypeAndQualifiers, TypeContext, TypeVarBoundOrConstraints, UnionType,
     UnionTypeInstance, any_over_type, todo_type,
@@ -1999,14 +1999,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             target.range.cover(rhs_value_node.range()),
                                         )
                                     {
-                                        let assigned_d = rhs_value_ty.display(db, env);
-                                        let object_d = object_ty.display(db, env);
+                                        let settings =
+                                            DisplaySettings::from_possibly_ambiguous_types(
+                                                db,
+                                                env,
+                                                [rhs_value_ty, object_ty, slice_ty],
+                                            );
+                                        let assigned_d =
+                                            rhs_value_ty.display_with(db, env, settings.clone());
+                                        let object_d =
+                                            object_ty.display_with(db, env, settings.clone());
 
                                         let mut diagnostic = builder.into_diagnostic(format_args!(
                                             "Invalid subscript assignment with key of type `{}` \
                                             and value of type `{assigned_d}` \
                                             on object of type `{object_d}`",
-                                            slice_ty.display(db, env),
+                                            slice_ty.display_with(db, env, settings),
                                         ));
 
                                         // Special diagnostic for dictionaries


### PR DESCRIPTION
## Summary

This PR improves name qualification for several diagnostics where we have ecosystem evidence that disambiguation clearly helps.

A [broader attempt](https://github.com/astral-sh/ruff/issues/27719) at fixing this whole class of bugs has [convinced me](https://gist.github.com/AlexWaygood/eb8abd07b2da0461c58c99a092cafce7) that a deeper architectural fix is probably in order here. But that would be invasive and hard to review, and I'm not sure it's urgent. So for now, here's some band-aids in cases where we know it'll actually help users.

---

Share display settings across the types appearing in each diagnostic so classes, aliases, method owners, and metaclasses are qualified when their unqualified names would otherwise collide.

```diff
- Attribute `load` is not defined on `GoogleOAuth` in union `apprise.plugins.fcm.oauth.GoogleOAuth | apprise.plugins.fcm.GoogleOAuth`
+ Attribute `load` is not defined on `apprise.plugins.fcm.GoogleOAuth` in union `apprise.plugins.fcm.oauth.GoogleOAuth | apprise.plugins.fcm.GoogleOAuth`
```

This PR covers callable special forms; bound and unbound methods, constructors, and builtin classes; union members, including aliases and redefined classes; attribute and subscript assignments; `assert_type`; inherited methods; and conflicting metaclasses.