### PR TITLE
[ty] Update CodSpeed action to v5.0.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1143,7 +1143,7 @@ jobs:
         run: cargo codspeed build -m simulation -m memory --features "codspeed,ruff_instrumented" --profile profiling --no-default-features -p ruff_benchmark --bench formatter --bench lexer --bench linter --bench parser
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: "simulation,memory"
           run: cargo codspeed run
@@ -1255,7 +1255,7 @@ jobs:
         run: find target/codspeed -type f -exec chmod +x {} +
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: ${{ matrix.mode }}
           cycle-estimation: false
@@ -1360,7 +1360,7 @@ jobs:
         run: find target/codspeed -type f -exec chmod +x {} +
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         env:
           # enabling walltime flamegraphs adds ~6 minutes to the CI time, and they don't
           # appear to provide much useful insight for our walltime benchmarks right now


### PR DESCRIPTION
CodSpeed jobs have been failing or timing out while installing their instrumentation dependencies. Update all three CodSpeed action pins to v5.0.3, which bundles runner v5.0.2 and retries interrupted binary downloads, including interrupted response bodies.

This is an incremental reliability improvement, not a complete fix for the current apt-mirror stalls. CodSpeed has confirmed that broken cache detection causes unnecessary Valgrind/libc reinstalls; the separate fix in https://github.com/CodSpeedHQ/codspeed/pull/509 is not included in this release.

## Test plan

The existing Ruff instrumented, ty simulation/memory, and ty walltime benchmark jobs exercise the updated action. Local workflow validation, security checks, and formatting passed. No new mdtests are needed because this changes CI tooling only.
