### PR TITLE
[ty] Don't union inherited instance attributes over constructor overrides

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1461,6 +1461,23 @@ reveal_type(Derived().undeclared)  # revealed: str
 reveal_type(Derived().pure_undeclared)  # revealed: str
 ```
 
+### Constructor assignment on a subclass
+
+A constructor assignment on a subclass is the type of that instance attribute. Inherited types from
+the base class are not unioned in.
+
+```py
+class Client:
+    def __init__(self) -> None:
+        self.db = 1
+
+class PatchedClient(Client):
+    def __init__(self) -> None:
+        self.db = "mock"
+
+reveal_type(PatchedClient().db)  # revealed: str
+```
+
 ## Allow replacing ordinary methods with compatible functions
 
 An ordinary method can be replaced directly on a class by another function with a compatible

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2226,15 +2226,20 @@ impl<'db> ClassType<'db> {
         name: &str,
         target_method_decorator: MethodDecorator,
     ) -> ImplicitAttribute<'db> {
-        let augmented_bindings = self
-            .static_class_literal(db)
-            .map(|(class, _)| class.implicit_attribute_bindings(db, name, target_method_decorator))
+        let implicit = self.static_class_literal(db).map(|(class, _)| {
+            class.implicit_attribute_bindings(db, name, target_method_decorator)
+        });
+        let established_in_constructor = implicit
+            .as_ref()
+            .is_some_and(|implicit| implicit.established_in_constructor);
+        let augmented_bindings = implicit
             .filter(|implicit| member.is_undefined() == implicit.member.is_undefined())
             .and_then(|implicit| implicit.augmented_bindings);
 
         ImplicitAttribute {
             member,
             augmented_bindings,
+            established_in_constructor,
         }
     }
 
@@ -3030,6 +3035,8 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         // If the attribute is not definitely declared on this class, keep looking
                         // higher up in the MRO, and build a union of all inferred types (and
                         // possibly-declared types):
+                        let originating_constructor =
+                            implicit.established_in_constructor && union.is_empty();
                         union = union.add(ty);
                         provenance = provenance.or(member_provenance);
 
@@ -3047,6 +3054,21 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                             provenance = provenance.or(inferred_provenance);
                             union_qualifiers |= TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
                             pending_augmented_bindings.clear();
+                        }
+
+                        if originating_constructor {
+                            // The looked-up class assigns this attribute in a constructor.
+                            // Do not union inherited instance types into the subclass.
+                            return InstanceMemberResult::Done(
+                                Place::Defined(DefinedPlace {
+                                    ty: union.build(),
+                                    origin: TypeOrigin::Inferred,
+                                    definedness: Definedness::AlwaysDefined,
+                                    public_type_policy: PublicTypePolicy::Raw,
+                                    provenance,
+                                })
+                                .with_qualifiers(union_qualifiers),
+                            );
                         }
                     }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2226,9 +2226,9 @@ impl<'db> ClassType<'db> {
         name: &str,
         target_method_decorator: MethodDecorator,
     ) -> ImplicitAttribute<'db> {
-        let implicit = self.static_class_literal(db).map(|(class, _)| {
-            class.implicit_attribute_bindings(db, name, target_method_decorator)
-        });
+        let implicit = self
+            .static_class_literal(db)
+            .map(|(class, _)| class.implicit_attribute_bindings(db, name, target_method_decorator));
         let established_in_constructor = implicit
             .as_ref()
             .is_some_and(|implicit| implicit.established_in_constructor);

--- a/crates/ty_python_semantic/src/types/class/implicit_attributes.rs
+++ b/crates/ty_python_semantic/src/types/class/implicit_attributes.rs
@@ -13,7 +13,7 @@ use crate::{
         member::Member,
     },
 };
-use ruff_db::parsed::parsed_module;
+use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::name::Name;
 use ty_python_core::{
     attribute_scopes,
@@ -64,6 +64,7 @@ impl<'db> StaticClassLiteral<'db> {
             return ImplicitAttribute {
                 member: Member::unbound(),
                 augmented_bindings: None,
+                established_in_constructor: false,
             };
         };
 
@@ -86,6 +87,7 @@ impl<'db> StaticClassLiteral<'db> {
                 inner: Place::bound(Type::divergent(id)).into(),
             },
             augmented_bindings: None,
+            established_in_constructor: false,
         },
         heap_size=ruff_memory_usage::heap_size,
     )]
@@ -111,6 +113,7 @@ impl<'db> StaticClassLiteral<'db> {
         // any method, we build a union of the raw types inferred from all bindings of that
         // attribute, then apply public-type promotion to the final union.
         let mut union_of_inferred_types = UnionBuilder::new(db, env);
+        let mut established_in_constructor = false;
         let mut qualifiers = TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
 
         let mut is_attribute_bound = false;
@@ -215,6 +218,10 @@ impl<'db> StaticClassLiteral<'db> {
                                     .with_qualifiers(all_qualifiers),
                             },
                             augmented_bindings: None,
+                            established_in_constructor: is_constructor_scope(
+                                declaration.scope(db).scope(db),
+                                &module,
+                            ),
                         };
                     }
 
@@ -226,6 +233,10 @@ impl<'db> StaticClassLiteral<'db> {
                 return ImplicitAttribute {
                     member: Member { inner: annotation },
                     augmented_bindings: None,
+                    established_in_constructor: is_constructor_scope(
+                        declaration.scope(db).scope(db),
+                        &module,
+                    ),
                 };
             }
         }
@@ -297,6 +308,9 @@ impl<'db> StaticClassLiteral<'db> {
 
                 if let Some(inferred_ty) = inferred_ty {
                     provenance = provenance.or(Provenance::SingleDefinition(binding));
+                    if is_constructor_scope(scope_for_reachability_analysis, &module) {
+                        established_in_constructor = true;
+                    }
                     union_of_inferred_types = union_of_inferred_types.add(inferred_ty);
                 }
             }
@@ -321,6 +335,7 @@ impl<'db> StaticClassLiteral<'db> {
             member,
             augmented_bindings: (!augmented_bindings.is_empty())
                 .then(|| AugmentedBindings::new(db, augmented_bindings.into_boxed_slice())),
+            established_in_constructor,
         }
     }
 }
@@ -336,6 +351,9 @@ pub(super) struct ImplicitAttribute<'db> {
     pub(super) member: Member<'db>,
     /// Augmented assignments that require an existing instance or class attribute.
     pub(super) augmented_bindings: Option<AugmentedBindings<'db>>,
+    /// Whether `__init__` or `__new__` assigned this attribute, so its inferred type
+    /// should shadow inherited instance types.
+    pub(super) established_in_constructor: bool,
 }
 
 /// Augmented assignments deferred until MRO lookup finds the attribute they read.
@@ -360,6 +378,12 @@ struct ImplicitAttributeName<'db> {
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for ImplicitAttributeName<'_> {}
+
+fn is_constructor_scope(scope: &Scope, module: &ParsedModuleRef) -> bool {
+    scope.node().as_function().is_some_and(|function| {
+        matches!(function.node(module).name.as_str(), "__init__" | "__new__")
+    })
+}
 
 /// Infer the value written by an attribute definition, including unpacked and iteration targets.
 fn implicit_attribute_binding_type<'db>(


### PR DESCRIPTION
## Summary

If a subclass assigns an instance attribute in `__init__` or `__new__`, ty no longer unions that type with the inherited instance type from the base class.

This matches the expected behavior for test fixtures that replace a real dependency with a mock in a subclass constructor:

```python
class Client:
    def __init__(self) -> None:
        self.db = Database()

class PatchedClient(Client):
    def __init__(self) -> None:
        self.db = mock.Mock()

client = PatchedClient()
client.db.get_list.return_value = ["test"]  # previously invalid-assignment
```

`PatchedClient().db` is now inferred as the mock type rather than `Mock | Database`.

Assignments that are not established in a constructor still union with inherited types, so `self.x += ...` on a subclass continues to see the superclass binding.

Fixes astral-sh/ty#4304

## Test Plan

- `INSTA_FORCE_PASS=1 INSTA_UPDATE=always MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic --test mdtest -- mdtest::attributes.md`
- `cargo clippy -p ty_python_semantic --all-targets -- -D warnings`