### PR TITLE
[ty] Add regression coverage for variadic generics and recursive aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -1900,6 +1900,36 @@ def _(source: tuple[bool, bool]):
     target: tuple[int, int] = source
 ```
 
+## Invariant variadic generic classes
+
+The invariance hint also explains incompatible specializations of a class parameterized by a type
+variable tuple.
+
+```py
+class Box[*Ts]:
+    values: tuple[*Ts]
+
+def accepts(value: Box[int]) -> None: ...
+def check(value: Box[bool]) -> None:
+    accepts(value)  # snapshot
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `accepts` is incorrect
+ --> src/mdtest_snippet.py:6:13
+  |
+6 |     accepts(value)  # snapshot
+  |             ^^^^^ Expected `Box[int]`, found `Box[bool]`
+info: the first tuple element is not compatible: `int` is not assignable to `bool`
+info: Function defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+4 | def accepts(value: Box[int]) -> None: ...
+  |     ^^^^^^^ --------------- Parameter declared here
+info: `Box` is invariant in its type parameter
+info: For more information, see https://docs.astral.sh/ty/reference/typing-faq/#invariant-generics
+```
+
 ## Error context in other scenarios
 
 ### In `invalid-return-type` diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/function/return_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/function/return_type.md
@@ -1099,3 +1099,29 @@ def returns_recursive_alias(value: Any) -> GrowingAlias[int]:
 def returns_recursive_alias_with_any(value: Any) -> GrowingAliasWithAny[int]:
     return value
 ```
+
+## Regression test: `unsound-return-statement` + callable type aliases
+
+A generic decorator factory cannot return a callback transformer that only supports one concrete
+return type. Comparing two specializations of the same callable alias does not treat their return
+types as interchangeable.
+
+```toml
+[environment]
+python-version = "3.12"
+
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from collections.abc import Callable
+
+type Callback[T] = Callable[[], T]
+
+def decorator_factory[T]() -> Callable[[Callback[T]], Callback[T]]:
+    def wrapper(callback: Callback[int]) -> Callback[int]:
+        return lambda: 1
+
+    return wrapper  # error: [unsound-return-statement]
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -422,6 +422,40 @@ def _(i: int, s: str) -> None:
     reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
+### Constructor inference with `Never` arguments
+
+A legacy variadic generic retains all constructor argument positions when one argument is `Never`.
+
+```py
+from typing import Generic, Never, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Factory(Generic[*Ts]):
+    def __init__(self, *args: *Ts) -> None: ...
+
+def check(value: Never) -> None:
+    reveal_type(Factory(1, value))  # revealed: Factory[int, Never]
+    reveal_type(Factory(value, 1))  # revealed: Factory[Never, int]
+```
+
+### Inherited variadic constructors
+
+A legacy variadic subclass can use its base class's constructor.
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Base(Generic[*Ts]):
+    def __init__(self, *args: *Ts) -> None: ...
+
+class Child(Base[*Ts], Generic[*Ts]): ...
+
+Child(1, "hello")
+```
+
 ### Unspecified type arguments
 
 When a generic class parameterized by a type variable tuple is used without any type parameters and
@@ -465,6 +499,32 @@ class WithDefault(Generic[*Ts]):
 
 reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
 reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
