### PR TITLE
[ty] Recognize ABC metaclass methods on protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -134,11 +134,11 @@ if TYPE_CHECKING:
         def f(x: "int" | "None"): ...
 ```
 
-### Protocol metaclass fallback
+### Protocol metaclasses
 
-An inferred `ABCMeta` does not imply that a protocol has a custom `__or__` method. Partially
-stringified unions with protocol classes and their subclasses still fail at runtime before Python
-3.14.
+Modeling a source protocol's metaclass as `ABCMeta` does not imply that it has a custom `__or__`
+method. Partially stringified unions with protocol classes and their subclasses fail at runtime
+before Python 3.14.
 
 ```toml
 [environment]
@@ -157,6 +157,21 @@ def f(
     # error: [unsupported-operator]
     y: "Child" | Child,
 ): ...
+```
+
+A custom metaclass can accept strings in `__or__`. Deriving it from `type(Protocol)` also makes it
+compatible with the protocol's runtime metaclass.
+
+```py
+from typing import Any
+
+class Meta(type(Protocol)):
+    def __or__(cls, other: str) -> Any:
+        return other
+
+class Custom(P, metaclass=Meta): ...
+
+def g(x: Custom | "Custom"): ...
 ```
 
 ### Python less than 3.14 in a stub file

--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -134,6 +134,31 @@ if TYPE_CHECKING:
         def f(x: "int" | "None"): ...
 ```
 
+### Protocol metaclass fallback
+
+An inferred `ABCMeta` does not imply that a protocol has a custom `__or__` method. Partially
+stringified unions with protocol classes and their subclasses still fail at runtime before Python
+3.14.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Protocol
+
+class P(Protocol): ...
+class Child(P): ...
+
+def f(
+    # error: [unsupported-operator]
+    x: P | "P",
+    # error: [unsupported-operator]
+    y: "Child" | Child,
+): ...
+```
+
 ### Python less than 3.14 in a stub file
 
 This error is never emitted on stub files, because they are never executed at runtime:

--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -136,9 +136,9 @@ if TYPE_CHECKING:
 
 ### Protocol metaclasses
 
-Modeling a source protocol's metaclass as `ABCMeta` does not imply that it has a custom `__or__`
-method. Partially stringified unions with protocol classes and their subclasses fail at runtime
-before Python 3.14.
+A source protocol's default `_ProtocolMeta` does not supply a string-accepting `__or__` method.
+Partially stringified unions with protocol classes and their subclasses fail at runtime before
+Python 3.14.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/call/new_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/new_class.md
@@ -130,25 +130,6 @@ class Base: ...
 types.new_class("Dup", (Base, Base))
 ```
 
-### Metaclass conflicts
-
-Unrelated metaclasses supplied by ordinary bases still conflict in assigned and inline calls:
-
-```py
-import types
-
-class Meta1(type): ...
-class Meta2(type): ...
-class A(metaclass=Meta1): ...
-class B(metaclass=Meta2): ...
-
-# error: [conflicting-metaclass]
-Bad = types.new_class("Bad", (A, B))
-
-# error: [conflicting-metaclass]
-types.new_class("InlineBad", (A, B))
-```
-
 ## Special bases
 
 `types.new_class()` properly handles `__mro_entries__` and metaclasses, so it supports bases that
@@ -211,58 +192,17 @@ MyEnum = types.new_class("MyEnum", (Enum,))
 reveal_type(MyEnum)  # revealed: <class 'MyEnum'>
 ```
 
-### Protocol metaclass fallback from stubs
+### Protocol bases
 
-Stubs can use protocol inheritance to describe an interface without requiring the same inheritance
-at runtime. A dynamic subclass retains the `ABCMeta` fallback for attribute access, but a later
-subclass can still choose an unrelated explicit metaclass.
-
-`interface.pyi`:
-
-```pyi
-from typing import Protocol
-
-class Interface(Protocol): ...
-```
-
-`main.py`:
-
-```py
-import types
-from interface import Interface
-
-Dynamic = types.new_class("Dynamic", (Interface,))
-reveal_type(type(Dynamic))  # revealed: <class 'ABCMeta'>
-
-class Meta(type): ...
-class Concrete(Dynamic, metaclass=Meta): ...
-
-reveal_type(type(Concrete))  # revealed: <class 'Meta'>
-```
-
-### Protocol metaclass fallback from source
-
-The implicit `ABCMeta` is also only a fallback for source-defined protocols. A custom metaclass
-takes precedence, including when it is inherited through a dynamic subclass.
+`types.new_class()` also preserves the `ABCMeta` metaclass inferred for source-defined protocols.
 
 ```py
 import types
 from typing import Protocol
 
 class Interface(Protocol): ...
-class Meta(type): ...
-class Other(metaclass=Meta): ...
 
-Dynamic = types.new_class("Dynamic", (Interface,))
-reveal_type(type(Dynamic))  # revealed: <class 'ABCMeta'>
-
-class Concrete(Dynamic, metaclass=Meta): ...
-
-reveal_type(type(Concrete))  # revealed: <class 'Meta'>
-
-Combined = types.new_class("Combined", (Dynamic, Other))
-reveal_type(type(Combined))  # revealed: <class 'Meta'>
-reveal_type(type(types.new_class("InlineCombined", (Interface, Other))))  # revealed: <class 'Meta'>
+reveal_type(type(types.new_class("Dynamic", (Interface,))))  # revealed: <class 'ABCMeta'>
 ```
 
 ### Generic and TypedDict bases

--- a/crates/ty_python_semantic/resources/mdtest/call/new_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/new_class.md
@@ -130,6 +130,25 @@ class Base: ...
 types.new_class("Dup", (Base, Base))
 ```
 
+### Metaclass conflicts
+
+Unrelated metaclasses supplied by ordinary bases still conflict in assigned and inline calls:
+
+```py
+import types
+
+class Meta1(type): ...
+class Meta2(type): ...
+class A(metaclass=Meta1): ...
+class B(metaclass=Meta2): ...
+
+# error: [conflicting-metaclass]
+Bad = types.new_class("Bad", (A, B))
+
+# error: [conflicting-metaclass]
+types.new_class("InlineBad", (A, B))
+```
+
 ## Special bases
 
 `types.new_class()` properly handles `__mro_entries__` and metaclasses, so it supports bases that
@@ -192,11 +211,11 @@ MyEnum = types.new_class("MyEnum", (Enum,))
 reveal_type(MyEnum)  # revealed: <class 'MyEnum'>
 ```
 
-### Protocol metaclasses from stubs
+### Protocol metaclass fallback from stubs
 
 Stubs can use protocol inheritance to describe an interface without requiring the same inheritance
-at runtime. A dynamic subclass retains the implicit protocol metaclass for attribute access, but a
-later subclass can still choose an unrelated explicit metaclass.
+at runtime. A dynamic subclass retains the `ABCMeta` fallback for attribute access, but a later
+subclass can still choose an unrelated explicit metaclass.
 
 `interface.pyi`:
 
@@ -213,7 +232,7 @@ import types
 from interface import Interface
 
 Dynamic = types.new_class("Dynamic", (Interface,))
-reveal_type(type(Dynamic))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Dynamic))  # revealed: <class 'ABCMeta'>
 
 class Meta(type): ...
 class Concrete(Dynamic, metaclass=Meta): ...
@@ -221,10 +240,10 @@ class Concrete(Dynamic, metaclass=Meta): ...
 reveal_type(type(Concrete))  # revealed: <class 'Meta'>
 ```
 
-### Protocol metaclass conflicts
+### Protocol metaclass fallback from source
 
-A source-defined protocol contributes its actual metaclass, including through a dynamic subclass.
-Combining it with an unrelated metaclass-bearing base is an error in both assigned and inline calls.
+The implicit `ABCMeta` is also only a fallback for source-defined protocols. A custom metaclass
+takes precedence, including when it is inherited through a dynamic subclass.
 
 ```py
 import types
@@ -235,13 +254,15 @@ class Meta(type): ...
 class Other(metaclass=Meta): ...
 
 Dynamic = types.new_class("Dynamic", (Interface,))
-reveal_type(type(Dynamic))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Dynamic))  # revealed: <class 'ABCMeta'>
 
-# error: [conflicting-metaclass]
-Bad = types.new_class("Bad", (Dynamic, Other))
+class Concrete(Dynamic, metaclass=Meta): ...
 
-# error: [conflicting-metaclass]
-types.new_class("InlineBad", (Interface, Other))
+reveal_type(type(Concrete))  # revealed: <class 'Meta'>
+
+Combined = types.new_class("Combined", (Dynamic, Other))
+reveal_type(type(Combined))  # revealed: <class 'Meta'>
+reveal_type(type(types.new_class("InlineCombined", (Interface, Other))))  # revealed: <class 'Meta'>
 ```
 
 ### Generic and TypedDict bases

--- a/crates/ty_python_semantic/resources/mdtest/call/new_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/new_class.md
@@ -194,7 +194,7 @@ reveal_type(MyEnum)  # revealed: <class 'MyEnum'>
 
 ### Protocol bases
 
-`types.new_class()` also preserves the `ABCMeta` metaclass inferred for source-defined protocols.
+`types.new_class()` also preserves the `_ProtocolMeta` metaclass of source-defined protocols.
 
 ```py
 import types
@@ -202,7 +202,7 @@ from typing import Protocol
 
 class Interface(Protocol): ...
 
-reveal_type(type(types.new_class("Dynamic", (Interface,))))  # revealed: <class 'ABCMeta'>
+reveal_type(type(types.new_class("Dynamic", (Interface,))))  # revealed: <class '_ProtocolMeta'>
 ```
 
 ### Generic and TypedDict bases

--- a/crates/ty_python_semantic/resources/mdtest/call/new_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/new_class.md
@@ -192,6 +192,58 @@ MyEnum = types.new_class("MyEnum", (Enum,))
 reveal_type(MyEnum)  # revealed: <class 'MyEnum'>
 ```
 
+### Protocol metaclasses from stubs
+
+Stubs can use protocol inheritance to describe an interface without requiring the same inheritance
+at runtime. A dynamic subclass retains the implicit protocol metaclass for attribute access, but a
+later subclass can still choose an unrelated explicit metaclass.
+
+`interface.pyi`:
+
+```pyi
+from typing import Protocol
+
+class Interface(Protocol): ...
+```
+
+`main.py`:
+
+```py
+import types
+from interface import Interface
+
+Dynamic = types.new_class("Dynamic", (Interface,))
+reveal_type(type(Dynamic))  # revealed: <class '_ProtocolMeta'>
+
+class Meta(type): ...
+class Concrete(Dynamic, metaclass=Meta): ...
+
+reveal_type(type(Concrete))  # revealed: <class 'Meta'>
+```
+
+### Protocol metaclass conflicts
+
+A source-defined protocol contributes its actual metaclass, including through a dynamic subclass.
+Combining it with an unrelated metaclass-bearing base is an error in both assigned and inline calls.
+
+```py
+import types
+from typing import Protocol
+
+class Interface(Protocol): ...
+class Meta(type): ...
+class Other(metaclass=Meta): ...
+
+Dynamic = types.new_class("Dynamic", (Interface,))
+reveal_type(type(Dynamic))  # revealed: <class '_ProtocolMeta'>
+
+# error: [conflicting-metaclass]
+Bad = types.new_class("Bad", (Dynamic, Other))
+
+# error: [conflicting-metaclass]
+types.new_class("InlineBad", (Interface, Other))
+```
+
 ### Generic and TypedDict bases
 
 Even though `types.new_class()` handles `__mro_entries__` at runtime, ty does not yet model the full

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1373,8 +1373,7 @@ instance = ProtoImpl()
 reveal_type(instance)  # revealed: ProtoImpl
 ```
 
-This is a real metaclass constraint, unlike the lookup-only `ABCMeta` fallback for protocol bases
-declared in typeshed. A subclass of the dynamic class cannot choose an unrelated metaclass.
+A subclass of the dynamic class cannot choose a metaclass unrelated to `_ProtocolMeta`.
 
 ```py
 class Meta(type): ...

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -846,6 +846,9 @@ class B(metaclass=Meta2): ...
 
 # error: [conflicting-metaclass] "The metaclass of a derived class (`Bad`) must be a subclass of the metaclasses of all its bases, but `Meta1` (metaclass of base class `<class 'A'>`) and `Meta2` (metaclass of base class `<class 'B'>`) have no subclass relationship"
 Bad = type("Bad", (A, B), {})
+
+# error: [conflicting-metaclass]
+type("InlineBad", (A, B), {})
 ```
 
 ## `__slots__` in namespace dictionary
@@ -1365,18 +1368,18 @@ class MyProtocol(Protocol):
 
 ProtoImpl = type("ProtoImpl", (MyProtocol,), {"method": lambda self: 42})
 reveal_type(ProtoImpl)  # revealed: <class 'ProtoImpl'>
-reveal_type(type(ProtoImpl))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(ProtoImpl))  # revealed: <class 'ABCMeta'>
 reveal_mro(ProtoImpl)  # revealed: (<class 'ProtoImpl'>, <class 'MyProtocol'>, typing.Protocol, typing.Generic, <class 'object'>)
 
 instance = ProtoImpl()
 reveal_type(instance)  # revealed: ProtoImpl
 ```
 
-### Protocol metaclasses from stubs
+### Protocol metaclass fallback from stubs
 
 Stubs can use protocol inheritance to describe an interface without requiring the same inheritance
-at runtime. A dynamic subclass retains the implicit protocol metaclass for attribute access, but a
-later subclass can still choose an unrelated explicit metaclass.
+at runtime. A dynamic subclass retains the `ABCMeta` fallback for attribute access, but a later
+subclass can still choose an unrelated explicit metaclass.
 
 `interface.pyi`:
 
@@ -1392,7 +1395,7 @@ class Interface(Protocol): ...
 from interface import Interface
 
 Dynamic = type("Dynamic", (Interface,), {})
-reveal_type(type(Dynamic))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Dynamic))  # revealed: <class 'ABCMeta'>
 
 class Meta(type): ...
 class Concrete(Dynamic, metaclass=Meta): ...
@@ -1400,10 +1403,10 @@ class Concrete(Dynamic, metaclass=Meta): ...
 reveal_type(type(Concrete))  # revealed: <class 'Meta'>
 ```
 
-### Protocol metaclass conflicts
+### Protocol metaclass fallback from source
 
-A source-defined protocol contributes its actual metaclass, including through a dynamic subclass.
-Combining it with an unrelated metaclass-bearing base is an error in both assigned and inline calls.
+The implicit `ABCMeta` is also only a fallback for source-defined protocols. A custom metaclass
+takes precedence, including when it is inherited through a dynamic subclass.
 
 ```py
 from typing import Protocol
@@ -1413,13 +1416,15 @@ class Meta(type): ...
 class Other(metaclass=Meta): ...
 
 Dynamic = type("Dynamic", (Interface,), {})
-reveal_type(type(Dynamic))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Dynamic))  # revealed: <class 'ABCMeta'>
 
-# error: [conflicting-metaclass]
-Bad = type("Bad", (Dynamic, Other), {})
+class Concrete(Dynamic, metaclass=Meta): ...
 
-# error: [conflicting-metaclass]
-type("InlineBad", (Interface, Other), {})
+reveal_type(type(Concrete))  # revealed: <class 'Meta'>
+
+Combined = type("Combined", (Dynamic, Other), {})
+reveal_type(type(Combined))  # revealed: <class 'Meta'>
+reveal_type(type(type("InlineCombined", (Interface, Other), {})))  # revealed: <class 'Meta'>
 ```
 
 ### TypedDict bases

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1365,10 +1365,61 @@ class MyProtocol(Protocol):
 
 ProtoImpl = type("ProtoImpl", (MyProtocol,), {"method": lambda self: 42})
 reveal_type(ProtoImpl)  # revealed: <class 'ProtoImpl'>
+reveal_type(type(ProtoImpl))  # revealed: <class '_ProtocolMeta'>
 reveal_mro(ProtoImpl)  # revealed: (<class 'ProtoImpl'>, <class 'MyProtocol'>, typing.Protocol, typing.Generic, <class 'object'>)
 
 instance = ProtoImpl()
 reveal_type(instance)  # revealed: ProtoImpl
+```
+
+### Protocol metaclasses from stubs
+
+Stubs can use protocol inheritance to describe an interface without requiring the same inheritance
+at runtime. A dynamic subclass retains the implicit protocol metaclass for attribute access, but a
+later subclass can still choose an unrelated explicit metaclass.
+
+`interface.pyi`:
+
+```pyi
+from typing import Protocol
+
+class Interface(Protocol): ...
+```
+
+`main.py`:
+
+```py
+from interface import Interface
+
+Dynamic = type("Dynamic", (Interface,), {})
+reveal_type(type(Dynamic))  # revealed: <class '_ProtocolMeta'>
+
+class Meta(type): ...
+class Concrete(Dynamic, metaclass=Meta): ...
+
+reveal_type(type(Concrete))  # revealed: <class 'Meta'>
+```
+
+### Protocol metaclass conflicts
+
+A source-defined protocol contributes its actual metaclass, including through a dynamic subclass.
+Combining it with an unrelated metaclass-bearing base is an error in both assigned and inline calls.
+
+```py
+from typing import Protocol
+
+class Interface(Protocol): ...
+class Meta(type): ...
+class Other(metaclass=Meta): ...
+
+Dynamic = type("Dynamic", (Interface,), {})
+reveal_type(type(Dynamic))  # revealed: <class '_ProtocolMeta'>
+
+# error: [conflicting-metaclass]
+Bad = type("Bad", (Dynamic, Other), {})
+
+# error: [conflicting-metaclass]
+type("InlineBad", (Interface, Other), {})
 ```
 
 ### TypedDict bases

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -846,9 +846,6 @@ class B(metaclass=Meta2): ...
 
 # error: [conflicting-metaclass] "The metaclass of a derived class (`Bad`) must be a subclass of the metaclasses of all its bases, but `Meta1` (metaclass of base class `<class 'A'>`) and `Meta2` (metaclass of base class `<class 'B'>`) have no subclass relationship"
 Bad = type("Bad", (A, B), {})
-
-# error: [conflicting-metaclass]
-type("InlineBad", (A, B), {})
 ```
 
 ## `__slots__` in namespace dictionary
@@ -1357,7 +1354,8 @@ NT = type("NT", (NamedTuple,), {})
 
 ### Protocol bases
 
-Inheriting from a class that is itself a protocol is valid:
+When a dynamic class inherits from a source-defined protocol, ty models the inherited metaclass as
+`ABCMeta`:
 
 ```py
 from typing import Protocol
@@ -1375,56 +1373,14 @@ instance = ProtoImpl()
 reveal_type(instance)  # revealed: ProtoImpl
 ```
 
-### Protocol metaclass fallback from stubs
-
-Stubs can use protocol inheritance to describe an interface without requiring the same inheritance
-at runtime. A dynamic subclass retains the `ABCMeta` fallback for attribute access, but a later
-subclass can still choose an unrelated explicit metaclass.
-
-`interface.pyi`:
-
-```pyi
-from typing import Protocol
-
-class Interface(Protocol): ...
-```
-
-`main.py`:
+Unlike protocol inheritance used only in a stub, the source declaration imposes a real metaclass
+constraint. A subclass of the dynamic class cannot choose an unrelated metaclass.
 
 ```py
-from interface import Interface
-
-Dynamic = type("Dynamic", (Interface,), {})
-reveal_type(type(Dynamic))  # revealed: <class 'ABCMeta'>
-
 class Meta(type): ...
-class Concrete(Dynamic, metaclass=Meta): ...
 
-reveal_type(type(Concrete))  # revealed: <class 'Meta'>
-```
-
-### Protocol metaclass fallback from source
-
-The implicit `ABCMeta` is also only a fallback for source-defined protocols. A custom metaclass
-takes precedence, including when it is inherited through a dynamic subclass.
-
-```py
-from typing import Protocol
-
-class Interface(Protocol): ...
-class Meta(type): ...
-class Other(metaclass=Meta): ...
-
-Dynamic = type("Dynamic", (Interface,), {})
-reveal_type(type(Dynamic))  # revealed: <class 'ABCMeta'>
-
-class Concrete(Dynamic, metaclass=Meta): ...
-
-reveal_type(type(Concrete))  # revealed: <class 'Meta'>
-
-Combined = type("Combined", (Dynamic, Other), {})
-reveal_type(type(Combined))  # revealed: <class 'Meta'>
-reveal_type(type(type("InlineCombined", (Interface, Other), {})))  # revealed: <class 'Meta'>
+# error: [conflicting-metaclass]
+class Invalid(ProtoImpl, metaclass=Meta): ...
 ```
 
 ### TypedDict bases

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1354,8 +1354,8 @@ NT = type("NT", (NamedTuple,), {})
 
 ### Protocol bases
 
