### PR TITLE
[ty] Preserve string annotation context in lambda defaults and TypedDicts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/lambda.md
@@ -97,6 +97,44 @@ expression.
 reveal_type(lambda a=lambda x, y: 0: 2)  # revealed: (a=...) -> Literal[2]
 ```
 
+## Defaults in string annotations
+
+`Annotated` metadata can contain lambdas. Names in their default values must still be resolved in
+the enclosing string annotation, whose expressions are not part of the module's semantic index.
+
+```py
+from typing_extensions import Annotated
+
+def f(value: "Annotated[int, lambda default=int: None]"):
+    reveal_type(value)  # revealed: int
+
+# error: [unresolved-reference]
+def invalid(value: "Annotated[int, lambda default=missing: None]"): ...
+```
+
+Nested lambdas must retain the same context. Dynamic classes created in a default value also need
+the original string annotation as their source anchor.
+
+```py
+def nested(value: "Annotated[int, lambda outer=(lambda inner=int: None): None]"):
+    reveal_type(value)  # revealed: int
+
+def dynamic(value: "Annotated[int, lambda default=type('C', (), {}): None]"):
+    reveal_type(value)  # revealed: int
+```
+
+## Defaults in stub string annotations
+
+Stub files must preserve the string-annotation context too, including for positional-only and
+keyword-only defaults.
+
+```pyi
+from typing_extensions import Annotated
+
+value: "Annotated[int, lambda positional=int, /, normal=str, *, keyword=bytes: None]"
+reveal_type(value)  # revealed: int
+```
+
 ## Assignment
 
 This does not enumerate all combinations of parameter kinds as that should be covered by the

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4748,6 +4748,19 @@ class TD12(TypedDict("TD12", {}, extra_items=InitVar[int])): ...  # error: [inva
 class TD13(TypedDict("TD13", {}, extra_items=Final[int])): ...  # error: [invalid-type-form]
 ```
 
+## Function syntax inside string annotations
+
+A functional `TypedDict` can appear in `Annotated` metadata. Inferring `extra_items` in a stub must
+retain the enclosing string's identity rather than looking up its parsed nodes in the module's
+semantic index.
+
+```pyi
+from typing_extensions import Annotated, TypedDict
+
+value: "Annotated[int, TypedDict('T', {}, extra_items=int)]"
+reveal_type(value)  # revealed: int
+```
+
 ## Function syntax with forward references
 
 Functional TypedDict supports forward references (string annotations):

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -923,6 +923,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.deferred_state.in_string_annotation()
     }
 
+    /// Temporarily changes lookup behavior without discarding the current string annotation.
+    ///
+    /// Parsed string nodes do not belong to the module's semantic index, so their enclosing
+    /// annotation must remain available even when nested expressions request another lookup mode.
+    fn replace_deferred_state(
+        &mut self,
+        state: DeferredExpressionState,
+    ) -> DeferredExpressionState {
+        let previous = self.deferred_state;
+        if !previous.in_string_annotation() {
+            self.deferred_state = state;
+        }
+        previous
+    }
+
     /// Returns `true` if `expr` is a call to a known diagnostic function
     /// (e.g., `reveal_type` or `assert_type`) whose return value should not
     /// trigger the `unused-awaitable` lint.
@@ -4615,7 +4630,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if is_pep_613_type_alias {
                 self.context.inference_flags |= InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS;
                 if self.in_stub() {
-                    self.deferred_state = DeferredExpressionState::Deferred;
+                    self.replace_deferred_state(DeferredExpressionState::Deferred);
                 }
             }
 
@@ -6280,7 +6295,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         tcx: TypeContext<'db>,
         state: DeferredExpressionState,
     ) -> Type<'db> {
-        let previous_deferred_state = std::mem::replace(&mut self.deferred_state, state);
+        let previous_deferred_state = self.replace_deferred_state(state);
         let ty = self.infer_expression(expression, tcx);
         self.deferred_state = previous_deferred_state;
         ty
