### PR TITLE
[ty] Skip invalid subscript arguments in string annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -239,8 +239,8 @@ c: "TypedDict('T', {}, extra_items=missing)[int]"
 ## Invalid subscript arguments in string annotations
 
 Even when a subscript's operand is a valid name, it might not be a generic type. We reject such
-specializations without evaluating their arguments in string annotations. This also applies inside
-`type[...]`, whose argument must itself be a valid type expression.
+specializations without evaluating their arguments in string annotations. Unsupported `type[...]`
+arguments also skip expression inference, while retaining their existing fallback type.
 
 `runtime.py`:
 
@@ -251,9 +251,7 @@ from typing import Any
 a: "int[(name := missing)]"
 # error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
 b: "type[int[(name := missing)]]"
-# error: [invalid-type-form] "Named expressions are not allowed"
 c: "type[(name := missing)]"
-# error: [invalid-type-form] "Special form `typing.Any` expected no type parameter"
 d: "type[Any[(name := missing)]]"
 ```
 
@@ -268,9 +266,7 @@ from typing import Any
 a: "int[(name := missing)]"
 # error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
 b: "type[int[(name := missing)]]"
-# error: [invalid-type-form] "Named expressions are not allowed"
 c: "type[(name := missing)]"
-# error: [invalid-type-form] "Special form `typing.Any` expected no type parameter"
 d: "type[Any[(name := missing)]]"
 ```
 
@@ -288,7 +284,6 @@ python-version = "3.13"
 # error: [unresolved-reference] "Name `missing` used when not defined"
 a: int[(name := missing)]
 
-# error: [invalid-type-form] "Named expressions are not allowed"
 # error: [unresolved-reference] "Name `other_missing` used when not defined"
 b: type[(other := other_missing)]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -236,6 +236,63 @@ b: "(lambda value=(name := int): None)[int]"
 c: "TypedDict('T', {}, extra_items=missing)[int]"
 ```
 
+## Invalid subscript arguments in string annotations
+
+Even when a subscript's operand is a valid name, it might not be a generic type. We reject such
+specializations without evaluating their arguments in string annotations. This also applies inside
+`type[...]`, whose argument must itself be a valid type expression.
+
+`runtime.py`:
+
+```py
+from typing import Any
+
+# error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
+a: "int[(name := missing)]"
+# error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
+b: "type[int[(name := missing)]]"
+# error: [invalid-type-form] "Named expressions are not allowed"
+c: "type[(name := missing)]"
+# error: [invalid-type-form] "Special form `typing.Any` expected no type parameter"
+d: "type[Any[(name := missing)]]"
+```
+
+Stub files use the same error recovery.
+
+`stub.pyi`:
+
+```pyi
+from typing import Any
+
+# error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
+a: "int[(name := missing)]"
+# error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
+b: "type[int[(name := missing)]]"
+# error: [invalid-type-form] "Named expressions are not allowed"
+c: "type[(name := missing)]"
+# error: [invalid-type-form] "Special form `typing.Any` expected no type parameter"
+d: "type[Any[(name := missing)]]"
+```
+
+## Invalid subscript arguments in evaluated annotations
+
+For annotations that are evaluated, we still report errors in the invalid argument.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+# error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
+# error: [unresolved-reference] "Name `missing` used when not defined"
+a: int[(name := missing)]
+
+# error: [invalid-type-form] "Named expressions are not allowed"
+# error: [unresolved-reference] "Name `other_missing` used when not defined"
+b: type[(other := other_missing)]
+```
+
 ## Multiple starred expressions in a `tuple` specialization
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -240,19 +240,25 @@ c: "TypedDict('T', {}, extra_items=missing)[int]"
 
 Even when a subscript's operand is a valid name, it might not be a generic type. We reject such
 specializations without evaluating their arguments in string annotations. Unsupported `type[...]`
-arguments also skip expression inference, while retaining their existing fallback type.
+arguments are checked as type expressions while retaining their existing fallback type.
 
 `runtime.py`:
 
 ```py
-from typing import Any
+from typing import Any, Tuple
 
 # error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
 a: "int[(name := missing)]"
 # error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
 b: "type[int[(name := missing)]]"
+# error: [invalid-type-form] "Named expressions are not allowed"
 c: "type[(name := missing)]"
+# error: [invalid-type-form] "Named expressions are not allowed"
 d: "type[Any[(name := missing)]]"
+# error: [invalid-type-form] "`lambda` expressions are not allowed"
+e: "type[Tuple[lambda default=(name := missing): None]]"
+# error: [invalid-type-form] "`lambda` expressions are not allowed"
+f: "type[lambda default=(name := missing): None]"
 ```
 
 Stub files use the same error recovery.
