### PR TITLE
[ty] Handle dynamic classes in string annotations

### DIFF
--- a/crates/ty_python_core/src/node_key.rs
+++ b/crates/ty_python_core/src/node_key.rs
@@ -7,6 +7,11 @@ use crate::ast_node_ref::AstNodeRef;
 pub struct NodeKey(NodeIndex);
 
 impl NodeKey {
+    /// Returns the index of the AST node.
+    pub fn index(self) -> NodeIndex {
+        self.0
+    }
+
     pub fn from_node<N>(node: N) -> Self
     where
         N: HasNodeIndex,

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -81,6 +81,14 @@ takes_foo1(foo2)
 takes_foo2(foo1)
 ```
 
+The classes also remain distinct when both calls occur in the same string annotation, even though
+the surrounding type expression is invalid:
+
+```py
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+distinct: "static_assert(type('Foo', (), {}) is not type('Foo', (), {}))[int]"
+```
+
 ## Instances and attribute access
 
 Instances of dynamic classes are typed with the synthesized class name. Attributes from all base
@@ -975,6 +983,30 @@ bases: tuple[type[C], type[D]] = (C, D)
 Y = type("Y", bases, {})
 ```
 
+Inside a string annotation, the diagnostic still highlights the class-creation call, not the whole
+string:
+
+```py
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+# snapshot: instance-layout-conflict
+bad: "type('Bad', (A, B), {})[int]"
+```
+
+```snapshot
+error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
+  --> src/mdtest_snippet.py:20:7
+   |
+20 | bad: "type('Bad', (A, B), {})[int]"
+   |       ^^^^^^^^^^^^^^^^^^^^^^^ Bases `A` and `B` cannot be combined in multiple inheritance
+info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
+  --> src/mdtest_snippet.py:20:20
+   |
+20 | bad: "type('Bad', (A, B), {})[int]"
+   |                    -  - `B` instances have a distinct memory layout because `B` defines non-empty `__slots__`
+   |                    |
+   |                    `A` instances have a distinct memory layout because `A` defines non-empty `__slots__`
+```
+
 ## Cyclic functional class definitions
 
 ### Self-referential
@@ -1178,6 +1210,20 @@ class Unrelated: ...
 
 # error: [invalid-assignment]
 Bad: type[Unrelated] = type("Bad", (Base,), {})
+```
+
+## Dynamic class calls in string annotations
+
+An invalid subscript of a `type()` call should produce the usual diagnostic, including when the call
+appears in a nested string annotation:
+
+```py
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+plain: "type('X', (), {})[int]"
+
+name = "Nested"
+# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+nested: "'type(name, (), {})[int]'"
 ```
 
 ## Dynamic class reassignment in a loop

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1214,6 +1214,30 @@ Bad: type[Unrelated] = type("Bad", (Base,), {})
 
 ## Dynamic class calls in string annotations
 
+Dynamic class constructors can appear as `Annotated` metadata inside valid string annotations:
+
+```py
+from collections import namedtuple
+from enum import Enum
+from types import new_class
+from typing import Annotated, NamedTuple, TypedDict
+
+def f(
+    builtin: "Annotated[int, type('X', (), {})]",
+    new: "Annotated[int, new_class('X', ())]",
+    enum: "Annotated[int, Enum('X', {'VALUE': 1})]",
+    named_tuple: "Annotated[int, NamedTuple('X', [('value', int)])]",
+    collections_named_tuple: "Annotated[int, namedtuple('X', ['value'])]",
+    typed_dict: "Annotated[int, TypedDict('X', {'value': int})]",
+):
+    reveal_type(builtin)  # revealed: int
+    reveal_type(new)  # revealed: int
+    reveal_type(enum)  # revealed: int
+    reveal_type(named_tuple)  # revealed: int
+    reveal_type(collections_named_tuple)  # revealed: int
+    reveal_type(typed_dict)  # revealed: int
+```
+
 An invalid subscript of a `type()` call should produce the usual diagnostic, including when the call
 appears in a nested string annotation:
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -77,7 +77,20 @@ mod typed_dict;
 #[derive(Clone, Copy)]
 enum DynamicClassHeaderAnchor<'db> {
     Definition(Definition<'db>),
-    ScopeOffset(u32),
+    ScopeOffset(DynamicClassScopeOffset),
+}
+
+/// Identifies a dangling dynamic-class call relative to its enclosing scope.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+pub enum DynamicClassScopeOffset {
+    /// A call in the module AST, identified by its scope-relative node index.
+    Node(u32),
+
+    /// A call in a parsed string annotation, whose nodes are not in the module AST.
+    ///
+    /// `offset` identifies the outermost string expression in the module AST, relative to the
+    /// scope's node index. `range` identifies the call within that string expression.
+    StringAnnotation { offset: u32, range: TextRange },
 }
 
 /// Returns the source range of a call that creates a dynamic class.
@@ -99,11 +112,24 @@ fn dynamic_class_header_range<'db>(
             .expect("dynamic class definitions should only be used for assignments")
             .range(),
         DynamicClassHeaderAnchor::ScopeOffset(offset) => {
+            let (offset, relative_range) = match offset {
+                DynamicClassScopeOffset::Node(offset) => (offset, None),
+                DynamicClassScopeOffset::StringAnnotation { offset, range } => {
+                    (offset, Some(range))
+                }
+            };
             let scope_anchor = scope.node(db).node_index().unwrap_or(NodeIndex::from(0));
             let anchor_u32 = scope_anchor
                 .as_u32()
                 .expect("anchor should not be NodeIndex::NONE");
             let absolute_index = NodeIndex::from(anchor_u32 + offset);
+            if let Some(relative_range) = relative_range {
+                let string: &ast::ExprStringLiteral = module
+                    .get_by_index(absolute_index)
+                    .try_into()
+                    .expect("string annotation offset should point to ExprStringLiteral");
+                return relative_range + string.start();
+            }
             let node: &ast::ExprCall = module
                 .get_by_index(absolute_index)
                 .try_into()

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -11,7 +11,7 @@ use crate::{
         SubclassOfType, Type,
         class::{
             ClassMemberResult, CodeGeneratorKind, DisjointBase, DynamicClassHeaderAnchor,
-            InstanceMemberResult, MroLookup, dynamic_class_header_range,
+            DynamicClassScopeOffset, InstanceMemberResult, MroLookup, dynamic_class_header_range,
             typed_dict::typed_dict_fallback_class_member,
         },
         definition_expression_type, extract_fixed_length_iterable_element_types,
@@ -49,7 +49,7 @@ use ty_python_core::{definition::Definition, scope::ScopeId};
 ///
 /// The `anchor` field provides stable identity:
 /// - For assigned calls, the `Definition` uniquely identifies the class.
-/// - For dangling calls, a relative node offset anchored to the enclosing scope
+/// - For dangling calls, a call location anchored to the enclosing scope
 ///   provides stable identity that only changes when the scope itself changes.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct DynamicClassLiteral<'db> {
@@ -61,8 +61,8 @@ pub struct DynamicClassLiteral<'db> {
     ///
     /// - `Definition`: The call is assigned to a variable. The definition
     ///   uniquely identifies this class and can be used to find the call expression.
-    /// - `ScopeOffset`: The call is "dangling" (not assigned). The offset
-    ///   is relative to the enclosing scope's anchor node index.
+    /// - `ScopeOffset`: The call is "dangling" (not assigned). Its location
+    ///   is relative to the enclosing scope.
     #[returns(ref)]
     pub anchor: DynamicClassAnchor<'db>,
 
@@ -98,14 +98,14 @@ pub enum DynamicClassAnchor<'db> {
 
     /// The call is "dangling" (not assigned to a variable).
     ///
-    /// The offset is relative to the enclosing scope's anchor node index.
-    /// For module scope, this is equivalent to an absolute index (anchor is 0).
+    /// The [`DynamicClassScopeOffset`] locates the call relative to the enclosing scope,
+    /// including when the call is inside a string annotation.
     ///
     /// The `explicit_bases` are computed eagerly at creation time since dangling
     /// calls cannot recursively reference the class being defined.
     ScopeOffset {
         scope: ScopeId<'db>,
-        offset: u32,
+        offset: DynamicClassScopeOffset,
         explicit_bases: Box<[Type<'db>]>,
     },
 }

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -8,7 +8,7 @@ use crate::place::{Place, PlaceAndQualifiers};
 use crate::types::Type;
 use crate::types::class::known::KnownClass;
 use crate::types::class::{
-    ClassLiteral, ClassType, DynamicClassHeaderAnchor, MemberLookupPolicy,
+    ClassLiteral, ClassType, DynamicClassHeaderAnchor, DynamicClassScopeOffset, MemberLookupPolicy,
     dynamic_class_header_range,
 };
 use crate::types::class_base::ClassBase;
@@ -63,7 +63,7 @@ pub enum DynamicEnumAnchor<'db> {
     },
     ScopeOffset {
         scope: ScopeId<'db>,
-        offset: u32,
+        offset: DynamicClassScopeOffset,
         spec: EnumSpec<'db>,
     },
 }

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -10,7 +10,7 @@ use crate::{
         BindingContext, BoundTypeVarInstance, ClassBase, ClassLiteral, ClassType, GenericContext,
         KnownClass, KnownInstanceType, MemberLookupPolicy, Parameter, Parameters,
         PropertyInstanceType, Signature, SubclassOfType, Type, TypeContext, TypeMapping,
-        class::{DynamicClassHeaderAnchor, dynamic_class_header_range},
+        class::{DynamicClassHeaderAnchor, DynamicClassScopeOffset, dynamic_class_header_range},
         definition_expression_type,
         member::Member,
         mro::Mro,
@@ -161,8 +161,8 @@ pub struct DynamicNamedTupleLiteral<'db> {
     ///
     /// - `Definition`: The call is assigned to a variable. The definition
     ///   uniquely identifies this namedtuple and can be used to find the call.
-    /// - `ScopeOffset`: The call is "dangling" (not assigned). The offset
-    ///   is relative to the enclosing scope's anchor node index.
+    /// - `ScopeOffset`: The call is "dangling" (not assigned). Its location
+    ///   is relative to the enclosing scope.
     #[returns(ref)]
     pub anchor: DynamicNamedTupleAnchor<'db>,
 }
@@ -515,8 +515,8 @@ pub enum DynamicNamedTupleAnchor<'db> {
     /// We're dealing with a `namedtuple()` or `NamedTuple` call that is
     /// "dangling" (not assigned to a variable).
     ///
-    /// The offset is relative to the enclosing scope's anchor node index.
-    /// For module scope, this is equivalent to an absolute index (anchor is 0).
+    /// The [`DynamicClassScopeOffset`] locates the call relative to the enclosing scope,
+    /// including when the call is inside a string annotation.
     ///
     /// Dangling calls can always store the spec. They *can* contain
     /// forward references if they appear in class bases:
@@ -532,7 +532,7 @@ pub enum DynamicNamedTupleAnchor<'db> {
     /// entirety during type inference.
     ScopeOffset {
         scope: ScopeId<'db>,
-        offset: u32,
+        offset: DynamicClassScopeOffset,
         spec: NamedTupleSpec<'db>,
     },
 }

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -11,7 +11,9 @@ use ty_module_resolver::KnownModule;
 use crate::place::PlaceAndQualifiers;
 use crate::place::known_module_symbol;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
-use crate::types::class::{DynamicClassHeaderAnchor, dynamic_class_header_range};
+use crate::types::class::{
+    DynamicClassHeaderAnchor, DynamicClassScopeOffset, dynamic_class_header_range,
+};
 use crate::types::generics::GenericContext;
 use crate::types::member::Member;
 use crate::types::mro::Mro;
@@ -847,12 +849,12 @@ pub enum DynamicTypedDictAnchor<'db> {
 
     /// The `TypedDict()` call is "dangling" (not assigned to a variable).
     ///
-    /// The offset is relative to the enclosing scope's anchor node index. The eagerly
-    /// computed `spec` preserves field types for inline uses like
+    /// The [`DynamicClassScopeOffset`] locates the call relative to the enclosing scope.
+    /// The eagerly computed `spec` preserves field types for inline uses like
     /// `TypedDict("Point", {"x": int})(x=1)`.
     ScopeOffset {
         scope: ScopeId<'db>,
-        offset: u32,
+        offset: DynamicClassScopeOffset,
         schema: TypedDictSchema<'db>,
         openness: TypedDictOpenness<'db>,
     },
@@ -893,9 +895,8 @@ pub struct DynamicTypedDictLiteral<'db> {
     ///
     /// - `Definition`: The call is assigned to a variable. The definition
     ///   uniquely identifies this TypedDict and can be used to find the call.
-    /// - `ScopeOffset`: The call is "dangling" (not assigned). The offset
-    ///   is relative to the enclosing scope's anchor node index, and the
-    ///   eagerly computed spec is stored on the anchor.
+    /// - `ScopeOffset`: The call is "dangling" (not assigned). Its location
+    ///   is relative to the enclosing scope, and the eagerly computed spec is stored on the anchor.
     #[returns(ref)]
     pub(crate) anchor: DynamicTypedDictAnchor<'db>,
 

--- a/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
-use ruff_python_ast::{self as ast, name::Name};
+use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex, name::Name};
 use ruff_text_size::Ranged;
 
-use crate::types::class::DynamicClassLiteral;
+use crate::types::class::{DynamicClassLiteral, DynamicClassScopeOffset};
 use crate::types::context::InferContext;
 use crate::types::diagnostic::{
     CYCLIC_CLASS_DEFINITION, DUPLICATE_BASE, INCONSISTENT_MRO, INVALID_ARGUMENT_TYPE, INVALID_BASE,
@@ -10,7 +10,7 @@ use crate::types::diagnostic::{
     report_inconsistent_generic_bases,
 };
 use crate::types::enums::is_enum_class_by_inheritance;
-use crate::types::infer::builder::TypeInferenceBuilder;
+use crate::types::infer::builder::{DeferredExpressionState, TypeInferenceBuilder};
 use crate::types::mro::{DynamicMroError, DynamicMroErrorKind};
 use crate::types::{ClassBase, KnownClass, Type, extract_fixed_length_iterable_element_types};
 
@@ -36,6 +36,44 @@ impl DynamicClassKind {
 }
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
+    /// Identify a dangling dynamic-class call without retaining an absolute source position.
+    pub(super) fn dynamic_class_scope_offset(
+        &self,
+        call: &ast::ExprCall,
+    ) -> DynamicClassScopeOffset {
+        let scope_anchor = self
+            .scope()
+            .node(self.db())
+            .node_index()
+            .unwrap_or(NodeIndex::from(0));
+        let anchor_u32 = scope_anchor
+            .as_u32()
+            .expect("scope anchor should not be NodeIndex::NONE");
+        let relative_index = |index: NodeIndex| {
+            index
+                .as_u32()
+                .expect("dynamic class anchor should not be NodeIndex::NONE")
+                - anchor_u32
+        };
+
+        if let DeferredExpressionState::InStringAnnotation(enclosing_node_key) = self.deferred_state
+        {
+            let enclosing_index = enclosing_node_key.index();
+            let string: &ast::ExprStringLiteral = self
+                .module()
+                .get_by_index(enclosing_index)
+                .try_into()
+                .expect("string annotation key should point to ExprStringLiteral");
+
+            DynamicClassScopeOffset::StringAnnotation {
+                offset: relative_index(enclosing_index),
+                range: call.range() - string.start(),
+            }
+        } else {
+            DynamicClassScopeOffset::Node(relative_index(call.node_index().load()))
+        }
+    }
+
     /// Extract base classes from the bases argument of a `type()` or `types.new_class()` call.
     ///
     /// Emits a diagnostic if `bases_type` is not a valid bases iterable for the given kind.

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -1,6 +1,6 @@
 use compact_str::ToCompactString;
 use ruff_python_ast::name::Name;
-use ruff_python_ast::{self as ast, NodeIndex, PythonVersion};
+use ruff_python_ast::{self as ast, PythonVersion};
 use rustc_hash::FxHashSet;
 
 use ty_python_core::definition::Definition;
@@ -637,23 +637,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     ) -> DynamicEnumAnchor<'db> {
         match definition {
             Some(definition) => DynamicEnumAnchor::Definition { definition, spec },
-            None => {
-                let db = self.db();
-                let call_node_index = call_expr.node_index.load();
-                let scope = self.scope();
-                let scope_anchor = scope.node(db).node_index().unwrap_or(NodeIndex::from(0));
-                let anchor_u32 = scope_anchor
-                    .as_u32()
-                    .expect("scope anchor should not be NodeIndex::NONE");
-                let call_u32 = call_node_index
-                    .as_u32()
-                    .expect("call node should not be NodeIndex::NONE");
-                DynamicEnumAnchor::ScopeOffset {
-                    scope,
-                    offset: call_u32 - anchor_u32,
-                    spec,
-                }
-            }
+            None => DynamicEnumAnchor::ScopeOffset {
+                scope: self.scope(),
+                offset: self.dynamic_class_scope_offset(call_expr),
+                spec,
+            },
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -381,18 +381,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
             },
             None => {
-                let call_node_index = call_expr.node_index.load();
                 let scope = self.scope();
-                let scope_anchor = scope
-                    .node(db)
-                    .node_index()
-                    .unwrap_or(ast::NodeIndex::from(0));
-                let anchor_u32 = scope_anchor
-                    .as_u32()
-                    .expect("scope anchor should not be NodeIndex::NONE");
-                let call_u32 = call_node_index
-                    .as_u32()
-                    .expect("call node should not be NodeIndex::NONE");
                 let spec = match kind {
                     NamedTupleKind::Collections => self.infer_collections_namedtuple_fields(
                         rename_type,
@@ -404,7 +393,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 };
                 DynamicNamedTupleAnchor::ScopeOffset {
                     scope,
-                    offset: call_u32 - anchor_u32,
+                    offset: self.dynamic_class_scope_offset(call_expr),
                     spec,
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -13,7 +13,7 @@ use crate::types::infer::builder::{
     },
 };
 use crate::types::{KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type};
-use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex};
+use ruff_python_ast as ast;
 use ty_python_core::definition::Definition;
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
@@ -111,15 +111,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             self.deferred.insert(def);
             DynamicClassAnchor::Definition(def)
         } else {
-            let call_node_index = call_expr.node_index().load();
-            let scope_anchor = scope.node(db).node_index().unwrap_or(NodeIndex::from(0));
-            let anchor_u32 = scope_anchor
-                .as_u32()
-                .expect("scope anchor should not be NodeIndex::NONE");
-            let call_u32 = call_node_index
-                .as_u32()
-                .expect("call node should not be NodeIndex::NONE");
-
             // Use [Unknown] as fallback if bases extraction failed (e.g., not a tuple).
             let anchor_bases = explicit_bases
                 .clone()
@@ -127,7 +118,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             DynamicClassAnchor::ScopeOffset {
                 scope,
-                offset: call_u32 - anchor_u32,
+                offset: self.dynamic_class_scope_offset(call_expr),
                 explicit_bases: anchor_bases,
             }
         };

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -12,7 +12,7 @@ use crate::types::infer::builder::{
     },
 };
 use crate::types::{KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type};
-use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex};
+use ruff_python_ast as ast;
 use ty_python_core::definition::Definition;
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
@@ -231,22 +231,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // Create the anchor for identifying this dynamic class.
         // - For assigned `type()` calls, the Definition uniquely identifies the class,
         //   and bases inference is deferred.
-        // - For dangling calls, compute a relative offset from the scope's node index,
+        // - For dangling calls, locate the call relative to the enclosing scope,
         //   and store the explicit bases directly (since they were inferred eagerly).
         let anchor = if let Some(def) = definition {
             // Register for deferred inference to infer bases and validate later.
             self.deferred.insert(def);
             DynamicClassAnchor::Definition(def)
         } else {
-            let call_node_index = call_expr.node_index().load();
-            let scope_anchor = scope.node(db).node_index().unwrap_or(NodeIndex::from(0));
-            let anchor_u32 = scope_anchor
-                .as_u32()
-                .expect("scope anchor should not be NodeIndex::NONE");
-            let call_u32 = call_node_index
-                .as_u32()
-                .expect("call node should not be NodeIndex::NONE");
-
             // Use [Unknown] as fallback if bases extraction failed (e.g., not a tuple).
             let anchor_bases = explicit_bases
                 .clone()
@@ -254,7 +245,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             DynamicClassAnchor::ScopeOffset {
                 scope,
-                offset: call_u32 - anchor_u32,
+                offset: self.dynamic_class_scope_offset(call_expr),
                 explicit_bases: anchor_bases,
             }
         };

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -331,19 +331,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let anchor = match definition {
             Some(definition) => DynamicTypedDictAnchor::Definition(definition),
             None => {
-                let call_node_index = call_expr.node_index.load();
-                let scope_anchor = scope.node(db).node_index().unwrap_or(NodeIndex::from(0));
-                let anchor_u32 = scope_anchor
-                    .as_u32()
-                    .expect("scope anchor should not be NodeIndex::NONE");
-                let call_u32 = call_node_index
-                    .as_u32()
-                    .expect("call node should not be NodeIndex::NONE");
                 let schema = self.infer_dangling_typeddict_spec(fields_arg, total);
 
                 DynamicTypedDictAnchor::ScopeOffset {
                     scope,
-                    offset: call_u32 - anchor_u32,
+                    offset: self.dynamic_class_scope_offset(call_expr),
                     schema,
                     openness: extra_items.unwrap_or(if closed {
                         TypedDictOpenness::Closed


### PR DESCRIPTION
## Summary

Previously, creating a dynamic class inside a string annotation could panic because the call's AST node belongs to a separately parsed annotation rather than the enclosing module:

```python
from types import new_class
from typing import Annotated


def example(
    first: "Annotated[int, type('First', (), {})]",
    second: "Annotated[int, new_class('Second', ())]",
) -> None: ...
```

Dynamic classes normally retain a scope-relative AST node index as their identity. For calls parsed from string annotations, that index was missing or later resolved against the wrong AST.

We now anchor those calls to the enclosing string expression and record the call's relative source range. This preserves distinct class identities, points diagnostics at the actual call, and handles nested annotations without retaining absolute source positions.

Supersedes https://github.com/astral-sh/ruff/pull/27851.
