### PR TITLE
[ty] Relocate function for filtering down to "user-visible" definitions.

### DIFF
--- a/crates/ty_python_semantic/src/definition_resolution.rs
+++ b/crates/ty_python_semantic/src/definition_resolution.rs
@@ -1,0 +1,62 @@
+use std::collections::VecDeque;
+
+use rustc_hash::FxHashSet;
+use ty_python_core::definition::{Definition, DefinitionKind, NestedBindingExecution};
+use ty_python_core::semantic_index;
+
+use crate::{Db, FxIndexSet};
+
+/// Returns definitions that correspond to concrete locations in source code.
+///
+/// This result excludes synthetic definitions such as loop headers and nested
+/// bindings.
+///
+/// For eager synthetic bindings representing comprehension walruses, the
+/// concrete definitions they represent are returned instead:
+///
+/// ```python
+/// [(last := item) for item in items]
+/// print(last)  # Go to definition should select `last := item` above.
+/// ```
+///
+/// The binding for the use in `print` is synthetic, so follow it into the
+/// comprehension's end-of-scope bindings. Nested comprehensions can produce a
+/// chain of these proxies. Only follow sources that resolve to the same
+/// variable, so `global` and `nonlocal` writes do not become definitions of
+/// each other.
+pub(crate) fn source_backed_definitions<'db>(
+    db: &'db dyn Db,
+    definitions: impl IntoIterator<Item = Definition<'db>>,
+) -> FxIndexSet<Definition<'db>> {
+    let mut pending = definitions.into_iter().collect::<VecDeque<_>>();
+    let mut seen = FxHashSet::default();
+    let mut result = FxIndexSet::default();
+
+    while let Some(definition) = pending.pop_front() {
+        if !seen.insert(definition) {
+            continue;
+        }
+
+        match definition.kind(db) {
+            DefinitionKind::NestedBindings(nested) => {
+                let index = semantic_index(db, definition.program_file(db));
+                let sources = nested
+                    .visible_binding_sources(index, definition.file_scope(db))
+                    .flatten()
+                    .filter_map(|binding| binding.binding.definition());
+                // A lazy function proxy can lead to an eager comprehension proxy. Follow that
+                // proxy-only chain without exposing ordinary lazy nested assignments.
+                pending.extend(sources.filter(|source| {
+                    nested.execution == NestedBindingExecution::Eager
+                        || matches!(source.kind(db), DefinitionKind::NestedBindings(_))
+                }));
+            }
+            kind if kind.is_user_visible() => {
+                result.insert(definition);
+            }
+            _ => {}
+        }
+    }
+
+    result
+}

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -54,6 +54,7 @@ pub use types::{
 };
 
 mod db;
+mod definition_resolution;
 mod dunder_all;
 mod fixes;
 pub mod lint;

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1,6 +1,7 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 
 use crate::FxIndexSet;
+use crate::definition_resolution::source_backed_definitions;
 use crate::place::implicit_builtins_symbol_scope;
 use crate::reachability::is_range_reachable;
 use crate::types::call::bind::CheckTypesMode;
