### PR TITLE
 [ty] Support generic functional `NamedTuple` and `TypedDict` declarations

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -163,6 +163,92 @@ fn benchmark_incremental(criterion: &mut Criterion) {
     });
 }
 
+fn setup_incremental_case(code: String, expect_no_diagnostics: bool) -> FileCase {
+    let system = TestSystem::default();
+    let fs = system.memory_file_system().clone();
+    let file_path = SystemPathBuf::from("src/test.py");
+    fs.write_file_all(file_path.clone(), code).unwrap();
+
+    let src_root = SystemPath::new("/src");
+    let mut metadata = ProjectMetadata::discover(src_root, &system).unwrap();
+    metadata.apply_override_options(Options {
+        environment: Some(EnvironmentOptions {
+            python_version: Some(RangedValue::cli(SupportedPythonVersion::Py312)),
+            ..EnvironmentOptions::default()
+        }),
+        ..Options::default()
+    });
+
+    let mut db = ProjectDatabase::fallible(metadata, system).unwrap();
+    let file = system_path_to_file(&db, &file_path).unwrap();
+    db.set_check_mode(CheckMode::OpenFiles);
+    db.project()
+        .set_open_files(&mut db, FxHashSet::from_iter([file]));
+    let diagnostics = db.check();
+    if expect_no_diagnostics {
+        assert!(diagnostics.is_empty());
+    } else {
+        std::hint::black_box(diagnostics.len());
+    }
+
+    fs.write_file_all(
+        file_path.clone(),
+        format!(
+            "{}\n# unrelated incremental edit\n",
+            source_text(&db, file).as_str()
+        ),
+    )
+    .unwrap();
+
+    FileCase {
+        db,
+        fs,
+        file,
+        file_path,
+    }
+}
+
+fn setup_functional_incremental_case() -> FileCase {
+    let mut code = String::from("from typing import NamedTuple, TypedDict\n\n");
+    for index in 0..500 {
+        writeln!(
+            &mut code,
+            "NT{index} = NamedTuple(\"NT{index}\", [(\"value\", int), (\"payload\", list[tuple[str, int]])])"
+        )
+        .unwrap();
+        writeln!(
+            &mut code,
+            "TD{index} = TypedDict(\"TD{index}\", {{\"value\": int, \"payload\": list[tuple[str, int]]}})"
+        )
+        .unwrap();
+        writeln!(&mut code, "nt_{index} = NT{index}(1, [(\"x\", 1)])").unwrap();
+        writeln!(
+            &mut code,
+            "td_{index} = TD{index}(value=1, payload=[(\"x\", 1)])"
+        )
+        .unwrap();
+    }
+    setup_incremental_case(code, true)
+}
+
+fn benchmark_functional_incremental(criterion: &mut Criterion) {
+    setup_rayon();
+
+    criterion.bench_function("ty_check_file[functional_incremental]", |b| {
+        b.iter_batched_ref(
+            setup_functional_incremental_case,
+            |case| {
+                case.db.apply_changes(&[ChangeEvent::Changed {
+                    path: case.file_path.clone(),
+                    kind: ChangedKind::FileContent,
+                }]);
+                assert!(case.db.check().is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_cold(criterion: &mut Criterion) {
     setup_rayon();
 
@@ -1426,6 +1512,311 @@ fn benchmark_repeated_statement_calls(criterion: &mut Criterion) {
     }
 }
 
+/// Measures the cold cost of unused, non-generic functional definitions.
+///
+/// The generic-context query should not execute for this workload.
+fn benchmark_unused_functional_type_definitions(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let mut code = String::from("from typing import NamedTuple, TypedDict\n\n");
+    for index in 0..500 {
+        writeln!(
+            &mut code,
+            "NT{index} = NamedTuple(\"NT{index}\", [(\"value\", int), (\"payload\", list[tuple[str, int]])])"
+        )
+        .unwrap();
+        writeln!(
+            &mut code,
+            "TD{index} = TypedDict(\"TD{index}\", {{\"value\": int, \"odd key\": list[tuple[str, int]]}})"
+        )
+        .unwrap();
+    }
+
+    criterion.bench_function("ty_micro[unused_functional_type_definitions]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                std::hint::black_box(db.check().len());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Measures non-generic functional definitions whose constructors are called.
+///
+/// The generic-context query should execute once per definition on a cold check.
+fn benchmark_demanded_functional_type_definitions(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let mut code = String::from("from typing import NamedTuple, TypedDict\n\n");
+    for index in 0..500 {
+        writeln!(
+            &mut code,
+            "NT{index} = NamedTuple(\"NT{index}\", [(\"value\", int), (\"payload\", list[tuple[str, int]])])"
+        )
+        .unwrap();
+        writeln!(
+            &mut code,
+            "TD{index} = TypedDict(\"TD{index}\", {{\"value\": int, \"payload\": list[tuple[str, int]]}})"
+        )
+        .unwrap();
+        writeln!(&mut code, "nt_{index} = NT{index}(1, [(\"x\", 1)])").unwrap();
+        writeln!(
+            &mut code,
+            "td_{index} = TD{index}(value=1, payload=[(\"x\", 1)])"
+        )
+        .unwrap();
+    }
+
+    criterion.bench_function("ty_micro[demanded_functional_type_definitions]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                std::hint::black_box(db.check().len());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Measures recording `TypeVar` candidates for unused functional definitions.
+///
+/// The generic-context query should not execute for this workload.
+fn benchmark_functional_typevar_candidates(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let mut code = String::from("from typing import NamedTuple, TypeVar\n\nT = TypeVar(\"T\")\n");
+    for index in 0..1_000 {
+        writeln!(
+            &mut code,
+            "NT{index} = NamedTuple(\"NT{index}\", [(\"value\", T), (\"payload\", list[tuple[str, T]])])"
+        )
+        .unwrap();
+    }
+
+    criterion.bench_function("ty_micro[functional_typevar_candidates]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                std::hint::black_box(db.check().len());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Measures resolving the generic context of every functional definition.
+fn benchmark_demanded_functional_typevar_candidates(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let mut code = String::from("from typing import NamedTuple, TypeVar\n\nT = TypeVar(\"T\")\n");
+    for index in 0..500 {
+        writeln!(
+            &mut code,
+            "NT{index} = NamedTuple(\"NT{index}\", [(\"value\", T), (\"payload\", list[tuple[str, T]])])"
+        )
+        .unwrap();
+        writeln!(
+            &mut code,
+            "def f{index}(value: NT{index}[int]) -> None: ..."
+        )
+        .unwrap();
+    }
+
+    criterion.bench_function("ty_micro[demanded_functional_typevar_candidates]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                assert!(db.check().is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn static_generic_origins_code(count: usize) -> String {
+    let mut code = String::from("from typing import Generic, TypeVar\n\nT = TypeVar(\"T\")\n");
+    for index in 0..count {
+        writeln!(
+            &mut code,
+            "class Box{index}(Generic[T]):\n    value: T\n\ndef use{index}(value: Box{index}[int]) -> int:\n    return value.value"
+        )
+        .unwrap();
+    }
+    code
+}
+
+fn static_generic_aliases_code(count: usize) -> String {
+    let mut code = String::from(
+        "from typing import Generic, Literal, TypeVar\n\nT = TypeVar(\"T\")\n\nclass Box(Generic[T]):\n    value: T\n",
+    );
+    for index in 0..count {
+        writeln!(
+            &mut code,
+            "def use{index}(value: Box[Literal[{index}]]) -> Literal[{index}]:\n    return value.value"
+        )
+        .unwrap();
+    }
+    code
+}
+
+/// Measures generic-alias origins across many distinct static generic classes.
+fn benchmark_static_generic_origins(criterion: &mut Criterion) {
+    setup_rayon();
+    let code = static_generic_origins_code(500);
+
+    criterion.bench_function("ty_micro[static_generic_origins]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                assert!(db.check().is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Measures generic-alias interning across many specializations of one static generic class.
+fn benchmark_static_generic_aliases(criterion: &mut Criterion) {
+    setup_rayon();
+    let code = static_generic_aliases_code(1_000);
+
+    criterion.bench_function("ty_micro[static_generic_aliases]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                assert!(db.check().is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn setup_static_generic_incremental_case() -> FileCase {
+    setup_incremental_case(static_generic_origins_code(500), true)
+}
+
+fn benchmark_static_generic_incremental(criterion: &mut Criterion) {
+    setup_rayon();
+
+    criterion.bench_function("ty_check_file[static_generic_incremental]", |b| {
+        b.iter_batched_ref(
+            setup_static_generic_incremental_case,
+            |case| {
+                case.db.apply_changes(&[ChangeEvent::Changed {
+                    path: case.file_path.clone(),
+                    kind: ChangedKind::FileContent,
+                }]);
+                assert!(case.db.check().is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn functional_generic_origins_code(count: usize) -> String {
+    let mut code =
+        String::from("from typing import NamedTuple, TypeVar, TypedDict\n\nT = TypeVar(\"T\")\n");
+    for index in 0..count {
+        writeln!(
+            &mut code,
+            "Pair{index} = NamedTuple(\"Pair{index}\", [(\"left\", \"T\"), (\"right\", \"T\"), (\"payload\", \"list[T]\")])"
+        )
+        .unwrap();
+        writeln!(
+            &mut code,
+            "Movie{index} = TypedDict(\"Movie{index}\", {{\"name\": str, \"payload\": \"T\", \"odd key\": \"list[T]\"}})"
+        )
+        .unwrap();
+        writeln!(
+            &mut code,
+            "def use{index}(pair: Pair{index}[int], movie: Movie{index}[str]) -> tuple[int, int, str, list[str]]:\n    return pair.left, pair[1], movie[\"payload\"], movie[\"odd key\"]"
+        )
+        .unwrap();
+    }
+    code
+}
+
+fn functional_generic_specializations_code(count: usize) -> String {
+    let movie_fields = (0..32)
+        .map(|index| format!("\"field{index}\": T"))
+        .chain(std::iter::once("\"odd key\": list[T]".to_string()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut code = format!(
+        "from typing import Literal, NamedTuple, TypeVar, TypedDict\n\nT = TypeVar(\"T\")\nPair = NamedTuple(\"Pair\", [(\"left\", T), (\"right\", T), (\"payload\", list[T])])\nMovie = TypedDict(\"Movie\", {{{movie_fields}}})\n"
+    );
+    for index in 0..count {
+        writeln!(
+            &mut code,
+            "def use{index}(pair: Pair[Literal[{index}]], movie: Movie[Literal[{index}]]) -> tuple[Literal[{index}], Literal[{index}], Literal[{index}], Literal[{index}], Literal[{index}], list[Literal[{index}]]]:\n    return pair.left, pair[1], movie[\"field0\"], movie[\"field15\"], movie[\"field31\"], movie[\"odd key\"]"
+        )
+        .unwrap();
+    }
+    code
+}
+
+fn benchmark_functional_generic_origins(criterion: &mut Criterion) {
+    setup_rayon();
+    let code = functional_generic_origins_code(250);
+
+    criterion.bench_function("ty_micro[functional_generic_origins]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                assert!(db.check().is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn benchmark_functional_generic_specializations(criterion: &mut Criterion) {
+    setup_rayon();
+    let code = functional_generic_specializations_code(1_000);
+
+    criterion.bench_function("ty_micro[functional_generic_specializations]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                assert!(db.check().is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn setup_functional_generic_incremental_case() -> FileCase {
+    setup_incremental_case(functional_generic_origins_code(250), true)
+}
+
+fn benchmark_functional_generic_incremental(criterion: &mut Criterion) {
+    setup_rayon();
+
+    criterion.bench_function("ty_check_file[functional_generic_incremental]", |b| {
+        b.iter_batched_ref(
+            setup_functional_generic_incremental_case,
+            |case| {
+                case.db.apply_changes(&[ChangeEvent::Changed {
+                    path: case.file_path.clone(),
+                    kind: ChangedKind::FileContent,
+                }]);
+                assert!(case.db.check().is_empty());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 struct ProjectBenchmark<'a> {
     project: InstalledProject<'a>,
     fs: MemoryFileSystem,
@@ -1601,7 +1992,14 @@ fn datetype(criterion: &mut Criterion) {
     bench_project(&benchmark, criterion);
 }
 
-criterion_group!(check_file, benchmark_cold, benchmark_incremental);
+criterion_group!(
+    check_file,
+    benchmark_cold,
+    benchmark_incremental,
+    benchmark_functional_incremental,
+    benchmark_static_generic_incremental,
+    benchmark_functional_generic_incremental
+);
 criterion_group!(
     micro,
     benchmark_many_string_assignments,
@@ -1632,6 +2030,14 @@ criterion_group!(
     benchmark_literal_or_pattern_reachability,
     benchmark_typeis_narrowing,
     benchmark_repeated_statement_calls,
+    benchmark_unused_functional_type_definitions,
+    benchmark_demanded_functional_type_definitions,
+    benchmark_functional_typevar_candidates,
+    benchmark_demanded_functional_typevar_candidates,
+    benchmark_static_generic_origins,
+    benchmark_static_generic_aliases,
+    benchmark_functional_generic_origins,
+    benchmark_functional_generic_specializations,
 );
 criterion_group!(project, anyio, attrs, hydra, datetype);
 criterion_main!(check_file, micro, project);

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1268,6 +1268,24 @@ class IntPair(Pair[int]):
 reveal_type(IntPair(1, 2).first)  # revealed: int
 ```
 
+### Functional syntax with recursive generics
+
+Type variables are also discovered inside forward annotations. Recursive fields retain the active
+specialization:
+
+```py
+from typing import NamedTuple, TypeVar
+
+T = TypeVar("T")
+
+Node = NamedTuple("Node", [("value", "T"), ("next", "Node[T] | None")])
+node = Node[int](1, None)
+
+reveal_type(node.value)  # revealed: int
+reveal_type(node[0])  # revealed: int
+reveal_type(node.next)  # revealed: Node[int] | None
+```
+
 ## Attributes on `NamedTuple`
 
 The following attributes are available on `NamedTuple` classes / instances:

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1245,32 +1245,27 @@ reveal_type(LegacyProperty("height", 3.4).value)  # revealed: float
 
 ### Functional syntax with generics
 
-Generic namedtuples can also be defined using the functional syntax with type variables in the field
-types. We don't currently support this, but mypy does:
+A functional named tuple is generic when a field annotation contains a type variable:
 
 ```py
 from typing import NamedTuple, TypeVar
 
 T = TypeVar("T")
 
-# TODO: ideally this would create a generic namedtuple class
 Pair = NamedTuple("Pair", [("first", T), ("second", T)])
 
-# For now, the TypeVar is not specialized, so the field types remain as `T@Pair` and argument type
-# errors are emitted when calling the constructor.
 reveal_type(Pair)  # revealed: <class 'Pair'>
+reveal_type(Pair(1, 2))  # revealed: Pair[int]
+reveal_type(Pair(1, 2).first)  # revealed: int
+reveal_type(Pair[str]("one", "two").second)  # revealed: str
 
 # error: [invalid-argument-type]
-# error: [invalid-argument-type]
-reveal_type(Pair(1, 2))  # revealed: Pair
+Pair[int]("one", 2)
 
-# error: [invalid-argument-type]
-# error: [invalid-argument-type]
-reveal_type(Pair(1, 2).first)  # revealed: TypeVar
+class IntPair(Pair[int]):
+    pass
 
-# error: [invalid-argument-type]
-# error: [invalid-argument-type]
-reveal_type(Pair(1, 2).second)  # revealed: TypeVar
+reveal_type(IntPair(1, 2).first)  # revealed: int
 ```
 
 ## Attributes on `NamedTuple`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4579,6 +4579,83 @@ inline_ref = TypedDict("InlineRef", {"director": "Director"})(director=Director(
 reveal_type(inline_ref["director"])  # revealed: Director
 ```
 
+## Generic function/assignment syntax
+
+A functional `TypedDict` is generic when a field annotation contains a type variable. Requiredness
+and read-only qualifiers are preserved when its fields are specialized:
+
+```py
+from typing import TypeVar
+from typing_extensions import NotRequired, ReadOnly, Required, TypedDict
+
+T = TypeVar("T")
+
+Payload = TypedDict(
+    "Payload",
+    {
+        "required": Required[T],
+        "optional": "NotRequired[list[T]]",
+        "readonly": ReadOnly[T],
+    },
+)
+
+def inspect_payload(payload: Payload[bytes]) -> None:
+    reveal_type(payload["required"])  # revealed: bytes
+    reveal_type(payload["optional"])  # revealed: list[bytes]
+    reveal_type(payload.get("optional"))  # revealed: list[bytes] | None
+    reveal_type(payload["readonly"])  # revealed: bytes
+
+    # error: [invalid-assignment] "key is marked read-only"
+    payload["readonly"] = b"new"
+
+# error: [invalid-argument-type]
+Payload[bytes](required="wrong", readonly=b"value")
+
+class BytesPayload(Payload[bytes]):
+    pass
+
+reveal_type(BytesPayload(required=b"value", readonly=b"value")["required"])  # revealed: bytes
+```
+
+## Recursive generic function/assignment syntax
+
+Type variables can occur only inside forward annotations, including recursive references:
+
+```py
+from typing import TypeVar
+from typing_extensions import TypedDict
+
+T = TypeVar("T")
+
+Node = TypedDict("Node", {"value": "T", "next": "Node[T] | None"})
+
+def inspect_node(node: Node[int]) -> None:
+    reveal_type(node["value"])  # revealed: int
+    reveal_type(node["next"])  # revealed: Node[int] | None
+```
+
+## Generic functional syntax with extra items
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+The `extra_items` annotation participates in the same specialization:
+
+```py
+from typing import TypeVar
+from typing_extensions import TypedDict
+
+T = TypeVar("T")
+
+Extras = TypedDict("Extras", {"known": T}, extra_items="list[T]")
+
+def inspect_extras(value: Extras[int]) -> None:
+    reveal_type(value["known"])  # revealed: int
+    reveal_type(value["other"])  # revealed: list[int]
+```
+
 ## Function syntax with `total=False`
 
 The `total=False` keyword makes all fields optional by default:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -105,7 +105,9 @@ pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::{any_over_type, dynamic_content};
 use crate::{Db, FxOrderSet, HasType, NameKind, Program, SemanticModel};
-pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
+pub(crate) use class::{
+    ClassLiteral, ClassType, GenericAlias, GenericClassLiteral, StaticClassLiteral,
+};
 pub use class::{KnownClass, MethodDecorator};
 use instance::Protocol;
 pub use instance::{NominalInstanceType, ProtocolInstanceType};
@@ -1979,7 +1981,7 @@ impl<'db> Type<'db> {
         known_class: KnownClass,
     ) -> Option<Specialization<'db>> {
         let class_literal = known_class.try_to_class_literal(db, env)?;
-        self.specialization_of(db, env, class_literal)
+        self.specialization_of(db, env, class_literal.into())
     }
 
     /// If the type is a specialized instance of the given class, returns the specialization.
@@ -1987,7 +1989,7 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        expected_class: StaticClassLiteral<'_>,
+        expected_class: ClassLiteral<'_>,
     ) -> Option<Specialization<'db>> {
         self.class_specialization(db, env)
             .filter(|(class_literal, _)| *class_literal == expected_class)
@@ -1999,15 +2001,14 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-    ) -> Option<(StaticClassLiteral<'db>, Specialization<'db>)> {
+    ) -> Option<(ClassLiteral<'db>, Specialization<'db>)> {
         let class = match self {
             Type::TypedDict(typed_dict) => typed_dict.defining_class()?,
             _ => self.nominal_class(db, env)?,
         };
 
-        class
-            .static_class_literal(db)
-            .and_then(|(class_literal, specialization)| Some((class_literal, specialization?)))
+        let (class_literal, specialization) = class.class_literal_and_specialization(db);
+        Some((class_literal, specialization?))
     }
 
     /// If this type is a class instance, returns its class.
@@ -8556,7 +8557,7 @@ impl<'db> Type<'db> {
             }
             Self::ModuleLiteral(module) => Some(TypeDefinition::Module(module.module(db))),
             Self::ClassLiteral(class_literal) => class_literal.type_definition(db),
-            Self::GenericAlias(alias) => Some(TypeDefinition::StaticClass(alias.definition(db))),
+            Self::GenericAlias(alias) => alias.origin(db).type_definition(db),
             Self::NominalInstance(instance) => instance.class(db, env).type_definition(db),
             Self::KnownInstance(instance) => match instance {
                 KnownInstanceType::TypeVar(var) => {
@@ -8739,11 +8740,11 @@ impl<'db> Type<'db> {
         env: &ProgramEnvironment<'db>,
     ) -> Option<StaticClassLiteral<'db>> {
         match self {
-            Type::GenericAlias(generic) => Some(generic.origin(db)),
+            Type::GenericAlias(generic) => generic.origin(db).as_static(),
             Type::NominalInstance(instance)
                 if let ClassType::Generic(generic) = instance.class(db, env) =>
             {
-                Some(generic.origin(db))
+                generic.origin(db).as_static()
             }
             _ => None,
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3217,13 +3217,11 @@ impl<'db> Type<'db> {
             }
 
             Type::GenericAlias(alias) if alias.is_typed_dict(db) => {
-                Some(alias.origin(db).typed_dict_member(
-                    db,
-                    env,
-                    (name == "__init__").then_some(alias.specialization(db)),
-                    name,
-                    policy,
-                ))
+                let origin = alias.origin(db);
+                let specialization = (name == "__init__"
+                    || matches!(origin, GenericClassLiteral::DynamicTypedDict(_)))
+                .then(|| alias.specialization(db));
+                Some(origin.typed_dict_member(db, env, specialization, name, policy))
             }
 
             Type::GenericAlias(alias) => {

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -363,9 +363,7 @@ impl<'db> ConstructorBinding<'db> {
         // constructing an already-specialized generic alias (`C[str](...)`), it'll be the
         // specialization of that alias.
         let (_, class_specialization) = constructed_instance_type.class_specialization(db, env)?;
-        let static_class_literal = self
-            .constructed_class_literal(db, env)
-            .and_then(ClassLiteral::as_static);
+        let class_literal = self.constructed_class_literal(db, env);
         let class_context = class_specialization.generic_context(db);
 
         let mut combined: Option<Specialization<'db>> = None;
@@ -376,7 +374,7 @@ impl<'db> ConstructorBinding<'db> {
             else {
                 return;
             };
-            let return_specialization = static_class_literal
+            let return_specialization = class_literal
                 // Use the already-resolved overload return type when possible.
                 .and_then(|lit| overload.return_ty.specialization_of(db, env, lit));
 
@@ -395,7 +393,7 @@ impl<'db> ConstructorBinding<'db> {
                             .is_some_and(|mapped_ty| !mapped_ty.is_unknown())
                     })
                 });
-            let self_parameter_specialization = static_class_literal.and_then(|lit| {
+            let self_parameter_specialization = class_literal.and_then(|lit| {
                 let self_param_ty = overload.signature.parameters().get(0)?.annotated_type();
                 let resolved_self_param_ty = overload
                     .specialization(db)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -370,6 +370,16 @@ impl<'db> CodeGeneratorKind<'db> {
     }
 }
 
+/// A possibly qualified name from a functional field annotation that may resolve to a legacy
+/// `TypeVar`.
+///
+/// Definitions and attribute names remain stable across unrelated edits, unlike AST references.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub struct FunctionalTypeVarCandidate<'db> {
+    pub(super) root_bindings: Box<[Definition<'db>]>,
+    pub(super) attributes: Box<[Name]>,
+}
+
 /// A class that can be the origin of a [`GenericAlias`].
 ///
 /// This is intentionally narrower than [`ClassLiteral`]. Each variant must explicitly implement

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -901,13 +901,17 @@ impl<'db> ClassLiteral<'db> {
     }
 
     /// Returns the default specialization for this class.
-    ///
-    /// For static classes, this applies default type arguments.
-    /// For dynamic classes, this returns a non-generic class type.
     pub(crate) fn default_specialization(self, db: &'db dyn Db) -> ClassType<'db> {
-        self.as_static().map_or_else(
+        self.as_generic_class().map_or_else(
             || ClassType::NonGeneric(self),
-            |class| class.default_specialization(db),
+            |origin| {
+                origin.apply_specialization(db, |generic_context| {
+                    generic_context.default_specialization(
+                        db,
+                        origin.as_static().and_then(|class| class.known(db)),
+                    )
+                })
+            },
         )
     }
 
@@ -917,17 +921,24 @@ impl<'db> ClassLiteral<'db> {
     /// For a non-specialized generic class, we return a generic alias that maps each of the class's
     /// typevars to `Unknown`.
     pub(crate) fn unknown_specialization(self, db: &'db dyn Db) -> ClassType<'db> {
-        self.as_static().map_or_else(
+        self.as_generic_class().map_or_else(
             || ClassType::NonGeneric(self),
-            |class| class.unknown_specialization(db),
+            |origin| {
+                origin.apply_specialization(db, |generic_context| {
+                    generic_context.unknown_specialization(
+                        db,
+                        origin.as_static().and_then(|class| class.known(db)),
+                    )
+                })
+            },
         )
     }
 
     /// Returns the identity specialization for this class (same as default for non-generic).
     pub(crate) fn identity_specialization(self, db: &'db dyn Db) -> ClassType<'db> {
-        self.as_static().map_or_else(
+        self.as_generic_class().map_or_else(
             || ClassType::NonGeneric(self),
-            |class| class.identity_specialization(db),
+            |origin| origin.identity_specialization(db),
         )
     }
 
@@ -1051,6 +1062,16 @@ impl<'db> ClassLiteral<'db> {
         }
     }
 
+    /// Returns this class if it is a supported generic-alias origin.
+    pub(crate) const fn as_generic_class(self) -> Option<GenericClassLiteral<'db>> {
+        match self {
+            Self::Static(class) => Some(GenericClassLiteral::Static(class)),
+            Self::DynamicNamedTuple(class) => Some(GenericClassLiteral::DynamicNamedTuple(class)),
+            Self::DynamicTypedDict(class) => Some(GenericClassLiteral::DynamicTypedDict(class)),
+            Self::Dynamic(_) | Self::DynamicEnum(_) => None,
+        }
+    }
+
     /// Returns the static class definition if this is one.
     pub(crate) fn as_static(self) -> Option<StaticClassLiteral<'db>> {
         match self {
@@ -1170,13 +1191,10 @@ impl<'db> ClassLiteral<'db> {
         db: &'db dyn Db,
         f: impl FnOnce(GenericContext<'db>) -> Specialization<'db>,
     ) -> ClassType<'db> {
-        match self {
-            Self::Static(class) => class.apply_specialization(db, f),
-            Self::Dynamic(_)
-            | Self::DynamicNamedTuple(_)
-            | Self::DynamicTypedDict(_)
-            | Self::DynamicEnum(_) => ClassType::NonGeneric(self),
-        }
+        self.as_generic_class().map_or_else(
+            || ClassType::NonGeneric(self),
+            |origin| origin.apply_specialization(db, f),
+        )
     }
 
     /// Returns the instance member lookup.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -20,8 +20,9 @@ pub(super) use self::typed_dict::{
 };
 use super::dedicated::pydantic;
 use super::{
-    BoundTypeVarIdentity, BoundTypeVarInstance, MemberLookupPolicy, MroIterator, SpecialFormType,
-    SubclassOfType, Type, TypeQualifiers, class_base::ClassBase, function::FunctionType,
+    BoundTypeVarIdentity, BoundTypeVarInstance, KnownInstanceType, MemberLookupPolicy, MroIterator,
+    SpecialFormType, SubclassOfType, Type, TypeQualifiers, class_base::ClassBase,
+    function::FunctionType,
 };
 use super::{TypeVarVariance, display};
 use crate::place::{DefinedPlace, Provenance, TypeOrigin};
@@ -31,7 +32,7 @@ use crate::types::constraints::{
 };
 use crate::types::enums::enum_metadata;
 use crate::types::function::{AbstractMethodKind, DataclassTransformerParams};
-use crate::types::generics::{GenericContext, Specialization, walk_specialization};
+use crate::types::generics::{GenericContext, Specialization, bind_typevar, walk_specialization};
 use crate::types::infer::infer_definition_types;
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::member::Member;
@@ -64,7 +65,7 @@ use ruff_python_ast::{self as ast, NodeIndex};
 use ruff_text_size::{Ranged, TextRange};
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{ProgramFile, place_table, use_def_map};
+use ty_python_core::{ProgramFile, place_table, semantic_index, use_def_map};
 
 mod dynamic_literal;
 mod enum_literal;
@@ -378,6 +379,60 @@ impl<'db> CodeGeneratorKind<'db> {
 pub struct FunctionalTypeVarCandidate<'db> {
     pub(super) root_bindings: Box<[Definition<'db>]>,
     pub(super) attributes: Box<[Name]>,
+}
+
+/// Resolve binding separately from the generic-context query so that its dependency on the
+/// file's semantic index does not invalidate a cached context after an unrelated edit.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial=|_, _, _, _| None,
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn bind_functional_typevar<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    typevar: crate::types::typevar::TypeVarInstance<'db>,
+) -> Option<BoundTypeVarInstance<'db>> {
+    let index = semantic_index(db, definition.program_file(db));
+    bind_typevar(
+        db,
+        index,
+        definition.scope(db).file_scope_id(db),
+        Some(definition),
+        typevar,
+    )
+}
+
+pub(super) fn functional_generic_context_from_candidates<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    candidates: &[FunctionalTypeVarCandidate<'db>],
+) -> Option<GenericContext<'db>> {
+    let env = ProgramEnvironment::from_definition(definition);
+    let mut variables = FxOrderSet::default();
+
+    for candidate in candidates {
+        for root_binding in &candidate.root_bindings {
+            let root_ty = infer_definition_types(db, *root_binding).binding_type(*root_binding);
+            let Some(ty) = candidate
+                .attributes
+                .iter()
+                .try_fold(root_ty, |ty, attribute| {
+                    ty.member(db, &env, attribute).ignore_possibly_undefined()
+                })
+            else {
+                continue;
+            };
+
+            if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
+                && let Some(bound) = bind_functional_typevar(db, definition, typevar)
+            {
+                variables.insert(bound);
+            }
+        }
+    }
+
+    (!variables.is_empty()).then(|| GenericContext::from_typevar_instances(db, &env, variables))
 }
 
 /// A class that can be the origin of a [`GenericAlias`].
@@ -878,7 +933,12 @@ impl<'db> ClassLiteral<'db> {
 
     /// Returns the generic context if this is a generic class.
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
-        self.as_static().and_then(|class| class.generic_context(db))
+        match self {
+            Self::Static(class) => class.generic_context(db),
+            Self::DynamicNamedTuple(class) => class.generic_context(db),
+            Self::DynamicTypedDict(class) => class.generic_context(db),
+            Self::Dynamic(_) | Self::DynamicEnum(_) => None,
+        }
     }
 
     /// Returns whether this class is a protocol.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -370,11 +370,132 @@ impl<'db> CodeGeneratorKind<'db> {
     }
 }
 
+/// A class that can be the origin of a [`GenericAlias`].
+///
+/// This is intentionally narrower than [`ClassLiteral`]. Each variant must explicitly implement
+/// how its type parameters and members are specialized.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub enum GenericClassLiteral<'db> {
+    Static(StaticClassLiteral<'db>),
+    DynamicNamedTuple(DynamicNamedTupleLiteral<'db>),
+    DynamicTypedDict(DynamicTypedDictLiteral<'db>),
+}
+
+impl<'db> GenericClassLiteral<'db> {
+    pub(crate) const fn class_literal(self) -> ClassLiteral<'db> {
+        match self {
+            Self::Static(class) => ClassLiteral::Static(class),
+            Self::DynamicNamedTuple(class) => ClassLiteral::DynamicNamedTuple(class),
+            Self::DynamicTypedDict(class) => ClassLiteral::DynamicTypedDict(class),
+        }
+    }
+
+    pub(crate) const fn as_static(self) -> Option<StaticClassLiteral<'db>> {
+        match self {
+            Self::Static(class) => Some(class),
+            Self::DynamicNamedTuple(_) | Self::DynamicTypedDict(_) => None,
+        }
+    }
+
+    pub(crate) fn type_definition(self, db: &'db dyn Db) -> Option<TypeDefinition<'db>> {
+        self.class_literal().type_definition(db)
+    }
+
+    pub(crate) fn name(self, db: &'db dyn Db) -> &'db Name {
+        self.class_literal().name(db)
+    }
+
+    pub(crate) fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.class_literal().program_file(db)
+    }
+
+    pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
+        self.class_literal().generic_context(db)
+    }
+
+    pub(crate) fn apply_specialization(
+        self,
+        db: &'db dyn Db,
+        f: impl FnOnce(GenericContext<'db>) -> Specialization<'db>,
+    ) -> ClassType<'db> {
+        self.generic_context(db).map_or_else(
+            || ClassType::NonGeneric(self.class_literal()),
+            |generic_context| ClassType::Generic(GenericAlias::new(db, self, f(generic_context))),
+        )
+    }
+
+    pub(crate) fn identity_specialization(self, db: &'db dyn Db) -> ClassType<'db> {
+        self.apply_specialization(db, |generic_context| {
+            generic_context.identity_specialization(db)
+        })
+    }
+
+    pub(crate) fn is_typed_dict(self, db: &'db dyn Db) -> bool {
+        self.class_literal().is_typed_dict(db)
+    }
+
+    pub(crate) fn is_tuple(self, db: &'db dyn Db) -> bool {
+        self.class_literal().is_tuple(db)
+    }
+
+    pub(crate) fn metaclass(self, db: &'db dyn Db) -> Type<'db> {
+        self.class_literal().metaclass(db)
+    }
+
+    pub(crate) fn typed_dict_member(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        specialization: Option<Specialization<'db>>,
+        name: &str,
+        policy: MemberLookupPolicy,
+    ) -> PlaceAndQualifiers<'db> {
+        match self {
+            Self::Static(class) => class.typed_dict_member(db, env, specialization, name, policy),
+            Self::DynamicTypedDict(class) => class
+                .class_member(db, env, specialization, name, policy)
+                .map_type(|ty| ty.apply_optional_specialization(db, specialization)),
+            Self::DynamicNamedTuple(_) => Place::Undefined.into(),
+        }
+    }
+
+    pub(crate) fn with_dataclass_params(
+        self,
+        db: &'db dyn Db,
+        dataclass_params: Option<DataclassParams<'db>>,
+    ) -> Self {
+        match self {
+            Self::Static(class) => Self::Static(class.with_dataclass_params(db, dataclass_params)),
+            Self::DynamicNamedTuple(_) | Self::DynamicTypedDict(_) => self,
+        }
+    }
+}
+
+impl<'db> From<StaticClassLiteral<'db>> for GenericClassLiteral<'db> {
+    fn from(class: StaticClassLiteral<'db>) -> Self {
+        Self::Static(class)
+    }
+}
+
+impl<'db> VarianceInferable<'db> for GenericClassLiteral<'db> {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        match self {
+            Self::Static(class) => class.variance_of(db, env, typevar),
+            Self::DynamicNamedTuple(_) | Self::DynamicTypedDict(_) => TypeVarVariance::Invariant,
+        }
+    }
+}
+
 /// A specialization of a generic class with a particular assignment of types to typevars.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct GenericAlias<'db> {
     #[returns(copy)]
-    pub(crate) origin: StaticClassLiteral<'db>,
+    pub(crate) origin: GenericClassLiteral<'db>,
     #[returns(copy)]
     pub(crate) specialization: Specialization<'db>,
 }
@@ -424,10 +545,6 @@ impl<'db> GenericAlias<'db> {
         ))
     }
 
-    pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
-        self.origin(db).definition(db)
-    }
-
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
@@ -437,7 +554,7 @@ impl<'db> GenericAlias<'db> {
     ) -> Self {
         let tcx = tcx
             .annotation
-            .and_then(|ty| ty.specialization_of(db, visitor.env, self.origin(db)))
+            .and_then(|ty| ty.specialization_of(db, visitor.env, self.origin(db).class_literal()))
             .map(|specialization| specialization.types(db))
             .unwrap_or(&[]);
 
@@ -673,8 +790,12 @@ impl<'db> ClassLiteral<'db> {
         match self {
             Self::Static(class) => class.class_member(db, env, name, policy),
             Self::Dynamic(class) => class.class_member(db, env, name, policy),
-            Self::DynamicNamedTuple(namedtuple) => namedtuple.class_member(db, env, name, policy),
-            Self::DynamicTypedDict(typeddict) => typeddict.class_member(db, env, name, policy),
+            Self::DynamicNamedTuple(namedtuple) => {
+                namedtuple.class_member(db, env, None, name, policy)
+            }
+            Self::DynamicTypedDict(typeddict) => {
+                typeddict.class_member(db, env, None, name, policy)
+            }
             Self::DynamicEnum(enum_lit) => enum_lit.class_member(db, env, name),
         }
     }
@@ -1027,7 +1148,9 @@ impl<'db> ClassLiteral<'db> {
     ) -> PlaceAndQualifiers<'db> {
         match self {
             Self::Static(class) => class.typed_dict_member(db, env, specialization, name, policy),
-            Self::DynamicTypedDict(typeddict) => typeddict.class_member(db, env, name, policy),
+            Self::DynamicTypedDict(typeddict) => {
+                typeddict.class_member(db, env, specialization, name, policy)
+            }
             Self::Dynamic(_) | Self::DynamicNamedTuple(_) | Self::DynamicEnum(_) => {
                 Place::Undefined.into()
             }
@@ -1161,7 +1284,7 @@ impl<'db> ClassType<'db> {
     pub(crate) fn class_literal(self, db: &'db dyn Db) -> ClassLiteral<'db> {
         match self {
             Self::NonGeneric(literal) => literal,
-            Self::Generic(generic) => ClassLiteral::Static(generic.origin(db)),
+            Self::Generic(generic) => generic.origin(db).class_literal(),
         }
     }
 
@@ -1176,7 +1299,7 @@ impl<'db> ClassType<'db> {
         match self {
             Self::NonGeneric(literal) => (literal, None),
             Self::Generic(generic) => (
-                ClassLiteral::Static(generic.origin(db)),
+                generic.origin(db).class_literal(),
                 Some(generic.specialization(db)),
             ),
         }
@@ -1196,7 +1319,10 @@ impl<'db> ClassType<'db> {
                 | ClassLiteral::DynamicTypedDict(_)
                 | ClassLiteral::DynamicEnum(_),
             ) => None,
-            Self::Generic(generic) => Some((generic.origin(db), Some(generic.specialization(db)))),
+            Self::Generic(generic) => generic
+                .origin(db)
+                .as_static()
+                .map(|origin| (origin, Some(generic.specialization(db)))),
         }
     }
 
@@ -1216,7 +1342,7 @@ impl<'db> ClassType<'db> {
                 | ClassLiteral::DynamicEnum(_),
             ) => None,
             Self::Generic(generic) => {
-                let origin = generic.origin(db);
+                let origin = generic.origin(db).as_static()?;
                 Some((
                     origin,
                     Some(
@@ -1326,7 +1452,7 @@ impl<'db> ClassType<'db> {
             Self::NonGeneric(class) => class.iter_mro(db),
             Self::Generic(generic) => MroIterator::new(
                 db,
-                ClassLiteral::Static(generic.origin(db)),
+                generic.origin(db).class_literal(),
                 Some(generic.specialization(db)),
             ),
         }
@@ -1345,7 +1471,7 @@ impl<'db> ClassType<'db> {
                 let origin = generic.origin(db);
                 MroIterator::new(
                     db,
-                    ClassLiteral::Static(origin),
+                    origin.class_literal(),
                     Some(
                         generic
                             .specialization(db)
@@ -1765,13 +1891,20 @@ impl<'db> ClassType<'db> {
     ) -> PlaceAndQualifiers<'db> {
         match self {
             Self::NonGeneric(class) => class.class_member(db, env, name, policy),
-            Self::Generic(generic) => generic.origin(db).class_member_inner(
-                db,
-                env,
-                Some(generic.specialization(db)),
-                name,
-                policy,
-            ),
+            Self::Generic(generic) => {
+                let specialization = Some(generic.specialization(db));
+                match generic.origin(db) {
+                    GenericClassLiteral::Static(class) => {
+                        class.class_member_inner(db, env, specialization, name, policy)
+                    }
+                    GenericClassLiteral::DynamicNamedTuple(class) => class
+                        .class_member(db, env, specialization, name, policy)
+                        .map_type(|ty| ty.apply_optional_specialization(db, specialization)),
+                    GenericClassLiteral::DynamicTypedDict(class) => class
+                        .class_member(db, env, specialization, name, policy)
+                        .map_type(|ty| ty.apply_optional_specialization(db, specialization)),
+                }
+            }
         }
     }
 
@@ -1809,16 +1942,32 @@ impl<'db> ClassType<'db> {
                 return dynamic.own_class_member(db, name);
             }
             Self::NonGeneric(ClassLiteral::DynamicNamedTuple(namedtuple)) => {
-                return namedtuple.own_class_member(db, name);
+                return namedtuple.own_class_member(db, None, name);
             }
             Self::NonGeneric(ClassLiteral::DynamicTypedDict(typeddict)) => {
-                return typeddict.own_class_member(db, name);
+                return typeddict.own_class_member(db, None, name);
             }
             Self::NonGeneric(ClassLiteral::DynamicEnum(enum_lit)) => {
                 return enum_lit.own_class_member(db, name);
             }
             Self::NonGeneric(ClassLiteral::Static(class)) => (class, None),
-            Self::Generic(generic) => (generic.origin(db), Some(generic.specialization(db))),
+            Self::Generic(generic) => match generic.origin(db) {
+                GenericClassLiteral::Static(class) => (class, Some(generic.specialization(db))),
+                GenericClassLiteral::DynamicNamedTuple(class) => {
+                    return class
+                        .own_class_member(db, Some(generic.specialization(db)), name)
+                        .map_type(|ty| {
+                            ty.apply_optional_specialization(db, Some(generic.specialization(db)))
+                        });
+                }
+                GenericClassLiteral::DynamicTypedDict(class) => {
+                    return class
+                        .own_class_member(db, Some(generic.specialization(db)), name)
+                        .map_type(|ty| {
+                            ty.apply_optional_specialization(db, Some(generic.specialization(db)))
+                        });
+                }
+            },
         };
 
         let fallback_member_lookup = || {
@@ -2133,10 +2282,11 @@ impl<'db> ClassType<'db> {
                 class.instance_member(db, env, None, name)
             }
             Self::Generic(generic) => {
-                let class_literal = generic.origin(db);
+                let origin = generic.origin(db);
+                let class_literal = origin.class_literal();
                 let specialization = Some(generic.specialization(db));
 
-                if class_literal.is_typed_dict(db) {
+                if origin.is_typed_dict(db) {
                     return Place::Undefined.into();
                 }
 
@@ -2159,6 +2309,7 @@ impl<'db> ClassType<'db> {
             }
             Self::Generic(generic) => generic
                 .origin(db)
+                .as_static()?
                 .converter_input_type_for_field(db, name)
                 .map(|ty| ty.apply_optional_specialization(db, Some(generic.specialization(db)))),
             Self::NonGeneric(
@@ -2194,10 +2345,14 @@ impl<'db> ClassType<'db> {
             }
             Self::Generic(generic) => {
                 let specialization = generic.specialization(db);
-                generic
-                    .origin(db)
-                    .own_instance_member(db, env, name)
-                    .map_type(|ty| ty.apply_optional_specialization(db, Some(specialization)))
+                let member = match generic.origin(db) {
+                    GenericClassLiteral::Static(class) => class.own_instance_member(db, env, name),
+                    GenericClassLiteral::DynamicNamedTuple(class) => {
+                        class.own_instance_member(db, name)
+                    }
+                    GenericClassLiteral::DynamicTypedDict(_) => Member::default(),
+                };
+                member.map_type(|ty| ty.apply_optional_specialization(db, Some(specialization)))
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -11,7 +11,7 @@ use crate::{
         BindingContext, BoundTypeVarInstance, ClassBase, ClassLiteral, ClassType, GenericContext,
         KnownClass, KnownInstanceType, MemberLookupPolicy, Parameter, Parameters,
         PropertyInstanceType, Signature, SubclassOfType, Type, TypeContext, TypeMapping,
-        class::{DynamicClassHeaderAnchor, dynamic_class_header_range},
+        class::{DynamicClassHeaderAnchor, FunctionalTypeVarCandidate, dynamic_class_header_range},
         definition_expression_type,
         member::Member,
         mro::Mro,
@@ -166,6 +166,9 @@ pub struct DynamicNamedTupleLiteral<'db> {
     ///   is relative to the enclosing scope's anchor node index.
     #[returns(ref)]
     pub anchor: DynamicNamedTupleAnchor<'db>,
+
+    #[returns(deref)]
+    pub(super) typevar_candidates: Box<[FunctionalTypeVarCandidate<'db>]>,
 }
 
 impl get_size2::GetSize for DynamicNamedTupleLiteral<'_> {}
@@ -183,6 +186,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
             self.name(db),
             self.anchor(db)
                 .recursive_type_normalized_impl(db, env, div, nested)?,
+            self.typevar_candidates(db),
         ))
     }
 }

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -3,6 +3,7 @@ use ruff_db::{diagnostic::Span, parsed::parsed_module};
 use ruff_python_ast::{PythonVersion, name::Name};
 use ruff_text_size::TextRange;
 
+use crate::types::class::functional_generic_context_from_candidates;
 use crate::types::{GenericAlias, GenericClassLiteral};
 use crate::{
     Db,
@@ -504,6 +505,30 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
 
     pub(super) fn has_known_fields(self, db: &'db dyn Db) -> bool {
         self.spec(db).has_known_fields(db)
+    }
+
+    pub(super) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
+        #[salsa::tracked(
+            returns(copy),
+            cycle_initial=|_, _, _| None,
+            heap_size=ruff_memory_usage::heap_size
+        )]
+        fn named_tuple_generic_context_from_candidates<'db>(
+            db: &'db dyn Db,
+            named_tuple: DynamicNamedTupleLiteral<'db>,
+        ) -> Option<GenericContext<'db>> {
+            let DynamicNamedTupleAnchor::TypingDefinition(definition) = named_tuple.anchor(db)
+            else {
+                return None;
+            };
+            functional_generic_context_from_candidates(
+                db,
+                *definition,
+                named_tuple.typevar_candidates(db),
+            )
+        }
+
+        named_tuple_generic_context_from_candidates(db, self)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -3,6 +3,7 @@ use ruff_db::{diagnostic::Span, parsed::parsed_module};
 use ruff_python_ast::{PythonVersion, name::Name};
 use ruff_text_size::TextRange;
 
+use crate::types::{GenericAlias, GenericClassLiteral};
 use crate::{
     Db,
     place::{Place, PlaceAndQualifiers},
@@ -207,8 +208,23 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
     }
 
     /// Returns an instance type for this dynamic namedtuple.
-    fn to_instance(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        Type::instance(db, env, ClassType::NonGeneric(self.into()))
+    fn to_instance(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        specialization: Option<crate::types::Specialization<'db>>,
+    ) -> Type<'db> {
+        let class = specialization.map_or_else(
+            || ClassType::NonGeneric(self.into()),
+            |specialization| {
+                ClassType::Generic(GenericAlias::new(
+                    db,
+                    GenericClassLiteral::DynamicNamedTuple(self),
+                    specialization,
+                ))
+            },
+        );
+        Type::instance(db, env, class)
     }
 
     /// Returns the range of the namedtuple call expression.
@@ -323,11 +339,12 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        specialization: Option<crate::types::Specialization<'db>>,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         // First check synthesized members and fields.
-        let member = self.own_class_member(db, name);
+        let member = self.own_class_member(db, specialization, name);
         if !member.is_undefined() {
             return member.inner;
         }
@@ -351,10 +368,15 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
     ///
     /// This only checks synthesized members and field properties, without falling
     /// back to tuple or other base classes.
-    pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Member<'db> {
+    pub(super) fn own_class_member(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<crate::types::Specialization<'db>>,
+        name: &str,
+    ) -> Member<'db> {
         let env = ProgramEnvironment::from_scope(self.scope(db));
         // Handle synthesized namedtuple attributes.
-        if let Some(ty) = self.synthesized_class_member(db, &env, name) {
+        if let Some(ty) = self.synthesized_class_member(db, &env, specialization, name) {
             return Member::definitely_declared(ty);
         }
 
@@ -373,9 +395,10 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        specialization: Option<crate::types::Specialization<'db>>,
         name: &str,
     ) -> Option<Type<'db>> {
-        let instance_ty = self.to_instance(db, env);
+        let instance_ty = self.to_instance(db, env, specialization);
 
         // When fields are unknown, handle constructor and field-specific methods specially.
         if !self.has_known_fields(db) {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -546,7 +546,11 @@ impl<'db> StaticClassLiteral<'db> {
             Some(generic_context) => {
                 let specialization = f(generic_context);
 
-                ClassType::Generic(GenericAlias::new(db, self, specialization))
+                ClassType::Generic(GenericAlias::new(
+                    db,
+                    super::GenericClassLiteral::Static(self),
+                    specialization,
+                ))
             }
         }
     }
@@ -2297,9 +2301,11 @@ impl<'db> StaticClassLiteral<'db> {
             Place::bound(member).into()
         } else {
             let class = match specialization {
-                Some(specialization) => {
-                    ClassType::Generic(GenericAlias::new(db, self, specialization))
-                }
+                Some(specialization) => ClassType::Generic(GenericAlias::new(
+                    db,
+                    super::GenericClassLiteral::Static(self),
+                    specialization,
+                )),
                 None => self.identity_specialization(db),
             };
             let Some(module) = self.typed_dict_module(db) else {
@@ -3121,7 +3127,7 @@ impl<'db> StaticClassLiteral<'db> {
                 for explicit_base in class.explicit_bases(db) {
                     let explicit_base_class_literal = match explicit_base {
                         Type::ClassLiteral(class_literal) => class_literal.as_static(),
-                        Type::GenericAlias(generic_alias) => Some(generic_alias.origin(db)),
+                        Type::GenericAlias(generic_alias) => generic_alias.origin(db).as_static(),
                         _ => continue,
                     };
                     let Some(explicit_base_class_literal) = explicit_base_class_literal else {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2346,7 +2346,7 @@ impl<'db> StaticClassLiteral<'db> {
     ) -> FxIndexMap<Name, Field<'db>> {
         enum FieldSource<'db> {
             Static(StaticClassLiteral<'db>, Option<Specialization<'db>>),
-            DynamicTypedDict(DynamicTypedDictLiteral<'db>),
+            DynamicTypedDict(DynamicTypedDictLiteral<'db>, Option<Specialization<'db>>),
         }
 
         debug_assert_ne!(
@@ -2372,9 +2372,10 @@ impl<'db> StaticClassLiteral<'db> {
                 }
 
                 if field_policy == CodeGeneratorKind::TypedDict
-                    && let ClassLiteral::DynamicTypedDict(typeddict) = class.class_literal(db)
+                    && let (ClassLiteral::DynamicTypedDict(typed_dict), specialization) =
+                        class.class_literal_and_specialization(db)
                 {
-                    return Some(FieldSource::DynamicTypedDict(typeddict));
+                    return Some(FieldSource::DynamicTypedDict(typed_dict, specialization));
                 }
 
                 None
@@ -2398,12 +2399,14 @@ impl<'db> StaticClassLiteral<'db> {
                             .map(|(name, field)| (name.clone(), field.clone())),
                     )
                 }
-                FieldSource::DynamicTypedDict(typeddict) => {
-                    Either::Right(typeddict.items(db).iter().map(|(name, td_field)| {
+                FieldSource::DynamicTypedDict(typed_dict, specialization) => {
+                    Either::Right(typed_dict.items(db).iter().map(move |(name, td_field)| {
                         (
                             name.clone(),
                             Field {
-                                declared_ty: td_field.declared_ty,
+                                declared_ty: td_field
+                                    .declared_ty
+                                    .apply_optional_specialization(db, specialization),
                                 kind: FieldKind::TypedDict {
                                     is_required: td_field.is_required(),
                                     is_read_only: td_field.is_read_only(),

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -25,6 +25,7 @@ use crate::types::{
     MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictType,
     TypingModule, UnionType, determine_upper_bound,
 };
+use crate::types::{GenericAlias, GenericClassLiteral, Specialization};
 use crate::{Db, FxIndexMap};
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
@@ -906,6 +907,23 @@ pub struct DynamicTypedDictLiteral<'db> {
 impl get_size2::GetSize for DynamicTypedDictLiteral<'_> {}
 
 impl<'db> DynamicTypedDictLiteral<'db> {
+    fn class_type(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> ClassType<'db> {
+        specialization.map_or_else(
+            || ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self)),
+            |specialization| {
+                ClassType::Generic(GenericAlias::new(
+                    db,
+                    GenericClassLiteral::DynamicTypedDict(self),
+                    specialization,
+                ))
+            },
+        )
+    }
+
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
@@ -1002,12 +1020,16 @@ impl<'db> DynamicTypedDictLiteral<'db> {
     }
 
     /// Look up a class-level member defined directly on this `TypedDict` (not inherited).
-    pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Member<'db> {
+    pub(super) fn own_class_member(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+        name: &str,
+    ) -> Member<'db> {
         let env = ProgramEnvironment::from_scope(self.scope(db));
-        let typed_dict =
-            TypedDictType::new(ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self)));
+        let typed_dict = TypedDictType::new(self.class_type(db, specialization));
         synthesize_typed_dict_method(db, &env, typed_dict, name, || {
-            TypedDictFields::Dynamic(self.items(db))
+            TypedDictFields::Dynamic(typed_dict.items(db))
         })
         .map(Member::definitely_declared)
         .unwrap_or_default()
@@ -1018,11 +1040,12 @@ impl<'db> DynamicTypedDictLiteral<'db> {
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        specialization: Option<Specialization<'db>>,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         // First check synthesized members (like __getitem__, __init__, get, etc.).
-        let member = self.own_class_member(db, name);
+        let member = self.own_class_member(db, specialization, name);
         if !member.is_undefined() {
             return member.inner;
         }
@@ -1032,7 +1055,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
         typed_dict_class_member(
             db,
             env,
-            ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self)),
+            self.class_type(db, specialization),
             self.typed_dict_module(db),
             policy,
             name,

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -11,6 +11,7 @@ use ty_module_resolver::KnownModule;
 use crate::place::PlaceAndQualifiers;
 use crate::place::known_module_symbol;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
+use crate::types::class::functional_generic_context_from_candidates;
 use crate::types::class::{
     DynamicClassHeaderAnchor, FunctionalTypeVarCandidate, dynamic_class_header_range,
 };
@@ -990,6 +991,29 @@ impl<'db> DynamicTypedDictLiteral<'db> {
             }
             DynamicTypedDictAnchor::ScopeOffset { schema, .. } => schema,
         }
+    }
+
+    pub(super) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
+        #[salsa::tracked(
+            returns(copy),
+            cycle_initial=|_, _, _| None,
+            heap_size=ruff_memory_usage::heap_size
+        )]
+        fn typed_dict_generic_context_from_candidates<'db>(
+            db: &'db dyn Db,
+            typed_dict: DynamicTypedDictLiteral<'db>,
+        ) -> Option<GenericContext<'db>> {
+            let DynamicTypedDictAnchor::Definition(definition) = typed_dict.anchor(db) else {
+                return None;
+            };
+            functional_generic_context_from_candidates(
+                db,
+                *definition,
+                typed_dict.typevar_candidates(db),
+            )
+        }
+
+        typed_dict_generic_context_from_candidates(db, self)
     }
 
     pub(crate) fn openness(self, db: &'db dyn Db) -> TypedDictOpenness<'db> {

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -11,7 +11,9 @@ use ty_module_resolver::KnownModule;
 use crate::place::PlaceAndQualifiers;
 use crate::place::known_module_symbol;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
-use crate::types::class::{DynamicClassHeaderAnchor, dynamic_class_header_range};
+use crate::types::class::{
+    DynamicClassHeaderAnchor, FunctionalTypeVarCandidate, dynamic_class_header_range,
+};
 use crate::types::generics::GenericContext;
 use crate::types::member::Member;
 use crate::types::mro::Mro;
@@ -902,6 +904,9 @@ pub struct DynamicTypedDictLiteral<'db> {
 
     #[returns(copy)]
     pub(crate) typed_dict_module: TypingModule,
+
+    #[returns(deref)]
+    pub(super) typevar_candidates: Box<[FunctionalTypeVarCandidate<'db>]>,
 }
 
 impl get_size2::GetSize for DynamicTypedDictLiteral<'_> {}
@@ -937,6 +942,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
             self.anchor(db)
                 .recursive_type_normalized_impl(db, env, div, nested)?,
             self.typed_dict_module(db),
+            self.typevar_candidates(db),
         ))
     }
 }

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -1072,7 +1072,7 @@ fn lax_input_type_impl<'db>(
     }
 
     let alias = if (module, symbol) == (KnownModule::Re, "Pattern") {
-        let Some(specialization) = field_type.specialization_of(db, env, class) else {
+        let Some(specialization) = field_type.specialization_of(db, env, class.into()) else {
             return Type::any();
         };
         let [pattern_type] = specialization.types(db) else {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1626,7 +1626,10 @@ pub(super) fn add_invariant_generic_hints<'db>(
     };
     diag.info(message);
 
-    if let Some(note) = covariant_supertype_hint(expected_class, db, &mismatch_indices) {
+    if let Some(note) = expected_class
+        .as_static()
+        .and_then(|class| covariant_supertype_hint(class, db, &mismatch_indices))
+    {
         diag.info(note);
     }
     diag.info(
@@ -4000,7 +4003,7 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
     // specialization seen and the index of the explicit base it
     // came from.
     let mut ancestor_specs =
-        FxHashMap::<StaticClassLiteral<'db>, (GenericAlias<'db>, usize)>::default();
+        FxHashMap::<super::class::GenericClassLiteral<'db>, (GenericAlias<'db>, usize)>::default();
 
     for (i, base) in explicit_bases.iter().enumerate() {
         let base_class = match base {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -614,7 +614,7 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'_, 'db> {
                 }
             }
             Type::GenericAlias(alias) => {
-                self.record_class(db, ClassLiteral::Static(alias.origin(db)));
+                self.record_class(db, alias.origin(db).class_literal());
             }
             Type::TypeAlias(type_alias) => self.record_type_alias(db, type_alias),
             // Visit the class (as if it were a nominal-instance type)
@@ -1885,7 +1885,7 @@ impl<'db> GenericAlias<'db> {
         settings: DisplaySettings<'db>,
     ) -> DisplayGenericAlias<'env, 'db> {
         DisplayGenericAlias {
-            origin: ClassLiteral::Static(self.origin(db)),
+            origin: self.origin(db).class_literal(),
             specialization: self.specialization(db),
             db,
             env,

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -2969,7 +2969,7 @@ fn extract_class_literal<'db>(
                 | crate::types::SubclassOfInner::TypeVar(_) => None,
             }
         }
-        Type::GenericAlias(generic_alias) => Some(ClassLiteral::Static(generic_alias.origin(db))),
+        Type::GenericAlias(generic_alias) => Some(generic_alias.origin(db).class_literal()),
         Type::NominalInstance(instance) => Some(instance.class(db, env).class_literal(db)),
         Type::Union(union) => union
             .elements(db)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3750,7 +3750,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if func_ty == Type::SpecialForm(SpecialFormType::NamedTuple) {
             // Only the `fields` argument is deferred for `NamedTuple`;
             // other arguments are inferred eagerly.
+            let previous_context = match self.region {
+                InferenceRegion::Deferred(definition) => {
+                    self.typevar_binding_context.replace(definition)
+                }
+                _ => None,
+            };
             self.infer_typing_namedtuple_fields(&arguments.args[1]);
+            self.typevar_binding_context = previous_context;
             return;
         }
         let known_class = func_ty
@@ -3775,7 +3782,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             _ => {}
         }
         if TypingModule::from_typed_dict_type(self.db(), func_ty).is_some() {
+            let previous_context = match self.region {
+                InferenceRegion::Deferred(definition) => {
+                    self.typevar_binding_context.replace(definition)
+                }
+                _ => None,
+            };
             self.infer_functional_typeddict_deferred(arguments);
+            self.typevar_binding_context = previous_context;
             return;
         }
         if let InferenceRegion::Deferred(definition) = self.region

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6,10 +6,11 @@ use compact_str::CompactString;
 use itertools::Itertools;
 use ruff_db::diagnostic::Span;
 use ruff_db::files::File;
-use ruff_db::parsed::ParsedModuleRef;
+use ruff_db::parsed::{ParsedModuleRef, parsed_string_annotation};
 use ruff_db::source::source_text;
 use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::visitor::{self, Visitor};
 use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
     PythonVersion,
@@ -54,7 +55,8 @@ use crate::types::call::bind::{
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::class::{
-    ClassLiteral, CodeGeneratorKind, FrozenDataclassDispatch, MethodDecorator,
+    ClassLiteral, CodeGeneratorKind, FrozenDataclassDispatch, FunctionalTypeVarCandidate,
+    MethodDecorator,
 };
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::context::InferContext;
@@ -202,6 +204,24 @@ fn should_preserve_inferred_binding_type(ty: Type<'_>) -> bool {
 /// uses 7 field specifiers. We could probably store more inline if this turns out to be a
 /// performance problem. For now, we optimize for memory usage.
 const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
+
+struct FunctionalTypeVarCandidateCollector<'ast> {
+    candidates: Vec<&'ast ast::Expr>,
+    strings: Vec<&'ast ast::ExprStringLiteral>,
+}
+
+impl<'ast> Visitor<'ast> for FunctionalTypeVarCandidateCollector<'ast> {
+    fn visit_expr(&mut self, expr: &'ast ast::Expr) {
+        match expr {
+            ast::Expr::Name(_) => self.candidates.push(expr),
+            ast::Expr::Attribute(attribute) if is_dotted_name(&attribute.value) => {
+                self.candidates.push(expr);
+            }
+            ast::Expr::StringLiteral(string) => self.strings.push(string),
+            _ => visitor::walk_expr(self, expr),
+        }
+    }
+}
 
 /// Builder to infer all types in a region.
 ///
@@ -455,6 +475,113 @@ fn transparent_callable_decorator_result<'db>(
 }
 
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
+    fn functional_typevar_candidate(
+        &self,
+        candidate: &ast::Expr,
+        from_string: bool,
+    ) -> Option<FunctionalTypeVarCandidate<'db>> {
+        let mut attributes = Vec::new();
+        let mut root = candidate;
+        while let ast::Expr::Attribute(attribute) = root {
+            attributes.push(Name::new(attribute.attr.id.as_str()));
+            root = &attribute.value;
+        }
+        let ast::Expr::Name(root) = root else {
+            return None;
+        };
+        attributes.reverse();
+
+        let db = self.db();
+        let scope = self.scope.file_scope_id(db);
+        let use_def = self.index.use_def_map(scope);
+        let possible_binding = |definition: Definition<'db>| {
+            !matches!(
+                definition.kind(db),
+                DefinitionKind::Function(_)
+                    | DefinitionKind::Class(_)
+                    | DefinitionKind::TypeAlias(_)
+                    | DefinitionKind::TypeVar(_)
+                    | DefinitionKind::ParamSpec(_)
+                    | DefinitionKind::TypeVarTuple(_)
+            )
+        };
+        let root_bindings = if from_string {
+            // Names parsed from string annotations have no use IDs in the semantic index.
+            let symbol = self.index.place_table(scope).symbol_id(root.id.as_str())?;
+            use_def
+                .reachable_bindings(symbol.into())
+                .filter_map(|binding| binding.binding.definition())
+                .filter(|definition| possible_binding(*definition))
+                .collect::<Box<[_]>>()
+        } else {
+            let root_use = root.scoped_use_id(db, self.program_file());
+            use_def
+                .bindings_at_use(root_use)
+                .filter_map(|binding| binding.binding.definition())
+                .filter(|definition| possible_binding(*definition))
+                .collect::<Box<[_]>>()
+        };
+
+        (!root_bindings.is_empty()).then_some(FunctionalTypeVarCandidate {
+            root_bindings,
+            attributes: attributes.into_boxed_slice(),
+        })
+    }
+
+    fn collect_functional_string_typevar_candidates(
+        &self,
+        string: &ast::ExprStringLiteral,
+        candidates: &mut FxIndexSet<FunctionalTypeVarCandidate<'db>>,
+    ) {
+        let Some(literal) = string.as_single_part_string() else {
+            return;
+        };
+        let source = source_text(self.db(), self.file());
+        if &source[literal.content_range()] != literal.as_str() {
+            return;
+        }
+        let Ok(parsed) = parsed_string_annotation(source.as_str(), literal) else {
+            return;
+        };
+        let mut collector = FunctionalTypeVarCandidateCollector {
+            candidates: Vec::new(),
+            strings: Vec::new(),
+        };
+        collector.visit_expr(parsed.expr());
+        candidates.extend(
+            collector
+                .candidates
+                .into_iter()
+                .filter_map(|candidate| self.functional_typevar_candidate(candidate, true)),
+        );
+        for nested in collector.strings {
+            self.collect_functional_string_typevar_candidates(nested, candidates);
+        }
+    }
+
+    pub(super) fn functional_typevar_candidates(
+        &self,
+        annotations: &[&ast::Expr],
+    ) -> Box<[FunctionalTypeVarCandidate<'db>]> {
+        let mut collector = FunctionalTypeVarCandidateCollector {
+            candidates: Vec::new(),
+            strings: Vec::new(),
+        };
+        for annotation in annotations {
+            collector.visit_expr(annotation);
+        }
+
+        let mut candidates = collector
+            .candidates
+            .into_iter()
+            .filter_map(|candidate| self.functional_typevar_candidate(candidate, false))
+            .collect::<FxIndexSet<_>>();
+        for string in collector.strings {
+            self.collect_functional_string_typevar_candidates(string, &mut candidates);
+        }
+        candidates.into_iter().collect()
+    }
+
     /// How big a string do we build before bailing?
     ///
     /// This is a fairly arbitrary number. It should be *far* more than enough

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -360,6 +360,26 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let name = name.unwrap_or("<unknown>");
 
+        let typevar_candidates = match (definition, kind) {
+            (Some(_), NamedTupleKind::Typing) => {
+                let fields = match fields_arg {
+                    ast::Expr::List(fields) => &*fields.elts,
+                    ast::Expr::Tuple(fields) => &*fields.elts,
+                    _ => &[],
+                };
+                let annotations = fields
+                    .iter()
+                    .filter_map(|field| match field {
+                        ast::Expr::Tuple(field) => field.elts.get(1),
+                        ast::Expr::List(field) => field.elts.get(1),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                self.functional_typevar_candidates(&annotations)
+            }
+            _ => Box::default(),
+        };
+
         // Handle fields based on which namedtuple variant.
         let anchor = match definition {
             Some(definition) => match kind {
@@ -410,7 +430,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        let namedtuple = DynamicNamedTupleLiteral::new(db, name, anchor);
+        let namedtuple = DynamicNamedTupleLiteral::new(db, name, anchor, typevar_candidates);
 
         Type::ClassLiteral(ClassLiteral::DynamicNamedTuple(namedtuple))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -28,9 +28,9 @@ use crate::types::typed_dict::{
 };
 use crate::types::typevar::TypeVarSet;
 use crate::types::{
-    BoundTypeVarInstance, CallArguments, CallDunderError, CallableBinding, CycleDetector,
-    DynamicType, InternedType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
-    MemberLookupPolicy, Parameter, Parameters, SpecialFormType, StaticClassLiteral, Type,
+    BoundTypeVarInstance, CallArguments, CallDunderError, CallableBinding, ClassLiteral,
+    CycleDetector, DynamicType, GenericClassLiteral, InternedType, KnownClass, KnownInstanceType,
+    LintDiagnosticGuard, MemberLookupPolicy, Parameter, Parameters, SpecialFormType, Type,
     TypeAliasType, TypeAndQualifiers, TypeContext, TypeVarBoundOrConstraints, UnionType,
     UnionTypeInstance, any_over_type, todo_type,
 };
@@ -80,8 +80,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     if typed_dict.explicit_extra_items(db).is_some() {
                         return Some(KnownClass::Str.to_instance(db, env));
                     }
-                    let keys = typed_dict
-                        .items(db)
+                    let items = typed_dict
+                        .defining_class()
+                        .and_then(|class| match class.class_literal(db) {
+                            ClassLiteral::DynamicTypedDict(dynamic) => Some(dynamic.items(db)),
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| typed_dict.items(db));
+                    let keys = items
                         .keys()
                         .map(|key| Type::string_literal(db, key))
                         .collect_vec();
@@ -255,7 +261,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
 
                 if let Some(generic_context) = class.generic_context(db)
-                    && let Some(class) = class.as_static()
+                    && let Some(class) = class.as_generic_class()
                 {
                     return Ok(self.infer_explicit_class_specialization(
                         subscript,
@@ -496,7 +502,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &mut self,
         subscript: &ast::ExprSubscript,
         value_ty: Type<'db>,
-        generic_class: StaticClassLiteral<'db>,
+        generic_class: GenericClassLiteral<'db>,
         generic_context: GenericContext<'db>,
     ) -> Type<'db> {
         let env = self.program_environment();
@@ -509,23 +515,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Avoid constructing an identity specialization and a full protocol interface for the
         // many generic protocols that do not directly declare `__class__`.
-        let disable_int_float_special_case = generic_class.is_protocol(db)
-            && place_table(db, generic_class.body_scope(db))
-                .symbol_id("__class__")
-                .is_some()
-            && generic_class
-                .identity_specialization(db)
-                .into_protocol_class(db)
-                .is_some_and(|protocol| {
-                    protocol
-                        .interface(db)
-                        .includes_generic_writable_instance_member(
-                            db,
-                            env,
-                            "__class__",
-                            generic_context,
-                        )
-                });
+        let disable_int_float_special_case = generic_class.as_static().is_some_and(|class| {
+            class.is_protocol(db)
+                && place_table(db, class.body_scope(db))
+                    .symbol_id("__class__")
+                    .is_some()
+                && generic_class
+                    .identity_specialization(db)
+                    .into_protocol_class(db)
+                    .is_some_and(|protocol| {
+                        protocol
+                            .interface(db)
+                            .includes_generic_writable_instance_member(
+                                db,
+                                env,
+                                "__class__",
+                                generic_context,
+                            )
+                    })
+        });
         let previously_disabled_int_float_special_case =
             disable_int_float_special_case.then(|| {
                 self.context

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1787,12 +1787,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 value_ty
             }
             Type::ClassLiteral(class) => {
-                match (class.generic_context(self.db()), class.as_static()) {
-                    (Some(generic_context), Some(static_class)) => {
+                match (class.generic_context(self.db()), class.as_generic_class()) {
+                    (Some(generic_context), Some(generic_class)) => {
                         let specialized_class = self.infer_explicit_class_specialization(
                             subscript,
                             value_ty,
-                            static_class,
+                            generic_class,
                             generic_context,
                         );
 

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -553,7 +553,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .is_some_and(|(class_literal, annotation)| {
                 any_over_type(db, env, annotation.resolve_type_alias(db), false, |ty| {
                     ty.resolve_type_alias(db)
-                        .specialization_of(db, env, class_literal)
+                        .specialization_of(db, env, class_literal.into())
                         .is_some_and(|specialization| {
                             specialization
                                 .types(db)

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -323,6 +323,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         self.validate_fields_arg(fields_arg);
 
+        let typevar_candidates = definition.map_or_else(Box::default, |_| {
+            let mut annotations = match fields_arg {
+                ast::Expr::Dict(fields) => fields
+                    .iter()
+                    .filter_map(|item| item.key.as_ref().map(|_| &item.value))
+                    .collect::<Vec<_>>(),
+                _ => Vec::new(),
+            };
+            if let Some(extra_items) = call_expr.arguments.find_keyword("extra_items") {
+                annotations.push(&extra_items.value);
+            }
+            self.functional_typevar_candidates(&annotations)
+        });
+
         if let Some(definition) = definition {
             self.deferred.insert(definition);
         }
@@ -354,7 +368,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        let typeddict = DynamicTypedDictLiteral::new(db, name, anchor, typed_dict_module);
+        let typeddict =
+            DynamicTypedDictLiteral::new(db, name, anchor, typed_dict_module, typevar_candidates);
         Type::ClassLiteral(ClassLiteral::DynamicTypedDict(typeddict))
     }
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -8,6 +8,7 @@ use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
 use ruff_python_ast::PythonVersion;
+use salsa::Database as _;
 use salsa::plumbing::AsId;
 use ty_python_core::definition::Definition;
 use ty_python_core::program::{Program, ProgramSettings};
@@ -492,6 +493,146 @@ fn pep695_type_params() {
 
     // a typevar with less than two constraints is treated as unconstrained
     check_typevar("Y", "TypeVar", None, None, None);
+}
+
+#[test]
+fn functional_generic_context_is_precisely_invalidated() {
+    fn executions(db: &TestDb, events: &[salsa::Event], query: &str, input: salsa::Id) -> usize {
+        events
+            .iter()
+            .filter(|event| {
+                let salsa::EventKind::WillExecute { database_key } = event.kind else {
+                    return false;
+                };
+                db.ingredient_debug_name(database_key.ingredient_index()) == query
+                    && database_key.key_index() == input
+            })
+            .count()
+    }
+
+    fn request_context(db: &TestDb, file: File, name: &str) -> (salsa::Id, bool) {
+        let class = global_symbol(db, file, name)
+            .place
+            .expect_type()
+            .as_class_literal()
+            .unwrap_or_else(|| panic!("expected `{name}` to be a class"));
+        let context_exists = class.generic_context(db).is_some();
+        let id = match class {
+            ClassLiteral::DynamicNamedTuple(class) => class.as_id(),
+            ClassLiteral::DynamicTypedDict(class) => class.as_id(),
+            _ => panic!("expected `{name}` to be a functional class"),
+        };
+        (id, context_exists)
+    }
+
+    let mut db = setup_db();
+    db.write_dedented(
+        "src/a.py",
+        r#"
+        from typing import NamedTuple, TypedDict, TypeVar
+        T = TypeVar("T")
+        Pair = NamedTuple("Pair", [("value", "list[T]"), ("next", "Pair[T] | None")])
+        Movie = TypedDict("Movie", {"value": "list[T]", "next": "Movie[T] | None"})
+        "#,
+    )
+    .unwrap();
+    let file = system_path_to_file(&db, "src/a.py").unwrap();
+
+    db.clear_salsa_events();
+    let (pair_id, pair_has_context) = request_context(&db, file, "Pair");
+    let (movie_id, movie_has_context) = request_context(&db, file, "Movie");
+    assert!(pair_has_context);
+    assert!(movie_has_context);
+    let events = db.take_salsa_events();
+    assert_eq!(
+        executions(
+            &db,
+            &events,
+            "named_tuple_generic_context_from_candidates",
+            pair_id,
+        ),
+        1
+    );
+    assert_eq!(
+        executions(
+            &db,
+            &events,
+            "typed_dict_generic_context_from_candidates",
+            movie_id,
+        ),
+        1
+    );
+    drop(events);
+
+    db.write_dedented(
+        "src/a.py",
+        r#"
+        from typing import NamedTuple, TypedDict, TypeVar
+        T = TypeVar("T")
+        # unrelated edit
+        Pair = NamedTuple("Pair", [("value", "list[T]"), ("next", "Pair[T] | None")])
+        Movie = TypedDict("Movie", {"value": "list[T]", "next": "Movie[T] | None"})
+        "#,
+    )
+    .unwrap();
+    db.clear_salsa_events();
+    assert_eq!(request_context(&db, file, "Pair"), (pair_id, true));
+    assert_eq!(request_context(&db, file, "Movie"), (movie_id, true));
+    let events = db.take_salsa_events();
+    assert_eq!(
+        executions(
+            &db,
+            &events,
+            "named_tuple_generic_context_from_candidates",
+            pair_id,
+        ),
+        0
+    );
+    assert_eq!(
+        executions(
+            &db,
+            &events,
+            "typed_dict_generic_context_from_candidates",
+            movie_id,
+        ),
+        0
+    );
+    drop(events);
+
+    db.write_dedented(
+        "src/a.py",
+        r#"
+        from typing import NamedTuple, TypedDict, TypeVar
+        T = TypeVar("T")
+        # unrelated edit
+        Pair = NamedTuple("Pair", [("value", "list[T]"), ("next", "Pair[T] | None")])
+        Movie = TypedDict("Movie", {"value": "list[int]", "next": "Movie[int] | None"})
+        "#,
+    )
+    .unwrap();
+    db.clear_salsa_events();
+    assert_eq!(request_context(&db, file, "Pair"), (pair_id, true));
+    let (new_movie_id, movie_has_context) = request_context(&db, file, "Movie");
+    assert!(!movie_has_context);
+    let events = db.take_salsa_events();
+    assert_eq!(
+        executions(
+            &db,
+            &events,
+            "named_tuple_generic_context_from_candidates",
+            pair_id,
+        ),
+        0
+    );
+    assert_eq!(
+        executions(
+            &db,
+            &events,
+            "typed_dict_generic_context_from_candidates",
+            new_movie_id,
+        ),
+        1
+    );
 }
 
 #[test]

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -266,15 +266,11 @@ impl<'db> AllMembers<'db> {
             }
 
             Type::GenericAlias(generic_alias) => {
-                let class_literal = generic_alias.origin(db);
-                self.extend_with_class_members(db, env, ty, ClassLiteral::Static(class_literal));
-                self.extend_with_synthetic_members(
-                    db,
-                    env,
-                    ty,
-                    ClassLiteral::Static(class_literal),
-                );
-                self.extend_with_metaclass_members(db, env, ty, class_literal.metaclass(db));
+                let origin = generic_alias.origin(db);
+                let class_literal = origin.class_literal();
+                self.extend_with_class_members(db, env, ty, class_literal);
+                self.extend_with_synthetic_members(db, env, ty, class_literal);
+                self.extend_with_metaclass_members(db, env, ty, origin.metaclass(db));
             }
 
             Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
@@ -387,12 +383,11 @@ impl<'db> AllMembers<'db> {
                     }
                 }
                 Type::GenericAlias(generic_alias) => {
-                    let class_literal = generic_alias.origin(db);
                     self.extend_with_class_members(
                         db,
                         env,
                         ty,
-                        ClassLiteral::Static(class_literal),
+                        generic_alias.origin(db).class_literal(),
                     );
                 }
                 _ => {}

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -10,7 +10,8 @@ use crate::types::class::{DynamicClassLiteral, DynamicEnumLiteral};
 use crate::types::class_base::ClassBase;
 use crate::types::generics::Specialization;
 use crate::types::{
-    ClassLiteral, ClassType, KnownInstanceType, SpecialFormType, StaticClassLiteral, Type,
+    ClassLiteral, ClassType, GenericAlias, GenericClassLiteral, KnownInstanceType, SpecialFormType,
+    StaticClassLiteral, Type,
 };
 
 use itertools::Itertools;
@@ -620,6 +621,24 @@ impl<'db> MroIterator<'db> {
         }
     }
 
+    fn dynamic_specialization(&self) -> Option<Specialization<'db>> {
+        match self.class {
+            ClassLiteral::DynamicNamedTuple(_) | ClassLiteral::DynamicTypedDict(_) => {
+                self.specialization
+            }
+            ClassLiteral::Static(_) | ClassLiteral::Dynamic(_) | ClassLiteral::DynamicEnum(_) => {
+                None
+            }
+        }
+    }
+
+    fn dynamic_class_type(&self, origin: GenericClassLiteral<'db>) -> ClassType<'db> {
+        self.specialization.map_or_else(
+            || ClassType::NonGeneric(origin.class_literal()),
+            |specialization| ClassType::Generic(GenericAlias::new(self.db, origin, specialization)),
+        )
+    }
+
     fn first_element(&self) -> ClassBase<'db> {
         let db = self.db;
         match self.class {
@@ -629,12 +648,12 @@ impl<'db> MroIterator<'db> {
             ClassLiteral::Dynamic(literal) => {
                 ClassBase::Class(ClassType::NonGeneric(literal.into()))
             }
-            ClassLiteral::DynamicNamedTuple(literal) => {
-                ClassBase::Class(ClassType::NonGeneric(literal.into()))
-            }
-            ClassLiteral::DynamicTypedDict(literal) => {
-                ClassBase::Class(ClassType::NonGeneric(literal.into()))
-            }
+            ClassLiteral::DynamicNamedTuple(literal) => ClassBase::Class(
+                self.dynamic_class_type(GenericClassLiteral::DynamicNamedTuple(literal)),
+            ),
+            ClassLiteral::DynamicTypedDict(literal) => ClassBase::Class(
+                self.dynamic_class_type(GenericClassLiteral::DynamicTypedDict(literal)),
+            ),
             ClassLiteral::DynamicEnum(literal) => {
                 ClassBase::Class(ClassType::NonGeneric(literal.into()))
             }
@@ -696,7 +715,11 @@ impl<'db> Iterator for MroIterator<'db> {
             self.first_element_yielded = true;
             return Some(self.first_element());
         }
-        self.full_mro_except_first_element().next().copied()
+        let specialization = self.dynamic_specialization();
+        self.full_mro_except_first_element()
+            .next()
+            .copied()
+            .map(|base| base.apply_optional_specialization(self.db, specialization))
     }
 }
 
@@ -704,9 +727,11 @@ impl std::iter::FusedIterator for MroIterator<'_> {}
 
 impl DoubleEndedIterator for MroIterator<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
+        let specialization = self.dynamic_specialization();
         self.full_mro_except_first_element()
             .next_back()
             .copied()
+            .map(|base| base.apply_optional_specialization(self.db, specialization))
             .or_else(|| {
                 if self.first_element_yielded {
                     None

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -250,7 +250,19 @@ impl<'db> TypedDictType<'db> {
             let static_class = match class_literal {
                 ClassLiteral::Static(static_class) => static_class,
                 ClassLiteral::DynamicTypedDict(dynamic) => {
-                    return dynamic.openness(db);
+                    let openness = dynamic.openness(db);
+                    return match (openness, specialization) {
+                        (TypedDictOpenness::Extra(extra_items), Some(specialization)) => {
+                            TypedDictOpenness::extra(
+                                db,
+                                extra_items
+                                    .declared_ty
+                                    .apply_optional_specialization(db, Some(specialization)),
+                                extra_items.is_read_only,
+                            )
+                        }
+                        _ => openness,
+                    };
                 }
                 ClassLiteral::Dynamic(_)
                 | ClassLiteral::DynamicNamedTuple(_)
@@ -366,7 +378,7 @@ impl<'db> TypedDictType<'db> {
     /// An undeclared key can still exist in an implicitly open `TypedDict` or one with explicit
     /// extra items. An optional field with an uninhabited value type can never be present.
     pub(crate) fn key_membership_truthiness(self, db: &'db dyn Db, key: &str) -> Truthiness {
-        match self.items(db).get(key) {
+        match self.item(db, key) {
             Some(field) if field.is_required() => Truthiness::AlwaysTrue,
             Some(field) if field.may_be_present(db) => Truthiness::Ambiguous,
             Some(_) => Truthiness::AlwaysFalse,
@@ -380,7 +392,24 @@ impl<'db> TypedDictType<'db> {
     /// Undeclared keys synthesize a field only for explicit extra items. Hidden items on an
     /// implicitly open `TypedDict` are intentionally not directly accessible.
     pub(crate) fn item(self, db: &'db dyn Db, key: &str) -> Option<TypedDictField<'db>> {
-        self.items(db).get(key).cloned().or_else(|| {
+        let declared = match self {
+            Self::Class(class) => {
+                let (literal, specialization) = class.class_literal_and_specialization(db);
+                match literal {
+                    ClassLiteral::DynamicTypedDict(dynamic) => {
+                        dynamic.items(db).get(key).cloned().map(|mut field| {
+                            field.declared_ty = field
+                                .declared_ty
+                                .apply_optional_specialization(db, specialization);
+                            field
+                        })
+                    }
+                    _ => self.items(db).get(key).cloned(),
+                }
+            }
+            Self::Synthesized(_) => self.items(db).get(key).cloned(),
+        };
+        declared.or_else(|| {
             let extra_items = self.explicit_extra_items(db)?;
             Some(
                 TypedDictFieldBuilder::new(extra_items.declared_ty)
@@ -555,11 +584,34 @@ impl<'db> TypedDictType<'db> {
                 .collect()
         }
 
+        #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+        fn specialized_dynamic_items<'db>(
+            db: &'db dyn Db,
+            class: super::class::DynamicTypedDictLiteral<'db>,
+            specialization: super::Specialization<'db>,
+        ) -> TypedDictSchema<'db> {
+            class
+                .items(db)
+                .iter()
+                .map(|(name, field)| {
+                    let mut field = field.clone();
+                    field.declared_ty = field
+                        .declared_ty
+                        .apply_optional_specialization(db, Some(specialization));
+                    (name.clone(), field)
+                })
+                .collect()
+        }
+
         match self {
             Self::Class(defining_class) => {
-                // Check if this is a dynamic TypedDict
-                if let ClassLiteral::DynamicTypedDict(class) = defining_class.class_literal(db) {
-                    return class.items(db);
+                let (class_literal, specialization) =
+                    defining_class.class_literal_and_specialization(db);
+                if let ClassLiteral::DynamicTypedDict(class) = class_literal {
+                    return specialization.map_or_else(
+                        || class.items(db),
+                        |specialization| specialized_dynamic_items(db, class, specialization),
+                    );
                 }
 
                 class_based_items(db, defining_class)


### PR DESCRIPTION
## Summary

ty rejects specialization of functional `NamedTuple` and `TypedDict` classes. `Pair[int]` produced `not-subscriptable` despite its `TypeVar` fields.

Closes astral-sh/ty#2512.

I updated ty to treat `TypeVar`s in their fields as class parameters, matching mypy:

```py
from typing import NamedTuple, TypeVar, TypedDict

T = TypeVar("T")
Pair = NamedTuple("Pair", [("first", T), ("second", T)])
Movie = TypedDict("Movie", {"payload": T})

reveal_type(Pair[int](1, 2).first)  # revealed: int
movie: Movie[bytes]
reveal_type(movie["payload"])  # revealed: bytes
```

I limited discovery to `TypeVar`s; `ParamSpec` and `TypeVarTuple` parameters were excluded.

The main implementation choice was the addition of a `GenericClassLiteral` enum to avoid trying to fit the generic semantics to the broader `ClassLiteral` type. I evaluated a few other approaches but this one seemed the best mix of aligning with current abstractions without opening the door for future undefined generic behavior on broader types (or weaken their compile-time guarantees). Performance was obviously a first-class concern as well.

The implementation reuses ty's `GenericContext`, `GenericAlias`, and `Specialization` machinery.
- Collect candidates from direct, qualified, and string annotations and resolve them lazily.
- Support recursion while keeping Salsa dependencies narrow.
- `GenericClassLiteral` limits origins to static classes, functional NamedTuples, and functional TypedDicts.
- Fields are specialized lazily, and synthetic `Self` preserves the active specialization.

Happy to adjust to feedback of course.

## Test Plan

I added:
- MD tests for explicit and inferred specialization, constructors, inherited fields, recursive string annotations, TypedDict qualifiers, and `extra_items`.
- Salsa regression test for caching, targeted invalidation, and recursive query convergence.

I ran the full workspace tests, Clippy (warnings denied), repository hooks, functional and static-control benchmarks.

Static-alias Salsa memory was unchanged and I did not observe any other notable regressions.

## Related work

Builds on #27760.
It does not depend on the seemingly related #27661.
Constructor inference in #27451 and #27452 also appears related but separate for the moment.