### PR TITLE
[ty] Preserve class objects in lazy protocol checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4687,6 +4687,44 @@ static_assert(not is_assignable_to(TypeOf[StringMembership], Container[int]))
 static_assert(not is_assignable_to(TypeOf[NonBooleanMembership], Container[int]))
 ```
 
+## Class objects with bounded type-variable receivers
+
+An iterable class combined with an empty fallback must contribute its member type to generic call
+inference. A classmethod can therefore collect its own instances without losing `Self`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Iterator
+from typing import Self
+
+class IterableMeta(type):
+    def __iter__[T](self: type[T]) -> Iterator[T]:
+        raise NotImplementedError
+
+class Item(metaclass=IterableMeta):
+    @classmethod
+    def all(cls, enabled: bool) -> frozenset[Self]:
+        items = frozenset(cls if enabled else ())
+        reveal_type(items)  # revealed: frozenset[Self@all]
+        return items
+```
+
+## Generic inference from gradual class objects
+
+`type[Any]` can be assigned to an iterable protocol. A concrete fallback must still contribute its
+element type to generic inference.
+
+```py
+from typing import Any
+
+def collect(cls: type[Any], enabled: bool) -> None:
+    reveal_type(list(cls if enabled else (1,)))  # revealed: list[int]
+```
+
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members
 
 The typing spec states that protocols may have `@classmethod` or `@staticmethod` method members.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2219,7 +2219,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // if `type` is a subtype of that protocol.
             (Type::SubclassOf(source_subclass_ty), Type::ProtocolInstance(_))
                 if (source_subclass_ty.is_dynamic() || source_subclass_ty.is_type_var())
-                    && !self.is_eager_assignability() =>
+                    && !self.relation.is_assignability() =>
             {
                 self.check_type_pair(db, KnownClass::Type.to_instance(db, env), target)
             }


### PR DESCRIPTION
Lazy protocol checks currently replace `type[T]` and `type[Any]` with plain `type`. This loses the class object's interface before generic inference can use it. For example, collecting an iterable class together with an empty fallback can lose `Self` and infer `Unknown` instead.

Allow lazy assignability to use the same structural protocol check as eager assignability. Strict subtyping keeps its existing behavior.

This is a prerequisite for #27812 and is related to astral-sh/ty#4291.

## Test plan

- Add a public mdtest using a generic metaclass iterator and a classmethod that collects `frozenset[Self]` through an empty fallback.
- Cover a gradual class object combined with a concrete iterable, ensuring the concrete element type still contributes to inference.
