### PR TITLE
[`flake8-use-pathlib`] Suppress file descriptor false positives for `os.stat` wrappers

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -100,6 +100,24 @@ os.chmod(p, dir_fd=7)
 os.chmod(8)
 os.chmod(x)
 
+# https://github.com/astral-sh/ruff/issues/17699
+# `getsize`/`getatime`/`getmtime`/`getctime`/`isdir`/`isfile`/`exists`/`samefile` all
+# delegate to `os.stat`, so they also accept a file descriptor in place of a path,
+# which `pathlib` doesn't support.
+os.path.getsize(8)
+os.path.getatime(8)
+os.path.getmtime(8)
+os.path.getctime(8)
+os.path.isdir(8)
+os.path.isfile(8)
+os.path.exists(8)
+os.path.samefile(8, "b")
+os.path.samefile("a", 8)
+
+# `islink` uses `os.lstat`, which doesn't accept a file descriptor, so it should
+# still be flagged.
+os.path.islink(8)
+
 # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
 os.replace("src", "dst", src_dir_fd=1, dst_dir_fd=2)
 os.replace("src", "dst", src_dir_fd=1)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_exists.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_exists.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_exists_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    check_os_pathlib_single_arg_calls, is_file_descriptor,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -63,6 +65,16 @@ impl Violation for OsPathExists {
 /// PTH110
 pub(crate) fn os_path_exists(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "exists"] {
+        return;
+    }
+
+    // `os.path.exists` delegates to `os.stat`, so it also accepts a file descriptor, which
+    // `pathlib` doesn't support.
+    if call
+        .arguments
+        .find_argument_value("path", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getatime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    check_os_pathlib_single_arg_calls, is_file_descriptor,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -66,6 +68,16 @@ impl Violation for OsPathGetatime {
 /// PTH203
 pub(crate) fn os_path_getatime(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "getatime"] {
+        return;
+    }
+
+    // `os.path.getatime` delegates to `os.stat`, so it also accepts a file descriptor, which
+    // `pathlib` doesn't support.
+    if call
+        .arguments
+        .find_argument_value("filename", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getctime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    check_os_pathlib_single_arg_calls, is_file_descriptor,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -67,6 +69,16 @@ impl Violation for OsPathGetctime {
 /// PTH205
 pub(crate) fn os_path_getctime(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "getctime"] {
+        return;
+    }
+
+    // `os.path.getctime` delegates to `os.stat`, so it also accepts a file descriptor, which
+    // `pathlib` doesn't support.
+    if call
+        .arguments
+        .find_argument_value("filename", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getmtime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    check_os_pathlib_single_arg_calls, is_file_descriptor,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -67,6 +69,16 @@ impl Violation for OsPathGetmtime {
 /// PTH204
 pub(crate) fn os_path_getmtime(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "getmtime"] {
+        return;
+    }
+
+    // `os.path.getmtime` delegates to `os.stat`, so it also accepts a file descriptor, which
+    // `pathlib` doesn't support.
+    if call
+        .arguments
+        .find_argument_value("filename", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getsize_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    check_os_pathlib_single_arg_calls, is_file_descriptor,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -67,6 +69,16 @@ impl Violation for OsPathGetsize {
 /// PTH202
 pub(crate) fn os_path_getsize(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "getsize"] {
+        return;
+    }
+
+    // `os.path.getsize` delegates to `os.stat`, so it also accepts a file descriptor, which
+    // `pathlib` doesn't support.
+    if call
+        .arguments
+        .find_argument_value("filename", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isdir.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isdir.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_isdir_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    check_os_pathlib_single_arg_calls, is_file_descriptor,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -64,6 +66,16 @@ impl Violation for OsPathIsdir {
 /// PTH112
 pub(crate) fn os_path_isdir(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "isdir"] {
+        return;
+    }
+
+    // `os.path.isdir` delegates to `os.stat`, so it also accepts a file descriptor, which
+    // `pathlib` doesn't support.
+    if call
+        .arguments
+        .find_argument_value("s", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isfile.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isfile.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_isfile_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    check_os_pathlib_single_arg_calls, is_file_descriptor,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -64,6 +66,16 @@ impl Violation for OsPathIsfile {
 /// PTH113
 pub(crate) fn os_path_isfile(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "isfile"] {
+        return;
+    }
+
+    // `os.path.isfile` delegates to `os.stat`, so it also accepts a file descriptor, which
+    // `pathlib` doesn't support.
+    if call
+        .arguments
+        .find_argument_value("path", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_samefile.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_samefile.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::ExprCall;
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_samefile_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    check_os_pathlib_two_arg_calls, has_unknown_keywords_or_starred_expr,
+    check_os_pathlib_two_arg_calls, has_unknown_keywords_or_starred_expr, is_file_descriptor,
 };
 use crate::{FixAvailability, Violation};
 
@@ -67,6 +67,20 @@ impl Violation for OsPathSamefile {
 /// PTH121
 pub(crate) fn os_path_samefile(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "samefile"] {
+        return;
+    }
+
+    // `os.path.samefile` delegates to `os.stat` for both arguments, so either one may be a
+    // file descriptor, which `pathlib` doesn't support.
+    if call
+        .arguments
+        .find_argument_value("f1", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+        || call
+            .arguments
+            .find_argument_value("f2", 1)
+            .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__full_name.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__full_name.py.snap
@@ -412,228 +412,240 @@ PTH123 `open()` should be replaced by `Path.open()`
    |
 help: Replace with `Path.open()`
 
-PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:108:1
+PTH114 `os.path.islink()` should be replaced by `Path.is_symlink()`
+   --> full_name.py:119:1
     |
-106 | os.replace("src", "dst", dst_dir_fd=2)
-107 |
-108 | os.getcwd()
-    | ^^^^^^^^^
-109 | os.getcwdb()
-    |
-help: Replace with `Path.cwd()`
-
-PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:109:1
-    |
-108 | os.getcwd()
-109 | os.getcwdb()
-    | ^^^^^^^^^^
-110 |
-111 | os.mkdir(path="directory")
-    |
-help: Replace with `Path.cwd()`
-
-PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:111:1
-    |
-109 | os.getcwdb()
-110 |
-111 | os.mkdir(path="directory")
-    | ^^^^^^^^
-112 |
-113 | os.mkdir(
-    |
-help: Replace with `Path(...).mkdir()`
-
-PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:113:1
-    |
-111 | os.mkdir(path="directory")
-112 |
-113 | os.mkdir(
-    | ^^^^^^^^
-114 |     # comment 1
-115 |     "directory",
-    |
-help: Replace with `Path(...).mkdir()`
-
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:121:1
-    |
-119 | os.mkdir("directory", mode=0o777, dir_fd=1)
+117 | # `islink` uses `os.lstat`, which doesn't accept a file descriptor, so it should
+118 | # still be flagged.
+119 | os.path.islink(8)
+    | ^^^^^^^^^^^^^^
 120 |
-121 | os.makedirs("name", 0o777, exist_ok=False)
-    | ^^^^^^^^^^^
-122 |
-123 | os.makedirs("name", 0o777, False)
+121 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
     |
-help: Replace with `Path(...).mkdir(parents=True)`
+help: Replace with `Path(...).is_symlink()`
 
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:123:1
+PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:126:1
     |
-121 | os.makedirs("name", 0o777, exist_ok=False)
-122 |
-123 | os.makedirs("name", 0o777, False)
-    | ^^^^^^^^^^^
-124 |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+124 | os.replace("src", "dst", dst_dir_fd=2)
+125 |
+126 | os.getcwd()
+    | ^^^^^^^^^
+127 | os.getcwdb()
     |
-help: Replace with `Path(...).mkdir(parents=True)`
+help: Replace with `Path.cwd()`
 
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:125:1
-    |
-123 | os.makedirs("name", 0o777, False)
-124 |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-    | ^^^^^^^^^^^
-126 |
-127 | os.makedirs("name", unknown_kwarg=True)
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
    --> full_name.py:127:1
     |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-126 |
-127 | os.makedirs("name", unknown_kwarg=True)
-    | ^^^^^^^^^^^
+126 | os.getcwd()
+127 | os.getcwdb()
+    | ^^^^^^^^^^
 128 |
-129 | # https://github.com/astral-sh/ruff/issues/20134
+129 | os.mkdir(path="directory")
+    |
+help: Replace with `Path.cwd()`
+
+PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
+   --> full_name.py:129:1
+    |
+127 | os.getcwdb()
+128 |
+129 | os.mkdir(path="directory")
+    | ^^^^^^^^
+130 |
+131 | os.mkdir(
+    |
+help: Replace with `Path(...).mkdir()`
+
+PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
+   --> full_name.py:131:1
+    |
+129 | os.mkdir(path="directory")
+130 |
+131 | os.mkdir(
+    | ^^^^^^^^
+132 |     # comment 1
+133 |     "directory",
+    |
+help: Replace with `Path(...).mkdir()`
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:139:1
+    |
+137 | os.mkdir("directory", mode=0o777, dir_fd=1)
+138 |
+139 | os.makedirs("name", 0o777, exist_ok=False)
+    | ^^^^^^^^^^^
+140 |
+141 | os.makedirs("name", 0o777, False)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:141:1
+    |
+139 | os.makedirs("name", 0o777, exist_ok=False)
+140 |
+141 | os.makedirs("name", 0o777, False)
+    | ^^^^^^^^^^^
+142 |
+143 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:143:1
+    |
+141 | os.makedirs("name", 0o777, False)
+142 |
+143 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+    | ^^^^^^^^^^^
+144 |
+145 | os.makedirs("name", unknown_kwarg=True)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:145:1
+    |
+143 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+144 |
+145 | os.makedirs("name", unknown_kwarg=True)
+    | ^^^^^^^^^^^
+146 |
+147 | # https://github.com/astral-sh/ruff/issues/20134
     |
 help: Replace with `Path(...).mkdir(parents=True)`
 
 PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:130:1
+   --> full_name.py:148:1
     |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+147 | # https://github.com/astral-sh/ruff/issues/20134
+148 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
     | ^^^^^^^^
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+149 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
     |
 help: Replace with `Path(...).chmod(...)`
 
 PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:131:1
+   --> full_name.py:149:1
     |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+147 | # https://github.com/astral-sh/ruff/issues/20134
+148 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+149 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
     | ^^^^^^^^
-132 |
-133 | # Only diagnostic
+150 |
+151 | # Only diagnostic
     |
 help: Replace with `Path(...).chmod(...)`
 
 PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:134:1
+   --> full_name.py:152:1
     |
-133 | # Only diagnostic
-134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+151 | # Only diagnostic
+152 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^
-135 |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+153 |
+154 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).chmod(...)`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:136:1
+   --> full_name.py:154:1
     |
-134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-135 |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+152 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+153 |
+154 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+155 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:137:1
+   --> full_name.py:155:1
     |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+154 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+155 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^
-138 |
-139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+156 |
+157 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH121 `os.path.samefile()` should be replaced by `Path.samefile()`
-   --> full_name.py:139:1
+   --> full_name.py:157:1
     |
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
-138 |
-139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+155 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+156 |
+157 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^^^^^^^
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
+158 |
+159 | # See: https://github.com/astral-sh/ruff/issues/21794
     |
 help: Replace with `Path(...).samefile()`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:144:4
+   --> full_name.py:162:4
     |
-142 | import sys
-143 |
-144 | if os.rename("pth1.py", "pth1.py.bak"):
+160 | import sys
+161 |
+162 | if os.rename("pth1.py", "pth1.py.bak"):
     |    ^^^^^^^^^
-145 |     print("rename: truthy")
-146 | else:
+163 |     print("rename: truthy")
+164 | else:
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:149:4
+   --> full_name.py:167:4
     |
-147 |     print("rename: falsey")
-148 |
-149 | if os.replace("pth1.py.bak", "pth1.py"):
+165 |     print("rename: falsey")
+166 |
+167 | if os.replace("pth1.py.bak", "pth1.py"):
     |    ^^^^^^^^^^
-150 |     print("replace: truthy")
-151 | else:
+168 |     print("replace: truthy")
+169 | else:
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:155:14
+   --> full_name.py:173:14
     |
-154 | try:
-155 |     for _ in os.getcwd():
+172 | try:
+173 |     for _ in os.getcwd():
     |              ^^^^^^^^^
-156 |         print("getcwd: iterable")
-157 |         break
+174 |         print("getcwd: iterable")
+175 |         break
     |
 help: Replace with `Path.cwd()`
 
 PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:162:14
+   --> full_name.py:180:14
     |
-161 | try:
-162 |     for _ in os.getcwdb():
+179 | try:
+180 |     for _ in os.getcwdb():
     |              ^^^^^^^^^^
-163 |         print("getcwdb: iterable")
-164 |         break
+181 |         print("getcwdb: iterable")
+182 |         break
     |
 help: Replace with `Path.cwd()`
 
 PTH115 `os.readlink()` should be replaced by `Path.readlink()`
-   --> full_name.py:169:14
+   --> full_name.py:187:14
     |
-168 | try:
-169 |     for _ in os.readlink(sys.executable):
+186 | try:
+187 |     for _ in os.readlink(sys.executable):
     |              ^^^^^^^^^^^
-170 |         print("readlink: iterable")
-171 |         break
+188 |         print("readlink: iterable")
+189 |         break
     |
 help: Replace with `Path(...).readlink()`
 
 PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:187:1
+   --> full_name.py:205:1
     |
-186 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
-187 | os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
+204 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
+205 | os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
     | ^^^^^^^^
 help: Replace with `Path(...).chmod(...)`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_full_name.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_full_name.py.snap
@@ -648,14 +648,36 @@ help: Replace with `Path.open()`
 73 |
    |
 
-PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:108:1
+PTH114 [*] `os.path.islink()` should be replaced by `Path.is_symlink()`
+   --> full_name.py:119:1
     |
-106 | os.replace("src", "dst", dst_dir_fd=2)
-107 |
-108 | os.getcwd()
+117 | # `islink` uses `os.lstat`, which doesn't accept a file descriptor, so it should
+118 | # still be flagged.
+119 | os.path.islink(8)
+    | ^^^^^^^^^^^^^^
+120 |
+121 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
+    |
+help: Replace with `Path(...).is_symlink()`
+    |
+2   | import os.path
+3   + import pathlib
+4   |
+--------------------------------------------------------------------------------
+119 | # still be flagged.
+    - os.path.islink(8)
+120 + pathlib.Path(8).is_symlink()
+121 |
+    |
+
+PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:126:1
+    |
+124 | os.replace("src", "dst", dst_dir_fd=2)
+125 |
+126 | os.getcwd()
     | ^^^^^^^^^
-109 | os.getcwdb()
+127 | os.getcwdb()
     |
 help: Replace with `Path.cwd()`
     |
@@ -663,20 +685,20 @@ help: Replace with `Path.cwd()`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-108 |
+126 |
     - os.getcwd()
-109 + pathlib.Path.cwd()
-110 | os.getcwdb()
+127 + pathlib.Path.cwd()
+128 | os.getcwdb()
     |
 
 PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:109:1
+   --> full_name.py:127:1
     |
-108 | os.getcwd()
-109 | os.getcwdb()
+126 | os.getcwd()
+127 | os.getcwdb()
     | ^^^^^^^^^^
-110 |
-111 | os.mkdir(path="directory")
+128 |
+129 | os.mkdir(path="directory")
     |
 help: Replace with `Path.cwd()`
     |
@@ -684,21 +706,21 @@ help: Replace with `Path.cwd()`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-109 | os.getcwd()
+127 | os.getcwd()
     - os.getcwdb()
-110 + pathlib.Path.cwd()
-111 |
+128 + pathlib.Path.cwd()
+129 |
     |
 
 PTH102 [*] `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:111:1
+   --> full_name.py:129:1
     |
-109 | os.getcwdb()
-110 |
-111 | os.mkdir(path="directory")
+127 | os.getcwdb()
+128 |
+129 | os.mkdir(path="directory")
     | ^^^^^^^^
-112 |
-113 | os.mkdir(
+130 |
+131 | os.mkdir(
     |
 help: Replace with `Path(...).mkdir()`
     |
@@ -706,21 +728,21 @@ help: Replace with `Path(...).mkdir()`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-111 |
+129 |
     - os.mkdir(path="directory")
-112 + pathlib.Path("directory").mkdir()
-113 |
+130 + pathlib.Path("directory").mkdir()
+131 |
     |
 
 PTH102 [*] `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:113:1
+   --> full_name.py:131:1
     |
-111 | os.mkdir(path="directory")
-112 |
-113 | os.mkdir(
+129 | os.mkdir(path="directory")
+130 |
+131 | os.mkdir(
     | ^^^^^^^^
-114 |     # comment 1
-115 |     "directory",
+132 |     # comment 1
+133 |     "directory",
     |
 help: Replace with `Path(...).mkdir()`
     |
@@ -728,26 +750,26 @@ help: Replace with `Path(...).mkdir()`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-113 |
+131 |
     - os.mkdir(
     -     # comment 1
     -     "directory",
     -     mode=0o777
     - )
-114 + pathlib.Path("directory").mkdir(mode=0o777)
-115 |
+132 + pathlib.Path("directory").mkdir(mode=0o777)
+133 |
     |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:121:1
+   --> full_name.py:139:1
     |
-119 | os.mkdir("directory", mode=0o777, dir_fd=1)
-120 |
-121 | os.makedirs("name", 0o777, exist_ok=False)
+137 | os.mkdir("directory", mode=0o777, dir_fd=1)
+138 |
+139 | os.makedirs("name", 0o777, exist_ok=False)
     | ^^^^^^^^^^^
-122 |
-123 | os.makedirs("name", 0o777, False)
+140 |
+141 | os.makedirs("name", 0o777, False)
     |
 help: Replace with `Path(...).mkdir(parents=True)`
     |
@@ -755,21 +777,21 @@ help: Replace with `Path(...).mkdir(parents=True)`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-121 |
+139 |
     - os.makedirs("name", 0o777, exist_ok=False)
-122 + pathlib.Path("name").mkdir(0o777, exist_ok=False, parents=True)
-123 |
+140 + pathlib.Path("name").mkdir(0o777, exist_ok=False, parents=True)
+141 |
     |
 
 PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:123:1
+   --> full_name.py:141:1
     |
-121 | os.makedirs("name", 0o777, exist_ok=False)
-122 |
-123 | os.makedirs("name", 0o777, False)
+139 | os.makedirs("name", 0o777, exist_ok=False)
+140 |
+141 | os.makedirs("name", 0o777, False)
     | ^^^^^^^^^^^
-124 |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+142 |
+143 | os.makedirs(name="name", mode=0o777, exist_ok=False)
     |
 help: Replace with `Path(...).mkdir(parents=True)`
     |
@@ -777,21 +799,21 @@ help: Replace with `Path(...).mkdir(parents=True)`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-123 |
+141 |
     - os.makedirs("name", 0o777, False)
-124 + pathlib.Path("name").mkdir(0o777, True, False)
-125 |
+142 + pathlib.Path("name").mkdir(0o777, True, False)
+143 |
     |
 
 PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:125:1
+   --> full_name.py:143:1
     |
-123 | os.makedirs("name", 0o777, False)
-124 |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+141 | os.makedirs("name", 0o777, False)
+142 |
+143 | os.makedirs(name="name", mode=0o777, exist_ok=False)
     | ^^^^^^^^^^^
-126 |
-127 | os.makedirs("name", unknown_kwarg=True)
+144 |
+145 | os.makedirs("name", unknown_kwarg=True)
     |
 help: Replace with `Path(...).mkdir(parents=True)`
     |
@@ -799,31 +821,31 @@ help: Replace with `Path(...).mkdir(parents=True)`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-125 |
+143 |
     - os.makedirs(name="name", mode=0o777, exist_ok=False)
-126 + pathlib.Path("name").mkdir(mode=0o777, exist_ok=False, parents=True)
-127 |
+144 + pathlib.Path("name").mkdir(mode=0o777, exist_ok=False, parents=True)
+145 |
     |
 
 PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:127:1
+   --> full_name.py:145:1
     |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-126 |
-127 | os.makedirs("name", unknown_kwarg=True)
+143 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+144 |
+145 | os.makedirs("name", unknown_kwarg=True)
     | ^^^^^^^^^^^
-128 |
-129 | # https://github.com/astral-sh/ruff/issues/20134
+146 |
+147 | # https://github.com/astral-sh/ruff/issues/20134
     |
 help: Replace with `Path(...).mkdir(parents=True)`
 
 PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:130:1
+   --> full_name.py:148:1
     |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+147 | # https://github.com/astral-sh/ruff/issues/20134
+148 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
     | ^^^^^^^^
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+149 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
     |
 help: Replace with `Path(...).chmod(...)`
     |
@@ -831,21 +853,21 @@ help: Replace with `Path(...).chmod(...)`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-130 | # https://github.com/astral-sh/ruff/issues/20134
+148 | # https://github.com/astral-sh/ruff/issues/20134
     - os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-131 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=      False)
-132 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+149 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=      False)
+150 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
     |
 
 PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:131:1
+   --> full_name.py:149:1
     |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+147 | # https://github.com/astral-sh/ruff/issues/20134
+148 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+149 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
     | ^^^^^^^^
-132 |
-133 | # Only diagnostic
+150 |
+151 | # Only diagnostic
     |
 help: Replace with `Path(...).chmod(...)`
     |
@@ -853,180 +875,180 @@ help: Replace with `Path(...).chmod(...)`
 3   + import pathlib
 4   |
 --------------------------------------------------------------------------------
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+149 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
     - os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-132 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=True)
-133 |
+150 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=True)
+151 |
     |
 
 PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:134:1
+   --> full_name.py:152:1
     |
-133 | # Only diagnostic
-134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+151 | # Only diagnostic
+152 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^
-135 |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+153 |
+154 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).chmod(...)`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:136:1
+   --> full_name.py:154:1
     |
-134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-135 |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+152 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+153 |
+154 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+155 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:137:1
+   --> full_name.py:155:1
     |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+154 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+155 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^
-138 |
-139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+156 |
+157 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH121 `os.path.samefile()` should be replaced by `Path.samefile()`
-   --> full_name.py:139:1
+   --> full_name.py:157:1
     |
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
-138 |
-139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+155 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+156 |
+157 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^^^^^^^
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
+158 |
+159 | # See: https://github.com/astral-sh/ruff/issues/21794
     |
 help: Replace with `Path(...).samefile()`
 
 PTH104 [*] `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:144:4
+   --> full_name.py:162:4
     |
-142 | import sys
-143 |
-144 | if os.rename("pth1.py", "pth1.py.bak"):
+160 | import sys
+161 |
+162 | if os.rename("pth1.py", "pth1.py.bak"):
     |    ^^^^^^^^^
-145 |     print("rename: truthy")
-146 | else:
+163 |     print("rename: truthy")
+164 | else:
     |
 help: Replace with `Path(...).rename(...)`
     |
-142 | import sys
-143 + import pathlib
-144 |
+160 | import sys
+161 + import pathlib
+162 |
     - if os.rename("pth1.py", "pth1.py.bak"):
-145 + if pathlib.Path("pth1.py").rename("pth1.py.bak"):
-146 |     print("rename: truthy")
+163 + if pathlib.Path("pth1.py").rename("pth1.py.bak"):
+164 |     print("rename: truthy")
     |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH105 [*] `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:149:4
+   --> full_name.py:167:4
     |
-147 |     print("rename: falsey")
-148 |
-149 | if os.replace("pth1.py.bak", "pth1.py"):
+165 |     print("rename: falsey")
+166 |
+167 | if os.replace("pth1.py.bak", "pth1.py"):
     |    ^^^^^^^^^^
-150 |     print("replace: truthy")
-151 | else:
+168 |     print("replace: truthy")
+169 | else:
     |
 help: Replace with `Path(...).replace(...)`
     |
-142 | import sys
-143 + import pathlib
-144 |
+160 | import sys
+161 + import pathlib
+162 |
 --------------------------------------------------------------------------------
-149 |
+167 |
     - if os.replace("pth1.py.bak", "pth1.py"):
-150 + if pathlib.Path("pth1.py.bak").replace("pth1.py"):
-151 |     print("replace: truthy")
+168 + if pathlib.Path("pth1.py.bak").replace("pth1.py"):
+169 |     print("replace: truthy")
     |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:155:14
+   --> full_name.py:173:14
     |
-154 | try:
-155 |     for _ in os.getcwd():
+172 | try:
+173 |     for _ in os.getcwd():
     |              ^^^^^^^^^
-156 |         print("getcwd: iterable")
-157 |         break
+174 |         print("getcwd: iterable")
+175 |         break
     |
 help: Replace with `Path.cwd()`
     |
-142 | import sys
-143 + import pathlib
-144 |
+160 | import sys
+161 + import pathlib
+162 |
 --------------------------------------------------------------------------------
-155 | try:
+173 | try:
     -     for _ in os.getcwd():
-156 +     for _ in pathlib.Path.cwd():
-157 |         print("getcwd: iterable")
+174 +     for _ in pathlib.Path.cwd():
+175 |         print("getcwd: iterable")
     |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:162:14
+   --> full_name.py:180:14
     |
-161 | try:
-162 |     for _ in os.getcwdb():
+179 | try:
+180 |     for _ in os.getcwdb():
     |              ^^^^^^^^^^
-163 |         print("getcwdb: iterable")
-164 |         break
+181 |         print("getcwdb: iterable")
+182 |         break
     |
 help: Replace with `Path.cwd()`
     |
-142 | import sys
-143 + import pathlib
-144 |
+160 | import sys
+161 + import pathlib
+162 |
 --------------------------------------------------------------------------------
-162 | try:
+180 | try:
     -     for _ in os.getcwdb():
-163 +     for _ in pathlib.Path.cwd():
-164 |         print("getcwdb: iterable")
+181 +     for _ in pathlib.Path.cwd():
+182 |         print("getcwdb: iterable")
     |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH115 [*] `os.readlink()` should be replaced by `Path.readlink()`
-   --> full_name.py:169:14
+   --> full_name.py:187:14
     |
-168 | try:
-169 |     for _ in os.readlink(sys.executable):
+186 | try:
+187 |     for _ in os.readlink(sys.executable):
     |              ^^^^^^^^^^^
-170 |         print("readlink: iterable")
-171 |         break
+188 |         print("readlink: iterable")
+189 |         break
     |
 help: Replace with `Path(...).readlink()`
     |
-142 | import sys
-143 + import pathlib
-144 |
+160 | import sys
+161 + import pathlib
+162 |
 --------------------------------------------------------------------------------
-169 | try:
+187 | try:
     -     for _ in os.readlink(sys.executable):
-170 +     for _ in pathlib.Path(sys.executable).readlink():
-171 |         print("readlink: iterable")
+188 +     for _ in pathlib.Path(sys.executable).readlink():
+189 |         print("readlink: iterable")
     |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:187:1
+   --> full_name.py:205:1
     |
-186 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
-187 | os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
+204 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
+205 | os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
     | ^^^^^^^^
 help: Replace with `Path(...).chmod(...)`
     |
-142 | import sys
-143 + import pathlib
-144 |
+160 | import sys
+161 + import pathlib
+162 |
 --------------------------------------------------------------------------------
-187 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
+205 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
     - os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
-188 + pathlib.Path(_AttrHolder.name).chmod(0o644)  # Diagnostic + fix: resolved as `str`
+206 + pathlib.Path(_AttrHolder.name).chmod(0o644)  # Diagnostic + fix: resolved as `str`
     |


### PR DESCRIPTION
## Summary

Part of #17699.

That issue tracks `PTH*` rules that suggest a `pathlib.Path` rewrite even when the code passes a file descriptor, which `pathlib` doesn't support. A few rules already guard against this (`os.chmod`/`os.stat`/`os.listdir`/`open`, via `is_file_descriptor`), but several `os.path.*` wrappers around `os.stat` were still missing the same guard:

```python
import os

fd = os.open(".", os.O_RDONLY)
os.path.getsize(fd)   # PTH202, but this works fine at runtime
```

I checked which of these functions actually accept a file descriptor in practice (some do, transitively, because they're pure-Python wrappers that call `os.stat`/`os.fstat` under the hood, even though that isn't part of their documented signature):

```
>>> os.path.getsize(fd), os.path.getmtime(fd), os.path.isdir(fd), os.path.exists(fd), os.path.samefile(fd, ".")
(4096, ..., True, True, True)
```

`os.path.islink` is the exception here — it goes through `os.lstat`, which does *not* accept a file descriptor, so `Path(...).is_symlink()` remains a correct suggestion there and I left it alone.

I initially also tried a broader sweep (`os.rename`, `os.remove`, `os.unlink`, `os.rmdir`, `os.replace`, `os.readlink`, `os.symlink`) but it turns out none of those functions accept a file descriptor as their path argument at all (`os.rename(fd, "b")` raises `TypeError` immediately), so there's no actual false positive to fix there — I left a comment on the issue with the details.

## Fix

Added the same `is_file_descriptor` check already used elsewhere to `os_path_getsize`, `os_path_getatime`, `os_path_getmtime`, `os_path_getctime`, `os_path_isdir`, `os_path_isfile`, `os_path_exists`, and `os_path_samefile` (both arguments, since either can be a file descriptor there).

## Test plan

- Added regression cases to `full_name.py` covering all 8 fixed rules with a file descriptor argument, plus a case confirming `os.path.islink` is still flagged.
- Reviewed the updated `full_name.py` / `preview_full_name.py` snapshot diffs — only the new cases changed.
- Ran the flake8_use_pathlib test suite and clippy.