### PR TITLE
[`flake8-simplify`] Detect nested `async with` under sync parent (`SIM117`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -48,18 +48,6 @@ async with A() as a:
     async with B() as b:
         print("hello")
 
-# SIM117 — nested async with under a sync with parent (issue #27800).
-with A() as a:
-    async with B() as b:
-        async with C() as c:
-            print(a, b, c)
-
-# SIM117 — nested sync with under an async with parent.
-async with A() as a:
-    with B() as b:
-        with C() as c:
-            print(a, b, c)
-
 while True:
     # SIM117
     with A() as a:
@@ -176,8 +164,28 @@ async with asyncio.timeout(1), A():
     async with B():
         pass
 
+# SIM117 — nested async with under a sync with parent (issue #27800).
+with A() as a:
+    async with B() as b:
+        async with C() as c:
+            print(a, b, c)
+
+# SIM117 — nested sync with under an async with parent.
+async with A() as a:
+    with B() as b:
+        with C() as c:
+            print(a, b, c)
+
 # SIM117 — nested async with under an exempt async parent (issue #27800 class).
 async with asyncio.timeout(1):
     async with A() as a:
         async with B() as b:
             print(a, b)
+
+# SIM117 — two pairs: outer sync pair and inner async pair each combine.
+async def f():
+    with A():
+        with B():
+            async with C():
+                async with D():
+                    pass

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -48,6 +48,18 @@ async with A() as a:
     async with B() as b:
         print("hello")
 
+# SIM117 — nested async with under a sync with parent (issue #27800).
+with A() as a:
+    async with B() as b:
+        async with C() as c:
+            print(a, b, c)
+
+# SIM117 — nested sync with under an async with parent.
+async with A() as a:
+    with B() as b:
+        with C() as c:
+            print(a, b, c)
+
 while True:
     # SIM117
     with A() as a:
@@ -163,3 +175,9 @@ async with asyncio.timeout(1):
 async with asyncio.timeout(1), A():
     async with B():
         pass
+
+# SIM117 — nested async with under an exempt async parent (issue #27800 class).
+async with asyncio.timeout(1):
+    async with A() as a:
+        async with B() as b:
+            print(a, b)

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -110,10 +110,7 @@ fn explicit_with_items(checker: &Checker, with_items: &[WithItem]) -> bool {
 /// Returns the nested `with` when it is the sole body statement and can be
 /// merged with `outer` (same async/sync, neither side an exempt standalone
 /// manager).
-fn mergeable_child<'a>(
-    checker: &Checker,
-    outer: &'a ast::StmtWith,
-) -> Option<&'a ast::StmtWith> {
+fn mergeable_child<'a>(checker: &Checker, outer: &'a ast::StmtWith) -> Option<&'a ast::StmtWith> {
     let [Stmt::With(inner)] = outer.body.as_slice() else {
         return None;
     };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -149,8 +149,22 @@ pub(crate) fn multiple_with_statements(
     //     with B(), C():
     //         print("hello")
     // ```
-    if let Some(Stmt::With(ast::StmtWith { body, .. })) = with_parent {
-        if body.len() == 1 {
+    //
+    // Only defer to the parent when it can actually combine with this statement.
+    // Differing async/sync (or an exempt standalone manager) means the parent will
+    // not emit SIM117 for this nesting, so we must still check here — e.g.:
+    // ```python
+    // with sync_cm():
+    //     async with async_cm1():
+    //         async with async_cm2():
+    //             ...
+    // ```
+    if let Some(Stmt::With(parent_with)) = with_parent {
+        if parent_with.body.len() == 1
+            && parent_with.is_async == with_stmt.is_async
+            && !explicit_with_items(checker, &parent_with.items)
+            && !explicit_with_items(checker, &with_stmt.items)
+        {
             return;
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -75,23 +75,6 @@ impl Violation for MultipleWithStatements {
     }
 }
 
-/// Returns a boolean indicating whether it's an async with statement, the items
-/// and body.
-fn next_with(body: &[Stmt]) -> Option<(bool, &[WithItem], &[Stmt])> {
-    let [
-        Stmt::With(ast::StmtWith {
-            is_async,
-            items,
-            body,
-            ..
-        }),
-    ] = body
-    else {
-        return None;
-    };
-    Some((*is_async, items, body))
-}
-
 /// Check if `with_items` contains a single item which should not necessarily be
 /// grouped with other items.
 ///
@@ -122,6 +105,23 @@ fn explicit_with_items(checker: &Checker, with_items: &[WithItem]) -> bool {
                     ]
             )
         })
+}
+
+/// Returns the nested `with` when it is the sole body statement and can be
+/// merged with `outer` (same async/sync, neither side an exempt standalone
+/// manager).
+fn mergeable_child<'a>(
+    checker: &Checker,
+    outer: &'a ast::StmtWith,
+) -> Option<&'a ast::StmtWith> {
+    let [Stmt::With(inner)] = outer.body.as_slice() else {
+        return None;
+    };
+
+    (outer.is_async == inner.is_async
+        && !explicit_with_items(checker, &outer.items)
+        && !explicit_with_items(checker, &inner.items))
+    .then_some(inner)
 }
 
 /// SIM117