-When a dynamic class inherits from a source-defined protocol, ty models the inherited metaclass as
-`ABCMeta`:
+When a dynamic class inherits from a source-defined protocol, it also inherits the protocol's
+`_ProtocolMeta` metaclass:
 
 ```py
 from typing import Protocol
@@ -1366,15 +1366,15 @@ class MyProtocol(Protocol):
 
 ProtoImpl = type("ProtoImpl", (MyProtocol,), {"method": lambda self: 42})
 reveal_type(ProtoImpl)  # revealed: <class 'ProtoImpl'>
-reveal_type(type(ProtoImpl))  # revealed: <class 'ABCMeta'>
+reveal_type(type(ProtoImpl))  # revealed: <class '_ProtocolMeta'>
 reveal_mro(ProtoImpl)  # revealed: (<class 'ProtoImpl'>, <class 'MyProtocol'>, typing.Protocol, typing.Generic, <class 'object'>)
 
 instance = ProtoImpl()
 reveal_type(instance)  # revealed: ProtoImpl
 ```
 
-Unlike protocol inheritance used only in a stub, the source declaration imposes a real metaclass
-constraint. A subclass of the dynamic class cannot choose an unrelated metaclass.
+This is a real metaclass constraint, unlike the lookup-only `ABCMeta` fallback for protocol bases
+declared in stubs. A subclass of the dynamic class cannot choose an unrelated metaclass.
 
 ```py
 class Meta(type): ...

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1374,7 +1374,7 @@ reveal_type(instance)  # revealed: ProtoImpl
 ```
 
 This is a real metaclass constraint, unlike the lookup-only `ABCMeta` fallback for protocol bases
-declared in stubs. A subclass of the dynamic class cannot choose an unrelated metaclass.
+declared in typeshed. A subclass of the dynamic class cannot choose an unrelated metaclass.
 
 ```py
 class Meta(type): ...

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -716,8 +716,8 @@ class InvalidNonFrozenChild(FrozenParent, frozen=False):
 
 #### Repeated explicit metaclasses
 
-Explicitly supplying the same transformer metaclass as a base class still makes the new class
-neither frozen nor non-frozen. This also applies when the base was created dynamically.
+A class that explicitly repeats its base's dataclass-transform metaclass is neither frozen nor
+non-frozen. The base can be defined by a class statement or created dynamically.
 
 ```py
 from typing import dataclass_transform

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -714,6 +714,28 @@ class InvalidNonFrozenChild(FrozenParent, frozen=False):
     y: int
 ```
 
+#### Repeated explicit metaclasses
+
+Explicitly supplying the same transformer metaclass as a base class still makes the new class
+neither frozen nor non-frozen. This also applies when the base was created dynamically.
+
+```py
+from typing import dataclass_transform
+
+@dataclass_transform(frozen_default=True)
+class FrozenMeta(type):
+    def __new__(cls, name, bases, namespace, *, frozen: bool = True): ...
+
+class Root(metaclass=FrozenMeta): ...
+class StaticRoot(Root, metaclass=FrozenMeta): ...
+class StaticMutable(StaticRoot, frozen=False): ...
+
+Dynamic = type("Dynamic", (Root,), {})
+
+class DynamicRoot(Dynamic, metaclass=FrozenMeta): ...
+class DynamicMutable(DynamicRoot, frozen=False): ...
+```
+
 #### Using base-class-based transformers
 
 Similarly, for base-class-based transformers, the class that is decorated with

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -171,24 +171,23 @@ reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTyp
 ## Class-preserving decorators
 
 A decorator that returns its class argument preserves the generic context of a base class. A
-subclass can forward type variables to the decorated base.
+subclass can forward a type variable to the decorated base.
 
 ```py
 import collections.abc
 from typing import Generic, TypeVar
 from ty_extensions._internal import generic_context
 
-K = TypeVar("K")
-V = TypeVar("V")
+T = TypeVar("T")
 
 @collections.abc.Mapping.register
-class Mapping(Generic[K, V]): ...
+class Base(Generic[T]): ...
 
-reveal_type(generic_context(Mapping))  # revealed: ty_extensions._internal.GenericContext[K@Mapping, V@Mapping]
+reveal_type(generic_context(Base))  # revealed: ty_extensions._internal.GenericContext[T@Base]
 
-class FrozenDict(Mapping[K, V]): ...
+class Child(Base[T]): ...
 
-mapping: FrozenDict[str, int]
+child: Child[int]
 ```
 
 ## Specializing classes with unavailable generic context

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -168,6 +168,29 @@ reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecialized))
 reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTypevar))
 ```
 
+## Class-preserving decorators
+
+A decorator that returns its class argument preserves the generic context of a base class. A
+subclass can forward type variables to the decorated base.
+
+```py
+import collections.abc
+from typing import Generic, TypeVar
+from ty_extensions._internal import generic_context
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+@collections.abc.Mapping.register
+class Mapping(Generic[K, V]): ...
+
+reveal_type(generic_context(Mapping))  # revealed: ty_extensions._internal.GenericContext[K@Mapping, V@Mapping]
+
+class FrozenDict(Mapping[K, V]): ...
+
+mapping: FrozenDict[str, int]
+```
+
 ## Specializing classes with unavailable generic context
 
 When an earlier error prevents ty from determining a class's generic context, specializing the class
@@ -197,25 +220,26 @@ parser: Parser[int]  # error: [invalid-type-form] "Non-generic class `Parser` ca
 
 ### Decorated generic bases
 
-A decorator that returns its class argument preserves the generic context of a base class. A
-subclass can forward type variables to the decorated base.
+An unresolved decorator obscures the generic context of a base class. Specializing a subclass that
+forwards a type variable to that base currently produces a cascading error.
 
 ```py
-import collections.abc
 from typing import Generic, TypeVar
 from ty_extensions._internal import generic_context
 
-K = TypeVar("K")
-V = TypeVar("V")
+T = TypeVar("T")
 
-@collections.abc.Mapping.register
-class Mapping(Generic[K, V]): ...
+# error: [unresolved-reference] "Name `unknown_decorator` used when not defined"
+@unknown_decorator
+class Base(Generic[T]): ...
 
-reveal_type(generic_context(Mapping))  # revealed: ty_extensions._internal.GenericContext[K@Mapping, V@Mapping]
+reveal_type(generic_context(Base))  # revealed: None
 
-class FrozenDict(Mapping[K, V]): ...
+class Child(Base[T]): ...
 
-mapping: FrozenDict[str, int]
+# TODO: Avoid this cascading error when the base's generic context is unavailable.
+# error: [invalid-type-form] "Non-generic class `Child` cannot be specialized in a type expression"
+child: Child[int]
 ```
 
 ### Unresolved generic bases

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -197,8 +197,8 @@ parser: Parser[int]  # error: [invalid-type-form] "Non-generic class `Parser` ca
 
 ### Decorated generic bases
 
-A decorator that ty cannot fully understand can obscure the generic context of a base class. A
-subclass that forwards type variables to that base remains possibly generic.
+A decorator that returns its class argument preserves the generic context of a base class. A
+subclass can forward type variables to the decorated base.
 
 ```py
 import collections.abc
@@ -208,17 +208,13 @@ from ty_extensions._internal import generic_context
 K = TypeVar("K")
 V = TypeVar("V")
 
-# error: [unresolved-attribute] "Class `Mapping` has no attribute `register`"
 @collections.abc.Mapping.register
 class Mapping(Generic[K, V]): ...
 
-# TODO: Invalid decorator causes us to lose the generic context from the class...
-reveal_type(generic_context(Mapping))  # revealed: None
+reveal_type(generic_context(Mapping))  # revealed: ty_extensions._internal.GenericContext[K@Mapping, V@Mapping]
 
 class FrozenDict(Mapping[K, V]): ...
 
-# TODO: ...which then causes us to emit this
-# error: [invalid-type-form] "Non-generic class `FrozenDict` cannot be specialized in a type expression"
 mapping: FrozenDict[str, int]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -674,7 +674,7 @@ reveal_type(C.__class__)  # revealed: <class 'M'>
 
 A protocol declared in Python source uses `typing._ProtocolMeta`, which derives from `ABCMeta`.
 Explicitly specifying `ABCMeta` selects the more derived `_ProtocolMeta`. A compatible custom
-metaclass must be preserved, including when its base is obtained by calling `type`.
+metaclass is preserved, including when its base is obtained by calling `type`.
 
 ```py
 from abc import ABC, ABCMeta
@@ -884,7 +884,7 @@ class OwnAttribute(Iterable[object]):
 ## Built-in collection metaclasses
 
 Typeshed includes collection ABCs in some built-in classes' bases to describe their interfaces.
-Those stub-only bases must not change the built-ins' runtime metaclasses or introduce conflicts when
+Those stub-only bases do not change the built-ins' runtime metaclasses or introduce conflicts when
 they are subclassed.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -866,18 +866,30 @@ reveal_type(type(Pinned))  # revealed: <class 'ABCMeta'>
 
 ## Typeshed protocol metaclass attributes in the class namespace
 
-A typeshed protocol fallback does not guarantee that the metaclass creates attributes in the class
-namespace, or impose a type on attributes defined there.
+The `ABCMeta` fallback inferred from typeshed bases does not guarantee that the runtime metaclass
+creates attributes in the class namespace. It therefore does not make attributes such as
+`__abstractmethods__` available on instances.
+
+For example, typeshed declares `weakref.WeakSet` as a `MutableSet` subclass, but at runtime it
+inherits directly from `object` and has metaclass `type`.
 
 ```py
-from collections.abc import Iterable
+from weakref import WeakSet
 
-class StubClass(Iterable[object]): ...
+class Child(WeakSet[object]): ...
 
-def f(stub: StubClass):
-    stub.__abstractmethods__  # error: [unresolved-attribute]
+reveal_type(type(Child))  # revealed: <class 'ABCMeta'>
 
-class OwnAttribute(Iterable[object]):
+def f(child: Child):
+    child.__abstractmethods__  # error: [unresolved-attribute]
+```
+
+The fallback also does not constrain the types of attributes defined in the class namespace. For
+example, a `WeakSet` subclass can define its own `__abstractmethods__` without matching `ABCMeta`'s
+declaration.
+
+```py
+class OwnAttribute(WeakSet[object]):
     __abstractmethods__ = 1
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -672,9 +672,9 @@ reveal_type(C.__class__)  # revealed: <class 'M'>
 
 ## Protocol metaclass inheritance
 
-A protocol declared in Python source imposes an `ABCMeta` constraint, which is compatible with an
-abstract base class. A compatible explicit metaclass must be preserved, including when its base is
-obtained by calling `type`.
+A protocol declared in Python source uses `typing._ProtocolMeta`, which derives from `ABCMeta`.
+Explicitly specifying `ABCMeta` selects the more derived `_ProtocolMeta`. A compatible custom
+metaclass must be preserved, including when its base is obtained by calling `type`.
 
 ```py
 from abc import ABC, ABCMeta
@@ -685,8 +685,8 @@ class Base(ABC): ...
 class Combined(Base, P): ...
 class ExplicitABC(Protocol, metaclass=ABCMeta): ...
 
-reveal_type(type(Combined))  # revealed: <class 'ABCMeta'>
-reveal_type(type(ExplicitABC))  # revealed: <class 'ABCMeta'>
+reveal_type(type(Combined))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(ExplicitABC))  # revealed: <class '_ProtocolMeta'>
 
 class Meta(type(Protocol)): ...
 class Derived(Base, P, metaclass=Meta): ...
@@ -700,16 +700,16 @@ subclassing an existing one.
 ```py
 class Unrelated(type): ...
 
-# error: [conflicting-metaclass] "`ABCMeta` (metaclass of base class `typing.Protocol`)"
+# error: [conflicting-metaclass] "`_ProtocolMeta` (metaclass of base class `typing.Protocol`)"
 class InvalidDirect(Protocol, metaclass=Unrelated): ...
 class InvalidSubclass(P, metaclass=Unrelated): ...  # error: [conflicting-metaclass]
 ```
 
-## Runtime-compatible custom protocol metaclasses
+## Obsolete protocol-metaclass workaround
 
-At least one library, beartype, uses `ABCMeta` while type checking and the actual protocol metaclass
-at runtime. This is valid at runtime, and its explicit metaclass satisfies the modeled `ABCMeta`
-constraint.
+An older beartype workaround, written before typeshed exposed `_ProtocolMeta`, substitutes `ABCMeta`
+while type checking and uses the actual protocol metaclass at runtime. Although this can work at
+runtime, its type-checking branch hides the required `_ProtocolMeta` base and is rejected.
 
 ```py
 from abc import ABCMeta
@@ -721,11 +721,17 @@ else:
     ProtocolMeta = type(Protocol)
 
 class Meta(ProtocolMeta): ...
-class P(Protocol, metaclass=Meta): ...
-class Child(P, Protocol): ...
+class P(Protocol, metaclass=Meta): ...  # error: [conflicting-metaclass]
+```
 
-reveal_type(type(P))  # revealed: <class 'Meta'>
-reveal_type(type(Child))  # revealed: <class 'Meta'>
+Deriving the custom metaclass directly from `type(Protocol)` exposes the correct relationship to the
+type checker and works at runtime.
+
+```py
+class SupportedMeta(type(Protocol)): ...
+class Supported(Protocol, metaclass=SupportedMeta): ...
+
+reveal_type(type(Supported))  # revealed: <class 'SupportedMeta'>
 ```
 
 ## Callable class metaclass with a stub protocol fallback
@@ -842,8 +848,8 @@ static_assert(not is_disjoint_from(Child, Other))
 static_assert(not is_subtype_of(type[Child], ABCMeta))
 ```
 
-Explicitly listing `Protocol` in source declares a new protocol with an `ABCMeta` constraint, even
-when another base contributes only the stub fallback.
+Explicitly listing `Protocol` in source declares a new protocol with a `_ProtocolMeta` constraint,
+even when another base contributes only the stub fallback.
 
 `source.py`:
 
@@ -909,8 +915,8 @@ class OwnAttribute(Interface):
 
 ## Source protocol metaclasses inherited through stubs
 
-A subclass defined in a stub inherits a source protocol's `ABCMeta` constraint. Passing through a
-stub does not turn that selected metaclass into a fallback.
+A subclass defined in a stub inherits a source protocol's `_ProtocolMeta` constraint. Passing
+through a stub does not turn that selected metaclass into a fallback.
 
 `source.py`:
 
@@ -936,7 +942,7 @@ from interface import Interface
 class Meta(type): ...
 class Derived(Interface, metaclass=Meta): ...  # error: [conflicting-metaclass]
 
-reveal_type(type(Interface))  # revealed: <class 'ABCMeta'>
+reveal_type(type(Interface))  # revealed: <class '_ProtocolMeta'>
 ```
 
 ## Built-in collection metaclasses

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -713,54 +713,74 @@ class UnrelatedABC(ABCMeta): ...
 class InvalidABC(P, metaclass=UnrelatedABC): ...  # error: [conflicting-metaclass]
 ```
 
-## Protocol metaclass fallback in stubs
+## Protocol metaclass fallback in typeshed
 
-A stub can list `Protocol` as a base even when the runtime class does not inherit from
-`typing.Protocol`. Typeshed does this for collection interfaces such as `collections.abc.Iterable`,
-which is an ordinary abstract base class at runtime. Unlike a source-defined protocol, the stub
-therefore does not establish that the class has `_ProtocolMeta` as its metaclass.
+Typeshed can list `Protocol` as a base even when the runtime class does not inherit from
+`typing.Protocol`. For example, `collections.abc.Iterable` is an ordinary abstract base class at
+runtime. Its typeshed definition therefore does not establish that the class has `_ProtocolMeta` as
+its metaclass.
 
 When no custom metaclass is selected, ty uses `ABCMeta` instead of `type` for class attribute
 lookup. This fallback makes ABC methods such as `register` available:
 
-`interface.pyi`:
-
-```pyi
-from typing import Protocol
-
-class Interface(Protocol): ...
-```
-
-`main.py`:
-
 ```py
-from interface import Interface
+from collections.abc import Iterable
 
 class Registered: ...
 
-reveal_type(type(Interface))  # revealed: <class 'ABCMeta'>
-reveal_type(Interface.register(Registered))  # revealed: type[Registered]
+reveal_type(type(Iterable))  # revealed: <class 'ABCMeta'>
+reveal_type(Iterable.register(Registered))  # revealed: type[Registered]
 ```
 
 The inferred `ABCMeta` is not a claim about the exact runtime metaclass. It does not constrain
 subclasses, so a subclass can choose a metaclass unrelated to `ABCMeta` without a conflict.
 
-`custom.py`:
-
 ```py
-from interface import Interface
-
 class Meta(type): ...
-class Direct(Interface, metaclass=Meta): ...
+class Direct(Iterable[object], metaclass=Meta): ...
 
 reveal_type(type(Direct))  # revealed: <class 'Meta'>
 ```
 
-## Inheritance of a stub protocol metaclass fallback
+## Protocol metaclass fallback in a custom typeshed
 
-A source-defined subclass inherits the same non-constraining fallback from a stub-defined protocol.
+The same fallback applies to a configured typeshed, including one stored inside the project. These
+minimal standard-library stubs provide the types needed to check that distinction.
 
-`interface.pyi`:
+```toml
+[environment]
+typeshed = "/src/custom-typeshed"
+```
+
+`/src/custom-typeshed/stdlib/builtins.pyi`:
+
+```pyi
+class object: ...
+class type: ...
+class tuple: ...
+```
+
+`/src/custom-typeshed/stdlib/abc.pyi`:
+
+```pyi
+class ABCMeta(type): ...
+```
+
+`/src/custom-typeshed/stdlib/typing.pyi`:
+
+```pyi
+from abc import ABCMeta
+
+class _SpecialForm: ...
+
+Protocol: _SpecialForm
+
+class _ProtocolMeta(ABCMeta): ...
+
+def reveal_type(obj, /): ...
+```
+
+`/src/custom-typeshed/stdlib/interface.pyi`:
 
 ```pyi
 from typing import Protocol
@@ -768,36 +788,50 @@ from typing import Protocol
 class Interface(Protocol): ...
 ```
 
-An indirect or dynamically created subclass can choose an unrelated metaclass. `Child` can also
-share a subclass with `Other`, despite `Other`'s final metaclass, and `type[Child]` is not a subtype
-of `ABCMeta`.
+The typeshed protocol gets the lookup fallback, but an unrelated explicit metaclass wins.
 
 `main.py`:
 
 ```py
-from abc import ABCMeta
 from interface import Interface
+from typing import reveal_type
+
+class Meta(type): ...
+class Derived(Interface, metaclass=Meta): ...
+
+reveal_type(Interface.__class__)  # revealed: <class 'ABCMeta'>
+reveal_type(Derived.__class__)  # revealed: <class 'Meta'>
+```
+
+## Inheritance of a typeshed protocol metaclass fallback
+
+A source-defined subclass inherits the same non-constraining fallback from a typeshed protocol. An
+indirect or dynamically created subclass can choose an unrelated metaclass. `Child` can also share a
+subclass with `Other`, despite `Other`'s final metaclass, and `type[Child]` is not a subtype of
+`ABCMeta`.
+
+```py
+from abc import ABCMeta
+from collections.abc import Iterable
 from typing import final
 from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from, is_subtype_of
 
