### PR TITLE
Preserve semantic and version-related errors in `test_contents`

### DIFF
--- a/crates/ruff_linter/resources/mdtest/syntax-errors.md
+++ b/crates/ruff_linter/resources/mdtest/syntax-errors.md
@@ -1,0 +1,29 @@
+# Syntax errors
+
+Syntax errors are reported even when no lint rules are enabled.
+
+```toml
+target-version = "py311"
+
+[lint]
+select = []
+```
+
+## Semantic syntax errors
+
+Some invalid programs parse successfully and are rejected during semantic analysis.
+
+```py
+# error: [invalid-syntax] "Duplicate parameter"
+def f(x, x):
+    pass
+```
+
+## Unsupported syntax
+
+Syntax introduced after the configured Python version is also reported.
+
+```py
+# error: [invalid-syntax] "Cannot use `type` alias statement on Python 3.11"
+type Alias = int
+```

--- a/crates/ruff_linter/src/lib.rs
+++ b/crates/ruff_linter/src/lib.rs
@@ -88,6 +88,7 @@ mod tests {
             &source_kind,
             Path::new("ruff_linter/rules/quick_test"),
             &LinterSettings::for_rule(rule),
+            true,
         );
 
         assert_eq!(print_messages(&diagnostics), "");

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -957,6 +957,7 @@ mod tests {
             &source_kind,
             path,
             &LinterSettings::for_rule(Rule::UnusedImport),
+            true,
         );
         let linted_notebook = transformed.into_owned().expect_ipy_notebook();
         let mut writer = Vec::new();
@@ -1236,6 +1237,7 @@ mod tests {
             },
             path,
             settings,
+            true,
         )
         .0;
         assert_diagnostics!(snapshot, diagnostics);

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -1478,7 +1478,7 @@ mod tests {
         }
 
         let source_kind = source_kind.updated(fixed, &source_map);
-        let (diagnostics, _) = test_contents(&source_kind, path, settings);
+        let (diagnostics, _) = test_contents(&source_kind, path, settings, true);
         if !diagnostics.is_empty() {
             writeln!(
                 output,

--- a/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
@@ -219,6 +219,7 @@ value: Literal[f\"\"\"{(\r\n1\r\n)=}\"\"\"] | Literal[f\"\"\"{(\n1\n)=}\"\"\"]\n
             },
             path,
             &settings::LinterSettings::for_rule(Rule::DuplicateUnionMember),
+            true,
         )
         .0;
 

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
@@ -255,6 +255,7 @@ mod tests {
             &LinterSettings::for_rule(Rule::LazyImportImmediatelyResolved)
                 .with_preview_mode()
                 .with_target_version(PythonVersion::PY315),
+            true,
         );
 
         assert_eq!(diagnostics.len(), 2);
@@ -333,6 +334,7 @@ mod tests {
                     .with_preview_mode()
                     .with_target_version(PythonVersion::PY315)
             },
+            true,
         );
 
         assert_eq!(diagnostics.len(), 3);
@@ -379,6 +381,7 @@ mod tests {
                     .with_preview_mode()
                     .with_target_version(PythonVersion::PY315)
             },
+            true,
         );
 
         assert_eq!(diagnostics.len(), 2);
@@ -422,6 +425,7 @@ mod tests {
                     .with_preview_mode()
                     .with_target_version(PythonVersion::PY315)
             },
+            true,
         );
 
         assert_eq!(diagnostics.len(), 2);
@@ -465,6 +469,7 @@ mod tests {
                     .with_preview_mode()
                     .with_target_version(PythonVersion::PY315)
             },
+            true,
         );
 
         assert_eq!(diagnostics.len(), 2);

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -319,6 +319,7 @@ mod tests {
                 },
                 ..LinterSettings::for_rule(Rule::UnusedImport)
             },
+            true,
         )
         .0;
         assert_diagnostics!(snapshot, diagnostics);
@@ -601,6 +602,7 @@ mod tests {
             },
             Path::new("f401_preview_submodule.py"),
             &LinterSettings::for_rule(Rule::UnusedImport).with_preview_mode(),
+            true,
         )
         .0;
         assert_diagnostics!(snapshot, diagnostics);

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -147,7 +147,7 @@ mod tests {
         let settings =
             settings::LinterSettings::for_rules(vec![Rule::UselessFinally, Rule::NeedlessElse]);
 
-        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings);
+        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings, true);
         assert_diagnostics!(diagnostics);
 
         insta::assert_snapshot!(transformed.source_code());
