### PR TITLE
[ty] Fix dynamic-class diagnostic snapshot in string annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -983,28 +983,29 @@ bases: tuple[type[C], type[D]] = (C, D)
 Y = type("Y", bases, {})
 ```
 
-Inside a string annotation, the diagnostic still highlights the class-creation call, not the whole
-string:
+When a class is created in the metadata of a string annotation, the diagnostic still highlights the
+class-creation call, not the whole string:
 
 ```py
-# error: [invalid-type-form] "Only simple names and dotted names can be subscripted in type expressions"
+from typing import Annotated
+
 # snapshot: instance-layout-conflict
-bad: "type('Bad', (A, B), {})[int]"
+bad: "Annotated[int, type('Bad', (A, B), {})]"
 ```
 
 ```snapshot
 error[instance-layout-conflict]: Class will raise `TypeError` at runtime due to incompatible bases
-  --> src/mdtest_snippet.py:20:7
+  --> src/mdtest_snippet.py:21:22
    |
-20 | bad: "type('Bad', (A, B), {})[int]"
-   |       ^^^^^^^^^^^^^^^^^^^^^^^ Bases `A` and `B` cannot be combined in multiple inheritance
+21 | bad: "Annotated[int, type('Bad', (A, B), {})]"
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^ Bases `A` and `B` cannot be combined in multiple inheritance
 info: Two classes cannot coexist in a class's MRO if their instances have incompatible memory layouts
-  --> src/mdtest_snippet.py:20:20
+  --> src/mdtest_snippet.py:21:35
    |
-20 | bad: "type('Bad', (A, B), {})[int]"
-   |                    -  - `B` instances have a distinct memory layout because `B` defines non-empty `__slots__`
-   |                    |
-   |                    `A` instances have a distinct memory layout because `A` defines non-empty `__slots__`
+21 | bad: "Annotated[int, type('Bad', (A, B), {})]"
+   |                                   -  - `B` instances have a distinct memory layout because `B` defines non-empty `__slots__`
+   |                                   |
+   |                                   `A` instances have a distinct memory layout because `A` defines non-empty `__slots__`
 ```
 
 ## Cyclic functional class definitions


### PR DESCRIPTION
## Summary

Fix the `main` CI failure caused by the interaction between #27883 and #27882.

#27883 added a regression test expecting an `instance-layout-conflict` diagnostic from a dynamic-class call inside an invalid string-annotation subscript. #27882 intentionally stopped evaluating invalid subscript operands in string annotations, so the diagnostic disappeared and the snapshot assertion began failing.

Move the dynamic-class call into valid `Annotated[int, type(...)]` metadata and update the diagnostic snapshot.

## Why the test still serves its original purpose

The original test verifies that a diagnostic from dynamic-class creation inside a separately parsed string annotation highlights the actual `type(...)` call and its incompatible bases, rather than the entire annotation. The revised test exercises the same string-annotation anchoring and source-range handling, and still snapshots both precise diagnostic locations. Its `Annotated[...]` form also matches the reproducer in #27883's original PR description.

The revised test no longer expects an additional `invalid-type-form` diagnostic, because the annotation is now valid. The rule that invalid string-annotation operands must not be evaluated remains covered separately in `annotations/invalid.md`.