### PR TITLE
[ty] Treat assignments in string annotation metadata conservatively

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
@@ -22,6 +22,60 @@ def _(x: Annotated[tuple[str, int], bytes]):
     reveal_type(x)  # revealed: tuple[str, int]
 ```
 
+## Assignment expressions in string annotations
+
+Metadata can contain assignment expressions, but parsed string annotations do not have a use-def
+model. If a string annotation contains an assignment expression, we treat its metadata as opaque and
+still check the annotated type. This avoids interpreting the assignment without its effects on later
+expressions. No binding is added to the surrounding Python scope.
+
+```py
+from typing_extensions import Annotated
+
+def f(value: "Annotated[int, (metadata := 0), metadata]"):
+    reveal_type(value)  # revealed: int
+
+metadata  # error: [unresolved-reference]
+```
+
+The policy applies to the whole parsed annotation, including conditional assignments, lambda
+defaults, and metadata in sibling `Annotated` expressions.
+
+```py
+flag = True
+
+def conditional(value: "Annotated[int, (metadata := 0) if flag else (metadata := 1), metadata]"):
+    reveal_type(value)  # revealed: int
+
+def nested(value: "Annotated[int, lambda default=(metadata := (other := 0)): None]"):
+    reveal_type(value)  # revealed: int
+
+def siblings(value: "Annotated[int, (metadata := 0)] | Annotated[str, metadata]"):
+    reveal_type(value)  # revealed: int | str
+```
+
+The type argument is still checked, and metadata without assignment expressions retains its usual
+diagnostics.
+
+```py
+# error: [unresolved-reference]
+def invalid_type(value: "Annotated[missing, (metadata := 0)]"): ...
+
+# error: [unresolved-reference]
+def invalid_metadata(value: "Annotated[int, missing]"): ...
+```
+
+## Assignment expressions in stub string annotations
+
+The same metadata is supported in stub files.
+
+```pyi
+from typing_extensions import Annotated
+
+value: "Annotated[int, (metadata := 0), metadata]"
+reveal_type(value)  # revealed: int
+```
+
 ## Inside `type[...]`
 
 `Annotated` can wrap a class or specialized generic class inside `type[...]` without changing the

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -357,6 +357,12 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// is a stub file but we're still in a non-deferred region.
     deferred_state: DeferredExpressionState,
 
+    /// The outermost module-AST string whose parsed annotation we are visiting.
+    ///
+    /// AST provenance is independent of name-lookup deferredness: temporarily changing lookup
+    /// modes must never make a parsed annotation's nodes appear to belong to the semantic index.
+    string_annotation: Option<NodeKey>,
+
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
@@ -481,6 +487,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return_types_and_ranges: vec![],
             called_functions: FxIndexSet::default(),
             deferred_state: DeferredExpressionState::None,
+            string_annotation: None,
             expressions: FxHashMap::default(),
             expression_cache: None,
             reachability_cache: OnceCell::new(),
@@ -903,16 +910,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Are we currently in a context where name resolution should be deferred
     /// (`__future__.annotations`, stub file, or stringified annotation)?
     fn is_deferred(&self) -> bool {
-        self.deferred_state.is_deferred()
+        self.in_string_annotation() || self.deferred_state.is_deferred()
     }
 
     /// Return the node key of the given AST node, or the key of the outermost enclosing string
     /// literal, if the node originates from inside a stringified annotation.
     fn enclosing_node_key(&self, node: AnyNodeRef<'_>) -> NodeKey {
-        match self.deferred_state {
-            DeferredExpressionState::InStringAnnotation(enclosing_node_key) => enclosing_node_key,
-            _ => NodeKey::from_node(node),
-        }
+        self.string_annotation
+            .unwrap_or_else(|| NodeKey::from_node(node))
     }
 
     fn in_stub(&self) -> bool {
@@ -920,7 +925,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn in_string_annotation(&self) -> bool {
-        self.deferred_state.in_string_annotation()
+        self.string_annotation.is_some()
+    }
+
+    /// Infer a parsed string annotation while retaining its outermost module-AST anchor.
+    ///
+    /// Nested annotations share that anchor. Name lookup remains deferred even if a nested
+    /// expression temporarily changes `deferred_state`, as lambda defaults do.
+    fn with_string_annotation<T>(
+        &mut self,
+        string: &ast::ExprStringLiteral,
+        infer: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        let anchor = self.enclosing_node_key(string.into());
+        let previous = self.string_annotation.replace(anchor);
+        let result = infer(self);
+        self.string_annotation = previous;
+        result
     }
 
     /// Temporarily changes lookup behavior without discarding the current string annotation.
@@ -931,11 +952,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &mut self,
         state: DeferredExpressionState,
     ) -> DeferredExpressionState {
-        let previous = self.deferred_state;
-        if !previous.in_string_annotation() {
-            self.deferred_state = state;
-        }
-        previous
+        std::mem::replace(&mut self.deferred_state, state)
     }
 
     /// Returns `true` if `expr` is a call to a known diagnostic function
@@ -9940,7 +9957,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expr_ref: ast::ExprRef,
     ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
         let env = self.program_environment();
-        let mode = if self.is_deferred() && self.in_string_annotation() {
+        let mode = if self.in_string_annotation() {
             PlaceLoadMode::StringAnnotation
         } else if self.is_deferred() {
             PlaceLoadMode::Deferred
@@ -11205,6 +11222,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             reachability_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
+            string_annotation: _,
             called_functions,
             index: _,
             region: _,
@@ -11267,6 +11285,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
+            string_annotation: _,
             index: _,
             region: _,
         } = self;
@@ -11373,6 +11392,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
             typevar_binding_context: _,
             deferred_state: _,
+            string_annotation: _,
             index: _,
             region: _,
             cycle_recovery: _,
@@ -11425,6 +11445,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
+            string_annotation: _,
             index: _,
             region: _,
             return_types_and_ranges: _,
@@ -11565,6 +11586,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
+            string_annotation: _,
             called_functions: _,
             index: _,
             region: _,
@@ -11616,6 +11638,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             index,
             cycle_recovery,
             deferred_state,
+            string_annotation,
             typevar_binding_context,
             ref expression_cache,
             ref reachability_cache,
@@ -11656,6 +11679,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Ensure the speculative builder has the same inference context as the current one.
         builder.cycle_recovery = cycle_recovery;
         builder.deferred_state = deferred_state;
+        builder.string_annotation = string_annotation;
         builder.typevar_binding_context = typevar_binding_context;
         builder.context.inference_flags = self.inference_flags();
         builder.expression_cache.clone_from(expression_cache);
@@ -11706,6 +11730,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             reachability_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
+            string_annotation: _,
             called_functions,
             index: _,
             region: _,
@@ -12073,47 +12098,15 @@ enum DeferredExpressionState {
 
     /// The expression is deferred.
     ///
-    /// In the following example,
-    /// ```py
-    /// from __future__ import annotation
-    ///
-    /// a: tuple[int, "ForwardRef"] = ...
-    /// ```
-    ///
-    /// The expression `tuple` and `int` are deferred but `ForwardRef` (after parsing) is both
-    /// deferred and in a string annotation context.
+    /// This controls lookup for module-AST expressions, for example in stub files or under
+    /// `from __future__ import annotations`. Parsed string annotations are always deferred,
+    /// independently of this state.
     Deferred,