-class Child(Interface): ...
+class Child(Iterable[object]): ...
 
 @final
 class Meta(type): ...
 
 class Other(metaclass=Meta): ...
-class Explicit(Child, metaclass=Meta): ...
 class Left(Child, Other): ...
 class Right(Other, Child): ...
 
-Dynamic = type("Dynamic", (Interface,), {})
+Dynamic = type("Dynamic", (Iterable,), {})
 Combined = type("Combined", (Child, Other), {})
 
 class ViaDynamic(Dynamic, metaclass=Meta): ...
 
 reveal_type(type(Child))  # revealed: <class 'ABCMeta'>
-reveal_type(type(Explicit))  # revealed: <class 'Meta'>
 reveal_type(type(Left))  # revealed: <class 'Meta'>
 reveal_type(type(Right))  # revealed: <class 'Meta'>
 reveal_type(type(Combined))  # revealed: <class 'Meta'>
@@ -807,100 +841,44 @@ static_assert(not is_subtype_of(type[Child], ABCMeta))
 ```
 
 Explicitly listing `Protocol` in source declares a new protocol with a `_ProtocolMeta` constraint,
-even when another base contributes only the stub fallback.
-
-`source.py`:
+even when another base contributes only the typeshed fallback.
 
 ```py
-from interface import Interface
 from typing import Protocol
 
-class SourceProtocol(Interface, Protocol): ...
-class Meta(type): ...
+class SourceProtocol(Iterable[object], Protocol): ...
 class Invalid(SourceProtocol, metaclass=Meta): ...  # error: [conflicting-metaclass]
 ```
 
-## Explicit stub protocol metaclasses
+## Explicit typeshed protocol metaclasses
 
 Explicitly choosing the inferred `ABCMeta` makes it a real constraint on later subclasses.
 
-`interface.pyi`:
-
-```pyi
-from typing import Protocol
-
-class Interface(Protocol): ...
-```
-
-`main.py`:
-
 ```py
-from interface import Interface
+from collections.abc import Iterable
 
 class Meta(type): ...
-class Pinned(Interface, metaclass=type(Interface)): ...
+class Pinned(Iterable[object], metaclass=type(Iterable)): ...
 class Invalid(Pinned, metaclass=Meta): ...  # error: [conflicting-metaclass]
 
 reveal_type(type(Pinned))  # revealed: <class 'ABCMeta'>
 ```
 
-## Stub protocol metaclass attributes in the class namespace
+## Typeshed protocol metaclass attributes in the class namespace
 
-A stub-origin protocol fallback does not guarantee that the metaclass creates attributes in the
-class namespace, or impose a type on attributes defined there.
-
-`interface.pyi`:
-
-```pyi
-from typing import Protocol
-
-class Interface(Protocol): ...
-```
-
-`main.py`:
+A typeshed protocol fallback does not guarantee that the metaclass creates attributes in the class
+namespace, or impose a type on attributes defined there.
 
 ```py
-from interface import Interface
+from collections.abc import Iterable
 
-class StubClass(Interface): ...
+class StubClass(Iterable[object]): ...
 
 def f(stub: StubClass):
     stub.__abstractmethods__  # error: [unresolved-attribute]
 
-class OwnAttribute(Interface):
+class OwnAttribute(Iterable[object]):
     __abstractmethods__ = 1
-```
-
-## Source protocol metaclasses inherited through stubs
-
-A subclass defined in a stub inherits a source protocol's `_ProtocolMeta` constraint. Passing
-through a stub does not turn that selected metaclass into a fallback.
-
-`source.py`:
-
-```py
-from typing import Protocol
-
-class P(Protocol): ...
-```
-
-`interface.pyi`:
-
-```pyi
-from source import P
-
-class Interface(P): ...
-```
-
-`main.py`:
-
-```py
-from interface import Interface
-
-class Meta(type): ...
-class Derived(Interface, metaclass=Meta): ...  # error: [conflicting-metaclass]
-
-reveal_type(type(Interface))  # revealed: <class '_ProtocolMeta'>
 ```
 
 ## Built-in collection metaclasses

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -705,102 +705,23 @@ class InvalidDirect(Protocol, metaclass=Unrelated): ...
 class InvalidSubclass(P, metaclass=Unrelated): ...  # error: [conflicting-metaclass]
 ```
 
-## Obsolete protocol-metaclass workaround
-
-An older beartype workaround, written before typeshed exposed `_ProtocolMeta`, substitutes `ABCMeta`
-while type checking and uses the actual protocol metaclass at runtime. Although this can work at
-runtime, its type-checking branch hides the required `_ProtocolMeta` base and is rejected.
+Deriving an otherwise unrelated metaclass from `ABCMeta` does not make it compatible with
+`_ProtocolMeta`.
 
 ```py
-from abc import ABCMeta
-from typing import TYPE_CHECKING, Protocol
-
-if TYPE_CHECKING:
-    ProtocolMeta = ABCMeta
-else:
-    ProtocolMeta = type(Protocol)
-
-class Meta(ProtocolMeta): ...
-class P(Protocol, metaclass=Meta): ...  # error: [conflicting-metaclass]
-```
-
-Deriving the custom metaclass directly from `type(Protocol)` exposes the correct relationship to the
-type checker and works at runtime.
-
-```py
-class SupportedMeta(type(Protocol)): ...
-class Supported(Protocol, metaclass=SupportedMeta): ...
-
-reveal_type(type(Supported))  # revealed: <class 'SupportedMeta'>
-```
-
-## Callable class metaclass with a stub protocol fallback
-
-An ordinary class can be used as an explicit metaclass when the base supplies only a stub-origin
-`ABCMeta` fallback. Checking whether that callable constructs an appropriate class is a separate
-concern.
-
-`interface.pyi`:
-
-```pyi
-from typing import Protocol
-
-class Interface(Protocol): ...
-```
-
-`factory.py`:
-
-```py
-from interface import Interface
-
-class Factory: ...
-class Explicit(Interface, metaclass=Factory): ...
-
-reveal_type(Explicit.__class__)  # revealed: <class 'Factory'>
-```
-
-A metaclass inherited from a later base takes precedence over an earlier base's implicit protocol
-fallback, in both static and dynamic class definitions.
-
-`main.py`:
-
-```py
-from factory import Factory
-from interface import Interface
-
-class FactoryBase(metaclass=Factory): ...
-class Static(Interface, FactoryBase): ...
-
-Dynamic = type("Dynamic", (Interface, FactoryBase), {})
-
-reveal_type(Static.__class__)  # revealed: <class 'Factory'>
-reveal_type(Dynamic.__class__)  # revealed: <class 'Factory'>
-```
-
-## Explicit protocol metaclass conflicts
-
-An explicitly declared protocol metaclass constrains the metaclasses of subclasses. Two unrelated
-custom protocol metaclasses conflict even when the derived class includes `Protocol` directly.
-
-```py
-from typing import Protocol
-
-class First(type(Protocol)): ...
-class Second(type(Protocol)): ...
-class P(Protocol, metaclass=First): ...
-
-# error: [conflicting-metaclass] "`First` (metaclass of base class `P`)"
-class Direct(P, Protocol, metaclass=Second): ...
-
-# error: [conflicting-metaclass] "`First` (metaclass of base class `P`)"
-class Indirect(P, metaclass=Second): ...
+class UnrelatedABC(ABCMeta): ...
+class InvalidABC(P, metaclass=UnrelatedABC): ...  # error: [conflicting-metaclass]
 ```
 
 ## Protocol metaclass fallback in stubs
 
-A stub may model a runtime class with `Protocol` even if its implementation does not inherit from
-`typing.Protocol`. Typeshed uses this technique for some collection interfaces. If no custom
-metaclass is selected, ty infers `ABCMeta` to expose methods such as `register`.
+A stub can list `Protocol` as a base even when the runtime class does not inherit from
+`typing.Protocol`. Typeshed does this for collection interfaces such as `collections.abc.Iterable`,
+which is an ordinary abstract base class at runtime. Unlike a source-defined protocol, the stub
+therefore does not establish that the class has `_ProtocolMeta` as its metaclass.
+
+When no custom metaclass is selected, ty uses `ABCMeta` instead of `type` for class attribute
+lookup. This fallback makes ABC methods such as `register` available:
 
 `interface.pyi`:
 
@@ -810,9 +731,46 @@ from typing import Protocol
 class Interface(Protocol): ...
 ```
 
-This fallback does not constrain direct or indirect subclasses, including dynamically created
-classes. `Child` can therefore share a subclass with `Other`, despite `Other`'s final metaclass, and
-`type[Child]` is not a subtype of `ABCMeta`.
+`main.py`:
+
+```py
+from interface import Interface
+
+class Registered: ...
+
+reveal_type(type(Interface))  # revealed: <class 'ABCMeta'>
+reveal_type(Interface.register(Registered))  # revealed: type[Registered]
+```
+
+The inferred `ABCMeta` is not a claim about the exact runtime metaclass. It does not constrain
+subclasses, so a subclass can choose a metaclass unrelated to `ABCMeta` without a conflict.
+
+`custom.py`:
+
+```py
+from interface import Interface
+
+class Meta(type): ...
+class Direct(Interface, metaclass=Meta): ...
+
+reveal_type(type(Direct))  # revealed: <class 'Meta'>
+```
+
+## Inheritance of a stub protocol metaclass fallback
+
+A source-defined subclass inherits the same non-constraining fallback from a stub-defined protocol.
+
+`interface.pyi`:
+
+```pyi
+from typing import Protocol
+
+class Interface(Protocol): ...
+```
+
+An indirect or dynamically created subclass can choose an unrelated metaclass. `Child` can also
+share a subclass with `Other`, despite `Other`'s final metaclass, and `type[Child]` is not a subtype
+of `ABCMeta`.
 
 `main.py`:
 
@@ -829,20 +787,20 @@ class Child(Interface): ...
 class Meta(type): ...
 
 class Other(metaclass=Meta): ...
-class Direct(Interface, metaclass=Meta): ...
 class Explicit(Child, metaclass=Meta): ...
 class Left(Child, Other): ...
 class Right(Other, Child): ...
 
 Dynamic = type("Dynamic", (Interface,), {})
+Combined = type("Combined", (Child, Other), {})
 
 class ViaDynamic(Dynamic, metaclass=Meta): ...
 
 reveal_type(type(Child))  # revealed: <class 'ABCMeta'>
-reveal_type(type(Direct))  # revealed: <class 'Meta'>
 reveal_type(type(Explicit))  # revealed: <class 'Meta'>
 reveal_type(type(Left))  # revealed: <class 'Meta'>
 reveal_type(type(Right))  # revealed: <class 'Meta'>
+reveal_type(type(Combined))  # revealed: <class 'Meta'>
 reveal_type(type(ViaDynamic))  # revealed: <class 'Meta'>
 static_assert(not is_disjoint_from(Child, Other))
 static_assert(not is_subtype_of(type[Child], ABCMeta))

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -744,15 +744,15 @@ reveal_type(type(Direct))  # revealed: <class 'Meta'>
 
 ## Protocol metaclass fallback in a custom typeshed
 
-The same fallback applies to a configured typeshed, including one stored inside the project. These
-minimal standard-library stubs provide the types needed to check that distinction.
+The same fallback applies to a configured typeshed. These minimal standard-library stubs provide the
+types used below.
 
 ```toml
 [environment]
-typeshed = "/src/custom-typeshed"
+typeshed = "/typeshed"
 ```
 
-`/src/custom-typeshed/stdlib/builtins.pyi`:
+`/typeshed/stdlib/builtins.pyi`:
 
 ```pyi
 class object: ...
@@ -760,13 +760,13 @@ class type: ...
 class tuple: ...
 ```
 
-`/src/custom-typeshed/stdlib/abc.pyi`:
+`/typeshed/stdlib/abc.pyi`:
 
 ```pyi
 class ABCMeta(type): ...
 ```
 
-`/src/custom-typeshed/stdlib/typing.pyi`:
+`/typeshed/stdlib/typing.pyi`:
 
 ```pyi
 from abc import ABCMeta
@@ -780,7 +780,7 @@ class _ProtocolMeta(ABCMeta): ...
 def reveal_type(obj, /): ...
 ```
 
-`/src/custom-typeshed/stdlib/interface.pyi`:
+`/typeshed/stdlib/interface.pyi`:
 
 ```pyi
 from typing import Protocol

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -670,6 +670,193 @@ class C(A, B): ...
 reveal_type(C.__class__)  # revealed: <class 'M'>
 ```
 
+## Protocol metaclass inheritance
+
+A protocol's metaclass is compatible with `ABCMeta`. A more specific explicitly supplied metaclass
+must be preserved, including when its bases are obtained by calling `type`.
+
+```py
+from abc import ABC, ABCMeta
+from typing import Protocol
+
+class P(Protocol): ...
+class Base(ABC): ...
+class Combined(Base, P): ...
+class ExplicitABC(Protocol, metaclass=ABCMeta): ...
+
+reveal_type(type(Combined))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(ExplicitABC))  # revealed: <class '_ProtocolMeta'>
+
+class Meta(type(P), type(Base)): ...
+class Derived(Base, P, metaclass=Meta): ...
+
+reveal_type(type(Derived))  # revealed: <class 'Meta'>
+```
+
+## Protocol metaclass conflicts
+
+An unrelated metaclass conflicts with the metaclass inherited from `Protocol`, whether the protocol
+base is direct or inherited through another class.
+
+```py
+from typing import Protocol
+
+class Meta(type): ...
+class P(Protocol): ...
+
+# error: [conflicting-metaclass] "`_ProtocolMeta` (metaclass of base class `typing.Protocol`)"
+class Direct(Protocol, metaclass=Meta): ...
+
+# error: [conflicting-metaclass] "`_ProtocolMeta` (metaclass of base class `P`)"
+class Indirect(P, metaclass=Meta): ...
+```
+
+## Protocol metaclass fallback in stubs
+
+A stub can describe a runtime class's interface using `Protocol` without guaranteeing that the
+runtime class inherits from it. Its inferred protocol metaclass therefore acts as a fallback: a
+declared custom metaclass takes precedence, including through another source-defined subclass.
+
+`interface.pyi`:
+
+```pyi
+from typing import Protocol
+
+class Interface(Protocol): ...
+```
+
+`main.py`:
+
+```py
+from abc import ABCMeta
+from interface import Interface
+from typing import final
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
+
+class Child(Interface): ...
+
+@final
+class Meta(type): ...
+
+class Other(metaclass=Meta): ...
+class Explicit(Child, metaclass=Meta): ...
+class Left(Child, Other): ...
+class Right(Other, Child): ...
+
+reveal_type(type(Child))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Explicit))  # revealed: <class 'Meta'>
+reveal_type(type(Left))  # revealed: <class 'Meta'>
+reveal_type(type(Right))  # revealed: <class 'Meta'>
+static_assert(not is_disjoint_from(Child, Other))
+static_assert(not is_subtype_of(type[Child], ABCMeta))
+```
+
+## Explicit stub protocol metaclasses
+
+Explicitly choosing an inferred metaclass makes it a real constraint on later subclasses.
+
+`interface.pyi`:
+
+```pyi
+from typing import Protocol
+
+class Interface(Protocol): ...
+```
+
+`main.py`:
+
+```py
+from interface import Interface
+
+class Meta(type): ...
+class Pinned(Interface, metaclass=type(Interface)): ...
+class Invalid(Pinned, metaclass=Meta): ...  # error: [conflicting-metaclass]
+```
+
+## Stub protocol metaclass attributes in the class namespace
+
+A metaclass inferred from a stub-only protocol base does not guarantee that the metaclass creates
+attributes in the class namespace, or impose a type on attributes defined there.
+
+`interface.pyi`:
+
+```pyi
+from typing import Protocol
+
+class Interface(Protocol): ...
+```
+
+`main.py`:
+
+```py
+from interface import Interface
+
+class Plain(Interface): ...
+
+def f(value: Plain):
+    value.__abstractmethods__  # error: [unresolved-attribute]
+
+class OwnAttribute(Interface):
+    __abstractmethods__ = 1
+```
+
+## Source protocol metaclasses inherited through stubs
+
+A stub does not weaken a metaclass that is known from an actual source-defined protocol.
+
+`source.py`:
+
+```py
+from typing import Protocol
+
+class P(Protocol): ...
+```
+
+`interface.pyi`:
+
+```pyi
+from source import P
+
+class Interface(P): ...
+```
+
+`main.py`:
+
+```py
+from interface import Interface
+
+class Meta(type): ...
+class Invalid(Interface, metaclass=Meta): ...  # error: [conflicting-metaclass]
+
+reveal_type(type(Interface))  # revealed: <class '_ProtocolMeta'>
+```
+
+## Built-in collection metaclasses
+
+Typeshed includes collection ABCs in some built-in classes' bases to describe their interfaces.
+Those stub-only bases must not change the built-ins' runtime metaclasses or introduce conflicts when
+they are subclassed.
+
+```py
+from collections import deque
+from types import GeneratorType
+
+reveal_type(type(str))  # revealed: <class 'type'>
+reveal_type(type(tuple))  # revealed: <class 'type'>
+reveal_type(type(list))  # revealed: <class 'type'>
+reveal_type(type(dict))  # revealed: <class 'type'>
+reveal_type(type(deque))  # revealed: <class 'type'>
+reveal_type(type(GeneratorType))  # revealed: <class 'type'>
+
+class Meta(type): ...
+class CustomList(list[int], metaclass=Meta): ...
+class OrdinaryList(list[int]): ...
+
+reveal_type(type(CustomList))  # revealed: <class 'Meta'>
+reveal_type(type(OrdinaryList))  # revealed: <class 'type'>
+```
+
 ## Metaclass metaclass
 
 A class has an explicit base with a custom metaclass. That metaclass itself has a custom metaclass.

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -672,8 +672,9 @@ reveal_type(C.__class__)  # revealed: <class 'M'>
 
 ## Protocol metaclass inheritance
 
-A protocol's implicit `ABCMeta` fallback is compatible with an abstract base class. An explicitly
-supplied metaclass must be preserved, including when its base is obtained by calling `type`.
+A protocol declared in Python source imposes an `ABCMeta` constraint, which is compatible with an
+abstract base class. A compatible explicit metaclass must be preserved, including when its base is
+obtained by calling `type`.
 
 ```py
 from abc import ABC, ABCMeta
@@ -693,11 +694,22 @@ class Derived(Base, P, metaclass=Meta): ...
 reveal_type(type(Derived))  # revealed: <class 'Meta'>
 ```
 
+An unrelated metaclass conflicts with this constraint, both when declaring a protocol and when
+subclassing an existing one.
+
+```py
+class Unrelated(type): ...
+
+# error: [conflicting-metaclass] "`ABCMeta` (metaclass of base class `typing.Protocol`)"
+class InvalidDirect(Protocol, metaclass=Unrelated): ...
+class InvalidSubclass(P, metaclass=Unrelated): ...  # error: [conflicting-metaclass]
+```
+
 ## Runtime-compatible custom protocol metaclasses
 
-Libraries can use `ABCMeta` while type checking and the runtime protocol metaclass otherwise. This
-beartype-style pattern is valid at runtime, so the implicit fallback must not conflict with its
-explicitly declared metaclass.
+At least one library, beartype, uses `ABCMeta` while type checking and the actual protocol metaclass
+at runtime. This is valid at runtime, and its explicit metaclass satisfies the modeled `ABCMeta`
+constraint.
 
 ```py
 from abc import ABCMeta
