### PR TITLE
[ty] Dogfood standalone scripts with inline configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -390,6 +390,13 @@ jobs:
         run: uv run --quiet --project=./python/py-fuzzer cargo run --quiet -p ty check --project=./python/py-fuzzer --color=always
       - name: Dogfood ty on ty_benchmark
         run: uv run --quiet --project=./scripts/ty_benchmark cargo run --quiet -p ty check --project=./scripts/ty_benchmark --color=always
+      - name: Dogfood ty on scripts
+        run: |
+          for script in scripts/*.py; do
+            echo "Checking $script"
+            uv sync --quiet --locked --script "$script"
+            cargo run --quiet -p ty check "$script" --python "$(uv python find --script "$script")" --color=always
+          done
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:

--- a/scripts/add_plugin.py
+++ b/scripts/add_plugin.py
@@ -4,6 +4,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -4,6 +4,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/build_ruff_pgo.py
+++ b/scripts/build_ruff_pgo.py
@@ -4,6 +4,15 @@
 # requires-python = ">=3.11"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/bump-workspace-crate-versions.py
+++ b/scripts/bump-workspace-crate-versions.py
@@ -9,6 +9,15 @@
 # requires-python = ">=3.13"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -4,6 +4,15 @@
 # requires-python = ">=3.12"
 # dependencies = ["ruff"]
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/collect_ty_ecosystem_run_metadata.py
+++ b/scripts/collect_ty_ecosystem_run_metadata.py
@@ -4,6 +4,15 @@
 # requires-python = ">=3.11"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///
@@ -70,7 +79,9 @@ def optional_value(log: str, pattern: str, label: str) -> str | None:
     if len(values) > 1:
         rendered = ", ".join(sorted(values))
         raise MetadataError(f"found conflicting {label} values: {rendered}")
-    return values.pop()
+    ret = values.pop()
+    assert isinstance(ret, str)
+    return ret
 
 
 def unique_value(log: str, pattern: str, label: str) -> str:
@@ -131,12 +142,10 @@ def parse_minimum_python(source: str) -> tuple[int, int]:
         ):
             continue
         value = ast.literal_eval(node.value)
-        if (
-            isinstance(value, tuple)
-            and len(value) == 2
-            and all(isinstance(part, int) for part in value)
-        ):
-            return value
+        if isinstance(value, tuple) and len(value) == 2:
+            major, minor = value
+            if isinstance(major, int) and isinstance(minor, int):
+                return (major, minor)
         break
     raise MetadataError("could not parse ecosystem-analyzer MINIMUM_PYTHON_VERSION")
 

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///
@@ -255,7 +264,7 @@ class ExpectedError:
 def diagnostics_are_equivalent(a: list[TyDiagnostic], b: list[TyDiagnostic]) -> bool:
     """Compare two diagnostic lists for equality, ignoring the ``source`` field."""
 
-    def fingerprint(d: TyDiagnostic) -> tuple:
+    def fingerprint(d: TyDiagnostic) -> tuple[str, str, str, str, int, int]:
         return (
             d.check_name,
             d.description,

--- a/scripts/ecosystem_all_check.py
+++ b/scripts/ecosystem_all_check.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = ["tqdm"]
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/generate-crate-readmes.py
+++ b/scripts/generate-crate-readmes.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.13"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/generate_builtin_modules.py
+++ b/scripts/generate_builtin_modules.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/generate_known_standard_library.py
+++ b/scripts/generate_known_standard_library.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = ["stdlibs"]
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -6,6 +6,15 @@
 #     "pyyaml>=6.0.3",
 # ]
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/memory_report.py
+++ b/scripts/memory_report.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///
@@ -131,7 +140,9 @@ def load_reports_from_directory(directory: Path) -> dict[str, MemoryReport]:
 
 def item_total_bytes(item: dict[str, Any]) -> int:
     """Get total bytes (metadata + fields) for a struct or query item."""
-    return item.get("metadata_bytes", 0) + item.get("fields_bytes", 0)
+    result = item.get("metadata_bytes", 0) + item.get("fields_bytes", 0)
+    assert isinstance(result, int)
+    return result
 
 
 def diff_items(
@@ -141,8 +152,8 @@ def diff_items(
 
     Returns a list of (name, old_bytes, new_bytes) sorted by absolute diff descending.
     """
-    old_by_name = {item["name"]: item for item in old_items}
-    new_by_name = {item["name"]: item for item in new_items}
+    old_by_name: dict[str, dict[str, Any]] = {item["name"]: item for item in old_items}
+    new_by_name: dict[str, dict[str, Any]] = {item["name"]: item for item in new_items}
 
     all_names = old_by_name.keys() | new_by_name.keys()
 

--- a/scripts/publish-crates.py
+++ b/scripts/publish-crates.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/setup-crates-io-publish.py
+++ b/scripts/setup-crates-io-publish.py
@@ -21,6 +21,15 @@
 # requires-python = ">=3.13"
 # dependencies = ["httpx"]
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///
@@ -36,6 +45,7 @@ import sys
 import tempfile
 import time
 import tomllib
+from typing import TypeGuard
 
 import httpx
 
@@ -103,6 +113,11 @@ def save_known_crates(crates: set[str]) -> None:
     KNOWN_CRATES_PATH.write_text("".join(lines))
 
 
+def is_str_keyed_dict(obj: object) -> TypeGuard[dict[str, object]]:
+    """Return True if *obj* is a dict with string keys."""
+    return isinstance(obj, dict) and all(isinstance(k, str) for k in obj)
+
+
 def get_crate_metadata(
     client: httpx.Client, crate_name: str
 ) -> dict[str, object] | None:
@@ -111,14 +126,16 @@ def get_crate_metadata(
     if response.status_code == 404:
         return None
     response.raise_for_status()
-    return response.json()
+    json = response.json()
+    assert is_str_keyed_dict(json)
+    return json
 
 
 def load_workspace_package_metadata() -> dict[str, object]:
     """Load shared package metadata from the workspace manifest."""
     manifest = tomllib.loads(WORKSPACE_MANIFEST_PATH.read_text())
     workspace_package = manifest.get("workspace", {}).get("package")
-    if not isinstance(workspace_package, dict):
+    if not is_str_keyed_dict(workspace_package):
         raise RuntimeError("workspace.package is missing from Cargo.toml")
     return workspace_package
 
@@ -208,6 +225,11 @@ def create_trusted_publisher(client: httpx.Client, crate_name: str) -> None:
     response.raise_for_status()
 
 
+def is_list_of_str_keyed_dicts(obj: object) -> TypeGuard[list[dict[str, object]]]:
+    """Return True if *obj* is a list of dicts with string keys."""
+    return isinstance(obj, list) and all(is_str_keyed_dict(item) for item in obj)
+
+
 def list_trusted_publishers(
     client: httpx.Client, crate_name: str
 ) -> list[dict[str, object]]:
@@ -218,7 +240,9 @@ def list_trusted_publishers(
     )
     response.raise_for_status()
     payload = response.json()
-    return payload.get("github_configs", [])
+    publishers = payload.get("github_configs", [])
+    assert is_list_of_str_keyed_dicts(publishers)
+    return publishers
 
 
 def delete_trusted_publisher(client: httpx.Client, config_id: int) -> None:

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -4,6 +4,15 @@
 # requires-python = ">=3.11"
 # dependencies = ["mypy-primer"]
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # # This is the default for ad hoc use. Historical ecosystem reproduction must
 # # bypass the adjacent lock and select ecosystem-analyzer's exact mypy-primer

--- a/scripts/transform_readme.py
+++ b/scripts/transform_readme.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///

--- a/scripts/ty.toml
+++ b/scripts/ty.toml
@@ -1,4 +1,0 @@
-[rules]
-division-by-zero = "error"
-possibly-unresolved-reference = "error"
-unused-ignore-comment = "error"

--- a/scripts/update_ambiguous_characters.py
+++ b/scripts/update_ambiguous_characters.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///
@@ -30,7 +39,7 @@ pub(crate) fn confusable(c: u32) -> Option<char> {
 postlude = """_ => return None, }; Some(result)}"""
 
 
-def get_mapping_data() -> dict:
+def get_mapping_data() -> dict[str, list[int]]:
     """
     Get the ambiguous character mapping data from the vscode-unicode-data repository.
 
@@ -42,7 +51,8 @@ def get_mapping_data() -> dict:
         encoding="utf-8",
     )
     # The content is a JSON object literal wrapped in a JSON string, so double decode:
-    return json.loads(json.loads(content))
+    mapping_data: dict[str, list[int]] = json.loads(json.loads(content))
+    return mapping_data
 
 
 def format_number(number: int) -> str:

--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -2,6 +2,15 @@
 # requires-python = ">=3.12"
 # dependencies = []
 #
+# [tool.ty.rules]
+# blanket-ignore-comment = "warn"
+# missing-type-argument = "warn"
+# possibly-unresolved-reference = "warn"
+# unsound-return-statement = "warn"
+# unsound-yield = "warn"
+# unsupported-dynamic-base = "warn"
+# division-by-zero = "warn"
+#
 # [tool.uv]
 # exclude-newer = "P7D"
 # ///


### PR DESCRIPTION
## Summary

- Move ty configuration into every PEP 723 script and remove the obsolete `scripts/ty.toml`.
- Fix diagnostics surfaced by the stricter script settings, including missing type arguments and unsound return values.
- Check every script in CI with the ty binary built from the current Ruff checkout and the script's own locked Python environment.