### PR TITLE
[ty] Highlight declarations in invalid-assignment diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_syntactic_variants.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_syntactic_variants.md
@@ -28,17 +28,197 @@ x: int
 x = "three"  # snapshot: invalid-assignment
 ```
 
-Here, we could ideally point to the annotation as well, but for now, we just call out the declared
-type in an annotation on the variable name:
+The diagnostic points to the earlier type annotation as well as the incompatible value:
 
 ```snapshot
 error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
  --> src/mdtest_snippet.py:2:5
   |
+1 | x: int
+  |    --- Declared type
 2 | x = "three"  # snapshot: invalid-assignment
-  | -   ^^^^^^^ Incompatible value of type `Literal["three"]`
-  | |
-  | Declared type `int`
+  |     ^^^^^^^ Incompatible value of type `Literal["three"]`
+```
+
+## Previously initialized declaration
+
+The original annotation remains the source of the declared type after the variable has been
+initialized.
+
+```py
+x: int = 1
+x = "three"  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
+ --> src/mdtest_snippet.py:2:5
+  |
+1 | x: int = 1
+  |    --- Declared type
+2 | x = "three"  # snapshot: invalid-assignment
+  |     ^^^^^^^ Incompatible value of type `Literal["three"]`
+```
+
+## Global declaration
+
+An assignment to a global variable points to the annotation in its defining scope.
+
+```py
+x: int
+
+def assign() -> None:
+    global x
+    x = "three"  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
+ --> src/mdtest_snippet.py:5:9
+  |
+1 | x: int
+  |    --- Declared type
+2 |
+3 | def assign() -> None:
+4 |     global x
+5 |     x = "three"  # snapshot: invalid-assignment
+  |         ^^^^^^^ Incompatible value of type `Literal["three"]`
+```
+
+## Annotated parameter
+
+An incompatible assignment to an annotated parameter points to the parameter's type annotation.
+
+```py
+def assign(value: int) -> None:
+    value = "three"  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
+ --> src/mdtest_snippet.py:2:13
+  |
+1 | def assign(value: int) -> None:
+  |                   --- Declared type
+2 |     value = "three"  # snapshot: invalid-assignment
+  |             ^^^^^^^ Incompatible value of type `Literal["three"]`
+```
+
+## Variadic positional parameter
+
+A variadic positional parameter's annotation describes its arguments, while the parameter itself is
+a tuple.
+
+```py
+def assign(*values: int) -> None:
+    values = "three"  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `tuple[int, ...]`
+ --> src/mdtest_snippet.py:2:14
+  |
+1 | def assign(*values: int) -> None:
+  |                     --- Variadic parameter annotation declares the type as `tuple[int, ...]`
+2 |     values = "three"  # snapshot: invalid-assignment
+  |              ^^^^^^^ Incompatible value of type `Literal["three"]`
+```
+
+## Variadic keyword parameter
+
+A variadic keyword parameter's annotation describes its values, while the parameter itself is a
+dictionary.
+
+```py
+def assign(**values: int) -> None:
+    values = "three"  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `dict[str, int]`
+ --> src/mdtest_snippet.py:2:14
+  |
+1 | def assign(**values: int) -> None:
+  |                      --- Keyword-variadic parameter annotation declares the type as `dict[str, int]`
+2 |     values = "three"  # snapshot: invalid-assignment
+  |              ^^^^^^^ Incompatible value of type `Literal["three"]`
+```
+
+## Nonlocal declaration
+
+An assignment to a nonlocal variable points to the annotation in its enclosing scope.
+
+```py
+def outer() -> None:
+    x: int = 1
+
+    def assign() -> None:
+        nonlocal x
+        x = "three"  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
+ --> src/mdtest_snippet.py:6:13
+  |
+2 |     x: int = 1
+  |        --- Declared type
+3 |
+4 |     def assign() -> None:
+5 |         nonlocal x
+6 |         x = "three"  # snapshot: invalid-assignment
+  |             ^^^^^^^ Incompatible value of type `Literal["three"]`
+```
+
+## Conflicting declarations
+
+When conflicting annotations contribute to the declared type, the diagnostic does not identify any
+one annotation as the declared type.
+
+```py
+def assign(flag: bool) -> None:
+    if flag:
+        x: int
+    else:
+        x: str
+
+    # error: [conflicting-declarations]
+    x = b"three"  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal[b"three"]` is not assignable to `int | str`
+ --> src/mdtest_snippet.py:8:9
+  |
+8 |     x = b"three"  # snapshot: invalid-assignment
+  |     -   ^^^^^^^^ Incompatible value of type `Literal[b"three"]`
+  |     |
+  |     Declared type `int | str`
+```
+
+## Equivalent declarations
+
+When distinct branches declare the same type, neither annotation is the unique source of the
+declared type.
+
+```py
+def assign(flag: bool) -> None:
+    if flag:
+        x: int
+    else:
+        x: int
+
+    x = "three"  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
+ --> src/mdtest_snippet.py:7:9
+  |
+7 |     x = "three"  # snapshot: invalid-assignment
+  |     -   ^^^^^^^ Incompatible value of type `Literal["three"]`
+  |     |
+  |     Declared type `int`
 ```
 
 ## Named expression