@@ -716,25 +728,40 @@ reveal_type(type(P))  # revealed: <class 'Meta'>
 reveal_type(type(Child))  # revealed: <class 'Meta'>
 ```
 
-## Callable class metaclass with a protocol fallback
+## Callable class metaclass with a stub protocol fallback
 
-The fallback also does not conflict with an ordinary class used as an explicit metaclass. Checking
-whether that callable constructs an appropriate class is a separate concern.
+An ordinary class can be used as an explicit metaclass when the base supplies only a stub-origin
+`ABCMeta` fallback. Checking whether that callable constructs an appropriate class is a separate
+concern.
 
-```py
+`interface.pyi`:
+
+```pyi
 from typing import Protocol
 
-class Factory: ...
-class P(Protocol, metaclass=Factory): ...
-
-reveal_type(P.__class__)  # revealed: <class 'Factory'>
+class Interface(Protocol): ...
 ```
 
-The same applies when the first base supplies only a fallback and a later base supplies the selected
-metaclass, including dynamic class creation.
+`factory.py`:
 
 ```py
-class Interface(Protocol): ...
+from interface import Interface
+
+class Factory: ...
+class Explicit(Interface, metaclass=Factory): ...
+
+reveal_type(Explicit.__class__)  # revealed: <class 'Factory'>
+```
+
+A metaclass inherited from a later base takes precedence over an earlier base's implicit protocol
+fallback, in both static and dynamic class definitions.
+
+`main.py`:
+
+```py
+from factory import Factory
+from interface import Interface
+
 class FactoryBase(metaclass=Factory): ...
 class Static(Interface, FactoryBase): ...
 
@@ -746,8 +773,8 @@ reveal_type(Dynamic.__class__)  # revealed: <class 'Factory'>
 
 ## Explicit protocol metaclass conflicts
 
-An explicitly declared protocol metaclass remains a real constraint on subclasses. Two unrelated
-custom protocol metaclasses conflict even when the derived class also includes `Protocol` directly.
+An explicitly declared protocol metaclass constrains the metaclasses of subclasses. Two unrelated
+custom protocol metaclasses conflict even when the derived class includes `Protocol` directly.
 
 ```py
 from typing import Protocol
@@ -765,9 +792,9 @@ class Indirect(P, metaclass=Second): ...
 
 ## Protocol metaclass fallback in stubs
 
-A stub can describe a runtime class's interface using `Protocol` without guaranteeing that the
-runtime class inherits from it. Its inferred protocol metaclass therefore acts as a fallback: a
-declared custom metaclass takes precedence, including through another source-defined subclass.
+A stub may model a runtime class with `Protocol` even if its implementation does not inherit from
+`typing.Protocol`. Typeshed uses this technique for some collection interfaces. If no custom
+metaclass is selected, ty infers `ABCMeta` to expose methods such as `register`.
 
 `interface.pyi`:
 
@@ -776,6 +803,10 @@ from typing import Protocol
 
 class Interface(Protocol): ...
 ```
+
+This fallback does not constrain direct or indirect subclasses, including dynamically created
+classes. `Child` can therefore share a subclass with `Other`, despite `Other`'s final metaclass, and
+`type[Child]` is not a subtype of `ABCMeta`.
 
 `main.py`:
 
@@ -792,16 +823,37 @@ class Child(Interface): ...
 class Meta(type): ...
 
 class Other(metaclass=Meta): ...
+class Direct(Interface, metaclass=Meta): ...
 class Explicit(Child, metaclass=Meta): ...
 class Left(Child, Other): ...
 class Right(Other, Child): ...
 
+Dynamic = type("Dynamic", (Interface,), {})
+
+class ViaDynamic(Dynamic, metaclass=Meta): ...
+
 reveal_type(type(Child))  # revealed: <class 'ABCMeta'>
+reveal_type(type(Direct))  # revealed: <class 'Meta'>
 reveal_type(type(Explicit))  # revealed: <class 'Meta'>
 reveal_type(type(Left))  # revealed: <class 'Meta'>
 reveal_type(type(Right))  # revealed: <class 'Meta'>
+reveal_type(type(ViaDynamic))  # revealed: <class 'Meta'>
 static_assert(not is_disjoint_from(Child, Other))
 static_assert(not is_subtype_of(type[Child], ABCMeta))
+```
+
+Explicitly listing `Protocol` in source declares a new protocol with an `ABCMeta` constraint, even
+when another base contributes only the stub fallback.
+
+`source.py`:
+
+```py
+from interface import Interface
+from typing import Protocol
+
+class SourceProtocol(Interface, Protocol): ...
+class Meta(type): ...
+class Invalid(SourceProtocol, metaclass=Meta): ...  # error: [conflicting-metaclass]
 ```
 
 ## Explicit stub protocol metaclasses
@@ -828,11 +880,10 @@ class Invalid(Pinned, metaclass=Meta): ...  # error: [conflicting-metaclass]
 reveal_type(type(Pinned))  # revealed: <class 'ABCMeta'>
 ```
 
-## Protocol metaclass attributes in the class namespace
+## Stub protocol metaclass attributes in the class namespace
 
-An implicit protocol metaclass does not guarantee that the metaclass creates attributes in the class
-namespace, or impose a type on attributes defined there. This applies to both source and stub
-protocols.
+A stub-origin protocol fallback does not guarantee that the metaclass creates attributes in the
+class namespace, or impose a type on attributes defined there.
 
 `interface.pyi`:
 
@@ -846,23 +897,20 @@ class Interface(Protocol): ...
 
 ```py
 from interface import Interface
-from typing import Protocol
 
-class SourceInterface(Protocol): ...
 class StubClass(Interface): ...
-class SourceClass(SourceInterface): ...
 
-def f(stub: StubClass, source: SourceClass):
+def f(stub: StubClass):
     stub.__abstractmethods__  # error: [unresolved-attribute]
-    source.__abstractmethods__  # error: [unresolved-attribute]
 
-class OwnAttribute(Interface, SourceInterface):
+class OwnAttribute(Interface):
     __abstractmethods__ = 1
 ```
 
 ## Source protocol metaclasses inherited through stubs
 
-An implicit source protocol metaclass remains a fallback when inherited through a stub.
+A subclass defined in a stub inherits a source protocol's `ABCMeta` constraint. Passing through a
+stub does not turn that selected metaclass into a fallback.
 
 `source.py`:
 
@@ -886,10 +934,9 @@ class Interface(P): ...
 from interface import Interface
 
 class Meta(type): ...
-class Derived(Interface, metaclass=Meta): ...
+class Derived(Interface, metaclass=Meta): ...  # error: [conflicting-metaclass]
 
 reveal_type(type(Interface))  # revealed: <class 'ABCMeta'>
-reveal_type(type(Derived))  # revealed: <class 'Meta'>
 ```
 
 ## Built-in collection metaclasses

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -672,8 +672,8 @@ reveal_type(C.__class__)  # revealed: <class 'M'>
 
 ## Protocol metaclass inheritance
 
-A protocol's metaclass is compatible with `ABCMeta`. A more specific explicitly supplied metaclass
-must be preserved, including when its bases are obtained by calling `type`.
+A protocol's implicit `ABCMeta` fallback is compatible with an abstract base class. An explicitly
+supplied metaclass must be preserved, including when its base is obtained by calling `type`.
 
 ```py
 from abc import ABC, ABCMeta
@@ -684,31 +684,83 @@ class Base(ABC): ...
 class Combined(Base, P): ...
 class ExplicitABC(Protocol, metaclass=ABCMeta): ...
 
-reveal_type(type(Combined))  # revealed: <class '_ProtocolMeta'>
-reveal_type(type(ExplicitABC))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Combined))  # revealed: <class 'ABCMeta'>
+reveal_type(type(ExplicitABC))  # revealed: <class 'ABCMeta'>
 
-class Meta(type(P), type(Base)): ...
+class Meta(type(Protocol)): ...
 class Derived(Base, P, metaclass=Meta): ...
 
 reveal_type(type(Derived))  # revealed: <class 'Meta'>
 ```
 
-## Protocol metaclass conflicts
+## Runtime-compatible custom protocol metaclasses
 
-An unrelated metaclass conflicts with the metaclass inherited from `Protocol`, whether the protocol
-base is direct or inherited through another class.
+Libraries can use `ABCMeta` while type checking and the runtime protocol metaclass otherwise. This
+beartype-style pattern is valid at runtime, so the implicit fallback must not conflict with its
+explicitly declared metaclass.
+
+```py
+from abc import ABCMeta
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    ProtocolMeta = ABCMeta
+else:
+    ProtocolMeta = type(Protocol)
+
+class Meta(ProtocolMeta): ...
+class P(Protocol, metaclass=Meta): ...
+class Child(P, Protocol): ...
+
+reveal_type(type(P))  # revealed: <class 'Meta'>
+reveal_type(type(Child))  # revealed: <class 'Meta'>
+```
+
+## Callable class metaclass with a protocol fallback
+
+The fallback also does not conflict with an ordinary class used as an explicit metaclass. Checking
+whether that callable constructs an appropriate class is a separate concern.
 
 ```py
 from typing import Protocol
 
-class Meta(type): ...
-class P(Protocol): ...
+class Factory: ...
+class P(Protocol, metaclass=Factory): ...
 
-# error: [conflicting-metaclass] "`_ProtocolMeta` (metaclass of base class `typing.Protocol`)"
-class Direct(Protocol, metaclass=Meta): ...
+reveal_type(P.__class__)  # revealed: <class 'Factory'>
+```
 
-# error: [conflicting-metaclass] "`_ProtocolMeta` (metaclass of base class `P`)"
-class Indirect(P, metaclass=Meta): ...
+The same applies when the first base supplies only a fallback and a later base supplies the selected
+metaclass, including dynamic class creation.
+
+```py
+class Interface(Protocol): ...
+class FactoryBase(metaclass=Factory): ...
+class Static(Interface, FactoryBase): ...
+
+Dynamic = type("Dynamic", (Interface, FactoryBase), {})
+
+reveal_type(Static.__class__)  # revealed: <class 'Factory'>
+reveal_type(Dynamic.__class__)  # revealed: <class 'Factory'>
+```
+
+## Explicit protocol metaclass conflicts
+
+An explicitly declared protocol metaclass remains a real constraint on subclasses. Two unrelated
+custom protocol metaclasses conflict even when the derived class also includes `Protocol` directly.
+
+```py
+from typing import Protocol
+
+class First(type(Protocol)): ...
+class Second(type(Protocol)): ...
+class P(Protocol, metaclass=First): ...
+
+# error: [conflicting-metaclass] "`First` (metaclass of base class `P`)"
+class Direct(P, Protocol, metaclass=Second): ...
+
+# error: [conflicting-metaclass] "`First` (metaclass of base class `P`)"
+class Indirect(P, metaclass=Second): ...
 ```
 
 ## Protocol metaclass fallback in stubs
@@ -744,7 +796,7 @@ class Explicit(Child, metaclass=Meta): ...
 class Left(Child, Other): ...
 class Right(Other, Child): ...
 
-reveal_type(type(Child))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Child))  # revealed: <class 'ABCMeta'>
 reveal_type(type(Explicit))  # revealed: <class 'Meta'>
 reveal_type(type(Left))  # revealed: <class 'Meta'>
 reveal_type(type(Right))  # revealed: <class 'Meta'>
@@ -754,7 +806,7 @@ static_assert(not is_subtype_of(type[Child], ABCMeta))
 
 ## Explicit stub protocol metaclasses
 
-Explicitly choosing an inferred metaclass makes it a real constraint on later subclasses.
+Explicitly choosing the inferred `ABCMeta` makes it a real constraint on later subclasses.
 
 `interface.pyi`:
 
@@ -772,12 +824,15 @@ from interface import Interface
 class Meta(type): ...
 class Pinned(Interface, metaclass=type(Interface)): ...
 class Invalid(Pinned, metaclass=Meta): ...  # error: [conflicting-metaclass]
+
+reveal_type(type(Pinned))  # revealed: <class 'ABCMeta'>
 ```
 
-## Stub protocol metaclass attributes in the class namespace
+## Protocol metaclass attributes in the class namespace
 
-A metaclass inferred from a stub-only protocol base does not guarantee that the metaclass creates
-attributes in the class namespace, or impose a type on attributes defined there.
+An implicit protocol metaclass does not guarantee that the metaclass creates attributes in the class
+namespace, or impose a type on attributes defined there. This applies to both source and stub
+protocols.
 
 `interface.pyi`:
 
@@ -791,19 +846,23 @@ class Interface(Protocol): ...
 
 ```py
 from interface import Interface
+from typing import Protocol
 
-class Plain(Interface): ...
+class SourceInterface(Protocol): ...
+class StubClass(Interface): ...
+class SourceClass(SourceInterface): ...
 
-def f(value: Plain):
-    value.__abstractmethods__  # error: [unresolved-attribute]
+def f(stub: StubClass, source: SourceClass):
+    stub.__abstractmethods__  # error: [unresolved-attribute]
+    source.__abstractmethods__  # error: [unresolved-attribute]
 
-class OwnAttribute(Interface):
+class OwnAttribute(Interface, SourceInterface):
     __abstractmethods__ = 1
 ```
 
 ## Source protocol metaclasses inherited through stubs
 
-A stub does not weaken a metaclass that is known from an actual source-defined protocol.
+An implicit source protocol metaclass remains a fallback when inherited through a stub.
 
 `source.py`:
 
@@ -827,9 +886,10 @@ class Interface(P): ...
 from interface import Interface
 
 class Meta(type): ...
-class Invalid(Interface, metaclass=Meta): ...  # error: [conflicting-metaclass]
+class Derived(Interface, metaclass=Meta): ...
 
-reveal_type(type(Interface))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Interface))  # revealed: <class 'ABCMeta'>
+reveal_type(type(Derived))  # revealed: <class 'Meta'>
 ```
 
 ## Built-in collection metaclasses

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -291,8 +291,8 @@ reveal_type(issubclass(MyProtocol, Protocol))  # revealed: bool
 
 ## Protocol metaclasses
 
-Protocols and their nominal subclasses inherit the metaclass of `Protocol`, even when they do not
-declare a metaclass explicitly.
+Protocols and their nominal subclasses use `ABCMeta` as an implicit fallback. This exposes abstract
+base class methods without imposing a metaclass constraint on subclasses.
 
 ```py
 from typing import Protocol
@@ -301,9 +301,9 @@ class Parent(Protocol): ...
 class Child(Parent, Protocol): ...
 class Concrete(Child): ...
 
-reveal_type(type(Parent))  # revealed: <class '_ProtocolMeta'>
-reveal_type(type(Child))  # revealed: <class '_ProtocolMeta'>
-reveal_type(type(Concrete))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Parent))  # revealed: <class 'ABCMeta'>
+reveal_type(type(Child))  # revealed: <class 'ABCMeta'>
+reveal_type(type(Concrete))  # revealed: <class 'ABCMeta'>
 ```
 
 The same applies to generic protocols and the `typing_extensions` backport.
@@ -317,13 +317,14 @@ T = TypeVar("T")
 class GenericProtocol(Protocol[T]): ...
 class BackportedProtocol(ExtensionsProtocol): ...
 
-reveal_type(type(GenericProtocol))  # revealed: <class '_ProtocolMeta'>
-reveal_type(type(BackportedProtocol))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(GenericProtocol))  # revealed: <class 'ABCMeta'>
+reveal_type(type(BackportedProtocol))  # revealed: <class 'ABCMeta'>
 ```
 
 ## Protocol metaclasses in stubs
 
-Protocols defined in stubs also contribute their metaclass when imported and subclassed.
+Protocols defined in stubs use the same fallback. An explicitly supplied custom metaclass takes
+precedence when they are subclassed.
 
 `interface.pyi`:
 
@@ -342,7 +343,7 @@ from typing import Protocol
 class Meta(type(Protocol)): ...
 class Concrete(Interface, metaclass=Meta): ...
 
-reveal_type(type(Interface))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Interface))  # revealed: <class 'ABCMeta'>
 reveal_type(type(Concrete))  # revealed: <class 'Meta'>
 ```
 
@@ -353,10 +354,10 @@ Protocol classes inherit `ABCMeta.register`. Its return type preserves the regis
 ```py
 from typing import Protocol
 
-class Parent(Protocol): ...
+class P(Protocol): ...
 class Concrete: ...
 
-reveal_type(Parent.register(Concrete))  # revealed: type[Concrete]
+reveal_type(P.register(Concrete))  # revealed: type[Concrete]
 ```
 
 The method is also available on collection ABCs that typeshed models using protocols. This is a
@@ -367,6 +368,24 @@ from collections.abc import Container, Mapping
 
 reveal_type(Container.register(Concrete))  # revealed: type[Concrete]
 reveal_type(Mapping.register(Concrete))  # revealed: type[Concrete]
+```
+
+Using `register` as a class decorator also preserves generic parameters in the decorated class and
+its subclasses.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+@P.register
+@Mapping.register
+class Registered(Generic[T]): ...
+
+class Child(Registered[T]): ...
+
+reveal_type(Registered[int])  # revealed: <class 'Registered[int]'>
+reveal_type(Child[int])  # revealed: <class 'Child[int]'>
 ```
 
 ## Diagnostics and autofixes for `Protocol` classes defined in invalid ways

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -291,8 +291,8 @@ reveal_type(issubclass(MyProtocol, Protocol))  # revealed: bool
 
 ## Protocol metaclasses
 
-A protocol declared in Python source uses `typing._ProtocolMeta`. Nominal subclasses inherit this
-metaclass and the abstract base class methods it provides through `ABCMeta`.
+By default, a protocol declared outside typeshed uses `typing._ProtocolMeta`. Nominal subclasses
+inherit this metaclass and the abstract base class methods it provides through `ABCMeta`.
 
 ```py
 from typing import Protocol, _ProtocolMeta

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -289,6 +289,86 @@ static_assert(is_subtype_of(TypeOf[Protocol], typing._ProtocolMeta))
 reveal_type(issubclass(MyProtocol, Protocol))  # revealed: bool
 ```
 
+## Protocol metaclasses
+
+Protocols and their nominal subclasses inherit the metaclass of `Protocol`, even when they do not
+declare a metaclass explicitly.
+
+```py
+from typing import Protocol
+
+class Parent(Protocol): ...
+class Child(Parent, Protocol): ...
+class Concrete(Child): ...
+
+reveal_type(type(Parent))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Child))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Concrete))  # revealed: <class '_ProtocolMeta'>
+```
+
+The same applies to generic protocols and the `typing_extensions` backport.
+
+```py
+from typing import TypeVar
+from typing_extensions import Protocol as ExtensionsProtocol
+
+T = TypeVar("T")
+
+class GenericProtocol(Protocol[T]): ...
+class BackportedProtocol(ExtensionsProtocol): ...
+
+reveal_type(type(GenericProtocol))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(BackportedProtocol))  # revealed: <class '_ProtocolMeta'>
+```
+
+## Protocol metaclasses in stubs
+
+Protocols defined in stubs also contribute their metaclass when imported and subclassed.
+
+`interface.pyi`:
+
+```pyi
+from typing import Protocol
+
+class Interface(Protocol): ...
+```
+
+`main.py`:
+
+```py
+from interface import Interface
+from typing import Protocol
+
+class Meta(type(Protocol)): ...
+class Concrete(Interface, metaclass=Meta): ...
+
+reveal_type(type(Interface))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Concrete))  # revealed: <class 'Meta'>
+```
+
+## Virtual subclass registration
+
+Protocol classes inherit `ABCMeta.register`. Its return type preserves the registered instance type.
+
+```py
+from typing import Protocol
+
+class Parent(Protocol): ...
+class Concrete: ...
+
+reveal_type(Parent.register(Concrete))  # revealed: type[Concrete]
+```
+
+The method is also available on collection ABCs that typeshed models using protocols. This is a
+regression test for <https://github.com/astral-sh/ty/issues/1204>.
+
+```py
+from collections.abc import Container, Mapping
+
+reveal_type(Container.register(Concrete))  # revealed: type[Concrete]
+reveal_type(Mapping.register(Concrete))  # revealed: type[Concrete]
+```
+
 ## Diagnostics and autofixes for `Protocol` classes defined in invalid ways
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -291,8 +291,8 @@ reveal_type(issubclass(MyProtocol, Protocol))  # revealed: bool
 
 ## Protocol metaclasses
 
