### PR TITLE
[ty] Experiment with strict open TypedDict unpacking

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -1321,14 +1321,16 @@ mod tests {
         class Movie(
             *,
             title: str,
-            year: int
+            year: int,
+            **kwargs: object
         )
         ---------------------------------------------
         ```python
         class Movie(
             *,
             title: str,
-            year: int
+            year: int,
+            **kwargs: object
         )
         ```
         ---------------------------------------------
@@ -1364,7 +1366,8 @@ mod tests {
             /,
             *,
             title: str = ...,
-            year: int = ...
+            year: int = ...,
+            **kwargs: object
         )
         ---------------------------------------------
         ```python
@@ -1373,7 +1376,8 @@ mod tests {
             /,
             *,
             title: str = ...,
-            year: int = ...
+            year: int = ...,
+            **kwargs: object
         )
         ```
         ---------------------------------------------
@@ -1408,7 +1412,8 @@ mod tests {
             /,
             *,
             title: str = ...,
-            year: int = ...
+            year: int = ...,
+            **kwargs: object
         )
         ---------------------------------------------
         ```python
@@ -1417,7 +1422,8 @@ mod tests {
             /,
             *,
             title: str = ...,
-            year: int = ...
+            year: int = ...,
+            **kwargs: object
         )
         ```
         ---------------------------------------------
@@ -1450,14 +1456,16 @@ mod tests {
         class Movie(
             *,
             title: str,
-            year: int = ...
+            year: int = ...,
+            **kwargs: object
         )
         ---------------------------------------------
         ```python
         class Movie(
             *,
             title: str,
-            year: int = ...
+            year: int = ...,
+            **kwargs: object
         )
         ```
         ---------------------------------------------
@@ -1490,14 +1498,16 @@ mod tests {
         class Movie(
             *,
             title: str = ...,
-            year: int = ...
+            year: int = ...,
+            **kwargs: object
         )
         ---------------------------------------------
         ```python
         class Movie(
             *,
             title: str = ...,
-            year: int = ...
+            year: int = ...,
+            **kwargs: object
         )
         ```
         ---------------------------------------------

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1073,7 +1073,7 @@ bindings. This prevents false positive "parameter already assigned" errors.
 Regression test for <https://github.com/astral-sh/ty/issues/1584>.
 
 ```py
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 def f(a: str, b: str, c: float) -> None: ...
 
@@ -1114,7 +1114,7 @@ def _(args: list[str], kwargs: dict[str, float]) -> None:
 
 # Keyword variadic with TypedDict has known keys but is still handled conservatively
 # but we could possibly improve this in the future.
-class CKwargs(TypedDict):
+class CKwargs(TypedDict, closed=True):
     c: float
 
 def _(args: list[str]) -> None:
@@ -1634,7 +1634,49 @@ def _(kwargs: dict[str, int]) -> None:
 
 f(**{"a": 1, "b": 2})
 f(**dict(a=1, b=2))
-f(**Foo(a=1, b=2))
+f(**Foo(a=1, b=2))  # error: [unknown-argument]
+```
+
+### Open TypedDicts require arbitrary keyword parameters
+
+An open `TypedDict` may contain undeclared keys, even when all its declared keys match named
+parameters. The callee must accept those additional keywords, and their values have type `object`.
+Closed `TypedDict`s have no hidden keys and can be unpacked into a fixed signature.
+
+```py
+from typing_extensions import Any, TypedDict, Unpack
+
+class Open(TypedDict):
+    value: int
+
+class Closed(TypedDict, closed=True):
+    value: int
+
+class EmptyOpen(TypedDict): ...
+class EmptyClosed(TypedDict, closed=True): ...
+
+def fixed(*, value: int) -> None: ...
+def no_keywords() -> None: ...
+def objects(*, value: int, **kwargs: object) -> None: ...
+def anything(*, value: int, **kwargs: Any) -> None: ...
+def ints(*, value: int, **kwargs: int) -> None: ...
+def unpacked_open(**kwargs: Unpack[Open]) -> None: ...
+def unpacked_closed(**kwargs: Unpack[Closed]) -> None: ...
+def _(open_value: Open, closed_value: Closed, empty_open: EmptyOpen, empty_closed: EmptyClosed) -> None:
+    # error: [unknown-argument] "Unpacked argument may contain keyword arguments that do not match any known parameter of function `fixed`"
+    fixed(**open_value)
+    fixed(**closed_value)
+
+    no_keywords(**empty_open)  # error: [unknown-argument]
+    no_keywords(**empty_closed)
+
+    objects(**open_value)
+    anything(**open_value)
+    ints(**open_value)  # error: [invalid-argument-type]
+
+    unpacked_open(**open_value)
+    unpacked_closed(**open_value)  # error: [unknown-argument]
+    unpacked_closed(**closed_value)
 ```
 
 ### Unpacked keyword values retain their individual generic types
@@ -1675,7 +1717,7 @@ def _(kwargs: dict[str, int]) -> None:
 
 f(**{"a": 1, "b": 2})
 f(**dict(a=1, b=2))
-f(**Foo(a=1, b=2))
+f(**Foo(a=1, b=2))  # error: [unknown-argument]
 ```
 
 ### Multiple keywords argument
@@ -1790,6 +1832,7 @@ def needs_known_keys(*, a: int, b: int, c: int) -> None: ...
 def takes_int_kwargs(**kwargs: int) -> None: ...
 def _(good: GoodA | GoodB, bad: BadA | BadB) -> None:
     # error: [missing-argument] "No argument provided for required parameter `c` of function `needs_known_keys`"
+    # error: [unknown-argument]
     needs_known_keys(**good)
 
     # error: [invalid-argument-type] "Argument to function `takes_int_kwargs` is incorrect: Expected `int`, found `str`"
@@ -2058,9 +2101,9 @@ explicitly-provided keyword argument. The case shown here, without the explicit 
 requires instead that we use our knowledge of the tuple length to prevent over-unpacking.)
 
 ```py
-from typing import TypedDict
+from typing_extensions import TypedDict
 
-class CKwargs(TypedDict):
+class CKwargs(TypedDict, closed=True):
     c: int
 
 def f(a: int = 0, b: int = 0, c: int = 0) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -823,8 +823,8 @@ reveal_type(p)  # revealed: partial[bool]
 
 ### Kwargs splat with TypedDict
 
-An open `TypedDict` may contain hidden extra items, so it cannot be normalized to a precise partial
-signature.
+An open `TypedDict` may contain hidden extra items, so the wrapped function must accept arbitrary
+keyword arguments. The partial signature cannot be normalized precisely.
 
 ```py
 from functools import partial
@@ -837,7 +837,7 @@ def f(a: int, b: str) -> bool:
     return True
 
 kwargs: MyKwargs = {"b": "hello"}
-p = partial(f, **kwargs)
+p = partial(f, **kwargs)  # error: [unknown-argument]
 reveal_type(p)  # revealed: partial[bool]
 ```
 
@@ -856,6 +856,7 @@ def f(*, b: str) -> bool:
 
 kwargs: MyKwargs = {"b": 1}
 # error: [invalid-argument-type] "Argument to class `partial` is incorrect: Expected `str`, found `int`"
+# error: [unknown-argument]
 p = partial(f, **kwargs)
 reveal_type(p)  # revealed: partial[bool]
 ```
@@ -897,7 +898,7 @@ def f(*, b: str) -> bool:
     return True
 
 def make(kwargs: KwargsA | KwargsB) -> None:
-    p = partial(f, **kwargs)
+    p = partial(f, **kwargs)  # error: [unknown-argument]
     reveal_type(p)  # revealed: partial[bool]
 ```
 
@@ -935,7 +936,7 @@ def f(a: int, b: str, c: float) -> bool:
     return True
 
 kwargs: MyKwargs = {"c": 3.14}
-p = partial(f, b="hello", **kwargs)
+p = partial(f, b="hello", **kwargs)  # error: [unknown-argument]
 reveal_type(p)  # revealed: partial[bool]
 ```
 
@@ -993,7 +994,7 @@ def f(a: int, *, b: str) -> None:
     pass
 
 def make(kwargs: MaybeKwargs) -> None:
-    p = partial(f, **kwargs)
+    p = partial(f, **kwargs)  # error: [unknown-argument]
     reveal_type(p)  # revealed: partial[None]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -785,15 +785,15 @@ class InvalidType(Base, arg="foo"): ...  # error: [invalid-argument-type]
 Keyword splats are allowed if their type can be determined:
 
 ```py
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 class RequiresKwarg:
     def __init_subclass__(cls, arg: int): ...
 
-class WrongArg(TypedDict):
+class WrongArg(TypedDict, closed=True):
     kwarg: int
 
-class InvalidType(TypedDict):
+class InvalidType(TypedDict, closed=True):
     arg: str
 
 wrong_arg: WrongArg = {"kwarg": 5}

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -1401,8 +1401,8 @@ def _(x1: int, x2: int, kwargs: dict[str, int]):
 
 ### `TypedDict`
 
-The keys in a `TypedDict` are static so there's no variable part to it, so step 4 shouldn't filter
-out any overloads.
+The keys in a closed `TypedDict` are static so there's no variable part to it, so step 4 shouldn't
+filter out any overloads.
 
 `overloaded.pyi`:
 
@@ -1418,16 +1418,34 @@ def f(**kwargs: int) -> tuple[int, ...]: ...
 ```
 
 ```py
-from typing import TypedDict
+from typing_extensions import TypedDict
 from overloaded import f
 
-class Foo(TypedDict):
+class Foo(TypedDict, closed=True):
     x: int
     y: int
 
 def _(foo: Foo, kwargs: dict[str, int]):
     reveal_type(f(**foo))  # revealed: tuple[int, int]
     reveal_type(f(**kwargs))  # revealed: tuple[int, ...]
+```
+
+An open `TypedDict` requires an overload that accepts arbitrary keyword arguments. Here, that
+overload only accepts `int` values, so it cannot accept hidden items of type `object`.
+
+`open.py`:
+
+```py
+from typing_extensions import TypedDict
+from overloaded import f
+
+class OpenFoo(TypedDict):
+    x: int
+    y: int
+
+def _(foo: OpenFoo):
+    # error: [invalid-argument-type]
+    reveal_type(f(**foo))  # revealed: Unknown
 ```
 
 ## Filtering based on `Any` / `Unknown`

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -52,7 +52,7 @@ keys into invalid named parameters:
 from typing import Optional, TypedDict
 
 Config = TypedDict("Config", {"in": int, "x-y": str, "ok": int})
-# revealed: Overload[(self: Config, map: Config, /, *, ok: int = ..., **kwargs) -> None, (self: Config, /, *, ok: int, **kwargs) -> None]
+# revealed: Overload[(self: Config, map: Config, /, *, ok: int = ..., **kwargs: object) -> None, (self: Config, /, *, ok: int, **kwargs: object) -> None]
 reveal_type(Config.__init__)
 ```
 
@@ -3794,7 +3794,7 @@ from typing import TypedDict
 class Box[T](TypedDict):
     value: T
 
-# revealed: Overload[(self: Box[int], map: Box[int], /, *, value: int = ...) -> None, (self: Box[int], /, *, value: int) -> None]
+# revealed: Overload[(self: Box[int], map: Box[int], /, *, value: int = ..., **kwargs: object) -> None, (self: Box[int], /, *, value: int, **kwargs: object) -> None]
 reveal_type(Box[int].__init__)
 ```
 
@@ -3842,6 +3842,18 @@ Box()  # error: [missing-typed-dict-key]
 Box(value=1, extra=2)  # error: [invalid-key]
 ```
 
+Known extra keys in an unpacked `TypedDict` are also rejected, even though the constructor accepts
+implicit hidden items.
+
+```py
+class SourceWithExtra(TypedDict):
+    value: int
+    extra: int
+
+def _(source: SourceWithExtra) -> None:
+    Box(**source)  # error: [invalid-key]
+```
+
 An invalid field value points to the field declaration and retains the usual `TypedDict`
 annotations.
 
@@ -3856,18 +3868,18 @@ LabeledBox(value=1, label=2)
 
 ```snapshot
 error[invalid-argument-type]: Invalid argument to key "label" with declared type `str` on TypedDict `LabeledBox`
-  --> src/mdtest_snippet.py:13:27
+  --> src/mdtest_snippet.py:19:27
    |
-13 | LabeledBox(value=1, label=2)
+19 | LabeledBox(value=1, label=2)
    | ----------          ------^
    | |                   |     |
    | |                   |     value of type `Literal[2]`
    | |                   key has declared type `str`
    | TypedDict `LabeledBox`
 info: Item declaration
-  --> src/mdtest_snippet.py:10:5
+  --> src/mdtest_snippet.py:16:5
    |
-10 |     label: str
+16 |     label: str
    |     ---------- Item declared here
 ```
 
@@ -7993,13 +8005,11 @@ def _(
     accepts_ints(**open_source)  # error: [invalid-argument-type]
     accepts_name(**ints)  # error: [unknown-argument]
 
-    # For backwards compatibility, implicit extra items on an ordinary open TypedDict are ignored
-    # when checking whether unpacking may supply unexpected arguments. Explicit extra items are not.
-    accepts_name(**open_source)
+    # Implicit extra items can also supply unexpected keyword arguments.
+    accepts_name(**open_source)  # error: [unknown-argument]
 
-    # TODO: This should arguably be rejected because `open_source` may contain a hidden `label`
-    # whose value is not assignable to `int`, but no other type checker rejects it.
-    accepts_optional_int_label(**open_source)
+    # A defaulted parameter does not make arbitrary additional keywords safe.
+    accepts_optional_int_label(**open_source)  # error: [unknown-argument]
     accepts_optional_label(**extra_only)  # error: [invalid-argument-type]
 
     OpenTarget(name="ok", **extra_only)  # error: [invalid-key]

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5206,9 +5206,9 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
 
     /// Match the possible arbitrary keyword arguments represented by a `TypedDict`'s openness.
     ///
-    /// Explicit extra items can constrain named parameters without satisfying required parameters,
-    /// and require a keyword-variadic parameter to accept all remaining names. An open `TypedDict`
-    /// only constrains an existing keyword-variadic parameter.
+    /// Both implicit and explicit extra items require a keyword-variadic parameter to accept all
+    /// remaining names. Explicit extra items can also constrain named parameters without satisfying
+    /// required parameters.
     fn match_typed_dict_openness(
         &mut self,
         argument_index: usize,
@@ -5252,7 +5252,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 false,
                 true,
             );
-        } else if has_explicit_extra_items {
+        } else {
             self.errors
                 .push(BindingError::UnknownKeywordVariadicArgument {
                     argument_index: self.get_argument_index(argument_index),

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -161,7 +161,8 @@ fn synthesize_typed_dict_init<'db>(
         .collect();
 
     let keyword_rest_param = typed_dict
-        .explicit_extra_items(db)
+        .openness(db)
+        .effective_extra_items()
         .map(|extra_items| {
             Parameter::keyword_variadic(Name::new_static("kwargs"))
                 .with_annotated_type(extra_items.declared_ty)

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -560,14 +560,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             && !has_gradual_class_context
             && arguments.keywords.iter().all(|keyword| {
                 let permits_field_inference = |name: &str| {
-                    typed_dict.item(db, name).is_none_or(|field| {
-                        !contains_generic_typed_dict(
-                            db,
-                            env,
-                            field.declared_ty,
-                            &ActiveRecursionDetector::default(),
-                        )
-                    })
+                    typed_dict.item(db, name).map_or_else(
+                        // The synthesized initializer accepts hidden items on open TypedDicts,
+                        // but explicitly provided unknown keys still need constructor validation.
+                        || typed_dict.explicit_extra_items(db).is_some(),
+                        |field| {
+                            !contains_generic_typed_dict(
+                                db,
+                                env,
+                                field.declared_ty,
+                                &ActiveRecursionDetector::default(),
+                            )
+                        },
+                    )
                 };
 
                 if let Some(name) = keyword.arg.as_ref() {


### PR DESCRIPTION
## Summary

Experimental draft to measure the mypy-primer/ecosystem impact of removing the compatibility exception for unpacking implicitly open TypedDicts. Unpacking now requires a callee that accepts arbitrary keyword arguments, just as explicit extra items already do. Hidden values retain their existing `object` type.

Model implicit extra kwargs in synthesized TypedDict initializer signatures so generic constructor inference continues to work. Keep explicitly supplied unknown keys on the dedicated constructor-validation path.

This is an experiment, not a proposal to merge before reviewing the ecosystem results.

## Initial ecosystem results

The [first completed run](https://github.com/astral-sh/ruff/actions/runs/32288355390) reports 117 added diagnostics and one removed diagnostic across 25 projects: 113 `unknown-argument`, three `no-matching-overload`, and one `type-assertion-failure` added; one `unused-type-ignore-comment` removed. No project failures or exit-status changes were reported. See the [detailed report](https://b8f82b50.ty-ecosystem-ext.pages.dev/diff). The subsequent commit only updates IDE hover snapshots.

## Test plan

Added mdtests for open versus closed TypedDicts, empty shapes, compatible and restrictive kwargs annotations, `Unpack[TypedDict]` parameters, overload selection, and generic constructor validation. Updated existing call, subclass-keyword, partial-application, and constructor-hover coverage for the stricter rule. The semantic-crate and focused hover tests pass; file-scoped hooks pass using the existing lockfile with `--frozen` because `--locked` rejects the checkout's current metadata.