### PR TITLE
[ty] Bound apt retries in instrumented CodSpeed jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1142,6 +1142,16 @@ jobs:
       - name: "Build benchmarks"
         run: cargo codspeed build -m simulation -m memory --features "codspeed,ruff_instrumented" --profile profiling --no-default-features -p ruff_benchmark --bench formatter --bench lexer --bench linter --bench parser
 
+      - name: "Configure apt mirror fallback"
+        run: |
+          # Let CodSpeed's dependency installation move past unhealthy mirrors quickly.
+          cat /etc/apt/apt-mirrors.txt
+          printf '%s\n' \
+            'Acquire::Retries "0";' \
+            'Acquire::http::Timeout "10";' \
+            'Acquire::https::Timeout "10";' \
+            | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
+
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
         with:
@@ -1253,6 +1263,17 @@ jobs:
       - name: "Restore binary permissions"
         # codspeed keeps changing the paths to the executable, so we have to be a bit more flexible
         run: find target/codspeed -type f -exec chmod +x {} +
+
+      - name: "Configure apt mirror fallback"
+        if: matrix.mode == 'simulation'
+        run: |
+          # Let CodSpeed's dependency installation move past unhealthy mirrors quickly.
+          cat /etc/apt/apt-mirrors.txt
+          printf '%s\n' \
+            'Acquire::Retries "0";' \
+            'Acquire::http::Timeout "10";' \
+            'Acquire::https::Timeout "10";' \
+            | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2


### PR DESCRIPTION
CodSpeed's dependency installation can stall on an unhealthy apt mirror. Apply the mitigation from https://github.com/astral-sh/uv/pull/21206 so apt gives up on failed downloads sooner and can reach its configured fallback mirrors.

Immediately before CodSpeed runs, disable apt download retries and set ten-second HTTP and HTTPS timeouts. Apply this to the Ruff instrumented job and the simulation entries in the ty instrumented matrix. Leave build-only, memory-only, and walltime jobs unchanged.

This does not change CodSpeed's cache detection. If every configured mirror is unavailable, installation may fail sooner rather than succeed.

## Test plan

No new mdtests are needed for this workflow-only change. Validate the workflow's formatting, schema, security checks, and shell syntax. CI exercises the Ruff instrumented job and ty simulation matrix with the new apt configuration.