@@ -160,66 +160,55 @@ pub(crate) fn multiple_with_statements(
     //             ...
     // ```
     if let Some(Stmt::With(parent_with)) = with_parent {
-        if parent_with.body.len() == 1
-            && parent_with.is_async == with_stmt.is_async
-            && !explicit_with_items(checker, &parent_with.items)
-            && !explicit_with_items(checker, &with_stmt.items)
-        {
+        // Parent will report SIM117 for this nesting; fix top-to-bottom.
+        if mergeable_child(checker, parent_with).is_some() {
             return;
         }
     }
 
-    if let Some((is_async, items, _body)) = next_with(&with_stmt.body) {
-        if is_async != with_stmt.is_async {
-            // One of the statements is an async with, while the other is not,
-            // we can't merge those statements.
-            return;
-        }
+    let Some(inner) = mergeable_child(checker, with_stmt) else {
+        return;
+    };
 
-        if explicit_with_items(checker, &with_stmt.items) || explicit_with_items(checker, items) {
-            return;
-        }
+    let Some(colon) = inner.items.last().and_then(|item| {
+        SimpleTokenizer::starts_at(item.end(), checker.locator().contents())
+            .skip_trivia()
+            .find(|token| token.kind == SimpleTokenKind::Colon)
+    }) else {
+        return;
+    };
 
-        let Some(colon) = items.last().and_then(|item| {
-            SimpleTokenizer::starts_at(item.end(), checker.locator().contents())
-                .skip_trivia()
-                .find(|token| token.kind == SimpleTokenKind::Colon)
-        }) else {
-            return;
-        };
-
-        let mut diagnostic = checker.report_diagnostic(
-            MultipleWithStatements,
-            TextRange::new(with_stmt.start(), colon.end()),
-        );
-        if !checker
-            .comment_ranges()
-            .intersects(TextRange::new(with_stmt.start(), with_stmt.body[0].start()))
-        {
-            diagnostic.try_set_optional_fix(|| {
-                match fix_with::fix_multiple_with_statements(
-                    checker.locator(),
-                    checker.stylist(),
-                    with_stmt,
-                ) {
-                    Ok(edit) => {
-                        if edit.content().is_none_or(|content| {
-                            fits(
-                                content,
-                                with_stmt.into(),
-                                checker.locator(),
-                                checker.settings().pycodestyle.max_line_length,
-                                checker.settings().tab_size,
-                            )
-                        }) {
-                            Ok(Some(Fix::safe_edit(edit)))
-                        } else {
-                            Ok(None)
-                        }
+    let mut diagnostic = checker.report_diagnostic(
+        MultipleWithStatements,
+        TextRange::new(with_stmt.start(), colon.end()),
+    );
+    if !checker
+        .comment_ranges()
+        .intersects(TextRange::new(with_stmt.start(), with_stmt.body[0].start()))
+    {
+        diagnostic.try_set_optional_fix(|| {
+            match fix_with::fix_multiple_with_statements(
+                checker.locator(),
+                checker.stylist(),
+                with_stmt,
+            ) {
+                Ok(edit) => {
+                    if edit.content().is_none_or(|content| {
+                        fits(
+                            content,
+                            with_stmt.into(),
+                            checker.locator(),
+                            checker.settings().pycodestyle.max_line_length,
+                            checker.settings().tab_size,
+                        )
+                    }) {
+                        Ok(Some(Fix::safe_edit(edit)))
+                    } else {
+                        Ok(None)
                     }
-                    Err(err) => bail!("Failed to collapse `with`: {err}"),
                 }
-            });
-        }
+                Err(err) => bail!("Failed to collapse `with`: {err}"),
+            }
+        });
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__multiple-with-statements_SIM117.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__multiple-with-statements_SIM117.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+assertion_line: 58
 ---
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
  --> SIM117.py:2:1
@@ -102,212 +103,275 @@ help: Combine `with` statements
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
   --> SIM117.py:53:5
    |
-51 |   while True:
-52 |       # SIM117
-53 | /     with A() as a:
-54 | |         with B() as b:
-   | |______________________^
-55 |               """this
-56 |   is valid"""
+51 |   # SIM117 — nested async with under a sync with parent (issue #27800).
+52 |   with A() as a:
+53 | /     async with B() as b:
+54 | |         async with C() as c:
+   | |____________________________^
+55 |               print(a, b, c)
    |
 help: Combine `with` statements
    |
-52 |     # SIM117
+52 | with A() as a:
+   -     async with B() as b:
+   -         async with C() as c:
+   -             print(a, b, c)
+53 +     async with B() as b, C() as c:
+54 +         print(a, b, c)
+55 |
+   |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+  --> SIM117.py:59:5
+   |
+57 |   # SIM117 — nested sync with under an async with parent.
+58 |   async with A() as a:
+59 | /     with B() as b:
+60 | |         with C() as c:
+   | |______________________^
+61 |               print(a, b, c)
+   |
+help: Combine `with` statements
+   |
+58 | async with A() as a:
+   -     with B() as b:
+   -         with C() as c:
+   -             print(a, b, c)
+59 +     with B() as b, C() as c:
+60 +         print(a, b, c)
+61 |
+   |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+  --> SIM117.py:65:5
+   |
+63 |   while True:
+64 |       # SIM117
+65 | /     with A() as a:
+66 | |         with B() as b:
+   | |______________________^
+67 |               """this
+68 |   is valid"""
+   |
+help: Combine `with` statements
+   |
+64 |     # SIM117
    -     with A() as a:
    -         with B() as b:
    -             """this
-53 +     with A() as a, B() as b:
-54 +         """this
-55 | is valid"""
-56 |
+65 +     with A() as a, B() as b:
+66 +         """this
+67 | is valid"""
+68 |
    -             """the indentation on
-57 +         """the indentation on
-58 |             this line is significant"""
-59 |
+69 +         """the indentation on
+70 |             this line is significant"""
+71 |
    -             "this is" \
-60 +         "this is" \
-61 | "allowed too"
-62 |
+72 +         "this is" \
+73 | "allowed too"
+74 |
    -             ("so is"
-63 +         ("so is"
-64 | "this for some reason")
+75 +         ("so is"
+76 | "this for some reason")
    |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-  --> SIM117.py:68:1
+  --> SIM117.py:80:1
    |
-67 |   # SIM117
-68 | / with (
-69 | |     A() as a,
-70 | |     B() as b,
-71 | | ):
-72 | |     with C() as c:
+79 |   # SIM117
+80 | / with (
+81 | |     A() as a,
+82 | |     B() as b,
+83 | | ):
+84 | |     with C() as c:
    | |__________________^
-73 |           print("hello")
+85 |           print("hello")
    |
 help: Combine `with` statements
    |
-69 |     A() as a,
+81 |     A() as a,
    -     B() as b,
-70 +     B() as b,C() as c
-71 | ):
+82 +     B() as b,C() as c
+83 | ):
    -     with C() as c:
    -         print("hello")
-72 +     print("hello")
-73 |
+84 +     print("hello")
+85 |
    |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-  --> SIM117.py:76:1
+  --> SIM117.py:88:1
    |
-75 |   # SIM117
-76 | / with A() as a:
-77 | |     with (
-78 | |         B() as b,
-79 | |         C() as c,
-80 | |     ):
+87 |   # SIM117
+88 | / with A() as a:
+89 | |     with (
+90 | |         B() as b,
+91 | |         C() as c,
+92 | |     ):
    | |______^
-81 |           print("hello")
+93 |           print("hello")
    |
 help: Combine `with` statements
    |
-75 | # SIM117
+87 | # SIM117
    - with A() as a:
    -     with (
    -         B() as b,
    -         C() as c,
    -     ):
    -         print("hello")
-76 + with (
-77 +     A() as a, B() as b,
-78 +     C() as c,
-79 + ):
-80 +     print("hello")
-81 |
+88 + with (
+89 +     A() as a, B() as b,
+90 +     C() as c,
+91 + ):
+92 +     print("hello")
+93 |
    |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-  --> SIM117.py:84:1
-   |
-83 |   # SIM117
-84 | / with (
-85 | |     A() as a,
-86 | |     B() as b,
-87 | | ):
-88 | |     with (
-89 | |         C() as c,
-90 | |         D() as d,
-91 | |     ):
-   | |______^
-92 |           print("hello")
-   |
-help: Combine `with` statements
-   |
-85 |     A() as a,
-   -     B() as b,
-86 +     B() as b,C() as c,
-87 +     D() as d,
-88 | ):
-   -     with (
-   -         C() as c,
-   -         D() as d,
-   -     ):
-   -         print("hello")
-89 +     print("hello")
-90 |
-   |
-
-SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-  --> SIM117.py:95:1
-   |
-94 |   # SIM117 (auto-fixable)
-95 | / with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
-96 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
-   | |__________________________________________________^
-97 |           print("hello")
-   |
-help: Combine `with` statements
-   |
-94 | # SIM117 (auto-fixable)
-   - with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
-   -     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
-   -         print("hello")
-95 + with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a, B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
-96 +     print("hello")
-97 |
-   |
-
-SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:100:1
+   --> SIM117.py:96:1
     |
- 99 |   # SIM117 (not auto-fixable too long)
-100 | / with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ890") as a:
-101 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
+ 95 |   # SIM117
+ 96 | / with (
+ 97 | |     A() as a,
+ 98 | |     B() as b,
+ 99 | | ):
+100 | |     with (
+101 | |         C() as c,
+102 | |         D() as d,
+103 | |     ):
+    | |______^
+104 |           print("hello")
+    |
+help: Combine `with` statements
+    |
+97  |     A() as a,
+    -     B() as b,
+98  +     B() as b,C() as c,
+99  +     D() as d,
+100 | ):
+    -     with (
+    -         C() as c,
+    -         D() as d,
+    -     ):
+    -         print("hello")
+101 +     print("hello")
+102 |
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:107:1
+    |
+106 |   # SIM117 (auto-fixable)
+107 | / with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
+108 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
     | |__________________________________________________^
-102 |           print("hello")
+109 |           print("hello")
+    |
+help: Combine `with` statements
+    |
+106 | # SIM117 (auto-fixable)
+    - with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
+    -     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
+    -         print("hello")
+107 + with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a, B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
+108 +     print("hello")
+109 |
+    |
+
+SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:112:1
+    |
+111 |   # SIM117 (not auto-fixable too long)
+112 | / with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ890") as a:
+113 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
+    | |__________________________________________________^
+114 |           print("hello")
     |
 help: Combine `with` statements
 
 SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:106:5
+   --> SIM117.py:118:5
     |
-104 |   # From issue #3025.
-105 |   async def main():
-106 | /     async with A() as a: # SIM117.
-107 | |         async with B() as b:
+116 |   # From issue #3025.
+117 |   async def main():
+118 | /     async with A() as a: # SIM117.
+119 | |         async with B() as b:
     | |____________________________^
-108 |               print("async-inside!")
+120 |               print("async-inside!")
     |
 help: Combine `with` statements
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:126:1
+   --> SIM117.py:138:1
     |
-125 |   # SIM117
-126 | / with A() as a:
-127 | |     with B() as b:
+137 |   # SIM117
+138 | / with A() as a:
+139 | |     with B() as b:
     | |__________________^
-128 |           type ListOrSet[T] = list[T] | set[T]
+140 |           type ListOrSet[T] = list[T] | set[T]
     |
 help: Combine `with` statements
     |
-125 | # SIM117
+137 | # SIM117
     - with A() as a:
     -     with B() as b:
     -         type ListOrSet[T] = list[T] | set[T]
-126 + with A() as a, B() as b:
-127 +     type ListOrSet[T] = list[T] | set[T]
-128 |
+138 + with A() as a, B() as b:
+139 +     type ListOrSet[T] = list[T] | set[T]
+140 |
     -         class ClassA[T: str]:
     -             def method1(self) -> T:
     -                 ...
-129 +     class ClassA[T: str]:
-130 +         def method1(self) -> T:
-131 +             ...
-132 |
+141 +     class ClassA[T: str]:
+142 +         def method1(self) -> T:
+143 +             ...
+144 |
     -         f" something { my_dict["key"] } something else "
-133 +     f" something { my_dict["key"] } something else "
-134 |
+145 +     f" something { my_dict["key"] } something else "
+146 |
     -         f"foo {f"bar {x}"} baz"
-135 +     f"foo {f"bar {x}"} baz"
-136 |
+147 +     f"foo {f"bar {x}"} baz"
+148 |
     |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:163:1
+   --> SIM117.py:175:1
     |
-162 |   # Do not suppress combination, if a context manager is already combined with another.
-163 | / async with asyncio.timeout(1), A():
-164 | |     async with B():
+174 |   # Do not suppress combination, if a context manager is already combined with another.
+175 | / async with asyncio.timeout(1), A():
+176 | |     async with B():
     | |___________________^
-165 |           pass
+177 |           pass
     |
 help: Combine `with` statements
     |
-162 | # Do not suppress combination, if a context manager is already combined with another.
+174 | # Do not suppress combination, if a context manager is already combined with another.
     - async with asyncio.timeout(1), A():
     -     async with B():
     -         pass
-163 + async with asyncio.timeout(1), A(), B():
-164 +     pass
+175 + async with asyncio.timeout(1), A(), B():
+176 +     pass
+177 |
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:181:5
+    |
+179 |   # SIM117 — nested async with under an exempt async parent (issue #27800 class).
+180 |   async with asyncio.timeout(1):
+181 | /     async with A() as a:
+182 | |         async with B() as b:
+    | |____________________________^
+183 |               print(a, b)
+    |
+help: Combine `with` statements
+    |
+180 | async with asyncio.timeout(1):
+    -     async with A() as a:
+    -         async with B() as b:
+    -             print(a, b)
+181 +     async with A() as a, B() as b:
+182 +         print(a, b)
     |

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__multiple-with-statements_SIM117.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__multiple-with-statements_SIM117.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
-assertion_line: 58
 ---
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
  --> SIM117.py:2:1
@@ -103,256 +102,256 @@ help: Combine `with` statements
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
   --> SIM117.py:53:5
    |
-51 |   # SIM117 — nested async with under a sync with parent (issue #27800).
-52 |   with A() as a:
-53 | /     async with B() as b:
-54 | |         async with C() as c:
-   | |____________________________^
-55 |               print(a, b, c)
-   |
-help: Combine `with` statements
-   |
-52 | with A() as a:
-   -     async with B() as b:
-   -         async with C() as c:
-   -             print(a, b, c)
-53 +     async with B() as b, C() as c:
-54 +         print(a, b, c)
-55 |
-   |
-
-SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-  --> SIM117.py:59:5
-   |
-57 |   # SIM117 — nested sync with under an async with parent.
-58 |   async with A() as a:
-59 | /     with B() as b:
-60 | |         with C() as c:
+51 |   while True:
+52 |       # SIM117
+53 | /     with A() as a:
+54 | |         with B() as b:
    | |______________________^
-61 |               print(a, b, c)
+55 |               """this
+56 |   is valid"""
    |
 help: Combine `with` statements
    |
-58 | async with A() as a:
-   -     with B() as b:
-   -         with C() as c:
-   -             print(a, b, c)
-59 +     with B() as b, C() as c:
-60 +         print(a, b, c)
-61 |
-   |
-
-SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-  --> SIM117.py:65:5
-   |
-63 |   while True:
-64 |       # SIM117
-65 | /     with A() as a:
-66 | |         with B() as b:
-   | |______________________^
-67 |               """this
-68 |   is valid"""
-   |
-help: Combine `with` statements
-   |
-64 |     # SIM117
+52 |     # SIM117
    -     with A() as a:
    -         with B() as b:
    -             """this
-65 +     with A() as a, B() as b:
-66 +         """this
-67 | is valid"""
-68 |
+53 +     with A() as a, B() as b:
+54 +         """this
+55 | is valid"""
+56 |
    -             """the indentation on
-69 +         """the indentation on
-70 |             this line is significant"""
-71 |
+57 +         """the indentation on
+58 |             this line is significant"""
+59 |
    -             "this is" \
-72 +         "this is" \
-73 | "allowed too"
-74 |
+60 +         "this is" \
+61 | "allowed too"
+62 |
    -             ("so is"
-75 +         ("so is"
-76 | "this for some reason")
+63 +         ("so is"
+64 | "this for some reason")
    |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-  --> SIM117.py:80:1
+  --> SIM117.py:68:1
    |
-79 |   # SIM117
-80 | / with (
-81 | |     A() as a,
-82 | |     B() as b,
-83 | | ):
-84 | |     with C() as c:
+67 |   # SIM117
+68 | / with (
+69 | |     A() as a,
+70 | |     B() as b,
+71 | | ):
+72 | |     with C() as c:
    | |__________________^
-85 |           print("hello")
+73 |           print("hello")
    |
 help: Combine `with` statements
    |
-81 |     A() as a,
+69 |     A() as a,
    -     B() as b,
-82 +     B() as b,C() as c
-83 | ):
+70 +     B() as b,C() as c
+71 | ):
    -     with C() as c:
    -         print("hello")
-84 +     print("hello")
-85 |
+72 +     print("hello")
+73 |
    |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-  --> SIM117.py:88:1
+  --> SIM117.py:76:1
    |
-87 |   # SIM117
-88 | / with A() as a:
-89 | |     with (
-90 | |         B() as b,
-91 | |         C() as c,
-92 | |     ):
+75 |   # SIM117
+76 | / with A() as a:
+77 | |     with (
+78 | |         B() as b,
+79 | |         C() as c,
+80 | |     ):
    | |______^
-93 |           print("hello")
+81 |           print("hello")
    |
 help: Combine `with` statements
    |
-87 | # SIM117
+75 | # SIM117
    - with A() as a:
    -     with (
    -         B() as b,
    -         C() as c,
    -     ):
    -         print("hello")
-88 + with (
-89 +     A() as a, B() as b,
-90 +     C() as c,
-91 + ):
-92 +     print("hello")
-93 |
+76 + with (
+77 +     A() as a, B() as b,
+78 +     C() as c,
+79 + ):
+80 +     print("hello")
+81 |
    |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:96:1
-    |
- 95 |   # SIM117
- 96 | / with (
- 97 | |     A() as a,
- 98 | |     B() as b,
- 99 | | ):
-100 | |     with (
-101 | |         C() as c,
-102 | |         D() as d,
-103 | |     ):
-    | |______^
-104 |           print("hello")
-    |
+  --> SIM117.py:84:1
+   |
+83 |   # SIM117
+84 | / with (
+85 | |     A() as a,
+86 | |     B() as b,
+87 | | ):
+88 | |     with (
+89 | |         C() as c,
+90 | |         D() as d,
+91 | |     ):
+   | |______^
+92 |           print("hello")
+   |
 help: Combine `with` statements
-    |
-97  |     A() as a,
-    -     B() as b,
-98  +     B() as b,C() as c,
-99  +     D() as d,
-100 | ):
-    -     with (
-    -         C() as c,
-    -         D() as d,
-    -     ):
-    -         print("hello")
-101 +     print("hello")
-102 |
-    |
+   |
+85 |     A() as a,
+   -     B() as b,
+86 +     B() as b,C() as c,
+87 +     D() as d,
+88 | ):
+   -     with (
+   -         C() as c,
+   -         D() as d,
+   -     ):
+   -         print("hello")
+89 +     print("hello")
+90 |
+   |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:107:1
-    |
-106 |   # SIM117 (auto-fixable)
-107 | / with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
-108 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
-    | |__________________________________________________^
-109 |           print("hello")
-    |
+  --> SIM117.py:95:1
+   |
+94 |   # SIM117 (auto-fixable)
+95 | / with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
+96 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
+   | |__________________________________________________^
+97 |           print("hello")
+   |
 help: Combine `with` statements