@@ -169,7 +169,7 @@ mod tests {
             Rule::SuppressibleException,
         ]);
 
-        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings);
+        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings, true);
         assert_diagnostics!(diagnostics);
 
         insta::assert_snapshot!(transformed.source_code());
@@ -191,7 +191,7 @@ mod tests {
             Rule::SuppressibleException,
         ]);
 
-        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings);
+        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings, true);
         assert_diagnostics!(diagnostics);
 
         insta::assert_snapshot!(transformed.source_code());
@@ -211,7 +211,7 @@ mod tests {
         let settings =
             settings::LinterSettings::for_rules(vec![Rule::NeedlessElse, Rule::UnnecessaryIf]);
 
-        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings);
+        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings, true);
         assert_diagnostics!(diagnostics);
 
         insta::assert_snapshot!(transformed.source_code());
@@ -232,7 +232,7 @@ mod tests {
         let settings =
             settings::LinterSettings::for_rules(vec![Rule::UnusedImport, Rule::UnnecessaryIf]);
 
-        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings);
+        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings, true);
         assert_diagnostics!(diagnostics);
 
         insta::assert_snapshot!(transformed.source_code());

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -131,7 +131,7 @@ pub(crate) fn test_path(
     let path = test_resource_path("fixtures").join(path);
     let source_type = ruff_python_ast::SourceType::Python(PySourceType::from(&path));
     let source_kind = SourceKind::from_path(path.as_ref(), source_type)?.expect("valid source");
-    Ok(test_contents(&source_kind, &path, settings).0)
+    Ok(test_contents(&source_kind, &path, settings, false).0)
 }
 
 /// Run the configuration TOML linter on a file in the `resources/test/fixtures` directory.
@@ -192,7 +192,7 @@ pub(crate) fn assert_notebook_path(
     let source_notebook = Notebook::from_path(path.as_ref())?;
 
     let source_kind = SourceKind::ipy_notebook(source_notebook);
-    let (messages, transformed) = test_contents(&source_kind, path.as_ref(), settings);
+    let (messages, transformed) = test_contents(&source_kind, path.as_ref(), settings, true);
     let expected_notebook = Notebook::from_path(expected.as_ref())?;
     let linted_notebook = transformed.into_owned().expect_ipy_notebook();
 
@@ -224,6 +224,7 @@ pub fn test_snippet(contents: &str, settings: &LinterSettings) -> Vec<Diagnostic
         },
         path,
         settings,
+        true,
     )
     .0
 }
@@ -242,10 +243,15 @@ pub(crate) fn max_iterations() -> usize {
 
 /// A convenient wrapper around [`check_path`], that additionally
 /// asserts that fixes converge after a fixed number of iterations.
+///
+/// Set `include_all_syntax_errors` to `false` only for temporary compatibility
+/// with existing tests. That retains ordinary parse errors, but omits semantic
+/// and target-version syntax errors.
 pub fn test_contents<'a>(
     source_kind: &'a SourceKind,
     path: &Path,
     settings: &LinterSettings,
+    include_all_syntax_errors: bool,
 ) -> (Vec<Diagnostic>, Cow<'a, SourceKind>) {
     let source_type = PySourceType::from(path);
     let target_version = settings.resolve_target_version(path);
@@ -376,54 +382,65 @@ Source with applied fixes:
     )
     .finish();
 
+    let mut messages = messages;
+    if !include_all_syntax_errors {
+        // Preserve the old diagnostic selection and ordering.
+        messages.retain(|message| message.secondary_code().is_some());
+        messages.extend(parsed.errors().iter().map(|parse_error| {
+            Diagnostic::invalid_syntax(source_code.clone(), &parse_error.error, parse_error)
+        }));
+    }
+
     let messages = messages
         .into_iter()