@@ -93,7 +94,7 @@ pub fn definitions_for_name<'db>(
         if is_global || is_nonlocal {
             // Assignments in a forwarding scope remain valid navigation targets, including eager
             // walrus bindings exported from comprehensions.
-            all_definitions.extend(user_visible_definitions(
+            all_definitions.extend(source_backed_definitions(
                 db,
                 use_def_map
                     .reachable_symbol_bindings(symbol_id)
@@ -121,7 +122,7 @@ pub fn definitions_for_name<'db>(
 
             if let Some(global_symbol_id) = global_place_table.symbol_id(name_str) {
                 let global_use_def_map = ty_python_core::use_def_map(db, global_scope_id);
-                all_definitions.extend(user_visible_definitions(
+                all_definitions.extend(source_backed_definitions(
                     db,
                     global_use_def_map
                         .reachable_symbol_bindings(global_symbol_id)
@@ -143,7 +144,7 @@ pub fn definitions_for_name<'db>(
         }
 
         // Get all definitions (both bindings and declarations) for this place
-        all_definitions.extend(user_visible_definitions(
+        all_definitions.extend(source_backed_definitions(
             db,
             use_def_map
                 .reachable_symbol_bindings(symbol_id)
@@ -1053,56 +1054,6 @@ fn collect_implementation_root_classes<'db>(
     }
 }
 
-/// Returns the user-visible definitions represented by a use-def binding.
-///
-/// Comprehension walruses are represented in the containing scope by synthetic eager bindings:
-///
-/// ```python
-/// [(last := item) for item in items]
-/// print(last)  # Go to definition should select `last := item` above.
-/// ```
-///
-/// The binding for the use in `print` is synthetic, so follow it into the comprehension's
-/// end-of-scope bindings. Nested comprehensions can produce a chain of these proxies. Only
-/// follow sources that resolve to the same variable, so `global` and `nonlocal` writes do not
-/// become definitions of each other.
-fn user_visible_definitions<'db>(
-    db: &'db dyn Db,
-    definitions: impl IntoIterator<Item = Definition<'db>>,
-) -> FxIndexSet<Definition<'db>> {
-    let mut pending = definitions.into_iter().collect::<VecDeque<_>>();
-    let mut seen = FxHashSet::default();
-    let mut result = FxIndexSet::default();
-
-    while let Some(definition) = pending.pop_front() {
-        if !seen.insert(definition) {
-            continue;
-        }
-
-        match definition.kind(db) {
-            DefinitionKind::NestedBindings(nested) => {
-                let index = semantic_index(db, definition.program_file(db));
-                let sources = nested
-                    .visible_binding_sources(index, definition.file_scope(db))
-                    .flatten()
-                    .filter_map(|binding| binding.binding.definition());
-                // A lazy function proxy can lead to an eager comprehension proxy. Follow that
-                // proxy-only chain without exposing ordinary lazy nested assignments.
-                pending.extend(sources.filter(|source| {
-                    nested.execution == NestedBindingExecution::Eager
-                        || matches!(source.kind(db), DefinitionKind::NestedBindings(_))
-                }));
-            }
-            kind if kind.is_user_visible() => {
-                result.insert(definition);
-            }
-            _ => {}
-        }
-    }
-
-    result
-}
-
 fn reachable_implementation_definitions<'db>(
     db: &'db dyn Db,
     definitions: impl IntoIterator<Item = Definition<'db>>,
@@ -1164,7 +1115,7 @@ fn resolve_reachable_definitions<'db>(
     symbol_name: &str,
     definitions: impl IntoIterator<Item = Definition<'db>>,
 ) -> Vec<ResolvedDefinition<'db>> {
-    user_visible_definitions(db, definitions)
+    source_backed_definitions(db, definitions)
         .into_iter()
         .flat_map(|definition| {
             resolve_definition(
@@ -2475,7 +2426,7 @@ mod resolve_definition {
             }
         }
 
-        super::user_visible_definitions(db, definitions)
+        super::source_backed_definitions(db, definitions)
             .into_iter()
             .collect()
     }

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -1,4 +1,5 @@
 use crate::Db;
+use crate::definition_resolution::source_backed_definitions;
 use crate::reachability::is_reachable;
 use crate::types::function::FunctionDecorators;
 use crate::types::infer::function_known_decorator_flags;
@@ -115,7 +116,7 @@ pub fn unused_bindings(db: &dyn Db, file: ProgramFile<'_>) -> Box<[UnusedBinding
             .definitions_with_usage()
             .filter_map(|(_, definition, is_used)| is_used.then_some(definition))
     });
-    let used_user_visible_definitions = super::user_visible_definitions(db, used_definitions);
+    let used_user_visible_definitions = source_backed_definitions(db, used_definitions);
 
     for scope_id in index.scope_ids() {
         let file_scope_id = scope_id.file_scope_id(db);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This moves and renames the `user_visible_definitions` function used to filter definitions down to those that are accessible to an end-user. The new location supports an [upcoming change](https://github.com/astral-sh/ruff/pull/27858) to introduce a more capable interface for resolving definitions for a value that does not depend on the IDE crate.

## Test Plan

This is a pure refactor that relies on existing tests.
<!-- How was it tested? -->