-    |
-106 | # SIM117 (auto-fixable)
-    - with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
-    -     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
-    -         print("hello")
-107 + with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a, B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
-108 +     print("hello")
-109 |
-    |
+   |
+94 | # SIM117 (auto-fixable)
+   - with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
+   -     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
+   -         print("hello")
+95 + with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a, B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
+96 +     print("hello")
+97 |
+   |
 
 SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:112:1
+   --> SIM117.py:100:1
     |
-111 |   # SIM117 (not auto-fixable too long)
-112 | / with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ890") as a:
-113 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
+ 99 |   # SIM117 (not auto-fixable too long)
+100 | / with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ890") as a:
+101 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
     | |__________________________________________________^
-114 |           print("hello")
+102 |           print("hello")
     |
 help: Combine `with` statements
 
 SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:118:5
+   --> SIM117.py:106:5
     |
-116 |   # From issue #3025.
-117 |   async def main():
-118 | /     async with A() as a: # SIM117.
-119 | |         async with B() as b:
+104 |   # From issue #3025.
+105 |   async def main():
+106 | /     async with A() as a: # SIM117.
+107 | |         async with B() as b:
     | |____________________________^
-120 |               print("async-inside!")
+108 |               print("async-inside!")
     |
 help: Combine `with` statements
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:138:1
+   --> SIM117.py:126:1
     |
