### PR TITLE
[ty] Handle file-valued workspace folders from Zed

### DIFF
--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -564,7 +564,18 @@ impl Session {
             }
         };
 
-        let settings = options.into_settings(&root, client, &*self.native_system);
+        // Zed sends a single file as a workspace folder. Preserve that path as the
+        // workspace's identity, but resolve configuration and imports from its parent directory.
+        // https://github.com/zed-industries/zed/issues/40627
+        let workspace_directory = if self.native_system.is_file(&root)
+            && let Some(parent) = root.parent()
+        {
+            parent
+        } else {
+            root.as_path()
+        };
+
+        let settings = options.into_settings(workspace_directory, client, &*self.native_system);
         let Some(workspace) = self.workspaces.workspaces.get_mut(&root) else {
             tracing::debug!("Ignoring workspace `{uri}` since it was not registered");
             return;
@@ -589,9 +600,13 @@ impl Session {
         let configuration_file = workspace.settings.configuration_file();
 
         let metadata = if let Some(configuration_file) = configuration_file {
-            ProjectMetadata::from_config_file(configuration_file.clone(), &root, &system)
+            ProjectMetadata::from_config_file(
+                configuration_file.clone(),
+                workspace_directory,
+                &system,
+            )
         } else {
-            ProjectMetadata::discover(&root, &system)
+            ProjectMetadata::discover(workspace_directory, &system)
         };
 
         let project = metadata
@@ -612,8 +627,8 @@ impl Session {
                 ProjectDatabase::fallible(metadata, system.clone())
             });
 
-        let (root, db) = match project {
-            Ok(db) => (root, db),
+        let db = match project {
+            Ok(db) => db,
             Err(err) => {
                 tracing::error!(
                     "Failed to create project for workspace `{uri}`: {err:#}. \
@@ -627,17 +642,11 @@ impl Session {
 
                 let Ok(metadata) = ProjectMetadata::from_options(
                     Options::default(),
-                    root,
+                    workspace_directory.to_path_buf(),
                     None,
                     &UseDefaultStrategy,
                 );
-                let db_with_default_settings = ProjectDatabase::use_defaults(metadata, system);
-                let default_root = db_with_default_settings
-                    .project()
-                    .root(&db_with_default_settings)
-                    .to_path_buf();
-
-                (default_root, db_with_default_settings)
+                ProjectDatabase::use_defaults(metadata, system)
             }
         };
 

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -1266,6 +1266,7 @@ impl TestServerBuilder {
     }
 
     /// Add a workspace to the test server with the given root path and options.
+    /// An existing file can also be used to model clients that send file-valued workspace roots.
     ///
     /// This option will be used to respond to the `workspace/configuration` request that the
     /// server will send to the client.
@@ -1278,7 +1279,9 @@ impl TestServerBuilder {
         options: Option<ClientOptions>,
     ) -> Result<Self> {
         let workspace_path = self.test_context.root().join(workspace_root);
-        fs::create_dir_all(workspace_path.as_std_path())?;
+        if !workspace_path.as_std_path().is_file() {
+            fs::create_dir_all(workspace_path.as_std_path())?;
+        }
 
         self.workspaces.push((
             WorkspaceFolder {

--- a/crates/ty_server/tests/e2e/workspace_folders.rs
+++ b/crates/ty_server/tests/e2e/workspace_folders.rs
@@ -15,6 +15,26 @@ use crate::{
     },
 };
 
+/// A file-valued workspace initializes successfully and discovers its parent configuration.
+#[test]
+fn single_file_workspace() -> Result<()> {
+    let main = SystemPath::new("project/main.py");
+    let mut server = TestServerBuilder::new()?
+        .with_file(main, "missing")?
+        .with_file("project/ty.toml", "[rules]\nunresolved-reference = 'warn'")?
+        .with_workspace(main, None)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(main, "missing", 1);
+    assert_eq!(
+        condensed_document_diagnostic_snapshot(server.document_diagnostic_request(main, None)),
+        "0:0..0:7[WARNING]: Name `missing` used when not defined",
+    );
+
+    Ok(())
+}
+
 /// Test that we can initialize multiple workspace folders.
 #[test]
 fn initialize_multiple_workspace_folders() -> Result<()> {


### PR DESCRIPTION
## Summary

Work around Zed passing a regular file in `workspaceFolders` by using its parent directory for project setup.

This is a clear spec violation, but Zed isn't making progress and it seems an easy enough fix on our end. 

Fixes https://github.com/astral-sh/ty/issues/4310. Upstream: https://github.com/zed-industries/zed/issues/40627.

## Test Plan

Testing: Added an end-to-end regression; the server test suite and repository hooks pass.