+```
+
+### Default type arguments containing `Never`
+
+A legacy variadic parameter retains `Never` elements in single-element, mixed, and stringified
+unpacked defaults.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Generic, Never, TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, Never]])
+OneNever = TypeVarTuple("OneNever", default=Unpack[tuple[Never]])
+QuotedNever = TypeVarTuple("QuotedNever", default=Unpack["tuple[int, Never]"])
+
+class WithNeverDefault(Generic[*Ts]): ...
+class WithOneNeverDefault(Generic[*OneNever]): ...
+class WithQuotedNeverDefault(Generic[*QuotedNever]): ...
+
+reveal_type(WithNeverDefault())  # revealed: WithNeverDefault[int, Never]
+reveal_type(WithOneNeverDefault())  # revealed: WithOneNeverDefault[Never]
+reveal_type(WithQuotedNeverDefault())  # revealed: WithQuotedNeverDefault[int, Never]
 ```
 
 ### Backported default type arguments

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -115,6 +115,59 @@ def _(value: Container) -> None:
     expected: Kind[int, Any] = value
 ```
 
+### Unpacked specializations containing `Never`
+
+Unpacking a sequence of type arguments preserves a required `Never` element, even though a tuple
+with the same elements would be uninhabited according to certain theories of product types.
+
+```py
+from typing import Never, Unpack
+
+class Container[*Ts]: ...
+
+def check(
+    first: Container[*tuple[int, Never]],
+    second: Container[*tuple[Never, int]],
+    one_element: Container[*tuple[Never]],
+    quoted: Container[Unpack["tuple[int, Never]"]],
+) -> None:
+    reveal_type(first)  # revealed: Container[int, Never]
+    reveal_type(second)  # revealed: Container[Never, int]
+    reveal_type(one_element)  # revealed: Container[Never]
+    reveal_type(quoted)  # revealed: Container[int, Never]
+```
+
+### Inconsistent inherited specializations
+
+An empty variadic argument sequence is a concrete specialization, so it conflicts with a nonempty
+specialization of the same base regardless of their order.
+
+```py
+class Base[*Ts]: ...
+class Empty(Base[()]): ...
+class Nonempty(Base[int]): ...
+
+# error: [invalid-generic-class]
+class EmptyFirst(Empty, Nonempty): ...
+
+# error: [invalid-generic-class]
+class EmptySecond(Nonempty, Empty): ...
+```
+
+A dynamically typed element does not erase the concrete length of a variadic specialization.
+
+```py
+from typing import Any
+
+class Dynamic(Base[Any]): ...
+
+# error: [invalid-generic-class]
+class DynamicFirst(Dynamic, Empty): ...
+
+# error: [invalid-generic-class]
+class DynamicSecond(Empty, Dynamic): ...
+```
+
 ### `TypeVarTuple` with `ParamSpec`
 
 ```py
@@ -173,6 +226,44 @@ indirect: Variadic[str] = inferred
 direct: Variadic[str] = Variadic(1)
 ```
 
+### Constructor inference with `Never` arguments
+
+A `Never` constructor argument does not erase the other arguments or its position in the inferred
+variadic specialization.
+
+```py
+from typing import Never
+
+class Factory[*Ts]:
+    def __init__(self, *args: *Ts) -> None: ...
+
+def check(value: Never) -> None:
+    reveal_type(Factory(1, value))  # revealed: Factory[Literal[1], Never]
+    reveal_type(Factory(value, 1))  # revealed: Factory[Never, Literal[1]]
+    reveal_type(Factory(1, value, "x"))  # revealed: Factory[Literal[1], Never, Literal["x"]]
+```
+
+### Inherited variadic constructors and `Self`
+
+A variadic subclass inherits its base class's constructor, and `Self` preserves the subclass's
+specialization.
+
+```py
+from typing import Self
+
+class Base[*Ts]:
+    def __init__(self, *args: *Ts) -> None: ...
+    def identity(self) -> Self:
+        return self
+
+class Child[*Ts](Base[*Ts]): ...
+
+Child(1, "hello")
+
+def check(value: Child[int, str]) -> None:
+    reveal_type(value.identity())  # revealed: Child[int, str]
+```
+
 ### Unspecified type arguments
 
 An unsubscripted variadic generic behaves as if it used an unknown-length tuple of `Any` arguments.
@@ -206,6 +297,26 @@ reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
 reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
 ```
 
+### Default type arguments containing `Never`
+
+A defaulted variadic parameter preserves its complete argument sequence when a required element is
+`Never`.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Never
+
+class WithNeverDefault[*Ts = *tuple[int, Never]]: ...
+class WithOneNeverDefault[*Ts = *tuple[Never]]: ...
+
+reveal_type(WithNeverDefault())  # revealed: WithNeverDefault[int, Never]
+reveal_type(WithOneNeverDefault())  # revealed: WithOneNeverDefault[Never]
+```
+
 ### Gradual specializations
 
 A type variable tuple remains assignable to an explicitly gradual specialization of its generic
@@ -220,6 +331,44 @@ class Array[*Ts]:
 ```
 
 ## Functions
