### PR TITLE
[`flake8-simplify`] Preserve operand order in `SIM109` fix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM109.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM109.py
@@ -11,7 +11,17 @@ if a == b or a == c or None:
     d
 
 # SIM109
+# Known limitation (see #18945): the unmatched operand falls *between* the
+# two merged comparisons, so it's moved after the merged `in` comparison
+# instead of staying in its original position.
 if a == b or None or a == c:
+    d
+
+# SIM109
+# Regression test for #18945: the unmatched operand precedes both merged
+# comparisons, so it must stay first in the fix instead of being moved
+# after the merged `in` comparison.
+if None or a == b or a == c:
     d
 
 # OK

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::iter;
 
 use itertools::Itertools;
 use ruff_python_ast::{self as ast, Arguments, BoolOp, CmpOp, Expr, ExprContext, UnaryOp};
@@ -89,6 +88,15 @@ impl Violation for DuplicateIsinstanceCall {
 /// if foo in (x, y):
 ///     ...
 /// ```
+///
+/// ## Fix safety
+///
+/// This fix is always unsafe. It may change the value of the expression if any of the
+/// comparators have side effects, and, for expressions that mix equality comparisons with
+/// other operands, it can change the order in which operands are evaluated. Ruff preserves
+/// the original order when an operand falls before or after the group of merged comparisons,
+/// but if an unmatched operand falls *between* two merged comparisons (e.g. `foo == x or bar
+/// or foo == y`), it's moved after the merged `in` comparison.
 ///
 /// ## References
 /// - [Python documentation: Membership test operations](https://docs.python.org/3/reference/expressions.html#membership-test-operations)
@@ -529,6 +537,16 @@ pub(crate) fn compare_with_tuple(checker: &Checker, expr: &Expr) {
             continue;
         }
 
+        // Anchor the replacement expression to the position of the earliest matched
+        // comparator, so that it sorts correctly against any unmatched operands below.
+        let Some(node_range) = comparators
+            .iter()
+            .map(Ranged::range)
+            .min_by_key(Ranged::start)
+        else {
+            continue;
+        };
+
         // Create a `x in (a, b)` expression.
         let node = ast::ExprTuple {
             elts: comparators.into_iter().cloned().collect(),
@@ -547,7 +565,7 @@ pub(crate) fn compare_with_tuple(checker: &Checker, expr: &Expr) {
             left: Box::new(node1.into()),
             ops: Box::from([CmpOp::In]),
             comparators: Box::from([node.into()]),
-            range: TextRange::default(),
+            range: node_range,
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         };
         let in_expr = node2.into();
@@ -557,7 +575,7 @@ pub(crate) fn compare_with_tuple(checker: &Checker, expr: &Expr) {
             },
             expr.range(),
         );
-        let unmatched: Vec<Expr> = values
+        let mut unmatched: Vec<Expr> = values
             .iter()
             .enumerate()
             .filter(|(index, _)| !indices.contains(index))
@@ -566,10 +584,13 @@ pub(crate) fn compare_with_tuple(checker: &Checker, expr: &Expr) {
         let in_expr = if unmatched.is_empty() {
             in_expr
         } else {
-            // Wrap in a `x in (a, b) or ...` boolean operation.
+            // Wrap in a `x in (a, b) or ...` boolean operation, preserving the original
+            // left-to-right order of the replacement and any unmatched operands.
+            unmatched.push(in_expr);
+            unmatched.sort_by_key(Ranged::start);
             let node = ast::ExprBoolOp {
                 op: BoolOp::Or,
-                values: iter::once(in_expr).chain(unmatched).collect(),
+                values: unmatched,
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             };

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
@@ -53,18 +53,37 @@ help: Replace with `a in (b, c)`
 note: This is an unsafe fix and may change runtime behavior
 
 SIM109 [*] Use `a in (b, c)` instead of multiple equality comparisons
-  --> SIM109.py:14:4
+  --> SIM109.py:17:4
    |
-13 | # SIM109
-14 | if a == b or None or a == c:
+15 | # two merged comparisons, so it's moved after the merged `in` comparison
+16 | # instead of staying in its original position.
+17 | if a == b or None or a == c:
    |    ^^^^^^^^^^^^^^^^^^^^^^^^
-15 |     d
+18 |     d
    |
 help: Replace with `a in (b, c)`
    |
-13 | # SIM109
+16 | # instead of staying in its original position.
    - if a == b or None or a == c:
-14 + if a in (b, c) or None:
-15 |     d
+17 + if a in (b, c) or None:
+18 |     d
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+SIM109 [*] Use `a in (b, c)` instead of multiple equality comparisons
+  --> SIM109.py:24:4
+   |
+22 | # comparisons, so it must stay first in the fix instead of being moved
+23 | # after the merged `in` comparison.
+24 | if None or a == b or a == c:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^
+25 |     d
+   |
+help: Replace with `a in (b, c)`
+   |
+23 | # after the merged `in` comparison.
+   - if None or a == b or a == c:
+24 + if None or a in (b, c):
+25 |     d
    |
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Fixes #18945.

`compare-with-tuple` (SIM109) merges repeated equality checks against the same target into a single `in` comparison, e.g. `a == b or a == c` becomes `a in (b, c)`. When the boolean expression also contains unrelated operands, the fix always placed the merged `in` comparison first and appended the unmatched operands after it, regardless of where they originally appeared. That reorders the expression and can change its value under short-circuit evaluation:

```python
x = None
y = "y"
z = "z"
w = "w"
print(x or y == z or y == w)  # False
```

was fixed to:

```python
print(y in (z, w) or x)  # None
```

## Fix

The merged `in` comparison is now anchored to the position of its earliest matched comparator, and sorted together with the unmatched operands by position instead of always being placed first. This preserves the original order for operands that appear before or after the group of merged comparisons.

There's one case this doesn't fully solve: if an unmatched operand sits *between* two merged comparisons (e.g. `a == b or None or a == c`), there's no reordering that keeps both the merged comparison contiguous and every operand in its original position, so it's still moved after the merged comparison. I've documented this as a known limitation in the rule's `## Fix safety` section, along with a regression test that pins down the current (documented) behavior.

This follows the approach @ntBre sketched in review on the earlier attempt at this fix (#19753, closed for inactivity).

## Test plan

- Extended `SIM109.py` with a regression case for the exact scenario from the issue (unmatched operand before the merged comparisons) and kept/annotated the existing case that demonstrates the documented limitation (unmatched operand between merged comparisons).
- Reviewed the updated snapshot diff.
- Ran the flake8_simplify test suite, clippy, and `cargo dev generate-all` (doc comment change).