-        .filter_map(|msg| Some((msg.secondary_code()?.to_string(), msg)))
-        .map(|(code, mut diagnostic)| {
-            let rule = Rule::from_code(&code).unwrap();
-            let fixable = diagnostic.fix().is_some_and(|fix| {
-                matches!(
-                    fix.applicability(),
-                    Applicability::Safe | Applicability::Unsafe
-                )
-            });
+        .map(|mut diagnostic| {
+            if let Some(code) = diagnostic.secondary_code() {
+                let rule = Rule::from_code(code).unwrap();
+                let fixable = diagnostic.fix().is_some_and(|fix| {
+                    matches!(
+                        fix.applicability(),
+                        Applicability::Safe | Applicability::Unsafe
+                    )
+                });
 
-            match (fixable, rule.fixable()) {
-                (true, FixAvailability::Sometimes | FixAvailability::Always)
-                | (false, FixAvailability::None | FixAvailability::Sometimes) => {
-                    // Ok
-                }
-                (true, FixAvailability::None) => {
-                    panic!(
-                        "Rule {rule:?} is marked as non-fixable but it created a fix.
+                match (fixable, rule.fixable()) {
+                    (true, FixAvailability::Sometimes | FixAvailability::Always)
+                    | (false, FixAvailability::None | FixAvailability::Sometimes) => {
+                        // Ok
+                    }
+                    (true, FixAvailability::None) => {
+                        panic!(
+                            "Rule {rule:?} is marked as non-fixable but it created a fix.
 Change the `Violation::FIX_AVAILABILITY` to either \
 `FixAvailability::Sometimes` or `FixAvailability::Always`"
-                    );
-                }
-                (false, FixAvailability::Always) if source_has_errors => {
-                    // Ok
-                }
-                (false, FixAvailability::Always) => {
-                    panic!(
-                        "\
+                        );
+                    }
+                    (false, FixAvailability::Always) if source_has_errors => {
+                        // Ok
+                    }
+                    (false, FixAvailability::Always) => {
+                        panic!(
+                            "\
 Rule {rule:?} is marked to always-fixable but the diagnostic has no fix.
 Either ensure you always emit a fix or change `Violation::FIX_AVAILABILITY` to either \
 `FixAvailability::Sometimes` or `FixAvailability::None`"
-                    )
+                        )
+                    }
+                }
+
+                assert!(
+                    !(fixable && diagnostic.first_help_text().is_none()),
+                    "Diagnostic emitted by {rule:?} is fixable but \
+                `Violation::fix_title` returns `None`"
+                );
+
+                // Not strictly necessary but adds some coverage for this code path by overriding
+                // the noqa offset.
+                if let Some(range) = diagnostic.range() {
+                    diagnostic.set_noqa_offset(directives.noqa_line_for.resolve(range.start()));
                 }
             }
 
-            assert!(
-                !(fixable && diagnostic.first_help_text().is_none()),
-                "Diagnostic emitted by {rule:?} is fixable but \
-                `Violation::fix_title` returns `None`"
-            );
-
-            // Not strictly necessary but adds some coverage for this code path by overriding the
-            // noqa offset and the source file
-            if let Some(range) = diagnostic.range() {
-                diagnostic.set_noqa_offset(directives.noqa_line_for.resolve(range.start()));
-            }
             // This part actually is necessary to avoid long relative paths in snapshots.
             for annotation in diagnostic.annotations_mut() {
                 if let Some(range) = annotation.get_span().range() {
@@ -440,9 +457,6 @@ Either ensure you always emit a fix or change `Violation::FIX_AVAILABILITY` to e
 
             diagnostic
         })
-        .chain(parsed.errors().iter().map(|parse_error| {
-            Diagnostic::invalid_syntax(source_code.clone(), &parse_error.error, parse_error)
-        }))
         .sorted_by(Diagnostic::ruff_start_ordering)
         .collect();
     (messages, transformed)

--- a/crates/ruff_mdtest/src/lib.rs
+++ b/crates/ruff_mdtest/src/lib.rs
@@ -124,7 +124,7 @@ fn run_test(
                                     is_stub: file.is_stub(db),
                                 }
                             };
-                            test_contents(&source_kind, path, &settings.linter).0
+                            test_contents(&source_kind, path, &settings.linter, true).0
                         }
                         SourceType::Toml(source_type) => {
                             lint_toml(path, source.as_str(), &settings.linter, source_type)


### PR DESCRIPTION
Summary
--

I've now bumped into the fact that `test_contents` filters out these classes of syntax errors
multiple times and decided to fix it. 

Unfortunately, making this change revealed that many of our existing tests in `ruff_linter` contain
accidental syntax errors. I iterated a couple times with Codex on trying to resolve these by setting
a higher `target-version` in the test runners, but it was trickier than anticipated to do this
without losing coverage, and splitting up the fixtures quickly caused a huge diff.

As a result, I ended up adding this `include_all_syntax_errors` flag that the mdtests and existing
linter tests without syntax errors could enable. I consider it a TODO to resolve all the `false`
positions and remove this argument, but it would be nice to get this behavior in mdtests without
making someone review the big diff.

Test Plan
--

Existing tests and a couple of new syntax error mdtests