+
+### Generic class arguments containing `Never`
+
+Inference from a generic class preserves each variadic type argument, including `Never` arguments
+and fixed type parameters beside the variadic pack.
+
+```py
+from typing import Never
+
+class Container[*Ts]:
+    values: tuple[*Ts]
+
+def identity[*Ts](value: Container[*Ts]) -> Container[*Ts]:
+    return value
+
+def first[T, *Ts](value: Container[T, *Ts]) -> T:
+    raise NotImplementedError
+
+def check(value: Container[int, Never]) -> None:
+    reveal_type(identity(value))  # revealed: Container[int, Never]
+    reveal_type(first(value))  # revealed: int
+```
+
+### Argument lengths containing `Never`
+
+A type variable tuple inferred from a generic argument determines the required number of variadic
+arguments even when one of its elements is `Never`.
+
+```py
+from typing import Never
+
+class Container[*Ts]: ...
+
+def use[*Ts](value: Container[*Ts], *args: *Ts) -> None: ...
+def check(value: Container[int, Never]) -> None:
+    use(value, 1)  # error: [invalid-argument-type]
+    use(value, 1, "wrong", "extra")  # error: [invalid-argument-type]
+```
 
 ### Multiple type variable tuples
 
@@ -640,6 +789,73 @@ reveal_type(simple(variadic2))  # revealed: tuple[Unknown, ...]
 reveal_type(simple(keyword_only))  # revealed: tuple[Unknown, ...]
 ```
 
+### Unpacked callable parameters containing `Never`
+
+An unpacked tuple containing `Never` retains every parameter in callable and variadic parameter
+annotations.
+
+```py
+from typing import Callable, Never
+
+def check(callback: Callable[[*tuple[int, Never]], None]) -> None:
+    reveal_type(callback)  # revealed: (*tuple[int, Never]) -> None
+
+def unpacked(*args: *tuple[int, Never]) -> None: ...
+
+reveal_type(unpacked)  # revealed: def unpacked(*args: tuple[int, Never]) -> None
+```
+
+### Callable inference with `Never` arguments
+
+Callable parameter lists are sequences of argument types. A `Never` parameter does not erase the
+other parameters when inferring a variadic specialization.
+
+```py
+from typing import Callable, Never
+
+class Container[*Ts]: ...
+
+def infer_callable[*Ts](callback: Callable[[*Ts], None]) -> Container[*Ts]:
+    raise NotImplementedError
+
+def callback(first: int, second: Never) -> None: ...
+
+reveal_type(infer_callable(callback))  # revealed: Container[int, Never]
+```
+
+A fixed suffix following the variadic pack is not part of the inferred pack.
+
+```py
+def infer_mixed_callable[*Ts](callback: Callable[[int, *Ts, str], None]) -> Container[*Ts]:
+    raise NotImplementedError
+
+def mixed_callback(first: int, middle: Never, last: str) -> None: ...
+
+reveal_type(infer_mixed_callable(mixed_callback))  # revealed: Container[Never]
+```
+
+### Protocol inference with `Never` arguments
+
+A structural protocol preserves each inferred positional argument, including `Never`, when its
+method is implemented by a concrete class.
+
+```py
+from typing import Never, Protocol
+
+class Container[*Ts]: ...
+
+class Runner[*Ts](Protocol):
+    def run(self, *args: *Ts) -> None: ...
+
+def infer_runner[*Ts](runner: Runner[*Ts]) -> Container[*Ts]:
+    raise NotImplementedError
+
+class Concrete:
+    def run(self, first: int, second: Never) -> None: ...
+
+reveal_type(infer_runner(Concrete()))  # revealed: Container[int, Never]
+```
+
 ### Callable inference through invariant and contravariant wrappers
 
 An unpacked `TypeVarTuple` keeps its precise inferred parameter types when a callable or callable
@@ -778,6 +994,25 @@ reveal_type(infer_return_middle(fixed_middle))  # revealed: tuple[str]
 reveal_type(infer_return_middle(mixed_middle))  # revealed: tuple[str, ...]
 ```
 