@@ -49,16 +229,83 @@ x: int
 (x := "three")  # snapshot: invalid-assignment
 ```
 
-Similar here, we could ideally point to the type annotation:
-
 ```snapshot
 error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
  --> src/mdtest_snippet.py:3:7
   |
+1 | x: int
+  |    --- Declared type
+2 |
 3 | (x := "three")  # snapshot: invalid-assignment
-  |  -    ^^^^^^^ Incompatible value of type `Literal["three"]`
-  |  |
-  |  Declared type `int`
+  |       ^^^^^^^ Incompatible value of type `Literal["three"]`
+```
+
+## For-loop target
+
+```py
+value: int
+
+for value in ["three"]:  # snapshot: invalid-assignment
+    pass
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
+ --> src/mdtest_snippet.py:3:5
+  |
+1 | value: int
+  |        --- Declared type
+2 |
+3 | for value in ["three"]:  # snapshot: invalid-assignment
+  |     ^^^^^
+```
+
+## Context manager target
+
+```py
+from contextlib import nullcontext
+
+value: int
+
+with nullcontext("three") as value:  # snapshot: invalid-assignment
+    pass
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `str` is not assignable to `int`
+ --> src/mdtest_snippet.py:5:30
+  |
+3 | value: int
+  |        --- Declared type
+4 |
+5 | with nullcontext("three") as value:  # snapshot: invalid-assignment
+  |                              ^^^^^
+```
+
+## Augmented assignment
+
+```py
+value: int = 1
+value += 1.0  # snapshot: invalid-assignment
+
+reveal_type(value)  # revealed: int
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `float` is not assignable to `int`
+ --> src/mdtest_snippet.py:2:1
+  |
+1 | value: int = 1
+  |        --- Declared type
+2 | value += 1.0  # snapshot: invalid-assignment
+  | ^^^^^ Augmented assignment produces a value of type `float`
+```
+
+The concise diagnostic reports the incompatible assignment:
+
+```py
+# error: [invalid-assignment] "Object of type `float` is not assignable to `int`"
+value += 1.0
 ```
 
 ## Multiline expressions
@@ -107,19 +354,24 @@ tuple:
 error[invalid-assignment]: Object of type `Literal["a"]` is not assignable to `int`
  --> src/mdtest_snippet.py:4:8
   |
+1 | x: int
+  |    --- Declared type
+2 | y: str
+3 |
 4 | x, y = ("a", "b")  # snapshot: invalid-assignment
-  | -      ^^^^^^^^^^ Incompatible value of type `Literal["a"]`
-  | |
-  | Declared type `int`
+  |        ^^^^^^^^^^ Incompatible value of type `Literal["a"]`
 
 
 error[invalid-assignment]: Object of type `Literal[0]` is not assignable to `str`
  --> src/mdtest_snippet.py:6:8
   |
+2 | y: str
+  |    --- Declared type
+3 |
+4 | x, y = ("a", "b")  # snapshot: invalid-assignment
+5 |
 6 | x, y = (0, 0)  # snapshot: invalid-assignment
-  |    -   ^^^^^^ Incompatible value of type `Literal[0]`
-  |    |
-  |    Declared type `str`
+  |        ^^^^^^ Incompatible value of type `Literal[0]`
 ```
 
 ## Shadowing of classes and functions

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/same_names.md
@@ -61,6 +61,117 @@ class DataFrame:
     pass
 ```
 
+## Variadic positional parameter annotations
+
+A variadic positional parameter's annotation uses the same qualified type name as the assignment
+diagnostic.
+
+`first.py`:
+
+```py
+class Value: ...
+```
+
+`second.py`:
+
+```py
+class Value: ...
+```
+
+```py
+import first
+import second
+
+def assign(*values: first.Value) -> None:
+    values = (second.Value(),)  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `tuple[second.Value]` is not assignable to `tuple[first.Value, ...]`
+ --> src/mdtest_snippet.py:5:14
+  |
+4 | def assign(*values: first.Value) -> None:
+  |                     ----------- Variadic parameter annotation declares the type as `tuple[first.Value, ...]`
+5 |     values = (second.Value(),)  # snapshot: invalid-assignment
+  |              ^^^^^^^^^^^^^^^^^ Incompatible value of type `tuple[second.Value]`
+```
+
+## Variadic keyword parameter annotations
+
+A variadic keyword parameter's annotation uses the same qualified type name as the assignment
+diagnostic.
+
+`first.py`:
+
+```py
+class Value: ...
+```
+
+`second.py`:
+
+```py
+class Value: ...
+```
+
+```py
+import first
+import second
+
+def assign(**values: first.Value) -> None:
+    values = {"item": second.Value()}  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `dict[str, first.Value | second.Value]` is not assignable to `dict[str, first.Value]`
+ --> src/mdtest_snippet.py:5:14
+  |
+4 | def assign(**values: first.Value) -> None:
+  |                      ----------- Keyword-variadic parameter annotation declares the type as `dict[str, first.Value]`
+5 |     values = {"item": second.Value()}  # snapshot: invalid-assignment
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible value of type `dict[str, first.Value | second.Value]`
+info: element `second.Value` of union `first.Value | second.Value` is not assignable to `first.Value`
+```
+
+## Ambiguous declaration origins
+
+When distinct branches declare the same type, the fallback annotation still distinguishes the
+declared class from a same-named assigned class.
+
+`first.py`:
+
+```py
+class Value: ...
+```
+
+`second.py`:
+
+```py
+class Value: ...
+```
+
+```py
+import first
+import second
+
+def assign(flag: bool) -> None:
+    if flag:
+        value: first.Value
+    else:
+        value: first.Value
+
+    value = second.Value()  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `second.Value` is not assignable to `first.Value`
+  --> src/mdtest_snippet.py:10:13
+   |
+10 |     value = second.Value()  # snapshot: invalid-assignment
+   |     -----   ^^^^^^^^^^^^^^ Incompatible value of type `second.Value`
+   |     |
+   |     Declared type `first.Value`
+```
+
 ## Class from different module with the same qualified name
 
 `package/__init__.py`:

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -49,7 +49,7 @@ use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::fmt::{self, Formatter};
 use ty_module_resolver::{KnownModule, Module, ModuleName, SearchPath, file_to_module};
-use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::definition::{Definition, DefinitionKind, ParameterDefinitionNodeKind};
 use ty_python_core::place::{PlaceTable, ScopedPlaceId};
 use ty_python_core::{ProgramFile, global_scope, place_table, use_def_map};
 
@@ -1649,6 +1649,7 @@ pub(super) fn report_invalid_assignment<'db>(
     context: &InferContext<'db, '_>,
     target_node: AnyNodeRef,
     definition: Definition<'db>,
+    declaration: Option<Definition<'db>>,
     target_ty: Type,
     value_ty: Type<'db>,
 ) {
@@ -1697,7 +1698,7 @@ pub(super) fn report_invalid_assignment<'db>(
         format_args!(
             "Object of type `{}` is not assignable to `{}`",
             value_ty.display_with(db, env, settings.clone()),
-            target_ty.display_with(db, env, settings)
+            target_ty.display_with(db, env, settings.clone())
         ),
     ) else {
         return;
@@ -1723,33 +1724,94 @@ pub(super) fn report_invalid_assignment<'db>(
         }
     }
 
-    if value_node.is_some() {
-        match definition_kind {
-            DefinitionKind::AnnotatedAssignment(assignment) => {
-                // For annotated assignments, just point to the annotation in the source code.
-                diag.annotate(
-                    context
-                        .secondary(assignment.annotation(context.module()))
-                        .message("Declared type"),
-                );
-            }
-            _ => {
-                // Otherwise, annotate the target with its declared type.
-                diag.annotate(context.secondary(target_node).message(format_args!(
-                    "Declared type `{}`",
-                    target_ty.display(db, env)
-                )));
-            }
+    let declaration_annotation = match definition_kind {
+        DefinitionKind::AnnotatedAssignment(assignment) => {
+            Some((assignment.annotation(context.module()), None))
         }
+        _ => declaration.and_then(|declaration| match declaration.kind(db) {
+            DefinitionKind::AnnotatedAssignment(assignment) => {
+                Some((assignment.annotation(context.module()), None))
+            }
+            DefinitionKind::Parameter(ParameterDefinitionNodeKind::Parameter(parameter)) => {
+                parameter
+                    .node(context.module())
+                    .parameter
+                    .annotation
+                    .as_deref()
+                    .map(|annotation| (annotation, None))
+            }
+            DefinitionKind::Parameter(
+                ParameterDefinitionNodeKind::VariadicPositionalParameter(parameter),
+            ) => parameter
+                .node(context.module())
+                .annotation
+                .as_deref()
+                .map(|annotation| (annotation, Some("Variadic"))),
+            DefinitionKind::Parameter(ParameterDefinitionNodeKind::VariadicKeywordParameter(
+                parameter,
+            )) => parameter
+                .node(context.module())
+                .annotation
+                .as_deref()
+                .map(|annotation| (annotation, Some("Keyword-variadic"))),
+            DefinitionKind::Import(_)
+            | DefinitionKind::ImportFrom(_)
+            | DefinitionKind::ImportFromSubmodule(_)
+            | DefinitionKind::StarImport(_)
+            | DefinitionKind::Function(_)
+            | DefinitionKind::Class(_)
+            | DefinitionKind::TypeAlias(_)
+            | DefinitionKind::NamedExpression(_)
+            | DefinitionKind::Assignment(_)
+            | DefinitionKind::AugmentedAssignment(_)
+            | DefinitionKind::DictKeyAssignment(_)
+            | DefinitionKind::For(_)
+            | DefinitionKind::Comprehension(_)
+            | DefinitionKind::LambdaParameter(_)
+            | DefinitionKind::WithItem(_)
+            | DefinitionKind::MatchPattern(_)
+            | DefinitionKind::ExceptHandler(_)
+            | DefinitionKind::TypeVar(_)
+            | DefinitionKind::ParamSpec(_)
+            | DefinitionKind::TypeVarTuple(_)
+            | DefinitionKind::LoopHeader(_)
+            | DefinitionKind::NestedBindings(_) => None,
+        }),
+    };
 
+    if let Some((annotation, variadic_parameter_kind)) = declaration_annotation {
+        let annotation = context.secondary(annotation);
+        diag.annotate(if let Some(kind) = variadic_parameter_kind {
+            annotation.message(format_args!(
+                "{kind} parameter annotation declares the type as `{}`",
+                target_ty.display_with(db, env, settings.clone())
+            ))
+        } else {
+            annotation.message("Declared type")
+        });
+    } else if value_node.is_some() {
+        diag.annotate(context.secondary(target_node).message(format_args!(
+            "Declared type `{}`",
+            target_ty.display_with(db, env, settings.clone())
+        )));
+    }
+
+    if value_node.is_some() {
         diag.set_primary_annotation_message(format_args!(
             "Incompatible value of type `{}`",
-            value_ty.display(db, env),
+            value_ty.display_with(db, env, settings),
         ));
 
         let error_context = value_ty.assignability_error_context(db, env, target_ty);
         error_context.attach_to(db, env, &mut diag);
+    } else if matches!(definition_kind, DefinitionKind::AugmentedAssignment(_)) {
+        diag.set_primary_annotation_message(format_args!(
+            "Augmented assignment produces a value of type `{}`",
+            value_ty.display_with(db, env, settings),
+        ));
+    }
 
+    if value_node.is_some() || matches!(definition_kind, DefinitionKind::AugmentedAssignment(_)) {
         // Overwrite the concise message to avoid showing the value type twice
         let message = diag.headline_message().to_string();
         diag.set_concise_message(message);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1469,6 +1469,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             qualifiers,
         } = place_and_quals;
 
+        let declaration = match resolved_place {
+            Place::Defined(DefinedPlace { provenance, .. }) => provenance
+                .definition()
+                .filter(|declaration| declaration.file(db) == self.context.file()),
+            Place::Undefined => None,
+        };
+
         let declared_ty = if resolved_place.is_undefined() && !place.is_symbol() {
             self.fallback_member_declared_type(node)
         } else {
@@ -1478,6 +1485,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         AddBinding {
             declared_ty,
+            declaration,
             binding,
             node,
             qualifiers,
@@ -1760,6 +1768,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         &self.context,
                         node,
                         definition,
+                        None,
                         declared_type,
                         inferred_ty,
                     );
@@ -4295,6 +4304,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let node = target.into();
             let add = AddBinding {
                 declared_ty: self.fallback_member_declared_type(node),
+                declaration: None,
                 binding: definition,
                 node,
                 qualifiers: TypeQualifiers::empty(),
@@ -12251,6 +12261,7 @@ impl<V> IntoIterator for VecSet<V> {
 #[must_use]
 struct AddBinding<'db, 'ast> {
     declared_ty: Option<Type<'db>>,
+    declaration: Option<Definition<'db>>,
     binding: Definition<'db>,
     node: AnyNodeRef<'ast>,
     qualifiers: TypeQualifiers,
@@ -12335,6 +12346,7 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                 &builder.context,
                 self.node,
                 self.binding,
+                self.declaration,
                 declared_ty,
                 bound_ty,
             );


### PR DESCRIPTION
## Summary

When an `invalid-assignment` diagnostic is caused by a previously declared type, point directly to the annotation that established that type instead of only annotating the assignment target.

## Example

```py
value: int
value = "three"
```

```text
error[invalid-assignment]: Object of type `Literal["three"]` is not assignable to `int`
 --> example.py:2:9
  |
1 | value: int
  |        --- Declared type
2 | value = "three"
  |         ^^^^^^^ Incompatible value of type `Literal["three"]`
```