### PR TITLE
Rename `RuleGroup` to `RuleStatus`

### DIFF
--- a/crates/ruff/src/commands/rule.rs
+++ b/crates/ruff/src/commands/rule.rs
@@ -7,7 +7,7 @@ use serde::{Serialize, Serializer};
 use strum::IntoEnumIterator;
 
 use ruff_linter::FixAvailability;
-use ruff_linter::codes::RuleGroup;
+use ruff_linter::codes::RuleStatus;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 
 use crate::args::HelpFormat;
@@ -24,7 +24,7 @@ struct Explanation<'a> {
     #[expect(clippy::struct_field_names)]
     explanation: Option<&'a str>,
     preview: bool,
-    status: RuleGroup,
+    status: RuleStatus,
     source_location: SourceLocation,
 }
 

--- a/crates/ruff/src/commands/rule.rs
+++ b/crates/ruff/src/commands/rule.rs
@@ -43,7 +43,7 @@ impl<'a> Explanation<'a> {
             fix_availability: rule.fixable(),
             explanation: rule.explanation(),
             preview: rule.is_preview(),
-            status: rule.group(),
+            status: rule.status(),
             source_location: SourceLocation {
                 file: rule.file(),
                 line: rule.line(),

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use itertools::Itertools;
 use regex::{Captures, Regex};
-use ruff_linter::codes::RuleGroup;
+use ruff_linter::codes::RuleStatus;
 use strum::IntoEnumIterator;
 
 use ruff_linter::FixAvailability;
@@ -33,22 +33,22 @@ pub(crate) fn main(args: &Args) -> Result<()> {
             let _ = writeln!(&mut output, "# {} ({})", rule.name(), rule.noqa_code());
 
             let status_text = match rule.group() {
-                RuleGroup::Stable { since } => {
+                RuleStatus::Stable { since } => {
                     format!(
                         r#"Added in <a href="https://github.com/astral-sh/ruff/releases/tag/{since}">{since}</a>"#
                     )
                 }
-                RuleGroup::Preview { since } => {
+                RuleStatus::Preview { since } => {
                     format!(
                         r#"Preview (since <a href="https://github.com/astral-sh/ruff/releases/tag/{since}">{since}</a>)"#
                     )
                 }
-                RuleGroup::Deprecated { since } => {
+                RuleStatus::Deprecated { since } => {
                     format!(
                         r#"Deprecated (since <a href="https://github.com/astral-sh/ruff/releases/tag/{since}">{since}</a>)"#
                     )
                 }
-                RuleGroup::Removed { since } => {
+                RuleStatus::Removed { since } => {
                     format!(
                         r#"Removed (since <a href="https://github.com/astral-sh/ruff/releases/tag/{since}">{since}</a>)"#
                     )

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -32,7 +32,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
 
             let _ = writeln!(&mut output, "# {} ({})", rule.name(), rule.noqa_code());
 
-            let status_text = match rule.group() {
+            let status_text = match rule.status() {
                 RuleStatus::Stable { since } => {
                     format!(
                         r#"Added in <a href="https://github.com/astral-sh/ruff/releases/tag/{since}">{since}</a>"#

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -39,7 +39,7 @@ fn generate_table(
     table_out.push_str("| ---- | ---- | ------- | -: |");
     table_out.push('\n');
     for rule in rules {
-        let status_token = match rule.group() {
+        let status_token = match rule.status() {
             RuleStatus::Removed { since } => {
                 format!(
                     "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule was removed in {since}'>{REMOVED_SYMBOL}</span><span class='sr-only'>Rule was removed in {since}</span>"

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -3,7 +3,7 @@
 //! Used for <https://docs.astral.sh/ruff/rules/>.
 
 use itertools::Itertools;
-use ruff_linter::codes::RuleGroup;
+use ruff_linter::codes::RuleStatus;
 use std::borrow::Cow;
 use std::fmt::Write;
 use strum::IntoEnumIterator;
@@ -40,22 +40,22 @@ fn generate_table(
     table_out.push('\n');
     for rule in rules {
         let status_token = match rule.group() {
-            RuleGroup::Removed { since } => {
+            RuleStatus::Removed { since } => {
                 format!(
                     "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule was removed in {since}'>{REMOVED_SYMBOL}</span><span class='sr-only'>Rule was removed in {since}</span>"
                 )
             }
-            RuleGroup::Deprecated { since } => {
+            RuleStatus::Deprecated { since } => {
                 format!(
                     "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule has been deprecated since {since}'>{WARNING_SYMBOL}</span><span class='sr-only'>Rule has been deprecated since {since}</span>"
                 )
             }
-            RuleGroup::Preview { since } => {
+            RuleStatus::Preview { since } => {
                 format!(
                     "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule has been in preview since {since}'>{PREVIEW_SYMBOL}</span><span class='sr-only'>Rule has been in preview since {since}</span>"
                 )
             }
-            RuleGroup::Stable { since } => {
+            RuleStatus::Stable { since } => {
                 format!(
                     "<span aria-hidden='true' {SYMBOL_STYLE} title='Rule has been stable since {since}'></span><span class='sr-only'>Rule has been stable since {since}</span>"
                 )

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -79,7 +79,7 @@ impl serde::Serialize for NoqaCode {
 }
 
 #[derive(Debug, Copy, Clone, Serialize)]
-pub enum RuleGroup {
+pub enum RuleStatus {
     /// The rule is stable since the provided Ruff version.
     Stable { since: &'static str },
     /// The rule has been unstable since the provided Ruff version, and preview mode must be enabled
@@ -93,7 +93,7 @@ pub enum RuleGroup {
 }
 
 #[ruff_macros::map_codes]
-pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
+pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleStatus, Rule)> {
     #[expect(clippy::enum_glob_use)]
     use Linter::*;
 

--- a/crates/ruff_linter/src/rule_redirects.rs
+++ b/crates/ruff_linter/src/rule_redirects.rs
@@ -140,7 +140,7 @@ static REDIRECTS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(
 
 #[cfg(test)]
 mod tests {
-    use crate::codes::{Rule, RuleGroup};
+    use crate::codes::{Rule, RuleStatus};
     use crate::rule_redirects::REDIRECTS;
     use strum::IntoEnumIterator;
 
@@ -150,7 +150,7 @@ mod tests {
         for rule in Rule::iter() {
             let (code, group) = (rule.noqa_code(), rule.group());
 
-            if matches!(group, RuleGroup::Removed { .. }) {
+            if matches!(group, RuleStatus::Removed { .. }) {
                 continue;
             }
 

--- a/crates/ruff_linter/src/rule_redirects.rs
+++ b/crates/ruff_linter/src/rule_redirects.rs
@@ -148,9 +148,9 @@ mod tests {
     #[test]
     fn overshadowing_redirects() {
         for rule in Rule::iter() {
-            let (code, group) = (rule.noqa_code(), rule.group());
+            let (code, status) = (rule.noqa_code(), rule.status());
 
-            if matches!(group, RuleStatus::Removed { .. }) {
+            if matches!(status, RuleStatus::Removed { .. }) {
                 continue;
             }
 

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -257,7 +257,7 @@ impl RuleSelector {
 }
 
 impl RuleSelector {
-    /// Return all matching rules, regardless of rule group filters like preview and deprecated.
+    /// Return all matching rules, regardless of rule status filters like preview and deprecated.
     pub fn all_rules(&self) -> impl Iterator<Item = Rule> + use<> {
         match self {
             RuleSelector::All => RuleSelectorIter::All(Rule::iter()),
@@ -278,13 +278,13 @@ impl RuleSelector {
         }
     }
 
-    /// Returns rules matching the selector, taking into account rule groups like preview and deprecated.
+    /// Returns rules matching the selector, taking into account rule statuses like preview and deprecated.
     pub fn rules<'a>(&'a self, preview: &PreviewOptions) -> impl Iterator<Item = Rule> + use<'a> {
         let preview_enabled = preview.mode.is_enabled();
         let preview_require_explicit = preview.require_explicit;
 
         self.all_rules().filter(move |rule| {
-            match rule.group() {
+            match rule.status() {
                 // Always include stable rules
                 RuleStatus::Stable { .. } => true,
                 // Enabling preview includes all preview rules unless explicit selection is turned on

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -8,7 +8,7 @@ use strum_macros::EnumIter;
 use ruff_ranged_value::{RangedValue, ValueSource};
 
 use crate::codes::RuleIter;
-use crate::codes::{RuleCodePrefix, RuleGroup};
+use crate::codes::{RuleCodePrefix, RuleStatus};
 use crate::preview::is_human_readable_names_enabled;
 use crate::registry::{Linter, Rule, RuleNamespace};
 use crate::rule_redirects::get_redirect;
@@ -286,15 +286,15 @@ impl RuleSelector {
         self.all_rules().filter(move |rule| {
             match rule.group() {
                 // Always include stable rules
-                RuleGroup::Stable { .. } => true,
+                RuleStatus::Stable { .. } => true,
                 // Enabling preview includes all preview rules unless explicit selection is turned on
-                RuleGroup::Preview { .. } => {
+                RuleStatus::Preview { .. } => {
                     preview_enabled && (self.is_exact() || !preview_require_explicit)
                 }
                 // Deprecated rules are excluded by default unless explicitly selected
-                RuleGroup::Deprecated { .. } => !preview_enabled && self.is_exact(),
+                RuleStatus::Deprecated { .. } => !preview_enabled && self.is_exact(),
                 // Removed rules are included if explicitly selected but will error downstream
-                RuleGroup::Removed { .. } => self.is_exact(),
+                RuleStatus::Removed { .. } => self.is_exact(),
             }
         })
     }

--- a/crates/ruff_linter/src/violation.rs
+++ b/crates/ruff_linter/src/violation.rs
@@ -7,7 +7,7 @@ use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 
 use crate::{
-    codes::{Rule, RuleGroup},
+    codes::{Rule, RuleStatus},
     message::create_lint_diagnostic,
 };
 
@@ -37,7 +37,7 @@ pub trait ViolationMetadata {
     fn explain() -> Option<&'static str>;
 
     /// Returns the rule group for this violation.
-    fn group() -> RuleGroup;
+    fn group() -> RuleStatus;
 
     /// Returns the file where the violation is declared.
     fn file() -> &'static str;

--- a/crates/ruff_linter/src/violation.rs
+++ b/crates/ruff_linter/src/violation.rs
@@ -36,8 +36,8 @@ pub trait ViolationMetadata {
     /// why it's bad, and what users should do instead.
     fn explain() -> Option<&'static str>;
 
-    /// Returns the rule group for this violation.
-    fn group() -> RuleStatus;
+    /// Returns the rule status for this violation.
+    fn status() -> RuleStatus;
 
     /// Returns the file where the violation is declared.
     fn file() -> &'static str;

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -58,8 +58,7 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
         ));
     };
 
-    // Map from: linter (e.g., `Flake8Bugbear`) to rule code (e.g.,`"002"`) to rule data (e.g.,
-    // `(Rule::UnaryPrefixIncrement, vec![])`).
+    // Map from: linter (e.g., `Flake8Bugbear`) to rule code (e.g.,`"002"`) to rule data.
     let mut linter_to_rules: BTreeMap<Ident, BTreeMap<String, Rule>> = BTreeMap::new();
 
     for arm in arms {

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -307,19 +307,19 @@ See also https://github.com/astral-sh/ruff/issues/2186.
             }
 
             pub fn is_preview(&self) -> bool {
-                matches!(self.group(), RuleStatus::Preview { .. })
+                matches!(self.status(), RuleStatus::Preview { .. })
             }
 
             pub(crate) fn is_stable(&self) -> bool {
-                matches!(self.group(), RuleStatus::Stable { .. })
+                matches!(self.status(), RuleStatus::Stable { .. })
             }
 
             pub fn is_deprecated(&self) -> bool {
-                matches!(self.group(), RuleStatus::Deprecated { .. })
+                matches!(self.status(), RuleStatus::Deprecated { .. })
             }
 
             pub fn is_removed(&self) -> bool {
-                matches!(self.group(), RuleStatus::Removed { .. })
+                matches!(self.status(), RuleStatus::Removed { .. })
             }
         }
 
@@ -394,7 +394,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
     let mut rule_message_formats_match_arms = quote!();
     let mut rule_fixable_match_arms = quote!();
     let mut rule_explanation_match_arms = quote!();
-    let mut rule_group_match_arms = quote!();
+    let mut rule_status_match_arms = quote!();
     let mut rule_file_match_arms = quote!();
     let mut rule_line_match_arms = quote!();
     let mut rule_parse_match_arms = quote!();
@@ -416,8 +416,8 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
             quote! {#(#attrs)* Self::#name => <#path as crate::Violation>::FIX_AVAILABILITY,},
         );
         rule_explanation_match_arms.extend(quote! {#(#attrs)* Self::#name => #path::explain(),});
-        rule_group_match_arms.extend(
-            quote! {#(#attrs)* Self::#name => <#path as crate::ViolationMetadata>::group(),},
+        rule_status_match_arms.extend(
+            quote! {#(#attrs)* Self::#name => <#path as crate::ViolationMetadata>::status(),},
         );
         rule_file_match_arms.extend(
             quote! {#(#attrs)* Self::#name => <#path as crate::ViolationMetadata>::file(),},
@@ -462,8 +462,8 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
                 match self { #rule_fixable_match_arms }
             }
 
-            pub fn group(&self) -> crate::codes::RuleStatus {
-                match self { #rule_group_match_arms }
+            pub fn status(&self) -> crate::codes::RuleStatus {
+                match self { #rule_status_match_arms }
             }
 
             pub fn file(&self) -> &'static str {

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// A rule entry in the big match statement such a
-/// `(Pycodestyle, "E112") => (RuleGroup::Preview, rules::pycodestyle::rules::logical_lines::NoIndentedBlock),`
+/// `(Pycodestyle, "E112") => (RuleStatus::Preview, rules::pycodestyle::rules::logical_lines::NoIndentedBlock),`
 #[derive(Clone)]
 struct Rule {
     /// The actual name of the rule, e.g., `NoIndentedBlock`.
@@ -59,7 +59,7 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
     };
 
     // Map from: linter (e.g., `Flake8Bugbear`) to rule code (e.g.,`"002"`) to rule data (e.g.,
-    // `(Rule::UnaryPrefixIncrement, RuleGroup::Stable, vec![])`).
+    // `(Rule::UnaryPrefixIncrement, RuleStatus::Stable, vec![])`).
     let mut linter_to_rules: BTreeMap<Ident, BTreeMap<String, Rule>> = BTreeMap::new();
 
     for arm in arms {
@@ -307,19 +307,19 @@ See also https://github.com/astral-sh/ruff/issues/2186.
             }
 
             pub fn is_preview(&self) -> bool {
-                matches!(self.group(), RuleGroup::Preview { .. })
+                matches!(self.group(), RuleStatus::Preview { .. })
             }
 
             pub(crate) fn is_stable(&self) -> bool {
-                matches!(self.group(), RuleGroup::Stable { .. })
+                matches!(self.group(), RuleStatus::Stable { .. })
             }
 
             pub fn is_deprecated(&self) -> bool {
-                matches!(self.group(), RuleGroup::Deprecated { .. })
+                matches!(self.group(), RuleStatus::Deprecated { .. })
             }
 
             pub fn is_removed(&self) -> bool {
-                matches!(self.group(), RuleGroup::Removed { .. })
+                matches!(self.group(), RuleStatus::Removed { .. })
             }
         }
 
@@ -462,7 +462,7 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
                 match self { #rule_fixable_match_arms }
             }
 
-            pub fn group(&self) -> crate::codes::RuleGroup {
+            pub fn group(&self) -> crate::codes::RuleStatus {
                 match self { #rule_group_match_arms }
             }
 

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// A rule entry in the big match statement such a
-/// `(Pycodestyle, "E112") => (RuleStatus::Preview, rules::pycodestyle::rules::logical_lines::NoIndentedBlock),`
+/// `(Pycodestyle, "E112") => rules::pycodestyle::rules::logical_lines::NoIndentedBlock,`
 #[derive(Clone)]
 struct Rule {
     /// The actual name of the rule, e.g., `NoIndentedBlock`.
@@ -59,7 +59,7 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
     };
 
     // Map from: linter (e.g., `Flake8Bugbear`) to rule code (e.g.,`"002"`) to rule data (e.g.,
-    // `(Rule::UnaryPrefixIncrement, RuleStatus::Stable, vec![])`).
+    // `(Rule::UnaryPrefixIncrement, vec![])`).
     let mut linter_to_rules: BTreeMap<Ident, BTreeMap<String, Rule>> = BTreeMap::new();
 
     for arm in arms {

--- a/crates/ruff_macros/src/violation_metadata.rs
+++ b/crates/ruff_macros/src/violation_metadata.rs
@@ -8,10 +8,10 @@ use syn::{Attribute, DeriveInput, Error, Lit, LitStr, Meta, meta::ParseNestedMet
 pub(crate) fn violation_metadata(input: DeriveInput) -> syn::Result<TokenStream> {
     let docs = get_docs(&input.attrs)?;
 
-    let Some(group) = get_rule_status(&input.attrs)? else {
+    let Some(status) = get_rule_status(&input.attrs)? else {
         return Err(Error::new_spanned(
             input,
-            "Missing required rule group metadata",
+            "Missing required rule status metadata",
         ));
     };
 
@@ -31,8 +31,8 @@ pub(crate) fn violation_metadata(input: DeriveInput) -> syn::Result<TokenStream>
                 Some(#docs)
             }
 
-            fn group() -> crate::codes::RuleStatus {
-                crate::codes::#group
+            fn status() -> crate::codes::RuleStatus {
+                crate::codes::#status
             }
 
             fn file() -> &'static str {
@@ -77,25 +77,25 @@ fn get_docs(attrs: &[Attribute]) -> syn::Result<String> {
 /// The result is returned as a `TokenStream` so that the version string literal can be combined
 /// with the proper `RuleStatus` variant, e.g. `RuleStatus::Stable` for `stable_since` above.
 fn get_rule_status(attrs: &[Attribute]) -> syn::Result<Option<TokenStream>> {
-    let mut group = None;
+    let mut status = None;
     for attr in attrs {
         if attr.path().is_ident("violation_metadata") {
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("stable_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleStatus::Stable { since: #lit }));
+                    status = Some(quote!(RuleStatus::Stable { since: #lit }));
                     return Ok(());
                 } else if meta.path.is_ident("preview_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleStatus::Preview { since: #lit }));
+                    status = Some(quote!(RuleStatus::Preview { since: #lit }));
                     return Ok(());
                 } else if meta.path.is_ident("deprecated_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleStatus::Deprecated { since: #lit }));
+                    status = Some(quote!(RuleStatus::Deprecated { since: #lit }));
                     return Ok(());
                 } else if meta.path.is_ident("removed_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleStatus::Removed { since: #lit }));
+                    status = Some(quote!(RuleStatus::Removed { since: #lit }));
                     return Ok(());
                 }
                 Err(Error::new_spanned(
@@ -105,7 +105,7 @@ fn get_rule_status(attrs: &[Attribute]) -> syn::Result<Option<TokenStream>> {
             })?;
         }
     }
-    Ok(group)
+    Ok(status)
 }
 
 fn parse_attr<'a, const LEN: usize>(

--- a/crates/ruff_macros/src/violation_metadata.rs
+++ b/crates/ruff_macros/src/violation_metadata.rs
@@ -31,7 +31,7 @@ pub(crate) fn violation_metadata(input: DeriveInput) -> syn::Result<TokenStream>
                 Some(#docs)
             }
 
-            fn group() -> crate::codes::RuleGroup {
+            fn group() -> crate::codes::RuleStatus {
                 crate::codes::#group
             }
 
@@ -75,7 +75,7 @@ fn get_docs(attrs: &[Attribute]) -> syn::Result<String> {
 /// ```
 ///
 /// The result is returned as a `TokenStream` so that the version string literal can be combined
-/// with the proper `RuleGroup` variant, e.g. `RuleGroup::Stable` for `stable_since` above.
+/// with the proper `RuleStatus` variant, e.g. `RuleStatus::Stable` for `stable_since` above.
 fn get_rule_status(attrs: &[Attribute]) -> syn::Result<Option<TokenStream>> {
     let mut group = None;
     for attr in attrs {
@@ -83,19 +83,19 @@ fn get_rule_status(attrs: &[Attribute]) -> syn::Result<Option<TokenStream>> {
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("stable_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleGroup::Stable { since: #lit }));
+                    group = Some(quote!(RuleStatus::Stable { since: #lit }));
                     return Ok(());
                 } else if meta.path.is_ident("preview_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleGroup::Preview { since: #lit }));
+                    group = Some(quote!(RuleStatus::Preview { since: #lit }));
                     return Ok(());
                 } else if meta.path.is_ident("deprecated_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleGroup::Deprecated { since: #lit }));
+                    group = Some(quote!(RuleStatus::Deprecated { since: #lit }));
                     return Ok(());
                 } else if meta.path.is_ident("removed_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleGroup::Removed { since: #lit }));
+                    group = Some(quote!(RuleStatus::Removed { since: #lit }));
                     return Ok(());
                 }
                 Err(Error::new_spanned(


### PR DESCRIPTION
Summary
--

Addresses https://github.com/astral-sh/ruff/pull/27666#discussion_r3801704517, where we want to
start using "group" to refer to secondary categories. This type is already referred to as `status`
in the user-facing JSON output, so this change aligns the internal type name with that usage.

Test Plan
--

Existing tests
