### PR TITLE
[ty] Do not prefer unsafe fixes in the language server

### DIFF
--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -647,6 +647,7 @@ pub(crate) struct FullDiagnosticData {
 pub(crate) struct DiagnosticFixData {
     pub(crate) fix_title: String,
     pub(crate) edits: HashMap<Uri, Vec<lsp_types::TextEdit>>,
+    pub(crate) preferred: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -722,6 +723,7 @@ impl DiagnosticData {
                 .map(ToString::to_string)
                 .unwrap_or_else(|| format!("Fix {}", diagnostic.id())),
             edits: lsp_edits,
+            preferred: fix.applies(Applicability::Safe),
         })
     }
 }

--- a/crates/ty_server/src/server/api/requests/code_action.rs
+++ b/crates/ty_server/src/server/api/requests/code_action.rs
@@ -81,7 +81,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
                             document_changes: None,
                             change_annotations: None,
                         }),
-                        is_preferred: Some(true),
+                        is_preferred: Some(fix.preferred),
                         command: None,
                         disabled: None,
                         data: None,

--- a/crates/ty_server/tests/e2e/code_actions.rs
+++ b/crates/ty_server/tests/e2e/code_actions.rs
@@ -83,6 +83,41 @@ unused-ignore-comment = \"warn\"
 }
 
 #[test]
+fn code_action_unsafe_fix() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    // Removing the suppression is unsafe because it would activate `fmt: off`.
+    let foo_content = "\
+# ty: ignore[division-by-zero] # fmt: off
+x = 20 / 2
+";
+
+    let ty_toml = SystemPath::new("ty.toml");
+    let ty_toml_content = "\
+[rules]
+unused-ignore-comment = \"warn\"
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(ty_toml, ty_toml_content)?
+        .with_file(foo, foo_content)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+
+    let diagnostics = server.document_diagnostic_request(foo, None);
+    let code_action_params = code_actions_at(&server, diagnostics, foo, full_range(foo_content));
+    let code_action_id = server.send_request::<CodeActionRequest>(code_action_params);
+    let code_actions = server.await_response::<CodeActionRequest>(&code_action_id);
+
+    insta::assert_json_snapshot!(code_actions);
+
+    Ok(())
+}
+
+#[test]
 fn no_code_action_for_non_overlapping_range_on_same_line() -> Result<()> {
     let workspace_root = SystemPath::new("src");
     let foo = SystemPath::new("src/foo.py");

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_unsafe_fix.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_unsafe_fix.snap
@@ -1,0 +1,102 @@
+---
+source: crates/ty_server/tests/e2e/code_actions.rs
+expression: code_actions
+---
+[
+  {
+    "title": "Remove the unused suppression comment",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 31
+          }
+        },
+        "severity": 2,
+        "code": "unused-ignore-comment",
+        "codeDescription": {
+          "href": "https://ty.dev/rules#unused-ignore-comment"
+        },
+        "source": "ty",
+        "message": "Unused `ty: ignore` directive\n\nhelp: Remove the unused suppression comment",
+        "tags": [
+          1
+        ]
+      }
+    ],
+    "isPreferred": false,
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/src/foo.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 31
+              }
+            },
+            "newText": ""
+          }
+        ]
+      }
+    }
+  },
+  {
+    "title": "Ignore 'unused-ignore-comment' for this line",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 31
+          }
+        },
+        "severity": 2,
+        "code": "unused-ignore-comment",
+        "codeDescription": {
+          "href": "https://ty.dev/rules#unused-ignore-comment"
+        },
+        "source": "ty",
+        "message": "Unused `ty: ignore` directive\n\nhelp: Remove the unused suppression comment",
+        "tags": [
+          1
+        ]
+      }
+    ],
+    "isPreferred": false,
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/src/foo.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 41
+              },
+              "end": {
+                "line": 0,
+                "character": 41
+              }
+            },
+            "newText": "  # ty: ignore[unused-ignore-comment]"
+          }
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary

From the LSP specification

```
/**
 * Marks this as a preferred action. Preferred actions are used by the
 * `auto fix` command and can be targeted by keybindings.
 *
 * A quick fix should be marked preferred if it properly addresses the
 * underlying error. A refactoring should be marked preferred if it is the
 * most reasonable choice of actions to take.
 *
 * @since 3.15.0
 */
```

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction

I'd argue, that unsafe fixes don't guarantee to address the underlying error *properly*. They likely will, but there's a non-zero chance that they break something. That's why I think using `preferred` for unsafe fixes is the right change here.


The distinction is important, e.g. VS Code uses it to:

> isPreferred is a recommendation, not a safety restriction. Clients decide how to use it. In VS Code:
> - Auto Fix (Shift+Alt+.; macOS ⌥⌘.) considers only preferred quick fixes. It applies one immediately if exactly one is available; otherwise, it offers a choice. Custom keybindings can also request only preferred actions. [Implementation](https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts#L254-L280)
> - The regular Quick Fix menu still includes non-preferred fixes, but generally sorts preferred fixes ahead of them. [Sorting logic](https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/codeAction/browser/codeAction.ts#L38-L80)
> - The lightbulb uses a distinct icon when a preferred quick fix is available. [Lightbulb implementation](https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts)

## Test Plan

Testing: Server tests and pre-commit hooks pass; Clippy is blocked by an existing warning.