+### Callable return inference with `Never` arguments
+
+A callable returning a variadic generic preserves the full specialized argument sequence, including
+required `Never` elements.
+
+```py
+from typing import Callable, Never
+
+class Container[*Ts]: ...
+
+def infer_return[*Ts](callback: Callable[[], Container[*Ts]]) -> Container[*Ts]:
+    raise NotImplementedError
+
+def callback() -> Container[int, Never]:
+    raise NotImplementedError
+
+reveal_type(infer_return(callback))  # revealed: Container[int, Never]
+```
+
 ### Callable inference with sub-call checking
 
 This usage pattern is similar to how `ParamSpec` can be used to accept a callable and its arguments
@@ -827,6 +1062,59 @@ def forward_mixed[*Ts](
     *args: *tuple[int, *Ts, str],
 ) -> None:
     accept_mixed_forwarded(callback, args)
+```
+
+### Callable inference with optional parameters
+
+When a callback's parameters have default values, it can be invoked without forwarding any
+arguments. The inferred type variable tuple does not treat those optional parameters as required.
+
+```py
+from functools import partial
+from typing import Callable
+
+def invoke[*Ts](callback: Callable[[*Ts], None], *args: *Ts) -> None: ...
+def optional(value: int = 1) -> None: ...
+def positional_only(value: int = 1, /) -> None: ...
+def multiple(first: int = 1, second: str = "") -> None: ...
+
+invoke(optional)
+invoke(positional_only)
+invoke(multiple)
+```
+
+The same signature rules apply to callable objects, bound methods, and partially applied functions.
+
+```py
+class Callback:
+    def __call__(self, value: int = 1) -> None: ...
+    def method(self, value: int = 1) -> None: ...
+
+def required(first: int, second: str = "") -> None: ...
+
+invoke(Callback())
+invoke(Callback().method)
+invoke(partial(required, 1))
+```
+
+### Protocol inference with optional parameters
+
+A structural protocol can be specialized with an empty type variable tuple when its implementation
+has only optional method parameters. Forwarding an empty argument sequence remains valid.
+
+```py
+from typing import Protocol
+
+class Runner[*Ts](Protocol):
+    def run(self, *args: *Ts) -> None: ...
+
+def invoke[*Ts](runner: Runner[*Ts], *args: *Ts) -> None: ...
+
+class OptionalRunner:
+    def run(self, value: int = 0) -> None: ...
+
+empty: Runner[()] = OptionalRunner()
+invoke(OptionalRunner())
 ```
 
 ### Callable inference through nested callable parameters
@@ -1319,6 +1607,24 @@ type Padded[T] = Container[T, Never]
 
 def _(value: Padded[int]) -> None:
     reveal_type(value)  # revealed: Container[int, Never]
+```
+
+### Union aliases containing variadic specializations
+
+A generic union retains a concrete alternative when specializing its variadic parameter to the empty
+tuple does not make that alternative redundant.
+
+```py
+class Container[*Ts]:
+    value: tuple[*Ts]
+
+type Unioned[*Ts] = Container[*Ts] | Container[int]
+
+def check(value: Unioned[()]) -> None:
+    reveal_type(value)  # revealed: Container[()] | Container[int]
+
+def accepts(value: Container[int]) -> Unioned[()]:
+    return value
 ```
 
 ### Unpacked tuple type arguments

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -256,6 +256,54 @@ def f(x: Foo[int]):
     reveal_type(x.foo())  # revealed: int
 ```
 
+A non-recursive generic union alias does not retain an alternative that becomes redundant after
+specialization.
+
+```py
+class Parent: ...
+class Child(Parent): ...
+
+type Alias[T] = T | Parent
+
+def reveal_alias(value: Alias[Child]) -> None:
+    reveal_type(value)  # revealed: Parent
+```
+
+## Generic callable aliases
+
+Expanding two specializations of the same callable alias applies each specialization separately.
+Callable return types are covariant, so a producer of `bool` is a subtype of a producer of `int`,
+but not vice versa.
+
+```py
+from collections.abc import Callable
+
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+
+type Producer[T] = Callable[[], T]
+
+static_assert(not is_assignable_to(Producer[int], Producer[str]))
+static_assert(not is_subtype_of(Producer[int], Producer[str]))
+static_assert(not is_equivalent_to(Producer[int], Producer[str]))
+
+static_assert(is_subtype_of(Producer[bool], Producer[int]))
+static_assert(not is_subtype_of(Producer[int], Producer[bool]))
+
+def incompatible_producer(value: Producer[int]) -> Producer[str]:
+    return value  # error: [invalid-return-type]
+```
+
+Callable parameter types are contravariant: a consumer accepting `int` also accepts every `bool`.
+
+```py
+type Consumer[T] = Callable[[T], None]
+
+static_assert(not is_equivalent_to(Consumer[int], Consumer[str]))
+static_assert(is_subtype_of(Consumer[int], Consumer[bool]))
+static_assert(not is_subtype_of(Consumer[bool], Consumer[int]))
+```
+
 ## Unpacking tuple aliases
 
 Both unpack spellings accept a tuple alias and preserve positional argument types and arity.
@@ -1001,6 +1049,150 @@ type WrappedRight[T] = tuple[Box[Box[WrappedRight[list[T]]]]]
 static_assert(not is_subtype_of(WrappedLeft[int], WrappedRight[int]))
 ```
 
