### PR TITLE
[ty] Simplify generic protocol inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4398,6 +4398,38 @@ factory_object: FactoryObject = factory
 factory_module: FactoryModule = factory
 ```
 
+## Generic protocol inference from module objects
+
+A module attribute can determine a protocol's type argument when the module itself is passed to a
+generic function.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+`values.py`:
+
+```py
+value: int = 1
+```
+
+`main.py`:
+
+```py
+from typing import Protocol
+
+import values
+
+class HasValue[T](Protocol):
+    value: T
+
+def get_value[T](obj: HasValue[T]) -> T:
+    return obj.value
+
+reveal_type(get_value(values))  # revealed: int
+```
+
 ## Class objects with class-method protocol members
 
 A class object implements a protocol when its directly accessible members have compatible types. The
@@ -4458,21 +4490,18 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Protocol, TypeVar
+from typing import Protocol
 
-T_co = TypeVar("T_co", covariant=True)
-T = TypeVar("T")
-
-class Factory(Protocol[T_co]):
+class Factory[T](Protocol):
     @classmethod
-    def make(cls) -> T_co: ...
+    def make(cls) -> T: ...
 
 class Concrete:
     @classmethod
     def make(cls) -> "Concrete":
         return cls()
 
-def from_protocol(factory: Factory[T]) -> T:
+def from_protocol[T](factory: Factory[T]) -> T:
     return factory.make()
 
 reveal_type(from_protocol(Concrete))  # revealed: Concrete
@@ -5740,6 +5769,32 @@ def get_value[T](factory: ConstructorWithValue[T]) -> T:
     return factory.value
 
 reveal_type(get_value(Product))  # revealed: int
+```
+
+## Generic callback inference from function attributes
+
+A function object's attributes also contribute to protocol inference. Here, the type argument comes
+from `__name__`, not the callback's return type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class NamedCallback[T](Protocol):
+    __name__: T
+
+    def __call__(self) -> object: ...
+
+def get_name[T](callback: NamedCallback[T]) -> T:
+    return callback.__name__
+
+def callback() -> None: ...
+
+reveal_type(get_name(callback))  # revealed: str
 ```
 
 ## Generic protocols and union arguments

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4432,8 +4432,8 @@ reveal_type(get_value(values))  # revealed: int
 
 ## Generic protocol inference through type aliases
 
-An alias for an instance type must not hide the members that determine a protocol's type arguments.
-Inference should preserve those arguments and check their bounds.
+An alias for an instance type does not obscure the members that determine a protocol's type arguments.
+Inference sees through these aliases and checks the bounds of these arguments.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4432,8 +4432,8 @@ reveal_type(get_value(values))  # revealed: int
 
 ## Generic protocol inference through type aliases
 
-An alias for an instance type does not obscure the members that determine a protocol's type arguments.
-Inference sees through these aliases and checks the bounds of these arguments.
+An alias for an instance type does not obscure the members that determine a protocol's type
+arguments. Inference sees through these aliases and checks the bounds of these arguments.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4430,6 +4430,54 @@ def get_value[T](obj: HasValue[T]) -> T:
 reveal_type(get_value(values))  # revealed: int
 ```
 
