### PR TITLE
[`pyflakes`] Emit semantic syntax errors in string type definitions as `F722`

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pyflakes/forward-annotation-syntax-error.md
+++ b/crates/ruff_linter/resources/mdtest/pyflakes/forward-annotation-syntax-error.md
@@ -1,0 +1,51 @@
+# `forward-annotation-syntax-error` (`F722`)
+
+```toml
+target-version = "py312"
+
+[lint]
+select = ["F722"]
+```
+
+## Parse errors
+
+Quoted annotations must parse as Python expressions.
+
+```py
+# error: [forward-annotation-syntax-error] "Expected an expression"
+invalid: "/"
+```
+
+## Semantic syntax errors
+
+An expression can parse successfully but still contain a semantic syntax error.
+
+```py
+# error: [forward-annotation-syntax-error] "Duplicate parameter"
+invalid: "(lambda x, x: 0)"
+```
+
+## Semantic syntax errors currently mapped to disabled lint rules
+
+`F722` reports semantic syntax errors even when their overlapping lint rules are disabled, in this
+case `yield-outside-function` (`F704`).
+
+```py
+# error: [forward-annotation-syntax-error] "`yield` statement outside of a function"
+invalid: "(yield 1)"
+```
+
+## Semantic syntax errors currently mapped to enabled lint rules
+
+Disabling `F722` suppresses the semantic syntax error even when `F704` remains enabled.
+
+```toml
+target-version = "py312"
+
+[lint]
+select = ["F704"]
+```
+
+```py
+invalid: "(yield 1)"
+```

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -708,6 +708,19 @@ impl SemanticSyntaxContext for Checker<'_> {
     }
 
     fn report_semantic_error(&self, error: SemanticSyntaxError) {
+        // F722
+        if self.semantic.in_string_type_definition() {
+            if self.is_rule_enabled(Rule::ForwardAnnotationSyntaxError) {
+                self.report_type_diagnostic(
+                    pyflakes::rules::ForwardAnnotationSyntaxError {
+                        parse_error: error.to_string(),
+                    },
+                    error.range,
+                );
+            }
+            return;
+        }
+
         match error.kind {
             SemanticSyntaxErrorKind::LateFutureImport => {
                 // F404


### PR DESCRIPTION
Summary
--

As uncovered in #17804, `F722` previously applied only to parse errors and not to semantic syntax
errors. More confusingly, we were emitting semantic syntax errors, and even other lint rule errors
that correspond to syntax errors, on string type definitions, even when `F722` was disabled.

This PR adds a check to `Checker::report_semantic_error` for the semantic model's
`in_string_type_definition` flag that converts these semantic errors into regular `F722`
diagnostics, when the rule is enabled, and returns without reporting an error when the rule is
disabled.

Test Plan
--

New mdtests covering semantic errors in forward annotations