+### Inhabited recursive generic aliases with tuple alternatives
+
+A recursive tuple alternative does not make an alias uninhabited when another union alternative
+contains values.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[Recursive[T]] | int
+
+def accepts_recursive(value: Recursive[int]) -> None:
+    reveal_type(value)  # revealed: tuple[Recursive[int]] | int
+
+static_assert(not is_equivalent_to(Recursive[int], Never))
+```
+
+### Inhabited recursive generic aliases with growing specializations
+
+A recursive generic alias is recognized even when each recursive reference uses a more deeply nested
+specialization.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Growing[T] = tuple[Growing[list[T]]] | int
+
+def accepts_growing(value: Growing[int]) -> None:
+    reveal_type(value)  # revealed: tuple[Growing[list[int]]] | int
+
+static_assert(not is_equivalent_to(Growing[int], Never))
+```
+
+### Mutually recursive generic aliases with tuple alternatives
+
+Recursive tuple alternatives remain inhabited when two generic aliases refer to each other and both
+provide inhabited alternatives.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Left[T] = tuple[Right[T]] | int
+type Right[T] = tuple[Left[T]] | str
+
+def accepts_mutually_recursive(value: Left[int]) -> None:
+    reveal_type(value)  # revealed: tuple[Right[int]] | int
+
+static_assert(not is_equivalent_to(Left[int], Never))
+```
+
+### Homogeneous recursive generic tuple aliases
+
+A homogeneous tuple can always be empty, even when its element type refers back to the same alias.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[Recursive[T], ...]
+
+def accepts_recursive(value: Recursive[int]) -> None:
+    reveal_type(value)  # revealed: tuple[Recursive[int], ...]
+
+static_assert(not is_equivalent_to(Recursive[int], Never))
+```
+
+A homogeneous recursive tuple also remains inhabited when each recursive reference has a more deeply
+nested specialization.
+
+```py
+type Growing[T] = tuple[Growing[list[T]], ...]
+
+static_assert(not is_equivalent_to(Growing[int], Never))
+```
+
+### Homogeneous recursive generic aliases nested inside tuples
+
+An extra tuple between a homogeneous element and its recursive alias does not prevent the
+homogeneous tuple from remaining inhabited, even when each specialization grows.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[tuple[Recursive[list[T]]], ...]
+
+def accepts_recursive(value: Recursive[int]) -> None: ...
+
+static_assert(not is_equivalent_to(Recursive[int], Never))
+```
+
+Wrapping the recursive element in a non-recursive generic alias also leaves the homogeneous tuple
+inhabited.
+
+```py
+type Box[T] = tuple[T]
+type Wrapped[T] = tuple[Box[Wrapped[list[T]]], ...] | T
+
+static_assert(not is_equivalent_to(Wrapped[Never], Never))
+```
+
+### Homogeneous recursive generic aliases nested inside unions
+
+A union inside a homogeneous tuple preserves its recursive element type even when another
+alternative specializes to `Never`; the tuple remains inhabited by its empty value.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[Recursive[list[T]] | T, ...]
+
+def accepts_recursive(value: Recursive[int]) -> None: ...
+
+static_assert(not is_equivalent_to(Recursive[int], Never))
+static_assert(not is_equivalent_to(Recursive[Never], Never))
+```
+
+### Recursive variadic generic aliases
+
+Recursive aliases preserve a variable number of type arguments while retaining an inhabited union
+alternative.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[*Ts] = tuple[Recursive[*Ts]] | int
+
+def accepts_recursive(value: Recursive[int, str]) -> None:
+    reveal_type(value)  # revealed: tuple[Recursive[int, str]] | int
+
+static_assert(not is_equivalent_to(Recursive[int, str], Never))
+```
+
 ### Non-recursive nested generic aliases
 
 A repeated use of the same generic alias can be a finite alias application instead of recursion.
@@ -1106,6 +1298,22 @@ def stable_wrapped(x: StableWrapped[int], y: StableWrapped[str]):
     x = y
     # error: [invalid-assignment] "Object of type `StableWrapped[int]` is not assignable to `StableWrapped[str]`"
     y = x
+```
+
+### Materializations of recursive homogeneous tuple aliases
+
+Top or bottom materialization preserves the empty tuple that inhabits a recursively defined
+homogeneous tuple, even when its specialization grows at each recursive reference.
+
+```py
+from typing import Any, Never
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type Recursive[T] = tuple[Recursive[list[T]], ...] | T
+
+static_assert(not is_equivalent_to(Top[Recursive[Any]], Never))
+static_assert(not is_equivalent_to(Bottom[Recursive[Any]], Never))
 ```
 
 ### Subtyping of materializations of cyclic aliases

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -353,6 +353,55 @@ reveal_type(f12(1))  # revealed: ((int, /) -> bool) | None
 reveal_type(f13(1))  # revealed: ((bool, /) -> Invariant[int]) | None
 ```
 
+## Variadic constructor promotion follows parameter variance
+
+Variadic type parameters follow the same promotion rules as ordinary type parameters. Covariant and
+bivariant arguments retain their literal types, while invariant and contravariant arguments are
+promoted.
+
+```py
+class BivariantVariadic[*Ts]:
+    def __init__(self, *values: *Ts) -> None: ...
+
+class CovariantVariadic[*Ts]:
+    def __init__(self, *values: *Ts) -> None: ...
+    def get(self) -> tuple[*Ts]:
+        raise NotImplementedError
+
+class ContravariantVariadic[*Ts]:
+    def __init__(self, *values: *Ts) -> None: ...
+    def put(self, *values: *Ts) -> None: ...
+
+class InvariantVariadic[*Ts]:
+    values: tuple[*Ts]
+
+    def __init__(self, *values: *Ts) -> None: ...
+
+reveal_type(BivariantVariadic(1))  # revealed: BivariantVariadic[Literal[1]]
+reveal_type(CovariantVariadic(1))  # revealed: CovariantVariadic[Literal[1]]
+reveal_type(ContravariantVariadic(1))  # revealed: ContravariantVariadic[int]
+reveal_type(InvariantVariadic(1))  # revealed: InvariantVariadic[int]
+```
+
+Explicitly declared legacy variance follows the same rules.
+
+```py
+from typing import Generic
+from typing_extensions import TypeVarTuple
+
+Ts_co = TypeVarTuple("Ts_co", covariant=True)
+Ts_invariant = TypeVarTuple("Ts_invariant")
+
+class LegacyCovariant(Generic[*Ts_co]):
+    def __init__(self, *values: *Ts_co) -> None: ...
+
+class LegacyInvariant(Generic[*Ts_invariant]):
+    def __init__(self, *values: *Ts_invariant) -> None: ...
+
+reveal_type(LegacyCovariant(1))  # revealed: LegacyCovariant[Literal[1]]
+reveal_type(LegacyInvariant(1))  # revealed: LegacyInvariant[int]
+```
+
 ## Promotion is recursive
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -1113,6 +1113,45 @@ static_assert(not is_disjoint_from(Covariant[A], CoSubB))
 static_assert(not is_disjoint_from(Sequence[int], Sequence[str]))
 ```
 
