### PR TITLE
[ty] Add `untrustedWorkspace` option to the LSP

### DIFF
--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -5,7 +5,7 @@ use crate::PositionEncoding;
 use crate::capabilities::{ResolvedClientCapabilities, server_capabilities};
 use crate::session::{ClientName, InitializationOptions, Session, warn_about_unknown_options};
 use anyhow::Context;
-use lsp_server::Connection;
+use lsp_server::{Connection, ErrorCode, Message, Response};
 use lsp_types::{
     ClientCapabilities, InitializeParams, MessageType, Uri, WorkspaceFolders,
     WorkspaceFoldersInitializeParams,
@@ -56,7 +56,17 @@ impl Server {
             .context("Failed to deserialize initialization parameters")?;
 
         let (initialization_options, deserialization_error) =
-            InitializationOptions::from_value(initialization_options);
+            match InitializationOptions::from_value(initialization_options) {
+                Ok(options) => options,
+                Err(error) => {
+                    connection.sender.send(Message::Response(Response::new_err(
+                        id,
+                        ErrorCode::InvalidParams as i32,
+                        format!("Invalid initialization options: {error:#}"),
+                    )))?;
+                    return Err(error).context("Failed to deserialize initialization options");
+                }
+            };
 
         if !in_test {
             crate::logging::init_logging(
@@ -240,5 +250,86 @@ impl Drop for ServerPanicHookHandler {
         if let Some(hook) = self.hook.take() {
             std::panic::set_hook(hook);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+
+    use lsp_server::{Connection, ErrorCode, Message, Notification, Request};
+    use ruff_db::system::OsSystem;
+    use serde_json::{Value, json};
+
+    use super::Server;
+    use crate::system::WorkspaceTrust;
+
+    #[test]
+    fn malformed_trust_rejects_initialization() -> anyhow::Result<()> {
+        let (connection, client) = initialize_connection(&json!({
+            "untrustedWorkspace": "true",
+            "logLevel": "invalid"
+        }))?;
+        assert!(
+            Server::new(
+                NonZeroUsize::MIN,
+                connection,
+                Arc::new(OsSystem::default()),
+                true,
+            )
+            .is_err()
+        );
+
+        let Message::Response(response) = client.receiver.try_recv()? else {
+            anyhow::bail!("Expected an initialization error response");
+        };
+        assert_eq!(response.id, 1.into());
+        let error = response.response_result.unwrap_err();
+        assert_eq!(error.code, ErrorCode::InvalidParams as i32);
+        assert_eq!(
+            error.message,
+            "Invalid initialization options: Invalid `untrustedWorkspace` setting: \
+             invalid type: string \"true\", expected a boolean",
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_initialization_options_preserve_workspace_trust() -> anyhow::Result<()> {
+        let (connection, _client_connection) = initialize_connection(&json!({
+            "untrustedWorkspace": true,
+            "diagnosticMode": "invalid"
+        }))?;
+        let server = Server::new(
+            NonZeroUsize::MIN,
+            connection,
+            Arc::new(OsSystem::default()),
+            true,
+        )?;
+        assert_eq!(
+            server.session.initialization_options().workspace_trust,
+            WorkspaceTrust::Untrusted,
+        );
+        Ok(())
+    }
+
+    fn initialize_connection(
+        initialization_options: &Value,
+    ) -> anyhow::Result<(Connection, Connection)> {
+        let (server, client) = Connection::memory();
+        client.sender.send(Message::Request(Request::new(
+            1.into(),
+            "initialize".into(),
+            json!({
+                "capabilities": {},
+                "initializationOptions": initialization_options
+            }),
+        )))?;
+        client.sender.send(Message::Notification(Notification::new(
+            "initialized".into(),
+            json!({}),
+        )))?;
+        Ok((server, client))
     }
 }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -187,7 +187,7 @@ impl Session {
         &mut self.request_queue
     }
 
-    fn initialization_options(&self) -> &InitializationOptions {
+    pub(crate) fn initialization_options(&self) -> &InitializationOptions {
         &self.initialization_options
     }
 
@@ -584,6 +584,7 @@ impl Session {
         let system = LSPSystem::new(
             self.index.as_ref().unwrap().clone(),
             self.native_system.clone(),
+            self.initialization_options.workspace_trust,
         );
 
         let configuration_file = workspace.settings.configuration_file();
@@ -2001,12 +2002,14 @@ pub(super) fn warn_about_unknown_options(
 
 #[cfg(test)]
 mod tests {
+    use std::io::ErrorKind;
     use std::sync::Arc;
 
-    use ruff_db::system::{CommandExecutor, OsSystem, System as _};
+    use anyhow::Context;
+    use ruff_db::system::{Command, CommandExecutor, OsSystem, System as _};
 
     use super::Index;
-    use crate::system::LSPSystem;
+    use crate::system::{LSPSystem, WorkspaceTrust};
 
     /// Mutating the document index requires exclusive ownership after Salsa cancels the current
     /// database snapshots. A background command executor must not retain an `LSPSystem`, because
@@ -2014,7 +2017,11 @@ mod tests {
     #[test]
     fn detached_command_executor_does_not_retain_document_index() {
         let index = Arc::new(Index::new());
-        let system = LSPSystem::new(index.clone(), Arc::new(OsSystem::default()));
+        let system = LSPSystem::new(
+            index.clone(),
+            Arc::new(OsSystem::default()),
+            WorkspaceTrust::default(),
+        );
         let executor = system.command_executor().map(CommandExecutor::dyn_clone);
         assert!(executor.is_some());
         drop(system);
@@ -2022,5 +2029,28 @@ mod tests {
         assert_eq!(Arc::strong_count(&index), 1);
 
         drop(executor);
+    }
+
+    #[test]
+    fn detached_untrusted_executor_rejects_commands() -> anyhow::Result<()> {
+        let system = LSPSystem::new(
+            Arc::new(Index::new()),
+            Arc::new(OsSystem::default()),
+            WorkspaceTrust::Untrusted,
+        )
+        .dyn_clone();
+        let executor = system
+            .command_executor()
+            .context("Expected an executor for the untrusted workspace")?
+            .dyn_clone();
+        drop(system);
+
+        let error = executor.execute(Command::new("must-not-run")).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert_eq!(
+            error.to_string(),
+            "external commands are disabled in an untrusted workspace",
+        );
+        Ok(())
     }
 }

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use anyhow::Context;
 use lsp_types::Uri;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_macros::Combine;
@@ -19,6 +20,7 @@ use ty_project::metadata::value::RelativePathBuf;
 use super::settings::{ExperimentalSettings, GlobalSettings, WorkspaceSettings};
 use crate::logging::LogLevel;
 use crate::session::client::Client;
+use crate::system::WorkspaceTrust;
 
 /// Initialization options that are set once at server startup that never change.
 ///
@@ -46,6 +48,16 @@ pub(crate) struct InitializationOptions {
     /// Tildes (`~`) and environment variables (e.g., `$HOME`) are expanded.
     pub(crate) log_file: Option<SystemPathBuf>,
 
+    /// Whether the client trusts the files in this workspace.
+    ///
+    /// This corresponds to VS Code's [Workspace Trust]. `untrustedWorkspace: true`
+    /// means Restricted Mode. The default is `false` (trusted).
+    /// Restart the server to change this setting.
+    ///
+    /// [Workspace Trust]: https://code.visualstudio.com/docs/editing/workspaces/workspace-trust
+    #[serde(default, rename = "untrustedWorkspace")]
+    pub(crate) workspace_trust: WorkspaceTrust,
+
     /// The remaining options that are dynamic and can change during the runtime of the server.
     #[serde(flatten)]
     pub(crate) options: ClientOptions,
@@ -55,18 +67,32 @@ impl InitializationOptions {
     /// Create the initialization options from the given JSON value that corresponds to the
     /// initialization options sent by the client.
     ///
-    /// It returns a tuple of the initialization options and an optional error if the JSON value
-    /// could not be deserialized into the initialization options. In case of an error, the default
-    /// initialization options are returned.
+    /// Invalid settings fall back to defaults, except that the workspace trust setting is
+    /// preserved. An invalid trust setting fails initialization instead of granting trust.
     pub(crate) fn from_value(
         options: Option<Value>,
-    ) -> (InitializationOptions, Option<serde_json::Error>) {
+    ) -> anyhow::Result<(Self, Option<serde_json::Error>)> {
         let Some(options) = options else {
-            return (InitializationOptions::default(), None);
+            return Ok((Self::default(), None));
         };
+
+        // Parse trust separately so an unrelated deserialization error cannot turn an
+        // untrusted workspace into a trusted one.
+        let workspace_trust = match options.get("untrustedWorkspace") {
+            Some(value) => WorkspaceTrust::deserialize(value)
+                .context("Invalid `untrustedWorkspace` setting")?,
+            None => WorkspaceTrust::default(),
+        };
+
         match serde_json::from_value(options) {
-            Ok(options) => (options, None),
-            Err(err) => (InitializationOptions::default(), Some(err)),
+            Ok(options) => Ok((options, None)),
+            Err(error) => Ok((
+                Self {
+                    workspace_trust,
+                    ..Self::default()
+                },
+                Some(error),
+            )),
         }
     }
 }

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher as _};
 use std::panic::RefUnwindSafe;
+use std::process::Output;
 use std::sync::Arc;
 
 use crate::Db;
@@ -13,11 +14,12 @@ use ruff_db::file_revision::FileRevision;
 use ruff_db::files::{File, FilePath};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
-    CommandExecutor, DirectoryEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf,
-    SystemVirtualPath, SystemVirtualPathBuf, WhichResult, WritableSystem,
+    Command, CommandExecutor, DirectoryEntry, FileType, Metadata, Result, System, SystemPath,
+    SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf, WhichResult, WritableSystem,
 };
 use ruff_notebook::{Notebook, NotebookError};
 use ruff_python_ast::PySourceType;
+use serde::{Deserialize, Deserializer};
 use ty_ide::cached_vendored_path;
 
 /// Returns a [`Uri`] for the given [`File`].
@@ -82,16 +84,20 @@ pub(crate) struct LSPSystem {
     /// This is used to delegate method calls that are not handled by the LSP system. It is also
     /// used as a fallback when the documents are not found in the LSP index.
     native_system: Arc<dyn System + 'static + Send + Sync + RefUnwindSafe>,
+
+    workspace_trust: WorkspaceTrust,
 }
 
 impl LSPSystem {
     pub(crate) fn new(
         index: Arc<Index>,
         native_system: Arc<dyn System + 'static + Send + Sync + RefUnwindSafe>,
+        workspace_trust: WorkspaceTrust,
     ) -> Self {
         Self {
             index: Some(index),
             native_system,
+            workspace_trust,
         }
     }
 
@@ -280,11 +286,51 @@ impl System for LSPSystem {
     }
 
     fn command_executor(&self) -> Option<&dyn CommandExecutor> {
-        self.native_system.command_executor()
+        match self.workspace_trust {
+            WorkspaceTrust::Trusted => self.native_system.command_executor(),
+            WorkspaceTrust::Untrusted => Some(&UntrustedWorkspaceExecutor),
+        }
     }
 
     fn dyn_clone(&self) -> Box<dyn System> {
         Box::new(self.clone())
+    }
+}
+
+/// Whether the client trusts the files in the workspace.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum WorkspaceTrust {
+    #[default]
+    Trusted,
+    Untrusted,
+}
+
+impl<'de> Deserialize<'de> for WorkspaceTrust {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // The LSP option is `untrustedWorkspace`, so `true` means untrusted.
+        Ok(match Option::<bool>::deserialize(deserializer)? {
+            Some(true) => Self::Untrusted,
+            Some(false) | None => Self::Trusted,
+        })
+    }
+}
+
+/// Rejects commands without retaining the LSP document index.
+struct UntrustedWorkspaceExecutor;
+
+impl CommandExecutor for UntrustedWorkspaceExecutor {
+    fn execute(&self, _command: Command) -> Result<Output> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "external commands are disabled in an untrusted workspace",
+        ))
+    }
+
+    fn dyn_clone(&self) -> Box<dyn CommandExecutor> {
+        Box::new(Self)
     }
 }
 


### PR DESCRIPTION
## Summary

This is a generic stop-gap solution for https://github.com/astral-sh/ty/issues/4275. 

This PR adds a new `untrustedWorkspace` initialization option and changes the `LSPSystem` to always return an IOError when trying to run a command. This seems like a safe default and is all we need for now. 

If we have a need in the future to run some commands in untrusted workspace, we can then extend `run_command` and add an option to bypass the early return. 

I plan to add dedicated handling of untrusted workspaces for https://github.com/astral-sh/ty/issues/4275 in the scripts LSP, to always disables uv support in an untrusted workspace. Because there's no point in showing an error that running `uv` isn't allowed in untrusted workspace for every script. But I still think this is worth landing independently as a general stop-gap solution for other cases where we might forget to add a dedicated check.

This PR takes extra care that we always respect `untrustedWorkspace`, even if other `initializationOptions` are invalid. I think it would be nice to have a more general system where ty tries to retain as many valid options as possible instead of falling back to the default when any option is invalid, but that felt like a separate change.

## Test Plan

Added tests
