### PR TITLE
[ty] Use invalid-type-form for non-generic class annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -171,7 +171,7 @@ reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTyp
 ## Specializing classes with unavailable generic context
 
 When an earlier error prevents ty from determining a class's generic context, specializing the class
-can emit a cascading `not-subscriptable` diagnostic.
+can emit a cascading `invalid-type-form` diagnostic.
 
 ### Conditional typing compatibility imports
 
@@ -192,7 +192,7 @@ T = typing.TypeVar("T")
 class Parser(typing.Generic[T]): ...
 
 # TODO: Remove this cascading error when https://github.com/astral-sh/ty/issues/1585 is fixed.
-parser: Parser[int]  # error: [not-subscriptable] "Cannot subscript non-generic type `<class 'Parser'>`"
+parser: Parser[int]  # error: [invalid-type-form] "Non-generic class `Parser` cannot be specialized in a type expression"
 ```
 
 ### Decorated generic bases
@@ -218,7 +218,7 @@ reveal_type(generic_context(Mapping))  # revealed: None
 class FrozenDict(Mapping[K, V]): ...
 
 # TODO: ...which then causes us to emit this
-# error: [not-subscriptable] "Cannot subscript non-generic type `<class 'FrozenDict'>`"
+# error: [invalid-type-form] "Non-generic class `FrozenDict` cannot be specialized in a type expression"
 mapping: FrozenDict[str, int]
 ```
 
@@ -235,7 +235,7 @@ T = TypeVar("T")
 
 class Child(Base[T]): ...
 
-# error: [not-subscriptable] "Cannot subscript non-generic type `<class 'Child'>`"
+# error: [invalid-type-form] "Non-generic class `Child` cannot be specialized in a type expression"
 child: Child[int]
 ```
 
@@ -274,7 +274,7 @@ T = TypeVar("T")
 # error: [unsupported-base]
 class Child(Base[T]): ...
 
-# error: [not-subscriptable] "Cannot subscript non-generic type `<class 'Child'>`"
+# error: [invalid-type-form] "Non-generic class `Child` cannot be specialized in a type expression"
 child: Child[int]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -152,7 +152,7 @@ class LegacyDict(TypedDict[T]):
     # error: [unbound-type-variable]
     x: T
 
-# error: [not-subscriptable] "Cannot subscript non-generic type `<class 'LegacyDict'>`"
+# error: [invalid-type-form] "Non-generic class `LegacyDict` cannot be specialized in a type expression"
 type LegacyDictInt = LegacyDict[int]
 
 # error: [not-subscriptable] "Cannot specialize non-generic type alias `LegacyDictInt`"

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -1043,7 +1043,7 @@ recovers to `Unknown`.
 ```py
 class NonGeneric: ...
 
-# error: [not-subscriptable] "Cannot subscript non-generic type `<class 'NonGeneric'>`"
+# error: [invalid-type-form] "Non-generic class `NonGeneric` cannot be specialized in a type expression"
 def direct(value: NonGeneric[int]) -> None:
     reveal_type(value)  # revealed: Unknown
 ```
@@ -1051,7 +1051,7 @@ def direct(value: NonGeneric[int]) -> None:
 The same diagnostic applies when the specialization is nested inside `type[...]`.
 
 ```py