+### Variadic generic specializations containing `Never`
+
+A variadic generic remains inhabited when one of its type arguments is `Never`. A writable
+`tuple[*Ts]` attribute makes the class invariant even though `tuple` itself is covariant, so
+specializations with incompatible type arguments are disjoint.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
+
+class Container[*Ts]:
+    values: tuple[*Ts]
+
+static_assert(not is_disjoint_from(Container[int, Never], Container[int, Never]))
+static_assert(not is_subtype_of(Container[Never, Never], Container[int, Never]))
+static_assert(is_disjoint_from(Container[int, Never], Container[str, Never]))
+static_assert(is_disjoint_from(Container[int, Never], Container[int, Never, Never]))
+static_assert(is_disjoint_from(Container[int, Never], Container[Never, int]))
+```
+
+If `tuple[*Ts]` appears only as a return type, the class is covariant. A specialization using
+`Never` is then a common subtype, so differently specialized classes overlap.
+
+```py
+class CovariantContainer[*Ts]:
+    def values(self) -> tuple[*Ts]:
+        raise NotImplementedError
+
+static_assert(is_subtype_of(CovariantContainer[Never, Never], CovariantContainer[int, Never]))
+static_assert(is_subtype_of(CovariantContainer[Never, Never], CovariantContainer[str, Never]))
+static_assert(not is_disjoint_from(CovariantContainer[int, Never], CovariantContainer[str, Never]))
+```
+
 ### Specialized `@final` types
 
 Final generic specializations can overlap through a shared subtype such as `Foo[Never]`.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -683,6 +683,50 @@ def contravariant(top: Top[ContravariantCallable], bottom: Bottom[ContravariantC
     reveal_type(bottom)  # revealed: (GenericContravariant[Never], /) -> None
 ```
 
