### PR TITLE
[ty] Preserve declared types in exception handlers

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -246,8 +246,6 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
 
     /// Per-scope exception contexts for nested `try` and `with` statements.
     exception_context_stack_manager: ExceptionContextStackManager,
-    /// Whether we are visiting an annotation that is not evaluated at runtime.
-    in_unevaluated_annotation: bool,
 
     /// Flags about the file's global scope
     has_future_annotations: bool,
@@ -321,7 +319,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             current_match_case: None,
             current_first_parameter_name: None,
             exception_context_stack_manager: ExceptionContextStackManager::default(),
-            in_unevaluated_annotation: false,
 
             has_future_annotations: false,
             in_type_checking_block: false,
@@ -2323,10 +2320,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         ) && !self.has_future_annotations
             && !self.source_type.is_stub()
             && !self.python_version.defers_annotations();
-        let was_unevaluated = self.in_unevaluated_annotation;
-        self.in_unevaluated_annotation |= !is_eager;
+        let was_suppressed = self
+            .exception_context_stack_manager
+            .suppress_exception_checkpoints_if(!is_eager);
         self.visit_annotation(annotation);
-        self.in_unevaluated_annotation = was_unevaluated;
+        self.exception_context_stack_manager
+            .restore_exception_checkpoint_suppression(was_suppressed);
     }
 
     /// Records the current flow state immediately before an operation that may raise an exception.