@@ -260,19 +266,26 @@ Stub files use the same error recovery.
 `stub.pyi`:
 
 ```pyi
-from typing import Any
+from typing import Any, Tuple
 
 # error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
 a: "int[(name := missing)]"
 # error: [invalid-type-form] "Non-generic class `int` cannot be specialized"
 b: "type[int[(name := missing)]]"
+# error: [invalid-type-form] "Named expressions are not allowed"
 c: "type[(name := missing)]"
+# error: [invalid-type-form] "Named expressions are not allowed"
 d: "type[Any[(name := missing)]]"
+# error: [invalid-type-form] "`lambda` expressions are not allowed"
+e: "type[Tuple[lambda default=(name := missing): None]]"
+# error: [invalid-type-form] "`lambda` expressions are not allowed"
+f: "type[lambda default=(name := missing): None]"
 ```
 
 ## Invalid subscript arguments in evaluated annotations
 
-For annotations that are evaluated, we still report errors in the invalid argument.
+For annotations that are evaluated, we report invalid type arguments and errors encountered while
+evaluating them.
 
 ```toml
 [environment]
@@ -284,8 +297,13 @@ python-version = "3.13"
 # error: [unresolved-reference] "Name `missing` used when not defined"
 a: int[(name := missing)]
 
+# error: [invalid-type-form] "Named expressions are not allowed"
 # error: [unresolved-reference] "Name `other_missing` used when not defined"
 b: type[(other := other_missing)]
+
+# error: [invalid-type-form] "Function calls are not allowed"
+# error: [unresolved-reference] "Name `missing_call` used when not defined"
+c: type[missing_call()]
 ```
 
 ## Multiple starred expressions in a `tuple` specialization

--- a/crates/ty_python_semantic/resources/mdtest/type_of/typing_dot_Type.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/typing_dot_Type.md
@@ -16,6 +16,20 @@ def _(c: Type, d: Type[A]):
     d = c  # fine
 ```
 
+## Legacy generic aliases
+
+Legacy generic aliases nested inside `type[...]` are not fully supported yet. They retain the same
+fallback in evaluated and string annotations.
+
+```py
+from typing import Set, Tuple, Type
+
+def f(a: Type[Set[int]], b: type[Tuple[int]], c: "type[Tuple[int]]"):
+    reveal_type(a)  # revealed: @Todo(unsupported nested subscript in type[X])
+    reveal_type(b)  # revealed: @Todo(unsupported nested subscript in type[X])
+    reveal_type(c)  # revealed: @Todo(unsupported nested subscript in type[X])
+```
+
 ## Inheritance
 
 Inheriting from `Type` results in a MRO with `builtins.type` and `typing.Generic`. `Type` itself is

--- a/crates/ty_python_semantic/resources/mdtest/type_of/typing_dot_Type.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/typing_dot_Type.md
@@ -30,6 +30,39 @@ def f(a: Type[Set[int]], b: type[Tuple[int]], c: "type[Tuple[int]]"):
     reveal_type(c)  # revealed: @Todo(unsupported nested subscript in type[X])
 ```
 
