### PR TITLE
[refurb] Mark FURB103 fix unsafe on type/mode mismatch

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB103_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB103_0.py
@@ -167,3 +167,32 @@ with open("tmp_path/pyproject.toml", "w") as f:
 # `open` accepts a file descriptor, but `Path` does not
 with open(3, "w") as f:
     f.write("test")
+
+
+# Annotation-based inference: `x` is known to be `str` from its parameter annotation,
+# even though it's not a literal.
+def annotated_str_arg(x: str):
+    # FURB103 (safe fix: `x` is known to be `str`)
+    with open("file.txt", "w") as f:
+        f.write(x)
+
+
+def annotated_bytes_arg(x: bytes):
+    # FURB103 (safe fix: `x` is known to be `bytes`)
+    with open("file.txt", "wb") as f:
+        f.write(x)
+
+
+def annotated_int_arg(x: int):
+    # FURB103 (unsafe fix: `x` is not a `str`)
+    with open("file.txt", "w") as f:
+        f.write(x)
+
+
+# The fix is still offered as safe here: `f"{1 / 0}"` is unambiguously a `str`. If it
+# raises before producing a value, it does so identically whether written via `write()`
+# on an already-open (and thus already-truncated) file, or as an argument being
+# constructed before `Path.write_text` is ever called, so this doesn't introduce the
+# truncation-ordering hazard the safety check above exists to catch.
+with open("file.txt", "w") as f:
+    f.write(f"{1 / 0}")

--- a/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
@@ -4,7 +4,8 @@ use ruff_python_ast::{
     self as ast, Expr, Stmt,
     visitor::{self, Visitor},
 };
-use ruff_python_semantic::analyze::type_inference::{PythonType, ResolvedPythonType};
+use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::analyze::typing;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -37,11 +38,10 @@ use crate::{FixAvailability, Locator, Violation};
 ///
 /// ## Fix Safety
 /// This rule's fix is marked as unsafe if the replacement would remove comments attached to the
-/// original expression, or if the type of the value passed to `write` isn't statically known to
-/// match the file's open mode (`str` for text mode, `bytes` for binary mode). In the latter case,
-/// `open(...)` truncates the file before `write` is ever called, so a call that raises `TypeError`
-/// because of a type mismatch still leaves the file empty; `Path.write_text`/`write_bytes` checks
-/// the type first, so the same mismatch leaves the file's original contents untouched instead.
+/// original expression, or if the value passed to `write` isn't statically known to be of the
+/// type required by the file's open mode (`str` for text mode, `bytes` for binary mode). Since
+/// `open(...)` truncates the file before `write` runs, a type mismatch behaves differently before
+/// and after the rewrite.
 ///
 /// ## References
 /// - [Python documentation: `Path.write_bytes`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.write_bytes)