-# error: [not-subscriptable] "Cannot subscript non-generic type `<class 'NonGeneric'>`"
+# error: [invalid-type-form] "Non-generic class `NonGeneric` cannot be specialized in a type expression"
 def nested(value: type[NonGeneric[int]]) -> None:
     reveal_type(value)  # revealed: Unknown
 ```
@@ -1064,12 +1064,88 @@ class Child(NonGeneric): ...
 class Generic[T, U = str]: ...
 class SpecializedChild(Generic[int]): ...
 
-# error: [not-subscriptable] "Cannot subscript non-generic type `<class 'Child'>`"
+# error: [invalid-type-form] "Non-generic class `Child` cannot be specialized in a type expression"
 def child(value: Child[str]) -> None:
     reveal_type(value)  # revealed: Unknown
 
-# error: [not-subscriptable] "Cannot subscript non-generic type `<class 'SpecializedChild'>`"
+# error: [invalid-type-form] "Non-generic class `SpecializedChild` cannot be specialized in a type expression"
 def specialized_child(value: SpecializedChild[bytes]) -> None:
+    reveal_type(value)  # revealed: Unknown
+```
+
+## Custom class subscriptions in type expressions
+
+Defining `__class_getitem__` makes a class subscriptable at runtime, but does not make it generic.
+Its return type is used for value expressions, not for interpreting type expressions.
+
+```py
+class U:
+    def __class_getitem__(cls, value: int) -> "type[U]":
+        return U
+
+reveal_type(U[0])  # revealed: type[U]
+reveal_type(U.__class_getitem__(0))  # revealed: type[U]
+
+# snapshot: invalid-type-form
+def direct(value: U[0]) -> None:
+    reveal_type(value)  # revealed: Unknown
+
+# error: [invalid-type-form] "Non-generic class `U` cannot be specialized in a type expression"
+def nested(value: type[U[0]]) -> None:
+    reveal_type(value)  # revealed: Unknown
+```
+
+```snapshot
+error[invalid-type-form]: Non-generic class `U` cannot be specialized in a type expression
+ --> src/mdtest_snippet.py:9:19
+  |
+9 | def direct(value: U[0]) -> None:
+  |                   ^^^^
+info: See the following page for a reference on valid type expressions:
+info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotation-expressions
+```
+
+## Custom class subscriptions with future annotations
+
+Postponing annotation evaluation does not make a non-generic class a valid generic type. The error
+concerns the type expression, not runtime subscription.
+
+```py
+from __future__ import annotations
+
+class U:
+    def __class_getitem__(cls, value: int) -> type[U]:
+        return U
+
+# error: [invalid-type-form]
+def direct(value: U[0]) -> None:
+    reveal_type(value)  # revealed: Unknown
+
+# error: [invalid-type-form]
+def nested(value: type[U[0]]) -> None:
+    reveal_type(value)  # revealed: Unknown
+```
+
+## Custom class subscriptions with Python 3.14 annotations
+
+The same type-expression error applies when Python defers annotation evaluation by default.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+class U:
+    def __class_getitem__(cls, value: int) -> type[U]:
+        return U
+
+# error: [invalid-type-form]
+def direct(value: U[0]) -> None:
+    reveal_type(value)  # revealed: Unknown
+
+# error: [invalid-type-form]
+def nested(value: type[U[0]]) -> None:
     reveal_type(value)  # revealed: Unknown
 ```
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1357,14 +1357,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 }
                                 None => {
                                     self.infer_expression(parameters, TypeContext::default());
-                                    if let Some(builder) =
-                                        self.context.report_lint(&NOT_SUBSCRIPTABLE, subscript)
-                                    {
-                                        builder.into_diagnostic(format_args!(
-                                            "Cannot subscript non-generic type `{}`",
-                                            value_ty.display(db, self.program_environment())
-                                        ));
-                                    }
+                                    self.report_invalid_type_expression(
+                                        subscript,
+                                        format_args!(
+                                            "Non-generic class `{}` cannot be specialized in a type expression",
+                                            class_literal.name(db)
+                                        ),
+                                    );
                                     Type::unknown()
                                 }
                             }
@@ -1808,14 +1807,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     _ => {
                         self.infer_expression(slice, TypeContext::default());
-                        if let Some(builder) =
-                            self.context.report_lint(&NOT_SUBSCRIPTABLE, subscript)
-                        {
-                            builder.into_diagnostic(format_args!(
-                                "Cannot subscript non-generic type `{}`",
-                                value_ty.display(db, self.program_environment())
-                            ));
-                        }
+                        self.report_invalid_type_expression(
+                            subscript,
+                            format_args!(
+                                "Non-generic class `{}` cannot be specialized in a type expression",
+                                class.name(db)
+                            ),
+                        );
                         Type::unknown()
                     }
                 }


### PR DESCRIPTION
## Summary

Specializing a non-generic class in a type expression currently emits `not-subscriptable`, even when the class defines `__class_getitem__` and subscription works at runtime. Report `invalid-type-form` instead, explaining that the class cannot be specialized in a type expression and linking to the typing specification.

Apply the correction both to direct annotations and to specializations nested inside `type[...]`. Keep `Unknown` recovery and runtime subscription behavior unchanged.

Existing suppressions of `not-subscriptable` no longer suppress these type-form errors; projects that intentionally ignore them can suppress `invalid-type-form` instead.

Fixes https://github.com/astral-sh/ty/issues/4331.

## Test plan

Update the existing non-generic-class expectations. Add mdtests covering custom `__class_getitem__` in value expressions, direct and nested type annotations, future annotations, Python 3.14's deferred annotations, and the full diagnostic output.
