### PR TITLE
[ty] Add an interface for retrieving the value providers for a module global

### DIFF
--- a/crates/ty_module_resolver/src/lib.rs
+++ b/crates/ty_module_resolver/src/lib.rs
@@ -11,8 +11,9 @@ pub use module::Module;
 pub use module_name::{ImportingFile, ModuleName, ModuleNameResolutionError};
 pub use path::{SearchPath, SearchPathError};
 pub use resolve::{
-    SearchPaths, file_to_module, resolve_module, resolve_module_confident, resolve_real_module,
-    resolve_real_module_confident, resolve_real_shadowable_module,
+    SearchPaths, file_to_module, resolve_module, resolve_module_confident,
+    resolve_module_for_import_from, resolve_real_module, resolve_real_module_confident,
+    resolve_real_shadowable_module,
 };
 pub use settings::{SearchPathSettings, SearchPathSettingsError};
 pub use strategy::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};

--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -312,7 +312,7 @@ impl ModuleName {
     pub fn from_import_statement<'db>(
         db: &'db dyn Db,
         importing_file: ImportingFile<'db>,
-        node: &'db ast::StmtImportFrom,
+        node: &ast::StmtImportFrom,
     ) -> Result<Self, ModuleNameResolutionError> {
         let ast::StmtImportFrom {
             module,

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -72,6 +72,18 @@ pub fn resolve_module<'db>(
         .or_else(|| desperately_resolve_module(db, importing_file.file(db), interned_name))
 }
 
+/// Resolves the module referenced by a `from` import statement.
+///
+/// Returns `None` if the statement does not name a valid module or the module cannot be resolved.
+pub fn resolve_module_for_import_from<'db>(
+    db: &'db dyn Db,
+    importing_file: ImportingFile<'db>,
+    import: &ast::StmtImportFrom,
+) -> Option<Module<'db>> {
+    let module_name = ModuleName::from_import_statement(db, importing_file, import).ok()?;
+    resolve_module(db, importing_file, &module_name)
+}
+
 /// Resolves a module name to a module, without desperate resolution available.
 ///
 /// This is appropriate for resolving a `KnownModule`, or cases where for whatever reason

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -19,7 +19,9 @@ use ruff_python_parser::semantic_errors::{
 };
 use ruff_text_size::{Ranged, TextRange};
 use smallvec::SmallVec;
-use ty_module_resolver::{ImportingFile, ModuleName, ResolverEnvironment, resolve_module};
+use ty_module_resolver::{
+    ImportingFile, ModuleName, ResolverEnvironment, resolve_module_for_import_from,
+};
 
 use crate::HasTrackedScope;
 use crate::ProgramFile;
@@ -3721,18 +3723,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             continue;
                         }
 
-                        let Ok(module_name) = ModuleName::from_import_statement(
+                        let Some(module) = resolve_module_for_import_from(
                             self.db,
                             ImportingFile::File(source_file, resolver_environment),
                             node,
-                        ) else {
-                            continue;
-                        };
-
-                        let Some(module) = resolve_module(
-                            self.db,
-                            ImportingFile::File(source_file, resolver_environment),
-                            &module_name,
                         ) else {
                             continue;
                         };

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -28,7 +28,7 @@ use ruff_python_ast::{
     visitor::{Visitor, walk_expr, walk_pattern, walk_stmt},
 };
 use rustc_hash::FxHashMap;
-use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, resolve_module_for_import_from};
 
 use crate::{Db, ProgramFile};
 
@@ -253,19 +253,11 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                             let program_file = self.program_file;
                             let file = program_file.file(db);
                             let resolver_environment = program_file.resolver_environment(db);