+## Generic protocol inference through type aliases
+
+An alias for an instance type must not hide the members that determine a protocol's type arguments.
+Inference should preserve those arguments and check their bounds.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+class HasValue[T](Protocol):
+    def get(self) -> T: ...
+
+class Box[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+type Alias[T] = Box[T]
+
+def get_value[T](value: HasValue[T]) -> T:
+    return value.get()
+
+def require_str[T: str](value: HasValue[T]) -> T:
+    return value.get()
+
+def check_alias(value: Alias[int]):
+    reveal_type(get_value(value))  # revealed: int
+    # error: [invalid-argument-type] "Argument type `int` does not satisfy upper bound `str` of type variable `T`"
+    require_str(value)
+```
+
+An equivalent generic alias constructed with `TypeAliasType` preserves the same information.
+
+```py
+from typing import TypeAliasType, TypeVar
+
+U = TypeVar("U")
+ConstructedAlias = TypeAliasType("ConstructedAlias", Box[U], type_params=(U,))
+
+def check_constructed_alias(value: ConstructedAlias[int]):
+    reveal_type(get_value(value))  # revealed: int
+    # error: [invalid-argument-type] "Argument type `int` does not satisfy upper bound `str` of type variable `T`"
+    require_str(value)
+```
+
 ## Class objects with class-method protocol members
 
 A class object implements a protocol when its directly accessible members have compatible types. The

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -4006,29 +4006,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 return Ok(());
             }
 
-            (
-                formal @ (Type::NominalInstance(_) | Type::ProtocolInstance(_)),
-                Type::NominalInstance(actual_nominal),
-            ) => {
-                // Extract formal_alias if this is a generic class
-                let formal_alias = match formal {
-                    Type::NominalInstance(formal_nominal) => {
-                        formal_nominal.class(db, self.env).into_generic_alias()
-                    }
-
-                    Type::ProtocolInstance(_) => {
-                        // TODO: For protocols, we use the new constraint set implementation, which
-                        // will handle implicitly implemented protocols and generic protocols. We
-                        // eventually want this logic to be used for _all_ nominal instances
-                        // (replacing the logic below).
-                        let when = self.constraint_for_relation(formal, actual, relation_polarity);
-                        return self.infer_from_constraint_set(when);
-                    }
-
-                    _ => None,
-                };
-
-                if let Some(formal_alias) = formal_alias {
+            (Type::NominalInstance(formal_nominal), Type::NominalInstance(actual_nominal)) => {
+                if let Some(formal_alias) = formal_nominal.class(db, self.env).into_generic_alias()
+                {
                     let formal_origin = formal_alias.origin(db);
                     for base in actual_nominal.class(db, self.env).iter_mro(db) {
                         let ClassBase::Class(ClassType::Generic(base_alias)) = base else {
@@ -4056,13 +4036,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            // TODO: in principle this could be a generalized Union-actual arm that maps over the
-            // union, but the old solver isn't well-equipped to handle that (due to side effects
-            // from even failed matches), so for now we handle this particular case.
-            (formal @ Type::ProtocolInstance(_), actual @ Type::Union(actual_union)) => {
+            (formal @ Type::ProtocolInstance(_), actual) => {
                 // Common TypedDict constraints prove only `actual <= formal`. Contravariance
                 // reverses that relation, while invariance additionally requires the reverse.
-                let when = if matches!(relation_polarity, TypeVarVariance::Covariant)
+                let when = if let Type::Union(actual_union) = actual
+                    && matches!(relation_polarity, TypeVarVariance::Covariant)
                     && let Some(common) =
                         self.common_typed_dict_protocol_constraints(formal, actual_union)
                 {
@@ -4071,40 +4049,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     self.constraint_for_relation(formal, actual, relation_polarity)
                 };
                 return self.infer_from_constraint_set(when);
-            }
-
-            (
-                formal @ Type::ProtocolInstance(_),
-                actual @ (Type::ClassLiteral(_)
-                | Type::GenericAlias(_)
-                | Type::SubclassOf(_)
-                | Type::TypedDict(_)),
-            ) => {
-                // A class object can itself implement a protocol. Compare its members directly;
-                // converting it to its instance type would infer from a different interface.
-                let when = self.constraint_for_relation(formal, actual, relation_polarity);
-                return self.infer_from_constraint_set(when);
-            }
-
-            // When the formal type is a protocol with a `__call__` method, infer the specialization
-            // from matching the actual type's callable signature against the protocol's `__call__`
-            // method signature.
-            (Type::ProtocolInstance(formal_protocol), _) => {
-                let Some(call_method) = formal_protocol.interface(db).call_method(db, self.env)
-                else {
-                    return Ok(());
-                };
-                let Some(actual_callables) = actual.try_upcast_to_callable(db, self.env) else {
-                    return Ok(());
-                };
-
-                // The protocol interface exposes the callable signature already bound for
-                // instance access.
-                self.infer_from_callable_signature(
-                    call_method,
-                    actual_callables,
-                    relation_polarity,
-                )?;
             }
 
             (Type::Callable(formal_callable), _) => {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -526,31 +526,6 @@ impl<'db> ProtocolInterfaceView<'db> {
         })
     }
 
-    /// Returns the callable signature exposed by instance access to a protocol's `__call__`
-    /// method.
-    ///
-    /// The callable is already in its instance-bound form, so callers must not bind it again.
-    pub(super) fn call_method(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Option<CallableType<'db>> {
-        self.member_by_name(db, "__call__").and_then(|member| {
-            if !member.is_method() {
-                return None;
-            }
-            match member
-                .access(db, env, ProtocolMemberAccessMode::Instance)
-                .read
-                .and_then(|read| read.resolve(db, env))
-                .map(ProtocolMemberType::ty)
-            {
-                Some(Type::Callable(callable)) => Some(callable),
-                _ => None,
-            }
-        })
-    }
-
     pub(super) fn instance_member(
         self,
         db: &'db dyn Db,


### PR DESCRIPTION
Generic protocol inference still treated some arguments as callable signatures even after class objects gained structural inference in #27812. That duplicated the protocol logic and could miss type-variable evidence from members other than `__call__`.

Use one structural-constraint branch for protocol formals, preserving the TypedDict-union optimization. Remove the protocol-specific `__call__` path and its unused helper. This also allows module attributes and ordinary function attributes to contribute to generic protocol inference, and preserves type-variable evidence hidden behind type aliases.

Stacked on #27812.

## Test plan

Added mdtests for inferring a protocol type argument from a module attribute and from a function's `__name__` alongside `__call__`. Added coverage for inference and type-variable bounds through both PEP 695 and `TypeAliasType` aliases. Simplified the class-method regression fixture to use PEP 695 syntax. Existing coverage continues to exercise class objects, callable overloads, ParamSpec, TypeVarTuple, TypedDict unions, and enum iteration.