@@ -8474,11 +8489,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = lambda_expression;
 
         // In stub files, default values may reference names that are defined later in the file.
-        // Preserve string-annotation context because those nodes are not in the semantic index.
-        let previous_deferred_state = self.deferred_state;
-        if !previous_deferred_state.in_string_annotation() {
-            self.deferred_state = self.in_stub().into();
-        }
+        let previous_deferred_state = self.replace_deferred_state(self.in_stub().into());
 
         // TODO: We could perform multi-inference here if there are multiple `Callable` annotations
         // in the union/intersection.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8474,8 +8474,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = lambda_expression;
 
         // In stub files, default values may reference names that are defined later in the file.
-        let in_stub = self.in_stub();
-        let previous_deferred_state = std::mem::replace(&mut self.deferred_state, in_stub.into());
+        // Preserve string-annotation context because those nodes are not in the semantic index.
+        let previous_deferred_state = self.deferred_state;
+        if !previous_deferred_state.in_string_annotation() {
+            self.deferred_state = self.in_stub().into();
+        }
 
         // TODO: We could perform multi-inference here if there are multiple `Callable` annotations
         // in the union/intersection.

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -83,7 +83,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             deferred_state
         };
 
-        let previous_deferred_state = std::mem::replace(&mut self.deferred_state, state);
+        let previous_deferred_state = self.replace_deferred_state(state);
         let previous_check_unbound_typevars = self
             .context
             .inference_flags

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -36,9 +36,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         self.infer_type_parameters(type_params);
 
         if class.arguments.is_some() {
-            let in_stub = self.in_stub();
-            let previous_deferred_state =
-                std::mem::replace(&mut self.deferred_state, in_stub.into());
+            let previous_deferred_state = self.replace_deferred_state(self.in_stub().into());
 
             // PEP 695 class headers are inferred in the type-parameter scope, before the completed
             // class type is available. Infer the bases first because `extra_items=T` is an
@@ -388,9 +386,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // and we don't need to run inference here
         if type_params.is_none() {
             // In stub files, keyword values may reference names that are defined later in the file.
-            let in_stub = self.in_stub();
-            let previous_deferred_state =
-                std::mem::replace(&mut self.deferred_state, in_stub.into());
+            let previous_deferred_state = self.replace_deferred_state(self.in_stub().into());
             for keyword in class_node.keywords() {
                 if keyword.arg.as_deref() != Some("extra_items") {
                     self.infer_expression(&keyword.value, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -708,8 +708,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let previous_typevar_binding_context = self.typevar_binding_context.replace(definition);
 
         // In stub files, default values may reference names that are defined later in the file.
-        let in_stub = self.in_stub();
-        let previous_deferred_state = std::mem::replace(&mut self.deferred_state, in_stub.into());
+        let previous_deferred_state = self.replace_deferred_state(self.in_stub().into());
 
         // Borrow annotation types from their own inference result instead of copying that result
         // into this query. Scope inference merges both regions when checking the whole function.

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -53,16 +53,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .inference_flags
             .replace(InferenceFlags::IN_TYPE_EXPRESSION, true);
 
-        // `DeferredExpressionState::InStringAnnotation` takes precedence over other states.
-        // However, if it's not a stringified annotation, we must still ensure that annotation expressions
-        // are always deferred in stub files.
-        match previous_deferred_state {
-            DeferredExpressionState::None => {
-                if self.in_stub() {
-                    self.deferred_state = DeferredExpressionState::Deferred;
-                }
-            }
-            DeferredExpressionState::InStringAnnotation(_) | DeferredExpressionState::Deferred => {}
+        // Annotation expressions are always deferred in stub files.
+        if self.in_stub() {
+            self.replace_deferred_state(DeferredExpressionState::Deferred);
         }
 
         let ty = self.infer_type_expression_no_store(expression);
@@ -87,7 +80,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         expression: &ast::Expr,
         deferred_state: DeferredExpressionState,
     ) -> Type<'db> {
-        let previous_deferred_state = std::mem::replace(&mut self.deferred_state, deferred_state);
+        let previous_deferred_state = self.replace_deferred_state(deferred_state);
         let annotation_ty = self.infer_type_expression(expression);
         self.deferred_state = previous_deferred_state;
         annotation_ty
@@ -2904,8 +2897,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         .insert(ruff_python_ast::ExprRef::StringLiteral(string).into());
                     let node_key = self.enclosing_node_key(string.into());
 
-                    let previous_deferred_state = std::mem::replace(
-                        &mut self.deferred_state,
+                    let previous_deferred_state = self.replace_deferred_state(
                         DeferredExpressionState::InStringAnnotation(node_key),
                     );
                     let result = matches!(
@@ -3062,10 +3054,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return None;
                 }
 
-                let previous_deferred_state = std::mem::replace(
-                    &mut self.deferred_state,
-                    DeferredExpressionState::InStringAnnotation(node_key),
-                );
+                let previous_deferred_state = self
+                    .replace_deferred_state(DeferredExpressionState::InStringAnnotation(node_key));
                 let result = self.infer_concatenate_tail(parsed.expr());
                 self.deferred_state = previous_deferred_state;
 

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -11,7 +11,6 @@ use crate::types::diagnostic::{
     INVALID_ARGUMENT_TYPE, INVALID_TYPE_FORM, MISSING_ARGUMENT, TOO_MANY_POSITIONAL_ARGUMENTS,
     UNKNOWN_ARGUMENT, report_mismatched_type_name,
 };
-use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
     TypedDictOpenness, TypedDictSchema, collect_guaranteed_keyword_keys,
@@ -809,12 +808,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     }
 
     pub(super) fn infer_extra_items_kwarg(&mut self, value: &ast::Expr) -> TypeAndQualifiers<'db> {
-        let state = if self.in_stub() {
-            DeferredExpressionState::Deferred
-        } else {
-            self.deferred_state
-        };
-        let annotation = self.infer_annotation_expression(value, state);
+        let annotation = self.infer_annotation_expression(value, self.deferred_state);
         for qualifier in TypeQualifier::iter() {
             if qualifier != TypeQualifier::ReadOnly
                 && annotation

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -96,7 +96,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
 
         let previous_deferred_state =
-            std::mem::replace(&mut self.deferred_state, DeferredExpressionState::Deferred);
+            self.replace_deferred_state(DeferredExpressionState::Deferred);
         let bound_node = bound.as_deref();
         let bound_or_constraints = match bound_node {
             Some(expr @ ast::Expr::Tuple(ast::ExprTuple { elts, .. })) => {
@@ -579,7 +579,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
         let previous_deferred_state =
-            std::mem::replace(&mut self.deferred_state, DeferredExpressionState::Deferred);
+            self.replace_deferred_state(DeferredExpressionState::Deferred);
         self.infer_paramspec_default(default, Some(&name.id));
         self.deferred_state = previous_deferred_state;
     }
@@ -708,7 +708,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
         let previous_deferred_state =
-            std::mem::replace(&mut self.deferred_state, DeferredExpressionState::Deferred);
+            self.replace_deferred_state(DeferredExpressionState::Deferred);
         self.infer_typevartuple_default(default, Some(&name.id));
         self.deferred_state = previous_deferred_state;
     }


### PR DESCRIPTION
## Summary

Follow-up to #27882.

Previously, changing deferred lookup modes while inferring `Annotated` metadata could discard the enclosing string-annotation context, causing parsed expressions to be looked up in the module's semantic index and panic:

```python
from typing_extensions import Annotated, TypedDict

value: "Annotated[int, lambda default=int: None]"
other: "Annotated[int, TypedDict('T', {}, extra_items=int)]"
```

We now preserve `InStringAnnotation` while inferring lambda defaults. For `TypedDict.extra_items`, we pass through the existing state and rely on annotation inference to defer stub annotations without losing their enclosing string context. This also covers nested lambdas, dynamic classes in defaults, and positional-only and keyword-only stub defaults.

All 838 semantic tests pass.