+## Variadic generic arguments containing `Never`
+
+Top and bottom materialization replace an `Any` argument with `object` or `Never` according to the
+variance of a type variable tuple. Other arguments, including `Never`, are preserved. Invariant type
+variable tuples retain their unevaluated materializations.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, Never
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+class Covariant[*Ts]:
+    def get(self) -> tuple[*Ts]:
+        raise NotImplementedError
+
+class Contravariant[*Ts]:
+    def put(self, value: tuple[*Ts]) -> None: ...
+
+class Invariant[*Ts]:
+    values: tuple[*Ts]
+
+static_assert(is_equivalent_to(Top[Covariant[Any, Never]], Covariant[object, Never]))
+static_assert(is_equivalent_to(Bottom[Covariant[Any, Never]], Covariant[Never, Never]))
+static_assert(is_equivalent_to(Top[Contravariant[Any, Never]], Contravariant[Never, Never]))
+static_assert(is_equivalent_to(Bottom[Contravariant[Any, Never]], Contravariant[object, Never]))
+
+def check(top: Top[Invariant[Any, Never]], bottom: Bottom[Invariant[Any, Never]]) -> None:
+    reveal_type(top)  # revealed: Top[Invariant[Any, Never]]
+    reveal_type(bottom)  # revealed: Bottom[Invariant[Any, Never]]
+```
+
+An unbounded sequence of `Never` elements can only contain zero elements, so materializing an
+unbounded gradual pack normalizes it to an empty sequence.
+
+```py
+static_assert(is_equivalent_to(Bottom[Covariant[*tuple[Any, ...]]], Covariant[()]))
+static_assert(is_equivalent_to(Top[Contravariant[*tuple[Any, ...]]], Contravariant[()]))
+```
+
 ## Bounded generic type parameters
 
 Top materialization of a covariant generic uses the type parameter's declared upper bound. Bottom


### PR DESCRIPTION
## Summary

This PR extends our regression coverage for `TypeVarTuple` and `tuple` in a variety of ways. Each of these tests was originally added in another experimental branch I have locally, as a regression test for things that the branch initially broke. Since they all pass on `main`, however, I'm proposing adding them in a standalone PR.