### PR TITLE
[flake8-simplify] Fix false negative for nested async with under a sync with (SIM117)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -163,3 +163,37 @@ async with asyncio.timeout(1):
 async with asyncio.timeout(1), A():
     async with B():
         pass
+
+# Regression test for #27800: an incompatible sync parent should not prevent
+# flagging a combinable pair of `async with` statements nested beneath it.
+with A() as a:
+    # SIM117
+    async with B() as b:
+        async with C() as c:
+            print(a, b, c)
+
+# Same as above, with an extra compatible level nested below. Only the top of
+# the async run is flagged; the inner pair is deferred to a subsequent lint
+# pass, matching the existing top-to-bottom fixing behavior for sync nesting.
+with A() as a:
+    # SIM117
+    async with B() as b:
+        async with C() as c:
+            async with D() as d:
+                print(a, b, c, d)
+
+# A sync/async mismatch deeper in the chain should not suppress a combinable
+# pair further down either.
+async with A() as a:
+    with B() as b:
+        # SIM117
+        async with C() as c:
+            async with D() as d:
+                print(a, b, c, d)
+
+# The `explicit_with_items` exemption should still suppress combination when
+# it directly follows an incompatible sync parent.
+with A() as a:
+    async with asyncio.timeout(1):
+        async with B() as b:
+            print(a, b)

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -123,6 +123,31 @@ fn explicit_with_items(checker: &Checker, with_items: &[WithItem]) -> bool {
         })
 }
 
+/// Returns `true` if a `with` statement using `is_async`/`items` could be combined with an
+/// adjacent, singly-nested `with` statement using `other_is_async`/`other_items`.
+///
+/// The two statements are combinable if they're both sync or both async, and neither one is
+/// exempt via [`explicit_with_items`].
+fn are_combinable(
+    checker: &Checker,
+    is_async: bool,
+    items: &[WithItem],
+    other_is_async: bool,
+    other_items: &[WithItem],
+) -> bool {
+    if is_async != other_is_async {
+        // One of the statements is an async with, while the other is not,
+        // we can't merge those statements.
+        return false;
+    }
+
+    if explicit_with_items(checker, items) || explicit_with_items(checker, other_items) {
+        return false;
+    }
+
+    true
+}
+
 /// SIM117
 pub(crate) fn multiple_with_statements(
     checker: &Checker,
@@ -148,20 +173,36 @@ pub(crate) fn multiple_with_statements(
     //     with B(), C():
     //         print("hello")
     // ```
-    if let Some(Stmt::With(ast::StmtWith { body, .. })) = with_parent {
-        if body.len() == 1 {
+    if let Some(Stmt::With(ast::StmtWith {
+        is_async: parent_is_async,
+        items: parent_items,
+        body: parent_body,
+        ..
+    })) = with_parent
+    {
+        if parent_body.len() == 1
+            && are_combinable(
+                checker,
+                *parent_is_async,
+                parent_items,
+                with_stmt.is_async,
+                &with_stmt.items,
+            )
+        {
+            // The parent statement will already be flagged for combination with `with_stmt`,
+            // so don't also flag `with_stmt` for combination with its own child.
             return;
         }
     }
 
     if let Some((is_async, items, _body)) = next_with(&with_stmt.body) {
-        if is_async != with_stmt.is_async {
-            // One of the statements is an async with, while the other is not,
-            // we can't merge those statements.
-            return;
-        }
-
-        if explicit_with_items(checker, &with_stmt.items) || explicit_with_items(checker, items) {
+        if !are_combinable(
+            checker,
+            with_stmt.is_async,
+            &with_stmt.items,
+            is_async,
+            items,
+        ) {
             return;
         }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -310,4 +310,71 @@ help: Combine `with` statements
     -         pass
 163 + async with asyncio.timeout(1), A(), B():
 164 +     pass
+165 |
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:171:5
+    |
+169 |   with A() as a:
+170 |       # SIM117
+171 | /     async with B() as b:
+172 | |         async with C() as c:
+    | |____________________________^
+173 |               print(a, b, c)
+    |
+help: Combine `with` statements
+    |
+170 |     # SIM117
+    -     async with B() as b:
+    -         async with C() as c:
+    -             print(a, b, c)
+171 +     async with B() as b, C() as c:
+172 +         print(a, b, c)
+173 |
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:180:5
+    |
+178 |   with A() as a:
+179 |       # SIM117
+180 | /     async with B() as b:
+181 | |         async with C() as c:
+    | |____________________________^
+182 |               async with D() as d:
+183 |                   print(a, b, c, d)
+    |
+help: Combine `with` statements
+    |
+179 |     # SIM117
+    -     async with B() as b:
+    -         async with C() as c:
+    -             async with D() as d:
+    -                 print(a, b, c, d)
+180 +     async with B() as b, C() as c:
+181 +         async with D() as d:
+182 +             print(a, b, c, d)
+183 |
+    |
+
+SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   --> SIM117.py:190:9
+    |
+188 |       with B() as b:
+189 |           # SIM117
+190 | /         async with C() as c:
+191 | |             async with D() as d:
+    | |________________________________^
+192 |                   print(a, b, c, d)
+    |
+help: Combine `with` statements
+    |
+189 |         # SIM117
+    -         async with C() as c:
+    -             async with D() as d:
+    -                 print(a, b, c, d)
+190 +         async with C() as c, D() as d:
+191 +             print(a, b, c, d)
+192 |
     |


### PR DESCRIPTION
## Summary

Fixes #27800.

SIM117 wasn't flagging a combinable pair of `async with` statements when they were nested inside an incompatible sync `with` block:

```python
with contextlib.nullcontext() as ctx:
    async with mycontext() as actx1:   # should be flagged, wasn't
        async with mycontext() as actx2:
            print(ctx, actx1, actx2)
```

The parent-skip guard in `multiple_with_statements` bails out early whenever the enclosing `with` statement has exactly one nested statement in its body, on the assumption that the parent will already be flagged for combination with the current statement (this avoids reporting overlapping/conflicting fixes for deeper nesting). That assumption doesn't hold when the parent and current statement can't actually be combined (e.g. one is sync and the other is async) — in that case the parent won't be flagged, but the guard still suppressed the check against the current statement's own child.

The fix factors the combinability check (matching sync/async-ness, and the `explicit_with_items` exemption for things like `asyncio.timeout`) into a shared `are_combinable` helper, and uses it for both the parent-skip guard and the existing child check, so the guard only defers when the parent would actually be flagged.

## Test plan

Added regression cases to `SIM117.py` covering:
- The exact scenario from the issue (sync parent, two combinable async children).
- An extra compatible level nested below, to confirm the top-to-bottom deferral for further nesting still works.
- A sync/async mismatch occurring deeper in the chain rather than at the root.
- The `explicit_with_items` exemption (e.g. `asyncio.timeout`) still suppressing combination right after an incompatible sync parent.

Ran the flake8_simplify test suite and reviewed the updated snapshot diff; also ran clippy and `prek` on the changed files.