### PR TITLE
[ty] Skip invalid subscript operands in string annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -202,6 +202,40 @@ annotation:
 x: "[[foo]]"
 ```
 
+## Invalid subscript operands in string annotations
+
+Invalid subscript operands in string annotations must not be evaluated. In particular, lambda
+defaults and functional `TypedDict` arguments should not produce cascading unresolved-reference
+diagnostics, and assignment expressions should not cause a panic.
+
+`runtime.py`:
+
+```py
+from typing_extensions import TypedDict
+
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+a: "(lambda value=missing: None)[int]"
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+b: "(lambda value=(name := int): None)[int]"
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+c: "TypedDict('T', {}, extra_items=missing)[int]"
+```
+
+The same error-recovery behavior applies to annotations in stub files:
+
+`stub.pyi`:
+
+```pyi
+from typing_extensions import TypedDict
+
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+a: "(lambda value=missing: None)[int]"
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+b: "(lambda value=(name := int): None)[int]"
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+c: "TypedDict('T', {}, extra_items=missing)[int]"
+```
+
 ## Multiple starred expressions in a `tuple` specialization
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -201,9 +201,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     node_index: _,
                 } = subscript;
 
-                let value_ty = self.infer_expression(value, TypeContext::default());
-
                 if is_dotted_name(value) {
+                    let value_ty = self.infer_expression(value, TypeContext::default());
+
                     // Preserve the flag for another `Unpack` so that nested unpacking emits a
                     // diagnostic. Other subscripts are no longer the direct unpack operand.
                     let previously_in_unpack_type_argument =
@@ -229,6 +229,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     ty
                 } else {
                     if !self.in_string_annotation() {
+                        self.infer_expression(value, TypeContext::default());
                         self.infer_expression(slice, TypeContext::default());
                     }
                     self.report_invalid_type_expression(


### PR DESCRIPTION
## Summary

Previously, we inferred an invalid subscript's value before checking whether it was a valid type-expression operand. Inside a string annotation, this could evaluate expressions that are absent from the semantic index, panic on assignment expressions, or emit cascading unresolved-reference diagnostics:

```python
value: "(lambda default=(name := int): None)[int]"
other: "TypedDict('T', {}, extra_items=missing)[int]"
```

We now infer invalid subscript operands only when annotations execute at runtime. String annotations instead report the existing `invalid-type-form` diagnostic without evaluating their invalid children, matching existing error-recovery behavior in both Python and stub files.

Supersedes https://github.com/astral-sh/ruff/pull/27852.
