### PR TITLE
[ty] Support unpacking tuple type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -23,6 +23,50 @@ def f() -> None:
     reveal_type(x)  # revealed: int | str
 ```
 
+## Unpacking tuple aliases
+
+Both unpack spellings accept a tuple alias and preserve positional argument types and arity.
+
+```py
+from typing import Unpack
+
+type Pair = tuple[int, str]
+
+def starred(*args: *Pair) -> None:
+    reveal_type(args)  # revealed: tuple[int, str]
+
+def explicit(*args: Unpack[Pair]) -> None:
+    reveal_type(args)  # revealed: tuple[int, str]
+
+starred(1, "a")
+starred(1)  # error: [missing-argument]
+starred(1, 2)  # error: [invalid-argument-type]
+explicit(1, "a")
+explicit(1, "a", 3)  # error: [too-many-positional-arguments]
+```
+
+Unpacking also follows alias chains and applies generic substitutions.
+
+```py
+type GenericPair[T] = tuple[T, str]
+type SpecializedPair = GenericPair[bytes]
+
+def specialized(*args: *SpecializedPair) -> None:
+    reveal_type(args)  # revealed: tuple[bytes, str]
+
+specialized(b"a", "b")
+specialized(1, "a")  # error: [invalid-argument-type]
+```
+
+Non-tuple aliases remain invalid.
+
+```py
+type NotTuple = list[int]
+
+def invalid_starred(*args: *NotTuple) -> None: ...  # error: [invalid-type-form]
+def invalid_explicit(*args: Unpack[NotTuple]) -> None: ...  # error: [invalid-type-form]
+```
+
 ## Runtime classes
 
 On Python 3.12, aliases defined by a `type` statement or the `typing.TypeAliasType` constructor are

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -23,50 +23,6 @@ def f() -> None:
     reveal_type(x)  # revealed: int | str
 ```
 
-## Unpacking tuple aliases
-
-Both unpack spellings accept a tuple alias and preserve positional argument types and arity.
-
-```py
-from typing import Unpack
-
-type Pair = tuple[int, str]
-
-def starred(*args: *Pair) -> None:
-    reveal_type(args)  # revealed: tuple[int, str]
-
-def explicit(*args: Unpack[Pair]) -> None:
-    reveal_type(args)  # revealed: tuple[int, str]
-
-starred(1, "a")
-starred(1)  # error: [missing-argument]
-starred(1, 2)  # error: [invalid-argument-type]
-explicit(1, "a")
-explicit(1, "a", 3)  # error: [too-many-positional-arguments]
-```
-
-Unpacking also follows alias chains and applies generic substitutions.
-
-```py
-type GenericPair[T] = tuple[T, str]
-type SpecializedPair = GenericPair[bytes]
-
-def specialized(*args: *SpecializedPair) -> None:
-    reveal_type(args)  # revealed: tuple[bytes, str]
-
-specialized(b"a", "b")
-specialized(1, "a")  # error: [invalid-argument-type]
-```
-
-Non-tuple aliases remain invalid.
-
-```py
-type NotTuple = list[int]
-
-def invalid_starred(*args: *NotTuple) -> None: ...  # error: [invalid-type-form]
-def invalid_explicit(*args: Unpack[NotTuple]) -> None: ...  # error: [invalid-type-form]
-```
-
 ## Runtime classes
 
 On Python 3.12, aliases defined by a `type` statement or the `typing.TypeAliasType` constructor are
@@ -298,6 +254,50 @@ except Exception:
 
 def f(x: Foo[int]):
     reveal_type(x.foo())  # revealed: int
+```
+
+## Unpacking tuple aliases
+
+Both unpack spellings accept a tuple alias and preserve positional argument types and arity.
+
+```py
+from typing import Unpack
+
+type Pair = tuple[int, str]
+
+def starred(*args: *Pair) -> None:
+    reveal_type(args)  # revealed: tuple[int, str]
+
+def explicit(*args: Unpack[Pair]) -> None:
+    reveal_type(args)  # revealed: tuple[int, str]
+
+starred(1, "a")
+starred(1)  # error: [missing-argument]
+starred(1, 2)  # error: [invalid-argument-type]
+explicit(1, "a")
+explicit(1, "a", 3)  # error: [too-many-positional-arguments]
+```
+
+Unpacking also follows alias chains and applies generic substitutions.
+
+```py
+type GenericPair[T] = tuple[T, str]
+type SpecializedPair = GenericPair[bytes]
+
+def specialized(*args: *SpecializedPair) -> None:
+    reveal_type(args)  # revealed: tuple[bytes, str]
+
+specialized(b"a", "b")
+specialized(1, "a")  # error: [invalid-argument-type]
+```
+
+Non-tuple aliases remain invalid.
+
+```py
+type NotTuple = list[int]
+
+def invalid_starred(*args: *NotTuple) -> None: ...  # error: [invalid-type-form]
+def invalid_explicit(*args: Unpack[NotTuple]) -> None: ...  # error: [invalid-type-form]
 ```
 
 ## Stringified values

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -970,7 +970,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .context
             .inference_flags
             .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
-        let starred_type = self.infer_type_expression(value);
+        let starred_type = self.infer_type_expression(value).resolve_type_alias(db);
         self.context.inference_flags.set(
             InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
             previously_in_unpack_type_argument,
@@ -2542,6 +2542,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 {
                     return inner_ty;
                 }
+
+                let inner_ty = inner_ty.resolve_type_alias(db);
 
                 // Preserve valid unpack targets so that `Unpack[...]` follows the same
                 // argument-binding path as an equivalent starred annotation.


### PR DESCRIPTION
## Summary

Resolve type aliases before validating `*Alias` and `Unpack[Alias]`. The unpack checker previously rejected PEP 695 alias wrappers instead of inspecting their underlying tuple types, producing false positives and losing argument checking.

## Tests

Add focused coverage for both unpack spellings, argument types and arity, specialized alias chains, and invalid non-tuple aliases.