@@ -2348,10 +2347,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     ///
     /// Skips snapshot construction when no enclosing `try` or `with` context can handle exceptions.
     fn record_exception_checkpoint(&mut self) {
-        if self.in_unevaluated_annotation
-            || !self
-                .exception_context_stack_manager
-                .has_active_exception_handler(self)
+        if !self
+            .exception_context_stack_manager
+            .has_active_exception_handler(self)
         {
             return;
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2311,23 +2311,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.scopes[scope_id].is_eager()
     }
 
-    /// Index a variable annotation without inventing exception paths when it is not evaluated.
-    /// Function-local annotations never execute; module and class annotations can also be deferred.
-    fn visit_variable_annotation(&mut self, annotation: &'ast ast::Expr) {
-        let is_eager = matches!(
-            self.scopes[self.current_scope()].kind(),
-            ScopeKind::Module | ScopeKind::Class
-        ) && !self.has_future_annotations
-            && !self.source_type.is_stub()
-            && !self.python_version.defers_annotations();
-        let was_suppressed = self
-            .exception_context_stack_manager
-            .suppress_exception_checkpoints_if(!is_eager);
-        self.visit_annotation(annotation);
-        self.exception_context_stack_manager
-            .restore_exception_checkpoint_suppression(was_suppressed);
-    }
-
     /// Records the current flow state immediately before an operation that may raise an exception.
     ///
     /// This models exceptions from ordinary operations, not every possible interruption. In
@@ -3950,7 +3933,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // not discard the declared type. The value is still bound only after the RHS
                 // completes, so a handler can observe an earlier binding (or an unbound name).
                 let pending = self.begin_annotated_assignment(node);
-                self.visit_variable_annotation(&node.annotation);
+                self.visit_expr(&node.annotation);
                 if let Some(value) = &node.value {
                     self.visit_expr(value);
                     if self.is_method_or_eagerly_executed_in_method().is_some() {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -246,6 +246,8 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
 
     /// Per-scope exception contexts for nested `try` and `with` statements.
     exception_context_stack_manager: ExceptionContextStackManager,
+    /// Whether we are visiting an annotation that is not evaluated at runtime.
+    in_unevaluated_annotation: bool,
 
     /// Flags about the file's global scope
     has_future_annotations: bool,
@@ -319,6 +321,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             current_match_case: None,
             current_first_parameter_name: None,
             exception_context_stack_manager: ExceptionContextStackManager::default(),
+            in_unevaluated_annotation: false,
 
             has_future_annotations: false,
             in_type_checking_block: false,
@@ -1416,12 +1419,19 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 self.add_dict_key_assignment_definitions(&node.targets, &node.value, assignment);
             }
-            Some(CurrentAssignment::AnnAssign(ann_assign)) => {
+            Some(CurrentAssignment::AnnAssign {
+                node: ann_assign,
+                pending,
+            }) => {
                 self.add_standalone_type_expression(&ann_assign.annotation);
-                let assignment = self.add_definition(
-                    place_id,
-                    AnnotatedAssignmentDefinitionNodeRef { node: ann_assign },
-                );
+                let assignment = if let Some(pending) = pending {
+                    self.finish_annotated_assignment(pending)
+                } else {
+                    self.add_definition(
+                        place_id,
+                        AnnotatedAssignmentDefinitionNodeRef { node: ann_assign },
+                    )
+                };
 
                 if let Some(value) = ann_assign.value.as_deref() {
                     self.add_dict_key_assignment_definitions(
@@ -1498,7 +1508,19 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         place: ScopedPlaceId,
         definition_node: impl Into<DefinitionNodeRef<'ast, 'db>> + std::fmt::Debug + Copy,
     ) -> Definition<'db> {
-        let (definition, num_definitions) = self.push_additional_definition(place, definition_node);
+        let definition = self.create_definition(place, definition_node);
+        self.record_definition(place, definition, None);
+        definition
+    }
+
+    /// Create a definition without making its declaration or binding visible in control flow.
+    fn create_definition(
+        &mut self,
+        place: ScopedPlaceId,
+        definition_node: impl Into<DefinitionNodeRef<'ast, 'db>> + std::fmt::Debug + Copy,
+    ) -> Definition<'db> {
+        let (definition, num_definitions) =
+            self.create_additional_definition(place, definition_node);
         debug_assert_eq!(
             num_definitions, 1,
             "Attempted to create multiple `Definition`s associated with AST node {definition_node:?}"
@@ -1528,14 +1550,24 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     /// Push a new [`Definition`] onto the list of definitions
     /// associated with the `definition_node` AST node.
     ///
-    /// Returns a 2-element tuple, where the first element is the newly created [`Definition`]
-    /// and the second element is the number of definitions that are now associated with
-    /// `definition_node`.
-    ///
     /// Most AST nodes can only be associated with at most one [`Definition`]. Generally prefer
     /// `add_definition` above, which enforces that. This method should currently only be used with
     /// `*` imports and loop headers.
     fn push_additional_definition(
+        &mut self,
+        place: ScopedPlaceId,
+        definition_node: impl Into<DefinitionNodeRef<'ast, 'db>>,
+    ) {
+        let (definition, _) = self.create_additional_definition(place, definition_node);
+        self.record_definition(place, definition, None);
+    }
+
+    /// Create a [`Definition`] without recording it in control flow.
+    ///
+    /// Returns the new definition and the number of definitions now associated with its AST
+    /// node. Loop headers are not stored by AST node, so their count is zero. Prefer
+    /// [`Self::create_definition`] when the node must have exactly one definition.
+    fn create_additional_definition(
         &mut self,
         place: ScopedPlaceId,
         definition_node: impl Into<DefinitionNodeRef<'ast, 'db>>,
@@ -1560,8 +1592,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             definitions.len()
         };
 
-        self.record_definition(place, definition, None);
-
         (definition, num_definitions)
     }
 
@@ -1578,8 +1608,82 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         previous_definitions: Option<PreviousDefinitions>,
     ) {
         let kind = definition.kind(self.db);
-        let is_loop_header = kind.is_loop_header();
         let category = kind.category(self.source_type.is_stub(), self.module);
+        match category {
+            DefinitionCategory::Declaration => {
+                self.mark_place_declared(place);
+                self.current_use_def_map_mut()
+                    .record_declaration(place, definition);
+            }
+            DefinitionCategory::DeclarationAndBinding => {
+                self.mark_place_declared(place);
+                self.record_binding_with(definition, |use_def, place| {
+                    use_def.record_combined_definition(place, definition, category);
+                });
+            }
+            DefinitionCategory::Binding => {
+                let previous = previous_definitions.unwrap_or(if kind.is_loop_header() {
+                    PreviousDefinitions::AreKept
+                } else {
+                    PreviousDefinitions::AreShadowed
+                });
+                self.record_binding_with(definition, |use_def, place| {
+                    use_def.record_binding(
+                        place,
+                        definition,
+                        previous,
+                        FutureDefinitions::ShadowThisOne,
+                    );
+                });
+            }
+        }
+    }
+
+    /// Declare an annotated name assignment whose value will be bound after visiting its RHS.
+    /// Other targets and annotations without a RHS are recorded in full by `add_definition`.
+    fn begin_annotated_assignment(
+        &mut self,
+        node: &'ast ast::StmtAnnAssign,
+    ) -> Option<PendingAnnotatedAssignment<'db>> {
+        let ast::Expr::Name(name) = &*node.target else {
+            return None;
+        };
+        node.value.as_ref()?;
+
+        let place = self.add_symbol(name.id.clone()).into();
+        let definition =
+            self.create_definition(place, AnnotatedAssignmentDefinitionNodeRef { node });
+        self.mark_place_declared(place);
+        self.current_use_def_map_mut().record_combined_definition(
+            place,
+            definition,
+            DefinitionCategory::Declaration,
+        );
+        Some(PendingAnnotatedAssignment { definition })
+    }
+
+    /// Bind the value of an annotated assignment whose declaration was recorded before its RHS.
+    fn finish_annotated_assignment(
+        &mut self,
+        pending: PendingAnnotatedAssignment<'db>,
+    ) -> Definition<'db> {
+        let definition = pending.definition;
+        self.record_binding_with(definition, |use_def, place| {
+            use_def.record_combined_definition(place, definition, DefinitionCategory::Binding);
+        });
+        definition
+    }
+
+    /// Record one binding while keeping aliases, captures, and lazy snapshots in sync.
+    /// The callback receives the definition's place and must append that binding to the current
+    /// use-def map.
+    fn record_binding_with(
+        &mut self,
+        definition: Definition<'db>,
+        record: impl FnOnce(&mut UseDefMapBuilder<'db>, ScopedPlaceId),
+    ) {
+        let place = definition.place(self.db);
+        let is_loop_header = definition.kind(self.db).is_loop_header();
 
         // We need to avoid marking places as bound as soon as we encounter a loop header
         // definition for them, because that would lead to false-positive semantic syntax errors in
@@ -1589,43 +1693,19 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         //     global x  # [invalid-syntax] if `x` is already used or bound
         //     x = 1
         // ```
-        if category.is_binding() && !is_loop_header {
+        if !is_loop_header {
             self.mark_place_bound(place);
             self.invalidate_narrowing_aliases_for(place);
         }
-        if category.is_declaration() {
-            self.mark_place_declared(place);
-        }
 
         let definition_id = self.current_use_def_map().next_definition_id();
-        let use_def = self.current_use_def_map_mut();
-        match category {
-            DefinitionCategory::DeclarationAndBinding => {
-                use_def.record_declaration_and_binding(place, definition);
-                self.delete_associated_bindings(place);
-            }
-            DefinitionCategory::Declaration => use_def.record_declaration(place, definition),
-            DefinitionCategory::Binding => {
-                let previous = previous_definitions.unwrap_or(if is_loop_header {
-                    PreviousDefinitions::AreKept
-                } else {
-                    PreviousDefinitions::AreShadowed
-                });
-                use_def.record_binding(
-                    place,
-                    definition,
-                    previous,
-                    FutureDefinitions::ShadowThisOne,
-                );
-                if !is_loop_header {
-                    self.delete_associated_bindings(place);
-                }
-            }
+        record(self.current_use_def_map_mut(), place);
+
+        if !is_loop_header {
+            self.delete_associated_bindings(place);
         }
 
-        if category.is_binding()
-            && let Some(id) = place.as_symbol()
-        {
+        if let Some(id) = place.as_symbol() {
             self.record_pending_capture_binding(id, definition_id);
             self.update_lazy_snapshots(id);
         }
@@ -2234,7 +2314,26 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.scopes[scope_id].is_eager()
     }
 
+    /// Index a variable annotation without inventing exception paths when it is not evaluated.
+    /// Function-local annotations never execute; module and class annotations can also be deferred.
+    fn visit_variable_annotation(&mut self, annotation: &'ast ast::Expr) {
+        let is_eager = matches!(
+            self.scopes[self.current_scope()].kind(),
+            ScopeKind::Module | ScopeKind::Class
+        ) && !self.has_future_annotations
+            && !self.source_type.is_stub()
+            && !self.python_version.defers_annotations();
+        let was_unevaluated = self.in_unevaluated_annotation;
+        self.in_unevaluated_annotation |= !is_eager;
+        self.visit_annotation(annotation);
+        self.in_unevaluated_annotation = was_unevaluated;
+    }
+
     /// Records the current flow state immediately before an operation that may raise an exception.
+    ///
+    /// This models exceptions from ordinary operations, not every possible interruption. In
+    /// particular, we do not add arbitrary exception points for asynchronously raised exceptions
+    /// such as those originating in signal handlers.
     ///
     /// Child expressions must already have been visited, so their completed assignments are
     /// visible if the parent operation fails:
@@ -2249,9 +2348,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     ///
     /// Skips snapshot construction when no enclosing `try` or `with` context can handle exceptions.
     fn record_exception_checkpoint(&mut self) {
-        if !self
-            .exception_context_stack_manager
-            .has_active_exception_handler(self)
+        if self.in_unevaluated_annotation
+            || !self
+                .exception_context_stack_manager
+                .has_active_exception_handler(self)
         {
             return;
         }
@@ -3848,7 +3948,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             ast::Stmt::AnnAssign(node) => {
                 debug_assert_eq!(&self.current_assignments, &[]);
-                self.visit_expr(&node.annotation);
+                // For an assignment with a value, an exception from the annotation or RHS must
+                // not discard the declared type. The value is still bound only after the RHS
+                // completes, so a handler can observe an earlier binding (or an unbound name).
+                let pending = self.begin_annotated_assignment(node);
+                self.visit_variable_annotation(&node.annotation);
                 if let Some(value) = &node.value {
                     self.visit_expr(value);
                     if self.is_method_or_eagerly_executed_in_method().is_some() {
@@ -3888,7 +3992,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     *node.target,
                     ast::Expr::Attribute(_) | ast::Expr::Subscript(_) | ast::Expr::Name(_)
                 ) {
-                    self.push_assignment(CurrentAssignment::AnnAssign(node));
+                    self.push_assignment(CurrentAssignment::AnnAssign { node, pending });
                     self.visit_expr(&node.target);
                     self.pop_assignment();
 
@@ -5705,13 +5809,23 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
     }
 }
 
+/// A simple-name annotated assignment with an RHS whose declaration is already recorded.
+/// Created only by `begin_annotated_assignment`; finishing it records the value binding.
+#[derive(Copy, Clone, Debug, PartialEq)]
+struct PendingAnnotatedAssignment<'db> {
+    definition: Definition<'db>,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum CurrentAssignment<'ast, 'db> {
     Assign {
         node: &'ast ast::StmtAssign,
         unpack: Option<Unpack<'db>>,
     },
-    AnnAssign(&'ast ast::StmtAnnAssign),
+    AnnAssign {
+        node: &'ast ast::StmtAnnAssign,
+        pending: Option<PendingAnnotatedAssignment<'db>>,
+    },
     AugAssign(&'ast ast::StmtAugAssign),
     For {
         node: &'ast ast::StmtFor,
@@ -5736,7 +5850,9 @@ impl CurrentAssignment<'_, '_> {
             Self::For { unpack, .. }
             | Self::WithItem { unpack, .. }
             | Self::Comprehension { unpack, .. } => unpack.as_mut().map(|(position, _)| position),
-            Self::Assign { .. } | Self::AnnAssign(_) | Self::AugAssign(_) | Self::Named(_) => None,
+            Self::Assign { .. } | Self::AnnAssign { .. } | Self::AugAssign(_) | Self::Named(_) => {
+                None
+            }
         }
     }
 }

--- a/crates/ty_python_core/src/builder/except_handlers.rs
+++ b/crates/ty_python_core/src/builder/except_handlers.rs
@@ -39,6 +39,8 @@ pub(super) struct ExceptionContextStackManager {
     stacks: Vec<ExceptionContextStack>,
     /// Number of `try` and `with` contexts still collecting exception checkpoints.
     active_handler_count: usize,
+    /// Whether the current traversal is unevaluated and cannot raise into a handler.
+    checkpoints_suppressed: bool,
 }
 
 impl ExceptionContextStackManager {
@@ -109,6 +111,19 @@ impl ExceptionContextStackManager {
         self.take_exception_snapshots()
     }
 
+    /// Suppress checkpoints without clearing an enclosing suppression or changing active contexts.
+    /// Returns the previous suppression state, which must be restored after the visit.
+    pub(super) fn suppress_exception_checkpoints_if(&mut self, suppress: bool) -> bool {
+        let previous = self.checkpoints_suppressed;
+        self.checkpoints_suppressed |= suppress;
+        previous
+    }
+
+    /// Restore the state saved by [`Self::suppress_exception_checkpoints_if`].
+    pub(super) fn restore_exception_checkpoint_suppression(&mut self, previous: bool) {
+        self.checkpoints_suppressed = previous;
+    }
+
     /// Records a checkpoint for every active `try` or `with` context that could handle an
     /// exception raised at the current point in control flow.
     ///
@@ -144,7 +159,7 @@ impl ExceptionContextStackManager {
     ///
     /// A context can remain on the stack for its `finally` suite after its handlers become inactive.
     pub(super) fn has_active_exception_handler(&self, builder: &SemanticIndexBuilder) -> bool {
-        if self.active_handler_count == 0 {
+        if self.checkpoints_suppressed || self.active_handler_count == 0 {
             return false;
         }
 

--- a/crates/ty_python_core/src/builder/except_handlers.rs
+++ b/crates/ty_python_core/src/builder/except_handlers.rs
@@ -39,8 +39,6 @@ pub(super) struct ExceptionContextStackManager {
     stacks: Vec<ExceptionContextStack>,
     /// Number of `try` and `with` contexts still collecting exception checkpoints.
     active_handler_count: usize,
-    /// Whether the current traversal is unevaluated and cannot raise into a handler.
-    checkpoints_suppressed: bool,
 }
 
 impl ExceptionContextStackManager {
@@ -111,19 +109,6 @@ impl ExceptionContextStackManager {
         self.take_exception_snapshots()
     }
 
-    /// Suppress checkpoints without clearing an enclosing suppression or changing active contexts.
-    /// Returns the previous suppression state, which must be restored after the visit.
-    pub(super) fn suppress_exception_checkpoints_if(&mut self, suppress: bool) -> bool {
-        let previous = self.checkpoints_suppressed;
-        self.checkpoints_suppressed |= suppress;
-        previous
-    }
-
-    /// Restore the state saved by [`Self::suppress_exception_checkpoints_if`].
-    pub(super) fn restore_exception_checkpoint_suppression(&mut self, previous: bool) {
-        self.checkpoints_suppressed = previous;
-    }
-
     /// Records a checkpoint for every active `try` or `with` context that could handle an
     /// exception raised at the current point in control flow.
     ///
@@ -159,7 +144,7 @@ impl ExceptionContextStackManager {
     ///
     /// A context can remain on the stack for its `finally` suite after its handlers become inactive.
     pub(super) fn has_active_exception_handler(&self, builder: &SemanticIndexBuilder) -> bool {
-        if self.checkpoints_suppressed || self.active_handler_count == 0 {
+        if self.active_handler_count == 0 {
             return false;
         }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -251,7 +251,7 @@ use smallvec::SmallVec;
 use thin_vec::ThinVec;
 
 use crate::ast_ids::ScopedUseId;
-use crate::definition::{Definition, DefinitionState};
+use crate::definition::{Definition, DefinitionCategory, DefinitionState};
 use crate::frozen::FrozenMap;
 use crate::member::ScopedMemberId;
 use crate::narrowing_constraints::{
@@ -645,79 +645,56 @@ static ALWAYS_UNBOUND_BINDINGS: LazyLock<Bindings> =
 static ALWAYS_UNDECLARED_DECLARATIONS: LazyLock<Declarations> =
     LazyLock::new(|| Declarations::undeclared(ScopedReachabilityConstraintId::ALWAYS_TRUE));
 
+/// One event in a scope's use-def history.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
-enum RetainedDefinitionState<'db> {
+enum DefinitionEntry<'db> {
+    /// The early declaration of a combined definition whose binding is recorded separately.
+    /// It participates in declaration lookup, but not in binding-usage analysis.
+    DeclarationPart(Definition<'db>),
+    /// A binding or standalone declaration with no recorded use.
     Unused(Definition<'db>),
     Used(Definition<'db>),
     Undefined,
     Deleted,
 }
 
-impl<'db> RetainedDefinitionState<'db> {
-    fn new(state: DefinitionState<'db>, used: bool) -> Self {
-        match state {
-            DefinitionState::Defined(definition) if used => Self::Used(definition),
-            DefinitionState::Defined(definition) => Self::Unused(definition),
-            DefinitionState::Undefined => {
-                debug_assert!(!used);
-                Self::Undefined
-            }
-            DefinitionState::Deleted => {
-                debug_assert!(!used);
-                Self::Deleted
-            }
-        }
-    }
-
+impl<'db> DefinitionEntry<'db> {
     fn state(self) -> DefinitionState<'db> {
         match self {
-            Self::Unused(definition) | Self::Used(definition) => {
-                DefinitionState::Defined(definition)
-            }
+            Self::DeclarationPart(definition)
+            | Self::Unused(definition)
+            | Self::Used(definition) => DefinitionState::Defined(definition),
             Self::Undefined => DefinitionState::Undefined,
             Self::Deleted => DefinitionState::Deleted,
         }
     }
-
-    fn is_used(self) -> bool {
-        matches!(self, Self::Used(_))
-    }
 }
 
-static_assertions::assert_eq_size!(RetainedDefinitionState<'static>, DefinitionState<'static>);
+static_assertions::assert_eq_size!(DefinitionEntry<'static>, DefinitionState<'static>);
 
 /// Retained definition states, excluding the implicit unbound definition at index zero.
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 struct RetainedDefinitions<'db> {
-    states: Box<[RetainedDefinitionState<'db>]>,
+    states: Box<[DefinitionEntry<'db>]>,
 }
 
 impl<'db> RetainedDefinitions<'db> {
-    fn new(
-        states: IndexVec<ScopedDefinitionId, DefinitionState<'db>>,
-        used: IndexVec<ScopedDefinitionId, bool>,
-    ) -> Self {
+    fn new(states: IndexVec<ScopedDefinitionId, DefinitionEntry<'db>>) -> Self {
         let mut states = states.into_iter();
-        let mut used = used.into_iter();
 
         let unbound_state = states.next();
-        let unbound_used = used.next();
-        debug_assert_eq!(unbound_state, Some(DefinitionState::Undefined));
-        debug_assert_eq!(unbound_used, Some(false));
+        debug_assert_eq!(unbound_state, Some(DefinitionEntry::Undefined));
 
         Self {
-            states: states
-                .zip(used)
-                .map(|(state, used)| RetainedDefinitionState::new(state, used))
-                .collect(),
+            states: states.collect(),
         }
     }
 
     #[inline]
-    fn get(&self, id: ScopedDefinitionId) -> RetainedDefinitionState<'db> {
+    fn get(&self, id: ScopedDefinitionId) -> DefinitionEntry<'db> {
         let index = id.index();
         if index == 0 {
-            RetainedDefinitionState::Undefined
+            DefinitionEntry::Undefined
         } else {
             self.states[index - 1]
         }
@@ -725,18 +702,12 @@ impl<'db> RetainedDefinitions<'db> {
 
     fn iter_enumerated(
         &self,
-    ) -> impl Iterator<Item = (ScopedDefinitionId, RetainedDefinitionState<'db>)> + '_ {
-        std::iter::once((
-            ScopedDefinitionId::UNBOUND,
-            RetainedDefinitionState::Undefined,
-        ))
-        .chain(
-            self.states
-                .iter()
-                .copied()
-                .enumerate()
-                .map(|(index, state)| (ScopedDefinitionId::new(index + 1), state)),
-        )
+    ) -> impl Iterator<Item = (ScopedDefinitionId, DefinitionEntry<'db>)> + '_ {
+        self.states
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(index, entry)| (ScopedDefinitionId::new(index + 1), entry))
     }
 }
 
@@ -888,12 +859,22 @@ impl<'db> UseDefMap<'db> {
         self.end_of_scope_reachability
     }
 
-    pub fn all_definitions_with_usage(
+    /// Definitions relevant to usage analysis, including standalone declarations.
+    ///
+    /// The early declaration part of a combined definition is omitted: its later binding entry
+    /// carries the usage information for that definition.
+    pub fn definitions_with_usage(
         &self,
-    ) -> impl Iterator<Item = (ScopedDefinitionId, DefinitionState<'db>, bool)> + '_ {
+    ) -> impl Iterator<Item = (ScopedDefinitionId, Definition<'db>, bool)> + '_ {
         self.all_definitions
             .iter_enumerated()
-            .map(|(id, state)| (id, state.state(), state.is_used()))
+            .filter_map(|(id, entry)| match entry {
+                DefinitionEntry::Unused(definition) => Some((id, definition, false)),
+                DefinitionEntry::Used(definition) => Some((id, definition, true)),
+                DefinitionEntry::DeclarationPart(_)
+                | DefinitionEntry::Undefined
+                | DefinitionEntry::Deleted => None,
+            })
     }
 
     pub fn bindings_at_use(&self, use_id: ScopedUseId) -> BindingWithConstraintsIterator<'_, 'db> {
@@ -1764,13 +1745,8 @@ pub(super) struct SingleSymbolSnapshot {
 
 #[derive(Debug)]
 pub(super) struct UseDefMapBuilder<'db> {
-    /// Append-only array of [`DefinitionState`].
-    all_definitions: IndexVec<ScopedDefinitionId, DefinitionState<'db>>,
-
-    /// Tracks whether each binding definition has at least one use.
-    ///
-    /// Uses the same index as `all_definitions`.
-    used_bindings: IndexVec<ScopedDefinitionId, bool>,
+    /// Append-only history of declarations and bindings, including their usage state.
+    all_definitions: IndexVec<ScopedDefinitionId, DefinitionEntry<'db>>,
 
     /// Builder of predicates.
     predicates: PredicatesBuilder<'db>,
@@ -1841,8 +1817,7 @@ pub(super) struct UseDefMapBuilder<'db> {
 impl<'db> UseDefMapBuilder<'db> {
     pub(super) fn new(is_class_scope: bool) -> Self {
         Self {
-            all_definitions: IndexVec::from_iter([DefinitionState::Undefined]),
-            used_bindings: IndexVec::from_iter([false]),
+            all_definitions: IndexVec::from_iter([DefinitionEntry::Undefined]),
             predicates: PredicatesBuilder::default(),
             reachability_constraints: ReachabilityConstraintsBuilder::default(),
             narrowing_constraints: NarrowingConstraintsBuilder::default(),
@@ -1872,16 +1847,14 @@ impl<'db> UseDefMapBuilder<'db> {
         self.loop_headers[id] = header;
     }
 
-    fn push_definition(&mut self, state: DefinitionState<'db>) -> ScopedDefinitionId {
+    fn push_definition(&mut self, entry: DefinitionEntry<'db>) -> ScopedDefinitionId {
+        // Declaration-only entries also change the type visible to an exception handler.
         self.checkpoint_state.record_binding_change();
-        let def_id = self.all_definitions.push(state);
-        let used_id = self.used_bindings.push(false);
-        debug_assert_eq!(def_id, used_id);
-        def_id
+        self.all_definitions.push(entry)
     }
 
     pub(super) fn definition(&self, def_id: ScopedDefinitionId) -> DefinitionState<'db> {
-        self.all_definitions[def_id]
+        self.all_definitions[def_id].state()
     }
 
     pub(super) fn mark_unreachable(&mut self) {
@@ -1946,7 +1919,7 @@ impl<'db> UseDefMapBuilder<'db> {
         can_be_shadowed: FutureDefinitions,
     ) {
         let pending = self.pending_reachability.current;
-        let def_id = self.push_definition(DefinitionState::Defined(binding));
+        let def_id = self.push_definition(DefinitionEntry::Unused(binding));
         let place_state =
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
         let place_state = self.pending_reachability.materialize(
@@ -2353,7 +2326,7 @@ impl<'db> UseDefMapBuilder<'db> {
         place: ScopedPlaceId,
         declaration: Definition<'db>,
     ) {
-        let def_id = self.push_definition(DefinitionState::Defined(declaration));
+        let def_id = self.push_definition(DefinitionEntry::Unused(declaration));
         let pending = self.pending_reachability.current;
         let place_state =
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
@@ -2385,14 +2358,24 @@ impl<'db> UseDefMapBuilder<'db> {
         );
     }
 
-    pub(super) fn record_declaration_and_binding(
+    /// Record some or all of a definition that both declares a type and binds a value.
+    ///
+    /// Annotated assignments can declare before their RHS and bind afterward. Each phase gets a
+    /// fresh scoped ID, so definitions created by the RHS remain in execution order.
+    pub(super) fn record_combined_definition(
         &mut self,
         place: ScopedPlaceId,
         definition: Definition<'db>,
+        part: DefinitionCategory,
     ) {
         // We don't need to store prior state for a definition that is both a declaration and a
         // binding.
-        let def_id = self.push_definition(DefinitionState::Defined(definition));
+        let entry = if part.is_binding() {
+            DefinitionEntry::Unused(definition)
+        } else {
+            DefinitionEntry::DeclarationPart(definition)
+        };
+        let def_id = self.push_definition(entry);
         let pending = self.pending_reachability.current;
         let place_state =
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
@@ -2402,38 +2385,41 @@ impl<'db> UseDefMapBuilder<'db> {
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
-        place_state.record_declaration(def_id, self.reachability);
-        place_state.record_binding(
-            def_id,
-            self.reachability,
-            self.is_class_scope,
-            place.is_symbol(),
-            PreviousDefinitions::AreShadowed,
-            FutureDefinitions::ShadowThisOne,
-        );
-
         let reachable_definitions = match place {
             ScopedPlaceId::Symbol(symbol) => &mut self.reachable_symbol_definitions[symbol],
             ScopedPlaceId::Member(member) => &mut self.reachable_member_definitions[member],
         };
 
-        reachable_definitions.declarations.record_declaration(
-            def_id,
-            self.reachability,
-            PreviousDefinitions::AreKept,
-        );
-        reachable_definitions.bindings.record_binding(
-            def_id,
-            self.reachability,
-            self.is_class_scope,
-            place.is_symbol(),
-            PreviousDefinitions::AreKept,
-            FutureDefinitions::ShadowThisOne,
-        );
+        if part.is_declaration() {
+            place_state.record_declaration(def_id, self.reachability);
+            reachable_definitions.declarations.record_declaration(
+                def_id,
+                self.reachability,
+                PreviousDefinitions::AreKept,
+            );
+        }
+        if part.is_binding() {
+            place_state.record_binding(
+                def_id,
+                self.reachability,
+                self.is_class_scope,
+                place.is_symbol(),
+                PreviousDefinitions::AreShadowed,
+                FutureDefinitions::ShadowThisOne,
+            );
+            reachable_definitions.bindings.record_binding(
+                def_id,
+                self.reachability,
+                self.is_class_scope,
+                place.is_symbol(),
+                PreviousDefinitions::AreKept,
+                FutureDefinitions::ShadowThisOne,
+            );
+        }
     }
 
     pub(super) fn delete_binding(&mut self, place: ScopedPlaceId) {
-        let def_id = self.push_definition(DefinitionState::Deleted);
+        let def_id = self.push_definition(DefinitionEntry::Deleted);
         let pending = self.pending_reachability.current;
         let place_state =
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
@@ -2671,15 +2657,9 @@ impl<'db> UseDefMapBuilder<'db> {
     }
 
     fn mark_definition_used(&mut self, definition_id: ScopedDefinitionId) {
-        if definition_id.is_unbound() {
-            return;
-        }
-
-        if matches!(
-            self.all_definitions[definition_id],
-            DefinitionState::Defined(_)
-        ) {
-            self.used_bindings[definition_id] = true;
+        let entry = &mut self.all_definitions[definition_id];
+        if let DefinitionEntry::Unused(definition) = *entry {
+            *entry = DefinitionEntry::Used(definition);
         }
     }
 
@@ -2937,7 +2917,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 narrowing_constraints,
             })
         });
-        let all_definitions = RetainedDefinitions::new(self.all_definitions, self.used_bindings);
+        let all_definitions = RetainedDefinitions::new(self.all_definitions);
 
         UseDefMap {
             all_definitions,

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -50,7 +50,8 @@ use crate::ReachabilityConstraintsBuilder;
 use crate::narrowing_constraints::{NarrowingConstraintsBuilder, ScopedNarrowingConstraint};
 use crate::reachability_constraints::ScopedReachabilityConstraintId;
 
-/// A newtype-index for a definition in a particular scope.
+/// An index into a scope's use-def history. A combined definition can have separate declaration
+/// and binding entries when they take effect at different points in control flow.
 #[newtype_index]
 #[derive(Ord, PartialOrd, get_size2::GetSize)]
 pub struct ScopedDefinitionId;

--- a/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
@@ -3,6 +3,9 @@
 These tests describe which names are defined and what types they have in the branches of a
 `try`/`except`/`else`/`finally` statement.
 
+The analysis models exceptions from ordinary Python operations. It intentionally does not treat
+every possible interruption, such as an exception raised by a signal handler, as an exception point.
+
 For a full writeup on the semantics of exception handlers, see [this document][1].
 
 Functions whose names start with `could_raise_` make it clear that a call may raise an exception
@@ -10,8 +13,8 @@ before an assignment completes. Any other function call can raise as well.
 
 ## Operations that cannot raise
 
-An exception handler can run only if the `try` block contains an operation that can raise. Assigning
-a literal to a local name cannot raise:
+Under this model, an exception handler is reachable only if the `try` block contains an operation
+that can raise. Assigning a literal to a local name does not introduce an exception point:
 
 ```py
 x = 1
@@ -44,6 +47,273 @@ def known_safe_conditions(value: int | None) -> None:
         state = 2
 
     reveal_type(state)  # revealed: Literal[1]
+```
+
+## Annotated assignments that can raise
+
+An annotation applies to assignments in the exception handler even if evaluating the annotated
+assignment's right-hand side raises. In particular, it provides type context for a collection
+literal in the handler.
+
+```py
+from typing import Any
+
+def could_raise_dict() -> dict[str, Any]:
+    return {}
+
+def requires_str(value: str) -> None: ...
+def fallback() -> None:
+    try:
+        result: dict[str, Any] = could_raise_dict()
+    except Exception:
+        result = {"correct": False, "message": "fallback"}
+        reveal_type(result)  # revealed: dict[str, Any]
+
+    reveal_type(result)  # revealed: dict[str, Any]
+    requires_str(result["message"])
+```
+
+The declaration also rejects an incompatible assignment in the handler.
+
+```py
+def could_raise_int() -> int:
+    return 1
+
+def incompatible_fallback() -> None:
+    try:
+        value: int = could_raise_int()
+    except Exception:
+        value = "wrong"  # error: [invalid-assignment]
+```
+
+The declaration does not make the new value available before the assignment completes. A handler
+still sees the previous value, or an unbound name if there was no previous binding.
+
+```py
+def previous_binding() -> None:
+    value = 0
+    try:
+        value: int = could_raise_int()
+    except Exception:
+        reveal_type(value)  # revealed: Literal[0]
+
+def no_previous_binding() -> None:
+    try:
+        value: int = could_raise_int()
+    except Exception:
+        # error: [unresolved-reference]
+        reveal_type(value)  # revealed: Unknown
+```
+
+A new annotation replaces an earlier declared type even if its right-hand side raises. Quoting the
+annotation does not change which declaration reaches the handler.
+
+```py
+def reannotated() -> None:
+    value: object = None
+    try:
+        value: int = could_raise_int()
+    except Exception:
+        value = 1
+
+    reveal_type(value)  # revealed: int
+
+def quoted_reannotation() -> None:
+    value: object = None
+    try:
+        value: "int" = could_raise_int()
+    except Exception:
+        value = 1
+
+    reveal_type(value)  # revealed: int
+```
+
+Assignments made while evaluating the right-hand side still reach the handler. When the call
+returns, its result replaces the value assigned by the walrus expression on the successful path.
+
+```py
+from collections.abc import Callable
+from typing import Literal
+
+def assignment_in_rhs(could_raise_after: Callable[[int], Literal[3]]) -> None:
+    value = 0
+    try:
+        value: int = could_raise_after(value := 2)
+    except Exception:
+        reveal_type(value)  # revealed: Literal[2]
+    else:
+        reveal_type(value)  # revealed: Literal[3]
+
+    reveal_type(value)  # revealed: Literal[2, 3]
+```
+
+## Function-local variable annotations
+
+Local variable annotations are not evaluated, even on Python versions where other annotations are
+eager. Calls inside them cannot make an exception handler reachable.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Annotated
+
+def could_raise_metadata() -> int:
+    return 0
+
+def local_annotation() -> None:
+    state = 0
+    try:
+        value: Annotated[int, could_raise_metadata()]
+        state = 1
+    except Exception:
+        state = 2
+
+    reveal_type(state)  # revealed: Literal[1]
+```
+
+## Deferred variable annotations
+
+With future annotations, module-level variable annotations do not execute either.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from __future__ import annotations
+from typing import Annotated
+
+def could_raise_metadata() -> int:
+    return 0
+
+state = 0
+try:
+    value: Annotated[int, could_raise_metadata()]
+    state = 1
+except Exception:
+    state = 2
+
+reveal_type(state)  # revealed: Literal[1]
+```
+
+## Variable annotations in Python 3.14
+
+Python 3.14 defers variable annotations without requiring a future import.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import Annotated
+
+def could_raise_metadata() -> int:
+    return 0
+
+state = 0
+try:
+    value: Annotated[int, could_raise_metadata()]
+    state = 1
+except Exception:
+    state = 2
+
+reveal_type(state)  # revealed: Literal[1]
+```
+
+## Variable annotations in stubs
+
+Stub annotations do not introduce runtime exception paths, regardless of the target Python version.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+`annotations.pyi`:
+
+```pyi
+from typing import Annotated
+
+def could_raise_metadata() -> int: ...
+
+state = 0
+try:
+    value: Annotated[int, could_raise_metadata()]
+    state = 1
+except Exception:
+    state = 2
+
+reveal_type(state)  # revealed: Literal[1]
+```
+
+## Eager variable annotations
+
+On Python 3.13 without future annotations, module and class variable annotations can raise. A class
+body still evaluates its annotations when it is nested inside a function.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Annotated
+
+def could_raise_metadata() -> int:
+    return 0
+
+state = 0
+try:
+    value: Annotated[int, could_raise_metadata()]
+    state = 1
+except Exception:
+    state = 2
+
+reveal_type(state)  # revealed: Literal[1, 2]
+
+def nested_class() -> None:
+    class Inner:
+        state = 0
+        try:
+            value: Annotated[int, could_raise_metadata()]
+            state = 1
+        except Exception:
+            state = 2
+
+        reveal_type(state)  # revealed: Literal[1, 2]
+```
+
+An eager annotation must not preserve an obsolete declared type in the handler.
+
+```py
+reannotated: object = None
+try:
+    reannotated: int = could_raise_metadata()
+except Exception:
+    reannotated = 1
+
+reveal_type(reannotated)  # revealed: int
+```
+
+Function signatures are separate from function-local variable annotations. An eager return
+annotation on a nested function can still raise while that function is being defined.
+
+```py
+def nested_signature() -> None:
+    state = 0
+    try:
+        def inner() -> Annotated[int, could_raise_metadata()]:
+            return 0
+        state = 1
+    except Exception:
+        state = 2
+
+    reveal_type(state)  # revealed: Literal[1, 2]
 ```
 
 ## Looking up an undefined name

--- a/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
@@ -86,6 +86,18 @@ def incompatible_fallback() -> None:
         value = "wrong"  # error: [invalid-assignment]
 ```
 
+An earlier call in the `try` block does not hide a declaration reached before a later call raises.
+
+```py
+def declaration_after_call() -> None:
+    value = int()
+    try:
+        could_raise_int()
+        value: int = could_raise_int()
+    except Exception:
+        value = "wrong"  # error: [invalid-assignment]
+```
+
 The declaration does not make the new value available before the assignment completes. A handler
 still sees the previous value, or an unbound name if there was no previous binding.
 

--- a/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
@@ -105,23 +105,13 @@ def no_previous_binding() -> None:
         reveal_type(value)  # revealed: Unknown
 ```
 
-A new annotation replaces an earlier declared type even if its right-hand side raises. Quoting the
-annotation does not change which declaration reaches the handler.
+A new annotation replaces an earlier declared type even if its right-hand side raises.
 
 ```py
 def reannotated() -> None:
     value: object = None
     try:
         value: int = could_raise_int()
-    except Exception:
-        value = 1
-
-    reveal_type(value)  # revealed: int
-
-def quoted_reannotation() -> None:
-    value: object = None
-    try:
-        value: "int" = could_raise_int()
     except Exception:
         value = 1
 
@@ -140,180 +130,11 @@ def assignment_in_rhs(could_raise_after: Callable[[int], Literal[3]]) -> None:
     try:
         value: int = could_raise_after(value := 2)
     except Exception:
-        reveal_type(value)  # revealed: Literal[2]
+        reveal_type(value)  # revealed: Literal[0, 2]
     else:
         reveal_type(value)  # revealed: Literal[3]
 
-    reveal_type(value)  # revealed: Literal[2, 3]
-```
-
-## Function-local variable annotations
-
-Local variable annotations are not evaluated, even on Python versions where other annotations are
-eager. Calls inside them cannot make an exception handler reachable.
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```py
-from typing import Annotated
-
-def could_raise_metadata() -> int:
-    return 0
-
-def local_annotation() -> None:
-    state = 0
-    try:
-        value: Annotated[int, could_raise_metadata()]
-        state = 1
-    except Exception:
-        state = 2
-
-    reveal_type(state)  # revealed: Literal[1]
-```
-
-## Deferred variable annotations
-
-With future annotations, module-level variable annotations do not execute either.
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```py
-from __future__ import annotations
-from typing import Annotated
-
-def could_raise_metadata() -> int:
-    return 0
-
-state = 0
-try:
-    value: Annotated[int, could_raise_metadata()]
-    state = 1
-except Exception:
-    state = 2
-
-reveal_type(state)  # revealed: Literal[1]
-```
-
-## Variable annotations in Python 3.14
-
-Python 3.14 defers variable annotations without requiring a future import.
-
-```toml
-[environment]
-python-version = "3.14"
-```
-
-```py
-from typing import Annotated
-
-def could_raise_metadata() -> int:
-    return 0
-
-state = 0
-try:
-    value: Annotated[int, could_raise_metadata()]
-    state = 1
-except Exception:
-    state = 2
-
-reveal_type(state)  # revealed: Literal[1]
-```
-
-## Variable annotations in stubs
-
-Stub annotations do not introduce runtime exception paths, regardless of the target Python version.
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-`annotations.pyi`:
-
-```pyi
-from typing import Annotated
-
-def could_raise_metadata() -> int: ...
-
-state = 0
-try:
-    value: Annotated[int, could_raise_metadata()]
-    state = 1
-except Exception:
-    state = 2
-
-reveal_type(state)  # revealed: Literal[1]
-```
-
-## Eager variable annotations
-
-On Python 3.13 without future annotations, module and class variable annotations can raise. A class
-body still evaluates its annotations when it is nested inside a function.
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```py
-from typing import Annotated
-
-def could_raise_metadata() -> int:
-    return 0
-
-state = 0
-try:
-    value: Annotated[int, could_raise_metadata()]
-    state = 1
-except Exception:
-    state = 2
-
-reveal_type(state)  # revealed: Literal[1, 2]
-
-def nested_class() -> None:
-    class Inner:
-        state = 0
-        try:
-            value: Annotated[int, could_raise_metadata()]
-            state = 1
-        except Exception:
-            state = 2
-
-        reveal_type(state)  # revealed: Literal[1, 2]
-```
-
-An eager annotation must not preserve an obsolete declared type in the handler.
-
-```py
-reannotated: object = None
-try:
-    reannotated: int = could_raise_metadata()
-except Exception:
-    reannotated = 1
-
-reveal_type(reannotated)  # revealed: int
-```
-
-Function signatures are separate from function-local variable annotations. An eager return
-annotation on a nested function can still raise while that function is being defined.
-
-```py
-def nested_signature() -> None:
-    state = 0
-    try:
-        def inner() -> Annotated[int, could_raise_metadata()]:
-            return 0
-        state = 1
-    except Exception:
-        state = 2
-
-    reveal_type(state)  # revealed: Literal[1, 2]
+    reveal_type(value)  # revealed: Literal[0, 2, 3]
 ```
 
 ## Looking up an undefined name

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -7,7 +7,7 @@ use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashSet;
-use ty_python_core::definition::{DefinitionCategory, DefinitionKind, DefinitionState};
+use ty_python_core::definition::{DefinitionCategory, DefinitionKind};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
 use ty_python_core::{ProgramFile, SemanticIndex, semantic_index};
@@ -112,8 +112,8 @@ pub fn unused_bindings(db: &dyn Db, file: ProgramFile<'_>) -> Box<[UnusedBinding
     let used_definitions = index.scope_ids().flat_map(|scope_id| {
         index
             .use_def_map(scope_id.file_scope_id(db))
-            .all_definitions_with_usage()
-            .filter_map(|(_, state, is_used)| is_used.then_some(state.definition()).flatten())
+            .definitions_with_usage()
+            .filter_map(|(_, definition, is_used)| is_used.then_some(definition))
     });
     let used_user_visible_definitions = super::user_visible_definitions(db, used_definitions);
 
@@ -142,10 +142,7 @@ pub fn unused_bindings(db: &dyn Db, file: ProgramFile<'_>) -> Box<[UnusedBinding
         // track used IDs as we go.
         let mut loop_header_used_definition_ids = FxHashSet::default();
 
-        for (definition_id, state, is_used) in use_def_map.all_definitions_with_usage() {
-            let DefinitionState::Defined(definition) = state else {
-                continue;
-            };
+        for (definition_id, definition, is_used) in use_def_map.definitions_with_usage() {
             let is_used = is_used || used_user_visible_definitions.contains(&definition);
 
             if is_used {
@@ -823,6 +820,23 @@ mod tests {
     }
 
     #[test]
+    fn closure_uses_later_annotated_binding() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def outer():
+                def inner():
+                    return value
+
+                value: int = 1
+                return inner
+            ",
+        );
+
+        assert!(collect_unused_names(&source)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
     fn nested_comprehension_capture_uses_intermediate_rebindings() -> anyhow::Result<()> {
         let source = dedent(
             "
@@ -948,6 +962,45 @@ mod tests {
 
         let names = collect_unused_names(&source)?;
         assert_eq!(names, Vec::<String>::new());
+        Ok(())
+    }
+
+    #[test]
+    fn skips_annotated_loop_carried_rebinding() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def f(items: list[int]) -> None:
+                value = 0
+                for item in items:
+                    print(value)
+                    value: int = item
+            ",
+        );
+
+        assert!(collect_unused_names(&source)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn reports_shadowed_annotated_binding() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def f() -> int:
+                value: int = 1
+                value: int = 2
+                return value
+            ",
+        );
+
+        let bindings = collect_unused_bindings(&source)?;
+        let start = TextSize::try_from(source.find("value: int = 1").unwrap()).unwrap();
+        assert_eq!(
+            bindings,
+            vec![UnusedBinding {
+                range: TextRange::new(start, start + TextSize::new(5)),
+                name: Name::new("value"),
+            }]
+        );
         Ok(())
     }
 


### PR DESCRIPTION
An annotated assignment could lose its declared type in an exception handler, when the path to the exception handler is through an exception evaluating its right-hand side. Assignments in the handler were then inferred without that type context, so a fallback assignment could acquire an incompatible value type, without the benefit of type context from the declared type.

This is arguably "expected behavior" in our flow-sensitive declared-types model, but intuitively it feels like the declaration should "take effect" before the RHS "executes". Modeling it that way requires a bit of new machinery in the use-def map to allow splitting the declaration and binding from a single assignment in control flow, but it's not too bad and even allows some simplifications.

Record the declaration before visiting the annotation and right-hand side, then record the value binding only after the right-hand side completes. The two control-flow entries retain their execution order, but only the binding participates in usage analysis. Keeping usage state in those entries also removes the parallel usage vector. This preserves ty's existing exception-point model.

Fixes astral-sh/ty#4293.

## Test plan

- Exception-flow mdtests cover contextual dictionary inference, incompatible fallback assignments, previous or unbound values, reannotations, declarations after an earlier exception checkpoint, and assignments made inside the right-hand side.
- Unused-binding tests cover annotated loop-carried values, shadowed annotated bindings, and later bindings captured by closures.
