### PR TITLE
[ty] Disambiguate type names across entire diagnostics

### DIFF
--- a/crates/ruff_db/src/diagnostic/message.rs
+++ b/crates/ruff_db/src/diagnostic/message.rs
@@ -1,0 +1,616 @@
+use std::cell::RefCell;
+use std::fmt::{self, Write};
+
+use ruff_text_size::TextSize;
+
+use crate::files::File;
+
+// `fmt::Formatter` does not expose its underlying writer, so semantic `Display` implementations
+// need a scoped transport to associate a name with the diagnostic message currently being written.
+// This is not persistent Salsa query state: each synchronous `from_display` call owns one stack
+// frame, nested calls receive independent frames, and `Drop` removes a frame even during unwinding.
+// Captured names contain only owned data and are resolved before a diagnostic is retained by Salsa.
+thread_local! {
+    static MESSAGE_CAPTURES: RefCell<Vec<MessageCapture>> = const { RefCell::new(Vec::new()) };
+}
+
+/// The semantic category of a named item embedded in a diagnostic message.
+///
+/// Classes and aliases can have the same spelling and source position while still denoting
+/// different items, so their category participates in their identity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
+pub enum DiagnosticNameKind {
+    Class,
+    TypeAlias,
+}
+
+/// The identity and alternative spellings of a name displayed in a diagnostic.
+///
+/// This representation is deliberately independent of Salsa database lifetimes. It is retained
+/// only while a diagnostic is assembled and discarded once its messages have been resolved.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
+pub struct DiagnosticName {
+    spelling: Box<str>,
+    qualified: Box<str>,
+    file: File,
+    offset: TextSize,
+    kind: DiagnosticNameKind,
+}
+
+impl DiagnosticName {
+    pub fn new(
+        spelling: impl Into<Box<str>>,
+        qualified: impl Into<Box<str>>,
+        file: File,
+        offset: TextSize,
+        kind: DiagnosticNameKind,
+    ) -> Self {
+        Self {
+            spelling: spelling.into(),
+            qualified: qualified.into(),
+            file,
+            offset,
+            kind,
+        }
+    }
+
+    pub(super) fn spelling(&self) -> &str {
+        &self.spelling
+    }
+
+    pub(super) fn qualified(&self) -> &str {
+        &self.qualified
+    }
+
+    pub(super) fn file(&self) -> File {
+        self.file
+    }
+
+    pub(super) fn offset(&self) -> TextSize {
+        self.offset
+    }
+
+    pub(super) fn has_same_identity(&self, other: &Self) -> bool {
+        self.file == other.file && self.offset == other.offset && self.kind == other.kind
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
+pub(super) struct DiagnosticNameOccurrence {
+    start: usize,
+    end: usize,
+    name: DiagnosticName,
+    replace_when_ambiguous: bool,
+}
+
+impl DiagnosticNameOccurrence {
+    pub(super) fn name(&self) -> &DiagnosticName {
+        &self.name
+    }
+}
+
+#[derive(Debug, Default)]
+struct MessageCapture {
+    offset: usize,
+    names: Vec<DiagnosticNameOccurrence>,
+}
+
+/// A semantic name and the formatting operation that displays it.
+///
+/// The named fields distinguish the formatting operation from its lazily constructed metadata.
+#[derive(Debug)]
+pub struct DiagnosticNameRecord<Render, Name> {
+    /// Writes the name into the current formatter.
+    pub render: Render,
+    /// Constructs identifying metadata only when a diagnostic message records this output.
+    pub name: Name,
+}
+
+impl<Render, Name> DiagnosticNameRecord<Render, Name>
+where
+    Render: FnOnce() -> fmt::Result,
+    Name: FnOnce() -> DiagnosticName,
+{
+    /// Records this name when its formatting operation writes into a diagnostic message.
+    ///
+    /// Ordinary displays, including IDE displays and tests, do not construct semantic metadata.
+    pub fn render(self) -> fmt::Result {
+        self.render_impl(true)
+    }
+
+    /// Records a semantic name without changing its displayed spelling during disambiguation.
+    ///
+    /// For example, `<module 'os'>` identifies Python's module class. Its `module` spelling should
+    /// disambiguate a user-defined `module` class without changing the conventional representation.
+    pub fn render_fixed(self) -> fmt::Result {
+        self.render_impl(false)
+    }
+
+    fn render_impl(self, replace_when_ambiguous: bool) -> fmt::Result {
+        let Self { render, name } = self;
+        // Either callback can evaluate Salsa queries or format another diagnostic, so no borrow
+        // of the capture stack may remain active while a callback runs.
+        let Some(start) = MESSAGE_CAPTURES
+            .with(|captures| captures.borrow().last().map(|capture| capture.offset))
+        else {
+            return render();
+        };
+
+        render()?;
+
+        let end = MESSAGE_CAPTURES
+            .with(|captures| captures.borrow().last().map(|capture| capture.offset));
+
+        // A nested `format!` writes into its own buffer, not this message's writer. Its output
+        // cannot be associated with a range until the caller preserves it as a DiagnosticMessage.
+        if let Some(end) = end
+            && end > start
+        {
+            let occurrence = DiagnosticNameOccurrence {
+                start,
+                end,
+                name: name(),
+                replace_when_ambiguous,
+            };
+            MESSAGE_CAPTURES.with(|captures| {
+                if let Some(capture) = captures.borrow_mut().last_mut() {
+                    capture.names.push(occurrence);
+                }
+            });
+        }
+
+        Ok(())
+    }
+}
+
+// This guard owns its stack frame. Cloning or copying it would let multiple guards remove the
+// same frame, so it deliberately does not implement `Clone` or `Copy`.
+#[derive(Debug, Eq, PartialEq)]
+struct MessageCaptureScope;
+
+impl MessageCaptureScope {
+    fn new() -> Self {
+        MESSAGE_CAPTURES.with(|captures| captures.borrow_mut().push(MessageCapture::default()));
+        Self
+    }
+
+    fn finish(self) -> Vec<DiagnosticNameOccurrence> {
+        MESSAGE_CAPTURES.with(|captures| {
+            captures
+                .borrow_mut()
+                .last_mut()
+                .map(|capture| std::mem::take(&mut capture.names))
+                .unwrap_or_default()
+        })
+    }
+}
+
+impl Drop for MessageCaptureScope {
+    fn drop(&mut self) {
+        MESSAGE_CAPTURES.with(|captures| captures.borrow_mut().pop());
+    }
+}
+
+#[derive(Debug, Default)]
+struct DiagnosticMessageWriter {
+    message: String,
+}
+
+impl Write for DiagnosticMessageWriter {
+    fn write_str(&mut self, text: &str) -> fmt::Result {
+        self.message.push_str(text);
+        MESSAGE_CAPTURES.with(|captures| {
+            if let Some(capture) = captures.borrow_mut().last_mut() {
+                capture.offset += text.len();
+            }
+        });
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
+struct StructuredDiagnosticMessage {
+    text: Box<str>,
+    names: Box<[DiagnosticNameOccurrence]>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
+enum DiagnosticMessageRepr {
+    Plain(Box<str>),
+    Structured(Box<StructuredDiagnosticMessage>),
+}
+
+/// A diagnostic message that may temporarily retain semantic names until finalization.
+///
+/// Finalized messages contain only their owned text. The value intentionally does not implement
+/// `Display`, allowing `IntoDiagnosticMessage` to move an existing message without copying its text
+/// or losing its metadata. Other displayable values use the trait's blanket implementation.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
+pub struct DiagnosticMessage(DiagnosticMessageRepr);
+
+impl DiagnosticMessage {
+    /// Formats a message while retaining the identities of any names emitted by its arguments.
+    pub fn from_display(display: impl fmt::Display) -> Self {
+        let capture = MessageCaptureScope::new();
+        let mut writer = DiagnosticMessageWriter::default();
+        let result = write!(&mut writer, "{display}");
+        let names = capture.finish();
+
+        if result.is_err() || names.is_empty() {
+            return Self::from(writer.message);
+        }
+
+        Self(DiagnosticMessageRepr::Structured(Box::new(
+            StructuredDiagnosticMessage {
+                text: writer.message.into_boxed_str(),
+                names: names.into_boxed_slice(),
+            },
+        )))
+    }
+
+    /// Returns this message as a borrowed string.
+    pub fn as_str(&self) -> &str {
+        match &self.0 {
+            DiagnosticMessageRepr::Plain(text) => text,
+            DiagnosticMessageRepr::Structured(message) => &message.text,
+        }
+    }
+
+    /// Prepends text without losing the semantic ranges already recorded in this message.
+    #[must_use]
+    pub fn with_prefix(self, prefix: &str) -> Self {
+        if prefix.is_empty() {
+            return self;
+        }
+
+        match self.0 {
+            DiagnosticMessageRepr::Plain(text) => Self::from(format!("{prefix}{text}")),
+            DiagnosticMessageRepr::Structured(mut message) => {
+                message.text = format!("{prefix}{}", message.text).into_boxed_str();
+                for occurrence in &mut message.names {
+                    occurrence.start += prefix.len();
+                    occurrence.end += prefix.len();
+                }
+                Self(DiagnosticMessageRepr::Structured(message))
+            }
+        }
+    }
+
+    pub(super) fn names(&self) -> &[DiagnosticNameOccurrence] {
+        match &self.0 {
+            DiagnosticMessageRepr::Plain(_) => &[],
+            DiagnosticMessageRepr::Structured(message) => &message.names,
+        }
+    }
+
+    pub(super) fn resolve_names(
+        &mut self,
+        qualification: impl Fn(&DiagnosticName) -> Option<String>,
+    ) {
+        let DiagnosticMessageRepr::Structured(message) = &self.0 else {
+            return;
+        };
+
+        let mut text = message.text.to_string();
+        let mut occurrences: Vec<_> = message.names.iter().collect();
+        occurrences.sort_unstable_by_key(|occurrence| occurrence.start);
+
+        for occurrence in occurrences.into_iter().rev() {
+            if occurrence.replace_when_ambiguous
+                && let Some(replacement) = qualification(&occurrence.name)
+                && occurrence.end <= text.len()
+                && text.is_char_boundary(occurrence.start)
+                && text.is_char_boundary(occurrence.end)
+            {
+                text.replace_range(occurrence.start..occurrence.end, &replacement);
+            }
+        }
+
+        self.0 = DiagnosticMessageRepr::Plain(text.into_boxed_str());
+    }
+}
+
+impl From<&str> for DiagnosticMessage {
+    fn from(text: &str) -> Self {
+        Self(DiagnosticMessageRepr::Plain(text.into()))
+    }
+}
+
+impl From<String> for DiagnosticMessage {
+    fn from(text: String) -> Self {
+        Self(DiagnosticMessageRepr::Plain(text.into_boxed_str()))
+    }
+}
+
+impl From<Box<str>> for DiagnosticMessage {
+    fn from(text: Box<str>) -> Self {
+        Self(DiagnosticMessageRepr::Plain(text))
+    }
+}
+
+impl IntoDiagnosticMessage for DiagnosticMessage {
+    fn into_diagnostic_message(self) -> DiagnosticMessage {
+        self
+    }
+}
+
+/// Converts either an existing message or any displayable value into a diagnostic message.
+///
+/// Existing messages can be moved without copying their text or discarding semantic metadata,
+/// while the blanket implementation accepts ordinary formatting arguments such as `format_args!`.
+pub trait IntoDiagnosticMessage {
+    fn into_diagnostic_message(self) -> DiagnosticMessage;
+}
+
+impl<T: fmt::Display> IntoDiagnosticMessage for T {
+    fn into_diagnostic_message(self) -> DiagnosticMessage {
+        DiagnosticMessage::from_display(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostic::{
+        Annotation, Diagnostic, DiagnosticId, Severity, Span, SubDiagnostic, SubDiagnosticSeverity,
+    };
+    use crate::files::system_path_to_file;
+    use crate::system::DbWithWritableSystem;
+    use crate::tests::TestDb;
+    use std::cell::Cell;
+    use std::error::Error;
+
+    fn files() -> Result<(TestDb, File, File), Box<dyn Error>> {
+        let mut db = TestDb::default();
+        db.write_file("/first.py", "class Model: ...")?;
+        db.write_file("/second.py", "class Model: ...")?;
+
+        let first = system_path_to_file(&db, "/first.py")?;
+        let second = system_path_to_file(&db, "/second.py")?;
+        Ok((db, first, second))
+    }
+
+    fn name(
+        file: File,
+        spelling: &'static str,
+        qualified: &'static str,
+        offset: u32,
+    ) -> impl fmt::Display {
+        fmt::from_fn(move |f| {
+            DiagnosticNameRecord {
+                render: || f.write_str(spelling),
+                name: || {
+                    DiagnosticName::new(
+                        spelling,
+                        qualified,
+                        file,
+                        TextSize::new(offset),
+                        DiagnosticNameKind::Class,
+                    )
+                },
+            }
+            .render()
+        })
+    }
+
+    #[salsa::tracked(returns(clone))]
+    fn cached_nested_message(db: &dyn crate::Db, file: File) -> String {
+        let _ = file.path(db);
+        DiagnosticMessage::from_display(format_args!(
+            "Nested `{}`",
+            name(file, "Model", "first.Model", 6)
+        ))
+        .as_str()
+        .to_owned()
+    }
+
+    #[test]
+    fn ordinary_formatting_does_not_construct_diagnostic_metadata() -> Result<(), Box<dyn Error>> {
+        let (_db, first, _second) = files()?;
+        let metadata_created = Cell::new(false);
+        let display = fmt::from_fn(|f| {
+            DiagnosticNameRecord {
+                render: || f.write_str("Model"),
+                name: || {
+                    metadata_created.set(true);
+                    DiagnosticName::new(
+                        "Model",
+                        "first.Model",
+                        first,
+                        TextSize::new(6),
+                        DiagnosticNameKind::Class,
+                    )
+                },
+            }
+            .render()
+        });
+
+        assert_eq!(display.to_string(), "Model");
+        assert!(!metadata_created.get());
+        Ok(())
+    }
+
+    #[test]
+    fn nested_message_capture_survives_cold_and_cached_salsa_queries() -> Result<(), Box<dyn Error>>
+    {
+        let (db, first, second) = files()?;
+
+        for _ in 0..2 {
+            let outer = fmt::from_fn(|f| {
+                DiagnosticNameRecord {
+                    render: || {
+                        let nested = cached_nested_message(&db, first);
+                        assert_eq!(nested, "Nested `Model`");
+                        f.write_str("Model")
+                    },
+                    name: || {
+                        DiagnosticName::new(
+                            "Model",
+                            "second.Model",
+                            second,
+                            TextSize::new(6),
+                            DiagnosticNameKind::Class,
+                        )
+                    },
+                }
+                .render()
+            });
+            let mut diagnostic = Diagnostic::new(
+                DiagnosticId::InvalidSyntax,
+                Severity::Error,
+                format_args!("Expected `{outer}`"),
+            );
+            diagnostic.info(format_args!(
+                "Found `{}`",
+                name(first, "Model", "first.Model", 6)
+            ));
+
+            diagnostic.disambiguate_names(|_, _| String::new());
+
+            assert_eq!(diagnostic.headline_message(), "Expected `second.Model`");
+            assert_eq!(
+                diagnostic.sub_diagnostics()[0].headline_message(),
+                "Found `first.Model`"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn unwinding_removes_the_current_message_capture() {
+        let result = std::panic::catch_unwind(|| {
+            DiagnosticMessage::from_display(fmt::from_fn(|_| {
+                panic!("diagnostic formatting failed")
+            }))
+        });
+
+        assert!(result.is_err());
+        MESSAGE_CAPTURES.with(|captures| assert!(captures.borrow().is_empty()));
+    }
+
+    #[test]
+    fn qualifies_names_across_all_diagnostic_messages() -> Result<(), Box<dyn Error>> {
+        let (_db, first, second) = files()?;
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Expected `{}`", name(first, "Model", "first.Model", 6)),
+        );
+        diagnostic.set_concise_message(format_args!(
+            "Concise `{}`",
+            name(second, "Model", "second.Model", 6)
+        ));
+        diagnostic.annotate(Annotation::primary(Span::from(first)).message(format_args!(
+            "Primary `{}`",
+            name(first, "Model", "first.Model", 6)
+        )));
+        diagnostic.info(format_args!(
+            "Found `{}`",
+            name(second, "Model", "second.Model", 6)
+        ));
+
+        let mut detail = SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            format_args!("Detail `{}`", name(first, "Model", "first.Model", 6)),
+        );
+        detail.annotate(
+            Annotation::secondary(Span::from(second)).message(format_args!(
+                "Secondary `{}`",
+                name(second, "Model", "second.Model", 6)
+            )),
+        );
+        diagnostic.sub(detail);
+
+        diagnostic.disambiguate_names(|_, _| String::new());
+
+        assert_eq!(diagnostic.headline_message(), "Expected `first.Model`");
+        assert_eq!(
+            diagnostic.concise_message().to_string(),
+            "Concise `second.Model`"
+        );
+        assert_eq!(
+            diagnostic
+                .primary_annotation()
+                .and_then(Annotation::get_message),
+            Some("Primary `first.Model`")
+        );
+        assert_eq!(
+            diagnostic.sub_diagnostics()[0].headline_message(),
+            "Found `second.Model`"
+        );
+        assert_eq!(
+            diagnostic.sub_diagnostics()[1].headline_message(),
+            "Detail `first.Model`"
+        );
+        assert_eq!(
+            diagnostic.sub_diagnostics()[1].annotations()[0].get_message(),
+            Some("Secondary `second.Model`")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn preserves_semantic_ranges_after_unicode_prefixes() -> Result<(), Box<dyn Error>> {
+        let (_db, first, second) = files()?;
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Expected `{}`", name(first, "Model", "first.Model", 6)),
+        );
+        let explanation = DiagnosticMessage::from_display(format_args!(
+            "élément `{}`",
+            name(second, "Model", "second.Model", 6)
+        ))
+        .with_prefix("├─ ");
+        diagnostic.info(explanation);
+
+        diagnostic.disambiguate_names(|_, _| String::new());
+
+        assert_eq!(diagnostic.headline_message(), "Expected `first.Model`");
+        assert_eq!(
+            diagnostic.sub_diagnostics()[0].headline_message(),
+            "├─ élément `second.Model`"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn fixed_names_disambiguate_other_names_without_changing_representation()
+    -> Result<(), Box<dyn Error>> {
+        let (_db, first, second) = files()?;
+        let module = fmt::from_fn(|f| {
+            DiagnosticNameRecord {
+                render: || f.write_str("module"),
+                name: || {
+                    DiagnosticName::new(
+                        "module",
+                        "types.ModuleType",
+                        first,
+                        TextSize::new(6),
+                        DiagnosticNameKind::Class,
+                    )
+                },
+            }
+            .render_fixed()
+        });
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Found `<{module} 'os'>`"),
+        );
+        diagnostic.info(format_args!(
+            "Expected `{}`",
+            name(second, "module", "custom.module", 6)
+        ));
+
+        diagnostic.disambiguate_names(|_, _| String::new());
+
+        assert_eq!(diagnostic.headline_message(), "Found `<module 'os'>`");
+        assert_eq!(
+            diagnostic.sub_diagnostics()[0].headline_message(),
+            "Expected `custom.module`"
+        );
+        Ok(())
+    }
+}

--- a/crates/ruff_db/src/diagnostic/message.rs
+++ b/crates/ruff_db/src/diagnostic/message.rs
@@ -214,11 +214,42 @@ struct StructuredDiagnosticMessage {
     names: Box<[DiagnosticNameOccurrence]>,
 }
 
+impl StructuredDiagnosticMessage {
+    fn resolve_names(&self, qualification: &dyn Fn(&DiagnosticName) -> Option<String>) -> Box<str> {
+        let mut text = self.text.to_string();
+        let mut occurrences: Vec<_> = self.names.iter().collect();
+        occurrences.sort_unstable_by_key(|occurrence| occurrence.start);
+
+        for occurrence in occurrences.into_iter().rev() {
+            if occurrence.replace_when_ambiguous
+                && let Some(replacement) = qualification(&occurrence.name)
+                && occurrence.end <= text.len()
+                && text.is_char_boundary(occurrence.start)
+                && text.is_char_boundary(occurrence.end)
+            {
+                text.replace_range(occurrence.start..occurrence.end, &replacement);
+            }
+        }
+
+        text.into_boxed_str()
+    }
+}
+
+/// Separate message text is retained only when full and concise qualification actually differ.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
+struct DiagnosticMessageVariants {
+    full: Box<str>,
+    concise: Box<str>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
 enum DiagnosticMessageRepr {
     Plain(Box<str>),
     Structured(Box<StructuredDiagnosticMessage>),
+    Variants(Box<DiagnosticMessageVariants>),
 }
+
+pub(super) type DiagnosticNameQualification<'a> = &'a dyn Fn(&DiagnosticName) -> Option<String>;
 
 /// A diagnostic message that may temporarily retain semantic names until finalization.
 ///
@@ -253,6 +284,15 @@ impl DiagnosticMessage {
         match &self.0 {
             DiagnosticMessageRepr::Plain(text) => text,
             DiagnosticMessageRepr::Structured(message) => &message.text,
+            DiagnosticMessageRepr::Variants(message) => &message.full,
+        }
+    }
+
+    pub(super) fn as_concise_str(&self) -> &str {
+        match &self.0 {
+            DiagnosticMessageRepr::Variants(message) => &message.concise,
+            DiagnosticMessageRepr::Plain(text) => text,
+            DiagnosticMessageRepr::Structured(message) => &message.text,
         }
     }
 
@@ -273,40 +313,40 @@ impl DiagnosticMessage {
                 }
                 Self(DiagnosticMessageRepr::Structured(message))
             }
+            DiagnosticMessageRepr::Variants(mut message) => {
+                message.full = format!("{prefix}{}", message.full).into_boxed_str();
+                message.concise = format!("{prefix}{}", message.concise).into_boxed_str();
+                Self(DiagnosticMessageRepr::Variants(message))
+            }
         }
     }
 
     pub(super) fn names(&self) -> &[DiagnosticNameOccurrence] {
         match &self.0 {
-            DiagnosticMessageRepr::Plain(_) => &[],
+            DiagnosticMessageRepr::Plain(_) | DiagnosticMessageRepr::Variants(_) => &[],
             DiagnosticMessageRepr::Structured(message) => &message.names,
         }
     }
 
     pub(super) fn resolve_names(
         &mut self,
-        qualification: impl Fn(&DiagnosticName) -> Option<String>,
+        full_qualification: impl Fn(&DiagnosticName) -> Option<String>,
+        concise_qualification: Option<DiagnosticNameQualification<'_>>,
     ) {
         let DiagnosticMessageRepr::Structured(message) = &self.0 else {
             return;
         };
 
-        let mut text = message.text.to_string();
-        let mut occurrences: Vec<_> = message.names.iter().collect();
-        occurrences.sort_unstable_by_key(|occurrence| occurrence.start);
+        let full = message.resolve_names(&full_qualification);
+        let concise = concise_qualification
+            .map(|qualification| message.resolve_names(qualification))
+            .filter(|concise| concise != &full);
 
-        for occurrence in occurrences.into_iter().rev() {
-            if occurrence.replace_when_ambiguous
-                && let Some(replacement) = qualification(&occurrence.name)
-                && occurrence.end <= text.len()
-                && text.is_char_boundary(occurrence.start)
-                && text.is_char_boundary(occurrence.end)
-            {
-                text.replace_range(occurrence.start..occurrence.end, &replacement);
-            }
-        }
-
-        self.0 = DiagnosticMessageRepr::Plain(text.into_boxed_str());
+        self.0 = if let Some(concise) = concise {
+            DiagnosticMessageRepr::Variants(Box::new(DiagnosticMessageVariants { full, concise }))
+        } else {
+            DiagnosticMessageRepr::Plain(full)
+        };
     }
 }
 
@@ -523,10 +563,7 @@ mod tests {
         diagnostic.disambiguate_names(&resolver);
 
         assert_eq!(diagnostic.headline_message(), "Expected `first.Model`");
-        assert_eq!(
-            diagnostic.concise_message().to_string(),
-            "Concise `second.Model`"
-        );
+        assert_eq!(diagnostic.concise_message().to_string(), "Concise `Model`");
         assert_eq!(
             diagnostic
                 .primary_annotation()
@@ -547,6 +584,102 @@ mod tests {
         );
         assert_eq!(resolver.qualified_calls.get(), 2);
         assert_eq!(resolver.location_calls.get(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn concise_messages_ignore_names_visible_only_in_notes() -> Result<(), Box<dyn Error>> {
+        let (_db, first, second) = files()?;
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Expected `{}`", name(first, "Model")),
+        );
+        diagnostic.info(format_args!("Found `{}`", name(second, "Model")));
+
+        diagnostic.disambiguate_names(&TestNameResolver::new(&[
+            (first, "first.Model"),
+            (second, "second.Model"),
+        ]));
+
+        assert_eq!(diagnostic.headline_message(), "Expected `first.Model`");
+        assert_eq!(diagnostic.concise_message().to_string(), "Expected `Model`");
+        assert_eq!(
+            diagnostic.sub_diagnostics()[0].headline_message(),
+            "Found `second.Model`"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn concise_messages_disambiguate_visible_headlines_and_annotations()
+    -> Result<(), Box<dyn Error>> {
+        let (_db, first, second) = files()?;
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Expected `{}`", name(first, "Model")),
+        );
+        diagnostic.annotate(
+            Annotation::primary(Span::from(second))
+                .message(format_args!("Found `{}`", name(second, "Model"))),
+        );
+
+        diagnostic.disambiguate_names(&TestNameResolver::new(&[
+            (first, "first.Model"),
+            (second, "second.Model"),
+        ]));
+
+        assert_eq!(
+            diagnostic.concise_message().to_string(),
+            "Expected `first.Model`: Found `second.Model`"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn custom_concise_messages_do_not_affect_full_diagnostics() -> Result<(), Box<dyn Error>> {
+        let (_db, first, second) = files()?;
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Expected `{}`", name(first, "Model")),
+        );
+        diagnostic.set_concise_message(format_args!("Found `{}`", name(second, "Model")));
+
+        let resolver = TestNameResolver::new(&[(first, "first.Model"), (second, "second.Model")]);
+        diagnostic.disambiguate_names(&resolver);
+
+        assert_eq!(diagnostic.headline_message(), "Expected `Model`");
+        assert_eq!(diagnostic.concise_message().to_string(), "Found `Model`");
+        assert_eq!(resolver.qualified_calls.get(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn custom_concise_messages_disambiguate_their_own_names() -> Result<(), Box<dyn Error>> {
+        let (_db, first, second) = files()?;
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Expected `{}`", name(first, "Model")),
+        );
+        diagnostic.set_concise_message(format_args!(
+            "Expected `{}`, found `{}`",
+            name(first, "Model"),
+            name(second, "Model"),
+        ));
+
+        diagnostic.disambiguate_names(&TestNameResolver::new(&[
+            (first, "first.Model"),
+            (second, "second.Model"),
+        ]));
+
+        assert_eq!(diagnostic.headline_message(), "Expected `Model`");
+        assert_eq!(
+            diagnostic.concise_message().to_string(),
+            "Expected `first.Model`, found `second.Model`"
+        );
         Ok(())
     }
 

--- a/crates/ruff_db/src/diagnostic/message.rs
+++ b/crates/ruff_db/src/diagnostic/message.rs
@@ -1,55 +1,48 @@
 use std::cell::RefCell;
 use std::fmt::{self, Write};
 
-use ruff_text_size::TextSize;
-
-use crate::files::File;
-
 // `fmt::Formatter` does not expose its underlying writer, so semantic `Display` implementations
 // need a scoped transport to associate a name with the diagnostic message currently being written.
 // This is not persistent Salsa query state: each synchronous `from_display` call owns one stack
 // frame, nested calls receive independent frames, and `Drop` removes a frame even during unwinding.
-// Captured names contain only owned data and are resolved before a diagnostic is retained by Salsa.
+// Captured names contain only owned data and lifetime-free Salsa identities.
 thread_local! {
     static MESSAGE_CAPTURES: RefCell<Vec<MessageCapture>> = const { RefCell::new(Vec::new()) };
 }
 
 /// The semantic category of a named item embedded in a diagnostic message.
 ///
-/// Classes and aliases can have the same spelling and source position while still denoting
-/// different items, so their category participates in their identity.
+/// Classes and aliases can have the same spelling while denoting different items. Their category
+/// determines which semantic value is reconstructed from its Salsa identity.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
 pub enum DiagnosticNameKind {
     Class,
     TypeAlias,
 }
 
-/// The identity and alternative spellings of a name displayed in a diagnostic.
+/// The spelling and semantic identity of a name displayed in a diagnostic.
 ///
-/// This representation is deliberately independent of Salsa database lifetimes. It is retained
-/// only while a diagnostic is assembled and discarded once its messages have been resolved.
+/// The identity carries no database lifetime, allowing inference queries to retain unresolved
+/// diagnostics without reading another file's syntax tree. It must be resolved against its
+/// originating database. Qualified names and source locations are requested only when the
+/// completed diagnostic actually needs them.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
 pub struct DiagnosticName {
     spelling: Box<str>,
-    qualified: Box<str>,
-    file: File,
-    offset: TextSize,
+    #[get_size(ignore)]
+    identity: salsa::Id,
     kind: DiagnosticNameKind,
 }
 
 impl DiagnosticName {
     pub fn new(
         spelling: impl Into<Box<str>>,
-        qualified: impl Into<Box<str>>,
-        file: File,
-        offset: TextSize,
+        identity: salsa::Id,
         kind: DiagnosticNameKind,
     ) -> Self {
         Self {
             spelling: spelling.into(),
-            qualified: qualified.into(),
-            file,
-            offset,
+            identity,
             kind,
         }
     }
@@ -58,21 +51,28 @@ impl DiagnosticName {
         &self.spelling
     }
 
-    pub(super) fn qualified(&self) -> &str {
-        &self.qualified
+    /// Returns the underlying Salsa identity for this named item.
+    pub fn identity(&self) -> salsa::Id {
+        self.identity
     }
 
-    pub(super) fn file(&self) -> File {
-        self.file
-    }
-
-    pub(super) fn offset(&self) -> TextSize {
-        self.offset
+    /// Returns the semantic category needed to reconstruct this named item.
+    pub fn kind(&self) -> DiagnosticNameKind {
+        self.kind
     }
 
     pub(super) fn has_same_identity(&self, other: &Self) -> bool {
-        self.file == other.file && self.offset == other.offset && self.kind == other.kind
+        self.identity == other.identity && self.kind == other.kind
     }
+}
+
+/// Resolves presentation details only for genuinely ambiguous diagnostic names.
+pub trait DiagnosticNameResolver {
+    /// Returns the fully qualified spelling of this named item.
+    fn qualified_name(&self, name: &DiagnosticName) -> String;
+
+    /// Returns a source-location suffix when qualified spellings are also identical.
+    fn location(&self, name: &DiagnosticName) -> String;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
@@ -354,9 +354,10 @@ mod tests {
     use crate::diagnostic::{
         Annotation, Diagnostic, DiagnosticId, Severity, Span, SubDiagnostic, SubDiagnosticSeverity,
     };
-    use crate::files::system_path_to_file;
+    use crate::files::{File, system_path_to_file};
     use crate::system::DbWithWritableSystem;
     use crate::tests::TestDb;
+    use salsa::plumbing::AsId;
     use std::cell::Cell;
     use std::error::Error;
 
@@ -370,38 +371,54 @@ mod tests {
         Ok((db, first, second))
     }
 
-    fn name(
-        file: File,
-        spelling: &'static str,
-        qualified: &'static str,
-        offset: u32,
-    ) -> impl fmt::Display {
+    fn name(file: File, spelling: &'static str) -> impl fmt::Display {
         fmt::from_fn(move |f| {
             DiagnosticNameRecord {
                 render: || f.write_str(spelling),
-                name: || {
-                    DiagnosticName::new(
-                        spelling,
-                        qualified,
-                        file,
-                        TextSize::new(offset),
-                        DiagnosticNameKind::Class,
-                    )
-                },
+                name: || DiagnosticName::new(spelling, file.as_id(), DiagnosticNameKind::Class),
             }
             .render()
         })
     }
 
+    struct TestNameResolver {
+        names: Vec<(File, &'static str)>,
+        qualified_calls: Cell<usize>,
+        location_calls: Cell<usize>,
+    }
+
+    impl TestNameResolver {
+        fn new(names: &[(File, &'static str)]) -> Self {
+            Self {
+                names: names.to_vec(),
+                qualified_calls: Cell::new(0),
+                location_calls: Cell::new(0),
+            }
+        }
+    }
+
+    impl DiagnosticNameResolver for TestNameResolver {
+        fn qualified_name(&self, name: &DiagnosticName) -> String {
+            self.qualified_calls.set(self.qualified_calls.get() + 1);
+            self.names
+                .iter()
+                .find(|(file, _)| file.as_id() == name.identity())
+                .map(|(_, qualified)| (*qualified).to_owned())
+                .unwrap_or_else(|| panic!("missing qualified name for {:?}", name.identity()))
+        }
+
+        fn location(&self, _name: &DiagnosticName) -> String {
+            self.location_calls.set(self.location_calls.get() + 1);
+            " @ definition".to_owned()
+        }
+    }
+
     #[salsa::tracked(returns(clone))]
     fn cached_nested_message(db: &dyn crate::Db, file: File) -> String {
         let _ = file.path(db);
-        DiagnosticMessage::from_display(format_args!(
-            "Nested `{}`",
-            name(file, "Model", "first.Model", 6)
-        ))
-        .as_str()
-        .to_owned()
+        DiagnosticMessage::from_display(format_args!("Nested `{}`", name(file, "Model")))
+            .as_str()
+            .to_owned()
     }
 
     #[test]
@@ -413,13 +430,7 @@ mod tests {
                 render: || f.write_str("Model"),
                 name: || {
                     metadata_created.set(true);
-                    DiagnosticName::new(
-                        "Model",
-                        "first.Model",
-                        first,
-                        TextSize::new(6),
-                        DiagnosticNameKind::Class,
-                    )
+                    DiagnosticName::new("Model", first.as_id(), DiagnosticNameKind::Class)
                 },
             }
             .render()
@@ -444,13 +455,7 @@ mod tests {
                         f.write_str("Model")
                     },
                     name: || {
-                        DiagnosticName::new(
-                            "Model",
-                            "second.Model",
-                            second,
-                            TextSize::new(6),
-                            DiagnosticNameKind::Class,
-                        )
+                        DiagnosticName::new("Model", second.as_id(), DiagnosticNameKind::Class)
                     },
                 }
                 .render()
@@ -460,12 +465,12 @@ mod tests {
                 Severity::Error,
                 format_args!("Expected `{outer}`"),
             );
-            diagnostic.info(format_args!(
-                "Found `{}`",
-                name(first, "Model", "first.Model", 6)
-            ));
+            diagnostic.info(format_args!("Found `{}`", name(first, "Model")));
 
-            diagnostic.disambiguate_names(|_, _| String::new());
+            diagnostic.disambiguate_names(&TestNameResolver::new(&[
+                (first, "first.Model"),
+                (second, "second.Model"),
+            ]));
 
             assert_eq!(diagnostic.headline_message(), "Expected `second.Model`");
             assert_eq!(
@@ -495,34 +500,27 @@ mod tests {
         let mut diagnostic = Diagnostic::new(
             DiagnosticId::InvalidSyntax,
             Severity::Error,
-            format_args!("Expected `{}`", name(first, "Model", "first.Model", 6)),
+            format_args!("Expected `{}`", name(first, "Model")),
         );
-        diagnostic.set_concise_message(format_args!(
-            "Concise `{}`",
-            name(second, "Model", "second.Model", 6)
-        ));
-        diagnostic.annotate(Annotation::primary(Span::from(first)).message(format_args!(
-            "Primary `{}`",
-            name(first, "Model", "first.Model", 6)
-        )));
-        diagnostic.info(format_args!(
-            "Found `{}`",
-            name(second, "Model", "second.Model", 6)
-        ));
+        diagnostic.set_concise_message(format_args!("Concise `{}`", name(second, "Model")));
+        diagnostic.annotate(
+            Annotation::primary(Span::from(first))
+                .message(format_args!("Primary `{}`", name(first, "Model"))),
+        );
+        diagnostic.info(format_args!("Found `{}`", name(second, "Model")));
 
         let mut detail = SubDiagnostic::new(
             SubDiagnosticSeverity::Info,
-            format_args!("Detail `{}`", name(first, "Model", "first.Model", 6)),
+            format_args!("Detail `{}`", name(first, "Model")),
         );
         detail.annotate(
-            Annotation::secondary(Span::from(second)).message(format_args!(
-                "Secondary `{}`",
-                name(second, "Model", "second.Model", 6)
-            )),
+            Annotation::secondary(Span::from(second))
+                .message(format_args!("Secondary `{}`", name(second, "Model"))),
         );
         diagnostic.sub(detail);
 
-        diagnostic.disambiguate_names(|_, _| String::new());
+        let resolver = TestNameResolver::new(&[(first, "first.Model"), (second, "second.Model")]);
+        diagnostic.disambiguate_names(&resolver);
 
         assert_eq!(diagnostic.headline_message(), "Expected `first.Model`");
         assert_eq!(
@@ -547,6 +545,51 @@ mod tests {
             diagnostic.sub_diagnostics()[1].annotations()[0].get_message(),
             Some("Secondary `second.Model`")
         );
+        assert_eq!(resolver.qualified_calls.get(), 2);
+        assert_eq!(resolver.location_calls.get(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn unambiguous_names_do_not_resolve_qualified_names_or_locations() -> Result<(), Box<dyn Error>>
+    {
+        let (_db, first, _second) = files()?;
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Expected `{}`", name(first, "Model")),
+        );
+        diagnostic.info(format_args!("Found `{}`", name(first, "Model")));
+
+        let resolver = TestNameResolver::new(&[(first, "first.Model")]);
+        diagnostic.disambiguate_names(&resolver);
+
+        assert_eq!(diagnostic.headline_message(), "Expected `Model`");
+        assert_eq!(resolver.qualified_calls.get(), 0);
+        assert_eq!(resolver.location_calls.get(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn identical_qualified_names_resolve_source_locations() -> Result<(), Box<dyn Error>> {
+        let (_db, first, second) = files()?;
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::InvalidSyntax,
+            Severity::Error,
+            format_args!("Expected `{}`", name(first, "Model")),
+        );
+        diagnostic.info(format_args!("Found `{}`", name(second, "Model")));
+
+        let resolver =
+            TestNameResolver::new(&[(first, "package.Model"), (second, "package.Model")]);
+        diagnostic.disambiguate_names(&resolver);
+
+        assert_eq!(
+            diagnostic.headline_message(),
+            "Expected `package.Model @ definition`"
+        );
+        assert_eq!(resolver.qualified_calls.get(), 2);
+        assert_eq!(resolver.location_calls.get(), 2);
         Ok(())
     }
 
@@ -556,16 +599,17 @@ mod tests {
         let mut diagnostic = Diagnostic::new(
             DiagnosticId::InvalidSyntax,
             Severity::Error,
-            format_args!("Expected `{}`", name(first, "Model", "first.Model", 6)),
+            format_args!("Expected `{}`", name(first, "Model")),
         );
-        let explanation = DiagnosticMessage::from_display(format_args!(
-            "élément `{}`",
-            name(second, "Model", "second.Model", 6)
-        ))
-        .with_prefix("├─ ");
+        let explanation =
+            DiagnosticMessage::from_display(format_args!("élément `{}`", name(second, "Model")))
+                .with_prefix("├─ ");
         diagnostic.info(explanation);
 
-        diagnostic.disambiguate_names(|_, _| String::new());
+        diagnostic.disambiguate_names(&TestNameResolver::new(&[
+            (first, "first.Model"),
+            (second, "second.Model"),
+        ]));
 
         assert_eq!(diagnostic.headline_message(), "Expected `first.Model`");
         assert_eq!(
@@ -582,15 +626,7 @@ mod tests {
         let module = fmt::from_fn(|f| {
             DiagnosticNameRecord {
                 render: || f.write_str("module"),
-                name: || {
-                    DiagnosticName::new(
-                        "module",
-                        "types.ModuleType",
-                        first,
-                        TextSize::new(6),
-                        DiagnosticNameKind::Class,
-                    )
-                },
+                name: || DiagnosticName::new("module", first.as_id(), DiagnosticNameKind::Class),
             }
             .render_fixed()
         });
@@ -599,12 +635,12 @@ mod tests {
             Severity::Error,
             format_args!("Found `<{module} 'os'>`"),
         );
-        diagnostic.info(format_args!(
-            "Expected `{}`",
-            name(second, "module", "custom.module", 6)
-        ));
+        diagnostic.info(format_args!("Expected `{}`", name(second, "module")));
 
-        diagnostic.disambiguate_names(|_, _| String::new());
+        diagnostic.disambiguate_names(&TestNameResolver::new(&[
+            (first, "types.ModuleType"),
+            (second, "custom.module"),
+        ]));
 
         assert_eq!(diagnostic.headline_message(), "Found `<module 'os'>`");
         assert_eq!(

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -6,9 +6,14 @@ use ruff_source_file::{LineColumn, SourceCode, SourceFile};
 
 use annotate_snippets::Level as AnnotateLevel;
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use rustc_hash::FxHashMap;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
+pub use self::message::{
+    DiagnosticMessage, DiagnosticName, DiagnosticNameKind, DiagnosticNameRecord,
+    IntoDiagnosticMessage,
+};
 pub use self::render::{
     DisplayDiagnostic, DisplayDiagnostics, DummyFileResolver, FileResolver, Input,
 };
@@ -16,6 +21,7 @@ pub use self::stylesheet::{DiagnosticStylesheet, fmt_with_hyperlink};
 use crate::cancellation::CancellationToken;
 use crate::{Db, files::File};
 
+mod message;
 mod render;
 mod stylesheet;
 
@@ -218,9 +224,116 @@ impl Diagnostic {
         self.inner.message.as_str()
     }
 
+    /// Clones the headline while preserving any semantic names awaiting diagnostic finalization.
+    pub fn clone_headline_message(&self) -> DiagnosticMessage {
+        self.inner.message.clone()
+    }
+
     /// Sets the headline message for this diagnostic.
     pub fn set_headline_message(&mut self, message: impl IntoDiagnosticMessage) {
         Arc::make_mut(&mut self.inner).message = message.into_diagnostic_message();
+    }
+
+    /// Resolves semantic names against every message belonging to this diagnostic.
+    ///
+    /// The location formatter is evaluated only when two distinct definitions also share the same
+    /// fully qualified name. All temporary name metadata is discarded before this method returns.
+    pub fn disambiguate_names(&mut self, format_location: impl Fn(File, TextSize) -> String) {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum Qualification {
+            Qualified,
+            Located,
+        }
+
+        let mut observed: FxHashMap<Box<str>, Vec<DiagnosticName>> = FxHashMap::default();
+        self.for_each_message(|message| {
+            for occurrence in message.names() {
+                let name = occurrence.name();
+                let identities = observed.entry(name.spelling().into()).or_default();
+                if !identities
+                    .iter()
+                    .any(|existing| existing.has_same_identity(name))
+                {
+                    identities.push(name.clone());
+                }
+            }
+        });
+
+        let qualification: FxHashMap<Box<str>, Qualification> = observed
+            .into_iter()
+            .filter_map(|(spelling, identities)| {
+                if identities.len() < 2 {
+                    return None;
+                }
+
+                let located = identities.iter().enumerate().any(|(index, identity)| {
+                    identities[..index]
+                        .iter()
+                        .any(|other| identity.qualified() == other.qualified())
+                });
+                Some((
+                    spelling,
+                    if located {
+                        Qualification::Located
+                    } else {
+                        Qualification::Qualified
+                    },
+                ))
+            })
+            .collect();
+
+        self.for_each_message_mut(|message| {
+            message.resolve_names(|name| match qualification.get(name.spelling()) {
+                None => None,
+                Some(Qualification::Qualified) => Some(name.qualified().to_string()),
+                Some(Qualification::Located) => Some(format!(
+                    "{}{}",
+                    name.qualified(),
+                    format_location(name.file(), name.offset())
+                )),
+            });
+        });
+    }
+
+    fn for_each_message(&self, mut visit: impl FnMut(&DiagnosticMessage)) {
+        visit(&self.inner.message);
+        if let Some(message) = &self.inner.custom_concise_message {
+            visit(message);
+        }
+        for annotation in &self.inner.annotations {
+            if let Some(message) = &annotation.message {
+                visit(message);
+            }
+        }
+        for diagnostic in &self.inner.subs {
+            visit(&diagnostic.inner.message);
+            for annotation in &diagnostic.inner.annotations {
+                if let Some(message) = &annotation.message {
+                    visit(message);
+                }
+            }
+        }
+    }
+
+    fn for_each_message_mut(&mut self, mut visit: impl FnMut(&mut DiagnosticMessage)) {
+        let inner = Arc::make_mut(&mut self.inner);
+        visit(&mut inner.message);
+        if let Some(message) = &mut inner.custom_concise_message {
+            visit(message);
+        }
+        for annotation in &mut inner.annotations {
+            if let Some(message) = &mut annotation.message {
+                visit(message);
+            }
+        }
+        for diagnostic in &mut inner.subs {
+            visit(&mut diagnostic.inner.message);
+            for annotation in &mut diagnostic.inner.annotations {
+                if let Some(message) = &mut annotation.message {
+                    visit(message);
+                }
+            }
+        }
     }
 
     /// Introspects this diagnostic and returns its message for concise formatting.
@@ -1692,77 +1805,6 @@ impl serde::Serialize for ConciseMessage<'_> {
         S: serde::Serializer,
     {
         serializer.collect_str(self)
-    }
-}
-
-/// A diagnostic message string.
-///
-/// This is, for all intents and purposes, equivalent to a `Box<str>`.
-/// But it does not implement `std::fmt::Display`. Indeed, that it its
-/// entire reason for existence. It provides a way to pass a string
-/// directly into diagnostic methods that accept messages without copying
-/// that string. This works via the `IntoDiagnosticMessage` trait.
-///
-/// In most cases, callers shouldn't need to use this. Instead, there is
-/// a blanket trait implementation for `IntoDiagnosticMessage` for
-/// anything that implements `std::fmt::Display`.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
-pub struct DiagnosticMessage(Box<str>);
-
-impl DiagnosticMessage {
-    /// Returns this message as a borrowed string.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<&str> for DiagnosticMessage {
-    fn from(s: &str) -> DiagnosticMessage {
-        DiagnosticMessage(s.into())
-    }
-}
-
-impl From<String> for DiagnosticMessage {
-    fn from(s: String) -> DiagnosticMessage {
-        DiagnosticMessage(s.into())
-    }
-}
-
-impl From<Box<str>> for DiagnosticMessage {
-    fn from(s: Box<str>) -> DiagnosticMessage {
-        DiagnosticMessage(s)
-    }
-}
-
-impl IntoDiagnosticMessage for DiagnosticMessage {
-    fn into_diagnostic_message(self) -> DiagnosticMessage {
-        self
-    }
-}
-
-/// A trait for values that can be converted into a diagnostic message.
-///
-/// Users of the diagnostic API can largely think of this trait as effectively
-/// equivalent to `std::fmt::Display`. Indeed, everything that implements
-/// `Display` also implements this trait. That means wherever this trait is
-/// accepted, you can use things like `format_args!`.
-///
-/// The purpose of this trait is to provide a means to give arguments _other_
-/// than `std::fmt::Display` trait implementations. Or rather, to permit
-/// the diagnostic API to treat them differently. For example, this lets
-/// callers wrap a string in a `DiagnosticMessage` and provide it directly
-/// to any of the diagnostic APIs that accept a message. This will move the
-/// string and avoid any unnecessary copies. (If we instead required only
-/// `std::fmt::Display`, then this would potentially result in a copy via the
-/// `ToString` trait implementation.)
-pub trait IntoDiagnosticMessage {
-    fn into_diagnostic_message(self) -> DiagnosticMessage;
-}
-
-/// Every `IntoDiagnosticMessage` is accepted, so to is `std::fmt::Display`.
-impl<T: std::fmt::Display> IntoDiagnosticMessage for T {
-    fn into_diagnostic_message(self) -> DiagnosticMessage {
-        DiagnosticMessage::from(self.to_string())
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -10,6 +10,7 @@ use rustc_hash::FxHashMap;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
+use self::message::DiagnosticNameQualification;
 pub use self::message::{
     DiagnosticMessage, DiagnosticName, DiagnosticNameKind, DiagnosticNameRecord,
     DiagnosticNameResolver, IntoDiagnosticMessage,
@@ -234,7 +235,7 @@ impl Diagnostic {
         Arc::make_mut(&mut self.inner).message = message.into_diagnostic_message();
     }
 
-    /// Resolves semantic names against every message belonging to this diagnostic.
+    /// Resolves semantic names against the messages visible in each diagnostic format.
     ///
     /// Qualified names are resolved only when distinct identities have the same displayed
     /// spelling. Source locations are resolved only when their qualified names also coincide.
@@ -246,69 +247,134 @@ impl Diagnostic {
             Located(String),
         }
 
-        let mut observed: FxHashMap<Box<str>, Vec<DiagnosticName>> = FxHashMap::default();
-        self.for_each_message(|message| {
-            for occurrence in message.names() {
-                let name = occurrence.name();
-                let identities = observed.entry(name.spelling().into()).or_default();
-                if !identities
-                    .iter()
-                    .any(|existing| existing.has_same_identity(name))
-                {
-                    identities.push(name.clone());
+        let observe =
+            |message: &DiagnosticMessage,
+             observed: &mut FxHashMap<Box<str>, Vec<DiagnosticName>>| {
+                for occurrence in message.names() {
+                    let name = occurrence.name();
+                    let identities = observed.entry(name.spelling().into()).or_default();
+                    if !identities
+                        .iter()
+                        .any(|existing| existing.has_same_identity(name))
+                    {
+                        identities.push(name.clone());
+                    }
                 }
-            }
-        });
+            };
 
-        let mut qualification: FxHashMap<DiagnosticName, Qualification> = FxHashMap::default();
-        for identities in observed.into_values() {
-            if identities.len() < 2 {
-                continue;
-            }
+        let mut full_names: FxHashMap<Box<str>, Vec<DiagnosticName>> = FxHashMap::default();
+        self.for_each_full_message(|message| observe(message, &mut full_names));
 
-            let qualified_names: Vec<_> = identities
-                .iter()
-                .map(|identity| resolver.qualified_name(identity))
-                .collect();
-            let located = qualified_names
-                .iter()
-                .enumerate()
-                .any(|(index, qualified)| {
-                    qualified_names[..index]
+        let mut concise_names: FxHashMap<Box<str>, Vec<DiagnosticName>> = FxHashMap::default();
+        if let Some(message) = &self.inner.custom_concise_message {
+            observe(message, &mut concise_names);
+        } else {
+            observe(&self.inner.message, &mut concise_names);
+            if let Some(message) = self
+                .primary_annotation()
+                .and_then(|annotation| annotation.message.as_ref())
+            {
+                observe(message, &mut concise_names);
+            }
+        }
+
+        let mut qualified_names: FxHashMap<DiagnosticName, String> = FxHashMap::default();
+        let mut qualify = |observed: FxHashMap<Box<str>, Vec<DiagnosticName>>| {
+            let mut qualification: FxHashMap<DiagnosticName, Qualification> = FxHashMap::default();
+            for identities in observed.into_values() {
+                if identities.len() < 2 {
+                    continue;
+                }
+
+                let resolved_names: Vec<_> = identities
+                    .iter()
+                    .map(|identity| {
+                        qualified_names
+                            .entry(identity.clone())
+                            .or_insert_with(|| resolver.qualified_name(identity))
+                            .clone()
+                    })
+                    .collect();
+                let located = resolved_names.iter().enumerate().any(|(index, qualified)| {
+                    resolved_names[..index]
                         .iter()
                         .any(|other| qualified == other)
                 });
 
-            qualification.extend(identities.into_iter().zip(qualified_names).map(
-                |(identity, qualified)| {
-                    (
-                        identity,
-                        if located {
-                            Qualification::Located(qualified)
-                        } else {
-                            Qualification::Qualified(qualified)
-                        },
-                    )
-                },
-            ));
+                qualification.extend(identities.into_iter().zip(resolved_names).map(
+                    |(identity, qualified)| {
+                        (
+                            identity,
+                            if located {
+                                Qualification::Located(qualified)
+                            } else {
+                                Qualification::Qualified(qualified)
+                            },
+                        )
+                    },
+                ));
+            }
+
+            qualification
+        };
+
+        let full_qualification = qualify(full_names);
+        let concise_qualification = qualify(concise_names);
+        let replacement =
+            |name: &DiagnosticName, qualification: &FxHashMap<DiagnosticName, Qualification>| {
+                match qualification.get(name) {
+                    None => None,
+                    Some(Qualification::Qualified(qualified)) => Some(qualified.clone()),
+                    Some(Qualification::Located(qualified)) => {
+                        Some(format!("{qualified}{}", resolver.location(name)))
+                    }
+                }
+            };
+        let full_replacement = |name: &DiagnosticName| replacement(name, &full_qualification);
+        let concise_replacement = |name: &DiagnosticName| replacement(name, &concise_qualification);
+        let concise_replacement: DiagnosticNameQualification<'_> = &concise_replacement;
+
+        let custom_concise = self.inner.custom_concise_message.is_some();
+        let primary_index = self
+            .inner
+            .annotations
+            .iter()
+            .position(|annotation| annotation.is_primary);
+        let inner = Arc::make_mut(&mut self.inner);
+        inner.message.resolve_names(
+            full_replacement,
+            (!custom_concise).then_some(concise_replacement),
+        );
+
+        if let Some(message) = &mut inner.custom_concise_message {
+            message.resolve_names(concise_replacement, None);
         }
 
-        self.for_each_message_mut(|message| {
-            message.resolve_names(|name| match qualification.get(name) {
-                None => None,
-                Some(Qualification::Qualified(qualified)) => Some(qualified.clone()),
-                Some(Qualification::Located(qualified)) => {
-                    Some(format!("{qualified}{}", resolver.location(name)))
+        for (index, annotation) in inner.annotations.iter_mut().enumerate() {
+            if let Some(message) = &mut annotation.message {
+                message.resolve_names(
+                    full_replacement,
+                    (!custom_concise && primary_index == Some(index))
+                        .then_some(concise_replacement),
+                );
+            }
+        }
+
+        for diagnostic in &mut inner.subs {
+            diagnostic
+                .inner
+                .message
+                .resolve_names(full_replacement, None);
+            for annotation in &mut diagnostic.inner.annotations {
+                if let Some(message) = &mut annotation.message {
+                    message.resolve_names(full_replacement, None);
                 }
-            });
-        });
+            }
+        }
     }
 
-    fn for_each_message(&self, mut visit: impl FnMut(&DiagnosticMessage)) {
+    fn for_each_full_message(&self, mut visit: impl FnMut(&DiagnosticMessage)) {
         visit(&self.inner.message);
-        if let Some(message) = &self.inner.custom_concise_message {
-            visit(message);
-        }
         for annotation in &self.inner.annotations {
             if let Some(message) = &annotation.message {
                 visit(message);
@@ -318,27 +384,6 @@ impl Diagnostic {
             visit(&diagnostic.inner.message);
             for annotation in &diagnostic.inner.annotations {
                 if let Some(message) = &annotation.message {
-                    visit(message);
-                }
-            }
-        }
-    }
-
-    fn for_each_message_mut(&mut self, mut visit: impl FnMut(&mut DiagnosticMessage)) {
-        let inner = Arc::make_mut(&mut self.inner);
-        visit(&mut inner.message);
-        if let Some(message) = &mut inner.custom_concise_message {
-            visit(message);
-        }
-        for annotation in &mut inner.annotations {
-            if let Some(message) = &mut annotation.message {
-                visit(message);
-            }
-        }
-        for diagnostic in &mut inner.subs {
-            visit(&mut diagnostic.inner.message);
-            for annotation in &mut diagnostic.inner.annotations {
-                if let Some(message) = &mut annotation.message {
                     visit(message);
                 }
             }
@@ -358,13 +403,14 @@ impl Diagnostic {
     /// you want.
     pub fn concise_message(&self) -> ConciseMessage<'_> {
         if let Some(custom_message) = &self.inner.custom_concise_message {
-            return ConciseMessage::Custom(custom_message.as_str());
+            return ConciseMessage::Custom(custom_message.as_concise_str());
         }
 
-        let main = self.inner.message.as_str();
+        let main = self.inner.message.as_concise_str();
         let annotation = self
             .primary_annotation()
-            .and_then(|ann| ann.get_message())
+            .and_then(|annotation| annotation.message.as_ref())
+            .map(DiagnosticMessage::as_concise_str)
             .unwrap_or_default();
         if annotation.is_empty() {
             ConciseMessage::MainDiagnostic(main)

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 
 pub use self::message::{
     DiagnosticMessage, DiagnosticName, DiagnosticNameKind, DiagnosticNameRecord,
-    IntoDiagnosticMessage,
+    DiagnosticNameResolver, IntoDiagnosticMessage,
 };
 pub use self::render::{
     DisplayDiagnostic, DisplayDiagnostics, DummyFileResolver, FileResolver, Input,
@@ -236,13 +236,14 @@ impl Diagnostic {
 
     /// Resolves semantic names against every message belonging to this diagnostic.
     ///
-    /// The location formatter is evaluated only when two distinct definitions also share the same
-    /// fully qualified name. All temporary name metadata is discarded before this method returns.
-    pub fn disambiguate_names(&mut self, format_location: impl Fn(File, TextSize) -> String) {
-        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    /// Qualified names are resolved only when distinct identities have the same displayed
+    /// spelling. Source locations are resolved only when their qualified names also coincide.
+    /// All temporary name metadata is discarded before this method returns.
+    pub fn disambiguate_names(&mut self, resolver: &impl DiagnosticNameResolver) {
+        #[derive(Clone, Debug, Eq, PartialEq)]
         enum Qualification {
-            Qualified,
-            Located,
+            Qualified(String),
+            Located(String),
         }
 
         let mut observed: FxHashMap<Box<str>, Vec<DiagnosticName>> = FxHashMap::default();
@@ -259,38 +260,46 @@ impl Diagnostic {
             }
         });
 
-        let qualification: FxHashMap<Box<str>, Qualification> = observed
-            .into_iter()
-            .filter_map(|(spelling, identities)| {
-                if identities.len() < 2 {
-                    return None;
-                }
+        let mut qualification: FxHashMap<DiagnosticName, Qualification> = FxHashMap::default();
+        for identities in observed.into_values() {
+            if identities.len() < 2 {
+                continue;
+            }
 
-                let located = identities.iter().enumerate().any(|(index, identity)| {
-                    identities[..index]
+            let qualified_names: Vec<_> = identities
+                .iter()
+                .map(|identity| resolver.qualified_name(identity))
+                .collect();
+            let located = qualified_names
+                .iter()
+                .enumerate()
+                .any(|(index, qualified)| {
+                    qualified_names[..index]
                         .iter()
-                        .any(|other| identity.qualified() == other.qualified())
+                        .any(|other| qualified == other)
                 });
-                Some((
-                    spelling,
-                    if located {
-                        Qualification::Located
-                    } else {
-                        Qualification::Qualified
-                    },
-                ))
-            })
-            .collect();
+
+            qualification.extend(identities.into_iter().zip(qualified_names).map(
+                |(identity, qualified)| {
+                    (
+                        identity,
+                        if located {
+                            Qualification::Located(qualified)
+                        } else {
+                            Qualification::Qualified(qualified)
+                        },
+                    )
+                },
+            ));
+        }
 
         self.for_each_message_mut(|message| {
-            message.resolve_names(|name| match qualification.get(name.spelling()) {
+            message.resolve_names(|name| match qualification.get(name) {
                 None => None,
-                Some(Qualification::Qualified) => Some(name.qualified().to_string()),
-                Some(Qualification::Located) => Some(format!(
-                    "{}{}",
-                    name.qualified(),
-                    format_location(name.file(), name.offset())
-                )),
+                Some(Qualification::Qualified(qualified)) => Some(qualified.clone()),
+                Some(Qualification::Located(qualified)) => {
+                    Some(format!("{qualified}{}", resolver.location(name)))
+                }
             });
         });
     }

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.64">0.0.64</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-and-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L995" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L997" target="_blank">View source</a>
 </small>
 
 
@@ -44,7 +44,7 @@ class Base(ABC):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1004" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1006" target="_blank">View source</a>
 </small>
 
 
@@ -90,7 +90,7 @@ class Derived(Base):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L341" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L343" target="_blank">View source</a>
 </small>
 
 
@@ -154,7 +154,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1049" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1051" target="_blank">View source</a>
 </small>
 
 
@@ -237,7 +237,7 @@ value = unknown  # ty: ignore[unresolved-reference]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1013" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1015" target="_blank">View source</a>
 </small>
 
 
@@ -292,7 +292,7 @@ Foo.method()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L195" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L197" target="_blank">View source</a>
 </small>
 
 
@@ -320,7 +320,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L204" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L206" target="_blank">View source</a>
 </small>
 
 
@@ -355,7 +355,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L222" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L224" target="_blank">View source</a>
 </small>
 
 
@@ -389,7 +389,7 @@ a = 1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L231" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L233" target="_blank">View source</a>
 </small>
 
 
@@ -424,7 +424,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L240" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L242" target="_blank">View source</a>
 </small>
 
 
@@ -460,7 +460,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L249" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L251" target="_blank">View source</a>
 </small>
 
 
@@ -496,7 +496,7 @@ type B = A  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L294" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L296" target="_blank">View source</a>
 </small>
 
 
@@ -533,7 +533,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L267" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L269" target="_blank">View source</a>
 </small>
 
 
@@ -572,7 +572,7 @@ old_func()  # error: [deprecated]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L258" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L260" target="_blank">View source</a>
 </small>
 
 
@@ -605,7 +605,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L276" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L278" target="_blank">View source</a>
 </small>
 
 
@@ -636,7 +636,7 @@ class B(A, A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L285" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L287" target="_blank">View source</a>
 </small>
 
 
@@ -679,7 +679,7 @@ class A:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L460" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L462" target="_blank">View source</a>
 </small>
 
 
@@ -756,7 +756,7 @@ def foo() -> "intt\b": ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.50">0.0.50</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22experimental-syntax%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L186" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L188" target="_blank">View source</a>
 </small>
 
 
@@ -796,7 +796,7 @@ def g(value: ~A) -> None: ...  # error: [experimental-syntax]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L977" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L979" target="_blank">View source</a>
 </small>
 
 
@@ -831,7 +831,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L986" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L988" target="_blank">View source</a>
 </small>
 
 
@@ -947,7 +947,7 @@ def test() -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L368" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L370" target="_blank">View source</a>
 </small>
 
 
@@ -983,7 +983,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L377" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L379" target="_blank">View source</a>
 </small>
 
 
@@ -1013,7 +1013,7 @@ t[3]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L968" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L970" target="_blank">View source</a>
 </small>
 
 
@@ -1050,7 +1050,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L322" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L324" target="_blank">View source</a>
 </small>
 
 
@@ -1151,7 +1151,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L414" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L416" target="_blank">View source</a>
 </small>
 
 
@@ -1183,7 +1183,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L469" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L471" target="_blank">View source</a>
 </small>
 
 
@@ -1214,7 +1214,7 @@ a: int = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1188" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1190" target="_blank">View source</a>
 </small>
 
 
@@ -1272,7 +1272,7 @@ C.instance_only_var = 56  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.33">0.0.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1269" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1271" target="_blank">View source</a>
 </small>
 
 
@@ -1318,7 +1318,7 @@ class Sub(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L478" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L480" target="_blank">View source</a>
 </small>
 
 
@@ -1360,7 +1360,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L487" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L489" target="_blank">View source</a>
 </small>
 
 
@@ -1387,7 +1387,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L514" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L516" target="_blank">View source</a>
 </small>
 
 
@@ -1417,7 +1417,7 @@ with 1:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L312" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L314" target="_blank">View source</a>
 </small>
 
 
@@ -1470,7 +1470,7 @@ See: <https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L303" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L305" target="_blank">View source</a>
 </small>
 
 
@@ -1506,7 +1506,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L523" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L525" target="_blank">View source</a>
 </small>
 
 
@@ -1538,7 +1538,7 @@ a: str  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L541" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L543" target="_blank">View source</a>
 </small>
 
 
@@ -1595,7 +1595,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L532" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L534" target="_blank">View source</a>
 </small>
 
 
@@ -1659,7 +1659,7 @@ This rule corresponds to Ruff's [`except-with-non-exception-classes` (`B030`)](h
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1022" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1024" target="_blank">View source</a>
 </small>
 
 
@@ -1712,7 +1712,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1288" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1290" target="_blank">View source</a>
 </small>
 
 
@@ -1763,7 +1763,7 @@ class NonFrozenChild(FrozenBase):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L559" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L561" target="_blank">View source</a>
 </small>
 
 
@@ -1812,7 +1812,7 @@ class D(Generic[U, T]): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L550" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L552" target="_blank">View source</a>
 </small>
 
 
@@ -1908,7 +1908,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L387" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L389" target="_blank">View source</a>
 </small>
 
 
@@ -1956,7 +1956,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1306" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1308" target="_blank">View source</a>
 </small>
 
 
@@ -2018,7 +2018,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L586" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L588" target="_blank">View source</a>
 </small>
 
 
@@ -2058,7 +2058,7 @@ def f(t: TypeVar("U")): ...  # ty: ignore[invalid-type-form]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L703" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L705" target="_blank">View source</a>
 </small>
 
 
@@ -2108,7 +2108,7 @@ match object():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L631" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L633" target="_blank">View source</a>
 </small>
 
 
@@ -2143,7 +2143,7 @@ class B(metaclass=42): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1278" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1280" target="_blank">View source</a>
 </small>
 
 
@@ -2261,7 +2261,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.72">0.0.72</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-module-getattr-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L568" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L570" target="_blank">View source</a>
 </small>
 
 
@@ -2299,7 +2299,7 @@ from module import missing  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L350" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L352" target="_blank">View source</a>
 </small>
 
 
@@ -2366,7 +2366,7 @@ TypeError: typing.ClassVar[int] is not valid as type argument
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.31">0.0.31</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L359" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L361" target="_blank">View source</a>
 </small>
 
 
@@ -2414,7 +2414,7 @@ admin[0]  # "Alice"
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L613" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L615" target="_blank">View source</a>
 </small>
 
 
@@ -2452,7 +2452,7 @@ Baz = NewType("Baz", int | str)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L640" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L642" target="_blank">View source</a>
 </small>
 
 
@@ -2509,7 +2509,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L658" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L660" target="_blank">View source</a>
 </small>
 
 
@@ -2538,7 +2538,7 @@ def f(a: int = ""): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L595" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L597" target="_blank">View source</a>
 </small>
 
 
@@ -2574,7 +2574,7 @@ P2 = ParamSpec()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L331" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L333" target="_blank">View source</a>
 </small>
 
 
@@ -2610,7 +2610,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L667" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L669" target="_blank">View source</a>
 </small>
 
 
@@ -2681,7 +2681,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L423" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L425" target="_blank">View source</a>
 </small>
 
 
@@ -2713,7 +2713,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L676" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L678" target="_blank">View source</a>
 </small>
 
 
@@ -2824,7 +2824,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1297" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1299" target="_blank">View source</a>
 </small>
 
 
@@ -2875,7 +2875,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L604" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L606" target="_blank">View source</a>
 </small>
 
 
@@ -2921,7 +2921,7 @@ InvalidAlias = TypeAliasType("InvalidAlias", list[T], type_params=(list[T],))  #
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L860" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L862" target="_blank">View source</a>
 </small>
 
 
@@ -2988,7 +2988,7 @@ Bar[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L685" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L687" target="_blank">View source</a>
 </small>
 
 
@@ -3021,7 +3021,7 @@ TYPE_CHECKING = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L694" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L696" target="_blank">View source</a>
 </small>
 
 
@@ -3057,7 +3057,7 @@ b: Annotated[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L712" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L714" target="_blank">View source</a>
 </small>
 
 
@@ -3114,7 +3114,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L742" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L744" target="_blank">View source</a>
 </small>
 
 
@@ -3158,7 +3158,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L733" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L735" target="_blank">View source</a>
 </small>
 
 
@@ -3215,7 +3215,7 @@ V = TypeVar("V", list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L751" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L753" target="_blank">View source</a>
 </small>
 
 
@@ -3257,7 +3257,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1251" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1253" target="_blank">View source</a>
 </small>
 
 
@@ -3293,7 +3293,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1260" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1262" target="_blank">View source</a>
 </small>
 
 
@@ -3336,7 +3336,7 @@ def f(options: dict[str, object]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1242" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1244" target="_blank">View source</a>
 </small>
 
 
@@ -3371,7 +3371,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L442" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L444" target="_blank">View source</a>
 </small>
 
 
@@ -3406,7 +3406,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L396" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L398" target="_blank">View source</a>
 </small>
 
 
@@ -3473,7 +3473,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L405" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L407" target="_blank">View source</a>
 </small>
 
 
@@ -3523,7 +3523,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22mismatched-type-name%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L622" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L624" target="_blank">View source</a>
 </small>
 
 
@@ -3566,7 +3566,7 @@ Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L769" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L771" target="_blank">View source</a>
 </small>
 
 
@@ -3597,7 +3597,7 @@ func()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.41">0.0.41</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-override-decorator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1031" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1033" target="_blank">View source</a>
 </small>
 
 
@@ -3656,7 +3656,7 @@ class ExplicitChild(Parent):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.45">0.0.45</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-type-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L778" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L780" target="_blank">View source</a>
 </small>
 
 
@@ -3695,7 +3695,7 @@ def handle(m: re.Match[str]) -> str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1233" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1235" target="_blank">View source</a>
 </small>
 
 
@@ -3734,7 +3734,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L842" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L844" target="_blank">View source</a>
 </small>
 
 
@@ -3772,7 +3772,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L577" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L579" target="_blank">View source</a>
 </small>
 
 
@@ -3810,7 +3810,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L869" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L871" target="_blank">View source</a>
 </small>
 
 
@@ -3839,7 +3839,7 @@ for i in 34:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L851" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L853" target="_blank">View source</a>
 </small>
 
 
@@ -3867,7 +3867,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L950" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L952" target="_blank">View source</a>
 </small>
 
 
@@ -3904,7 +3904,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L959" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L961" target="_blank">View source</a>
 </small>
 
 
@@ -3941,7 +3941,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L887" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L889" target="_blank">View source</a>
 </small>
 
 
@@ -3972,7 +3972,7 @@ f(1, x=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1116" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1118" target="_blank">View source</a>
 </small>
 
 
@@ -4003,7 +4003,7 @@ f(x=1)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L896" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L898" target="_blank">View source</a>
 </small>
 
 
@@ -4042,7 +4042,7 @@ A.c  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L213" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L215" target="_blank">View source</a>
 </small>
 
 
@@ -4081,7 +4081,7 @@ A()[0]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L914" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L916" target="_blank">View source</a>
 </small>
 
 
@@ -4127,7 +4127,7 @@ from module import a  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L905" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L907" target="_blank">View source</a>
 </small>
 
 
@@ -4159,7 +4159,7 @@ html.parser  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L923" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L925" target="_blank">View source</a>
 </small>
 
 
@@ -4196,7 +4196,7 @@ print(x)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.60">0.0.60</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22pydantic-discarded-extra-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1103" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1105" target="_blank">View source</a>
 </small>
 
 
@@ -4271,7 +4271,7 @@ def test() -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1197" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1199" target="_blank">View source</a>
 </small>
 
 
@@ -4306,7 +4306,7 @@ cast(int, f())  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1206" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1208" target="_blank">View source</a>
 </small>
 
 
@@ -4344,7 +4344,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1215" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1217" target="_blank">View source</a>
 </small>
 
 
@@ -4388,7 +4388,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1179" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1181" target="_blank">View source</a>
 </small>
 
 
@@ -4423,7 +4423,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.39">0.0.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-dataclass-with-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L941" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L943" target="_blank">View source</a>
 </small>
 
 
@@ -4474,7 +4474,7 @@ Consider using [`functools.total_ordering`][total_ordering] instead, which does 
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L932" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L934" target="_blank">View source</a>
 </small>
 
 
@@ -4508,7 +4508,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1076" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1078" target="_blank">View source</a>
 </small>
 
 
@@ -4548,7 +4548,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1058" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1060" target="_blank">View source</a>
 </small>
 
 
@@ -4578,7 +4578,7 @@ f("foo")  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1040" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1042" target="_blank">View source</a>
 </small>
 
 
@@ -4617,7 +4617,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1067" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1069" target="_blank">View source</a>
 </small>
 
 
@@ -4675,7 +4675,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L760" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L762" target="_blank">View source</a>
 </small>
 
 
@@ -4719,7 +4719,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1085" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1087" target="_blank">View source</a>
 </small>
 
 
@@ -4748,7 +4748,7 @@ reveal_type(1)  # revealed: Literal[1]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1094" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1096" target="_blank">View source</a>
 </small>
 
 
@@ -4779,7 +4779,7 @@ f(x=1, y=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1125" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1127" target="_blank">View source</a>
 </small>
 
 
@@ -4812,7 +4812,7 @@ A().foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1224" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1226" target="_blank">View source</a>
 </small>
 
 
@@ -4887,7 +4887,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1134" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1136" target="_blank">View source</a>
 </small>
 
 
@@ -4916,7 +4916,7 @@ import foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1143" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1145" target="_blank">View source</a>
 </small>
 
 
@@ -4944,7 +4944,7 @@ print(x)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.70">0.0.70</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsound-return-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L432" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L434" target="_blank">View source</a>
 </small>
 
 
@@ -5087,7 +5087,7 @@ Python code.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.70">0.0.70</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsound-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L451" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L453" target="_blank">View source</a>
 </small>
 
 
@@ -5230,7 +5230,7 @@ generator boundaries.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L496" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L498" target="_blank">View source</a>
 </small>
 
 
@@ -5277,7 +5277,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L878" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L880" target="_blank">View source</a>
 </small>
 
 
@@ -5326,7 +5326,7 @@ b1 < b2 < b1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L505" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L507" target="_blank">View source</a>
 </small>
 
 
@@ -5373,7 +5373,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1152" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1154" target="_blank">View source</a>
 </small>
 
 
@@ -5406,7 +5406,7 @@ A() + A()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1161" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1163" target="_blank">View source</a>
 </small>
 
 
@@ -5526,7 +5526,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L649" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L651" target="_blank">View source</a>
 </small>
 
 
@@ -5605,7 +5605,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1170" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1172" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -677,3 +677,471 @@ class Meta(type): ...
 # error: [conflicting-metaclass] "derived class (`Other`) must be a subclass of the metaclasses of all its bases, but `mdtest_snippet.Meta` (metaclass of `Other`) and `first.Meta` (metaclass of base class `Model`) have no subclass relationship"
 class Other(first.Model, metaclass=Meta): ...
 ```
+
+## Parameter defaults
+
+A diagnostic that formats two types independently still disambiguates classes sharing the same name.
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+`main.py`:
+
+```py
+import first
+import second
+
+# error: [invalid-parameter-default] "Default value of type `second.Model` is not assignable to annotated parameter type `first.Model`"
+def accepts_model(value: first.Model = second.Model()) -> None: ...
+```
+
+## TypedDict field explanations
+
+An explanation disambiguates both the enclosing TypedDict classes and their nested field types
+across the complete diagnostic.
+
+`first.py`:
+
+```py
+from typing import TypedDict
+
+class Model: ...
+
+class Record(TypedDict):
+    value: Model
+```
+
+`second.py`:
+
+```py
+from typing import TypedDict
+
+class Model: ...
+
+class Record(TypedDict):
+    value: Model
+```
+
+`main.py`:
+
+```py
+import first
+import second
+
+def update(value: first.Record, replacement: second.Record) -> None:
+    value = replacement  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `second.Record` is not assignable to `first.Record`
+ --> src/main.py:5:13
+  |
+5 |     value = replacement  # snapshot: invalid-assignment
+  |     -----   ^^^^^^^^^^^ Incompatible value of type `second.Record`
+  |     |
+  |     Declared type `first.Record`
+info: field "value" on TypedDict `second.Record` has type `second.Model` which is not assignable to type `first.Model` expected by TypedDict `first.Record`
+```
+
+## Overload signatures
+
+Types inside different callable signatures share the diagnostic's name resolver and remain
+distinguishable in explanatory notes.
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+`main.py`:
+
+```py
+from typing import overload
+import first
+import second
+
+@overload
+def convert(value: first.Model) -> None: ...  # snapshot: invalid-overload
+@overload
+def convert(value: int) -> None: ...
+def convert(value: second.Model | int) -> None: ...
+```
+
+```snapshot
+error[invalid-overload]: Implementation does not accept all arguments of this overload
+ --> src/main.py:6:5
+  |
+6 | def convert(value: first.Model) -> None: ...  # snapshot: invalid-overload
+  |     ^^^^^^^
+7 | @overload
+8 | def convert(value: int) -> None: ...
+9 | def convert(value: second.Model | int) -> None: ...
+  |     ------- Implementation defined here
+info: Implementation signature `(value: second.Model | int) -> None` is not assignable to overload signature `(value: first.Model) -> None`
+info: parameter `value` has an incompatible type: `first.Model` is not assignable to `second.Model | int`
+```
+
+## Specialized runtime classes
+
+Specialized runtime values retain the identity of their actual class even when their formatter
+normally uses a short, hand-written name.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+`custom.py`:
+
+```py
+class property: ...
+class range: ...
+class TypeAliasType: ...
+class TypeVar: ...
+class ParamSpec: ...
+class TypeVarTuple: ...
+class UnionType: ...
+class module: ...
+```
+
+`main.py`:
+
+```py
+from typing import ParamSpec, TypeVar, TypeVarTuple
+import os
+import custom
+
+class Owner:
+    @property
+    def value(self) -> int:
+        return 1
+
+type Alias = int
+T = TypeVar("T")
+P = ParamSpec("P")
+Ts = TypeVarTuple("Ts")
+
+# error: [invalid-assignment] "Object of type `builtins.property` is not assignable to `custom.property`"
+wrong_property: custom.property = Owner.value
+
+# error: [invalid-assignment] "Object of type `builtins.range` is not assignable to `custom.range`"
+wrong_range: custom.range = range(3)
+
+# error: [invalid-assignment] "Object of type `typing.TypeAliasType` is not assignable to `custom.TypeAliasType`"
+wrong_alias: custom.TypeAliasType = Alias
+
+# error: [invalid-assignment] "Object of type `typing.TypeVar` is not assignable to `custom.TypeVar`"
+wrong_typevar: custom.TypeVar = T
+
+# error: [invalid-assignment] "Object of type `typing.ParamSpec` is not assignable to `custom.ParamSpec`"
+wrong_paramspec: custom.ParamSpec = P
+
+# error: [invalid-assignment] "Object of type `typing.TypeVarTuple` is not assignable to `custom.TypeVarTuple`"
+wrong_typevartuple: custom.TypeVarTuple = Ts
+
+# error: [invalid-assignment] "Object of type `<types.UnionType special-form 'int | str'>` is not assignable to `custom.UnionType`"
+wrong_union: custom.UnionType = int | str
+
+# error: [invalid-assignment] "Object of type `<module 'os'>` is not assignable to `custom.module`"
+wrong_module: custom.module = os
+```
+
+## Specialized alias values
+
+A specialized PEP 695 alias retains the identity of the alias itself, not just the identities of its
+type arguments.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+`first.py`:
+
+```py
+class Alias: ...
+```
+
+`main.py`:
+
+```py
+import first
+
+type Alias[T] = list[T]
+
+# error: [invalid-assignment] "Object of type `<type alias 'main.Alias[int]'>` is not assignable to `first.Alias`"
+wrong_alias: first.Alias = Alias[int]
+```
+
+## Partial instances
+
+The specialized formatter for `functools.partial` preserves the identity of its runtime class.
+
+`custom.py`:
+
+```py
+class partial: ...
+```
+
+`main.py`:
+
+```py
+from functools import partial
+import custom
+
+def identity(value: int) -> int:
+    return value
+
+# error: [invalid-assignment] "Object of type `functools.partial[(value: int) -> int]` is not assignable to `custom.partial`"
+wrong: custom.partial = partial(identity)
+```
+
+## Generator return classes
+
+Generator diagnostics retain the existing fully qualified runtime class spelling without introducing
+spurious unknown type arguments.
+
+`custom.py`:
+
+```py
+class GeneratorType: ...
+class AsyncGeneratorType: ...
+```
+
+`main.py`:
+
+```py
+import custom
+
+# error: [invalid-return-type] "Return type does not match returned value: expected `custom.GeneratorType`, found `types.GeneratorType`"
+def synchronous() -> custom.GeneratorType:
+    yield 1
+
+# error: [invalid-return-type] "Return type does not match returned value: expected `custom.AsyncGeneratorType`, found `types.AsyncGeneratorType`"
+async def asynchronous() -> custom.AsyncGeneratorType:
+    yield 1
+```
+
+## Generator yield and send types
+
+Yielded values and delegated send types retain their class identities in concise messages and
+annotations until the complete diagnostic is finalized.
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+`main.py`:
+
+```py
+from collections.abc import Generator
+import first
+import second
+
+def yielded() -> Generator[first.Model, None, None]:
+    # error: [invalid-yield] "Yield type `second.Model` does not match annotated yield type `first.Model`"
+    yield second.Model()
+
+def accepts_second() -> Generator[int, second.Model, None]:
+    yield 1
+
+def delegates() -> Generator[int, first.Model, None]:
+    # error: [invalid-yield] "Send type `second.Model` does not match annotated send type `first.Model`"
+    yield from accepts_second()
+```
+
+## Runtime wrapper owners
+
+A method wrapper's owning runtime class participates in name resolution alongside a separately
+displayed expected class.
+
+`custom.py`:
+
+```py
+class property: ...
+```
+
+`main.py`:
+
+```py
+import custom
+
+class Owner:
+    @property
+    def value(self) -> int:
+        return 1
+
+# error: [invalid-assignment] "Object of type `<method-wrapper '__get__' of builtins.property 'value'>` is not assignable to `custom.property`"
+wrong_wrapper: custom.property = Owner.value.__get__
+
+# error: [invalid-assignment] "Object of type `<wrapper-descriptor '__get__' of 'builtins.property' objects>` is not assignable to `custom.property`"
+wrong_descriptor: custom.property = property.__get__
+```
+
+## Conflicting declaration enumerations
+
+A human-readable enumeration formats each declared type directly into the diagnostic instead of
+flattening the list into a string before name resolution.
+
+`first.py`:
+
+```py
+class Model: ...
+```
+
+`second.py`:
+
+```py
+class Model: ...
+```
+
+`main.py`:
+
+```py
+import first
+import second
+
+def conflicting(flag: bool) -> None:
+    if flag:
+        value: first.Model
+    else:
+        value: second.Model
+
+    # error: [conflicting-declarations] "Conflicting declared types for `value`: `first.Model` and `second.Model`"
+    value = first.Model()
+```
+
+## Class inheritance
+
+A derived class and its same-named base remain distinguishable in class-validation diagnostics,
+including protocol and TypedDict inheritance.
+
+`first.py`:
+
+```py
+from typing import final
+
+@final
+class Model: ...
+
+class Interface: ...
+class Record: ...
+```
+
+`main.py`:
+
+```py
+from typing import Protocol, TypedDict
+import first
+
+# error: [subclass-of-final-class] "Class `main.Model` cannot inherit from final class `first.Model`"
+class Model(first.Model): ...
+
+# error: [invalid-protocol] "Protocol class `main.Interface` cannot inherit from non-protocol class `first.Interface`"
+class Interface(first.Interface, Protocol): ...
+
+# error: [invalid-typed-dict-header] "TypedDict class `main.Record` can only inherit from TypedDict classes: `first.Record` is not a `TypedDict` class"
+class Record(first.Record, TypedDict): ...
+```
+
+## Dynamic class inheritance
+
+Dynamic classes retain their own class identity while their base classes are validated.
+
+`first.py`:
+
+```py
+from typing import final
+
+@final
+class Model: ...
+```
+
+`main.py`:
+
+```py
+import first
+
+# error: [subclass-of-final-class] "Class `main.Model` cannot inherit from final class `first.Model`"
+Model = type("Model", (first.Model,), {})
+```
+
+## Dynamic metaclass conflicts
+
+Conflicting metaclasses and their originating classes remain distinguishable while their existing
+dynamic class representations are preserved.
+
+`first.py`:
+
+```py
+class Meta(type): ...
+class Model(metaclass=Meta): ...
+```
+
+`second.py`:
+
+```py
+class Meta(type): ...
+class Model(metaclass=Meta): ...
+```
+
+`main.py`:
+
+```py
+import first
+import second
+
+# error: [conflicting-metaclass] "`first.Meta` (metaclass of base class `<class 'first.Model'>`) and `second.Meta` (metaclass of base class `<class 'second.Model'>`)"
+Dynamic = type("Dynamic", (first.Model, second.Model), {})
+```
+
+## TypedDict openness
+
+Diagnostics that compare a closed TypedDict subclass with a same-named base preserve both class
+identities.
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+`first.py`:
+
+```py
+from typing import TypedDict
+
+class Record(TypedDict, closed=True): ...
+```
+
+`main.py`:
+
+```py
+import first
+
+# error: [invalid-typed-dict-header] "TypedDict `main.Record` must remain closed because base `first.Record` is closed"
+class Record(first.Record, closed=False): ...
+```

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -799,8 +799,7 @@ info: parameter `value` has an incompatible type: `first.Model` is not assignabl
 
 ## Specialized runtime classes
 
-Specialized runtime values retain the identity of their actual class even when their formatter
-normally uses a short, hand-written name.
+Diagnostics distinguish specialized runtime values from unrelated classes with the same name.
 
 ```toml
 [environment]
@@ -823,7 +822,8 @@ class module: ...
 `main.py`:
 
 ```py
-from typing import ParamSpec, TypeVar, TypeVarTuple
+from typing import ParamSpec, TypeAliasType, TypeVar, TypeVarTuple
+from typing_extensions import TypeAliasType as ExtensionsTypeAliasType
 import os
 import custom
 
@@ -833,6 +833,8 @@ class Owner:
         return 1
 
 type Alias = int
+StdlibAlias = TypeAliasType("StdlibAlias", int)
+ExtensionsAlias = ExtensionsTypeAliasType("ExtensionsAlias", int)
 T = TypeVar("T")
 P = ParamSpec("P")
 Ts = TypeVarTuple("Ts")
@@ -845,6 +847,12 @@ wrong_range: custom.range = range(3)
 
 # error: [invalid-assignment] "Object of type `typing.TypeAliasType` is not assignable to `custom.TypeAliasType`"
 wrong_alias: custom.TypeAliasType = Alias
+
+# error: [invalid-assignment] "Object of type `typing_extensions.TypeAliasType` is not assignable to `typing.TypeAliasType`"
+wrong_extensions_alias: TypeAliasType = ExtensionsAlias
+
+# error: [invalid-assignment] "Object of type `typing.TypeAliasType` is not assignable to `typing_extensions.TypeAliasType`"
+wrong_stdlib_alias: ExtensionsTypeAliasType = StdlibAlias
 
 # error: [invalid-assignment] "Object of type `typing.TypeVar` is not assignable to `custom.TypeVar`"
 wrong_typevar: custom.TypeVar = T
@@ -941,7 +949,7 @@ async def asynchronous() -> custom.AsyncGeneratorType:
 ## Generator yield and send types
 
 Yielded values and delegated send types retain their class identities in concise messages and
-annotations until the complete diagnostic is finalized.
+annotations.
 
 `first.py`:
 
@@ -1004,8 +1012,7 @@ wrong_descriptor: custom.property = property.__get__
 
 ## Conflicting declaration enumerations
 
-A human-readable enumeration formats each declared type directly into the diagnostic instead of
-flattening the list into a string before name resolution.
+A human-readable enumeration distinguishes declared types with the same name.
 
 `first.py`:
 

--- a/crates/ty_python_semantic/resources/mdtest/loops/async_for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/async_for.md
@@ -152,13 +152,13 @@ async def foo(flag: bool):
 ```
 
 ```snapshot
-error[not-iterable]: Object of type `AsyncIterable` may not be async-iterable
+error[not-iterable]: Object of type `mdtest_snippet.<locals of function 'foo'>.AsyncIterable` may not be async-iterable
   --> src/mdtest_snippet.py:12:20
    |
 12 |     async for x in AsyncIterable():
    |                    ^^^^^^^^^^^^^^^
 info: Its `__aiter__` method returns an object of type `PossiblyUnboundAnext`, which may not have a `__anext__` method
-info: type `AsyncIterable` is not assignable to protocol `AsyncIterable[Unknown]`
+info: type `mdtest_snippet.<locals of function 'foo'>.AsyncIterable` is not assignable to protocol `ty_extensions._internal.AsyncIterable[Unknown]`
 info: └── protocol member `__aiter__` is incompatible
 info:     └── incompatible return types: `PossiblyUnboundAnext` is not assignable to `AsyncIterator[Unknown]`
 info:         └── type `PossiblyUnboundAnext` is not assignable to protocol `AsyncIterator[Unknown]`
@@ -210,13 +210,13 @@ async def foo():
 ```
 
 ```snapshot
-error[not-iterable]: Object of type `AsyncIterable` is not async-iterable
+error[not-iterable]: Object of type `mdtest_snippet.AsyncIterable` is not async-iterable
   --> src/mdtest_snippet.py:11:20
    |
 11 |     async for x in AsyncIterable():
    |                    ^^^^^^^^^^^^^^^
 info: Its `__aiter__` method has an invalid signature
-info: type `AsyncIterable` is not assignable to protocol `AsyncIterable[Unknown]`
+info: type `mdtest_snippet.AsyncIterable` is not assignable to protocol `ty_extensions._internal.AsyncIterable[Unknown]`
 info: └── protocol member `__aiter__` is incompatible
 info:     └── unexpected extra parameter `arg`
 help: Parameter `arg` must have a default value
@@ -241,16 +241,16 @@ async def foo():
 ```
 
 ```snapshot
-error[not-iterable]: Object of type `AsyncIterable` is not async-iterable
+error[not-iterable]: Object of type `mdtest_snippet.AsyncIterable` is not async-iterable
   --> src/mdtest_snippet.py:11:20
    |
 11 |     async for x in AsyncIterable():
    |                    ^^^^^^^^^^^^^^^
-info: Its `__aiter__` method returns an object of type `AsyncIterator`, which has an invalid `__anext__` method
-info: type `AsyncIterable` is not assignable to protocol `AsyncIterable[Unknown]`
+info: Its `__aiter__` method returns an object of type `mdtest_snippet.AsyncIterator`, which has an invalid `__anext__` method
+info: type `mdtest_snippet.AsyncIterable` is not assignable to protocol `ty_extensions._internal.AsyncIterable[Unknown]`
 info: └── protocol member `__aiter__` is incompatible
-info:     └── incompatible return types: `AsyncIterator` is not assignable to `AsyncIterator[Unknown]`
-info:         └── type `AsyncIterator` is not assignable to protocol `AsyncIterator[Unknown]`
+info:     └── incompatible return types: `mdtest_snippet.AsyncIterator` is not assignable to `ty_extensions._internal.AsyncIterator[Unknown]`
+info:         └── type `mdtest_snippet.AsyncIterator` is not assignable to protocol `ty_extensions._internal.AsyncIterator[Unknown]`
 info:             └── protocol member `__anext__` is incompatible
 info:                 └── unexpected extra parameter `arg`
 help: Parameter `arg` must have a default value

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -882,13 +882,13 @@ for x in Iterable():
 ```
 
 ```snapshot
-error[not-iterable]: Object of type `Iterable` is not iterable
+error[not-iterable]: Object of type `mdtest_snippet.Iterable` is not iterable
   --> src/mdtest_snippet.py:10:10
    |
 10 | for x in Iterable():
    |          ^^^^^^^^^^
 info: Its `__iter__` method has an invalid signature
-info: type `Iterable` is not assignable to protocol `Iterable[Unknown]`
+info: type `mdtest_snippet.Iterable` is not assignable to protocol `ty_extensions._internal.Iterable[Unknown]`
 info: └── protocol member `__iter__` is incompatible
 info:     └── unexpected extra parameter `extra_arg`
 help: Parameter `extra_arg` must have a default value
@@ -929,7 +929,7 @@ def _(flag: bool):
         def __iter__(self) -> Iterator:
             return Iterator()
 
-    # error: [not-iterable] "Object of type `Iterable` may not be iterable"
+    # error: [not-iterable] "Object of type `mdtest_snippet.<locals of function '_'>.Iterable` may not be iterable"
     for x in Iterable():
         reveal_type(x)  # revealed: int
 ```

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -929,7 +929,7 @@ def _(flag: bool):
         def __iter__(self) -> Iterator:
             return Iterator()
 
-    # error: [not-iterable] "Object of type `mdtest_snippet.<locals of function '_'>.Iterable` may not be iterable"
+    # error: [not-iterable] "Object of type `Iterable` may not be iterable"
     for x in Iterable():
         reveal_type(x)  # revealed: int
 ```

--- a/crates/ty_python_semantic/src/diagnostic/mod.rs
+++ b/crates/ty_python_semantic/src/diagnostic/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
-    Db, PythonVersionSource, PythonVersionWithSource,
-    lint::lint_documentation_url,
-    types::{TypeCheckDiagnostics, diagnostic_file_location},
+    Db, PythonVersionSource, PythonVersionWithSource, lint::lint_documentation_url,
+    types::TypeCheckDiagnostics,
 };
 use levenshtein::{HideUnderscoredSuggestions, find_best_suggestion};
 use ruff_db::{
@@ -187,8 +186,6 @@ pub(crate) fn format_enumeration<D: std::fmt::Display>(
 /// if either is violated, then the `Drop` impl on `DiagnosticGuard` will
 /// panic.
 pub(super) struct DiagnosticGuard<'sink> {
-    db: &'sink dyn Db,
-
     /// The file of the primary span (to which file does this diagnostic belong).
     file: File,
 
@@ -216,13 +213,11 @@ pub(super) struct DiagnosticGuard<'sink> {
 
 impl<'sink> DiagnosticGuard<'sink> {
     pub(crate) fn new(
-        db: &'sink dyn Db,
         file: File,
         sink: &'sink std::cell::RefCell<TypeCheckDiagnostics>,
         diag: Diagnostic,
     ) -> Self {
         Self {
-            db,
             file,
             sink,
             diag: Some(diag),
@@ -300,7 +295,6 @@ impl Drop for DiagnosticGuard<'_> {
             diag.set_documentation_url(Some(lint_documentation_url(lint_name)));
         }
 
-        diag.disambiguate_names(|file, offset| diagnostic_file_location(self.db, file, offset));
         self.sink.borrow_mut().push(diag);
     }
 }

--- a/crates/ty_python_semantic/src/diagnostic/mod.rs
+++ b/crates/ty_python_semantic/src/diagnostic/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
-    Db, PythonVersionSource, PythonVersionWithSource, lint::lint_documentation_url,
-    types::TypeCheckDiagnostics,
+    Db, PythonVersionSource, PythonVersionWithSource,
+    lint::lint_documentation_url,
+    types::{TypeCheckDiagnostics, diagnostic_file_location},
 };
 use levenshtein::{HideUnderscoredSuggestions, find_best_suggestion};
 use ruff_db::{
@@ -8,7 +9,6 @@ use ruff_db::{
     files::File,
 };
 use std::cell::RefCell;
-use std::fmt::Write;
 
 mod levenshtein;
 
@@ -153,25 +153,25 @@ pub(crate) fn add_inferred_python_version_hint_to_diagnostic(
 /// Format a list of elements as a human-readable enumeration.
 ///
 /// Encloses every element in backticks (`1`, `2` and `3`).
-pub(crate) fn format_enumeration<I, IT, D>(elements: I) -> String
-where
-    I: IntoIterator<IntoIter = IT>,
-    IT: ExactSizeIterator<Item = D> + DoubleEndedIterator,
-    D: std::fmt::Display,
-{
-    let mut elements = elements.into_iter();
+pub(crate) fn format_enumeration<D: std::fmt::Display>(
+    elements: impl IntoIterator<Item = D>,
+) -> impl std::fmt::Display {
+    let elements: Vec<_> = elements.into_iter().collect();
     debug_assert!(elements.len() >= 2);
 
-    let final_element = elements.next_back().unwrap();
-    let penultimate_element = elements.next_back().unwrap();
+    std::fmt::from_fn(move |f| {
+        let Some((final_element, preceding)) = elements.split_last() else {
+            return Ok(());
+        };
+        let Some((penultimate_element, preceding)) = preceding.split_last() else {
+            return write!(f, "`{final_element}`");
+        };
 
-    let mut buffer = String::new();
-    for element in elements {
-        write!(&mut buffer, "`{element}`, ").ok();
-    }
-    write!(&mut buffer, "`{penultimate_element}` and `{final_element}`").ok();
-
-    buffer
+        for element in preceding {
+            write!(f, "`{element}`, ")?;
+        }
+        write!(f, "`{penultimate_element}` and `{final_element}`")
+    })
 }
 
 /// An abstraction for mutating a diagnostic.
@@ -187,6 +187,8 @@ where
 /// if either is violated, then the `Drop` impl on `DiagnosticGuard` will
 /// panic.
 pub(super) struct DiagnosticGuard<'sink> {
+    db: &'sink dyn Db,
+
     /// The file of the primary span (to which file does this diagnostic belong).
     file: File,
 
@@ -214,11 +216,13 @@ pub(super) struct DiagnosticGuard<'sink> {
 
 impl<'sink> DiagnosticGuard<'sink> {
     pub(crate) fn new(
+        db: &'sink dyn Db,
         file: File,
         sink: &'sink std::cell::RefCell<TypeCheckDiagnostics>,
         diag: Diagnostic,
     ) -> Self {
         Self {
+            db,
             file,
             sink,
             diag: Some(diag),
@@ -296,6 +300,7 @@ impl Drop for DiagnosticGuard<'_> {
             diag.set_documentation_url(Some(lint_documentation_url(lint_name)));
         }
 
+        diag.disambiguate_names(|file, offset| diagnostic_file_location(self.db, file, offset));
         self.sink.borrow_mut().push(diag);
     }
 }

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -303,7 +303,7 @@ impl<'ctx, 'db> SuppressionDiagnosticGuardBuilder<'ctx, 'db> {
 
         let primary_span = Span::from(self.ctx.file).with_range(self.range);
         diag.annotate(Annotation::primary(primary_span));
-        DiagnosticGuard::new(self.ctx.db, self.ctx.file, &self.ctx.diagnostics, diag)
+        DiagnosticGuard::new(self.ctx.file, &self.ctx.diagnostics, diag)
     }
 }
 

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -303,7 +303,7 @@ impl<'ctx, 'db> SuppressionDiagnosticGuardBuilder<'ctx, 'db> {
 
         let primary_span = Span::from(self.ctx.file).with_range(self.range);
         diag.annotate(Annotation::primary(primary_span));
-        DiagnosticGuard::new(self.ctx.file, &self.ctx.diagnostics, diag)
+        DiagnosticGuard::new(self.ctx.db, self.ctx.file, &self.ctx.diagnostics, diag)
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -71,6 +71,7 @@ use crate::types::diagnostic::{
     AttributeAccessMethod, INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_attribute_access_call,
     report_bad_dunder_get_call, report_bad_import_call,
 };
+pub(crate) use crate::types::display::diagnostic_file_location;
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
 pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_metadata};
 pub(crate) use crate::types::equality::{ComparisonSoundnessPolicy, equality_truthiness};

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -71,7 +71,6 @@ use crate::types::diagnostic::{
     AttributeAccessMethod, INVALID_AWAIT, INVALID_TYPE_FORM, report_bad_attribute_access_call,
     report_bad_dunder_get_call, report_bad_import_call,
 };
-pub(crate) use crate::types::display::diagnostic_file_location;
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
 pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_metadata};
 pub(crate) use crate::types::equality::{ComparisonSoundnessPolicy, equality_truthiness};
@@ -207,7 +206,8 @@ pub fn check_types(db: &dyn Db, file: ProgramFile<'_>) -> Vec<Diagnostic> {
             .map(|error| Diagnostic::invalid_syntax(source_file, error, error)),
     );
 
-    let diagnostics = check_suppressions(db, file.python_file(db), diagnostics);
+    let mut diagnostics = check_suppressions(db, file.python_file(db), diagnostics);
+    display::disambiguate_diagnostic_names(db, &mut diagnostics);
 
     let elapsed = start.elapsed();
     if elapsed >= Duration::from_millis(100) {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -78,7 +78,7 @@ use crate::types::{
 };
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_python_ast::{self as ast, AnyNodeRef, ArgOrKeyword, PythonVersion};
-use ty_python_core::{ProgramFile, semantic_index};
+use ty_python_core::{ProgramFile, scope::NodeWithScopeKind, semantic_index};
 
 pub(crate) use self::constructor::ConstructorCallableKind;
 
@@ -8303,14 +8303,11 @@ impl<'db> CallableDescription<'db> {
         ) -> Option<ClassLiteral<'db>> {
             let semantic_index = semantic_index(db, function.program_file(db));
             let enclosing_scope = semantic_index.scope(function.definition(db).file_scope(db));
-            if let Some(class_node) = enclosing_scope.node().as_class()
-                && let Some(class) =
-                    original_class_type(db, semantic_index.expect_single_definition(class_node))
-            {
-                Some(class)
-            } else {
-                None
-            }
+            let NodeWithScopeKind::Class(class_node) = enclosing_scope.node() else {
+                return None;
+            };
+
+            original_class_type(db, semantic_index.expect_single_definition(class_node))
         }
 
         match callable_type {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -14,9 +14,10 @@ mod enum_property;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
-use std::fmt;
+use std::fmt::{self, Display};
 
 use itertools::Itertools;
+use ruff_db::diagnostic::DiagnosticMessage;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::{Ranged, TextRange};
@@ -25,6 +26,7 @@ use smallvec::{SmallVec, smallvec, smallvec_inline};
 
 use self::constructor::{ConstructorBinding, ConstructorContext};
 use super::{Argument, CallArguments, CallError, CallErrorKind, InferContext, Signature, Type};
+use crate::FxOrderSet;
 use crate::db::Db;
 use crate::dunder_all::dunder_all_names;
 use crate::lint::LintMetadata;
@@ -74,7 +76,6 @@ use crate::types::{
     TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance, UnionAccumulator, UnionBuilder,
     UnionType, WrapperDescriptorKind, enums, list_members,
 };
-use crate::{DisplaySettings, FxOrderSet};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_python_ast::{self as ast, AnyNodeRef, ArgOrKeyword, PythonVersion};
 use ty_python_core::{ProgramFile, semantic_index};
@@ -89,8 +90,8 @@ pub(crate) use self::constructor::ConstructorCallableKind;
 /// ranges.
 pub(crate) struct CallDiagnosticOverride<'a> {
     pub(crate) lint: &'static LintMetadata,
-    pub(crate) message: String,
-    pub(crate) info: &'a str,
+    pub(crate) message: DiagnosticMessage,
+    pub(crate) info: DiagnosticMessage,
     pub(crate) argument_ranges: &'a [TextRange],
 }
 
@@ -109,7 +110,7 @@ impl<'db> CallDiagnosticContext<'_, '_, 'db, '_> {
         let lint = self.overrides.map_or(lint, |overrides| overrides.lint);
         self.context.report_lint(lint, ranged).map(|builder| {
             if let Some(overrides) = self.overrides {
-                builder.with_message_override(overrides.message.clone(), overrides.info)
+                builder.with_message_override(overrides.message.clone(), overrides.info.clone())
             } else {
                 builder
             }
@@ -4554,9 +4555,7 @@ impl<'db> CallableBinding<'db> {
                 let callable_description = CallableDescription::new(db, self.callable_type);
                 let mut diag = builder.into_diagnostic(format_args!(
                     "No overload{} matches arguments",
-                    callable_description
-                        .map(|description| format!(" of {description}"))
-                        .unwrap_or_default()
+                    display_callable_description(db, callable_description.as_ref(), "of")
                 ));
 
                 if let Some(index) =
@@ -8290,57 +8289,27 @@ impl CallableBindingSnapshotter {
 pub(crate) struct CallableDescription<'a> {
     name: Cow<'a, str>,
     kind: Option<&'static str>,
+    owner: Option<ClassLiteral<'a>>,
 }
 
 impl<'db> CallableDescription<'db> {
-    fn defining_class(db: &'db dyn Db, callable_type: Type<'db>) -> Option<ClassLiteral<'db>> {
-        let function = match callable_type {
-            Type::FunctionLiteral(function) => function,
-            Type::BoundMethod(method) => method.function(db),
-            Type::ClassLiteral(class) => return Some(class),
-            _ => return None,
-        };
-
-        let semantic_index = semantic_index(db, function.program_file(db));
-        let enclosing_scope = semantic_index.scope(function.definition(db).file_scope(db));
-        let class_node = enclosing_scope.node().as_class()?;
-
-        original_class_type(db, semantic_index.expect_single_definition(class_node))
-    }
-
     pub(crate) fn new(
         db: &'db dyn Db,
         callable_type: Type<'db>,
     ) -> Option<CallableDescription<'db>> {
-        Self::new_with_settings(db, callable_type, None)
-    }
-
-    fn new_with_settings(
-        db: &'db dyn Db,
-        callable_type: Type<'db>,
-        settings: Option<&DisplaySettings<'db>>,
-    ) -> Option<CallableDescription<'db>> {
-        fn qualified_function_name<'db>(
+        fn function_owner<'db>(
             db: &'db dyn Db,
             function: FunctionType<'db>,
-            settings: Option<&DisplaySettings<'db>>,
-        ) -> Cow<'db, str> {
-            if let Some(class) =
-                CallableDescription::defining_class(db, Type::FunctionLiteral(function))
+        ) -> Option<ClassLiteral<'db>> {
+            let semantic_index = semantic_index(db, function.program_file(db));
+            let enclosing_scope = semantic_index.scope(function.definition(db).file_scope(db));
+            if let Some(class_node) = enclosing_scope.node().as_class()
+                && let Some(class) =
+                    original_class_type(db, semantic_index.expect_single_definition(class_node))
             {
-                settings
-                    .map(|settings| {
-                        Cow::Owned(format!(
-                            "{}.{}",
-                            class.display_with(db, settings.clone()),
-                            function.name(db)
-                        ))
-                    })
-                    .unwrap_or_else(|| {
-                        Cow::Owned(format!("{}.{}", class.name(db), function.name(db)))
-                    })
+                Some(class)
             } else {
-                Cow::Borrowed(function.name(db))
+                None
             }
         }
 
@@ -8351,20 +8320,19 @@ impl<'db> CallableDescription<'db> {
                 } else {
                     "function"
                 }),
-                name: qualified_function_name(db, function, settings),
+                name: Cow::Borrowed(function.name(db)),
+                owner: function_owner(db, function),
             }),
             Type::ClassLiteral(class_type) => Some(CallableDescription {
                 kind: Some("class"),
-                name: settings
-                    .map(|settings| {
-                        Cow::Owned(class_type.display_with(db, settings.clone()).to_string())
-                    })
-                    .unwrap_or_else(|| Cow::Borrowed(class_type.name(db).as_str())),
+                name: Cow::Borrowed(""),
+                owner: Some(class_type),
             }),
             Type::SubclassOf(subclass) if let Some(typevar) = subclass.into_type_var() => {
                 Some(CallableDescription {
                     kind: None,
                     name: Cow::Owned(format!("type[{}]", typevar.name(db))),
+                    owner: None,
                 })
             }
             Type::BoundMethod(bound_method) => Some({
@@ -8376,25 +8344,29 @@ impl<'db> CallableDescription<'db> {
                 };
                 CallableDescription {
                     kind,
-                    name: qualified_function_name(db, function, settings),
+                    name: Cow::Borrowed(function.name(db)),
+                    owner: function_owner(db, function),
                 }
             }),
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
                 Some(CallableDescription {
                     kind: Some("method wrapper `__get__` of function"),
                     name: Cow::Borrowed(function.name(db)),
+                    owner: None,
                 })
             }
             Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(_)) => {
                 Some(CallableDescription {
                     kind: Some("method wrapper"),
                     name: Cow::Borrowed("`__get__` of property"),
+                    owner: None,
                 })
             }
             Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(_)) => {
                 Some(CallableDescription {
                     kind: Some("method wrapper"),
                     name: Cow::Borrowed("`__delete__` of property"),
+                    owner: None,
                 })
             }
             Type::WrapperDescriptor(kind) => Some(CallableDescription {
@@ -8405,20 +8377,45 @@ impl<'db> CallableDescription<'db> {
                     WrapperDescriptorKind::PropertyDunderSet => "property.__set__",
                     WrapperDescriptorKind::PropertyDunderDelete => "property.__delete__",
                 }),
+                owner: None,
             }),
             _ => None,
         }
     }
+
+    fn display<'a>(&'a self, db: &'db dyn Db) -> impl Display + 'a {
+        fmt::from_fn(move |f| {
+            if let Some(kind) = self.kind {
+                write!(f, "{kind} `")?;
+            } else {
+                f.write_str("`")?;
+            }
+
+            if let Some(owner) = self.owner {
+                owner.display(db).fmt(f)?;
+                if !self.name.is_empty() {
+                    f.write_str(".")?;
+                }
+            }
+
+            write!(f, "{}`", self.name)
+        })
+    }
 }
 
-impl std::fmt::Display for CallableDescription<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(kind) = self.kind {
-            write!(f, "{kind} `{}`", self.name)
+/// Formats an optional callable without flattening semantic owner names into a `String`.
+pub(crate) fn display_callable_description<'a, 'db>(
+    db: &'db dyn Db,
+    description: Option<&'a CallableDescription<'db>>,
+    preposition: &'static str,
+) -> impl Display + 'a {
+    fmt::from_fn(move |f| {
+        if let Some(description) = description {
+            write!(f, " {preposition} {}", description.display(db))
         } else {
-            write!(f, "`{}`", self.name)
+            Ok(())
         }
-    }
+    })
 }
 
 /// Information needed to emit a diagnostic regarding a parameter.
@@ -8881,29 +8878,12 @@ impl<'db> BindingError<'db> {
                     return;
                 };
 
-                let defining_class =
-                    CallableDescription::defining_class(db, callable_ty).map(Type::ClassLiteral);
-                let types = [*provided_ty, *expected_ty]
-                    .into_iter()
-                    .chain(defining_class);
-                let display_settings =
-                    DisplaySettings::from_possibly_ambiguous_types(db, env, types);
-                let qualified_callable_description = CallableDescription::new_with_settings(
-                    db,
-                    callable_ty,
-                    Some(&display_settings),
-                );
-                let provided_ty_display =
-                    provided_ty.display_with(db, env, display_settings.clone());
-                let expected_ty_display = expected_ty.display_with(db, env, display_settings);
+                let provided_ty_display = provided_ty.display(db, env);
+                let expected_ty_display = expected_ty.display(db, env);
 
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Argument{} is incorrect",
-                    qualified_callable_description
-                        .as_ref()
-                        .or(callable_description)
-                        .map(|description| format!(" to {description}"))
-                        .unwrap_or_default()
+                    display_callable_description(db, callable_description, "to")
                 ));
                 if matches!(
                     provenance,
@@ -9053,9 +9033,10 @@ impl<'db> BindingError<'db> {
                     return;
                 };
                 let provided_ty_display = provided_ty.display(db, env);
-                let mut diag = builder.into_diagnostic(
-                    "Argument expression after ** must be a mapping with `str` key type",
-                );
+                let mut diag = builder.into_diagnostic(format_args!(
+                    "Argument expression after ** must be a mapping with `{}` key type",
+                    KnownClass::Str.to_instance(db, env).display(db, env)
+                ));
                 diag.set_primary_annotation_message(format_args!("Found `{provided_ty_display}`"));
 
                 if let Some(compound_diag) = compound_diag {
@@ -9073,9 +9054,7 @@ impl<'db> BindingError<'db> {
                     let mut diag = builder.into_diagnostic(format_args!(
                         "Too many positional arguments{}: expected \
                         {expected_positional_count}, got {provided_positional_count}",
-                        callable_description
-                            .map(|description| format!(" to {description}"))
-                            .unwrap_or_default()
+                        display_callable_description(db, callable_description, "to")
                     ));
                     if let Some(compound_diag) = compound_diag {
                         compound_diag.add_context(db, env, &mut diag);
@@ -9099,9 +9078,7 @@ impl<'db> BindingError<'db> {
                     let s = if parameters.0.len() == 1 { "" } else { "s" };
                     let mut diag = builder.into_diagnostic(format_args!(
                         "No argument{s} provided for required parameter{s} {parameters}{}",
-                        callable_description
-                            .map(|description| format!(" of {description}"))
-                            .unwrap_or_default()
+                        display_callable_description(db, callable_description, "of")
                     ));
                     if let Some(compound_diag) = compound_diag {
                         compound_diag.add_context(db, env, &mut diag);
@@ -9143,9 +9120,7 @@ impl<'db> BindingError<'db> {
                 if let Some(builder) = context.report_lint(&UNKNOWN_ARGUMENT, range) {
                     let mut diag = builder.into_diagnostic(format_args!(
                         "Argument `{argument_name}` does not match any known parameter{}",
-                        callable_description
-                            .map(|description| format!(" of {description}"))
-                            .unwrap_or_default()
+                        display_callable_description(db, callable_description, "of")
                     ));
                     if let Some(compound_diag) = compound_diag {
                         compound_diag.add_context(db, env, &mut diag);
@@ -9165,9 +9140,7 @@ impl<'db> BindingError<'db> {
                 if let Some(builder) = context.report_lint(&UNKNOWN_ARGUMENT, range) {
                     let mut diag = builder.into_diagnostic(format_args!(
                         "Unpacked argument may contain keyword arguments that do not match any known parameter{}",
-                        callable_description
-                            .map(|description| format!(" of {description}"))
-                            .unwrap_or_default()
+                        display_callable_description(db, callable_description, "of")
                     ));
                     if let Some(compound_diag) = compound_diag {
                         compound_diag.add_context(db, env, &mut diag);
@@ -9192,9 +9165,7 @@ impl<'db> BindingError<'db> {
                 {
                     let mut diag = builder.into_diagnostic(format_args!(
                         "Positional-only parameter {parameter} passed as keyword argument{}",
-                        callable_description
-                            .map(|description| format!(" of {description}"))
-                            .unwrap_or_default()
+                        display_callable_description(db, callable_description, "of")
                     ));
                     if let Some(compound_diag) = compound_diag {
                         compound_diag.add_context(db, env, &mut diag);
@@ -9217,9 +9188,7 @@ impl<'db> BindingError<'db> {
                 if let Some(builder) = context.report_lint(&PARAMETER_ALREADY_ASSIGNED, range) {
                     let mut diag = builder.into_diagnostic(format_args!(
                         "Multiple values provided for parameter {parameter}{}",
-                        callable_description
-                            .map(|description| format!(" of {description}"))
-                            .unwrap_or_default()
+                        display_callable_description(db, callable_description, "of")
                     ));
                     if let Some(compound_diag) = compound_diag {
                         compound_diag.add_context(db, env, &mut diag);
@@ -9240,9 +9209,7 @@ impl<'db> BindingError<'db> {
 
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Argument{} is incorrect",
-                    callable_description
-                        .map(|description| format!(" to {description}"))
-                        .unwrap_or_default()
+                    display_callable_description(db, callable_description, "to")
                 ));
 
                 match error {
@@ -9352,9 +9319,7 @@ impl<'db> BindingError<'db> {
                 if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, range) {
                     let mut diag = builder.into_diagnostic(format_args!(
                         "Call{} failed: {reason}",
-                        callable_description
-                            .map(|description| format!(" of {description}"))
-                            .unwrap_or_default()
+                        display_callable_description(db, callable_description, "of")
                     ));
                     if let Some(compound_diag) = compound_diag {
                         compound_diag.add_context(db, env, &mut diag);

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use itertools::Either;
+
 use crate::ProgramEnvironment;
 use crate::types::class::CodeGeneratorKind;
 use crate::types::generics::{ApplySpecialization, Specialization};
@@ -79,6 +81,15 @@ impl<'db> ClassBase<'db> {
             ClassBase::Protocol => "Protocol",
             ClassBase::Generic => "Generic",
             ClassBase::TypedDict(_) => "TypedDict",
+        }
+    }
+
+    /// Displays this base's source-style name without losing a class's semantic identity.
+    pub(super) fn display_name(self, db: &'db dyn Db) -> impl Display {
+        if let ClassBase::Class(class) = self {
+            Either::Left(class.class_literal(db).display(db))
+        } else {
+            Either::Right(self.name(db))
         }
     }
 

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -21,7 +21,6 @@ use crate::diagnostic::DiagnosticGuard;
 use crate::lint::LintSource;
 use crate::reachability::is_range_reachable;
 use crate::types::diagnostic::{INVALID_TYPE_FORM, UNBOUND_TYPE_VARIABLE};
-use crate::types::display::diagnostic_file_location;
 use crate::types::function::FunctionDecorators;
 use crate::types::infer::InferenceFlags;
 use crate::{
@@ -543,9 +542,6 @@ impl Drop for LintDiagnosticGuard<'_, '_> {
             });
         }
 
-        diag.disambiguate_names(|file, offset| {
-            diagnostic_file_location(self.ctx.db(), file, offset)
-        });
         self.ctx.diagnostics.borrow_mut().push(diag);
     }
 }
@@ -757,6 +753,6 @@ impl<'db, 'ctx> DiagnosticGuardBuilder<'db, 'ctx> {
     ) -> DiagnosticGuard<'ctx> {
         let diag = Diagnostic::new(self.id, self.severity, message);
 
-        DiagnosticGuard::new(self.ctx.db(), self.ctx.file, &self.ctx.diagnostics, diag)
+        DiagnosticGuard::new(self.ctx.file, &self.ctx.diagnostics, diag)
     }
 }

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -5,7 +5,10 @@ use ruff_db::PythonFile;
 use ruff_db::diagnostic::DiagnosticTag;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::{
-    diagnostic::{Annotation, Diagnostic, DiagnosticId, IntoDiagnosticMessage, Severity, Span},
+    diagnostic::{
+        Annotation, Diagnostic, DiagnosticId, DiagnosticMessage, IntoDiagnosticMessage, Severity,
+        Span,
+    },
     files::File,
 };
 use ruff_python_ast::PythonVersion;
@@ -18,6 +21,7 @@ use crate::diagnostic::DiagnosticGuard;
 use crate::lint::LintSource;
 use crate::reachability::is_range_reachable;
 use crate::types::diagnostic::{INVALID_TYPE_FORM, UNBOUND_TYPE_VARIABLE};
+use crate::types::display::diagnostic_file_location;
 use crate::types::function::FunctionDecorators;
 use crate::types::infer::InferenceFlags;
 use crate::{
@@ -408,7 +412,7 @@ pub(super) struct LintDiagnosticGuard<'db, 'ctx> {
     diag: Option<Diagnostic>,
 
     source: LintSource,
-    message_override: Option<String>,
+    message_override: Option<DiagnosticMessage>,
 }
 
 impl LintDiagnosticGuard<'_, '_> {
@@ -503,7 +507,7 @@ impl Drop for LintDiagnosticGuard<'_, '_> {
                 .primary_annotation()
                 .and_then(Annotation::get_message)
                 .is_some_and(|message| !message.is_empty());
-            let original_message = diag.headline_message().to_string();
+            let original_message = diag.clone_headline_message();
             if primary_annotation_has_message {
                 diag.prepend_info(original_message);
             } else if let Some(annotation) = diag.primary_annotation_mut() {
@@ -539,6 +543,9 @@ impl Drop for LintDiagnosticGuard<'_, '_> {
             });
         }
 
+        diag.disambiguate_names(|file, offset| {
+            diagnostic_file_location(self.ctx.db(), file, offset)
+        });
         self.ctx.diagnostics.borrow_mut().push(diag);
     }
 }
@@ -575,7 +582,7 @@ pub(super) struct LintDiagnosticGuardBuilder<'db, 'ctx> {
     severity: Severity,
     source: LintSource,
     primary_range: TextRange,
-    message_override: Option<(String, String)>,
+    message_override: Option<(DiagnosticMessage, DiagnosticMessage)>,
 }
 
 impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
@@ -673,7 +680,7 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
     /// sub-diagnostic otherwise. Any custom concise message is discarded.
     pub(super) fn into_diagnostic(
         self,
-        message: impl std::fmt::Display,
+        message: impl IntoDiagnosticMessage,
     ) -> LintDiagnosticGuard<'db, 'ctx> {
         // This is why `LintDiagnosticGuard::set_primary_annotation_message` exists.
         // We add the primary annotation here (because it's required). Without a message
@@ -697,8 +704,12 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
     /// Replace the headline message when the diagnostic is finalized and add an info
     /// sub-diagnostic. The original message is retained on the primary annotation if it has no
     /// message, or as an info sub-diagnostic otherwise.
-    pub(super) fn with_message_override(mut self, message: String, info: &str) -> Self {
-        self.message_override = Some((message, info.to_string()));
+    pub(super) fn with_message_override(
+        mut self,
+        message: DiagnosticMessage,
+        info: DiagnosticMessage,
+    ) -> Self {
+        self.message_override = Some((message, info));
         self
     }
 }
@@ -740,9 +751,12 @@ impl<'db, 'ctx> DiagnosticGuardBuilder<'db, 'ctx> {
     ///
     /// The diagnostic can be further mutated on the guard via its `DerefMut`
     /// impl to `Diagnostic`.
-    pub(super) fn into_diagnostic(self, message: impl std::fmt::Display) -> DiagnosticGuard<'ctx> {
+    pub(super) fn into_diagnostic(
+        self,
+        message: impl IntoDiagnosticMessage,
+    ) -> DiagnosticGuard<'ctx> {
         let diag = Diagnostic::new(self.id, self.severity, message);
 
-        DiagnosticGuard::new(self.ctx.file, &self.ctx.diagnostics, diag)
+        DiagnosticGuard::new(self.ctx.db(), self.ctx.file, &self.ctx.diagnostics, diag)
     }
 }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -31,11 +31,13 @@ use crate::types::{
     protocol_class::ProtocolClass,
 };
 use crate::types::{KnownInstanceType, MemberLookupPolicy, TypeVarKind, TypedDictType, UnionType};
-use crate::{Db, DisplaySettings, FxIndexMap, ProgramEnvironment, declare_lint};
-use itertools::Itertools;
+use crate::{Db, FxIndexMap, ProgramEnvironment, declare_lint};
+use itertools::{Either, Itertools};
 use ruff_db::source::source_text;
 use ruff_db::{
-    diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity},
+    diagnostic::{
+        Annotation, Diagnostic, DiagnosticMessage, Span, SubDiagnostic, SubDiagnosticSeverity,
+    },
     files::File,
     parsed::parsed_module,
 };
@@ -1662,8 +1664,6 @@ pub(super) fn report_invalid_assignment<'db>(
     }
 
     let env = &context.program_environment();
-    let settings = DisplaySettings::from_possibly_ambiguous_types(db, env, [target_ty, value_ty]);
-
     let diagnostic_range = if let Some(value_node) = value_node {
         // Expand the range to include parentheses around the value, if any. This allows
         // invalid-assignment diagnostics to be suppressed on the opening or closing parenthesis:
@@ -1685,8 +1685,8 @@ pub(super) fn report_invalid_assignment<'db>(
         diagnostic_range,
         format_args!(
             "Object of type `{}` is not assignable to `{}`",
-            value_ty.display_with(db, env, settings.clone()),
-            target_ty.display_with(db, env, settings)
+            value_ty.display(db, env),
+            target_ty.display(db, env)
         ),
     ) else {
         return;
@@ -1740,7 +1740,7 @@ pub(super) fn report_invalid_assignment<'db>(
         error_context.attach_to(db, env, &mut diag);
 
         // Overwrite the concise message to avoid showing the value type twice
-        let message = diag.headline_message().to_string();
+        let message = diag.clone_headline_message();
         diag.set_concise_message(message);
     }
 
@@ -1763,14 +1763,13 @@ pub(super) fn report_invalid_attribute_assignment(
     // diagnostic being emitted here.
 
     let env = &context.program_environment();
-    let settings = DisplaySettings::from_possibly_ambiguous_types(db, env, [source_ty, target_ty]);
     let Some(mut diag) = report_invalid_assignment_with_message(
         context,
         range,
         format_args!(
             "Object of type `{}` is not assignable to attribute `{attribute_name}` of type `{}`",
-            source_ty.display_with(db, env, settings.clone()),
-            target_ty.display_with(db, env, settings),
+            source_ty.display(db, env),
+            target_ty.display(db, env),
         ),
     ) else {
         return;
@@ -1824,14 +1823,14 @@ pub(super) fn report_bad_dunder_get_call<'db>(
             target.into(),
             &CallDiagnosticOverride {
                 lint: &INVALID_ATTRIBUTE_ACCESS,
-                message: format!(
+                message: DiagnosticMessage::from_display(format_args!(
                     "Invalid access to descriptor attribute `{attribute}` on type `{}`",
                     object_type.display(db, env),
-                ),
-                info: &format!(
+                )),
+                info: DiagnosticMessage::from_display(format_args!(
                     "This access implicitly calls `__get__` on a descriptor of type `{}`",
                     descriptor_type.display(db, env),
-                ),
+                )),
                 argument_ranges: &[target.range(), target.value.range(), target.value.range()],
             },
         );
@@ -1880,11 +1879,14 @@ pub(super) fn report_bad_attribute_access_call<'db>(
         target.into(),
         &CallDiagnosticOverride {
             lint: &INVALID_ATTRIBUTE_ACCESS,
-            message: format!(
+            message: DiagnosticMessage::from_display(format_args!(
                 "Invalid access to attribute `{attribute}` on type `{}`",
                 object_type.display(db, env),
-            ),
-            info: &format!("This access implicitly calls `{}`", method.as_str()),
+            )),
+            info: DiagnosticMessage::from_display(format_args!(
+                "This access implicitly calls `{}`",
+                method.as_str()
+            )),
             argument_ranges: &[target.range()],
         },
     );
@@ -1909,11 +1911,13 @@ pub(super) fn report_bad_import_call<'db>(
         target.into(),
         &CallDiagnosticOverride {
             lint: &INVALID_MODULE_GETATTR_CALL,
-            message: format!(
+            message: DiagnosticMessage::from_display(format_args!(
                 "Cannot import `{name}` from module `{}`",
                 module.module(db).name(db),
+            )),
+            info: DiagnosticMessage::from(
+                "This import implicitly calls a module-level `__getattr__` function",
             ),
-            info: "This import implicitly calls a module-level `__getattr__` function",
             argument_ranges: &[target.range()],
         },
     );
@@ -1962,14 +1966,14 @@ pub(super) fn report_bad_dunder_set_call<'db>(
             target.into(),
             &CallDiagnosticOverride {
                 lint: &INVALID_ASSIGNMENT,
-                message: format!(
+                message: DiagnosticMessage::from_display(format_args!(
                     "Invalid assignment to data descriptor attribute `{attribute}` on type `{}`",
                     object_type.display(db, env)
-                ),
-                info: &format!(
+                )),
+                info: DiagnosticMessage::from_display(format_args!(
                     "This assignment implicitly calls `__set__` on a descriptor of type `{}`",
                     descriptor_type.display(db, env)
-                ),
+                )),
                 argument_ranges,
             },
         );
@@ -2061,20 +2065,18 @@ pub(super) fn report_invalid_return_type(
     };
 
     let env = &context.program_environment();
-    let settings =
-        DisplaySettings::from_possibly_ambiguous_types(db, env, [expected_ty, actual_ty]);
     let return_type_span = context.span(return_type_range);
 
     let mut diag = builder.into_diagnostic("Return type does not match returned value");
     diag.set_primary_annotation_message(format_args!(
         "expected `{expected_ty}`, found `{actual_ty}`",
-        expected_ty = expected_ty.display_with(db, env, settings.clone()),
-        actual_ty = actual_ty.display_with(db, env, settings.clone()),
+        expected_ty = expected_ty.display(db, env),
+        actual_ty = actual_ty.display(db, env),
     ));
     diag.annotate(
         Annotation::secondary(return_type_span).message(format_args!(
             "Expected `{expected_ty}` because of return type",
-            expected_ty = expected_ty.display_with(db, env, settings),
+            expected_ty = expected_ty.display(db, env),
         )),
     );
 
@@ -2104,12 +2106,9 @@ pub(super) fn report_unsound_return_statement(
         _ => expected_ty,
     };
 
-    let settings =
-        DisplaySettings::from_possibly_ambiguous_types(db, env, [expected_ty, actual_ty]);
-
     let mut diag = builder.into_diagnostic("Unsound return statement");
-    let actual_ty_display = actual_ty.display_with(db, env, settings.clone());
-    let expected_ty_display = expected_ty.display_with(db, env, settings);
+    let actual_ty_display = actual_ty.display(db, env);
+    let expected_ty_display = expected_ty.display(db, env);
 
     diag.set_concise_message(format_args!(
         "Unsound return statement: `{actual_ty_display}` is not a subtype \
@@ -2142,7 +2141,11 @@ pub(super) fn report_invalid_generator_function_return_type(
 
     let env = &context.program_environment();
     let mut diag = builder.into_diagnostic("Return type does not match returned value");
-    let inferred_ty = inferred_return.display(env.python_version(db));
+    let inferred_ty = if let Some(class) = inferred_return.try_to_class_literal(db, env) {
+        Either::Left(class.display_qualified(db))
+    } else {
+        Either::Right(inferred_return.display(env.python_version(db)))
+    };
     diag.set_primary_annotation_message(format_args!(
         "expected `{expected_ty}`, found `{inferred_ty}`",
         expected_ty = expected_ty.display(db, env),
@@ -2186,46 +2189,39 @@ pub(super) fn report_invalid_generator_yield_type(
     };
 
     let env = &context.program_environment();
-    let settings =
-        DisplaySettings::from_possibly_ambiguous_types(db, env, [expected_ty, actual_ty]);
-    let expected_display = expected_ty.display_with(db, env, settings.clone());
-    let actual_display = actual_ty.display_with(db, env, settings);
+    let expected_display = expected_ty.display(db, env);
+    let actual_display = actual_ty.display(db, env);
 
-    let (kind_name, title, concise) = match kind {
+    let (kind_name, title, capitalized_kind, primary_prefix) = match kind {
         GeneratorMismatchKind::YieldType => (
             "yield",
             "Yield expression type does not match annotation",
-            format!(
-                "Yield type `{actual_display}` does not match annotated yield type \
-                `{expected_display}`"
-            ),
+            "Yield",
+            "expression of type",
         ),
         GeneratorMismatchKind::SendType => (
             "send",
             "Send type does not match annotation",
-            format!(
-                "Send type `{actual_display}` does not match annotated send type \
-                `{expected_display}`"
-            ),
+            "Send",
+            "generator with send type",
         ),
     };
 
     let mut diag = builder.into_diagnostic(title);
-    diag.set_concise_message(concise);
-    let primary = match kind {
-        GeneratorMismatchKind::YieldType => {
-            format!("expression of type `{actual_display}`, expected `{expected_display}`")
-        }
-        GeneratorMismatchKind::SendType => {
-            format!("generator with send type `{actual_display}`, expected `{expected_display}`")
-        }
-    };
-    diag.set_primary_annotation_message(primary);
+    diag.set_concise_message(format_args!(
+        "{capitalized_kind} type `{actual_display}` does not match annotated {kind_name} type \
+        `{expected_display}`"
+    ));
+    diag.set_primary_annotation_message(format_args!(
+        "{primary_prefix} `{actual_display}`, expected `{expected_display}`"
+    ));
 
     if let Some(return_type_span) = return_type_span {
-        diag.annotate(Annotation::secondary(return_type_span).message(format!(
-            "Function annotated with {kind_name} type `{expected_display}` here"
-        )));
+        diag.annotate(
+            Annotation::secondary(return_type_span).message(format_args!(
+                "Function annotated with {kind_name} type `{expected_display}` here"
+            )),
+        );
     }
 
     let error_context = actual_ty.assignability_error_context(db, env, expected_ty);
@@ -2246,10 +2242,8 @@ pub(super) fn report_unsound_yield(
     };
 
     let env = context.program_environment();
-    let settings =
-        DisplaySettings::from_possibly_ambiguous_types(db, env, [expected_ty, actual_ty]);
-    let actual_display = actual_ty.display_with(db, env, settings.clone());
-    let expected_display = expected_ty.display_with(db, env, settings);
+    let actual_display = actual_ty.display(db, env);
+    let expected_display = expected_ty.display(db, env);
 
     let mut diagnostic = builder.into_diagnostic(format_args!("Unsound `{kind}`"));
     diagnostic.set_concise_message(format_args!(
@@ -2592,14 +2586,14 @@ pub(crate) fn report_instance_layout_conflict(
                     annotation = annotation.message(format_args!(
                         "`{base}` instances have a distinct memory layout \
                         because `{base}` defines non-empty `__slots__`",
-                        base = originating_base.name(db)
+                        base = originating_base.display(db)
                     ));
                 }
                 DisjointBaseKind::DisjointBaseDecorator => {
                     annotation = annotation.message(format_args!(
                         "`{base}` instances have a distinct memory layout \
                         because of the way `{base}` is implemented in a C extension",
-                        base = originating_base.name(db)
+                        base = originating_base.display(db)
                     ));
                 }
             }
@@ -2608,8 +2602,8 @@ pub(crate) fn report_instance_layout_conflict(
             annotation = annotation.message(format_args!(
                 "`{base}` instances have a distinct memory layout \
                 because `{base}` inherits from `{disjoint_base}`",
-                base = originating_base.name(db),
-                disjoint_base = disjoint_base.class.name(db)
+                base = originating_base.display(db),
+                disjoint_base = disjoint_base.class.display(db)
             ));
             subdiagnostic.annotate(annotation);
 
@@ -2619,14 +2613,14 @@ pub(crate) fn report_instance_layout_conflict(
                 DisjointBaseKind::DefinesSlots => additional_annotation.message(format_args!(
                     "`{disjoint_base}` instances have a distinct memory layout \
                     because `{disjoint_base}` defines non-empty `__slots__`",
-                    disjoint_base = disjoint_base.class.name(db),
+                    disjoint_base = disjoint_base.class.display(db),
                 )),
 
                 DisjointBaseKind::DisjointBaseDecorator => {
                     additional_annotation.message(format_args!(
                         "`{disjoint_base}` instances have a distinct memory layout \
                         because of the way `{disjoint_base}` is implemented in a C extension",
-                        disjoint_base = disjoint_base.class.name(db),
+                        disjoint_base = disjoint_base.class.display(db),
                     ))
                 }
             };
@@ -2643,7 +2637,7 @@ pub(crate) fn report_instance_layout_conflict(
 pub(super) fn report_conflicting_metaclass_from_bases(
     context: &InferContext,
     node: AnyNodeRef,
-    class_name: &str,
+    class_name: impl std::fmt::Display,
     metaclass1: ClassType,
     base1: impl std::fmt::Display,
     metaclass2: ClassType,
@@ -2659,8 +2653,8 @@ pub(super) fn report_conflicting_metaclass_from_bases(
             but `{metaclass1}` (metaclass of base class `{base1}`) \
             and `{metaclass2}` (metaclass of base class `{base2}`) \
             have no subclass relationship",
-        metaclass1 = metaclass1.name(db),
-        metaclass2 = metaclass2.name(db),
+        metaclass1 = metaclass1.class_literal(db).display(db),
+        metaclass2 = metaclass2.class_literal(db).display(db),
     ));
 }
 
@@ -2689,8 +2683,14 @@ impl<'db> IncompatibleBases<'db> {
     }
 
     /// List the problematic class bases in a human-readable format.
-    fn describe_problematic_class_bases(&self, db: &dyn Db) -> String {
-        let bad_base_names = self.0.values().map(|info| info.originating_base.name(db));
+    fn describe_problematic_class_bases(
+        &self,
+        db: &'db dyn Db,
+    ) -> impl std::fmt::Display + use<'_, 'db> {
+        let bad_base_names = self
+            .0
+            .values()
+            .map(|info| info.originating_base.display(db));
 
         format_enumeration(bad_base_names)
     }
@@ -3330,14 +3330,14 @@ pub(crate) fn report_duplicate_bases(
         later_indices,
     } = duplicate_base_error;
 
-    let duplicate_name = duplicate_base.name(db);
+    let duplicate_name = duplicate_base.display_name(db);
 
     let mut diagnostic =
         builder.into_diagnostic(format_args!("Duplicate base class `{duplicate_name}`"));
 
     diagnostic.info(format_args!(
         "Definition of class `{}` will raise `TypeError` at runtime",
-        class.name(db)
+        class.display(db)
     ));
 
     let first_base = bases_list[*first_index].source_node();
@@ -4366,18 +4366,9 @@ pub(super) fn report_incompatible_base_method<'db>(
 
     let (selected_owner, selected_definition, selected_decorator) = selected;
     let (contract_owner, contract_definition, contract_decorator) = contract;
-    let types = [
-        Type::from(class),
-        Type::from(selected_owner),
-        Type::from(contract_owner),
-    ];
-    let settings =
-        DisplaySettings::from_possibly_ambiguous_types(db, context.program_environment(), types);
-    let class_name = ClassLiteral::Static(class).display_with(db, settings.clone());
-    let selected_name = selected_owner
-        .class_literal(db)
-        .display_with(db, settings.clone());
-    let contract_name = contract_owner.class_literal(db).display_with(db, settings);
+    let class_name = class.display(db);
+    let selected_name = selected_owner.class_literal(db).display(db);
+    let contract_name = contract_owner.class_literal(db).display(db);
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Base classes for class `{class_name}` define method `{member}` incompatibly",
     ));
@@ -4661,39 +4652,34 @@ pub(super) fn report_unsupported_comparison<'db>(
     };
 
     let env = &context.program_environment();
-    let display_settings = DisplaySettings::from_possibly_ambiguous_types(
-        db,
-        env,
-        [error.left_ty, error.right_ty, left_ty, right_ty],
-    );
-
     let mut diagnostic =
         diagnostic_builder.into_diagnostic(format_args!("Unsupported `{}` operation", error.op));
 
     if left_ty.is_equivalent_to(db, env, right_ty) {
         diagnostic.set_primary_annotation_message(format_args!(
             "Both operands have type `{}`",
-            left_ty.display_with(db, env, display_settings.clone())
+            left_ty.display(db, env)
         ));
         diagnostic.annotate(context.secondary(left));
         diagnostic.annotate(context.secondary(right));
         diagnostic.set_concise_message(format_args!(
             "Operator `{}` is not supported between two objects of type `{}`",
             error.op,
-            left_ty.display_with(db, env, display_settings.clone())
+            left_ty.display(db, env)
         ));
     } else {
         for (ty, expr) in [(left_ty, left), (right_ty, right)] {
-            diagnostic.annotate(context.secondary(expr).message(format_args!(
-                "Has type `{}`",
-                ty.display_with(db, env, display_settings.clone())
-            )));
+            diagnostic.annotate(
+                context
+                    .secondary(expr)
+                    .message(format_args!("Has type `{}`", ty.display(db, env))),
+            );
         }
         diagnostic.set_concise_message(format_args!(
             "Operator `{}` is not supported between objects of type `{}` and `{}`",
             error.op,
-            left_ty.display_with(db, env, display_settings.clone()),
-            right_ty.display_with(db, env, display_settings.clone())
+            left_ty.display(db, env),
+            right_ty.display(db, env)
         ));
     }
 
@@ -4722,7 +4708,7 @@ pub(super) fn report_unsupported_comparison<'db>(
                     the tuple elements at index {} (both of type `{}`)",
                     error.op,
                     position + 1,
-                    error.left_ty.display_with(db, env, display_settings),
+                    error.left_ty.display(db, env),
                 ));
             } else {
                 diagnostic.info(format_args!(
@@ -4730,10 +4716,8 @@ pub(super) fn report_unsupported_comparison<'db>(
                     the tuple elements at index {} (of type `{}` and `{}`)",
                     error.op,
                     position + 1,
-                    error
-                        .left_ty
-                        .display_with(db, env, display_settings.clone()),
-                    error.right_ty.display_with(db, env, display_settings),
+                    error.left_ty.display(db, env),
+                    error.right_ty.display(db, env),
                 ));
             }
         } else {
@@ -4742,17 +4726,15 @@ pub(super) fn report_unsupported_comparison<'db>(
                     "Operation fails because operator `{}` is not supported \
                     between two objects of type `{}`",
                     error.op,
-                    error.left_ty.display_with(db, env, display_settings),
+                    error.left_ty.display(db, env),
                 ));
             } else {
                 diagnostic.info(format_args!(
                     "Operation fails because operator `{}` is not supported \
                     between objects of type `{}` and `{}`",
                     error.op,
-                    error
-                        .left_ty
-                        .display_with(db, env, display_settings.clone()),
-                    error.right_ty.display_with(db, env, display_settings)
+                    error.left_ty.display(db, env),
+                    error.right_ty.display(db, env)
                 ));
             }
         }
@@ -4828,34 +4810,32 @@ fn report_unsupported_binary_operation_impl<'a>(
     let db = context.db();
     let diagnostic_builder = context.report_lint(&UNSUPPORTED_OPERATOR, range)?;
     let env = &context.program_environment();
-    let display_settings =
-        DisplaySettings::from_possibly_ambiguous_types(db, env, [left_ty, right_ty]);
-
     let mut diagnostic =
         diagnostic_builder.into_diagnostic(format_args!("Unsupported `{operator}` operation"));
 
     if left_ty.is_equivalent_to(db, env, right_ty) {
         diagnostic.set_primary_annotation_message(format_args!(
             "Both operands have type `{}`",
-            left_ty.display_with(db, env, display_settings.clone())
+            left_ty.display(db, env)
         ));
         diagnostic.annotate(context.secondary(left));
         diagnostic.annotate(context.secondary(right));
         diagnostic.set_concise_message(format_args!(
             "Operator `{operator}` is not supported between two objects of type `{}`",
-            left_ty.display_with(db, env, display_settings.clone())
+            left_ty.display(db, env)
         ));
     } else {
         for (ty, expr) in [(left_ty, left), (right_ty, right)] {
-            diagnostic.annotate(context.secondary(expr).message(format_args!(
-                "Has type `{}`",
-                ty.display_with(db, env, display_settings.clone())
-            )));
+            diagnostic.annotate(
+                context
+                    .secondary(expr)
+                    .message(format_args!("Has type `{}`", ty.display(db, env))),
+            );
         }
         diagnostic.set_concise_message(format_args!(
             "Operator `{operator}` is not supported between objects of type `{}` and `{}`",
-            left_ty.display_with(db, env, display_settings.clone()),
-            right_ty.display_with(db, env, display_settings.clone())
+            left_ty.display(db, env),
+            right_ty.display(db, env)
         ));
     }
 
@@ -4882,13 +4862,13 @@ pub(super) fn report_bad_frozen_dataclass_inheritance<'db>(
             builder.into_diagnostic("Non-frozen dataclass cannot inherit from frozen dataclass");
         diagnostic.set_concise_message(format_args!(
             "Non-frozen dataclass `{}` cannot inherit from frozen dataclass `{}`",
-            class.name(db),
-            base_class.name(db)
+            class.display(db),
+            base_class.display(db)
         ));
         diagnostic.set_primary_annotation_message(format_args!(
             "Subclass `{}` is not frozen but base class `{}` is",
-            class.name(db),
-            base_class.name(db)
+            class.display(db),
+            base_class.display(db)
         ));
         diagnostic
     } else {
@@ -4896,13 +4876,13 @@ pub(super) fn report_bad_frozen_dataclass_inheritance<'db>(
             builder.into_diagnostic("Frozen dataclass cannot inherit from non-frozen dataclass");
         diagnostic.set_concise_message(format_args!(
             "Frozen dataclass `{}` cannot inherit from non-frozen dataclass `{}`",
-            class.name(db),
-            base_class.name(db)
+            class.display(db),
+            base_class.display(db)
         ));
         diagnostic.set_primary_annotation_message(format_args!(
             "Subclass `{}` is frozen but base class `{}` is not",
-            class.name(db),
-            base_class.name(db)
+            class.display(db),
+            base_class.display(db)
         ));
         diagnostic
     };
@@ -4913,7 +4893,7 @@ pub(super) fn report_bad_frozen_dataclass_inheritance<'db>(
         diagnostic.annotate(
             context
                 .secondary(&class_node.decorator_list[position])
-                .message(format_args!("`{}` dataclass parameters", class.name(db))),
+                .message(format_args!("`{}` dataclass parameters", class.display(db))),
         );
     }
     diagnostic.info("This causes the class creation to fail");
@@ -4925,7 +4905,7 @@ pub(super) fn report_bad_frozen_dataclass_inheritance<'db>(
         );
         sub.annotate(
             Annotation::primary(base_class.header_span(db))
-                .message(format_args!("`{}` definition", base_class.name(db))),
+                .message(format_args!("`{}` definition", base_class.display(db))),
         );
 
         let base_class_file = base_class.file(db);

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -7,7 +7,9 @@ use std::collections::hash_map::Entry;
 use std::fmt::{self, Display, Formatter, Write};
 use std::rc::Rc;
 
-use ruff_db::diagnostic::{DiagnosticName, DiagnosticNameKind, DiagnosticNameRecord};
+use ruff_db::diagnostic::{
+    Diagnostic, DiagnosticName, DiagnosticNameKind, DiagnosticNameRecord, DiagnosticNameResolver,
+};
 use ruff_db::files::{File, FilePath};
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::{line_index, source_text};
@@ -16,6 +18,7 @@ use ruff_python_literal::escape::AsciiEscape;
 use ruff_source_file::LineColumn;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::plumbing::{AsId, FromIdWithDb};
 
 use ty_module_resolver::file_to_module;
 
@@ -85,28 +88,66 @@ impl<'db> NamedItem<'db> {
 
     fn diagnostic_name(self, db: &'db dyn Db, spelling: &str) -> DiagnosticName {
         match self {
-            NamedItem::Class(class) => DiagnosticName::new(
+            NamedItem::Class(class) => {
+                DiagnosticName::new(spelling, class.as_id(), DiagnosticNameKind::Class)
+            }
+            NamedItem::TypeAlias(alias) => DiagnosticName::new(
                 spelling,
-                class.qualified_name(db).to_string(),
-                class.file(db),
-                class.header_range(db).start(),
-                DiagnosticNameKind::Class,
+                alias.unspecialized(db).as_id(),
+                DiagnosticNameKind::TypeAlias,
             ),
-            NamedItem::TypeAlias(alias) => {
-                let definition = alias.definition(db);
-                let offset = definition
-                    .focus_range(db, &parsed_module(db, definition.python_file(db)).load(db))
-                    .range()
-                    .start();
-                DiagnosticName::new(
-                    spelling,
-                    alias.qualified_name(db).to_string(),
-                    definition.file(db),
-                    offset,
-                    DiagnosticNameKind::TypeAlias,
-                )
+        }
+    }
+
+    fn from_diagnostic_name(db: &'db dyn Db, name: &DiagnosticName) -> Self {
+        match name.kind() {
+            DiagnosticNameKind::Class => {
+                Self::Class(FromIdWithDb::from_id(name.identity(), db.zalsa()))
+            }
+            DiagnosticNameKind::TypeAlias => {
+                Self::TypeAlias(FromIdWithDb::from_id(name.identity(), db.zalsa()))
             }
         }
+    }
+}
+
+struct TypeDiagnosticNameResolver<'db> {
+    db: &'db dyn Db,
+}
+
+impl DiagnosticNameResolver for TypeDiagnosticNameResolver<'_> {
+    fn qualified_name(&self, name: &DiagnosticName) -> String {
+        match NamedItem::from_diagnostic_name(self.db, name) {
+            NamedItem::Class(class) => class.qualified_name(self.db).to_string(),
+            NamedItem::TypeAlias(alias) => alias.qualified_name(self.db).to_string(),
+        }
+    }
+
+    fn location(&self, name: &DiagnosticName) -> String {
+        let (file, offset) = match NamedItem::from_diagnostic_name(self.db, name) {
+            NamedItem::Class(class) => (class.file(self.db), class.header_range(self.db).start()),
+            NamedItem::TypeAlias(alias) => {
+                let definition = alias.definition(self.db);
+                let offset = definition
+                    .focus_range(
+                        self.db,
+                        &parsed_module(self.db, definition.python_file(self.db)).load(self.db),
+                    )
+                    .range()
+                    .start();
+                (definition.file(self.db), offset)
+            }
+        };
+
+        diagnostic_file_location(self.db, file, offset)
+    }
+}
+
+/// Finalizes names only after all fine-grained inference queries have completed.
+pub(super) fn disambiguate_diagnostic_names(db: &dyn Db, diagnostics: &mut [Diagnostic]) {
+    let resolver = TypeDiagnosticNameResolver { db };
+    for diagnostic in diagnostics {
+        diagnostic.disambiguate_names(&resolver);
     }
 }
 
@@ -855,7 +896,7 @@ impl fmt::Debug for DisplayType<'_, '_> {
 }
 
 /// Format a file location suffix for disambiguation (e.g., " @ path:line:column")
-pub(crate) fn diagnostic_file_location(db: &dyn Db, file: File, offset: TextSize) -> String {
+fn diagnostic_file_location(db: &dyn Db, file: File, offset: TextSize) -> String {
     let path = file.path(db);
     let path = match path {
         FilePath::System(path) => Cow::Owned(FilePath::from(
@@ -3834,7 +3875,7 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
                     f.write_known_class(
                         db,
                         self.env,
-                        KnownClassName::displayed_as(KnownClass::TypeAliasType, "TypeAliasType")
+                        KnownClassName::displayed_as(alias.known_class(db), "TypeAliasType")
                             .with_detailed_type(ty),
                     )
                 }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -7,7 +7,8 @@ use std::collections::hash_map::Entry;
 use std::fmt::{self, Display, Formatter, Write};
 use std::rc::Rc;
 
-use ruff_db::files::FilePath;
+use ruff_db::diagnostic::{DiagnosticName, DiagnosticNameKind, DiagnosticNameRecord};
+use ruff_db::files::{File, FilePath};
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::{line_index, source_text};
 use ruff_python_ast::str::{Quote, TripleQuotes};
@@ -21,7 +22,7 @@ use ty_module_resolver::file_to_module;
 use crate::Db;
 use crate::place::{DefinedPlace, Place};
 use crate::types::callable::CallableTypeKind;
-use crate::types::class::{ClassLiteral, ClassType, GenericAlias};
+use crate::types::class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::function::{FunctionType, OverloadLiteral};
 use crate::types::generics::{GenericContext, Specialization};
@@ -78,6 +79,32 @@ impl<'db> NamedItem<'db> {
             NamedItem::Class(class) => class.qualified_name(db).components_excluding_self(),
             NamedItem::TypeAlias(type_alias) => {
                 type_alias.qualified_name(db).components_excluding_self()
+            }
+        }
+    }
+
+    fn diagnostic_name(self, db: &'db dyn Db, spelling: &str) -> DiagnosticName {
+        match self {
+            NamedItem::Class(class) => DiagnosticName::new(
+                spelling,
+                class.qualified_name(db).to_string(),
+                class.file(db),
+                class.header_range(db).start(),
+                DiagnosticNameKind::Class,
+            ),
+            NamedItem::TypeAlias(alias) => {
+                let definition = alias.definition(db);
+                let offset = definition
+                    .focus_range(db, &parsed_module(db, definition.python_file(db)).load(db))
+                    .range()
+                    .start();
+                DiagnosticName::new(
+                    spelling,
+                    alias.qualified_name(db).to_string(),
+                    definition.file(db),
+                    offset,
+                    DiagnosticNameKind::TypeAlias,
+                )
             }
         }
     }
@@ -347,6 +374,42 @@ impl<'db> TypeDetailsWriter<'db> {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct KnownClassName<'db, 'spelling> {
+    class: KnownClass,
+    rendered_spelling: &'spelling str,
+    collision_spelling: &'spelling str,
+    detailed_type: Option<Type<'db>>,
+    replace_when_ambiguous: bool,
+}
+
+impl<'db, 'spelling> KnownClassName<'db, 'spelling> {
+    fn displayed_as(class: KnownClass, spelling: &'spelling str) -> Self {
+        Self {
+            class,
+            rendered_spelling: spelling,
+            collision_spelling: spelling,
+            detailed_type: None,
+            replace_when_ambiguous: true,
+        }
+    }
+
+    fn with_collision_spelling(mut self, spelling: &'spelling str) -> Self {
+        self.collision_spelling = spelling;
+        self
+    }
+
+    fn with_detailed_type(mut self, ty: Type<'db>) -> Self {
+        self.detailed_type = Some(ty);
+        self
+    }
+
+    fn without_replacement(mut self) -> Self {
+        self.replace_when_ambiguous = false;
+        self
+    }
+}
+
 impl<'a, 'b, 'db> TypeWriter<'a, 'b, 'db> {
     /// Indicate the given detail is about to start being written to this Writer
     ///
@@ -367,6 +430,45 @@ impl<'a, 'b, 'db> TypeWriter<'a, 'b, 'db> {
     /// Convenience for `with_detail(TypeDetail::Type(ty))`
     fn with_type<'c>(&'c mut self, ty: Type<'db>) -> TypeDetailGuard<'a, 'b, 'c, 'db> {
         self.with_detail(TypeDetail::Type(ty))
+    }
+
+    /// Writes a known class name while preserving its semantic identity in diagnostics.
+    ///
+    /// Several runtime values deliberately use spellings such as `function` instead of their
+    /// defining class's name, `FunctionType`. The displayed spelling is therefore the collision
+    /// key, while the class itself determines the qualified replacement.
+    fn write_known_class(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        display_name: KnownClassName<'db, '_>,
+    ) -> fmt::Result {
+        let KnownClassName {
+            class: known_class,
+            rendered_spelling,
+            collision_spelling,
+            detailed_type,
+            replace_when_ambiguous,
+        } = display_name;
+
+        if let Some(class) = known_class.try_to_class_literal(db, env) {
+            let class = ClassLiteral::Static(class);
+            let detailed_type = detailed_type.unwrap_or(Type::ClassLiteral(class));
+            let record = DiagnosticNameRecord {
+                render: || self.with_type(detailed_type).write_str(rendered_spelling),
+                name: || NamedItem::Class(class).diagnostic_name(db, collision_spelling),
+            };
+            if replace_when_ambiguous {
+                record.render()
+            } else {
+                record.render_fixed()
+            }
+        } else if replace_when_ambiguous {
+            self.with_type(detailed_type.unwrap_or_else(Type::unknown))
+                .write_str(rendered_spelling)
+        } else {
+            self.write_str(rendered_spelling)
+        }
     }
 
     fn set_invalid_type_annotation(&mut self) {
@@ -753,12 +855,7 @@ impl fmt::Debug for DisplayType<'_, '_> {
 }
 
 /// Format a file location suffix for disambiguation (e.g., " @ path:line:column")
-fn fmt_file_location<'db>(
-    db: &'db dyn Db,
-    file: ruff_db::files::File,
-    offset: TextSize,
-    f: &mut TypeWriter<'_, '_, 'db>,
-) -> fmt::Result {
+pub(crate) fn diagnostic_file_location(db: &dyn Db, file: File, offset: TextSize) -> String {
     let path = file.path(db);
     let path = match path {
         FilePath::System(path) => Cow::Owned(FilePath::from(
@@ -770,8 +867,17 @@ fn fmt_file_location<'db>(
     };
     let line_index = line_index(db, file);
     let LineColumn { line, column } = line_index.line_column(offset, &source_text(db, file));
+    format!(" @ {path}:{line}:{column}")
+}
+
+fn fmt_file_location<'db>(
+    db: &'db dyn Db,
+    file: File,
+    offset: TextSize,
+    f: &mut TypeWriter<'_, '_, 'db>,
+) -> fmt::Result {
     f.set_invalid_type_annotation();
-    write!(f, " @ {path}:{line}:{column}")
+    f.write_str(&diagnostic_file_location(db, file, offset))
 }
 
 /// Returns the qualified name components for a scope, excluding the item itself.
@@ -824,7 +930,12 @@ pub(super) fn qualified_name_components_from_scope(
 }
 
 impl<'db> ClassLiteral<'db> {
-    pub(crate) fn display_with(
+    /// Displays this class's name while allowing a diagnostic to resolve name collisions.
+    pub(crate) fn display(self, db: &'db dyn Db) -> ClassDisplay<'db> {
+        self.display_with(db, DisplaySettings::default())
+    }
+
+    pub(super) fn display_with(
         self,
         db: &'db dyn Db,
         settings: DisplaySettings<'db>,
@@ -837,6 +948,26 @@ impl<'db> ClassLiteral<'db> {
     }
 }
 
+impl<'db> StaticClassLiteral<'db> {
+    /// Displays this class's name while preserving its identity for diagnostics.
+    pub(crate) fn display(self, db: &'db dyn Db) -> ClassDisplay<'db> {
+        ClassLiteral::Static(self).display(db)
+    }
+
+    /// Displays this class's qualified name while preserving its diagnostic identity.
+    pub(crate) fn display_qualified(self, db: &'db dyn Db) -> impl Display + 'db {
+        let class = ClassLiteral::Static(self);
+        fmt::from_fn(move |f| {
+            let spelling = class.name(db);
+            DiagnosticNameRecord {
+                render: || class.qualified_name(db).fmt(f),
+                name: || NamedItem::Class(class).diagnostic_name(db, spelling),
+            }
+            .render()
+        })
+    }
+}
+
 pub(crate) struct ClassDisplay<'db> {
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
@@ -845,22 +976,28 @@ pub(crate) struct ClassDisplay<'db> {
 
 impl<'db> FmtDetailed<'db> for ClassDisplay<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
-        let qualification_level = self.settings.qualified.get(&**self.class.name(self.db));
+        let spelling = self.class.name(self.db);
+        DiagnosticNameRecord {
+            render: || {
+                let qualification_level = self.settings.qualified.get(&**spelling);
+                let ty = Type::ClassLiteral(self.class);
+                if qualification_level.is_some() {
+                    let qualified_name = self.class.qualified_name(self.db);
+                    write!(f.with_type(ty), "{qualified_name}")?;
+                } else {
+                    write!(f.with_type(ty), "{spelling}")?;
+                }
 
-        let ty = Type::ClassLiteral(self.class);
-        if qualification_level.is_some() {
-            let qualified_name = self.class.qualified_name(self.db);
-            write!(f.with_type(ty), "{qualified_name}")?;
-        } else {
-            write!(f.with_type(ty), "{}", self.class.name(self.db))?;
+                if qualification_level == Some(&QualificationLevel::FileAndLineNumber) {
+                    let file = self.class.file(self.db);
+                    let offset = self.class.header_range(self.db).start();
+                    fmt_file_location(self.db, file, offset, f)?;
+                }
+                Ok(())
+            },
+            name: || NamedItem::Class(self.class).diagnostic_name(self.db, spelling),
         }
-
-        if qualification_level == Some(&QualificationLevel::FileAndLineNumber) {
-            let file = self.class.file(self.db);
-            let offset = self.class.header_range(self.db).start();
-            fmt_file_location(self.db, file, offset, f)?;
-        }
-        Ok(())
+        .render()
     }
 }
 
@@ -912,32 +1049,35 @@ struct TypeAliasDisplay<'db> {
 
 impl<'db> FmtDetailed<'db> for TypeAliasDisplay<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
-        let qualification_level = self
-            .settings
-            .qualified_type_aliases
-            .get(self.type_alias.name(self.db));
+        let spelling = self.type_alias.name(self.db);
+        DiagnosticNameRecord {
+            render: || {
+                let qualification_level = self.settings.qualified_type_aliases.get(spelling);
+                let ty = Type::TypeAlias(self.type_alias);
+                if qualification_level.is_some() {
+                    let qualified_name = self.type_alias.qualified_name(self.db);
+                    write!(f.with_type(ty), "{qualified_name}")?;
+                } else {
+                    write!(f.with_type(ty), "{spelling}")?;
+                }
 
-        let ty = Type::TypeAlias(self.type_alias);
-        if qualification_level.is_some() {
-            let qualified_name = self.type_alias.qualified_name(self.db);
-            write!(f.with_type(ty), "{qualified_name}")?;
-        } else {
-            write!(f.with_type(ty), "{}", self.type_alias.name(self.db))?;
+                if qualification_level == Some(&QualificationLevel::FileAndLineNumber) {
+                    let definition = self.type_alias.definition(self.db);
+                    let file = definition.file(self.db);
+                    let offset = definition
+                        .focus_range(
+                            self.db,
+                            &parsed_module(self.db, definition.python_file(self.db)).load(self.db),
+                        )
+                        .range()
+                        .start();
+                    fmt_file_location(self.db, file, offset, f)?;
+                }
+                Ok(())
+            },
+            name: || NamedItem::TypeAlias(self.type_alias).diagnostic_name(self.db, spelling),
         }
-
-        if qualification_level == Some(&QualificationLevel::FileAndLineNumber) {
-            let definition = self.type_alias.definition(self.db);
-            let file = definition.file(self.db);
-            let offset = definition
-                .focus_range(
-                    self.db,
-                    &parsed_module(self.db, definition.python_file(self.db)).load(self.db),
-                )
-                .range()
-                .start();
-            fmt_file_location(self.db, file, offset, f)?;
-        }
-        Ok(())
+        .render()
     }
 }
 
@@ -1129,14 +1269,24 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                     f.write_char('>')
                 }
             },
-            Type::PropertyInstance(property) => f
-                .with_type(self.ty)
-                .write_str(property_display_name(db, property)),
+            Type::PropertyInstance(property) => f.write_known_class(
+                db,
+                self.env,
+                KnownClassName::displayed_as(
+                    property.instance_class(db),
+                    property_display_name(db, property),
+                )
+                .with_detailed_type(self.ty),
+            ),
             Type::ModuleLiteral(module) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
-                f.with_type(KnownClass::ModuleType.to_class_literal(db, self.env))
-                    .write_str("module")?;
+                f.write_known_class(
+                    db,
+                    self.env,
+                    KnownClassName::displayed_as(KnownClass::ModuleType, "module")
+                        .without_replacement(),
+                )?;
                 f.write_str(" '")?;
                 f.with_type(self.ty).write_str(module.module(db).name(db))?;
                 f.write_str("'>")
@@ -1161,8 +1311,11 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
             }
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
                 SubclassOfInner::Class(ClassType::NonGeneric(class)) => {
-                    f.with_type(KnownClass::Type.to_class_literal(db, self.env))
-                        .write_str("type")?;
+                    f.write_known_class(
+                        db,
+                        self.env,
+                        KnownClassName::displayed_as(KnownClass::Type, "type"),
+                    )?;
                     f.write_char('[')?;
                     class
                         .display_with(db, self.settings.clone())
@@ -1170,8 +1323,11 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                     f.write_char(']')
                 }
                 SubclassOfInner::Class(ClassType::Generic(alias)) => {
-                    f.with_type(KnownClass::Type.to_class_literal(db, self.env))
-                        .write_str("type")?;
+                    f.write_known_class(
+                        db,
+                        self.env,
+                        KnownClassName::displayed_as(KnownClass::Type, "type"),
+                    )?;
                     f.write_char('[')?;
                     alias
                         .display_with(db, self.env, self.settings.clone())
@@ -1179,15 +1335,21 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                     f.write_char(']')
                 }
                 SubclassOfInner::Dynamic(dynamic) => {
-                    f.with_type(KnownClass::Type.to_class_literal(db, self.env))
-                        .write_str("type")?;
+                    f.write_known_class(
+                        db,
+                        self.env,
+                        KnownClassName::displayed_as(KnownClass::Type, "type"),
+                    )?;
                     f.write_char('[')?;
                     write!(f.with_type(Type::Dynamic(dynamic)), "{dynamic}")?;
                     f.write_char(']')
                 }
                 SubclassOfInner::Protocol(protocol) => {
-                    f.with_type(KnownClass::Type.to_class_literal(db, self.env))
-                        .write_str("type")?;
+                    f.write_known_class(
+                        db,
+                        self.env,
+                        KnownClassName::displayed_as(KnownClass::Type, "type"),
+                    )?;
                     f.write_char('[')?;
                     Type::ProtocolInstance(protocol)
                         .display_with(db, self.env, self.settings.clone())
@@ -1196,8 +1358,11 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                 }
                 SubclassOfInner::TypeVar(bound_typevar) => {
                     f.set_invalid_type_annotation();
-                    f.with_type(KnownClass::Type.to_class_literal(db, self.env))
-                        .write_str("type")?;
+                    f.write_known_class(
+                        db,
+                        self.env,
+                        KnownClassName::displayed_as(KnownClass::Type, "type"),
+                    )?;
                     f.write_char('[')?;
                     write!(
                         f.with_type(Type::TypeVar(bound_typevar)),
@@ -1387,7 +1552,11 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                     f.write_str(member_name)?;
                 }
                 f.write_str("' of ")?;
-                f.with_type(class_ty).write_str(cls_name)?;
+                f.write_known_class(
+                    db,
+                    self.env,
+                    KnownClassName::displayed_as(cls, cls_name).with_detailed_type(class_ty),
+                )?;
                 if let Some(name) = ty_name {
                     f.write_str(" '")?;
                     f.with_type(ty).write_str(name)?;
@@ -1418,8 +1587,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                 f.write_str(" '")?;
                 f.write_str(method)?;
                 f.write_str("' of '")?;
-                f.with_type(cls.to_class_literal(db, self.env))
-                    .write_str(object)?;
+                f.write_known_class(db, self.env, KnownClassName::displayed_as(cls, object))?;
                 f.write_str("' objects>")
             }
             Type::DataclassDecorator(_) => {
@@ -1506,7 +1674,13 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
             Type::AlwaysFalsy => f.with_type(self.ty).write_str("AlwaysFalsy"),
             Type::BoundSuper(bound_super) => {
                 f.set_invalid_type_annotation();
-                f.write_str("<super: ")?;
+                f.write_char('<')?;
+                f.write_known_class(
+                    db,
+                    self.env,
+                    KnownClassName::displayed_as(KnownClass::Super, "super"),
+                )?;
+                f.write_str(": ")?;
                 Type::from(bound_super.pivot_class(db))
                     .display_with(db, self.env, self.settings.singleline())
                     .fmt_detailed(f)?;
@@ -3644,7 +3818,9 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
                 if let Some(specialization) = alias.specialization(db) {
                     f.set_invalid_type_annotation();
                     f.write_str("<type alias '")?;
-                    f.with_type(ty).write_str(alias.name(db))?;
+                    alias
+                        .display_with(db, self.settings.clone())
+                        .fmt_detailed(f)?;
                     specialization
                         .display_short(
                             db,
@@ -3655,24 +3831,46 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
                         .fmt_detailed(f)?;
                     f.write_str("'>")
                 } else {
-                    f.with_type(ty).write_str("TypeAliasType")
+                    f.write_known_class(
+                        db,
+                        self.env,
+                        KnownClassName::displayed_as(KnownClass::TypeAliasType, "TypeAliasType")
+                            .with_detailed_type(ty),
+                    )
                 }
             }
             // This is a legacy `TypeVar` _outside_ of any generic class or function, so we render
             // it as an instance of `typing.TypeVar`. Inside of a generic class or function, we'll
             // have a `Type::TypeVar(_)`, which is rendered as the typevar's name.
             KnownInstanceType::TypeVar(typevar_instance) => {
-                if typevar_instance.kind(db).is_paramspec() {
-                    f.with_type(ty).write_str("ParamSpec")
+                let (known_class, spelling) = if typevar_instance.kind(db).is_paramspec() {
+                    (KnownClass::ParamSpec, "ParamSpec")
                 } else if typevar_instance.kind(db).is_typevartuple() {
-                    f.with_type(ty).write_str("TypeVarTuple")
+                    (KnownClass::TypeVarTuple, "TypeVarTuple")
                 } else {
-                    f.with_type(ty).write_str("TypeVar")
-                }
+                    (KnownClass::TypeVar, "TypeVar")
+                };
+                f.write_known_class(
+                    db,
+                    self.env,
+                    KnownClassName::displayed_as(known_class, spelling).with_detailed_type(ty),
+                )
             }
-            KnownInstanceType::Deprecated(_) => f.write_str("warnings.deprecated"),
+            KnownInstanceType::Deprecated(_) => f.write_known_class(
+                db,
+                self.env,
+                KnownClassName::displayed_as(KnownClass::Deprecated, "warnings.deprecated")
+                    .with_collision_spelling("deprecated")
+                    .with_detailed_type(ty),
+            ),
             KnownInstanceType::Field(field) => {
-                f.with_type(ty).write_str("dataclasses.Field")?;
+                f.write_known_class(
+                    db,
+                    self.env,
+                    KnownClassName::displayed_as(KnownClass::Field, "dataclasses.Field")
+                        .with_collision_spelling("Field")
+                        .with_detailed_type(ty),
+                )?;
 
                 let field_type = field
                     .converter(db)
@@ -3729,8 +3927,12 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
             KnownInstanceType::UnionType(union) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
-                f.with_type(KnownClass::UnionType.to_class_literal(db, self.env))
-                    .write_str("types.UnionType")?;
+                f.write_known_class(
+                    db,
+                    self.env,
+                    KnownClassName::displayed_as(KnownClass::UnionType, "types.UnionType")
+                        .with_collision_spelling("UnionType"),
+                )?;
                 f.write_str(" special-form")?;
                 if let Ok(ty) = union.union_type(db) {
                     f.write_str(" '")?;
@@ -3772,8 +3974,11 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
             KnownInstanceType::TypeGenericAlias(inner) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<special-form '")?;
-                f.with_type(KnownClass::Type.to_class_literal(db, self.env))
-                    .write_str("type")?;
+                f.write_known_class(
+                    db,
+                    self.env,
+                    KnownClassName::displayed_as(KnownClass::Type, "type"),
+                )?;
                 f.write_char('[')?;
                 inner.inner(db).display(db, self.env).fmt_detailed(f)?;
                 f.write_str("]'>")
@@ -3795,15 +4000,23 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
             }
             KnownInstanceType::NamedTupleSpec(_) => f.write_str("NamedTupleSpec"),
             KnownInstanceType::FunctoolsPartial(partial) => {
-                f.write_str("partial[")?;
+                f.write_known_class(
+                    db,
+                    self.env,
+                    KnownClassName::displayed_as(KnownClass::FunctoolsPartial, "partial")
+                        .with_detailed_type(ty),
+                )?;
+                f.write_char('[')?;
                 Type::Callable(partial.partial(db))
                     .display_with(db, self.env, DisplaySettings::default().singleline())
                     .fmt_detailed(f)?;
                 f.write_str("]")
             }
-            KnownInstanceType::Range { .. } => f
-                .with_type(KnownClass::Range.to_class_literal(db, self.env))
-                .write_str("range"),
+            KnownInstanceType::Range { .. } => f.write_known_class(
+                db,
+                self.env,
+                KnownClassName::displayed_as(KnownClass::Range, "range"),
+            ),
             KnownInstanceType::FunctoolsPartialCall(partial) => Type::Callable(partial.partial(db))
                 .display_with(db, self.env, DisplaySettings::default().singleline())
                 .fmt_detailed(f),

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -49,7 +49,7 @@
 //! the public type of `f` is resolved at position 3, correctly giving you all of the overloads
 //! (and the implementation).
 
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, fmt::Display, str::FromStr};
 
 use bitflags::bitflags;
 use itertools::Either;
@@ -79,7 +79,6 @@ use crate::types::diagnostic::{
     report_runtime_check_against_non_runtime_checkable_protocol,
     report_runtime_check_against_typed_dict,
 };
-use crate::types::display::DisplaySettings;
 use crate::types::generics::{ApplySpecialization, GenericContext, typing_self};
 use crate::types::infer::{infer_definition_types, nearest_enclosing_class, original_class_type};
 use crate::types::known_instance::DeprecatedInstance;
@@ -92,10 +91,10 @@ use crate::types::variance::{TypeVarVariance, VarianceInferable};
 use crate::types::visitor::non_any_dynamic_content;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundMethodType, BoundTypeVarIdentity, BoundTypeVarInstance,
-    CallableType, ClassBase, ClassLiteral, ClassType, FindLegacyTypeVarsVisitor,
-    IntersectionBuilder, KnownClass, KnownInstanceType, SpecialFormType, SubclassOfInner,
-    SubclassOfType, Truthiness, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-    UnionBuilder, UnionType, binding_type, definition_expression_type, walk_signature,
+    CallableType, ClassLiteral, ClassType, FindLegacyTypeVarsVisitor, IntersectionBuilder,
+    KnownClass, KnownInstanceType, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
+    Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionBuilder, UnionType,
+    binding_type, definition_expression_type, walk_signature,
 };
 use crate::{Db, FxOrderSet, ProgramEnvironment};
 use ty_python_core::ast_ids::HasScopedUseId;
@@ -1905,15 +1904,16 @@ fn report_invalid_union_type_elements<'db>(
     // When we have a secondary annotation pointing at the UnionType expression,
     // "the union" is unambiguous. Otherwise, spell out the union type in the message.
     let env = context.program_environment();
-    let union_suffix = match (&union_type_expr, union_type) {
-        (None, Type::KnownInstance(KnownInstanceType::UnionType(instance))) => {
-            match instance.union_type(db) {
-                Ok(ty) => format!(" `{}`", ty.display(db, env)),
-                Err(_) => String::new(),
-            }
+    let union_suffix = std::fmt::from_fn(|f| {
+        if let (None, Type::KnownInstance(KnownInstanceType::UnionType(instance))) =
+            (&union_type_expr, union_type)
+            && let Ok(ty) = instance.union_type(db)
+        {
+            write!(f, " `{}`", ty.display(db, env))
+        } else {
+            Ok(())
         }
-        _ => String::new(),
-    };
+    });
 
     match other_invalid_elements {
         [] => diagnostic.info(format_args!(
@@ -2518,14 +2518,9 @@ impl KnownFunction {
                     &ASSERT_TYPE_UNSPELLABLE_SUBTYPE
                 };
                 if let Some(builder) = context.report_lint(diagnostic, call_expression) {
-                    let settings = DisplaySettings::from_possibly_ambiguous_types(
-                        db,
-                        env,
-                        [*actual_ty, asserted_ty],
-                    );
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Argument does not have asserted type `{}`",
-                        asserted_ty.display_with(db, env, settings.clone()),
+                        asserted_ty.display(db, env),
                     ));
 
                     diagnostic.annotate(
@@ -2537,28 +2532,28 @@ impl KnownFunction {
                         )
                         .message(format_args!(
                             "Inferred type is `{}`",
-                            actual_ty.display_with(db, env, settings.clone())
+                            actual_ty.display(db, env)
                         )),
                     );
 
                     if actual_ty.is_subtype_of(db, env, asserted_ty) {
                         diagnostic.info(format_args!(
                             "`{inferred_type}` is a subtype of `{asserted_type}`, but they are not equivalent",
-                            asserted_type = asserted_ty.display_with(db, env, settings.clone()),
-                            inferred_type = actual_ty.display_with(db, env, settings.clone()),
+                            asserted_type = asserted_ty.display(db, env),
+                            inferred_type = actual_ty.display(db, env),
                         ));
                     } else {
                         diagnostic.info(format_args!(
                             "`{asserted_type}` and `{inferred_type}` are not equivalent types",
-                            asserted_type = asserted_ty.display_with(db, env, settings.clone()),
-                            inferred_type = actual_ty.display_with(db, env, settings.clone()),
+                            asserted_type = asserted_ty.display(db, env),
+                            inferred_type = actual_ty.display(db, env),
                         ));
                     }
 
                     diagnostic.set_concise_message(format_args!(
                         "Type `{}` does not match asserted type `{}`",
-                        actual_ty.display_with(db, env, settings.clone()),
-                        asserted_ty.display_with(db, env, settings),
+                        actual_ty.display(db, env),
+                        asserted_ty.display(db, env),
                     ));
                 }
             }
@@ -2799,43 +2794,28 @@ impl KnownFunction {
                         call_argument_node(call_expression, "cls", 0)
                             .unwrap_or_else(|| ast::AnyNodeRef::from(call_expression)),
                     );
-                    let mut message = String::new();
-                    let display_settings = DisplaySettings::from_possibly_ambiguous_types(
-                        db,
-                        env,
-                        classes
-                            .iter()
-                            .flat_map(|class| class.iter_mro(db))
-                            .filter_map(ClassBase::into_class),
-                    );
-                    for (i, class) in classes.iter().enumerate() {
-                        message.push('(');
-                        for class in class.iter_mro(db) {
-                            message.push_str(
-                                &class
-                                    .display_with(db, env, display_settings.clone())
-                                    .to_string(),
-                            );
-                            // Omit the comma for the last element (which is always `object`)
-                            if class
-                                .into_class()
-                                .is_none_or(|base| !base.is_object(context.db()))
-                            {
-                                message.push_str(", ");
+                    let message = std::fmt::from_fn(|f| {
+                        for (index, class) in classes.iter().enumerate() {
+                            f.write_str("(")?;
+                            for base in class.iter_mro(db) {
+                                base.display(db, env).fmt(f)?;
+                                // Omit the comma for the last element (which is always `object`).
+                                if base.into_class().is_none_or(|base| !base.is_object(db)) {
+                                    f.write_str(", ")?;
+                                }
+                            }
+                            // A length-one tuple needs a trailing comma and only occurs when
+                            // revealing `object` itself.
+                            if class.is_object(db) {
+                                f.write_str(",")?;
+                            }
+                            f.write_str(")")?;
+                            if index < classes.len() - 1 {
+                                f.write_str(" | ")?;
                             }
                         }
-                        // If the last element was also the first element
-                        // (i.e., it's a length-1 tuple -- which can only happen if we're revealing
-                        // the MRO for `object` itself), add a trailing comma so that it's still a
-                        // valid tuple display.
-                        if class.is_object(db) {
-                            message.push(',');
-                        }
-                        message.push(')');
-                        if i < classes.len() - 1 {
-                            message.push_str(" | ");
-                        }
-                    }
+                        Ok(())
+                    });
                     diag.annotate(Annotation::primary(span).message(message));
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -124,7 +124,7 @@ use crate::types::{
     any_over_type, binding_type, extract_fixed_length_iterable_element_types,
     infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
-use crate::{AnalysisSettings, Db, DisplaySettings, FxIndexSet, FxOrderSet};
+use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet};
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
     Definition, DefinitionKind, DefinitionNodeKey, DefinitionState, ExceptHandlerDefinitionKind,
@@ -3768,7 +3768,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .report_lint(&INVALID_NEWTYPE, &arguments.args[1])
         {
             let mut diag = builder.into_diagnostic("invalid base for `typing.NewType`");
-            diag.set_primary_annotation_message(format!("type `{}`", inferred.display(db, env)));
+            diag.set_primary_annotation_message(format_args!(
+                "type `{}`",
+                inferred.display(db, env)
+            ));
             if matches!(inferred, Type::ProtocolInstance(_)) {
                 diag.info("The base of a `NewType` is not allowed to be a protocol class.");
             } else if matches!(inferred, Type::TypedDict(_)) {
@@ -10449,24 +10452,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             if let Some(builder) =
                                 self.context.report_lint(&UNRESOLVED_ATTRIBUTE, attribute)
                             {
-                                let types = std::iter::once(union_like_type)
-                                    .chain(elements_missing_the_attribute.iter().copied());
-                                let settings =
-                                    DisplaySettings::from_possibly_ambiguous_types(db, env, types);
-                                let missing_types = elements_missing_the_attribute
-                                    .iter()
-                                    .map(|ty| {
-                                        format!("`{}`", ty.display_with(db, env, settings.clone()))
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join(", ");
-
                                 builder.into_diagnostic(format_args!(
                                     "Attribute `{attr_name}` is not defined on {} \
                                     in union `{union_like_type}`",
-                                    missing_types,
-                                    union_like_type =
-                                        union_like_type.display_with(db, env, settings),
+                                    elements_missing_the_attribute.iter().format_with(
+                                        ", ",
+                                        |ty, formatter| {
+                                            formatter(&format_args!("`{}`", ty.display(db, env)))
+                                        }
+                                    ),
+                                    union_like_type = union_like_type.display(db, env),
                                 ));
                             }
                             return type_when_bound;

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -1,3 +1,4 @@
+use ruff_db::diagnostic::DiagnosticMessage;
 use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
 
@@ -15,9 +16,7 @@ use crate::types::diagnostic::{
     INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, UNRESOLVED_ATTRIBUTE, report_bad_dunder_set_call,
     report_invalid_attribute_assignment, report_possibly_missing_attribute,
 };
-use crate::types::{
-    CallDunderError, DisplaySettings, MemberLookupPolicy, Type, TypeContext, TypeQualifiers,
-};
+use crate::types::{CallDunderError, MemberLookupPolicy, Type, TypeContext, TypeQualifiers};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Make sure that the attribute assignment `obj.attribute = value` is valid.
@@ -810,16 +809,11 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     .context
                     .report_lint(&INVALID_ASSIGNMENT, self.target)
                 {
-                    let settings = DisplaySettings::from_possibly_ambiguous_types(
-                        db,
-                        env,
-                        [value_ty, object_ty],
-                    );
                     builder.into_diagnostic(format_args!(
                         "Object of type `{}` is not assignable to attribute `{}` on type `{}`",
-                        value_ty.display_with(db, env, settings.clone()),
+                        value_ty.display(db, env),
                         self.attribute,
-                        object_ty.display_with(db, env, settings),
+                        object_ty.display(db, env),
                     ));
                 }
             }
@@ -859,23 +853,23 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     .report_lint(&INVALID_ASSIGNMENT, self.target)
                 {
                     let message = if !member_exists {
-                        format!(
+                        DiagnosticMessage::from_display(format_args!(
                             "Cannot assign to unresolved attribute `{}` on type `{}`",
                             self.attribute,
                             self.object_ty.display(db, env)
-                        )
+                        ))
                     } else if is_setattr_synthesized {
-                        format!(
+                        DiagnosticMessage::from_display(format_args!(
                             "Property `{}` defined in `{}` is read-only",
                             self.attribute,
                             self.object_ty.display(db, env)
-                        )
+                        ))
                     } else {
-                        format!(
+                        DiagnosticMessage::from_display(format_args!(
                             "Cannot assign to attribute `{}` on type `{}` whose `__setattr__` method returns `Never`/`NoReturn`",
                             self.attribute,
                             self.object_ty.display(db, env)
-                        )
+                        ))
                     };
                     builder.into_diagnostic(message);
                 }
@@ -922,13 +916,15 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     self.target.into(),
                     &CallDiagnosticOverride {
                         lint: &INVALID_ASSIGNMENT,
-                        message: format!(
+                        message: DiagnosticMessage::from_display(format_args!(
                             "Cannot assign object of type `{}` to attribute `{}` on type `{}`",
                             value_ty.display(db, env),
                             self.attribute,
                             self.object_ty.display(db, env)
+                        )),
+                        info: DiagnosticMessage::from(
+                            "This assignment implicitly calls a custom `__setattr__` method",
                         ),
-                        info: "This assignment implicitly calls a custom `__setattr__` method",
                         argument_ranges: &[self.target.range(), self.value.range()],
                     },
                 );

--- a/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
-use ruff_python_ast::{self as ast, name::Name};
+use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
 
-use crate::types::class::DynamicClassLiteral;
+use crate::types::class::{ClassLiteral, DynamicClassLiteral};
 use crate::types::context::InferContext;
 use crate::types::diagnostic::{
     CYCLIC_CLASS_DEFINITION, DUPLICATE_BASE, INCONSISTENT_MRO, INVALID_ARGUMENT_TYPE, INVALID_BASE,
@@ -86,10 +86,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         bases_node: &ast::Expr,
         bases: &[Type<'db>],
-        name: &Name,
+        class: DynamicClassLiteral<'db>,
         kind: DynamicClassKind,
     ) -> IncompatibleBases<'db> {
         let db = self.db();
+        let name = class.name(db);
 
         let bases_tuple_elts = bases_node
             .as_tuple_expr()
@@ -166,8 +167,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             .report_lint(&SUBCLASS_OF_FINAL_CLASS, diagnostic_node)
                         {
                             builder.into_diagnostic(format_args!(
-                                "Class `{name}` cannot inherit from final class `{}`",
-                                class_type.name(db)
+                                "Class `{}` cannot inherit from final class `{}`",
+                                ClassLiteral::Dynamic(class).display(db),
+                                class_type.class_literal(db).display(db)
                             ));
                         }
                         if let Some(disjoint_base) = class_type.nearest_disjoint_base(db) {
@@ -222,22 +224,16 @@ pub(super) fn report_dynamic_mro_errors<'db>(
     bases: &ast::Expr,
 ) -> bool {
     let db = context.db();
-    let env = context.program_environment();
     let Err(error) = dynamic_class.try_mro(db) else {
         return true;
     };
-    let bases_display = dynamic_class
-        .explicit_bases(db)
-        .iter()
-        .map(|base| base.display(db, env))
-        .join(", ");
     report_mro_error_kind(
         context,
         error,
-        dynamic_class.name(db),
+        ClassLiteral::Dynamic(dynamic_class),
         call_expr,
         Some(bases),
-        Some(&bases_display),
+        Some(dynamic_class.explicit_bases(db)),
     );
 
     false
@@ -277,18 +273,18 @@ pub(super) fn report_inconsistent_dynamic_generic_bases<'db>(
 /// at specific elements in the tuple. When `None` (enums), `InvalidBases`
 /// is skipped since enum bases are always valid.
 ///
-/// `bases_display` is an optional pre-formatted string of the bases list
-/// (e.g. `"<class 'X'>, <class 'Y'>"`). When provided, the `UnresolvableMro`
-/// message includes `with bases [...]`.
+/// `displayed_bases` contains the bases to include in an `UnresolvableMro` message. They remain
+/// unformatted until the diagnostic is constructed so their class identities are preserved.
 pub(super) fn report_mro_error_kind<'db>(
     context: &InferContext<'db, '_>,
     error: &DynamicMroError<'db>,
-    class_name: &Name,
+    class: ClassLiteral<'db>,
     call_expr: &ast::ExprCall,
     bases_expr: Option<&ast::Expr>,
-    bases_display: Option<&str>,
+    displayed_bases: Option<&[Type<'db>]>,
 ) {
     let db = context.db();
+    let class_name = class.display(db);
     match error.reason() {
         DynamicMroErrorKind::InvalidBases(invalid_bases) => {
             let Some(bases) = bases_expr else {
@@ -342,17 +338,22 @@ pub(super) fn report_mro_error_kind<'db>(
                     maybe_s = if duplicates.len() == 1 { "" } else { "es" },
                     dupes = duplicates
                         .iter()
-                        .map(|base: &ClassBase<'_>| base.display(db, env))
-                        .join(", "),
+                        .format_with(", ", |base: &ClassBase<'_>, formatter| {
+                            formatter(&base.display(db, env))
+                        }),
                 ));
             }
         }
         DynamicMroErrorKind::UnresolvableMro => {
             if let Some(builder) = context.report_lint(&INCONSISTENT_MRO, call_expr) {
-                if let Some(bases) = bases_display {
+                if let Some(bases) = displayed_bases {
+                    let env = context.program_environment();
                     builder.into_diagnostic(format_args!(
                         "Cannot create a consistent method resolution order (MRO) \
-                            for class `{class_name}` with bases `[{bases}]`",
+                            for class `{class_name}` with bases `[{}]`",
+                        bases
+                            .iter()
+                            .format_with(", ", |base, formatter| formatter(&base.display(db, env)))
                     ));
                 } else {
                     builder.into_diagnostic(format_args!(

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -458,7 +458,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             report_mro_error_kind(
                 &self.context,
                 error,
-                enum_lit.name(db),
+                ClassLiteral::DynamicEnum(enum_lit),
                 call_expr,
                 None,
                 None,
@@ -548,8 +548,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             {
                 builder.into_diagnostic(format_args!(
                     "Class `{}` cannot be used as an enum mixin with `{}`",
-                    mixin_class.name(db),
-                    base_class.name(self.program_environment().python_version(db)),
+                    mixin_class.class_literal(db).display(db),
+                    enum_base.class_literal(db).display(db),
                 ));
                 return (None, false);
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -158,7 +158,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut disjoint_bases = self.validate_dynamic_type_bases(
                 bases_arg,
                 explicit_bases,
-                dynamic_class.name(db),
+                dynamic_class,
                 DynamicClassKind::NewClass,
             );
 
@@ -188,7 +188,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 report_conflicting_metaclass_from_bases(
                     &self.context,
                     call_expr.into(),
-                    dynamic_class.name(db),
+                    ClassLiteral::Dynamic(dynamic_class).display(db),
                     metaclass1,
                     base1.display(db, env),
                     metaclass2,
@@ -209,8 +209,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         definition: Definition<'db>,
         call_expr: &ast::Expr,
     ) {
-        let db = self.db();
-
         let ast::Expr::Call(call) = call_expr else {
             return;
         };
@@ -243,8 +241,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         };
 
         // Validate individual bases for special types that aren't allowed in dynamic classes.
-        let name = dynamic_class.name(db);
-        self.validate_dynamic_type_bases(bases_arg, &bases, name, DynamicClassKind::NewClass);
+        self.validate_dynamic_type_bases(
+            bases_arg,
+            &bases,
+            dynamic_class,
+            DynamicClassKind::NewClass,
+        );
     }
 
     /// Preserve normal call-binding diagnostics for `types.new_class()` while still allowing

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
@@ -91,7 +91,7 @@ pub(crate) fn check_dynamic_class_definition<'db>(
         report_conflicting_metaclass_from_bases(
             context,
             call_expr.into(),
-            dynamic_class.name(db),
+            ClassLiteral::Dynamic(dynamic_class).display(db),
             metaclass1,
             base1.display(db, env),
             metaclass2,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -14,10 +14,9 @@ use crate::{
     diagnostic::format_enumeration,
     place::{DefinedPlace, Place, TypeOrigin, place_from_bindings, place_from_declarations},
     types::{
-        CallArguments, ClassBase, ClassLiteral, ClassType, DataclassFlags, DisplaySettings,
-        KnownClass, KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters,
-        Signature, SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypingModule,
-        binding_type,
+        CallArguments, ClassBase, ClassLiteral, ClassType, DataclassFlags, KnownClass,
+        KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters, Signature,
+        SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypingModule, binding_type,
         call::Argument,
         class::{
             AbstractMethod, CodeGeneratorKind, Field, FieldKind, MetaclassErrorKind,
@@ -359,13 +358,13 @@ pub(crate) fn check_static_class_definitions<'db>(
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Variance of type variable `{}` is incompatible with base class `{}`",
                         typevar.typevar(db).name(db),
-                        base_alias.origin(db).name(db),
+                        base_alias.origin(db).display(db),
                     ));
                     diagnostic.help(format_args!(
                         "Type variable `{}` is declared as {}, but base class `{}` requires it to be {}",
                         typevar.typevar(db).name(db),
                         declared_variance.as_str(),
-                        base_alias.origin(db).name(db),
+                        base_alias.origin(db).display(db),
                         required_variance.as_str(),
                     ));
                 }
@@ -386,8 +385,8 @@ pub(crate) fn check_static_class_definitions<'db>(
             {
                 builder.into_diagnostic(format_args!(
                     "Protocol class `{}` cannot inherit from non-protocol class `{}`",
-                    class.name(db),
-                    base_class.name(db),
+                    class.display(db),
+                    base_class.class_literal(db).display(db),
                 ));
             }
         } else if class_kind == Some(CodeGeneratorKind::TypedDict) {
@@ -396,15 +395,19 @@ pub(crate) fn check_static_class_definitions<'db>(
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "TypedDict class `{}` can only inherit from TypedDict classes",
-                    class.name(db),
+                    class.display(db),
                 ));
                 diagnostic.set_primary_annotation_message(format_args!(
                     "`{}` is not a `TypedDict` class",
-                    base_class.name(db)
+                    base_class.class_literal(db).display(db)
                 ));
                 diagnostic.annotate(
-                    Annotation::secondary(base_class.class_literal(db).header_span(db))
-                        .message(format_args!("`{}` defined here", base_class.name(db))),
+                    Annotation::secondary(base_class.class_literal(db).header_span(db)).message(
+                        format_args!(
+                            "`{}` defined here",
+                            base_class.class_literal(db).display(db)
+                        ),
+                    ),
                 );
             }
             if base_class.class_literal(db).is_typed_dict(db) {
@@ -417,8 +420,8 @@ pub(crate) fn check_static_class_definitions<'db>(
         {
             builder.into_diagnostic(format_args!(
                 "Class `{}` cannot inherit from final class `{}`",
-                class.name(db),
-                base_class.name(db),
+                class.display(db),
+                base_class.class_literal(db).display(db),
             ));
         }
 
@@ -448,8 +451,8 @@ pub(crate) fn check_static_class_definitions<'db>(
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Class `{}` inherits from dataclass `{}` which has `order=True`",
-                    class.name(db),
-                    ordered_base_class.name(db),
+                    class.display(db),
+                    ordered_base_class.class_literal(db).display(db),
                 ));
                 diagnostic.info(
                     "Comparison of instances of the child class with instances \
@@ -495,11 +498,10 @@ pub(crate) fn check_static_class_definitions<'db>(
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Cannot create a consistent method resolution order (MRO) \
                                     for class `{}` with bases list `[{}]`",
-                        class.name(db),
+                        class.display(db),
                         bases_list
                             .iter()
-                            .map(|base| base.display(db, env))
-                            .join(", ")
+                            .format_with(", ", |base, formatter| formatter(&base.display(db, env)))
                     ));
                     let can_rewrite_bases = bases_list.len() == class_node.bases().len()
                         && !class_node.bases().iter().any(ast::Expr::is_starred_expr);
@@ -641,36 +643,25 @@ pub(crate) fn check_static_class_definitions<'db>(
                     report_conflicting_metaclass_from_bases(
                         context,
                         class_node.into(),
-                        class.name(db),
+                        class.display(db),
                         *metaclass1,
-                        class1.name(db),
+                        class1.display(db),
                         *metaclass2,
-                        class2.name(db),
+                        class2.display(db),
                     );
                 } else if let Some(builder) =
                     context.report_lint(&CONFLICTING_METACLASS, class_node)
                 {
-                    let types = [
-                        Type::from(class),
-                        Type::from(*metaclass1),
-                        Type::from(*metaclass2),
-                        Type::from(*class2),
-                    ];
-                    let settings = DisplaySettings::from_possibly_ambiguous_types(db, env, types);
                     builder.into_diagnostic(format_args!(
                         "The metaclass of a derived class (`{class}`) \
                             must be a subclass of the metaclasses of all its bases, \
                             but `{metaclass_of_class}` (metaclass of `{class}`) \
                             and `{metaclass_of_base}` (metaclass of base class `{base}`) \
                             have no subclass relationship",
-                        class = ClassLiteral::Static(class).display_with(db, settings.clone()),
-                        metaclass_of_class = metaclass1
-                            .class_literal(db)
-                            .display_with(db, settings.clone()),
-                        metaclass_of_base = metaclass2
-                            .class_literal(db)
-                            .display_with(db, settings.clone()),
-                        base = ClassLiteral::Static(*class2).display_with(db, settings),
+                        class = class.display(db),
+                        metaclass_of_class = metaclass1.class_literal(db).display(db),
+                        metaclass_of_base = metaclass2.class_literal(db).display(db),
+                        base = class2.display(db),
                     ));
                 }
             }
@@ -1359,7 +1350,7 @@ fn check_final_class_abstract_methods<'db>(
         return;
     };
 
-    let class_name = class.name(db);
+    let class_name = class.display(db);
 
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Final class `{class_name}` has unimplemented abstract methods",
@@ -1427,7 +1418,7 @@ fn check_final_class_abstract_methods<'db>(
         kind,
     } = abstract_method;
 
-    let defining_class_name = defining_class.name(db);
+    let defining_class_name = defining_class.class_literal(db).display(db);
 
     if let Type::FunctionLiteral(function) = binding_type(db, *definition) {
         let policy = if kind.is_explicit() {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
@@ -183,8 +183,8 @@ fn validate_typed_dict_openness<'db>(
                         class,
                         format_args!(
                             "TypedDict `{}` must remain closed because base `{}` is closed",
-                            class.name(db),
-                            base.name(db),
+                            class.display(db),
+                            base.class_literal(db).display(db),
                         ),
                     );
                     continue;
@@ -199,7 +199,7 @@ fn validate_typed_dict_openness<'db>(
                         class,
                         format_args!(
                             "Cannot add item `{field_name}` to closed TypedDict base `{}`",
-                            base.name(db),
+                            base.class_literal(db).display(db),
                         ),
                     );
                 }
@@ -212,8 +212,8 @@ fn validate_typed_dict_openness<'db>(
                             class,
                             format_args!(
                                 "TypedDict `{}` cannot be open because base `{}` has extra items",
-                                class.name(db),
-                                base.name(db),
+                                class.display(db),
+                                base.class_literal(db).display(db),
                             ),
                         );
                         continue;
@@ -232,7 +232,7 @@ fn validate_typed_dict_openness<'db>(
                                     "Extra items type `{}` is not assignable to `{}` from base `{}`",
                                     child_extra_items.declared_ty.display(db, env),
                                     base_extra_items.declared_ty.display(db, env),
-                                    base.name(db),
+                                    base.class_literal(db).display(db),
                                 ),
                             );
                             continue;
@@ -255,7 +255,7 @@ fn validate_typed_dict_openness<'db>(
                             "Item `{field_name}` of type `{}` is not assignable to extra items type `{}` from base `{}`",
                             field.declared_ty.display(db, env),
                             base_extra_items.declared_ty.display(db, env),
-                            base.name(db),
+                            base.class_literal(db).display(db),
                         ),
                     );
                 }
@@ -267,8 +267,8 @@ fn validate_typed_dict_openness<'db>(
                         class,
                         format_args!(
                             "TypedDict `{}` must preserve mutable extra items from base `{}`",
-                            class.name(db),
-                            base.name(db),
+                            class.display(db),
+                            base.class_literal(db).display(db),
                         ),
                     );
                     continue;
@@ -291,9 +291,9 @@ fn validate_typed_dict_openness<'db>(
                         class,
                         format_args!(
                             "TypedDict `{}` must preserve mutable extra items type `{}` from base `{}`",
-                            class.name(db),
+                            class.display(db),
                             base_extra_items.declared_ty.display(db, env),
-                            base.name(db),
+                            base.class_literal(db).display(db),
                         ),
                     );
                     continue;
@@ -320,7 +320,7 @@ fn validate_typed_dict_openness<'db>(
                         format_args!(
                             "Item `{field_name}` must be mutable, not required, and consistent with extra items type `{}` from base `{}`",
                             base_extra_items.declared_ty.display(db, env),
-                            base.name(db),
+                            base.class_literal(db).display(db),
                         ),
                     );
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -8,7 +8,7 @@ use ty_module_resolver::file_to_module;
 use super::TypeInferenceBuilder;
 use crate::place::{DefinedPlace, Definedness, Place};
 use crate::types::call::CallErrorKind;
-use crate::types::call::bind::CallableDescription;
+use crate::types::call::bind::{CallableDescription, display_callable_description};
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::diagnostic::{
     CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY,
@@ -29,7 +29,7 @@ use crate::types::typed_dict::{
 use crate::types::typevar::TypeVarSet;
 use crate::types::{
     BoundTypeVarInstance, CallArguments, CallDunderError, CallableBinding, CycleDetector,
-    DisplaySettings, DynamicType, InternedType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
+    DynamicType, InternedType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
     MemberLookupPolicy, Parameter, Parameters, SpecialFormType, StaticClassLiteral, Type,
     TypeAliasType, TypeAndQualifiers, TypeContext, TypeVarBoundOrConstraints, UnionType,
     UnionTypeInstance, any_over_type, todo_type,
@@ -1116,9 +1116,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .iter()
                         .map(|tv| tv.typevar(db).name(db))
                         .format("`, `"),
-                    description
-                        .map(|description| format!(" of {description}"))
-                        .unwrap_or_default()
+                    display_callable_description(db, description.as_ref(), "of")
                 ));
             }
             error = Some(ExplicitSpecializationError::MissingTypeVars);
@@ -1154,9 +1152,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let description = CallableDescription::new(db, value_ty);
                     builder.into_diagnostic(format_args!(
                         "Too many type arguments{}: expected {}, got {}",
-                        description
-                            .map(|description| format!(" to {description}"))
-                            .unwrap_or_default(),
+                        display_callable_description(db, description.as_ref(), "to"),
                         if typevar_with_defaults == 0 {
                             format!("{typevars_len}")
                         } else {
@@ -1999,22 +1995,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             target.range.cover(rhs_value_node.range()),
                                         )
                                     {
-                                        let settings =
-                                            DisplaySettings::from_possibly_ambiguous_types(
-                                                db,
-                                                env,
-                                                [rhs_value_ty, object_ty, slice_ty],
-                                            );
-                                        let assigned_d =
-                                            rhs_value_ty.display_with(db, env, settings.clone());
-                                        let object_d =
-                                            object_ty.display_with(db, env, settings.clone());
+                                        let assigned_d = rhs_value_ty.display(db, env);
+                                        let object_d = object_ty.display(db, env);
 
                                         let mut diagnostic = builder.into_diagnostic(format_args!(
                                             "Invalid subscript assignment with key of type `{}` \
                                             and value of type `{assigned_d}` \
                                             on object of type `{object_d}`",
-                                            slice_ty.display_with(db, env, settings),
+                                            slice_ty.display(db, env),
                                         ));
 
                                         // Special diagnostic for dictionaries

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -269,7 +269,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut disjoint_bases = self.validate_dynamic_type_bases(
                 bases_arg,
                 explicit_bases,
-                dynamic_class.name(db),
+                dynamic_class,
                 DynamicClassKind::TypeCall,
             );
 
@@ -300,7 +300,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 report_conflicting_metaclass_from_bases(
                     &self.context,
                     call_expr.into(),
-                    dynamic_class.name(db),
+                    ClassLiteral::Dynamic(dynamic_class).display(db),
                     metaclass1,
                     base1.display(db, env),
                     metaclass2,
@@ -321,8 +321,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         definition: Definition<'db>,
         call_expr: &ast::Expr,
     ) {
-        let db = self.db();
-
         let ast::Expr::Call(call) = call_expr else {
             return;
         };
@@ -355,7 +353,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         };
 
         // Validate individual bases for special types that aren't allowed in dynamic classes.
-        let name = dynamic_class.name(db);
-        self.validate_dynamic_type_bases(bases_arg, &bases, name, DynamicClassKind::TypeCall);
+        self.validate_dynamic_type_bases(
+            bases_arg,
+            &bases,
+            dynamic_class,
+            DynamicClassKind::TypeCall,
+        );
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -829,6 +829,84 @@ fn dependency_internal_symbol_change() -> anyhow::Result<()> {
 }
 
 #[test]
+fn diagnostic_class_names_do_not_invalidate_dependent_inference() -> anyhow::Result<()> {
+    for (source, expected) in [
+        (
+            "from dependency import Model\nvalue: Model = 1",
+            "Object of type `Literal[1]` is not assignable to `Model`",
+        ),
+        (
+            "import dependency\nclass Model: ...\nvalue: dependency.Model = Model()",
+            "Object of type `main.Model` is not assignable to `dependency.Model`",
+        ),
+    ] {
+        let mut db = setup_db();
+        db.write_files([
+            ("/src/main.py", source),
+            ("/src/dependency.py", "class Model:\n    pass"),
+        ])?;
+
+        let main = system_path_to_file(&db, "/src/main.py").unwrap();
+        assert_file_diagnostics(&db, "/src/main.py", &[expected]);
+
+        db.write_file(
+            "/src/dependency.py",
+            "class Model:\n    # This does not change the class.\n    pass",
+        )?;
+        db.clear_salsa_events();
+
+        assert_file_diagnostics(&db, "/src/main.py", &[expected]);
+
+        let events = db.take_salsa_events();
+        assert_function_query_was_not_run(
+            &db,
+            infer_definition_types,
+            first_public_binding(&db, main, "value"),
+            &events,
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn diagnostic_alias_names_do_not_invalidate_dependent_inference() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_files([
+        (
+            "/src/main.py",
+            "from dependency import Model\ndef make() -> Model: return \"\"\nvalue = make().present",
+        ),
+        (
+            "/src/dependency.py",
+            "class Item:\n    present: int\ntype Model = Item | str",
+        ),
+    ])?;
+
+    let main = system_path_to_file(&db, "/src/main.py").unwrap();
+    let expected = "Attribute `present` is not defined on `str` in union `Model`";
+    assert_file_diagnostics(&db, "/src/main.py", &[expected]);
+
+    db.write_file(
+        "/src/dependency.py",
+        "class Item:\n    # This does not change the class.\n    present: int\ntype Model = Item | str",
+    )?;
+    db.clear_salsa_events();
+
+    assert_file_diagnostics(&db, "/src/main.py", &[expected]);
+
+    let events = db.take_salsa_events();
+    assert_function_query_was_not_run(
+        &db,
+        infer_definition_types,
+        first_public_binding(&db, main, "value"),
+        &events,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn dependency_unrelated_symbol() -> anyhow::Result<()> {
     let mut db = setup_db();
 

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -3,16 +3,34 @@ use crate::types::relation::TypeRelation;
 /// This module defines a tree structure for collecting contextual information about type relation errors
 /// ("why is this complex type not assignable to that other complex type?").
 use std::cell::{Cell, RefCell};
+use std::fmt::{self, Display};
 use std::rc::Rc;
 
+use ruff_db::diagnostic::DiagnosticMessage;
 use ruff_python_ast::name::Name;
 use ty_python_core::semantic_index;
 
 use crate::types::context::LintDiagnosticGuard;
 use crate::types::infer::nearest_enclosing_class;
 use crate::types::tuple::TupleLength;
-use crate::types::{DisplaySettings, Type, TypedDictType};
+use crate::types::{ClassLiteral, DisplaySettings, Type, TypedDictType};
 use crate::{FxOrderSet, ProgramEnvironment};
+
+fn typed_dict_name<'db, 'env>(
+    db: &'db dyn Db,
+    env: &'env ProgramEnvironment<'db>,
+    typed_dict: TypedDictType<'db>,
+) -> impl Display + 'env
+where
+    'db: 'env,
+{
+    fmt::from_fn(move |f| match typed_dict {
+        TypedDictType::Class(class) => {
+            write!(f, "TypedDict `{}`", class.class_literal(db).display(db))
+        }
+        TypedDictType::Synthesized(_) => Type::TypedDict(typed_dict).display(db, env).fmt(f),
+    })
+}
 
 /// Identifies a parameter, either by name or by position.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -180,13 +198,8 @@ impl<'db> ErrorContext<'db> {
         env: &ProgramEnvironment<'db>,
         relation: TypeRelation,
         help_messages: &mut FxOrderSet<HelpMessages<'db>>,
-    ) -> Option<String> {
-        let typed_dict_name = |typed_dict: &TypedDictType<'db>| match typed_dict {
-            TypedDictType::Class(class) => format!("TypedDict `{}`", class.name(db)),
-            TypedDictType::Synthesized(_) => {
-                Type::TypedDict(*typed_dict).display(db, env).to_string()
-            }
-        };
+    ) -> Option<DiagnosticMessage> {
+        let message = |arguments: fmt::Arguments<'_>| DiagnosticMessage::from_display(arguments);
 
         Some(match self {
             Self::Empty => {
@@ -196,225 +209,218 @@ impl<'db> ErrorContext<'db> {
                 element,
                 union,
                 target,
-            } => {
-                let settings = DisplaySettings::from_possibly_ambiguous_types(
+            } => message(format_args!(
+                "element `{}` of union `{}` is not {} `{}`",
+                element.display(db, env),
+                union.display_with(
                     db,
                     env,
-                    [*element, *union, *target],
-                );
-                format!(
-                    "element `{}` of union `{}` is not {} `{}`",
-                    element.display_with(db, env, settings.clone()),
-                    union.display_with(db, env, settings.expand_numeric_tower_unions()),
-                    relation.description(),
-                    target.display_with(db, env, settings),
-                )
-            }
-            Self::NotAssignableToAnyUnionElement { source, union } => {
-                let settings =
-                    DisplaySettings::from_possibly_ambiguous_types(db, env, [*source, *union]);
-                format!(
-                    "type `{}` is not {} any element of the union `{}`",
-                    source.display_with(db, env, settings.clone()),
-                    relation.description(),
-                    union.display_with(db, env, settings.expand_numeric_tower_unions()),
-                )
-            }
-            Self::NotAssignableToNOtherUnionElements { n } => format!(
+                    DisplaySettings::default().expand_numeric_tower_unions()
+                ),
+                relation.description(),
+                target.display(db, env),
+            )),
+            Self::NotAssignableToAnyUnionElement { source, union } => message(format_args!(
+                "type `{}` is not {} any element of the union `{}`",
+                source.display(db, env),
+                relation.description(),
+                union.display_with(
+                    db,
+                    env,
+                    DisplaySettings::default().expand_numeric_tower_unions()
+                ),
+            )),
+            Self::NotAssignableToNOtherUnionElements { n } => message(format_args!(
                 "... omitted {n} union element{} without additional context",
                 if *n == 1 { "" } else { "s" }
-            ),
+            )),
             Self::NotAssignableToIntersectionElement {
                 source,
                 element,
                 intersection,
-            } => format!(
+            } => message(format_args!(
                 "type `{}` is not {} element `{}` of intersection `{}`",
                 source.display(db, env),
                 relation.description(),
                 element.display(db, env),
                 intersection.display(db, env),
-            ),
+            )),
             Self::NoIntersectionElementAssignableToTarget {
                 intersection,
                 target,
-            } => format!(
+            } => message(format_args!(
                 "no element of intersection `{}` is {} `{}`",
                 intersection.display(db, env),
                 relation.description(),
                 target.display(db, env),
-            ),
-            Self::TypedDictFieldMissing { field_name, source } => {
-                format!(
-                    "required field \"{field_name}\" is not present in source {source}",
-                    source = typed_dict_name(source)
-                )
-            }
+            )),
+            Self::TypedDictFieldMissing { field_name, source } => message(format_args!(
+                "required field \"{field_name}\" is not present in source {source}",
+                source = typed_dict_name(db, env, *source)
+            )),
             Self::TypedDictFieldNotRequiredInSource {
                 field_name,
                 source,
                 target,
-            } => {
-                format!(
-                    "field \"{field_name}\" is required in {target} but not required in {source}",
-                    source = typed_dict_name(source),
-                    target = typed_dict_name(target)
-                )
-            }
+            } => message(format_args!(
+                "field \"{field_name}\" is required in {target} but not required in {source}",
+                source = typed_dict_name(db, env, *source),
+                target = typed_dict_name(db, env, *target)
+            )),
             Self::TypedDictFieldNotRequiredAndMutableInTarget {
                 field_name,
                 source,
                 target,
             } => {
                 help_messages.insert(HelpMessages::RequiredFieldCouldBeRemoved);
-                format!(
+                message(format_args!(
                     "field \"{field_name}\" is required in {source} \
                     but not required and mutable in {target}",
-                    source = typed_dict_name(source),
-                    target = typed_dict_name(target)
-                )
+                    source = typed_dict_name(db, env, *source),
+                    target = typed_dict_name(db, env, *target)
+                ))
             }
             Self::TypedDictFieldReadOnlyInSource {
                 field_name,
                 source,
                 target,
-            } => {
-                format!(
-                    "field \"{field_name}\" is read-only in {source} but mutable in {target}",
-                    source = typed_dict_name(source),
-                    target = typed_dict_name(target)
-                )
-            }
+            } => message(format_args!(
+                "field \"{field_name}\" is read-only in {source} but mutable in {target}",
+                source = typed_dict_name(db, env, *source),
+                target = typed_dict_name(db, env, *target)
+            )),
             Self::TypedDictFieldIncompatible {
                 field_name,
                 source,
                 target,
                 source_field,
                 target_field,
-            } => format!(
+            } => message(format_args!(
                 "field \"{field_name}\" on {source} has type `{source_field}` \
                 which is not {relation} type `{target_field}` expected by {target}",
-                source = typed_dict_name(source),
-                target = typed_dict_name(target),
+                source = typed_dict_name(db, env, *source),
+                target = typed_dict_name(db, env, *target),
                 relation = relation.description(),
                 source_field = source_field.display(db, env),
                 target_field = target_field.display(db, env),
-            ),
+            )),
             Self::TypedDictNotAssignableToDict(typed_dict) => {
                 help_messages.insert(HelpMessages::TypedDictNotAssignableToDict(relation));
                 help_messages.insert(HelpMessages::ConsiderUsingMappingInsteadOfDict);
 
-                format!(
+                message(format_args!(
                     "{source} is not {relation} `dict`",
-                    source = typed_dict_name(typed_dict),
+                    source = typed_dict_name(db, env, *typed_dict),
                     relation = relation.description()
-                )
+                ))
             }
             Self::OpenTypedDictNotAssignableToMapping { source, target } => {
-                let name = source.defining_class().map(|class| class.name(db));
+                let class = source.defining_class().map(|class| class.class_literal(db));
                 help_messages.insert(HelpMessages::OpenTypedDictNotAssignableToMapping {
-                    typed_dict_name: name,
+                    typed_dict_class: class,
                     mapping_target: *target,
                 });
                 help_messages.insert(HelpMessages::ExplainOpenTypedDictUnsoundness {
-                    typed_dict_name: name,
+                    typed_dict_class: class,
                     mapping_target: *target,
                 });
 
-                format!(
+                message(format_args!(
                     "{source} is not {relation} `{target}`",
-                    source = typed_dict_name(source),
+                    source = typed_dict_name(db, env, *source),
                     relation = relation.description(),
                     target = target.display(db, env)
-                )
+                ))
             }
-            Self::IncompatibleReturnTypes { source, target } => format!(
+            Self::IncompatibleReturnTypes { source, target } => message(format_args!(
                 "incompatible return types: `{source}` is not {relation} `{target}`",
                 source = source.display(db, env),
                 relation = relation.description(),
                 target = target.display(db, env),
-            ),
+            )),
             Self::IncompatibleParameterTypes {
                 source,
                 target,
                 parameter,
             } => {
                 // reversed order due to contravariance of parameter types
-                format!(
+                message(format_args!(
                     "{parameter} has an incompatible type: `{target}` is not {relation} `{source}`",
                     source = source.display(db, env),
                     relation = relation.description(),
                     target = target.display(db, env),
-                )
+                ))
             }
-            Self::InferredCallableType { source, callable } => format!(
+            Self::InferredCallableType { source, callable } => message(format_args!(
                 "type `{}` has inferred callable type `{}`",
                 source.display(db, env),
                 callable.display(db, env),
-            ),
+            )),
             Self::ExtraRequiredParameter { parameter } => match parameter {
                 ParameterDescription::Named(name) => {
                     help_messages.insert(HelpMessages::ConsiderAddingADefaultValue {
                         parameter_name: Some(name.clone()),
                     });
-                    format!("unexpected extra parameter `{name}`")
+                    message(format_args!("unexpected extra parameter `{name}`"))
                 }
                 ParameterDescription::Index(_) => {
                     help_messages.insert(HelpMessages::ConsiderAddingADefaultValue {
                         parameter_name: None,
                     });
-                    "unexpected extra parameter".to_string()
+                    DiagnosticMessage::from("unexpected extra parameter")
                 }
             },
-            Self::MissingParameter { parameter } => format!("{parameter} is missing"),
+            Self::MissingParameter { parameter } => message(format_args!("{parameter} is missing")),
             Self::RequiredParameterMustHaveDefault { parameter } => {
-                format!("{parameter} must have a default value")
+                message(format_args!("{parameter} must have a default value"))
             }
             Self::MissingVariadicPositionalParameter => {
-                "the signature must accept arbitrary positional arguments".to_string()
+                DiagnosticMessage::from("the signature must accept arbitrary positional arguments")
             }
             Self::MissingVariadicKeywordParameter => {
-                "the signature must accept arbitrary keyword arguments".to_string()
+                DiagnosticMessage::from("the signature must accept arbitrary keyword arguments")
             }
             Self::TopCallableAssignedToNonTop { return_type } => {
                 help_messages.insert(HelpMessages::TopCallableExplanation);
-                format!(
+                message(format_args!(
                     "Object of type `Top[(...) -> {}]` is not safe to call; \
                     its signature is not known",
                     return_type.display(db, env)
-                )
+                ))
             }
             Self::ParameterNameMismatch {
                 source_name,
                 target_name,
-            } => format!(
+            } => message(format_args!(
                 "the parameter named `{source_name}` does not match `{target_name}` \
                 (and can be used as a keyword parameter)",
-            ),
+            )),
             Self::ParameterMustAcceptKeywordArguments {
                 source_name,
                 target_name,
             } => {
                 if let Some(source_name) = source_name {
-                    format!(
+                    message(format_args!(
                         "parameter `{source_name}` is positional-only \
                         but must also accept keyword arguments",
-                    )
+                    ))
                 } else {
-                    format!("parameter `{target_name}` must accept keyword arguments")
+                    message(format_args!(
+                        "parameter `{target_name}` must accept keyword arguments"
+                    ))
                 }
             }
-            Self::ParameterMustAcceptPositionalArguments { name } => format!(
+            Self::ParameterMustAcceptPositionalArguments { name } => message(format_args!(
                 "parameter `{name}` is keyword-only but must also accept positional arguments",
-            ),
+            )),
             Self::TupleLengthMismatch {
                 source_len,
                 target_len,
-            } => format!(
+            } => message(format_args!(
                 "a tuple of length {source_len} is not {} a tuple of length {}",
                 relation.description(),
                 target_len.display_minimum(),
-            ),
+            )),
             Self::TupleElementNotCompatible {
                 source,
                 target,
@@ -428,57 +434,58 @@ impl<'db> ErrorContext<'db> {
                     (3, _) => "the third tuple element".to_string(),
                     (n, c) => format!("tuple element {n} of {c}"),
                 };
-                format!(
+                message(format_args!(
                     "{which} is not compatible: `{source}` is not {relation} `{target}`",
                     source = source.display(db, env),
                     relation = relation.description(),
                     target = target.display(db, env)
-                )
+                ))
             }
             Self::TypeNotCompatibleWithProtocol { ty, protocol } => {
                 if let Type::ProtocolInstance(_) = ty {
-                    format!(
+                    message(format_args!(
                         "protocol `{}` is not {} protocol `{}`",
                         ty.display(db, env),
                         relation.description(),
                         protocol.display(db, env),
-                    )
+                    ))
                 } else {
-                    format!(
+                    message(format_args!(
                         "type `{}` is not {} protocol `{}`",
                         ty.display(db, env),
                         relation.description(),
                         protocol.display(db, env),
-                    )
+                    ))
                 }
             }
-            Self::ProtocolMemberNotDefined { member_name, ty } => format!(
+            Self::ProtocolMemberNotDefined { member_name, ty } => message(format_args!(
                 "protocol member `{member_name}` is not defined on type `{}`",
                 ty.display(db, env),
-            ),
-            Self::ProtocolMemberClassVarMismatch { member_name, ty } => format!(
+            )),
+            Self::ProtocolMemberClassVarMismatch { member_name, ty } => message(format_args!(
                 "protocol member `{member_name}` is an instance variable on type `{}`, \
                 but a class variable is required",
                 ty.display(db, env),
+            )),
+            Self::ProtocolSpecialMethodNotDefinedOnMetaType => DiagnosticMessage::from(
+                "special methods must be defined on the meta-type when matching a protocol",
             ),
-            Self::ProtocolSpecialMethodNotDefinedOnMetaType => {
-                "special methods must be defined on the meta-type when matching a protocol"
-                    .to_string()
-            }
-            Self::ProtocolMemberIncompatible { member_name } => {
-                format!("protocol member `{member_name}` is incompatible")
-            }
-            Self::ProtocolMemberReadTypeIncompatible { source, target } => format!(
+            Self::ProtocolMemberIncompatible { member_name } => message(format_args!(
+                "protocol member `{member_name}` is incompatible"
+            )),
+            Self::ProtocolMemberReadTypeIncompatible { source, target } => message(format_args!(
                 "read type `{source}` is not {relation} `{target}`",
                 source = source.display(db, env),
                 relation = relation.description(),
                 target = target.display(db, env),
-            ),
-            Self::ProtocolMemberNotWritable => "the member is not writable".to_string(),
-            Self::ProtocolMemberWriteTypeIncompatible { target } => format!(
+            )),
+            Self::ProtocolMemberNotWritable => {
+                DiagnosticMessage::from("the member is not writable")
+            }
+            Self::ProtocolMemberWriteTypeIncompatible { target } => message(format_args!(
                 "the member does not accept writes of type `{}`",
                 target.display(db, env),
-            ),
+            )),
         })
     }
 }
@@ -493,17 +500,17 @@ enum HelpMessages<'db> {
         parameter_name: Option<Name>,
     },
     OpenTypedDictNotAssignableToMapping {
-        typed_dict_name: Option<&'db Name>,
+        typed_dict_class: Option<ClassLiteral<'db>>,
         mapping_target: Type<'db>,
     },
     ExplainOpenTypedDictUnsoundness {
-        typed_dict_name: Option<&'db Name>,
+        typed_dict_class: Option<ClassLiteral<'db>>,
         mapping_target: Type<'db>,
     },
     SuggestMakingParameterPositionalOnly {
         ty: Type<'db>,
         protocol: Type<'db>,
-        declaring_protocol_name: &'db Name,
+        declaring_protocol: ClassLiteral<'db>,
         method_name: Name,
         parameter_name: Name,
     },
@@ -533,34 +540,40 @@ impl<'db> HelpMessages<'db> {
                 f.write_str("Consider using `Mapping[..]` instead of `dict[..]`")
             }
             HelpMessages::OpenTypedDictNotAssignableToMapping {
-                typed_dict_name,
+                typed_dict_class,
                 mapping_target,
             } => {
-                let name = typed_dict_name
-                    .as_ref()
-                    .map(|name| format!("`{name}`"))
-                    .unwrap_or_else(|| "this TypedDict".to_string());
                 write!(
                     f,
-                    "{name} would be {relation} `{mapping}` \
+                    "{} would be {relation} `{mapping}` \
                     if it were declared with `closed=True`, \
                     but TypedDicts are open by default",
+                    std::fmt::from_fn(|f| {
+                        if let Some(class) = typed_dict_class {
+                            write!(f, "`{}`", class.display(db))
+                        } else {
+                            f.write_str("this TypedDict")
+                        }
+                    }),
                     relation = relation.description(),
                     mapping = mapping_target.display(db, env)
                 )
             }
             HelpMessages::ExplainOpenTypedDictUnsoundness {
-                typed_dict_name,
+                typed_dict_class,
                 mapping_target,
             } => {
-                let name = typed_dict_name
-                    .as_ref()
-                    .map(|name| format!("`{name}`"))
-                    .unwrap_or_else(|| "this TypedDict".to_string());
                 write!(
                     f,
-                    "A subclass of {name} could validly add a new field \
+                    "A subclass of {} could validly add a new field \
                     of an arbitrary type, violating subtyping with `{mapping_type}`",
+                    std::fmt::from_fn(|f| {
+                        if let Some(class) = typed_dict_class {
+                            write!(f, "`{}`", class.display(db))
+                        } else {
+                            f.write_str("this TypedDict")
+                        }
+                    }),
                     mapping_type = mapping_target.display(db, env)
                 )
             }
@@ -576,22 +589,19 @@ impl<'db> HelpMessages<'db> {
             HelpMessages::SuggestMakingParameterPositionalOnly {
                 ty,
                 protocol,
-                declaring_protocol_name,
+                declaring_protocol,
                 method_name,
                 parameter_name,
-            } => {
-                let settings =
-                    DisplaySettings::from_possibly_ambiguous_types(db, env, [*ty, *protocol]);
-                write!(
-                    f,
-                    "`{source}` might be {relation} `{target}` \
-                    if the parameter `{parameter_name}` were made positional-only \
-                    in `{declaring_protocol_name}.{method_name}`",
-                    source = ty.display_with(db, env, settings.clone()),
-                    relation = relation.description(),
-                    target = protocol.display_with(db, env, settings),
-                )
-            }
+            } => write!(
+                f,
+                "`{source}` might be {relation} `{target}` \
+                if the parameter `{parameter_name}` were made positional-only \
+                in `{}.{method_name}`",
+                declaring_protocol.display(db),
+                source = ty.display(db, env),
+                relation = relation.description(),
+                target = protocol.display(db, env),
+            ),
         })
     }
 }
@@ -623,13 +633,13 @@ impl<'db> ErrorContextNode<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         relation: TypeRelation,
-        output_lines: &mut Vec<String>,
+        output_lines: &mut Vec<DiagnosticMessage>,
         help_messages: &mut FxOrderSet<HelpMessages<'db>>,
         prefix: &str,
         continuation: &str,
     ) {
         if let Some(line) = self.context.render(db, env, relation, help_messages) {
-            output_lines.push(format!("{prefix}{line}"));
+            output_lines.push(line.with_prefix(prefix));
         }
 
         if let ErrorContext::TypeNotCompatibleWithProtocol { ty, protocol } = &self.context
@@ -652,7 +662,7 @@ impl<'db> ErrorContextNode<'db> {
             help_messages.insert(HelpMessages::SuggestMakingParameterPositionalOnly {
                 ty: *ty,
                 protocol: *protocol,
-                declaring_protocol_name: declaring_protocol.name(db),
+                declaring_protocol: declaring_protocol.into(),
                 method_name: member_name.clone(),
                 parameter_name: target_name.clone(),
             });

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -301,7 +301,9 @@ fn apply_type_alias_specialization<'db>(
     )
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue, salsa::Supertype,
+)]
 pub enum TypeAliasType<'db> {
     /// A type alias defined using the PEP 695 `type` statement.
     PEP695(PEP695TypeAliasType<'db>),

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2903,8 +2903,9 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
         if !key_ty.is_assignable_to(db, env, KnownClass::Str.to_instance(db, env)) {
             if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, nodes.value) {
                 builder.into_diagnostic(format_args!(
-                    "Unpacked argument has key type `{}` that is not assignable to `str`",
+                    "Unpacked argument has key type `{}` that is not assignable to `{}`",
                     key_ty.display(db, env),
+                    KnownClass::Str.to_instance(db, env).display(db, env),
                 ));
             }
             return false;


### PR DESCRIPTION
## Summary

Make type-name disambiguation a property of the completed diagnostic instead of requiring every diagnostic author to predict collisions and manually propagate shared `DisplaySettings` through every formatting call.

The implementation preserves the semantic identity of class and type-alias names as they are formatted, resolves collisions across the messages that will actually be visible, and delays database-dependent resolution until fine-grained inference and diagnostic suppression have finished.

## The problem

Two unrelated types can have the same short name:

```python
# first.py
class Model: ...

# second.py
class Model: ...

# main.py
import first
import second

value: first.Model = second.Model()
```

Without disambiguation, the resulting diagnostic appears to contradict itself:

```text
error[invalid-assignment]: Object of type `Model` is not assignable to `Model`
```

The useful version identifies both definitions:

```text
error[invalid-assignment]: Object of type `second.Model` is not assignable to `first.Model`
```

Previously, each diagnostic needed to anticipate every potentially related type, construct shared settings, and consistently pass those settings to every type display:

```rust
let settings = DisplaySettings::from_possibly_ambiguous_types(
    db,
    env,
    [expected_ty, actual_ty],
);

format_args!(
    "Object of type `{}` is not assignable to `{}`",
    actual_ty.display_with(db, env, settings.clone()),
    expected_ty.display_with(db, env, settings),
)
```

That approach becomes fragile as soon as a collision spans independently constructed messages: a headline and its primary annotation, an explanatory note and a nested `TypedDict` field, two overload signatures, or a callable description and a separately displayed expected type. It also requires every intermediate helper to preserve and propagate the same settings. PR #27719 illustrated how easily this becomes a large, repetitive, incomplete call-site migration.

After this change, ordinary diagnostic call sites can simply write:

```rust
format_args!(
    "Object of type `{}` is not assignable to `{}`",
    actual_ty.display(db, env),
    expected_ty.display(db, env),
)
```

The diagnostic infrastructure discovers whether those names, or names introduced by any other visible part of the diagnostic, require qualification.

## Architectural overview

```mermaid
flowchart LR
    A[Semantic Display implementations] --> B[DiagnosticMessage captures text and semantic name identities]
    B --> C[Cached inference retains unresolved diagnostics]
    C --> D[check_types collects diagnostics and applies suppressions]
    D --> E[Resolve names separately for full and concise output]
    E --> F[Final messages retain owned strings only]
```

The key separation is between **capturing which semantic names were actually displayed**, which is cheap and happens during normal message construction, and **resolving those names into qualified paths or source locations**, which can depend on foreign syntax trees and must happen only after inference has completed.

## Implementation walkthrough

### 1. Record names at the point where the formatter actually emits them

`crates/ruff_db/src/diagnostic/message.rs` introduces `DiagnosticNameRecord`, which pairs an existing formatting operation with a lazily constructed semantic name:

```rust
DiagnosticNameRecord {
    render: || f.write_str(spelling),
    name: || NamedItem::Class(class).diagnostic_name(db, spelling),
}
.render()
```

The display layer uses this at the actual class-name and type-alias-name emission sites, so nested unions, generic arguments, callable signatures, overloads, and other composite displays participate naturally. Discovery follows the text that was really written instead of guessing from a separate walk over the semantic type graph.

When the same display is used outside diagnostic construction, `render` executes normally and the `name` closure is never evaluated. IDE displays and ordinary `Display` usage therefore do not construct diagnostic metadata.

Each recorded occurrence contains its byte range in the formatted message and a lightweight identity:

```rust
struct DiagnosticName {
    spelling: Box<str>,
    identity: salsa::Id,
    kind: DiagnosticNameKind,
}
```

`kind` distinguishes classes from type aliases, while aliases are normalized to their unspecialized identity so multiple specializations of the same alias are not mistaken for unrelated definitions. Crucially, the record contains no database reference, borrowed semantic value, qualified name, parsed syntax node, file, or source offset.

`TypeAliasType` derives `salsa::Supertype` so its enum identity can be converted to a lifetime-free Salsa ID and reconstructed later as the correct concrete alias variant. This is what allows aliases to use the same deferred-resolution mechanism as class literals without retaining a `'db` lifetime in cached diagnostics.

### 2. Use a narrowly scoped capture bridge across `std::fmt::Display`

Rust's `fmt::Formatter` does not expose its underlying writer. A nested semantic `Display` implementation cannot inspect the formatter to discover whether it is currently writing into a diagnostic message, and adding an explicit capture parameter would require replacing or threading context through the existing formatting API.

`DiagnosticMessage::from_display` therefore establishes a synchronous, thread-local capture frame around one formatting operation. Its writer advances the frame's byte offset as text is written, and `DiagnosticNameRecord` associates emitted names with the corresponding ranges.

This thread-local is a scoped transport, not persistent semantic state or an input to a Salsa query:

- Every message owns a separate stack frame, so nested diagnostic formatting cannot overwrite its parent's capture.
- No `RefCell` borrow is held while either formatting or metadata callbacks run, allowing those callbacks to invoke Salsa or format another message.
- The guard removes its frame during normal completion and panic unwinding.
- Captured values are owned and lifetime-free, and are removed from the thread-local as soon as the synchronous formatting call finishes.
- Cached and uncached nested Salsa queries produce the same diagnostic capture behavior.

The tradeoff is intentional: a small, tightly scoped bridge preserves compatibility with `format_args!`, existing `Display` implementations, and the existing diagnostic construction APIs.

### 3. Preserve structure only while it is needed

`DiagnosticMessage` has three representations:

- `Plain`: ordinary owned text with no captured semantic names.
- `Structured`: owned text plus the recorded semantic names and their byte ranges while a diagnostic is still being assembled.
- `Variants`: separate owned full and concise strings, allocated only when the two output formats genuinely need different qualification.

Finalization rewrites captured ranges from right to left, then discards all semantic metadata. Unambiguous messages collapse back to the same simple owned-string representation. Prefixing an explanation updates its byte offsets, including for multibyte Unicode prefixes.

`IntoDiagnosticMessage` accepts both ordinary displayable values and an existing `DiagnosticMessage`. `DiagnosticMessage` intentionally does not implement `Display`: that avoids an overlap with the blanket conversion and, more importantly, prevents moving an already structured message through an accidental stringification step that would destroy its identities.

### 4. Compute qualification from semantic identities, not precomputed settings

`Diagnostic::disambiguate_names` groups every visible occurrence by its displayed spelling and retains every distinct semantic identity, including identities that initially appear unambiguous.

For each group:

1. One semantic identity means the short spelling is sufficient; no qualified name or source location is requested.
2. Multiple identities with distinct qualified names are rewritten using their qualified names.
3. Distinct identities that also share a qualified name receive the existing source-location fallback.

The shared diagnostic crate only knows about lightweight IDs and a small `DiagnosticNameResolver` trait. `TypeDiagnosticNameResolver` in `types/display.rs` reconstructs the class or alias against the originating Salsa database and supplies its qualified name or location only if the collision actually requires it. Qualified names are cached across the full and concise passes.

This keeps `ruff_db` independent of ty's semantic types while ensuring that an unambiguous `Model` never reads a foreign parsed module merely to prepare metadata it will not use.

### 5. Finalize after inference and suppression, not while constructing the diagnostic

Fine-grained inference queries cache diagnostics alongside inferred types. Eagerly looking up every displayed class's qualified name, definition range, or source file while constructing those diagnostics would make an inference query for `main.py` depend on the parsed syntax tree of `dependency.py`. A harmless comment-only edit to the dependency could then invalidate inference in the importing file.

The implementation therefore keeps messages unresolved while they flow through inference and calls the finalizer only at the outer `check_types` boundary:

```rust
let mut diagnostics = check_suppressions(db, file.python_file(db), diagnostics);
display::disambiguate_diagnostic_names(db, &mut diagnostics);
```

At this point, fine-grained inference queries have already completed, suppressed diagnostics have been removed, and only diagnostics that will actually be reported need expensive qualification. Any necessary source-tree dependency belongs to final diagnostic presentation rather than to cached semantic inference.

### 6. Resolve full and concise output against different visible surfaces

A name that is ambiguous in the complete diagnostic is not necessarily ambiguous in concise output. For example:

```text
# Full output
error: Expected `first.Model`
info: Found `second.Model`

# Concise output
error: Expected `Model`
```

Because the explanatory note is absent from concise output, qualifying `first.Model` there would add an unexplained module prefix without helping the reader distinguish anything.

The resolver therefore builds two independent observation sets:

| Output | Names considered |
| --- | --- |
| Full diagnostic | Headline, all top-level annotations, all subdiagnostic messages, and their annotations. |
| Default concise diagnostic | Headline and the first primary annotation, because those are the messages concise output actually combines. |
| Custom concise diagnostic | The custom concise message alone. |

A custom concise message cannot force qualification in full output, and a hidden note cannot force qualification in concise output. When both output surfaces render a shared message identically, only one owned string is retained; separate strings are stored only when the results differ.

### 7. Preserve semantic names through helpers and specialized displays

The remaining changes are primarily about preventing semantic identities from being flattened into `String` before the parent diagnostic is complete:

- Type-relation explanations now produce `DiagnosticMessage` values rather than `String`, and tree prefixes preserve recorded ranges.
- Diagnostic message overrides, cloned headlines, and custom concise messages retain structured messages rather than calling `.to_string()`.
- Callable descriptions keep their owning `ClassLiteral` and display it only when the complete description is formatted.
- `TypedDict` explanations retain both the enclosing class identity and the identities of its field types.
- Enumeration helpers and method-resolution-order displays return lazy `Display` values rather than preformatted strings.
- Class inheritance, protocol validation, metaclass conflicts, dynamic classes, and `TypedDict` headers display semantic class values rather than bare `.name(db)` strings.

Specialized runtime displays need some extra care because their displayed spelling is not always identical to their defining class name. `KnownClassName` keeps the runtime class, rendered spelling, collision spelling, optional detailed type, and replacement policy together. This covers properties, ranges, `functools.partial`, type variables, parameter specifications, union objects, generator classes, wrapper owners, `warnings.deprecated`, `dataclasses.Field`, and aliases from both `typing` and `typing_extensions`.

Some representations should identify a collision without changing their conventional Python spelling. For example, `<module 'os'>` participates in a collision with a user-defined `module` class, but remains `<module 'os'>`; only the user-defined class becomes qualified. `DiagnosticNameRecord::render_fixed()` handles this case.

### 8. Retain `DisplaySettings` where it still has a different responsibility

This does not remove `DisplaySettings` entirely. Its remaining `from_possibly_ambiguous_types` uses are inside the display layer itself:

- `Type::display` must still disambiguate names within a standalone type when no diagnostic exists.
- A type-alias declaration must still coordinate the alias and its value when displayed independently.
- `Signature::display` must still coordinate parameter and return types when a signature is rendered outside diagnostics.

Other display settings also continue to control local presentation decisions such as multiline signatures, numeric-tower expansion, and union formatting. What disappears is the repetitive diagnostic-specific plumbing that tried to use local display settings as a substitute for knowledge of the complete diagnostic.

## Alternatives considered

**Keep propagating shared `DisplaySettings` at every diagnostic call site.** This can fix individual reports, but requires every author to predict all relevant types and thread identical settings through unrelated annotations, notes, call overrides, and recursive relation explanations. It cannot retroactively correct a message that was formatted before a later explanation introduced a collision.

**Merge separately computed `DisplaySettings`.** Existing settings remember names that were already ambiguous, not every identity that was observed. If one helper sees only `first.Model` and another sees only `second.Model`, both settings appear unambiguous; merging them cannot discover the collision that exists only across the combined diagnostic.

**Walk the semantic type graph before displaying it.** The semantic graph is not the same as the text actually shown. Specialized runtime values, callable owners, hidden return types, aliases, and abbreviated representations can omit internal types or display names that a generic visitor would not predict. Capturing names at their emission sites avoids both missed collisions and qualification caused by invisible implementation details.

**Introduce an entirely separate ty-specific pending-diagnostic representation.** A typed fragment tree with a second rendering pass could solve the same problem, but would require a parallel diagnostic API, much broader call-site migration, careful management of `'db` lifetimes, and duplication of existing message/annotation plumbing. The lightweight `ruff_db` representation and resolver interface achieve the same diagnostic-wide behavior while preserving `format_args!`, existing builders, and fully owned final diagnostics.

**Pass an explicit resolver or capture context through every formatter.** `std::fmt::Display` and `fmt::Formatter` do not provide a channel for such application-specific state. Replacing those interfaces would substantially expand the migration and recreate the very context-plumbing problem this change is intended to remove. A synchronous, stack-scoped thread-local is the narrower integration boundary.

**Compute qualified names and source positions eagerly.** This simplifies the finalizer but introduces foreign-AST dependencies into cached inference queries and performs unnecessary work even when a name is unambiguous or its diagnostic is suppressed. Lightweight Salsa identities plus deferred resolution preserve incrementality and make expensive lookups conditional.

**Use one qualification policy for both full and concise output.** This is simpler, but it exposes module prefixes in concise diagnostics when the conflicting name exists only in a hidden note, or allows a custom concise message to affect unrelated full output. Separate policies match what users can actually see.

## Testing strategy

The tests exercise the architecture at three levels rather than relying only on changed diagnostic snapshots.

**Diagnostic infrastructure:** Focused `ruff_db` tests cover name collisions across headlines, primary and secondary annotations, subdiagnostics, and subdiagnostic annotations; repeated appearances of the same identity; distinct definitions with identical qualified names; independent full/default-concise/custom-concise resolution; lazy qualified-name and source-location lookups; Unicode-safe prefixed ranges; fixed Python representations; nested cold and cached Salsa queries; panic-unwind cleanup; and ordinary non-diagnostic formatting that must never construct metadata.

**Salsa incrementality:** Dedicated semantic tests construct importing and imported files, report both ambiguous and unambiguous class diagnostics as well as an alias diagnostic, edit only an irrelevant comment in the imported file, and inspect Salsa execution events to assert that the dependent `infer_definition_types` query is not rerun. These tests specifically guard against the eager foreign-AST dependency that an earlier design introduced.

**End-to-end diagnostics:** `same_names.md` covers collisions spanning parameter defaults, `TypedDict` field explanations, overload signatures, specialized runtime classes, stdlib versus `typing_extensions` aliases, specialized PEP 695 aliases, `functools.partial`, generator return/yield/send types, wrapper owners, conflicting declaration enumerations, class/protocol/`TypedDict` inheritance, dynamic classes, dynamic metaclass conflicts, and `TypedDict` openness. Inline snapshots verify the complete relationship between headlines, annotations, and explanatory notes where that context matters.

Existing loop snapshots also document the intentional full-output changes when user-defined `Iterable`, `AsyncIterable`, or `AsyncIterator` classes collide with protocol names. Concise output was compared against the existing baseline separately so names that are visible only in hidden explanatory notes do not introduce unexplained qualification.

## Suggested review order

1. `crates/ruff_db/src/diagnostic/message.rs`: semantic identities, scoped capture, message representations, and focused infrastructure tests.
2. `crates/ruff_db/src/diagnostic/mod.rs`: full-versus-concise observation sets and diagnostic-wide qualification.
3. `crates/ty_python_semantic/src/types/display.rs` and `crates/ty_python_semantic/src/types.rs`: emission sites, the ty-specific resolver, specialized runtime names, and the post-inference finalization boundary.
4. `crates/ty_python_semantic/src/types/relation_error.rs`, `types/context.rs`, and `types/call/bind.rs`: preserving structured messages through explanations, overrides, and callable descriptions.
5. `crates/ty_python_semantic/src/types/infer/tests.rs` and `resources/mdtest/diagnostics/same_names.md`: incrementality guarantees and end-to-end behavioral coverage.
6. Remaining diagnostic and inference-builder changes: removal of redundant `DisplaySettings` plumbing and replacement of bare name strings with semantic displays.
