### PR TITLE
[ty] Introduce a helper to centralize logic for resolving modules referenced by `from ...` imports

### DIFF
--- a/crates/ty_module_resolver/src/lib.rs
+++ b/crates/ty_module_resolver/src/lib.rs
@@ -11,8 +11,9 @@ pub use module::Module;
 pub use module_name::{ImportingFile, ModuleName, ModuleNameResolutionError};
 pub use path::{SearchPath, SearchPathError};
 pub use resolve::{
-    SearchPaths, file_to_module, resolve_module, resolve_module_confident, resolve_real_module,
-    resolve_real_module_confident, resolve_real_shadowable_module,
+    SearchPaths, file_to_module, resolve_module, resolve_module_confident,
+    resolve_module_for_import_from, resolve_real_module, resolve_real_module_confident,
+    resolve_real_shadowable_module,
 };
 pub use settings::{SearchPathSettings, SearchPathSettingsError};
 pub use strategy::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};

--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -312,7 +312,7 @@ impl ModuleName {
     pub fn from_import_statement<'db>(
         db: &'db dyn Db,
         importing_file: ImportingFile<'db>,
-        node: &'db ast::StmtImportFrom,
+        node: &ast::StmtImportFrom,
     ) -> Result<Self, ModuleNameResolutionError> {
         let ast::StmtImportFrom {
             module,

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -72,6 +72,18 @@ pub fn resolve_module<'db>(
         .or_else(|| desperately_resolve_module(db, importing_file.file(db), interned_name))
 }
 
+/// Resolves the module referenced by a `from` import statement.
+///
+/// Returns `None` if the statement does not name a valid module or the module cannot be resolved.
+pub fn resolve_module_for_import_from<'db>(
+    db: &'db dyn Db,
+    importing_file: ImportingFile<'db>,
+    import: &ast::StmtImportFrom,
+) -> Option<Module<'db>> {
+    let module_name = ModuleName::from_import_statement(db, importing_file, import).ok()?;
+    resolve_module(db, importing_file, &module_name)
+}
+
 /// Resolves a module name to a module, without desperate resolution available.
 ///
 /// This is appropriate for resolving a `KnownModule`, or cases where for whatever reason

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -19,7 +19,9 @@ use ruff_python_parser::semantic_errors::{
 };
 use ruff_text_size::{Ranged, TextRange};
 use smallvec::SmallVec;
-use ty_module_resolver::{ImportingFile, ModuleName, ResolverEnvironment, resolve_module};
+use ty_module_resolver::{
+    ImportingFile, ModuleName, ResolverEnvironment, resolve_module_for_import_from,
+};
 
 use crate::HasTrackedScope;
 use crate::ProgramFile;
@@ -3721,18 +3723,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             continue;
                         }
 
-                        let Ok(module_name) = ModuleName::from_import_statement(
+                        let Some(module) = resolve_module_for_import_from(
                             self.db,
                             ImportingFile::File(source_file, resolver_environment),
                             node,
-                        ) else {
-                            continue;
-                        };
-
-                        let Some(module) = resolve_module(
-                            self.db,
-                            ImportingFile::File(source_file, resolver_environment),
-                            &module_name,
                         ) else {
                             continue;
                         };

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -28,7 +28,7 @@ use ruff_python_ast::{
     visitor::{Visitor, walk_expr, walk_pattern, walk_stmt},
 };
 use rustc_hash::FxHashMap;
-use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, resolve_module_for_import_from};
 
 use crate::{Db, ProgramFile};
 
@@ -253,19 +253,11 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                             let program_file = self.program_file;
                             let file = program_file.file(db);
                             let resolver_environment = program_file.resolver_environment(db);
-                            for export in ModuleName::from_import_statement(
+                            for export in resolve_module_for_import_from(
                                 db,
                                 ImportingFile::File(file, resolver_environment),
                                 node,
                             )
-                            .ok()
-                            .and_then(|module_name| {
-                                resolve_module(
-                                    db,
-                                    ImportingFile::File(file, resolver_environment),
-                                    &module_name,
-                                )
-                            })
                             .iter()
                             .flat_map(|module| {
                                 module

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{self as ast};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, resolve_module_for_import_from};
 
 use crate::types::{Type, TypeContext, infer_expression_types};
 use crate::{Db, ProgramEnvironment};
@@ -165,9 +165,7 @@ impl<'db> DunderAllNamesCollector<'db> {
 
         let importing_file =
             ImportingFile::File(self.file.file(db), self.env.resolver_environment(db));
-        let module_name =
-            ModuleName::from_import_statement(db, importing_file, import_from).ok()?;
-        let module = resolve_module(db, importing_file, &module_name)?;
+        let module = resolve_module_for_import_from(db, importing_file, import_from)?;
         dunder_all_names(
             db,
             ProgramFile::new(db, module.file(db)?, self.env.program(db)),

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -2081,7 +2081,8 @@ mod resolve_definition {
     use rustc_hash::FxHashSet;
     use tracing::trace;
     use ty_module_resolver::{
-        ImportingFile, ModuleName, file_to_module, resolve_module, resolve_real_module,
+        ImportingFile, ModuleName, file_to_module, resolve_module, resolve_module_for_import_from,
+        resolve_real_module,
     };
 
     use crate::Db;
@@ -2365,13 +2366,8 @@ mod resolve_definition {
             }
         }
 
-        // Resolve the module being imported from (handles both relative and absolute imports)
-        let Some(module_name) =
-            ModuleName::from_import_statement(db, importing_file, import_node).ok()
+        let Some(resolved_module) = resolve_module_for_import_from(db, importing_file, import_node)
         else {
-            return Vec::new();
-        };
-        let Some(resolved_module) = resolve_module(db, importing_file, &module_name) else {
             return Vec::new();
         };
 
@@ -2387,7 +2383,7 @@ mod resolve_definition {
                 env,
                 importing_file,
                 symbol_name,
-                module_name,
+                resolved_module.name(db),
             ));
         };
 
@@ -2421,7 +2417,7 @@ mod resolve_definition {
                 env,
                 importing_file,
                 symbol_name,
-                module_name,
+                resolved_module.name(db),
             ))
         } else {
             resolved_definitions
@@ -2434,10 +2430,10 @@ mod resolve_definition {
         env: &ProgramEnvironment<'db>,
         importing_file: ImportingFile<'db>,
         symbol_name: &str,
-        module_name: ModuleName,
+        module_name: &ModuleName,
     ) -> Option<ResolvedDefinition<'db>> {
         let submodule_name = ModuleName::new(symbol_name)?;
-        let mut full_submodule_name = module_name;
+        let mut full_submodule_name = module_name.clone();
         full_submodule_name.extend(&submodule_name);
         let module = resolve_module(db, importing_file, &full_submodule_name)?;
         let file = ProgramFile::new(db, module.file(db)?, env.program(db));


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This reduces some unnecessary duplication across code that resolves a module for a `from ...` import.

## Test Plan

This is a pure refactor that relies on existing test coverage.
<!-- How was it tested? -->