-Protocols and their nominal subclasses use `ABCMeta` as an implicit fallback. This exposes abstract
-base class methods without imposing a metaclass constraint on subclasses.
+A protocol declared in Python source is modeled with `ABCMeta`, which approximates its private
+runtime metaclass. Nominal subclasses inherit this metaclass and its abstract base class methods.
 
 ```py
 from typing import Protocol
@@ -321,35 +321,10 @@ reveal_type(type(GenericProtocol))  # revealed: <class 'ABCMeta'>
 reveal_type(type(BackportedProtocol))  # revealed: <class 'ABCMeta'>
 ```
 
-## Protocol metaclasses in stubs
-
-Protocols defined in stubs use the same fallback. An explicitly supplied custom metaclass takes
-precedence when they are subclassed.
-
-`interface.pyi`:
-
-```pyi
-from typing import Protocol
-
-class Interface(Protocol): ...
-```
-
-`main.py`:
-
-```py
-from interface import Interface
-from typing import Protocol
-
-class Meta(type(Protocol)): ...
-class Concrete(Interface, metaclass=Meta): ...
-
-reveal_type(type(Interface))  # revealed: <class 'ABCMeta'>
-reveal_type(type(Concrete))  # revealed: <class 'Meta'>
-```
-
 ## Virtual subclass registration
 
-Protocol classes inherit `ABCMeta.register`. Its return type preserves the registered instance type.
+Protocol classes inherit `ABCMeta.register`, which returns the registered class with its type
+intact.
 
 ```py
 from typing import Protocol
@@ -368,24 +343,6 @@ from collections.abc import Container, Mapping
 
 reveal_type(Container.register(Concrete))  # revealed: type[Concrete]
 reveal_type(Mapping.register(Concrete))  # revealed: type[Concrete]
-```
-
-Using `register` as a class decorator also preserves generic parameters in the decorated class and
-its subclasses.
-
-```py
-from typing import Generic, TypeVar
-
-T = TypeVar("T")
-
-@P.register
-@Mapping.register
-class Registered(Generic[T]): ...
-
-class Child(Registered[T]): ...
-
-reveal_type(Registered[int])  # revealed: <class 'Registered[int]'>
-reveal_type(Child[int])  # revealed: <class 'Child[int]'>
 ```
 
 ## Diagnostics and autofixes for `Protocol` classes defined in invalid ways

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -291,19 +291,22 @@ reveal_type(issubclass(MyProtocol, Protocol))  # revealed: bool
 
 ## Protocol metaclasses
 
-A protocol declared in Python source is modeled with `ABCMeta`, which approximates its private
-runtime metaclass. Nominal subclasses inherit this metaclass and its abstract base class methods.
+A protocol declared in Python source uses `typing._ProtocolMeta`. Nominal subclasses inherit this
+metaclass and the abstract base class methods it provides through `ABCMeta`.
 
 ```py
-from typing import Protocol
+from typing import Protocol, _ProtocolMeta
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
 
 class Parent(Protocol): ...
 class Child(Parent, Protocol): ...
 class Concrete(Child): ...
 
-reveal_type(type(Parent))  # revealed: <class 'ABCMeta'>
-reveal_type(type(Child))  # revealed: <class 'ABCMeta'>
-reveal_type(type(Concrete))  # revealed: <class 'ABCMeta'>
+reveal_type(type(Parent))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Child))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(Concrete))  # revealed: <class '_ProtocolMeta'>
+static_assert(is_subtype_of(type[Concrete], _ProtocolMeta))
 ```
 
 The same applies to generic protocols and the `typing_extensions` backport.
@@ -317,8 +320,8 @@ T = TypeVar("T")
 class GenericProtocol(Protocol[T]): ...
 class BackportedProtocol(ExtensionsProtocol): ...
 