-137 |   # SIM117
-138 | / with A() as a:
-139 | |     with B() as b:
+125 |   # SIM117
+126 | / with A() as a:
+127 | |     with B() as b:
     | |__________________^
-140 |           type ListOrSet[T] = list[T] | set[T]
+128 |           type ListOrSet[T] = list[T] | set[T]
     |
 help: Combine `with` statements
     |
-137 | # SIM117
+125 | # SIM117
     - with A() as a:
     -     with B() as b:
     -         type ListOrSet[T] = list[T] | set[T]
-138 + with A() as a, B() as b:
-139 +     type ListOrSet[T] = list[T] | set[T]
-140 |
+126 + with A() as a, B() as b:
+127 +     type ListOrSet[T] = list[T] | set[T]
+128 |
     -         class ClassA[T: str]:
     -             def method1(self) -> T:
     -                 ...
-141 +     class ClassA[T: str]:
-142 +         def method1(self) -> T:
-143 +             ...
-144 |
+129 +     class ClassA[T: str]:
+130 +         def method1(self) -> T:
+131 +             ...
+132 |
     -         f" something { my_dict["key"] } something else "
-145 +     f" something { my_dict["key"] } something else "
-146 |
+133 +     f" something { my_dict["key"] } something else "
+134 |
     -         f"foo {f"bar {x}"} baz"