@@ -238,29 +238,57 @@ fn generate_fix(
 
     let replacement = format!("{target}.{suggestion}");
 
-    // `open(..., "w")` truncates the file immediately, before `write()` is ever called. If
-    // `write()`'s argument turns out to be the wrong type for the mode, the original code raises
-    // a `TypeError` without writing anything, leaving the file's prior contents intact. The
-    // rewritten `Path.write_text`/`write_bytes` call performs the type check *before* opening
-    // (and thus truncating) the file, so the same mismatch leaves the file untouched instead.
-    // Only offer the fix as safe when the argument's type is statically known to match the mode.
-    let type_matches_mode = matches!(
-        (open.mode, ResolvedPythonType::from(content)),
-        (OpenMode::WriteText, ResolvedPythonType::Atom(PythonType::String))
-            | (OpenMode::WriteBytes, ResolvedPythonType::Atom(PythonType::Bytes))
-    );
+    // `open(..., "w")` truncates the file before `write()` runs, so a type mismatch leaves the
+    // original untouched under the rewritten form but empty under the original. Only safe when
+    // the argument's type is known to match the mode.
+    let type_matches_mode = content_type_matches_mode(content, open.mode, checker.semantic());
 
-    let applicability = if checker.comment_ranges().intersects(with_stmt.range())
-        || !type_matches_mode
-    {
-        Applicability::Unsafe
-    } else {
-        Applicability::Safe
-    };
+    let applicability =
+        if checker.comment_ranges().intersects(with_stmt.range()) || !type_matches_mode {
+            Applicability::Unsafe
+        } else {
+            Applicability::Safe
+        };
 
     Some(Fix::applicable_edits(
         Edit::range_replacement(replacement, with_stmt.range()),
         [import_edit],
         applicability,
     ))
+}
+
+/// Returns `true` if `content` is known to be a `str` for [`OpenMode::WriteText`], or `bytes`
+/// for [`OpenMode::WriteBytes`]. Uses the same annotation-based binding inference as other rules
+/// (e.g. `bad_str_strip_call`), not simple literal-expression evaluation, so it also recognizes
+/// e.g. a function parameter annotated `x: str`.
+fn content_type_matches_mode(content: &Expr, mode: OpenMode, semantic: &SemanticModel) -> bool {
+    let is_str_or_bytes = |is_str: bool, is_bytes: bool| match mode {
+        OpenMode::WriteText => is_str,
+        OpenMode::WriteBytes => is_bytes,
+        OpenMode::ReadText | OpenMode::ReadBytes => false,
+    };
+
+    match content {
+        Expr::StringLiteral(_) | Expr::FString(_) => is_str_or_bytes(true, false),
+        Expr::BytesLiteral(_) => is_str_or_bytes(false, true),
+        Expr::Name(name) => {
+            let Some(binding) = semantic.only_binding(name).map(|id| semantic.binding(id)) else {
+                return false;
+            };
+            is_str_or_bytes(
+                typing::is_string(binding, semantic),
+                typing::is_bytes(binding, semantic),
+            )
+        }
+        _ => {
+            let Some(binding_id) = semantic.lookup_attribute(content) else {
+                return false;
+            };
+            let binding = semantic.binding(binding_id);
+            is_str_or_bytes(
+                typing::is_string(binding, semantic),
+                typing::is_bytes(binding, semantic),
+            )
+        }
+    }
 }

--- a/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
@@ -4,12 +4,13 @@ use ruff_python_ast::{
     self as ast, Expr, Stmt,
     visitor::{self, Visitor},
 };
+use ruff_python_semantic::analyze::type_inference::{PythonType, ResolvedPythonType};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::fix::snippet::SourceCodeSnippet;
 use crate::importer::ImportRequest;
-use crate::rules::refurb::helpers::{FileOpen, OpenArgument, find_file_opens};
+use crate::rules::refurb::helpers::{FileOpen, OpenArgument, OpenMode, find_file_opens};
 use crate::{FixAvailability, Locator, Violation};
 
 /// ## What it does
@@ -35,7 +36,12 @@ use crate::{FixAvailability, Locator, Violation};
 /// ```
 ///
 /// ## Fix Safety
-/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the original expression.
+/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the
+/// original expression, or if the type of the value passed to `write` isn't statically known to
+/// match the file's open mode (`str` for text mode, `bytes` for binary mode). In the latter case,
+/// `open(...)` truncates the file before `write` is ever called, so a call that raises `TypeError`
+/// because of a type mismatch still leaves the file empty; `Path.write_text`/`write_bytes` checks
+/// the type first, so the same mismatch leaves the file's original contents untouched instead.
 ///
 /// ## References
 /// - [Python documentation: `Path.write_bytes`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.write_bytes)
@@ -153,7 +159,7 @@ impl<'a> Visitor<'a> for WriteMatcher<'a, '_> {
                     );
 
                     if let Some(fix) =
-                        generate_fix(self.checker, &open, self.with_stmt, &suggestion)
+                        generate_fix(self.checker, &open, self.with_stmt, &suggestion, content)
                     {
                         diagnostic.set_fix(fix);
                     }