-reveal_type(type(GenericProtocol))  # revealed: <class 'ABCMeta'>
-reveal_type(type(BackportedProtocol))  # revealed: <class 'ABCMeta'>
+reveal_type(type(GenericProtocol))  # revealed: <class '_ProtocolMeta'>
+reveal_type(type(BackportedProtocol))  # revealed: <class '_ProtocolMeta'>
 ```
 
 ## Virtual subclass registration

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -10384,7 +10384,7 @@ impl<'db> ModuleLiteralType<'db> {
 pub(super) struct MetaclassCandidate<'db> {
     metaclass: ClassType<'db>,
     /// The base that supplied this candidate, or `None` for the class's own metaclass.
-    base: Option<ClassBase<'db>>,
+    base: Option<ClassType<'db>>,
 }
 
 /// Information about a `@dataclass_transform`-decorated metaclass.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -10383,8 +10383,9 @@ impl<'db> ModuleLiteralType<'db> {
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) struct MetaclassCandidate<'db> {
     metaclass: ClassType<'db>,
-    /// The base that supplied this candidate, or `None` for the class's own metaclass.
-    base: Option<ClassType<'db>>,
+    /// The base that supplied this candidate, including the `Protocol` pseudo-base,
+    /// or `None` for the class's own metaclass.
+    base: Option<ClassBase<'db>>,
 }
 
 /// Information about a `@dataclass_transform`-decorated metaclass.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3715,7 +3715,8 @@ impl<'db> Type<'db> {
             .find_name_in_mro_with_policy(db, env, name, policy)
             .expect("The meta-type of an instance-like type should always have an MRO");
         let Some(metaclass) = class
-            .metaclass(db)
+            .inferred_metaclass(db)
+            .for_inheritance(db, env)
             .to_instance_approximation(db, env)
             .and_then(|metaclass| metaclass.nominal_class(db, env))
         else {
@@ -10382,7 +10383,8 @@ impl<'db> ModuleLiteralType<'db> {
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) struct MetaclassCandidate<'db> {
     metaclass: ClassType<'db>,
-    explicit_metaclass_of: StaticClassLiteral<'db>,
+    /// The base that supplied this candidate, or `None` for the class's own metaclass.
+    base: Option<ClassBase<'db>>,
 }
 
 /// Information about a `@dataclass_transform`-decorated metaclass.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3351,19 +3351,19 @@ pub(super) enum DisjointBaseKind {
     DefinesSlots,
 }
 
-/// A selected metaclass, or the `ABCMeta` fallback inferred from a stub-only protocol base.
+/// A selected metaclass, or the `ABCMeta` fallback inferred from a typeshed stdlib protocol base.
 ///
-/// Stub files can list `Protocol` as a base even when the runtime class does not inherit from it;
-/// typeshed does this for collection ABCs. Inferring a metaclass constraint from those bases would
-/// therefore produce false conflicts. The fallback exposes ABC methods such as `register`, but
-/// does not participate in metaclass selection.
+/// Typeshed lists `Protocol` as a base for some classes, such as collection ABCs, that do not
+/// inherit from it at runtime. Inferring a metaclass constraint from those bases would therefore
+/// produce false conflicts. The fallback exposes ABC methods such as `register`, but does not
+/// participate in metaclass selection.
 ///
-/// A `Protocol` base declared in source instead selects its actual `_ProtocolMeta` metaclass,
-/// which participates in metaclass selection and constrains subclasses in the usual way.
+/// Outside those stubs, a `Protocol` base selects its actual `_ProtocolMeta` metaclass, even in a
+/// stub file. It participates in metaclass selection and constrains subclasses in the usual way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) enum ClassMetaclass<'db> {
     Selected(Type<'db>),
-    /// A lookup-only fallback originating in a stub. Inheritance preserves this provenance.
+    /// A lookup-only fallback originating in typeshed. Inheritance preserves this provenance.
     ProtocolFallback,
 }
 
@@ -3391,7 +3391,7 @@ impl<'db> ClassMetaclass<'db> {
         }
     }
 
-    /// Return the metaclass guaranteed by class declarations, without the stub-only fallback.
+    /// Return the metaclass guaranteed by class declarations, without the typeshed fallback.
     pub(super) fn for_inheritance(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3358,11 +3358,13 @@ pub(super) enum DisjointBaseKind {
     DefinesSlots,
 }
 
-/// A selected metaclass, or the default inferred from a stub-only protocol base.
+/// A selected metaclass, or the `ABCMeta` fallback inferred from a protocol base.
 ///
 /// Typeshed sometimes uses protocol inheritance to describe an interface that a runtime class
-/// implements without actually inheriting from it. The fallback exposes protocol metaclass
-/// attributes, such as `register`, but must not conflict with an explicitly declared metaclass.
+/// implements without actually inheriting from it. Source code also uses `ABCMeta` as a
+/// type-checking stand-in for the private metaclass of `typing.Protocol`. Following mypy, the
+/// fallback exposes ABC methods such as `register`, but does not participate in metaclass
+/// selection or conflict with an explicitly declared metaclass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) enum ClassMetaclass<'db> {
     Selected(Type<'db>),
@@ -3389,10 +3391,11 @@ impl<'db> ClassMetaclass<'db> {
     pub(super) fn to_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         match self {
             Self::Selected(metaclass) => metaclass,
-            Self::ProtocolFallback => KnownClass::ProtocolMeta.to_class_literal(db, env),
+            Self::ProtocolFallback => KnownClass::ABCMeta.to_class_literal(db, env),
         }
     }
 
+    /// Return the metaclass guaranteed by explicit declarations, without the protocol fallback.
     pub(super) fn for_inheritance(
         self,
         db: &'db dyn Db,
@@ -3402,10 +3405,6 @@ impl<'db> ClassMetaclass<'db> {
             Self::Selected(metaclass) => metaclass,
             Self::ProtocolFallback => KnownClass::Type.to_class_literal(db, env),
         }
-    }
-
-    const fn is_protocol_fallback(self) -> bool {
-        matches!(self, Self::ProtocolFallback)
     }
 }
 
@@ -3432,7 +3431,7 @@ pub(super) enum MetaclassErrorKind<'db> {
         candidate: MetaclassCandidate<'db>,
         /// The incompatible metaclass of `base`.
         base_metaclass: ClassType<'db>,
-        base: ClassBase<'db>,
+        base: ClassType<'db>,
     },
     /// The metaclass is a parameterized generic class, which is not supported.
     GenericMetaclass,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -3358,9 +3358,8 @@ pub(super) enum DisjointBaseKind {
 /// therefore produce false conflicts. The fallback exposes ABC methods such as `register`, but
 /// does not participate in metaclass selection.
 ///
-/// A `Protocol` base declared in source instead imposes an `ABCMeta` constraint. We use `ABCMeta`
-/// rather than the private `_ProtocolMeta` because libraries such as beartype use `ABCMeta` as a
-/// type-checking stand-in for `type(Protocol)`, while inheriting the real metaclass at runtime.
+/// A `Protocol` base declared in source instead selects its actual `_ProtocolMeta` metaclass,
+/// which participates in metaclass selection and constrains subclasses in the usual way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) enum ClassMetaclass<'db> {
     Selected(Type<'db>),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1543,24 +1543,17 @@ impl<'db> ClassType<'db> {
 
     /// Return the metaclass of this class, or `type[Unknown]` if the metaclass cannot be inferred.
     pub(super) fn metaclass(self, db: &'db dyn Db) -> Type<'db> {
-        match self {
-            Self::NonGeneric(class) => class.metaclass(db),
-            Self::Generic(generic) => generic
-                .origin(db)
-                .metaclass(db)
-                .apply_optional_specialization(db, Some(generic.specialization(db))),
-        }
+        let env = ProgramEnvironment::from_file(self.class_literal(db).program_file(db));
+        self.inferred_metaclass(db).to_type(db, &env)
     }
 
     pub(super) fn inferred_metaclass(self, db: &'db dyn Db) -> ClassMetaclass<'db> {
-        match self {
-            Self::NonGeneric(class) => class.inferred_metaclass(db),
-            Self::Generic(generic) => match generic.origin(db).inferred_metaclass(db) {
-                ClassMetaclass::Selected(metaclass) => ClassMetaclass::Selected(
-                    metaclass.apply_optional_specialization(db, Some(generic.specialization(db))),
-                ),
-                ClassMetaclass::ProtocolFallback => ClassMetaclass::ProtocolFallback,
-            },
+        let (class, specialization) = self.class_literal_and_specialization(db);
+        match class.inferred_metaclass(db) {
+            ClassMetaclass::Selected(metaclass) => ClassMetaclass::Selected(
+                metaclass.apply_optional_specialization(db, specialization),
+            ),
+            ClassMetaclass::ProtocolFallback => ClassMetaclass::ProtocolFallback,
         }
     }
 
@@ -3358,16 +3351,20 @@ pub(super) enum DisjointBaseKind {
     DefinesSlots,
 }
 
-/// A selected metaclass, or the `ABCMeta` fallback inferred from a protocol base.
+/// A selected metaclass, or the `ABCMeta` fallback inferred from a stub-only protocol base.
 ///
-/// Typeshed sometimes uses protocol inheritance to describe an interface that a runtime class
-/// implements without actually inheriting from it. Source code also uses `ABCMeta` as a
-/// type-checking stand-in for the private metaclass of `typing.Protocol`. Following mypy, the
-/// fallback exposes ABC methods such as `register`, but does not participate in metaclass
-/// selection or conflict with an explicitly declared metaclass.
+/// Stub files can list `Protocol` as a base even when the runtime class does not inherit from it;
+/// typeshed does this for collection ABCs. Inferring a metaclass constraint from those bases would
+/// therefore produce false conflicts. The fallback exposes ABC methods such as `register`, but
+/// does not participate in metaclass selection.
+///
+/// A `Protocol` base declared in source instead imposes an `ABCMeta` constraint. We use `ABCMeta`
+/// rather than the private `_ProtocolMeta` because libraries such as beartype use `ABCMeta` as a
+/// type-checking stand-in for `type(Protocol)`, while inheriting the real metaclass at runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) enum ClassMetaclass<'db> {
     Selected(Type<'db>),
+    /// A lookup-only fallback originating in a stub. Inheritance preserves this provenance.
     ProtocolFallback,
 }
 
@@ -3395,7 +3392,7 @@ impl<'db> ClassMetaclass<'db> {
         }
     }
 
-    /// Return the metaclass guaranteed by explicit declarations, without the protocol fallback.
+    /// Return the metaclass guaranteed by class declarations, without the stub-only fallback.
     pub(super) fn for_inheritance(
         self,
         db: &'db dyn Db,
@@ -3431,7 +3428,7 @@ pub(super) enum MetaclassErrorKind<'db> {
         candidate: MetaclassCandidate<'db>,
         /// The incompatible metaclass of `base`.
         base_metaclass: ClassType<'db>,
-        base: ClassType<'db>,
+        base: ClassBase<'db>,
     },
     /// The metaclass is a parameterized generic class, which is not supported.
     GenericMetaclass,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -688,6 +688,16 @@ impl<'db> ClassLiteral<'db> {
         }
     }
 
+    pub(super) fn inferred_metaclass(self, db: &'db dyn Db) -> ClassMetaclass<'db> {
+        match self {
+            Self::Static(class) => class.inferred_metaclass(db),
+            Self::Dynamic(class) => class.inferred_metaclass(db),
+            Self::DynamicNamedTuple(_) | Self::DynamicTypedDict(_) | Self::DynamicEnum(_) => {
+                ClassMetaclass::Selected(self.metaclass(db))
+            }
+        }
+    }
+
     /// Look up a class-level member by iterating through the MRO.
     pub(crate) fn class_member(
         self,
@@ -1542,6 +1552,18 @@ impl<'db> ClassType<'db> {
         }
     }
 
+    pub(super) fn inferred_metaclass(self, db: &'db dyn Db) -> ClassMetaclass<'db> {
+        match self {
+            Self::NonGeneric(class) => class.inferred_metaclass(db),
+            Self::Generic(generic) => match generic.origin(db).inferred_metaclass(db) {
+                ClassMetaclass::Selected(metaclass) => ClassMetaclass::Selected(
+                    metaclass.apply_optional_specialization(db, Some(generic.specialization(db))),
+                ),
+                ClassMetaclass::ProtocolFallback => ClassMetaclass::ProtocolFallback,
+            },
+        }
+    }
+
     /// Return the [`DisjointBase`] that appears first in the MRO of this class.
     ///
     /// Returns `None` if this class does not have any disjoint bases in its MRO.
@@ -1740,11 +1762,11 @@ impl<'db> ClassType<'db> {
         // that `type` is its own metaclass (and we know that `type` can coexist in an MRO
         // with any other arbitrary class, anyway).
         let type_class = KnownClass::Type.to_class_literal(db, env);
-        let self_metaclass = self.metaclass(db);
+        let self_metaclass = self.inferred_metaclass(db).for_inheritance(db, env);
         if self_metaclass == type_class {
             return true;
         }
-        let other_metaclass = other.metaclass(db);
+        let other_metaclass = other.inferred_metaclass(db).for_inheritance(db, env);
         if other_metaclass == type_class {
             return true;
         }
@@ -3336,6 +3358,57 @@ pub(super) enum DisjointBaseKind {
     DefinesSlots,
 }
 
+/// A selected metaclass, or the default inferred from a stub-only protocol base.
+///
+/// Typeshed sometimes uses protocol inheritance to describe an interface that a runtime class
+/// implements without actually inheriting from it. The fallback exposes protocol metaclass
+/// attributes, such as `register`, but must not conflict with an explicitly declared metaclass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+pub(super) enum ClassMetaclass<'db> {
+    Selected(Type<'db>),
+    ProtocolFallback,
+}
+
+impl<'db> ClassMetaclass<'db> {
+    fn with_protocol_fallback(
+        db: &'db dyn Db,
+        selected: Type<'db>,
+        has_protocol_fallback: bool,
+    ) -> Self {
+        if has_protocol_fallback
+            && selected
+                .to_class_type(db)
+                .is_some_and(|class| class.is_known(db, KnownClass::Type))
+        {
+            Self::ProtocolFallback
+        } else {
+            Self::Selected(selected)
+        }
+    }
+
+    pub(super) fn to_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
+        match self {
+            Self::Selected(metaclass) => metaclass,
+            Self::ProtocolFallback => KnownClass::ProtocolMeta.to_class_literal(db, env),
+        }
+    }
+
+    pub(super) fn for_inheritance(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Type<'db> {
+        match self {
+            Self::Selected(metaclass) => metaclass,
+            Self::ProtocolFallback => KnownClass::Type.to_class_literal(db, env),
+        }
+    }
+
+    const fn is_protocol_fallback(self) -> bool {
+        matches!(self, Self::ProtocolFallback)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) struct MetaclassError<'db> {
     kind: MetaclassErrorKind<'db>,
@@ -3355,16 +3428,11 @@ pub(super) enum MetaclassErrorKind<'db> {
     /// The metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all
     /// its bases.
     Conflict {
-        /// `candidate1` will either be the explicit `metaclass=` keyword in the class definition,
-        /// or the inferred metaclass of a base class
-        candidate1: MetaclassCandidate<'db>,
-
-        /// `candidate2` will always be the inferred metaclass of a base class
-        candidate2: MetaclassCandidate<'db>,
-
-        /// Flag to indicate whether `candidate1` is the explicit `metaclass=` keyword or the
-        /// inferred metaclass of a base class. This helps us give better error messages in diagnostics.
-        candidate1_is_base_class: bool,
+        /// The explicit `metaclass=` keyword or a previously visited base's metaclass.
+        candidate: MetaclassCandidate<'db>,
+        /// The incompatible metaclass of `base`.
+        base_metaclass: ClassType<'db>,
+        base: ClassBase<'db>,
     },
     /// The metaclass is a parameterized generic class, which is not supported.
     GenericMetaclass,

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -10,9 +10,9 @@ use crate::{
         ClassBase, ClassLiteral, ClassType, DataclassParams, KnownClass, MemberLookupPolicy,
         SubclassOfType, Type,
         class::{
-            ClassMemberResult, CodeGeneratorKind, DisjointBase, DynamicClassHeaderAnchor,
-            DynamicClassScopeOffset, InstanceMemberResult, MroLookup, dynamic_class_header_range,
-            typed_dict::typed_dict_fallback_class_member,
+            ClassMemberResult, ClassMetaclass, CodeGeneratorKind, DisjointBase,
+            DynamicClassHeaderAnchor, DynamicClassScopeOffset, InstanceMemberResult, MroLookup,
+            dynamic_class_header_range, typed_dict::typed_dict_fallback_class_member,
         },
         definition_expression_type, extract_fixed_length_iterable_element_types,
         member::Member,
@@ -265,6 +265,11 @@ impl<'db> DynamicClassLiteral<'db> {
             .unwrap_or_else(|_| SubclassOfType::subclass_of_unknown())
     }
 
+    pub(super) fn inferred_metaclass(self, db: &'db dyn Db) -> ClassMetaclass<'db> {
+        self.try_infer_metaclass(db)
+            .unwrap_or_else(|_| ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()))
+    }
+
     /// Try to get the metaclass of this dynamic class.
     ///
     /// Returns `Err(DynamicMetaclassConflict)` if there's a metaclass conflict
@@ -275,6 +280,15 @@ impl<'db> DynamicClassLiteral<'db> {
         self,
         db: &'db dyn Db,
     ) -> Result<Type<'db>, DynamicMetaclassConflict<'db>> {
+        let env = ProgramEnvironment::from_scope(self.scope(db));
+        self.try_infer_metaclass(db)
+            .map(|metaclass| metaclass.to_type(db, &env))
+    }
+
+    fn try_infer_metaclass(
+        self,
+        db: &'db dyn Db,
+    ) -> Result<ClassMetaclass<'db>, DynamicMetaclassConflict<'db>> {
         let original_bases = self.explicit_bases(db);
         let env = ProgramEnvironment::from_scope(self.scope(db));
 
@@ -282,36 +296,51 @@ impl<'db> DynamicClassLiteral<'db> {
         // To dynamically create a class with no bases that has a custom metaclass,
         // you have to invoke that metaclass rather than `type()`.
         if original_bases.is_empty() {
-            return Ok(KnownClass::Type.to_class_literal(db, &env));
+            return Ok(ClassMetaclass::Selected(
+                KnownClass::Type.to_class_literal(db, &env),
+            ));
         }
 
         // If there's an MRO error, return unknown to avoid cascading errors.
         if self.try_mro(db).is_err() {
-            return Ok(SubclassOfType::subclass_of_unknown());
+            return Ok(ClassMetaclass::Selected(
+                SubclassOfType::subclass_of_unknown(),
+            ));
         }
 
         // Convert Types to ClassBases for metaclass computation.
         // All bases should convert successfully here: `try_mro()` above would have
         // returned `Err(InvalidBases)` if any failed, causing us to return early.
-        let bases: Vec<ClassBase<'db>> = original_bases
+        let mut bases = original_bases
             .iter()
-            .filter_map(|base_type| ClassBase::try_from_type(db, &env, *base_type, None))
-            .collect();
+            .filter_map(|base_type| ClassBase::try_from_type(db, &env, *base_type, None));
 
         // If all bases failed to convert, return type as the metaclass.
-        if bases.is_empty() {
-            return Ok(KnownClass::Type.to_class_literal(db, &env));
-        }
+        let Some(mut candidate_base) = bases.next() else {
+            return Ok(ClassMetaclass::Selected(
+                KnownClass::Type.to_class_literal(db, &env),
+            ));
+        };
+
+        let is_stub = self.scope(db).file(db).is_stub(db);
+        let infer_base_metaclass = |base: ClassBase<'db>| {
+            if is_stub && matches!(base, ClassBase::Protocol) {
+                ClassMetaclass::ProtocolFallback
+            } else {
+                base.inferred_metaclass(db, &env)
+            }
+        };
 
         // Start with the first base's metaclass as the candidate.
-        let mut candidate = bases[0].metaclass(db, &env);
-
-        // Track which base the candidate metaclass came from.
-        let (mut candidate_base, rest) = bases.split_first().unwrap();
+        let first_metaclass = infer_base_metaclass(candidate_base);
+        let mut candidate = first_metaclass.for_inheritance(db, &env);
+        let mut has_protocol_fallback = first_metaclass.is_protocol_fallback();
 
         // Reconcile with other bases' metaclasses.
-        for base in rest {
-            let base_metaclass = base.metaclass(db, &env);
+        for base in bases {
+            let inferred_metaclass = infer_base_metaclass(base);
+            has_protocol_fallback |= inferred_metaclass.is_protocol_fallback();
+            let base_metaclass = inferred_metaclass.for_inheritance(db, &env);
 
             // Get the ClassType for comparison.
             let Some(candidate_class) = candidate.to_class_type(db) else {
@@ -322,6 +351,11 @@ impl<'db> DynamicClassLiteral<'db> {
                 continue;
             };
 
+            // Keep the incumbent when both metaclasses are equal.
+            if candidate_class.is_subclass_of(db, &env, base_metaclass_class) {
+                continue;
+            }
+
             // If base's metaclass is more derived, use it.
             if base_metaclass_class.is_subclass_of(db, &env, candidate_class) {
                 candidate = base_metaclass;
@@ -329,22 +363,21 @@ impl<'db> DynamicClassLiteral<'db> {
                 continue;
             }
 
-            // If candidate is already more derived, keep it.
-            if candidate_class.is_subclass_of(db, &env, base_metaclass_class) {
-                continue;
-            }
-
             // Conflict: neither metaclass is a subclass of the other.
             // Python raises `TypeError: metaclass conflict` at runtime.
             return Err(DynamicMetaclassConflict {
                 metaclass1: candidate_class,
-                base1: *candidate_base,
+                base1: candidate_base,
                 metaclass2: base_metaclass_class,
-                base2: *base,
+                base2: base,
             });
         }
 
-        Ok(candidate)
+        Ok(ClassMetaclass::with_protocol_fallback(
+            db,
+            candidate,
+            has_protocol_fallback,
+        ))
     }
 
     /// Iterate over the MRO of this class using C3 linearization.

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -311,37 +311,29 @@ impl<'db> DynamicClassLiteral<'db> {
         // Convert Types to ClassBases for metaclass computation.
         // All bases should convert successfully here: `try_mro()` above would have
         // returned `Err(InvalidBases)` if any failed, causing us to return early.
+        let mut has_protocol_fallback = false;
         let mut bases = original_bases
             .iter()
-            .filter_map(|base_type| ClassBase::try_from_type(db, &env, *base_type, None));
+            .filter_map(|base_type| ClassBase::try_from_type(db, &env, *base_type, None))
+            .filter_map(|base| match base.inferred_metaclass(db, &env) {
+                ClassMetaclass::Selected(metaclass) => Some((base, metaclass)),
+                ClassMetaclass::ProtocolFallback => {
+                    has_protocol_fallback = true;
+                    None
+                }
+            });
 
-        // If all bases failed to convert, return type as the metaclass.
-        let Some(mut candidate_base) = bases.next() else {
-            return Ok(ClassMetaclass::Selected(
+        // Start with the first selected metaclass, ignoring protocol fallbacks.
+        let Some((mut candidate_base, mut candidate)) = bases.next() else {
+            return Ok(ClassMetaclass::with_protocol_fallback(
+                db,
                 KnownClass::Type.to_class_literal(db, &env),
+                has_protocol_fallback,
             ));
         };
 
-        let is_stub = self.scope(db).file(db).is_stub(db);
-        let infer_base_metaclass = |base: ClassBase<'db>| {
-            if is_stub && matches!(base, ClassBase::Protocol) {
-                ClassMetaclass::ProtocolFallback
-            } else {
-                base.inferred_metaclass(db, &env)
-            }
-        };
-
-        // Start with the first base's metaclass as the candidate.
-        let first_metaclass = infer_base_metaclass(candidate_base);
-        let mut candidate = first_metaclass.for_inheritance(db, &env);
-        let mut has_protocol_fallback = first_metaclass.is_protocol_fallback();
-
         // Reconcile with other bases' metaclasses.
-        for base in bases {
-            let inferred_metaclass = infer_base_metaclass(base);
-            has_protocol_fallback |= inferred_metaclass.is_protocol_fallback();
-            let base_metaclass = inferred_metaclass.for_inheritance(db, &env);
-
+        for (base, base_metaclass) in bases {
             // Get the ClassType for comparison.
             let Some(candidate_class) = candidate.to_class_type(db) else {
                 // If candidate isn't a class type, keep it as is.

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -261,12 +261,12 @@ impl<'db> DynamicClassLiteral<'db> {
     ///
     /// See <https://docs.python.org/3/reference/datamodel.html#determining-the-appropriate-metaclass>
     pub(crate) fn metaclass(self, db: &'db dyn Db) -> Type<'db> {
-        self.try_metaclass(db)
-            .unwrap_or_else(|_| SubclassOfType::subclass_of_unknown())
+        let env = ProgramEnvironment::from_scope(self.scope(db));
+        self.inferred_metaclass(db).to_type(db, &env)
     }
 
     pub(super) fn inferred_metaclass(self, db: &'db dyn Db) -> ClassMetaclass<'db> {
-        self.try_infer_metaclass(db)
+        self.try_metaclass(db)
             .unwrap_or_else(|_| ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()))
     }
 
@@ -276,16 +276,7 @@ impl<'db> DynamicClassLiteral<'db> {
     /// (i.e., two base classes have metaclasses that are not in a subclass relationship).
     ///
     /// See <https://docs.python.org/3/reference/datamodel.html#determining-the-appropriate-metaclass>
-    pub(crate) fn try_metaclass(
-        self,
-        db: &'db dyn Db,
-    ) -> Result<Type<'db>, DynamicMetaclassConflict<'db>> {
-        let env = ProgramEnvironment::from_scope(self.scope(db));
-        self.try_infer_metaclass(db)
-            .map(|metaclass| metaclass.to_type(db, &env))
-    }
-
-    fn try_infer_metaclass(
+    pub(in crate::types) fn try_metaclass(
         self,
         db: &'db dyn Db,
     ) -> Result<ClassMetaclass<'db>, DynamicMetaclassConflict<'db>> {
@@ -315,11 +306,13 @@ impl<'db> DynamicClassLiteral<'db> {
         let mut bases = original_bases
             .iter()
             .filter_map(|base_type| ClassBase::try_from_type(db, &env, *base_type, None))
-            .filter_map(|base| match base.inferred_metaclass(db, &env) {
-                ClassMetaclass::Selected(metaclass) => Some((base, metaclass)),
-                ClassMetaclass::ProtocolFallback => {
-                    has_protocol_fallback = true;
-                    None
+            .filter_map(|base| {
+                match base.inferred_metaclass(db, &env, ClassLiteral::Dynamic(self)) {
+                    ClassMetaclass::Selected(metaclass) => Some((base, metaclass)),
+                    ClassMetaclass::ProtocolFallback => {
+                        has_protocol_fallback = true;
+                        None
+                    }
                 }
             });
 

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -171,10 +171,119 @@ impl KnownClass {
     /// Built-in and extension types can inherit from collection ABCs only in their stubs. Those
     /// bases must not give the runtime class an inferred protocol metaclass.
     pub(super) fn has_known_type_metaclass(self, python_version: PythonVersion) -> bool {
-        matches!(
-            self.canonical_module(python_version),
-            KnownModule::Builtins | KnownModule::Types
-        ) || matches!(self, Self::Deque)
+        match self {
+            Self::Bool
+            | Self::Object
+            | Self::Bytes
+            | Self::Bytearray
+            | Self::Memoryview
+            | Self::Type
+            | Self::Int
+            | Self::Float
+            | Self::Complex
+            | Self::Str
+            | Self::List
+            | Self::Tuple
+            | Self::Range
+            | Self::Set
+            | Self::FrozenSet
+            | Self::Dict
+            | Self::Slice
+            | Self::Property
+            | Self::BaseException
+            | Self::Exception
+            | Self::Warning
+            | Self::BaseExceptionGroup
+            | Self::ExceptionGroup
+            | Self::Staticmethod
+            | Self::Classmethod
+            | Self::Super
+            | Self::NotImplementedError
+            | Self::GenericAlias
+            | Self::ModuleType
+            | Self::FunctionType
+            | Self::MethodType
+            | Self::MethodWrapperType
+            | Self::WrapperDescriptorType
+            | Self::UnionType
+            | Self::GeneratorType
+            | Self::AsyncGeneratorType
+            | Self::CoroutineType
+            | Self::NotImplementedType
+            | Self::BuiltinFunctionType
+            | Self::EllipsisType
+            | Self::Deque => true,
+
+            Self::Sentinel => python_version >= PythonVersion::PY315,
+
+            Self::Enum
+            | Self::EnumProperty
+            | Self::EnumType
+            | Self::Auto
+            | Self::Member
+            | Self::Nonmember
+            | Self::StrEnum
+            | Self::IntEnum
+            | Self::Flag
+            | Self::IntFlag
+            | Self::ABCMeta
+            | Self::NoneType
+            | Self::SupportsKeysAndGetItem
+            | Self::Awaitable
+            | Self::Generator
+            | Self::AsyncGenerator
+            | Self::Deprecated
+            | Self::StdlibAlias
+            | Self::SpecialForm
+            | Self::TypeVar
+            | Self::ParamSpec
+            | Self::ExtensionsParamSpec
+            | Self::ParamSpecArgs
+            | Self::ParamSpecKwargs
+            | Self::ProtocolMeta
+            | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
+            | Self::TypeAliasType
+            | Self::ExtensionsTypeAliasType
+            | Self::NoDefaultType
+            | Self::NewType
+            | Self::Hashable
+            | Self::SupportsIndex
+            | Self::Iterable
+            | Self::Iterator
+            | Self::AsyncIterator
+            | Self::Sequence
+            | Self::Mapping
+            | Self::MutableMapping
+            | Self::ExtensionsTypeVar
+            | Self::ExtensionTypedDictFallback
+            | Self::ChainMap
+            | Self::Counter
+            | Self::DefaultDict
+            | Self::OrderedDict
+            | Self::VersionInfo
+            | Self::Field
+            | Self::KwOnly
+            | Self::NamedTupleFallback
+            | Self::NamedTupleLike
+            | Self::TypedDictFallback
+            | Self::Template
+            | Self::Path
+            | Self::FunctoolsPartial
+            | Self::ConstraintSet
+            | Self::ConstraintSetSolution
+            | Self::GenericContext
+            | Self::Specialization
+            | Self::TyExtensionsAsyncIterable
+            | Self::TyExtensionsAsyncIterator
+            | Self::TyExtensionsIterable
+            | Self::TyExtensionsIterator
+            | Self::PydanticBaseModel
+            | Self::PydanticBaseSettings
+            | Self::PydanticConfigDict
+            | Self::PydanticRootModel
+            | Self::PydanticStrict => false,
+        }
     }
 
     pub(crate) const fn is_bool(self) -> bool {

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -166,20 +166,15 @@ pub enum KnownClass {
 }
 
 impl KnownClass {
-    /// Return a runtime metaclass that is known independently of typeshed's inheritance graph.
+    /// Return whether this class is known to have `type` as its runtime metaclass.
     ///
     /// Built-in and extension types can inherit from collection ABCs only in their stubs. Those
     /// bases must not give the runtime class an inferred protocol metaclass.
-    pub(super) fn known_metaclass(self, python_version: PythonVersion) -> Option<Self> {
-        if matches!(
+    pub(super) fn has_known_type_metaclass(self, python_version: PythonVersion) -> bool {
+        matches!(
             self.canonical_module(python_version),
             KnownModule::Builtins | KnownModule::Types
         ) || matches!(self, Self::Deque)
-        {
-            Some(Self::Type)
-        } else {
-            None
-        }
     }
 
     pub(crate) const fn is_bool(self) -> bool {

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -166,6 +166,22 @@ pub enum KnownClass {
 }
 
 impl KnownClass {
+    /// Return a runtime metaclass that is known independently of typeshed's inheritance graph.
+    ///
+    /// Built-in and extension types can inherit from collection ABCs only in their stubs. Those
+    /// bases must not give the runtime class an inferred protocol metaclass.
+    pub(super) fn known_metaclass(self, python_version: PythonVersion) -> Option<Self> {
+        if matches!(
+            self.canonical_module(python_version),
+            KnownModule::Builtins | KnownModule::Types
+        ) || matches!(self, Self::Deque)
+        {
+            Some(Self::Type)
+        } else {
+            None
+        }
+    }
+
     pub(crate) const fn is_bool(self) -> bool {
         matches!(self, Self::Bool)
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1213,14 +1213,6 @@ impl<'db> StaticClassLiteral<'db> {
             let module = parsed_module(db, python_file).load(db);
 
             let explicit_metaclass = class.explicit_metaclass(db, &module);
-            let is_stub = class.file(db).is_stub(db);
-            let infer_base_metaclass = |base: ClassBase<'db>| {
-                if is_stub && matches!(base, ClassBase::Protocol) {
-                    ClassMetaclass::ProtocolFallback
-                } else {
-                    base.inferred_metaclass(db, &env)
-                }
-            };
 
             // Generic metaclasses parameterized by type variables are not supported.
             // `metaclass=Meta[int]` is fine, but `metaclass=Meta[T]` is not.
@@ -1238,19 +1230,24 @@ impl<'db> StaticClassLiteral<'db> {
                 }
             }
 
-            let (metaclass, base, mut has_protocol_fallback) =
-                if let Some(metaclass) = explicit_metaclass {
-                    (metaclass, None, false)
-                } else if let Some(base_class) = base_classes.next() {
-                    let metaclass = infer_base_metaclass(base_class);
-                    (
-                        metaclass.for_inheritance(db, &env),
-                        Some(base_class),
-                        metaclass.is_protocol_fallback(),
-                    )
-                } else {
-                    (KnownClass::Type.to_class_literal(db, &env), None, false)
-                };
+            let mut has_protocol_fallback = false;
+            let mut base_metaclasses =
+                base_classes.filter_map(|base| match base.inferred_metaclass(db, &env) {
+                    ClassMetaclass::Selected(metaclass) => {
+                        base.into_class().map(|base| (base, metaclass))
+                    }
+                    ClassMetaclass::ProtocolFallback => {
+                        has_protocol_fallback = true;
+                        None
+                    }
+                });
+            let (metaclass, base) = if let Some(metaclass) = explicit_metaclass {
+                (metaclass, None)
+            } else if let Some((base_class, metaclass)) = base_metaclasses.next() {
+                (metaclass, Some(base_class))
+            } else {
+                (KnownClass::Type.to_class_literal(db, &env), None)
+            };
 
             let mut candidate = if let Some(metaclass_ty) = metaclass.to_class_type(db) {
                 MetaclassCandidate {
@@ -1296,10 +1293,7 @@ impl<'db> StaticClassLiteral<'db> {
             // See:
             // - https://docs.python.org/3/reference/datamodel.html#determining-the-appropriate-metaclass
             // - https://github.com/python/cpython/blob/83ba8c2bba834c0b92de669cac16fcda17485e0e/Objects/typeobject.c#L3629-L3663
-            for base_class in base_classes {
-                let metaclass = infer_base_metaclass(base_class);
-                has_protocol_fallback |= metaclass.is_protocol_fallback();
-                let metaclass = metaclass.for_inheritance(db, &env);
+            for (base_class, metaclass) in base_metaclasses {
                 let Some(metaclass) = metaclass.to_class_type(db) else {
                     continue;
                 };
@@ -1334,8 +1328,7 @@ impl<'db> StaticClassLiteral<'db> {
                 });
             let metaclass = if class
                 .known(db)
-                .and_then(|known| known.known_metaclass(env.python_version(db)))
-                == Some(KnownClass::Type)
+                .is_some_and(|known| known.has_known_type_metaclass(env.python_version(db)))
             {
                 ClassMetaclass::Selected(candidate.metaclass.into())
             } else {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1148,28 +1148,18 @@ impl<'db> StaticClassLiteral<'db> {
 
     /// Return the metaclass of this class, or `type[Unknown]` if the metaclass cannot be inferred.
     pub(crate) fn metaclass(self, db: &'db dyn Db) -> Type<'db> {
-        self.try_metaclass(db)
-            .map(|(ty, _)| ty)
-            .unwrap_or_else(|_| SubclassOfType::subclass_of_unknown())
+        let env = ProgramEnvironment::from_scope(self.body_scope(db));
+        self.inferred_metaclass(db).to_type(db, &env)
     }
 
     pub(in crate::types) fn inferred_metaclass(self, db: &'db dyn Db) -> ClassMetaclass<'db> {
-        self.infer_metaclass(db)
+        self.try_metaclass(db)
             .map(|(metaclass, _)| metaclass)
             .unwrap_or_else(|_| ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()))
     }
 
-    /// Return the metaclass of this class, or an error if the metaclass cannot be inferred.
+    /// Return the selected metaclass or protocol fallback, or an error if it cannot be inferred.
     pub(in crate::types) fn try_metaclass(
-        self,
-        db: &'db dyn Db,
-    ) -> Result<(Type<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
-        let env = ProgramEnvironment::from_scope(self.body_scope(db));
-        self.infer_metaclass(db)
-            .map(|(metaclass, info)| (metaclass.to_type(db, &env), info))
-    }
-
-    fn infer_metaclass(
         self,
         db: &'db dyn Db,
     ) -> Result<(ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>>
@@ -1194,16 +1184,11 @@ impl<'db> StaticClassLiteral<'db> {
             // Identify the class's own metaclass (or take the first base class's metaclass).
             let mut base_classes = class.metaclass_bases(db).peekable();
 
-            if base_classes.peek().is_some() && class.inheritance_cycle(db).is_some() {
+            if (base_classes.peek().is_some() && class.inheritance_cycle(db).is_some())
+                || class.try_mro(db, None).is_err_and(StaticMroError::is_cycle)
+            {
                 // We emit diagnostics for cyclic class definitions elsewhere.
                 // Avoid attempting to infer the metaclass if the class is cyclically defined.
-                return Ok((
-                    ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()),
-                    None,
-                ));
-            }
-
-            if class.try_mro(db, None).is_err_and(StaticMroError::is_cycle) {
                 return Ok((
                     ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()),
                     None,
@@ -1231,16 +1216,15 @@ impl<'db> StaticClassLiteral<'db> {
             }
 
             let mut has_protocol_fallback = false;
-            let mut base_metaclasses =
-                base_classes.filter_map(|base| match base.inferred_metaclass(db, &env) {
-                    ClassMetaclass::Selected(metaclass) => {
-                        base.into_class().map(|base| (base, metaclass))
-                    }
+            let mut base_metaclasses = base_classes.filter_map(|base| {
+                match base.inferred_metaclass(db, &env, ClassLiteral::Static(class)) {
+                    ClassMetaclass::Selected(metaclass) => Some((base, metaclass)),
                     ClassMetaclass::ProtocolFallback => {
                         has_protocol_fallback = true;
                         None
                     }
-                });
+                }
+            });
             let (metaclass, base) = if let Some(metaclass) = explicit_metaclass {
                 (metaclass, None)
             } else if let Some((base_class, metaclass)) = base_metaclasses.next() {
@@ -1326,19 +1310,18 @@ impl<'db> StaticClassLiteral<'db> {
                     params,
                     from_explicit_metaclass: candidate.base.is_none(),
                 });
-            let metaclass = if class
-                .known(db)
-                .is_some_and(|known| known.has_known_type_metaclass(env.python_version(db)))
-            {
-                ClassMetaclass::Selected(candidate.metaclass.into())
-            } else {
+            let use_protocol_fallback = has_protocol_fallback
+                && !class
+                    .known(db)
+                    .is_some_and(|known| known.has_known_type_metaclass(env.python_version(db)));
+            Ok((
                 ClassMetaclass::with_protocol_fallback(
                     db,
                     candidate.metaclass.into(),
-                    has_protocol_fallback,
-                )
-            };
-            Ok((metaclass, transform_info))
+                    use_protocol_fallback,
+                ),
+                transform_info,
+            ))
         }
 
         if !self.has_explicit_bases(db) && !self.has_explicit_metaclass(db) {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -31,7 +31,7 @@ use crate::{
         call::{CallError, CallErrorKind},
         callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
-            ClassInstanceFlags, ClassMemberResult, CodeGeneratorKind, DisjointBase,
+            ClassInstanceFlags, ClassMemberResult, ClassMetaclass, CodeGeneratorKind, DisjointBase,
             DynamicTypedDictLiteral, Field, FieldKind, InstanceMemberResult, MetaclassError,
             MetaclassErrorKind, MethodDecorator, MroLookup, NamedTupleField, SlotsKind,
             synthesize_namedtuple_class_member,
@@ -661,17 +661,16 @@ impl<'db> StaticClassLiteral<'db> {
         }
     }
 
-    /// Iterate over this class's explicit bases, resolving them in the same way as MRO
-    /// construction, filtering out any bases that are not fully static class objects.
-    fn fully_static_explicit_bases(self, db: &'db dyn Db) -> impl Iterator<Item = ClassType<'db>> {
+    /// Iterate over the explicit bases that contribute to metaclass selection.
+    fn metaclass_bases(self, db: &'db dyn Db) -> impl Iterator<Item = ClassBase<'db>> {
         let env = ProgramEnvironment::from_scope(self.body_scope(db));
         self.explicit_bases(db)
             .iter()
             .copied()
             .filter_map(move |ty| {
                 ClassBase::try_from_type(db, &env, ty, Some(ClassLiteral::Static(self)))
-                    .and_then(ClassBase::into_class)
             })
+            .filter(|base| matches!(base, ClassBase::Class(_) | ClassBase::Protocol))
     }
 
     /// Determine if this class is a protocol.
@@ -1154,11 +1153,27 @@ impl<'db> StaticClassLiteral<'db> {
             .unwrap_or_else(|_| SubclassOfType::subclass_of_unknown())
     }
 
+    pub(in crate::types) fn inferred_metaclass(self, db: &'db dyn Db) -> ClassMetaclass<'db> {
+        self.infer_metaclass(db)
+            .map(|(metaclass, _)| metaclass)
+            .unwrap_or_else(|_| ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()))
+    }
+
     /// Return the metaclass of this class, or an error if the metaclass cannot be inferred.
     pub(in crate::types) fn try_metaclass(
         self,
         db: &'db dyn Db,
     ) -> Result<(Type<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
+        let env = ProgramEnvironment::from_scope(self.body_scope(db));
+        self.infer_metaclass(db)
+            .map(|(metaclass, info)| (metaclass.to_type(db, &env), info))
+    }
+
+    fn infer_metaclass(
+        self,
+        db: &'db dyn Db,
+    ) -> Result<(ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>>
+    {
         #[salsa::tracked(
             returns(clone),
             cycle_initial=|_, _, _| Err(MetaclassError {
@@ -1169,28 +1184,43 @@ impl<'db> StaticClassLiteral<'db> {
         fn try_metaclass_inner<'db>(
             db: &'db dyn Db,
             class: StaticClassLiteral<'db>,
-        ) -> Result<(Type<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
+        ) -> Result<(ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>>
+        {
             let program_file = class.program_file(db);
             let python_file = program_file.python_file(db);
             let env = ProgramEnvironment::from_file(program_file);
             tracing::trace!("StaticClassLiteral::try_metaclass: {}", class.name(db));
 
             // Identify the class's own metaclass (or take the first base class's metaclass).
-            let mut base_classes = class.fully_static_explicit_bases(db).peekable();
+            let mut base_classes = class.metaclass_bases(db).peekable();
 
             if base_classes.peek().is_some() && class.inheritance_cycle(db).is_some() {
                 // We emit diagnostics for cyclic class definitions elsewhere.
                 // Avoid attempting to infer the metaclass if the class is cyclically defined.
-                return Ok((SubclassOfType::subclass_of_unknown(), None));
+                return Ok((
+                    ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()),
+                    None,
+                ));
             }
 
             if class.try_mro(db, None).is_err_and(StaticMroError::is_cycle) {
-                return Ok((SubclassOfType::subclass_of_unknown(), None));
+                return Ok((
+                    ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()),
+                    None,
+                ));
             }
 
             let module = parsed_module(db, python_file).load(db);
 
             let explicit_metaclass = class.explicit_metaclass(db, &module);
+            let is_stub = class.file(db).is_stub(db);
+            let infer_base_metaclass = |base: ClassBase<'db>| {
+                if is_stub && matches!(base, ClassBase::Protocol) {
+                    ClassMetaclass::ProtocolFallback
+                } else {
+                    base.inferred_metaclass(db, &env)
+                }
+            };
 
             // Generic metaclasses parameterized by type variables are not supported.
             // `metaclass=Meta[int]` is fine, but `metaclass=Meta[T]` is not.
@@ -1208,25 +1238,24 @@ impl<'db> StaticClassLiteral<'db> {
                 }
             }
 
-            let (metaclass, class_metaclass_was_from) = if let Some(metaclass) = explicit_metaclass
-            {
-                (metaclass, class)
-            } else if let Some(base_class) = base_classes.next() {
-                // For dynamic classes, we can't get a StaticClassLiteral, so use this class for
-                // tracking.
-                let base_class_literal = base_class
-                    .static_class_literal(db)
-                    .map(|(lit, _)| lit)
-                    .unwrap_or(class);
-                (base_class.metaclass(db), base_class_literal)
-            } else {
-                (KnownClass::Type.to_class_literal(db, &env), class)
-            };
+            let (metaclass, base, mut has_protocol_fallback) =
+                if let Some(metaclass) = explicit_metaclass {
+                    (metaclass, None, false)
+                } else if let Some(base_class) = base_classes.next() {
+                    let metaclass = infer_base_metaclass(base_class);
+                    (
+                        metaclass.for_inheritance(db, &env),
+                        Some(base_class),
+                        metaclass.is_protocol_fallback(),
+                    )
+                } else {
+                    (KnownClass::Type.to_class_literal(db, &env), None, false)
+                };
 
             let mut candidate = if let Some(metaclass_ty) = metaclass.to_class_type(db) {
                 MetaclassCandidate {
                     metaclass: metaclass_ty,
-                    explicit_metaclass_of: class_metaclass_was_from,
+                    base,
                 }
             } else {
                 let name = Type::string_literal(db, class.name(db));
@@ -1258,7 +1287,8 @@ impl<'db> StaticClassLiteral<'db> {
                     }),
                 };
 
-                return return_ty_result.map(|ty| (ty.to_meta_type(db, &env), None));
+                return return_ty_result
+                    .map(|ty| (ClassMetaclass::Selected(ty.to_meta_type(db, &env)), None));
             };
 
             // Reconcile all base classes' metaclasses with the candidate metaclass.
@@ -1267,34 +1297,27 @@ impl<'db> StaticClassLiteral<'db> {
             // - https://docs.python.org/3/reference/datamodel.html#determining-the-appropriate-metaclass
             // - https://github.com/python/cpython/blob/83ba8c2bba834c0b92de669cac16fcda17485e0e/Objects/typeobject.c#L3629-L3663
             for base_class in base_classes {
-                let metaclass = base_class.metaclass(db);
+                let metaclass = infer_base_metaclass(base_class);
+                has_protocol_fallback |= metaclass.is_protocol_fallback();
+                let metaclass = metaclass.for_inheritance(db, &env);
                 let Some(metaclass) = metaclass.to_class_type(db) else {
                     continue;
                 };
-                // For dynamic classes, we can't get a StaticClassLiteral, so use this class for
-                // tracking.
-                let base_class_literal = base_class
-                    .static_class_literal(db)
-                    .map(|(lit, _)| lit)
-                    .unwrap_or(class);
+                if candidate.metaclass.is_subclass_of(db, &env, metaclass) {
+                    continue;
+                }
                 if metaclass.is_subclass_of(db, &env, candidate.metaclass) {
                     candidate = MetaclassCandidate {
                         metaclass,
-                        explicit_metaclass_of: base_class_literal,
+                        base: Some(base_class),
                     };
-                    continue;
-                }
-                if candidate.metaclass.is_subclass_of(db, &env, metaclass) {
                     continue;
                 }
                 return Err(MetaclassError {
                     kind: MetaclassErrorKind::Conflict {
-                        candidate1: candidate,
-                        candidate2: MetaclassCandidate {
-                            metaclass,
-                            explicit_metaclass_of: base_class_literal,
-                        },
-                        candidate1_is_base_class: explicit_metaclass.is_none(),
+                        candidate,
+                        base_metaclass: metaclass,
+                        base: base_class,
                     },
                 });
             }
@@ -1307,14 +1330,30 @@ impl<'db> StaticClassLiteral<'db> {
                 })
                 .map(|params| MetaclassTransformInfo {
                     params,
-                    from_explicit_metaclass: candidate.explicit_metaclass_of == class,
+                    from_explicit_metaclass: candidate.base.is_none(),
                 });
-            Ok((candidate.metaclass.into(), transform_info))
+            let metaclass = if class
+                .known(db)
+                .and_then(|known| known.known_metaclass(env.python_version(db)))
+                == Some(KnownClass::Type)
+            {
+                ClassMetaclass::Selected(candidate.metaclass.into())
+            } else {
+                ClassMetaclass::with_protocol_fallback(
+                    db,
+                    candidate.metaclass.into(),
+                    has_protocol_fallback,
+                )
+            };
+            Ok((metaclass, transform_info))
         }
 
         if !self.has_explicit_bases(db) && !self.has_explicit_metaclass(db) {
             let env = ProgramEnvironment::from_scope(self.body_scope(db));
-            return Ok((KnownClass::Type.to_class_literal(db, &env), None));
+            return Ok((
+                ClassMetaclass::Selected(KnownClass::Type.to_class_literal(db, &env)),
+                None,
+            ));
         }
         try_metaclass_inner(db, self)
     }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::ProgramEnvironment;
-use crate::types::class::CodeGeneratorKind;
+use crate::types::class::{ClassMetaclass, CodeGeneratorKind};
 use crate::types::generics::{ApplySpecialization, Specialization};
 use crate::types::mro::MroIterator;
 use crate::types::tuple::TupleType;
@@ -368,10 +368,19 @@ impl<'db> ClassBase<'db> {
             Self::Any => Type::Dynamic(DynamicType::Any),
             Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
             Self::Divergent(divergent) => Type::Divergent(divergent),
-            // TODO: all `Protocol` classes actually have `_ProtocolMeta` as their metaclass.
-            Self::Protocol | Self::Generic | Self::TypedDict(_) => {
-                KnownClass::Type.to_instance(db, env)
-            }
+            Self::Protocol => KnownClass::ProtocolMeta.to_class_literal(db, env),
+            Self::Generic | Self::TypedDict(_) => KnownClass::Type.to_instance(db, env),
+        }
+    }
+
+    pub(super) fn inferred_metaclass(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> ClassMetaclass<'db> {
+        match self {
+            Self::Class(class) => class.inferred_metaclass(db),
+            _ => ClassMetaclass::Selected(self.metaclass(db, env)),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use ruff_db::files::FilePath;
+
 use crate::ProgramEnvironment;
 use crate::types::class::{ClassMetaclass, CodeGeneratorKind};
 use crate::types::generics::{ApplySpecialization, Specialization};
@@ -363,9 +365,9 @@ impl<'db> ClassBase<'db> {
 
     /// Return this base's selected metaclass or inferred protocol fallback.
     ///
-    /// `subclass` is the class whose declaration names this base. Only a direct `Protocol`
-    /// base depends on whether that declaration is in a stub; named bases retain their own
-    /// metaclass constraints or fallback regardless of where they are inherited.
+    /// `subclass` is the class whose declaration names this base. Only a direct `Protocol` base
+    /// depends on whether its declaration is in the bundled or configured typeshed stdlib;
+    /// named bases retain their own metaclass constraints or fallback wherever they are inherited.
     pub(super) fn inferred_metaclass(
         self,
         db: &'db dyn Db,
@@ -374,10 +376,25 @@ impl<'db> ClassBase<'db> {
     ) -> ClassMetaclass<'db> {
         let metaclass = match self {
             Self::Class(class) => return class.inferred_metaclass(db),
-            Self::Protocol if subclass.file(db).is_stub(db) => {
-                return ClassMetaclass::ProtocolFallback;
+            Self::Protocol => {
+                let file = subclass.file(db);
+                // Use the file's location rather than its resolved module: a custom typeshed
+                // directory can also be inside a first-party search path.
+                let is_typeshed_stub = file.is_stub(db)
+                    && match file.path(db) {
+                        FilePath::Vendored(path) => path.strip_prefix("stdlib").is_ok(),
+                        FilePath::System(path) => subclass
+                            .program_file(db)
+                            .program(db)
+                            .custom_stdlib_search_path(db)
+                            .is_some_and(|stdlib| path.starts_with(stdlib)),
+                        FilePath::SystemVirtual(_) => false,
+                    };
+                if is_typeshed_stub {
+                    return ClassMetaclass::ProtocolFallback;
+                }
+                KnownClass::ProtocolMeta.to_class_literal(db, env)
             }
-            Self::Protocol => KnownClass::ProtocolMeta.to_class_literal(db, env),
             Self::Any => Type::Dynamic(DynamicType::Any),
             Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
             Self::Divergent(divergent) => Type::Divergent(divergent),

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use ruff_db::files::FilePath;
+use ty_module_resolver::{SearchPath, file_to_module};
 
 use crate::ProgramEnvironment;
 use crate::types::class::{ClassMetaclass, CodeGeneratorKind};
@@ -377,20 +377,11 @@ impl<'db> ClassBase<'db> {
         let metaclass = match self {
             Self::Class(class) => return class.inferred_metaclass(db),
             Self::Protocol => {
-                let file = subclass.file(db);
-                // Use the file's location rather than its resolved module: a custom typeshed
-                // directory can also be inside a first-party search path.
-                let is_typeshed_stub = file.is_stub(db)
-                    && match file.path(db) {
-                        FilePath::Vendored(path) => path.strip_prefix("stdlib").is_ok(),
-                        FilePath::System(path) => subclass
-                            .program_file(db)
-                            .program(db)
-                            .custom_stdlib_search_path(db)
-                            .is_some_and(|stdlib| path.starts_with(stdlib)),
-                        FilePath::SystemVirtual(_) => false,
-                    };
-                if is_typeshed_stub {
+                if subclass.file(db).is_stub(db)
+                    && file_to_module(db, subclass.program_file(db).resolver_file(db))
+                        .and_then(|module| module.search_path(db))
+                        .is_some_and(SearchPath::is_standard_library)
+                {
                     return ClassMetaclass::ProtocolFallback;
                 }
                 KnownClass::ProtocolMeta.to_class_literal(db, env)

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -362,14 +362,22 @@ impl<'db> ClassBase<'db> {
     }
 
     /// Return this base's selected metaclass or inferred protocol fallback.
+    ///
+    /// `subclass` is the class whose declaration names this base. Only a direct `Protocol`
+    /// base depends on whether that declaration is in a stub; named bases retain their own
+    /// metaclass constraints or fallback regardless of where they are inherited.
     pub(super) fn inferred_metaclass(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        subclass: ClassLiteral<'db>,
     ) -> ClassMetaclass<'db> {
         let metaclass = match self {
             Self::Class(class) => return class.inferred_metaclass(db),
-            Self::Protocol => return ClassMetaclass::ProtocolFallback,
+            Self::Protocol if subclass.file(db).is_stub(db) => {
+                return ClassMetaclass::ProtocolFallback;
+            }
+            Self::Protocol => KnownClass::ABCMeta.to_class_literal(db, env),
             Self::Any => Type::Dynamic(DynamicType::Any),
             Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
             Self::Divergent(divergent) => Type::Divergent(divergent),

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -377,7 +377,7 @@ impl<'db> ClassBase<'db> {
             Self::Protocol if subclass.file(db).is_stub(db) => {
                 return ClassMetaclass::ProtocolFallback;
             }
-            Self::Protocol => KnownClass::ABCMeta.to_class_literal(db, env),
+            Self::Protocol => KnownClass::ProtocolMeta.to_class_literal(db, env),
             Self::Any => Type::Dynamic(DynamicType::Any),
             Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
             Self::Divergent(divergent) => Type::Divergent(divergent),

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -361,27 +361,21 @@ impl<'db> ClassBase<'db> {
         }
     }
 
-    /// Return the metaclass of this class base.
-    pub(crate) fn metaclass(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        match self {
-            Self::Class(class) => class.metaclass(db),
-            Self::Any => Type::Dynamic(DynamicType::Any),
-            Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
-            Self::Divergent(divergent) => Type::Divergent(divergent),
-            Self::Protocol => KnownClass::ProtocolMeta.to_class_literal(db, env),
-            Self::Generic | Self::TypedDict(_) => KnownClass::Type.to_instance(db, env),
-        }
-    }
-
+    /// Return this base's selected metaclass or inferred protocol fallback.
     pub(super) fn inferred_metaclass(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> ClassMetaclass<'db> {
-        match self {
-            Self::Class(class) => class.inferred_metaclass(db),
-            _ => ClassMetaclass::Selected(self.metaclass(db, env)),
-        }
+        let metaclass = match self {
+            Self::Class(class) => return class.inferred_metaclass(db),
+            Self::Protocol => return ClassMetaclass::ProtocolFallback,
+            Self::Any => Type::Dynamic(DynamicType::Any),
+            Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
+            Self::Divergent(divergent) => Type::Divergent(divergent),
+            Self::Generic | Self::TypedDict(_) => KnownClass::Type.to_instance(db, env),
+        };
+        ClassMetaclass::Selected(metaclass)
     }
 
     fn apply_type_mapping_impl<'a>(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1,5 +1,5 @@
 use crate::Db;
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use ruff_db::{
     diagnostic::{Annotation, SubDiagnostic, SubDiagnosticSeverity},
     source::source_text,
@@ -653,6 +653,11 @@ pub(crate) fn check_static_class_definitions<'db>(
                         Type::from(*base2),
                     ];
                     let settings = DisplaySettings::from_possibly_ambiguous_types(db, env, types);
+                    let base = if let ClassBase::Class(base) = base2 {
+                        Either::Left(base.class_literal(db).display_with(db, settings.clone()))
+                    } else {
+                        Either::Right(base2.display_with(db, env, settings.clone()))
+                    };
                     builder.into_diagnostic(format_args!(
                         "The metaclass of a derived class (`{class}`) \
                             must be a subclass of the metaclasses of all its bases, \
@@ -666,7 +671,6 @@ pub(crate) fn check_static_class_definitions<'db>(
                         metaclass_of_base = metaclass2
                             .class_literal(db)
                             .display_with(db, settings.clone()),
-                        base = base2.class_literal(db).display_with(db, settings),
                     ));
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1,5 +1,5 @@
 use crate::Db;
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 use ruff_db::{
     diagnostic::{Annotation, SubDiagnostic, SubDiagnosticSeverity},
     source::source_text,
@@ -653,11 +653,6 @@ pub(crate) fn check_static_class_definitions<'db>(
                         Type::from(*base2),
                     ];
                     let settings = DisplaySettings::from_possibly_ambiguous_types(db, env, types);
-                    let base = if let ClassBase::Class(base) = base2 {
-                        Either::Left(base.class_literal(db).display_with(db, settings.clone()))
-                    } else {
-                        Either::Right(base2.display_with(db, env, settings.clone()))
-                    };
                     builder.into_diagnostic(format_args!(
                         "The metaclass of a derived class (`{class}`) \
                             must be a subclass of the metaclasses of all its bases, \
@@ -671,6 +666,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                         metaclass_of_base = metaclass2
                             .class_literal(db)
                             .display_with(db, settings.clone()),
+                        base = base2.class_literal(db).display_with(db, settings),
                     ));
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -668,9 +668,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                         metaclass_of_class = metaclass1
                             .class_literal(db)
                             .display_with(db, settings.clone()),
-                        metaclass_of_base = metaclass2
-                            .class_literal(db)
-                            .display_with(db, settings.clone()),
+                        metaclass_of_base = metaclass2.class_literal(db).display_with(db, settings),
                     ));
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1,5 +1,5 @@
 use crate::Db;
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use ruff_db::{
     diagnostic::{Annotation, SubDiagnostic, SubDiagnosticSeverity},
     source::source_text,
@@ -625,27 +625,23 @@ pub(crate) fn check_static_class_definitions<'db>(
                 }
             }
             MetaclassErrorKind::Conflict {
-                candidate1:
+                candidate:
                     MetaclassCandidate {
                         metaclass: metaclass1,
-                        explicit_metaclass_of: class1,
+                        base: base1,
                     },
-                candidate2:
-                    MetaclassCandidate {
-                        metaclass: metaclass2,
-                        explicit_metaclass_of: class2,
-                    },
-                candidate1_is_base_class,
+                base_metaclass: metaclass2,
+                base: base2,
             } => {
-                if *candidate1_is_base_class {
+                if let Some(base1) = base1 {
                     report_conflicting_metaclass_from_bases(
                         context,
                         class_node.into(),
                         class.name(db),
                         *metaclass1,
-                        class1.name(db),
+                        base1.name(db),
                         *metaclass2,
-                        class2.name(db),
+                        base2.name(db),
                     );
                 } else if let Some(builder) =
                     context.report_lint(&CONFLICTING_METACLASS, class_node)
@@ -654,9 +650,14 @@ pub(crate) fn check_static_class_definitions<'db>(
                         Type::from(class),
                         Type::from(*metaclass1),
                         Type::from(*metaclass2),
-                        Type::from(*class2),
+                        Type::from(*base2),
                     ];
                     let settings = DisplaySettings::from_possibly_ambiguous_types(db, env, types);
+                    let base = if let ClassBase::Class(base) = base2 {
+                        Either::Left(base.class_literal(db).display_with(db, settings.clone()))
+                    } else {
+                        Either::Right(base2.display_with(db, env, settings.clone()))
+                    };
                     builder.into_diagnostic(format_args!(
                         "The metaclass of a derived class (`{class}`) \
                             must be a subclass of the metaclasses of all its bases, \
@@ -670,7 +671,6 @@ pub(crate) fn check_static_class_definitions<'db>(
                         metaclass_of_base = metaclass2
                             .class_literal(db)
                             .display_with(db, settings.clone()),
-                        base = ClassLiteral::Static(*class2).display_with(db, settings),
                     ));
                 }
             }
@@ -1157,7 +1157,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
 ) {
     let db = context.db();
     let env = context.program_environment();
-    let metaclass = class.metaclass(db);
+    let metaclass = class.inferred_metaclass(db).for_inheritance(db, env);
     if metaclass == KnownClass::Type.to_class_literal(db, env) {
         return;
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -276,17 +276,22 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             // we also check for the case where one of the operands is a class-literal type
                             // or generic-alias type and the other is a string literal. The normal dunder lookup
                             // fails to catch this error, since typeshed annotates `type.__(r)or__` as accepting `Any`.
-                            // An inferred protocol metaclass does not establish a custom operator either.
+                            // ABCMeta also inherits these operators unchanged. Neither a source protocol's
+                            // ABCMeta constraint nor a stub-only fallback establishes a custom operator.
                             let should_emit_error = if dunder_fails {
                                 true
                             } else {
                                 let literal = match (left_type_value, right_type_value) {
                                     (Type::ClassLiteral(class), Type::LiteralValue(literal))
                                     | (Type::LiteralValue(literal), Type::ClassLiteral(class))
-                                        if class
-                                            .inferred_metaclass(db)
-                                            .for_inheritance(db, env)
-                                            == KnownClass::Type.to_class_literal(db, env) =>
+                                        if matches!(
+                                            class
+                                                .inferred_metaclass(db)
+                                                .for_inheritance(db, env)
+                                                .to_class_type(db)
+                                                .and_then(|metaclass| metaclass.known(db)),
+                                            Some(KnownClass::Type | KnownClass::ABCMeta)
+                                        ) =>
                                     {
                                         Some(literal)
                                     }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -276,8 +276,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             // we also check for the case where one of the operands is a class-literal type
                             // or generic-alias type and the other is a string literal. The normal dunder lookup
                             // fails to catch this error, since typeshed annotates `type.__(r)or__` as accepting `Any`.
-                            // ABCMeta also inherits these operators unchanged. Neither a source protocol's
-                            // ABCMeta constraint nor a stub-only fallback establishes a custom operator.
+                            // ABCMeta and _ProtocolMeta inherit these operators unchanged. A stub-only
+                            // protocol fallback does not establish a custom operator either.
                             let should_emit_error = if dunder_fails {
                                 true
                             } else {
@@ -290,7 +290,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                                 .for_inheritance(db, env)
                                                 .to_class_type(db)
                                                 .and_then(|metaclass| metaclass.known(db)),
-                                            Some(KnownClass::Type | KnownClass::ABCMeta)
+                                            Some(
+                                                KnownClass::Type
+                                                    | KnownClass::ABCMeta
+                                                    | KnownClass::ProtocolMeta
+                                            )
                                         ) =>
                                     {
                                         Some(literal)

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -276,13 +276,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             // we also check for the case where one of the operands is a class-literal type
                             // or generic-alias type and the other is a string literal. The normal dunder lookup
                             // fails to catch this error, since typeshed annotates `type.__(r)or__` as accepting `Any`.
+                            // An inferred protocol metaclass does not establish a custom operator either.
                             let should_emit_error = if dunder_fails {
                                 true
                             } else {
                                 let literal = match (left_type_value, right_type_value) {
                                     (Type::ClassLiteral(class), Type::LiteralValue(literal))
                                     | (Type::LiteralValue(literal), Type::ClassLiteral(class))
-                                        if class.metaclass(db)
+                                        if class
+                                            .inferred_metaclass(db)
+                                            .for_inheritance(db, env)
                                             == KnownClass::Type.to_class_literal(db, env) =>
                                     {
                                         Some(literal)

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -276,7 +276,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             // we also check for the case where one of the operands is a class-literal type
                             // or generic-alias type and the other is a string literal. The normal dunder lookup
                             // fails to catch this error, since typeshed annotates `type.__(r)or__` as accepting `Any`.
-                            // ABCMeta and _ProtocolMeta inherit these operators unchanged. A stub-only
+                            // ABCMeta and _ProtocolMeta inherit these operators unchanged. The typeshed
                             // protocol fallback does not establish a custom operator either.
                             let should_emit_error = if dunder_fails {
                                 true

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -314,7 +314,7 @@ impl<'db> AllMembers<'db> {
                             db,
                             env,
                             ty,
-                            class_literal.metaclass(db),
+                            class_type.inferred_metaclass(db).for_inheritance(db, env),
                         );
                     }
                 }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2598,15 +2598,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // Similarly `type[enum.Enum]`  is a subtype of `enum.EnumMeta` because `enum.Enum`
             // is an instance of `enum.EnumMeta`. `type[Any]` and `type[Unknown]` do not participate in subtyping,
             // however, as they are not fully static types.
-            (Type::SubclassOf(subclass_of_ty), _) => self.check_type_pair(
-                db,
-                subclass_of_ty
-                    .subclass_of()
-                    .into_class(db, env)
-                    .map(|source_class| source_class.metaclass_instance_type(db, env))
-                    .unwrap_or_else(|| KnownClass::Type.to_instance(db, env)),
-                target,
-            ),
+            (Type::SubclassOf(subclass_of_ty), _) => {
+                self.check_type_pair(db, subclass_of_ty.to_metaclass_instance(db, env), target)
+            }
 
             (Type::TypeForm(_), _) => self.check_type_pair(db, Type::object(), target),
 
@@ -3475,9 +3469,11 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                     SubclassOfInner::Dynamic(_) => {
                         self.check_type_pair(db, KnownClass::Type.to_instance(db, env), other)
                     }
-                    SubclassOfInner::Class(class) => {
-                        self.check_type_pair(db, class.metaclass_instance_type(db, env), other)
-                    }
+                    SubclassOfInner::Class(_) => self.check_type_pair(
+                        db,
+                        subclass_of_ty.to_metaclass_instance(db, env),
+                        other,
+                    ),
                     SubclassOfInner::Protocol(_) => {
                         self.check_type_pair(db, KnownClass::Type.to_instance(db, env), other)
                     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3466,7 +3466,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::SubclassOf(subclass_of_ty), other)
             | (other, Type::SubclassOf(subclass_of_ty)) => {
                 nontrivial_check(self, || match subclass_of_ty.subclass_of() {
-                    SubclassOfInner::Dynamic(_) => {
+                    SubclassOfInner::Dynamic(_) | SubclassOfInner::Protocol(_) => {
                         self.check_type_pair(db, KnownClass::Type.to_instance(db, env), other)
                     }
                     SubclassOfInner::Class(_) => self.check_type_pair(
@@ -3474,9 +3474,6 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                         subclass_of_ty.to_metaclass_instance(db, env),
                         other,
                     ),
-                    SubclassOfInner::Protocol(_) => {
-                        self.check_type_pair(db, KnownClass::Type.to_instance(db, env), other)
-                    }
                     SubclassOfInner::TypeVar(_) => unreachable!(),
                 })
             }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -314,9 +314,9 @@ impl<'db> SubclassOfType<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
-        // This kind of looks like a no-op, but it's not. For `type[C]` where `C` has guaranteed
-        // metaclass `M`, `to_meta_type` transforms `type[C]` to `type[M]`, and then `to_instance` makes it
-        // just `M`. And `to_meta_type` will transpose `type[T: C]` into `T: type[C]`, collapse to
+        // This kind of looks like a no-op, but it's not. For `type[C]` with guaranteed metaclass
+        // `M`, `to_meta_type` produces `type[M]`, and then `to_instance` makes it just `M`.
+        // And `to_meta_type` will transpose `type[T: C]` into `T: type[C]`, collapse to
         // the upper bound `type[C]`, and transform that to the meta-type `type[M]`, which
         // `to_instance` then resolves to `M`.
         self.to_meta_type(db, env)
@@ -326,8 +326,8 @@ impl<'db> SubclassOfType<'db> {
 
     /// Compute the metatype of this `type[T]`.
     ///
-    /// For a concrete class `C`, this uses its guaranteed metaclass, excluding the lookup-only
-    /// protocol fallback.
+    /// For a concrete class `C`, this returns `type[M]`, where `M` is its guaranteed metaclass,
+    /// excluding the lookup-only typeshed fallback.
     /// For `type[T]` where `T` is a `TypeVar`, this computes the metatype based on the
     /// `TypeVar`'s bounds or constraints.
     pub(crate) fn to_meta_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -314,8 +314,8 @@ impl<'db> SubclassOfType<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
-        // This kind of looks like a no-op, but it's not. For `type[C]` where `C` has metaclass
-        // `M`, `to_meta_type` transforms `type[C]` to `type[M]`, and then `to_instance` makes it
+        // This kind of looks like a no-op, but it's not. For `type[C]` where `C` has guaranteed
+        // metaclass `M`, `to_meta_type` transforms `type[C]` to `type[M]`, and then `to_instance` makes it
         // just `M`. And `to_meta_type` will transpose `type[T: C]` into `T: type[C]`, collapse to
         // the upper bound `type[C]`, and transform that to the meta-type `type[M]`, which
         // `to_instance` then resolves to `M`.
@@ -326,7 +326,8 @@ impl<'db> SubclassOfType<'db> {
 
     /// Compute the metatype of this `type[T]`.
     ///
-    /// For `type[C]` where `C` is a concrete class, this returns `type[metaclass(C)]`.
+    /// For a concrete class `C`, this uses its guaranteed metaclass, excluding the lookup-only
+    /// protocol fallback.
     /// For `type[T]` where `T` is a `TypeVar`, this computes the metatype based on the
     /// `TypeVar`'s bounds or constraints.
     pub(crate) fn to_meta_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -334,10 +334,12 @@ impl<'db> SubclassOfType<'db> {
             SubclassOfInner::Dynamic(dynamic) => {
                 SubclassOfType::from(db, env, SubclassOfInner::Dynamic(dynamic))
             }
-            SubclassOfInner::Class(class) => {
-                SubclassOfType::try_from_type(db, env, class.metaclass(db))
-                    .unwrap_or(SubclassOfType::subclass_of_unknown())
-            }
+            SubclassOfInner::Class(class) => SubclassOfType::try_from_type(
+                db,
+                env,
+                class.inferred_metaclass(db).for_inheritance(db, env),
+            )
+            .unwrap_or(SubclassOfType::subclass_of_unknown()),
             // Structural implementations of a protocol can have arbitrary metaclasses. The only
             // guaranteed upper bound is therefore `type`, not the protocol origin's metaclass.
             SubclassOfInner::Protocol(_) => KnownClass::Type.to_subclass_of(db, env),


### PR DESCRIPTION
Valid calls such as `collections.abc.Mapping.register(...)` currently produce missing-attribute errors. Using `register` as a class decorator can also hide the registered class’s members and generic parameters, causing further false positives and negatives.

This PR gives protocol classes declared in source or ordinary `.pyi` files the metaclass `typing._ProtocolMeta`, which derives from `ABCMeta`. That makes ABC methods available and preserves the types of registered classes. It also lets ty report incompatible custom metaclasses.

Typeshed’s standard-library stubs need a narrow compatibility exception: they sometimes list `Protocol` bases that the runtime class does not inherit. When those bases do not select a custom metaclass, ty uses `ABCMeta` for attribute lookup but does not let that inferred metaclass create artificial inheritance conflicts. This applies to bundled or configured typeshed, not to other `.pyi` files. An explicitly chosen custom metaclass continues to constrain subclasses. Known built-ins retain their actual `type` metaclass.

Mypy applies a similar permissive fallback more broadly; this PR limits the exception to typeshed.

Fixes https://github.com/astral-sh/ty/issues/1204.

## Ecosystem results

The [current ecosystem run](https://github.com/astral-sh/ruff/actions/runs/32385816515/attempts/1) removes missing-`register` errors in pandas, ppb-vector, Jinja, Spack, and Ibis, plus two spurious metaclass conflicts in Spack’s legacy `typing_extensions`. All 294 Ibis changes follow from recovering registered classes’ members and generic parameters. The added diagnostics expose existing annotation gaps, deliberately invalid tests, and the known [virtual ABC subclass limitation](https://github.com/astral-sh/ty/issues/2391).

The beartype library has an [old compatibility workaround](https://github.com/beartype/beartype/blob/d6c056225f2e5632ea72006b43ffb066bd9a2c6b/beartype/typing/_typingpep544.py#L73-L79) for the fact that `_ProtocolMeta` used to be missing from typeshed; it substitutes `ABCMeta` under `if TYPE_CHECKING`, so it now produces a metaclass conflict. We accept this false positive: typeshed now declares `_ProtocolMeta`, and beartype can remove the workaround and derive from `type(Protocol)` directly.

## Test plan

- Cover protocol metaclasses, bundled and custom typeshed, and registration decorators that preserve generic classes.
- Check compatible and conflicting metaclasses, built-in collections, and inheritance through ordinary and dynamically created classes.
- Protect subclass-type bounds, class-namespace attributes, quoted unions, and dataclass-transform inheritance.