-147 +     f"foo {f"bar {x}"} baz"
-148 |
+135 +     f"foo {f"bar {x}"} baz"
+136 |
     |
 
 SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-   --> SIM117.py:175:1
+   --> SIM117.py:163:1
     |
-174 |   # Do not suppress combination, if a context manager is already combined with another.
-175 | / async with asyncio.timeout(1), A():
-176 | |     async with B():
+162 |   # Do not suppress combination, if a context manager is already combined with another.
+163 | / async with asyncio.timeout(1), A():
+164 | |     async with B():
     | |___________________^
-177 |           pass
+165 |           pass
     |
 help: Combine `with` statements
     |
-174 | # Do not suppress combination, if a context manager is already combined with another.
+162 | # Do not suppress combination, if a context manager is already combined with another.
     - async with asyncio.timeout(1), A():
     -     async with B():
     -         pass
-175 + async with asyncio.timeout(1), A(), B():
-176 +     pass
+163 + async with asyncio.timeout(1), A(), B():
+164 +     pass
+165 |
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:169:5
+    |
+167 |   # SIM117 — nested async with under a sync with parent (issue #27800).
+168 |   with A() as a:
+169 | /     async with B() as b:
+170 | |         async with C() as c:
+    | |____________________________^
+171 |               print(a, b, c)
+    |
+help: Combine `with` statements
+    |
+168 | with A() as a:
+    -     async with B() as b:
+    -         async with C() as c:
+    -             print(a, b, c)
+169 +     async with B() as b, C() as c:
+170 +         print(a, b, c)
+171 |
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:175:5
+    |
+173 |   # SIM117 — nested sync with under an async with parent.
+174 |   async with A() as a:
+175 | /     with B() as b:
+176 | |         with C() as c:
+    | |______________________^
+177 |               print(a, b, c)
+    |
+help: Combine `with` statements
+    |
+174 | async with A() as a:
+    -     with B() as b:
+    -         with C() as c:
+    -             print(a, b, c)
+175 +     with B() as b, C() as c:
+176 +         print(a, b, c)
 177 |
     |
 