-                            for export in ModuleName::from_import_statement(
+                            for export in resolve_module_for_import_from(
                                 db,
                                 ImportingFile::File(file, resolver_environment),
                                 node,
                             )
-                            .ok()
-                            .and_then(|module_name| {
-                                resolve_module(
-                                    db,
-                                    ImportingFile::File(file, resolver_environment),
-                                    &module_name,
-                                )
-                            })
                             .iter()
                             .flat_map(|module| {
                                 module

--- a/crates/ty_python_semantic/src/definition_resolution.rs
+++ b/crates/ty_python_semantic/src/definition_resolution.rs
@@ -1,0 +1,113 @@
+use smallvec::SmallVec;
+use ty_module_resolver::Module;
+use ty_python_core::definition::{Definition, DefinitionState};
+use ty_python_core::{
+    BindingWithConstraintsIterator, Program, ProgramFile, global_scope, place_table, use_def_map,
+};
+
+use crate::Db;
+use crate::reachability::ReachabilityConstraintsExtension;
+
+/// Returns the definitions that may supply the value for a module global at the end of its scope.
+pub(crate) fn definitions_for_module_global<'db>(
+    db: &'db dyn Db,
+    program: Program<'db>,
+    module: Module<'db>,
+    name: &str,
+) -> Option<DefinitionResolution<'db>> {
+    let file = ProgramFile::new(db, module.file(db)?, program);
+    let scope = global_scope(db, file);
+    let symbol = place_table(db, scope).symbol_id(name)?;
+
+    Some(DefinitionResolution::from_bindings(
+        db,
+        use_def_map(db, scope).end_of_scope_symbol_bindings(symbol),
+    ))
+}
+
+/// A set of definitions found by name resolution along with facts about their availability.
+pub(crate) struct DefinitionResolution<'db> {
+    definitions: SmallVec<[Definition<'db>; 2]>,
+}
+
+impl<'db> DefinitionResolution<'db> {
+    /// Returns the definitions found by name resolution.
+    pub(crate) fn definitions(&self) -> &[Definition<'db>] {
+        &self.definitions
+    }
+
+    fn from_bindings(
+        db: &'db dyn Db,
+        mut bindings: BindingWithConstraintsIterator<'db, 'db>,
+    ) -> Self {
+        let mut resolution = Self {
+            definitions: SmallVec::new(),
+        };
+
+        while let Some(binding) = bindings.next() {
+            let reachability = bindings.reachability_constraints().evaluate(
+                db,
+                bindings.predicates(),
+                binding.reachability_constraint,
+            );
+            if reachability.is_always_false() {
+                continue;
+            }
+
+            match binding.binding {
+                DefinitionState::Defined(definition) => {
+                    resolution.push_definition(definition);
+                }
+                DefinitionState::Deleted | DefinitionState::Undefined => {}
+            }
+        }
+
+        resolution
+    }
+
+    fn push_definition(&mut self, definition: Definition<'db>) {
+        if !self.definitions.contains(&definition) {
+            self.definitions.push(definition);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ty_python_core::ProgramFile;
+
+    use super::definitions_for_module_global;
+    use crate::SemanticModel;
+    use crate::db::tests::TestDbBuilder;
+
+    #[test]
+    fn definitions_for_module_global_retains_conditional_definitions() {
+        let db = TestDbBuilder::new()
+            .with_file(
+                "/src/pkg/__init__.py",
+                r#"
+if flag:
+    from . import first as value
+else:
+    from . import second as value
+"#,
+            )
+            .with_file("/src/pkg/first.py", "")
+            .with_file("/src/pkg/second.py", "")
+            .with_file("/src/use.py", "import pkg")
+            .build()
+            .expect("valid TestDb setup");
+        let file = system_path_to_file(&db, "/src/use.py").expect("test file should exist");
+        let program = db.program_environment().program(&db);
+        let model = SemanticModel::new(&db, ProgramFile::new(&db, file, program));
+        let module = model
+            .resolve_module(Some("pkg"), 0)
+            .expect("test package should resolve");
+
+        let resolution = definitions_for_module_global(&db, program, module, "value")
+            .expect("module global should exist");
+
+        assert_eq!(resolution.definitions().len(), 2);
+    }
+}

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{self as ast};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, resolve_module_for_import_from};
 
 use crate::types::{Type, TypeContext, infer_expression_types};
 use crate::{Db, ProgramEnvironment};
@@ -165,9 +165,7 @@ impl<'db> DunderAllNamesCollector<'db> {
 
         let importing_file =
             ImportingFile::File(self.file.file(db), self.env.resolver_environment(db));
-        let module_name =
-            ModuleName::from_import_statement(db, importing_file, import_from).ok()?;
-        let module = resolve_module(db, importing_file, &module_name)?;
+        let module = resolve_module_for_import_from(db, importing_file, import_from)?;
         dunder_all_names(
             db,
             ProgramFile::new(db, module.file(db)?, self.env.program(db)),

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -54,6 +54,7 @@ pub use types::{
 };
 
 mod db;
+mod definition_resolution;
 mod dunder_all;
 mod fixes;
 pub mod lint;

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -2081,7 +2081,8 @@ mod resolve_definition {
     use rustc_hash::FxHashSet;
     use tracing::trace;
     use ty_module_resolver::{
-        ImportingFile, ModuleName, file_to_module, resolve_module, resolve_real_module,
+        ImportingFile, ModuleName, file_to_module, resolve_module, resolve_module_for_import_from,
+        resolve_real_module,
     };
 
     use crate::Db;
@@ -2365,13 +2366,8 @@ mod resolve_definition {
             }
         }
 
-        // Resolve the module being imported from (handles both relative and absolute imports)
-        let Some(module_name) =
-            ModuleName::from_import_statement(db, importing_file, import_node).ok()
+        let Some(resolved_module) = resolve_module_for_import_from(db, importing_file, import_node)
         else {
-            return Vec::new();
-        };
-        let Some(resolved_module) = resolve_module(db, importing_file, &module_name) else {
             return Vec::new();
         };
 
@@ -2387,7 +2383,7 @@ mod resolve_definition {
                 env,
                 importing_file,
                 symbol_name,
-                module_name,
+                resolved_module.name(db),
             ));
         };
 
@@ -2421,7 +2417,7 @@ mod resolve_definition {
                 env,
                 importing_file,
                 symbol_name,
-                module_name,
+                resolved_module.name(db),
             ))
         } else {
             resolved_definitions
@@ -2434,10 +2430,10 @@ mod resolve_definition {
         env: &ProgramEnvironment<'db>,
         importing_file: ImportingFile<'db>,
         symbol_name: &str,
-        module_name: ModuleName,
+        module_name: &ModuleName,
     ) -> Option<ResolvedDefinition<'db>> {
         let submodule_name = ModuleName::new(symbol_name)?;
-        let mut full_submodule_name = module_name;
+        let mut full_submodule_name = module_name.clone();
         full_submodule_name.extend(&submodule_name);
         let module = resolve_module(db, importing_file, &full_submodule_name)?;
         let file = ProgramFile::new(db, module.file(db)?, env.program(db));


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
- Does this pull request include adequate tests?
- Does this pull request include user-facing changes? If so, have those changes been documented?
-->

## Summary

<!--
Several upcoming language server features need to understand all of the bindings that might supply the value of a particular load (as opposed to just the resulting type of that load or its value):.

- For [goto definition from pytest fixture requests](https://github.com/astral-sh/ty/issues/4115), we need to be able to follow module-global providers through imports and re-exports until we reach a decorated fixture function. This process must retain fixture that is conditionally reachable.

- Find References can extend the same provider model to a particular name load and associate that load with only the definitions that can supply its value ([#3410](https://github.com/astral-sh/ty/issues/3410), [#3411](https://github.com/astral-sh/ty/issues/3411)).
- File and folder rename planning can use provider completeness and availability to rewrite an import only when every possible provider can be updated safely ([#1560](https://github.com/astral-sh/ty/issues/1560)).


For instance, suppose a module exposed a handler with code like this:

```py
if use_fallback:
    handler = fallback_handler
else:
    handler = primary_handler
```

From the perspective of a consumer of that module, either assignment can provide `handler`. An unconditional assignment after the `if` would shadow both assignments; omitting the `else` could leave `handler` unbound; and a reachable `del handler` could delete it. A provider query therefore needs to return the possible source definitions together with facts about the value's availability.

This PR introduces that query in neutral semantic infrastructure. `value_providers_for_module_global` reduces a module global's end-of-scope bindings to its reachable, user-visible definitions. `ValueProviders` also records when a provider has no source representation or when the value may be unbound or deleted.

The query exposes direct edges in the use-def graph: an import remains an import definition rather than being resolved recursively. Each consumer can follow those edges according to its own policy. As part of this work, `user_visible_definitions` moves out of IDE support so that existing IDE code and the new provider query share the translation from synthetic bindings to source definitions.

This result supports several upcoming features:
-->

## Test Plan

See included tests.
<!-- How was it tested? -->
