### PR TITLE
[ty] Preserve all alternatives in bounded intersections

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1539,6 +1539,40 @@ def _(any_value: Any, unknown_value: Unknown, upper: Callable[[list[int]], None]
     reveal_type(unknown_result[0])  # revealed: int & Unknown
 ```
 
+## Redundant upper bounds preserve large gradual unions
+
+The invariant list fixes `T` to the entire union, while the callback adds the redundant upper bound
+`object`. Restricting the inferred gradual type by these bounds must preserve all five union
+members.
+
+```py
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+Bound = None | int | set[int] | Sequence[Any] | Mapping[str, Any]
+
+def first[T: Bound](values: list[T], sink: Callable[[T], None]) -> T:
+    return values[0]
+
+def _(values: list[Bound], sink: Callable[[object], None]) -> None:
+    # revealed: None | int | set[int] | Sequence[Any] | Mapping[str, Any]
+    reveal_type(first(values, sink))
+```
+
+The same holds for recursive aliases, whose recursive positions currently fall back to `Divergent`.
+This is a reduced regression test for [ty#4335](https://github.com/astral-sh/ty/issues/4335).
+
+```py
+Recursive = None | int | set[int] | Sequence["Recursive"] | Mapping[str, "Recursive"]
+
+def first_recursive[T: Recursive](values: list[T], sink: Callable[[T], None]) -> T:
+    return values[0]
+
+def _(values: list[Recursive], sink: Callable[[object], None]) -> None:
+    # revealed: None | int | set[int] | Sequence[Divergent] | Mapping[str, Divergent]
+    reveal_type(first_recursive(values, sink))
+```
+
 ## Typevars in a union
 
 ```py

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -899,7 +899,10 @@ impl<'db> IntersectionType<'db> {
 
         let non_union_elements = elements.clone().filter(|element| !element.is_union());
         let initial = Self::from_elements(db, env, non_union_elements);
-        let insert_candidate = |candidates: &mut Vec<Type<'db>>, new_ty: Type<'db>| -> Option<()> {
+        let insert_candidate = |candidates: &mut Vec<Type<'db>>,
+                                new_ty: Type<'db>,
+                                check_budget: bool|
+         -> Option<()> {
             if new_ty.is_never()
                 || candidates
                     .iter()
@@ -909,7 +912,7 @@ impl<'db> IntersectionType<'db> {
             }
 
             candidates.retain(|old| !old.is_redundant_with(db, env, new_ty));
-            if candidates.len() >= MAX_INTERSECTION_DNF_TERMS {
+            if check_budget && candidates.len() >= MAX_INTERSECTION_DNF_TERMS {
                 return None;
             }
             candidates.push(new_ty);
@@ -918,7 +921,7 @@ impl<'db> IntersectionType<'db> {
 
         let mut frontier = Vec::new();
         let mut next = Vec::new();
-        insert_candidate(&mut frontier, initial)?;
+        insert_candidate(&mut frontier, initial, true)?;
 
         for (idx, clause) in elements.filter_map(Type::as_union).enumerate() {
             // Don't check the budget for the first union clause. That ensures that we have a
@@ -926,13 +929,13 @@ impl<'db> IntersectionType<'db> {
             // result. For instance, this allows us to return the precise result for
             // `(A | B | C | D | E) & (A | B | F | G | H)` (in which each class is final), since
             // most of the pairs are disjoint.
-            let skip_budget_check = (idx == 0).then_some(());
+            let check_budget = idx > 0;
 
             next.clear();
             for candidate in &frontier {
                 for alternative in clause.elements(db) {
                     let refined = Self::from_two_elements(db, env, *candidate, *alternative);
-                    insert_candidate(&mut next, refined).or(skip_budget_check)?;
+                    insert_candidate(&mut next, refined, check_budget)?;
                 }
             }
 

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -10,6 +10,43 @@ use test_case::test_case;
 use ty_python_core::program::Program;
 use ty_python_core::{ProgramFile, TestProgramDb as _};
 
+#[test]
+fn bounded_intersection_preserves_late_union_elements() {
+    let db = setup_db();
+    let db = &db;
+    let env = db.program_environment();
+    let wide = UnionType::from_elements(db, &env, (1..=6).map(Type::int_literal));
+    let narrow = UnionType::from_elements(db, &env, (5..=7).map(Type::int_literal));
+    let expected = UnionType::from_elements(db, &env, (5..=6).map(Type::int_literal));
+
+    // The first union exceeds the budget, but its last two elements survive the intersection.
+    for elements in [[wide, narrow], [narrow, wide]] {
+        assert_eq!(
+            IntersectionType::bounded_from_elements(db, &env, elements),
+            Some(expected)
+        );
+    }
+}
+
+#[test]
+fn bounded_intersection_returns_none_when_budget_exhausted() {
+    let db = setup_db();
+    let db = &db;
+    let env = db.program_environment();
+    let wide = UnionType::from_elements(db, &env, (1..=6).map(Type::int_literal));
+
+    // A single union requires no distribution and is returned exactly, regardless of its size.
+    assert_eq!(
+        IntersectionType::bounded_from_elements(db, &env, [wide]),
+        Some(wide)
+    );
+    // Exceeding the budget must return `None`, not a partial intersection.
+    assert_eq!(
+        IntersectionType::bounded_from_elements(db, &env, [wide, wide]),
+        None
+    );
+}
+
 /// Explicitly test for Python version <3.13 and >=3.13, to ensure that
 /// the fallback to `typing_extensions` is working correctly.
 /// See [`KnownClass::canonical_module`] for more information.


### PR DESCRIPTION
Bounded intersection expansion could silently drop alternatives after the first four members of a union. The first union is intentionally exempt from the expansion budget, but ignoring a failed insertion did not actually insert the omitted member. This let the helper return a partial type as though it were exact, causing false-positive diagnostics such as the regression exposed by #27664.

Apply the budget exemption inside candidate insertion. Preserve every alternative of the first union, while continuing to return `None` if later expansion exceeds the budget.

Fixes astral-sh/ty#4335.

## Test plan

- Unit tests cover late union members surviving an intersection in either operand order, the single-union fast path, and genuine budget exhaustion returning `None` instead of a partial result.
- Mdtests cover redundant upper bounds on five-member gradual unions, including a reduced recursive-alias regression with `Divergent` members.