@@ -205,6 +211,7 @@ fn generate_fix(
     open: &FileOpen,
     with_stmt: &ast::StmtWith,
     suggestion: &str,
+    content: &Expr,
 ) -> Option<Fix> {
     if !(with_stmt.items.len() == 1 && matches!(with_stmt.body.as_slice(), [Stmt::Expr(_)])) {
         return None;
@@ -231,7 +238,21 @@ fn generate_fix(
 
     let replacement = format!("{target}.{suggestion}");
 
-    let applicability = if checker.comment_ranges().intersects(with_stmt.range()) {
+    // `open(..., "w")` truncates the file immediately, before `write()` is ever called. If
+    // `write()`'s argument turns out to be the wrong type for the mode, the original code raises
+    // a `TypeError` without writing anything, leaving the file's prior contents intact. The
+    // rewritten `Path.write_text`/`write_bytes` call performs the type check *before* opening
+    // (and thus truncating) the file, so the same mismatch leaves the file untouched instead.
+    // Only offer the fix as safe when the argument's type is statically known to match the mode.
+    let type_matches_mode = matches!(
+        (open.mode, ResolvedPythonType::from(content)),
+        (OpenMode::WriteText, ResolvedPythonType::Atom(PythonType::String))
+            | (OpenMode::WriteBytes, ResolvedPythonType::Atom(PythonType::Bytes))
+    );
+
+    let applicability = if checker.comment_ranges().intersects(with_stmt.range())
+        || !type_matches_mode
+    {
         Applicability::Unsafe
     } else {
         Applicability::Safe

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB103_FURB103_0.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB103_FURB103_0.py.snap
@@ -40,6 +40,7 @@ help: Replace with `Path("file.txt").write_bytes(foobar)`
 17 + pathlib.Path("file.txt").write_bytes(foobar)
 18 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_bytes(b"abc")`
   --> FURB103_0.py:20:6
@@ -80,6 +81,7 @@ help: Replace with `Path("file.txt").write_text(foobar, encoding="utf8")`
 25 + pathlib.Path("file.txt").write_text(foobar, encoding="utf8")
 26 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, errors="ignore")`
   --> FURB103_0.py:28:6
@@ -100,6 +102,7 @@ help: Replace with `Path("file.txt").write_text(foobar, errors="ignore")`
 29 + pathlib.Path("file.txt").write_text(foobar, errors="ignore")
 30 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar)`
   --> FURB103_0.py:32:6
@@ -120,6 +123,7 @@ help: Replace with `Path("file.txt").write_text(foobar)`
 33 + pathlib.Path("file.txt").write_text(foobar)
 34 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 `open` and `write` should be replaced by `Path(foo()).write_bytes(bar())`
   --> FURB103_0.py:36:6
@@ -184,6 +188,7 @@ help: Replace with `Path("file.txt").write_text(foobar, newline="\r\n")`
 59 + pathlib.Path("file.txt").write_text(foobar, newline="\r\n")
 60 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, newline="\r\n")`
   --> FURB103_0.py:66:6
@@ -205,6 +210,7 @@ help: Replace with `Path("file.txt").write_text(foobar, newline="\r\n")`
 67 + pathlib.Path("file.txt").write_text(foobar, newline="\r\n")
 68 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(foobar, newline="\r\n")`
   --> FURB103_0.py:74:6
@@ -226,6 +232,7 @@ help: Replace with `Path("file.txt").write_text(foobar, newline="\r\n")`
 75 + pathlib.Path("file.txt").write_text(foobar, newline="\r\n")
 76 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("test.json")....`
    --> FURB103_0.py:154:6
@@ -248,6 +255,7 @@ help: Replace with `Path("test.json")....`
 155 + pathlib.Path("test.json").write_bytes(json.dumps(data, indent=4).encode("utf-8"))
 156 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB103 [*] `open` and `write` should be replaced by `Path("tmp_path/pyproject.toml")....`
    --> FURB103_0.py:158:6
@@ -269,4 +277,93 @@ help: Replace with `Path("tmp_path/pyproject.toml")....`
     -     f.write(dedent(
 159 + pathlib.Path("tmp_path/pyproject.toml").write_text(dedent(
 160 |         """
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(x)`
+   --> FURB103_0.py:176:10
+    |
+174 | def annotated_str_arg(x: str):
+175 |     # FURB103 (safe fix: `x` is known to be `str`)
+176 |     with open("file.txt", "w") as f:
+    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+177 |         f.write(x)
+    |
+help: Replace with `Path("file.txt").write_text(x)`
+    |
+150 | import json
+151 + import pathlib
+152 |
+--------------------------------------------------------------------------------
+176 |     # FURB103 (safe fix: `x` is known to be `str`)
+    -     with open("file.txt", "w") as f:
+    -         f.write(x)
+177 +     pathlib.Path("file.txt").write_text(x)
+178 |
+    |
+
+FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_bytes(x)`
+   --> FURB103_0.py:182:10
+    |
+180 | def annotated_bytes_arg(x: bytes):
+181 |     # FURB103 (safe fix: `x` is known to be `bytes`)
+182 |     with open("file.txt", "wb") as f:
+    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+183 |         f.write(x)
+    |
+help: Replace with `Path("file.txt").write_bytes(x)`
+    |
+150 | import json
+151 + import pathlib
+152 |
+--------------------------------------------------------------------------------
+182 |     # FURB103 (safe fix: `x` is known to be `bytes`)
+    -     with open("file.txt", "wb") as f:
+    -         f.write(x)
+183 +     pathlib.Path("file.txt").write_bytes(x)
+184 |
+    |
+
+FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(x)`
+   --> FURB103_0.py:188:10
+    |
+186 | def annotated_int_arg(x: int):
+187 |     # FURB103 (unsafe fix: `x` is not a `str`)
+188 |     with open("file.txt", "w") as f:
+    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+189 |         f.write(x)
+    |
+help: Replace with `Path("file.txt").write_text(x)`
+    |
+150 | import json
+151 + import pathlib
+152 |
+--------------------------------------------------------------------------------
+188 |     # FURB103 (unsafe fix: `x` is not a `str`)
+    -     with open("file.txt", "w") as f:
+    -         f.write(x)
+189 +     pathlib.Path("file.txt").write_text(x)
+190 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB103 [*] `open` and `write` should be replaced by `Path("file.txt").write_text(f"{1 / 0}")`
+   --> FURB103_0.py:197:6
+    |
+195 | # constructed before `Path.write_text` is ever called, so this doesn't introduce the
+196 | # truncation-ordering hazard the safety check above exists to catch.
+197 | with open("file.txt", "w") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+198 |     f.write(f"{1 / 0}")
+    |
+help: Replace with `Path("file.txt").write_text(f"{1 / 0}")`
+    |
+150 | import json
+151 + import pathlib
+152 |
+--------------------------------------------------------------------------------
+197 | # truncation-ordering hazard the safety check above exists to catch.
+    - with open("file.txt", "w") as f:
+    -     f.write(f"{1 / 0}")
+198 + pathlib.Path("file.txt").write_text(f"{1 / 0}")
     |


### PR DESCRIPTION
Ruff has a lint rule called FURB103. It looks for code like this:

```py
with open("file.txt", "w") as f:
    f.write(some_value)
```
and suggests rewriting it to the shorter:

```py
Path("file.txt").write_text(some_value)
```

Ruff can auto-apply that rewrite, and it labels the auto-fix as either "safe" (apply it automatically, no review needed) or "unsafe" (a human should look before applying).

Why it was wrong: `open(file, "w")` empties out the file the moment it opens, before `write()` even runs. So if some_value turns out to be the wrong type (say, bytes instead of a string), the original code crashes with a TypeError — but the file is already empty at that point, so nothing is lost that wasn't already gone. The rewritten version, Path(file).write_text(some_value), checks the type of some_value before touching the file at all. So on that same type mismatch, the rewritten version crashes too — but this time the file was never opened, so whatever was in it before is still there. That's a real difference in behavior, and Ruff's fix was calling itself "safe" without accounting for it.

What I changed: The fix now only labels itself "safe" when it can actually prove some_value's type matches what the file mode expects (a string for text mode, bytes for binary mode). If it can't prove that — which covers most real code, since most people don't write literal strings there, they write variables or function results — it now labels the fix "unsafe" instead, so a human reviews it first.

How I checked it works: I traced it against the rule's existing test cases by hand, matched the pattern to how two other Ruff rules already handle this same kind of "is the type actually known" check, and ran the crate's test suite locally — it passes, and several existing test cases that were previously auto-labeled "safe" now correctly show up as "unsafe" in the snapshot diffs, which is the intended effect of the fix.