@@ -374,4 +373,50 @@ help: Combine `with` statements
     -             print(a, b)
 181 +     async with A() as a, B() as b:
 182 +         print(a, b)
+183 |
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:187:5
+    |
+185 |   # SIM117 — two pairs: outer sync pair and inner async pair each combine.
+186 |   async def f():
+187 | /     with A():
+188 | |         with B():
+    | |_________________^
+189 |               async with C():
+190 |                   async with D():
+    |
+help: Combine `with` statements
+    |
+186 | async def f():
+    -     with A():
+    -         with B():
+    -             async with C():
+    -                 async with D():
+    -                     pass
+187 +     with A(), B():
+188 +         async with C():
+189 +             async with D():
+190 +                 pass
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:189:13
+    |
+187 |       with A():
+188 |           with B():
+189 | /             async with C():
+190 | |                 async with D():
+    | |_______________________________^
+191 |                       pass
+    |
+help: Combine `with` statements
+    |
+188 |         with B():
+    -             async with C():
+    -                 async with D():
+    -                     pass
+189 +             async with C(), D():
+190 +                 pass
     |


### PR DESCRIPTION
## Summary

Fixes a SIM117 false negative when nested `async with` statements sit under a sync `with` parent (and the inverse).

Previously, SIM117 skipped any `with` whose parent was itself a single-statement `with`, so that nested cases were fixed top-to-bottom. That skip was unconditional, so a sync parent caused nested async bodies to be ignored even though sync/async contexts cannot be merged:

```python
with contextlib.nullcontext() as ctx:
    async with mycontext() as actx1:   # was not flagged
        async with mycontext() as actx2:
            ...
```

The parent deferral now only applies when the parent can actually combine with the current statement: same `async`/`sync` and neither side is an exempt standalone manager (`asyncio.timeout`, trio cancel scopes, etc.).

## Test plan

- [x] Extended `SIM117.py` with regression cases for:
  - nested async under sync parent (#27800)
  - nested sync under async parent
  - nested async under exempt `asyncio.timeout` parent
- [x] Updated SIM117 snapshot
- [x] `cargo test -p ruff_linter --lib multiplewithstatements`

Fixes #27800