-
-    /// The expression is in a string annotation context.
-    ///
-    /// This is required to differentiate between a deferred annotation and a string annotation.
-    /// The former can occur when there's a `from __future__ import annotations` statement or we're
-    /// in a stub file.
-    ///
-    /// In the following example,
-    /// ```py
-    /// a: "List[int]" = ...
-    /// b: tuple[int, "ForwardRef"] = ...
-    /// ```
-    ///
-    /// The annotation of `a` is completely inside a string while for `b`, it's only partially
-    /// stringified.
-    ///
-    /// This variant wraps a [`NodeKey`] that allows us to retrieve the original
-    /// [`ast::ExprStringLiteral`] node which created the string annotation.
-    InStringAnnotation(NodeKey),
 }
 
 impl DeferredExpressionState {
     const fn is_deferred(self) -> bool {
-        matches!(
-            self,
-            DeferredExpressionState::Deferred | DeferredExpressionState::InStringAnnotation(_)
-        )
-    }
-
-    const fn in_string_annotation(self) -> bool {
-        matches!(self, DeferredExpressionState::InStringAnnotation(_))
+        matches!(self, DeferredExpressionState::Deferred)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -361,7 +361,7 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     ///
     /// AST provenance is independent of name-lookup deferredness: temporarily changing lookup
     /// modes must never make a parsed annotation's nodes appear to belong to the semantic index.
-    string_annotation: Option<NodeKey>,
+    string_annotation: Option<StringAnnotationContext>,
 
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
@@ -917,7 +917,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// literal, if the node originates from inside a stringified annotation.
     fn enclosing_node_key(&self, node: AnyNodeRef<'_>) -> NodeKey {
         self.string_annotation
-            .unwrap_or_else(|| NodeKey::from_node(node))
+            .map_or_else(|| NodeKey::from_node(node), |context| context.anchor)
     }
 
     fn in_stub(&self) -> bool {
@@ -935,10 +935,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn with_string_annotation<T>(
         &mut self,
         string: &ast::ExprStringLiteral,
+        expression: &ast::Expr,
         infer: impl FnOnce(&mut Self) -> T,
     ) -> T {
         let anchor = self.enclosing_node_key(string.into());
-        let previous = self.string_annotation.replace(anchor);
+        let opaque_metadata = self
+            .string_annotation
+            .is_some_and(|context| context.opaque_metadata)
+            || crate::types::string_annotation::contains_assignment_expression(expression);
+        let previous = self.string_annotation.replace(StringAnnotationContext {
+            anchor,
+            opaque_metadata,
+        });
         let result = infer(self);
         self.string_annotation = previous;
         result
@@ -12087,6 +12095,15 @@ impl<'a> Iterator for ArgumentsIter<'a> {
             ArgumentsIter::Synthesized(args) => args.next().copied(),
         }
     }
+}
+
+/// Provenance and metadata policy for the parsed annotation currently being inferred.
+#[derive(Debug, Clone, Copy)]
+struct StringAnnotationContext {
+    /// The outermost string expression in the module AST.
+    anchor: NodeKey,
+    /// Assignment-bearing metadata needs a use-def model, not ordinary module inference.
+    opaque_metadata: bool,
 }
 
 /// The deferred state of a specific expression in an inference region.

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -379,7 +379,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             Some(parsed) => {
                 self.string_annotations
                     .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
-                self.with_string_annotation(string, |builder| {
+                self.with_string_annotation(string, parsed.expr(), |builder| {
                     builder.infer_annotation_expression(
                         parsed.expr(),
                         DeferredExpressionState::Deferred,

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -72,12 +72,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         deferred_state: DeferredExpressionState,
         pep_613_policy: PEP613Policy,
     ) -> TypeAndQualifiers<'db> {
-        // `DeferredExpressionState::InStringAnnotation` takes precedence over other deferred states.
-        // However, if it's not a stringified annotation, we must still ensure that annotation expressions
-        // are always deferred in stub files.
-        let state = if deferred_state.in_string_annotation() {
-            deferred_state
-        } else if self.in_stub() {
+        // Annotation expressions are always deferred in stub files.
+        let state = if self.in_stub() {
             DeferredExpressionState::Deferred
         } else {
             deferred_state
@@ -383,13 +379,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             Some(parsed) => {
                 self.string_annotations
                     .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
-                // String annotations are always evaluated in the deferred context.
-                self.infer_annotation_expression(
-                    parsed.expr(),
-                    DeferredExpressionState::InStringAnnotation(
-                        self.enclosing_node_key(string.into()),
-                    ),
-                )
+                self.with_string_annotation(string, |builder| {
+                    builder.infer_annotation_expression(
+                        parsed.expr(),
+                        DeferredExpressionState::Deferred,
+                    )
+                })
             }
             None => TypeAndQualifiers::declared(Type::unknown()),
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
@@ -56,8 +56,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 - anchor_u32
         };
 
-        if let Some(enclosing_node_key) = self.string_annotation {
-            let enclosing_index = enclosing_node_key.index();
+        if let Some(context) = self.string_annotation {
+            let enclosing_index = context.anchor.index();
             let string: &ast::ExprStringLiteral = self
                 .module()
                 .get_by_index(enclosing_index)

--- a/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
@@ -10,7 +10,7 @@ use crate::types::diagnostic::{
     report_inconsistent_generic_bases,
 };
 use crate::types::enums::is_enum_class_by_inheritance;
-use crate::types::infer::builder::{DeferredExpressionState, TypeInferenceBuilder};
+use crate::types::infer::builder::TypeInferenceBuilder;
 use crate::types::mro::{DynamicMroError, DynamicMroErrorKind};
 use crate::types::{ClassBase, KnownClass, Type, extract_fixed_length_iterable_element_types};
 
@@ -56,8 +56,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 - anchor_u32
         };
 
-        if let DeferredExpressionState::InStringAnnotation(enclosing_node_key) = self.deferred_state
-        {
+        if let Some(enclosing_node_key) = self.string_annotation {
             let enclosing_index = enclosing_node_key.index();
             let string: &ast::ExprStringLiteral = self
                 .module()

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -2379,6 +2379,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return TypeAndQualifiers::declared(Type::unknown());
         };
 
+        if self
+            .string_annotation
+            .is_some_and(|context| context.opaque_metadata)
+        {
+            // Metadata does not affect the annotated type. Without an index for the parsed
+            // annotation, interpreting assignments would lose their effects on later metadata
+            // (including metadata in sibling `Annotated` expressions). Keep the entire metadata
+            // opaque rather than report errors from an incomplete binding model.
+            return subscript_context.infer(self, first_argument);
+        }
+
         let previous_in_type_alias = self
             .context
             .inference_flags

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1031,7 +1031,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .context
                     .inference_flags
                     .replace(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, string_was_nested);
-                let ty = self.with_string_annotation(string, |builder| {
+                let ty = self.with_string_annotation(string, parsed_expr, |builder| {
                     builder.infer_type_expression(parsed_expr)
                 });
                 self.context.inference_flags.set(
@@ -2892,7 +2892,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 {
                     self.string_annotations
                         .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
-                    let result = self.with_string_annotation(string, |builder| {
+                    let result = self.with_string_annotation(string, parsed.expr(), |builder| {
                         matches!(
                             parsed.expr(),
                             ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_)
@@ -3045,7 +3045,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return None;
                 }
 
-                self.with_string_annotation(string, |builder| {
+                self.with_string_annotation(string, parsed.expr(), |builder| {
                     builder.infer_concatenate_tail(parsed.expr())
                 })
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -131,7 +131,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
         let env = self.program_environment();
         let ignore_runtime_errors = |builder: &Self| {
-            builder.deferred_state.is_deferred()
+            builder.is_deferred()
                 || builder.in_stub()
                 || builder.is_in_type_checking_block(builder.scope(), expression)
                 || builder
@@ -1031,12 +1031,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .context
                     .inference_flags
                     .replace(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, string_was_nested);
-                let ty = self.infer_type_expression_with_state(
-                    parsed_expr,
-                    DeferredExpressionState::InStringAnnotation(
-                        self.enclosing_node_key(string.into()),
-                    ),
-                );
+                let ty = self.with_string_annotation(string, |builder| {
+                    builder.infer_type_expression(parsed_expr)
+                });
                 self.context.inference_flags.set(
                     InferenceFlags::IN_NESTED_TYPE_EXPRESSION,
                     previously_in_nested_type_expression,
@@ -2895,17 +2892,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 {
                     self.string_annotations
                         .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
-                    let node_key = self.enclosing_node_key(string.into());
-
-                    let previous_deferred_state = self.replace_deferred_state(
-                        DeferredExpressionState::InStringAnnotation(node_key),
-                    );
-                    let result = matches!(
-                        parsed.expr(),
-                        ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_)
-                    )
-                    .then(|| self.infer_callable_parameter_types(parsed.expr()));
-                    self.deferred_state = previous_deferred_state;
+                    let result = self.with_string_annotation(string, |builder| {
+                        matches!(
+                            parsed.expr(),
+                            ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_)
+                        )
+                        .then(|| builder.infer_callable_parameter_types(parsed.expr()))
+                    });
 
                     if let Some(result) = result {
                         return result;
@@ -3044,8 +3037,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 self.string_annotations
                     .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
-                let node_key = self.enclosing_node_key(string.into());
-
                 if !matches!(
                     parsed.expr(),
                     ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_)
@@ -3054,12 +3045,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return None;
                 }
 
-                let previous_deferred_state = self
-                    .replace_deferred_state(DeferredExpressionState::InStringAnnotation(node_key));
-                let result = self.infer_concatenate_tail(parsed.expr());
-                self.deferred_state = previous_deferred_state;
-
-                result
+                self.with_string_annotation(string, |builder| {
+                    builder.infer_concatenate_tail(parsed.expr())
+                })
             }
             _ => {
                 let ty = self.infer_type_expression(expr);

--- a/crates/ty_python_semantic/src/types/string_annotation.rs
+++ b/crates/ty_python_semantic/src/types/string_annotation.rs
@@ -1,5 +1,6 @@
 use ruff_db::parsed::parsed_string_annotation;
 use ruff_db::source::source_text;
+use ruff_python_ast::visitor::{Visitor, walk_expr};
 use ruff_python_ast::{self as ast, ModExpression, StringFlags};
 use ruff_python_parser::{ParseError, ParseErrorType, Parsed};
 use ruff_text_size::Ranged;
@@ -9,6 +10,30 @@ use crate::lint::{Level, LintStatus};
 use crate::types::infer::InferenceFlags;
 
 use super::context::InferContext;
+
+/// Whether an expression needs assignment bindings to be interpreted faithfully.
+///
+/// This includes assignments in lambda defaults and nested scopes. String-annotation metadata
+/// containing these expressions is opaque until parsed annotations have a use-def model.
+pub(crate) fn contains_assignment_expression(expression: &ast::Expr) -> bool {
+    let mut visitor = AssignmentExpressionVisitor { found: false };
+    visitor.visit_expr(expression);
+    visitor.found
+}
+
+struct AssignmentExpressionVisitor {
+    found: bool,
+}
+
+impl<'ast> Visitor<'ast> for AssignmentExpressionVisitor {
+    fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+        if expression.is_named_expr() {
+            self.found = true;
+        } else if !self.found {
+            walk_expr(self, expression);
+        }
+    }
+}
 
 declare_lint! {
     #[doc = include_str!("../../resources/lint_docs/raw-string-type-annotation.md")]


### PR DESCRIPTION
## Summary

Stacked on #27914.

Assignment expressions are valid in `Annotated` metadata, but parsed string annotations do not have a use-def model. Inferring only the assigned value avoids a panic while still getting later references wrong:

```python
from typing import Annotated

value: "Annotated[int, (metadata := 0), metadata]"
```

We now treat metadata as opaque when the parsed annotation contains an assignment expression. The policy applies to the whole annotation, including conditional assignments, lambda defaults, and sibling `Annotated` expressions, so we do not pretend to model bindings or their control-flow effects. We still check the annotated type, and metadata without assignments retains its existing diagnostics and inference.

This removes the broad missing-definition fallback from ordinary assignment-expression inference. Full inference of this metadata can be added when parsed annotations have a proper use-def model.

All 485 semantic mdtests and 339 selected crate unit tests pass. Clippy and the standalone panic and binding-regression reproducers also pass.