+## Invalid arguments in unsupported string annotations
+
+Unsupported `type[...]` arguments are still checked as type expressions. Missing names and invalid
+calls are reported instead of silently accepting the annotation.
+
+`runtime.py`:
+
+```py
+from typing import Any, Tuple
+
+# error: [unresolved-reference] "Name `missing_alias` used when not defined"
+alias: "type[Tuple[missing_alias]]"
+# error: [invalid-type-form] "Function calls are not allowed"
+call: "type[missing_call()]"
+# error: [unresolved-reference] "Name `missing_any` used when not defined"
+any_annotation: "type[Any[missing_any]]"
+```
+
+Stub files retain the same diagnostics.
+
+`stub.pyi`:
+
+```pyi
+from typing import Any, Tuple
+
+# error: [unresolved-reference] "Name `missing_alias` used when not defined"
+alias: "type[Tuple[missing_alias]]"
+# error: [invalid-type-form] "Function calls are not allowed"
+call: "type[missing_call()]"
+# error: [unresolved-reference] "Name `missing_any` used when not defined"
+any_annotation: "type[Any[missing_any]]"
+```
+
 ## Inheritance
 
 Inheriting from `Type` results in a MRO with `builtins.type` and `typing.Generic`. `Type` itself is

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1349,7 +1349,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                     )
                                 }
                                 None => {
-                                    self.infer_expression(parameters, TypeContext::default());
+                                    if !self.in_string_annotation() {
+                                        self.infer_expression(parameters, TypeContext::default());
+                                    }
                                     self.report_invalid_type_expression(
                                         subscript,
                                         format_args!(
@@ -1372,27 +1374,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         );
                         invalid_type_argument(self, slice)
                     }
-                    value_ty @ (Type::SpecialForm(
-                        SpecialFormType::Top | SpecialFormType::Bottom | SpecialFormType::Annotated,
-                    )
-                    | Type::KnownInstance(_)
-                    | Type::GenericAlias(_)
-                    | Type::Callable(_)) => {
+                    value_ty => {
                         let slice_ty = self.infer_subscript_type_expression(subscript, value_ty);
                         subclass_of_type_argument(self, slice, slice_ty)
-                    }
-                    _ => {
-                        self.infer_expression(parameters, TypeContext::default());
-                        todo_type!("unsupported nested subscript in type[X]")
                     }
                 };
                 self.store_expression_type(slice, parameters_ty);
                 parameters_ty
             }
-            _ => {
-                self.infer_expression(slice, TypeContext::default());
-                todo_type!("unsupported type[X] special form")
-            }
+            _ => infer_type_argument(self, slice),
         }
     }
 
@@ -1799,7 +1789,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             .unwrap_or(Type::unknown())
                     }
                     _ => {
-                        self.infer_expression(slice, TypeContext::default());
+                        if !self.in_string_annotation() {
+                            self.infer_expression(slice, TypeContext::default());
+                        }
                         self.report_invalid_type_expression(
                             subscript,
                             format_args!(

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1374,15 +1374,31 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         );
                         invalid_type_argument(self, slice)
                     }
-                    value_ty => {
+                    value_ty @ (Type::SpecialForm(
+                        SpecialFormType::Top | SpecialFormType::Bottom | SpecialFormType::Annotated,
+                    )
+                    | Type::KnownInstance(_)
+                    | Type::GenericAlias(_)
+                    | Type::Callable(_)) => {
                         let slice_ty = self.infer_subscript_type_expression(subscript, value_ty);
                         subclass_of_type_argument(self, slice, slice_ty)
+                    }
+                    _ => {
+                        if !self.in_string_annotation() {
+                            self.infer_expression(parameters, TypeContext::default());
+                        }
+                        todo_type!("unsupported nested subscript in type[X]")
                     }
                 };
                 self.store_expression_type(slice, parameters_ty);
                 parameters_ty
             }
-            _ => infer_type_argument(self, slice),
+            _ => {
+                if !self.in_string_annotation() {
+                    self.infer_expression(slice, TypeContext::default());
+                }
+                todo_type!("unsupported type[X] special form")
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1384,9 +1384,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         subclass_of_type_argument(self, slice, slice_ty)
                     }
                     _ => {
-                        if !self.in_string_annotation() {
-                            self.infer_expression(parameters, TypeContext::default());
-                        }
+                        self.infer_type_expression(parameters);
                         todo_type!("unsupported nested subscript in type[X]")
                     }
                 };
@@ -1394,9 +1392,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 parameters_ty
             }
             _ => {
-                if !self.in_string_annotation() {
-                    self.infer_expression(slice, TypeContext::default());
-                }
+                self.infer_type_expression(slice);
                 todo_type!("unsupported type[X] special form")
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to #27882.

Previously, the non-generic-class and `type[...]` fallback paths could evaluate invalid subscript arguments inside string annotations, reaching assignment expressions that are absent from the semantic index:

```python
value: "int[(other := 0)]"
another: "type[(other := 0)]"
```

We now skip expression inference in these error-recovery paths when the arguments come from a string annotation. Non-generic classes retain their existing `invalid-type-form` diagnostic, unsupported `type[...]` forms retain their existing fallback type, and evaluated annotations retain their runtime diagnostics. We do not add support for additional `type[...]` forms.

This fix is independent of #27914 and #27913.
