### PR TITLE
[ty] Preserve tuple Never shape and disjointness invariants

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
@@ -13,6 +13,44 @@ def _(x: tuple[int, str], y: tuple[None, tuple[int]]):
     reveal_type(y + x)  # revealed: tuple[None | tuple[int] | int | str, ...]
 ```
 
+Concatenating two statically empty built-in tuples preserves their fixed-length shape.
+
+```py
+def concatenate_empty(left: tuple[()], right: tuple[()]) -> None:
+    reveal_type(left + right)  # revealed: tuple[()]
+```
+
+Direct builtin method calls still use the generic homogeneous return type.
+
+```py
+# TODO: This should also preserve the exact empty tuple result.
+reveal_type(().__add__(()))  # revealed: tuple[Never, ...]
+```
+
+An empty tuple subclass can override ordinary or reflected addition, so its methods must still
+determine the result.
+
+```py
+class EmptyTupleWithAddition(tuple[()]):
+    def __add__(self, other: object) -> "EmptyTupleWithAddition":
+        return self
+
+class EmptyTupleWithReflectedAddition(tuple[()]):
+    def __radd__(self, other: object) -> str:
+        return "reflected"
+
+def concatenate_subclasses(
+    left: EmptyTupleWithAddition,
+    right: EmptyTupleWithReflectedAddition,
+) -> None:
+    reveal_type(left + ())  # revealed: EmptyTupleWithAddition
+    reveal_type(left.__add__(()))  # revealed: EmptyTupleWithAddition
+    reveal_type(right.__radd__(()))  # revealed: str
+    # TODO: Preserve the tuple literal's exact runtime class. Its inferred `tuple[()]`
+    # type admits subclasses, so we cannot yet rule out calling `tuple.__add__`.
+    reveal_type(() + right)  # revealed: str | tuple[Never, ...]
+```
+
 ## Concatenation for homogeneous tuples
 
 ```py
@@ -45,4 +83,48 @@ def _(one_two: OneTwo, x: IntTuple, y: StrTuple, three_four: ThreeFour):
     reveal_type(x + three_four)  # revealed: tuple[int, ...]
     reveal_type(one_two + x + three_four)  # revealed: tuple[int, ...]
     reveal_type(one_two + y + three_four + x)  # revealed: tuple[int | str, ...]
+```
+
+## Repetition of empty tuples
+
+Repeating a statically empty built-in tuple by an integer literal preserves its fixed-length shape,
+regardless of the multiplier or operand order.
+
+```py
+reveal_type(() * 0)  # revealed: tuple[()]
+reveal_type(() * 3)  # revealed: tuple[()]
+reveal_type(() * -1)  # revealed: tuple[()]
+reveal_type(3 * ())  # revealed: tuple[()]
+reveal_type(() * True)  # revealed: tuple[()]
+reveal_type(False * ())  # revealed: tuple[()]
+
+def repeat_empty(value: tuple[()]) -> None:
+    reveal_type(value * 2)  # revealed: tuple[()]
+    reveal_type(2 * value)  # revealed: tuple[()]
+```
+
+TODO: Preserve the exact empty result for non-literal multipliers and direct builtin method calls.
+
+```py
+def repeat_non_literal(multiplier: int) -> None:
+    reveal_type(() * multiplier)  # revealed: tuple[Never, ...]
+    reveal_type(multiplier * ())  # revealed: tuple[Never, ...]
+
+reveal_type(().__mul__(2))  # revealed: tuple[Never, ...]
+reveal_type(().__rmul__(2))  # revealed: tuple[Never, ...]
+```
+
+Tuple subclasses can also override repetition in either operand order.
+
+```py
+class EmptyTupleWithRepetition(tuple[()]):
+    def __mul__(self, other: object) -> "EmptyTupleWithRepetition":
+        return self
+
+    def __rmul__(self, other: object) -> "EmptyTupleWithRepetition":
+        return self
+
+def repeat_subclass(value: EmptyTupleWithRepetition) -> None:
+    reveal_type(value * 2)  # revealed: EmptyTupleWithRepetition
+    reveal_type(2 * value)  # revealed: EmptyTupleWithRepetition
 ```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
@@ -425,10 +425,19 @@ c = (1, 2, 3)
 
 reveal_type(a is (1, 2))  # revealed: bool
 reveal_type(a is not (1, 2))  # revealed: bool
+```
 
-reveal_type(a is b)  # revealed: Literal[False]
-reveal_type(a is not b)  # revealed: Literal[True]
+Tuples with incompatible element types can still share a subclass, so equal lengths do not rule out
+identity.
 
+```py
+reveal_type(a is b)  # revealed: bool
+reveal_type(a is not b)  # revealed: bool
+```
+
+Tuples with incompatible lengths cannot be the same object.
+
+```py
 reveal_type(a is c)  # revealed: Literal[False]
 reveal_type(a is not c)  # revealed: Literal[True]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
@@ -427,10 +427,11 @@ reveal_type(a is (1, 2))  # revealed: bool
 reveal_type(a is not (1, 2))  # revealed: bool
 ```
 
-Tuples with incompatible element types can still share a subclass, so equal lengths do not rule out
-identity.
+Tuple types with incompatible element types can have a non-bottom static intersection even when no
+runtime value inhabits it. Identity comparisons currently use this conservative static relation.
 
 ```py
+# TODO: A runtime-disjointness check should reveal Literal[False] and Literal[True], respectively.
 reveal_type(a is b)  # revealed: bool
 reveal_type(a is not b)  # revealed: bool
 ```

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -608,6 +608,50 @@ def no_invalid_return_diagnostic_here_either[T](x: A[T]) -> ASub[T]:
         return x
 ```
 
+## Class patterns with variadic generics
+
+A class pattern matches every specialization of its variadic generic class, including a symbolic
+type variable tuple.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Variadic(Generic[*Ts]): ...
+
+def symbolic(value: Variadic[*Ts]) -> int:
+    match value:
+        case Variadic():
+            reveal_type(value)  # revealed: Variadic[*tuple[*Ts@symbolic]]
+            return 1
+```
+
+The same pattern is exhaustive when the type variable tuple has an empty specialization.
+
+```py
+def empty(value: Variadic[()]) -> int:
+    match value:
+        case Variadic():
+            reveal_type(value)  # revealed: Variadic[()]
+            return 1
+```
+
+A nonempty specialization must also remain reachable and exhaustive.
+
+```py
+def nonempty(value: Variadic[int]) -> int:
+    match value:
+        case Variadic():
+            reveal_type(value)  # revealed: Variadic[int]
+            return 1
+```
+
 ## More `match` pattern types
 
 ### `as` patterns

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -709,7 +709,7 @@ def check_structural(
 ```
 
 Unions of structurally compatible protocols retain the same tuple. Incompatible alternatives are
-rejected without widening their inferred tuple to an unknown-length tuple.
+rejected, but their overlapping tuple constraints are preserved in the fallback result.
 
 ```py
 class Other[*Ts](Protocol):
@@ -724,9 +724,9 @@ def check_unions(
     reveal_type(invariant_structural(invariant_match))  # revealed: tuple[str]
     reveal_type(contravariant_structural(contravariant_match))  # revealed: tuple[str]
     # error: [invalid-argument-type]
-    reveal_type(invariant_structural(invariant_mismatch))  # revealed: tuple[()]
+    reveal_type(invariant_structural(invariant_mismatch))  # revealed: tuple[tuple[str] & tuple[bytes], ...]
     # error: [invalid-argument-type]
-    reveal_type(contravariant_structural(contravariant_mismatch))  # revealed: tuple[()]
+    reveal_type(contravariant_structural(contravariant_mismatch))  # revealed: tuple[tuple[str] & tuple[bytes], ...]
 ```
 
 A nominal class implementing the same variadic protocol retains its precise method parameter.

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -711,6 +711,10 @@ def check_structural(
 Unions of structurally compatible protocols retain the same tuple. Incompatible alternatives are
 rejected, but their overlapping tuple constraints are preserved in the fallback result.
 
+TODO: Intersect fixed-length tuples elementwise, so `tuple[str] & tuple[bytes]` becomes
+`tuple[Never]`. The fallback should preserve that one-element pack instead of producing a nested,
+arbitrary-length tuple.
+
 ```py
 class Other[*Ts](Protocol):
     def call(self, *args: *Ts) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -851,8 +851,9 @@ def narrow_tuple_subclass(value: object) -> None:
         reveal_type(value[1])  # revealed: str
 ```
 
-A tuple subclass with a required `Never` element can still have instances. Narrowing a compatible
-tuple to that subclass must preserve its nominal type and continue checking the reachable branch.
+A tuple subclass with a required `Never` element retains its nominal type even though no runtime
+value can satisfy that element type. Narrowing currently preserves the static intersection and
+continues checking the branch.
 
 ```py
 from typing import Never
@@ -860,6 +861,7 @@ from typing import Never
 class BottomTuple(tuple[Never]): ...
 
 def narrow_bottom_tuple(value: tuple[int]) -> None:
+    # TODO: Runtime inhabitability analysis should mark this branch unreachable.
     if isinstance(value, BottomTuple):
         reveal_type(value)  # revealed: BottomTuple
         # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -851,6 +851,21 @@ def narrow_tuple_subclass(value: object) -> None:
         reveal_type(value[1])  # revealed: str
 ```
 
+A tuple subclass with a required `Never` element can still have instances. Narrowing a compatible
+tuple to that subclass must preserve its nominal type and continue checking the reachable branch.
+
+```py
+from typing import Never
+
+class BottomTuple(tuple[Never]): ...
+
+def narrow_bottom_tuple(value: tuple[int]) -> None:
+    if isinstance(value, BottomTuple):
+        reveal_type(value)  # revealed: BottomTuple
+        # error: [invalid-assignment]
+        invalid: int = "not an int"
+```
+
 The behavior of `issubclass()` is similar.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -46,6 +46,8 @@ def f0(h0: HeterogeneousSubclass0, i: int):
     # error: [index-out-of-bounds]
     reveal_type(h0[-1])  # revealed: Unknown
 
+    reveal_type(h0[:])  # revealed: tuple[()]
+    reveal_type(h0.__getitem__(slice(None)))  # revealed: tuple[()]
     reveal_type(h0[i])  # revealed: Never
 
 class HeterogeneousSubclass1(tuple[I0]): ...

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -359,9 +359,9 @@ from ty_extensions._internal import is_equivalent_to
 from typing_extensions import Never, Union
 
 static_assert(is_equivalent_to(type, type[object]))
-static_assert(is_equivalent_to(tuple[Never, ...], tuple[()]))
 static_assert(is_equivalent_to(int | str, Union[int, str]))
 
+static_assert(not is_equivalent_to(tuple[Never, ...], tuple[()]))
 static_assert(not is_equivalent_to(int, str))
 static_assert(not is_equivalent_to(int | str, int | str | bytes))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
@@ -171,8 +171,9 @@ x: list[Never] = []
 
 ## Tuples involving `Never`
 
-A type like `tuple[int, Never]` remains distinct from `Never`. A tuple annotation can describe
-user-defined subclasses, so its element types remain part of the type:
+A type like `tuple[int, Never]` remains distinct from `Never`. No runtime value satisfies its
+required `Never` element, but its tuple shape and other element types remain part of the static
+type:
 
 ```py
 from ty_extensions import static_assert

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -2,9 +2,9 @@
 
 ## Tuples as product types
 
-Tuples can be used to construct product types. Inhabitants of the type `tuple[P, Q]` are ordered
-pairs `(p, q)` where `p` is an inhabitant of `P` and `q` is an inhabitant of `Q`, analogous to the
-Cartesian product of sets.
+Tuples can be used to construct product types. Runtime inhabitants of the type `tuple[P, Q]` are
+ordered pairs `(p, q)` where `p` is an inhabitant of `P` and `q` is an inhabitant of `Q`, analogous
+to the Cartesian product of sets.
 
 ```py
 from typing_extensions import assert_type
@@ -75,6 +75,23 @@ reveal_type((1, 2).__class__())  # revealed: tuple[Literal[1], Literal[2]]
 def g(x: tuple[int, str] | tuple[bytes, bool], y: tuple[int, str] | tuple[bytes, bool, bytes]):
     reveal_type(tuple(x))  # revealed: tuple[int, str] | tuple[bytes, bool]
     reveal_type(tuple(y))  # revealed: tuple[int, str] | tuple[bytes, bool, bytes]
+```
+
+Calling `tuple` constructs a runtime value, so a homogeneous `Never` segment contributes no elements
+to the result. The argument's static type still retains that segment, and any required prefix or
+suffix remains present in the constructed tuple.
+
+```py
+def construct_from_never_segment(
+    homogeneous: tuple[Never, ...],
+    mixed: tuple[int, *tuple[Never, ...], str],
+    alternatives: list[Never] | tuple[int],
+) -> None:
+    reveal_type(homogeneous)  # revealed: tuple[Never, ...]
+    reveal_type(tuple(homogeneous))  # revealed: tuple[()]
+    reveal_type(mixed)  # revealed: tuple[int, *tuple[Never, ...], str]
+    reveal_type(tuple(mixed))  # revealed: tuple[int, str]
+    reveal_type(tuple(alternatives))  # revealed: tuple[()] | tuple[int]
 ```
 
 ## Instantiating tuple subclasses
@@ -227,18 +244,19 @@ static_assert(not is_singleton(tuple[None]))
 python-version = "3.11"
 ```
 
-The `Never` type contains no inhabitants, but a tuple annotation can also describe user-defined
-subclasses. A tuple type containing `Never` as a mandatory element therefore retains its shape
-instead of simplifying to `Never`.
+The `Never` type contains no inhabitants, so a tuple with a mandatory `Never` element is also
+runtime-uninhabited. We nevertheless retain its length and element types instead of simplifying it
+to `Never`. This preserves its tuple shape and prevents assignment to unrelated types.
 
 ```py
 from typing import Never
 from ty_extensions import static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
 
 static_assert(not is_equivalent_to(tuple[Never], Never))
 static_assert(not is_equivalent_to(tuple[int, Never], Never))
 static_assert(not is_equivalent_to(tuple[Never, *tuple[int, ...]], Never))
+static_assert(not is_assignable_to(tuple[Never], str))
 ```
 
 Tuple expressions also preserve their element types when an element has type `Never`.
@@ -249,18 +267,35 @@ def tuple_from_never(value: Never) -> None:
     reveal_type((1, value))  # revealed: tuple[Literal[1], Never]
 ```
 
-If the variable-length portion of a tuple is `Never`, then that portion of the tuple must always be
-empty. This means that the tuple is not actually variable-length!
+A homogeneous `Never` tuple can only be empty at runtime, but its static type retains every possible
+tuple length. Fixed-length tuples containing `Never` remain subtypes, and the empty tuple remains a
+proper subtype rather than becoming equivalent to the homogeneous tuple.
 
 ```py
-from typing import Never
-from ty_extensions import static_assert
-from ty_extensions._internal import is_equivalent_to
+static_assert(not is_equivalent_to(tuple[Never, ...], tuple[()]))
+static_assert(not is_equivalent_to(tuple[Never, ...], Never))
 
-static_assert(is_equivalent_to(tuple[Never, ...], tuple[()]))
-static_assert(is_equivalent_to(tuple[int, *tuple[Never, ...]], tuple[int]))
-static_assert(is_equivalent_to(tuple[int, *tuple[Never, ...], int], tuple[int, int]))
-static_assert(is_equivalent_to(tuple[*tuple[Never, ...], int], tuple[int]))
+static_assert(is_subtype_of(tuple[()], tuple[Never, ...]))
+static_assert(is_subtype_of(tuple[Never], tuple[Never, ...]))
+static_assert(is_subtype_of(tuple[Never, Never], tuple[Never, ...]))
+static_assert(not is_subtype_of(tuple[Never, ...], tuple[()]))
+
+static_assert(not is_assignable_to(tuple[Never, ...], str))
+```
+
+A homogeneous `Never` segment in a mixed tuple also retains its variable-length shape. The required
+prefix and suffix remain present even though the segment can only be empty at runtime.
+
+```py
+static_assert(not is_equivalent_to(tuple[int, *tuple[Never, ...]], tuple[int]))
+static_assert(not is_equivalent_to(tuple[int, *tuple[Never, ...], str], tuple[int, str]))
+static_assert(not is_equivalent_to(tuple[*tuple[Never, ...], str], tuple[str]))
+
+static_assert(is_subtype_of(tuple[int], tuple[int, *tuple[Never, ...]]))
+static_assert(is_subtype_of(tuple[int, Never], tuple[int, *tuple[Never, ...]]))
+static_assert(is_subtype_of(tuple[int, str], tuple[int, *tuple[Never, ...], str]))
+static_assert(is_subtype_of(tuple[int, Never, str], tuple[int, *tuple[Never, ...], str]))
+static_assert(not is_subtype_of(tuple[int, *tuple[Never, ...]], tuple[int]))
 ```
 
 ## Homogeneous non-empty tuples
@@ -362,8 +397,9 @@ static_assert(not is_disjoint_from(tuple[int], tuple[int, ...]))
 static_assert(not is_disjoint_from(tuple[str, ...], tuple[int, ...]))
 ```
 
-Tuple elements are covariant, and a tuple type containing `Never` can be inhabited by a subclass.
-Consequently, even tuples with disjoint element types can overlap through a common tuple subtype.
+Tuple elements are covariant, and a tuple type containing `Never` retains its shape as a non-bottom
+static type. Consequently, even tuples with disjoint element types can have a common static subtype
+without sharing a runtime inhabitant.
 
 ```py
 from typing import Never, final
@@ -399,9 +435,8 @@ static_assert(not is_disjoint_from(tuple[N1, F1, *tuple[object, ...]], tuple[*tu
 static_assert(not is_disjoint_from(tuple[N1, N2, *tuple[object, ...]], tuple[*tuple[object, ...], N2, N1]))
 ```
 
-The variable-length portion of a tuple can never cause the tuples to be disjoint, since all
-variable-length tuple types contain the empty tuple. (Note that per above, the variable-length
-portion of a tuple cannot be `Never`; internally we simplify this to a fixed-length tuple.)
+Every homogeneous variable-length tuple admits the empty tuple, regardless of its element type.
+Thus, differing element types in the variable-length portion alone do not establish disjointness.
 
 ```py
 static_assert(not is_disjoint_from(tuple[F1, ...], tuple[F2, ...]))

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -354,7 +354,7 @@ of the other.)
 
 ```py
 from ty_extensions import static_assert
-from ty_extensions._internal import is_disjoint_from
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
 
 static_assert(is_disjoint_from(tuple[()], tuple[int]))
 static_assert(not is_disjoint_from(tuple[()], tuple[int, ...]))
@@ -362,11 +362,11 @@ static_assert(not is_disjoint_from(tuple[int], tuple[int, ...]))
 static_assert(not is_disjoint_from(tuple[str, ...], tuple[int, ...]))
 ```
 
-A tuple that is required to contain elements `P1, P2` is disjoint from a tuple that is required to
-contain elements `Q1, Q2` if either `P1` is disjoint from `Q1` or if `P2` is disjoint from `Q2`.
+Tuple elements are covariant, and a tuple type containing `Never` can be inhabited by a subclass.
+Consequently, even tuples with disjoint element types can overlap through a common tuple subtype.
 
 ```py
-from typing import final
+from typing import Never, final
 
 @final
 class F1: ...
@@ -380,14 +380,17 @@ class N2: ...
 static_assert(is_disjoint_from(F1, F2))
 static_assert(not is_disjoint_from(N1, N2))
 
-static_assert(is_disjoint_from(tuple[F1, F2], tuple[F2, F1]))
-static_assert(is_disjoint_from(tuple[F1, N1], tuple[F2, N2]))
-static_assert(is_disjoint_from(tuple[N1, F1], tuple[N2, F2]))
+static_assert(is_subtype_of(tuple[Never, Never], tuple[F1, F2]))
+static_assert(is_subtype_of(tuple[Never, Never], tuple[F2, F1]))
+
+static_assert(not is_disjoint_from(tuple[F1, F2], tuple[F2, F1]))
+static_assert(not is_disjoint_from(tuple[F1, N1], tuple[F2, N2]))
+static_assert(not is_disjoint_from(tuple[N1, F1], tuple[N2, F2]))
 static_assert(not is_disjoint_from(tuple[N1, N2], tuple[N2, N1]))
 
-static_assert(is_disjoint_from(tuple[F1, *tuple[int, ...], F2], tuple[F2, *tuple[int, ...], F1]))
-static_assert(is_disjoint_from(tuple[F1, *tuple[int, ...], N1], tuple[F2, *tuple[int, ...], N2]))
-static_assert(is_disjoint_from(tuple[N1, *tuple[int, ...], F1], tuple[N2, *tuple[int, ...], F2]))
+static_assert(not is_disjoint_from(tuple[F1, *tuple[int, ...], F2], tuple[F2, *tuple[int, ...], F1]))
+static_assert(not is_disjoint_from(tuple[F1, *tuple[int, ...], N1], tuple[F2, *tuple[int, ...], N2]))
+static_assert(not is_disjoint_from(tuple[N1, *tuple[int, ...], F1], tuple[N2, *tuple[int, ...], F2]))
 static_assert(not is_disjoint_from(tuple[N1, *tuple[int, ...], N2], tuple[N2, *tuple[int, ...], N1]))
 
 static_assert(not is_disjoint_from(tuple[F1, F2, *tuple[object, ...]], tuple[*tuple[object, ...], F2, F1]))
@@ -416,9 +419,8 @@ static_assert(not is_disjoint_from(tuple[int, str], C))
 class CommonSubtype(tuple[int, str], C): ...
 ```
 
-However, we model heterogeneous tuples to be disjoint from other heterogeneous tuples. To reconcile
-these two things, we explicitly ban two differently specialized heterogeneous tuples from coexisting
-in the same MRO:
+Although differently specialized tuple types can overlap through a common subtype, a class cannot
+directly inherit two incompatible tuple specializations through its MRO:
 
 ```py
 class I1(tuple[F1, F2]): ...

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -840,16 +840,17 @@ from ty_extensions import static_assert
 from ty_extensions._internal import is_assignable_to
 
 # The bottom materialization of `tuple[Any]` is `tuple[Never]`. Because
-# `tuple[Never]` can be inhabited by a tuple subclass and is a subtype of
-# `tuple[int]`, `tuple[int]` is not assignable to `~tuple[Any]`.
+# `tuple[Never]` is a non-bottom static subtype of `tuple[int]`, `tuple[int]`
+# is not assignable to `~tuple[Any]` under the current disjointness-based rule.
 # `tuple[()]` remains disjoint because it has an incompatible length.
 static_assert(not is_assignable_to(tuple[int], ~tuple[Any]))
 static_assert(is_assignable_to(tuple[()], ~tuple[Any]))
 
-# But the bottom materialization of `tuple[Any, ...]` is `tuple[Never, ...]`,
-# which simplifies to `tuple[()]`, so `tuple[int]` is still assignable to
-# `~tuple[Any, ...]`, but `tuple[()]` is not
-static_assert(is_assignable_to(tuple[int], ~tuple[Any, ...]))
+# Currently, the bottom materialization of `tuple[Any, ...]` is
+# `tuple[Never, ...]`. It retains every possible static tuple length, so
+# neither `tuple[int]` nor `tuple[()]` is disjoint from it.
+# TODO: Account for gradual tuple length when computing this lower bound.
+static_assert(not is_assignable_to(tuple[int], ~tuple[Any, ...]))
 static_assert(not is_assignable_to(tuple[()], ~tuple[Any, ...]))
 
 # Similarly, the bottom materialization of `Sequence[Any]` is `Sequence[Never]`,
@@ -861,14 +862,14 @@ static_assert(not is_assignable_to(tuple[()], ~tuple[Any, ...]))
 # `tuple[int, ...]` and `Sequence[Never]` cannot be considered disjoint.
 #
 # `tuple[int]` also overlaps `Sequence[Never]` because `tuple[Never]` is a
-# common subtype. `list[int]`, by contrast, should be assignable to
-# `~Sequence[Any]` because its invariant type argument prevents that overlap.
+# common subtype. Practical assignability may eventually permit additional
+# assignments to negated types whose static intersection is runtime-uninhabited.
 static_assert(not is_assignable_to(tuple[()], ~Sequence[Any]))
 static_assert(not is_assignable_to(list[Never], ~Sequence[Any]))
 static_assert(not is_assignable_to(tuple[int, ...], ~Sequence[Any]))
 static_assert(not is_assignable_to(tuple[int], ~Sequence[Any]))
 
-# TODO: should pass (`list[int]` should be considered disjoint from `Sequence[Never]`)
+# TODO: Revisit practical assignability here without requiring static disjointness.
 static_assert(is_assignable_to(list[int], ~Sequence[Any]))  # error: [static-assert-error]
 
 # If the left-hand side is also not fully static,
@@ -878,20 +879,22 @@ static_assert(is_assignable_to(list[int], ~Sequence[Any]))  # error: [static-ass
 
 # `tuple[Any, ...]` cannot be assignable to `~tuple[Any, ...]`,
 # because the bottom materialization of `tuple[Any, ...]` is
-# `tuple[()]`, and `tuple[()]` is not disjoint from itself
+# `tuple[Never, ...]`, which is not disjoint from itself.
 static_assert(not is_assignable_to(tuple[Any, ...], ~tuple[Any, ...]))
 
 # `tuple[Any]` also cannot be assigned to `~tuple[Any]`: its bottom
 # materialization is `tuple[Never]`, which is not disjoint from itself.
 static_assert(not is_assignable_to(tuple[Any], ~tuple[Any]))
 
-# The same principle applies for non-fully-static `list` specializations.
-# TODO: this should pass (`Bottom[list[Any]]` should simplify to `Never`)
+# The same question arises for non-fully-static `list` specializations.
+# TODO: Revisit practical assignability while preserving the non-bottom static
+# type `Bottom[list[Any]]`.
 static_assert(is_assignable_to(list[Any], ~list[Any]))  # error: [static-assert-error]
 
-# `Bottom[list[Any]]` is `Never`, which is disjoint from `Bottom[Sequence[Any]]`
-# (which is `Sequence[Never]`).
-# TODO: this should pass (`Bottom[list[Any]]` should simplify to `Never`)
+# `Bottom[list[Any]]` and `Bottom[Sequence[Any]]` (which is `Sequence[Never]`)
+# have no common runtime inhabitant, but that does not make their static
+# intersection `Never`.
+# TODO: Revisit this together with practical assignability to negated types.
 static_assert(is_assignable_to(list[Any], ~Sequence[Any]))  # error: [static-assert-error]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -839,10 +839,11 @@ from typing_extensions import Any, Never, Sequence
 from ty_extensions import static_assert
 from ty_extensions._internal import is_assignable_to
 
-# The bottom materialization of `tuple[Any]` is `tuple[Never]`. Both
-# `tuple[int]` and `tuple[()]` are disjoint from `tuple[Never]`, so they are
-# assignable to `~tuple[Any]`.
-static_assert(is_assignable_to(tuple[int], ~tuple[Any]))
+# The bottom materialization of `tuple[Any]` is `tuple[Never]`. Because
+# `tuple[Never]` can be inhabited by a tuple subclass and is a subtype of
+# `tuple[int]`, `tuple[int]` is not assignable to `~tuple[Any]`.
+# `tuple[()]` remains disjoint because it has an incompatible length.
+static_assert(not is_assignable_to(tuple[int], ~tuple[Any]))
 static_assert(is_assignable_to(tuple[()], ~tuple[Any]))
 
 # But the bottom materialization of `tuple[Any, ...]` is `tuple[Never, ...]`,
@@ -859,15 +860,13 @@ static_assert(not is_assignable_to(tuple[()], ~tuple[Any, ...]))
 # `tuple[()]` is a subtype of both `Sequence[Never]` and `tuple[int, ...]`, so
 # `tuple[int, ...]` and `Sequence[Never]` cannot be considered disjoint.
 #
-# Other `list` and `tuple` specializations *are* assignable to `~Sequence[Any]`,
-# however, since there are many fully static materializations of `Sequence[Any]`
-# that would be disjoint from a given `list` or `tuple` specialization.
+# `tuple[int]` also overlaps `Sequence[Never]` because `tuple[Never]` is a
+# common subtype. `list[int]`, by contrast, should be assignable to
+# `~Sequence[Any]` because its invariant type argument prevents that overlap.
 static_assert(not is_assignable_to(tuple[()], ~Sequence[Any]))
 static_assert(not is_assignable_to(list[Never], ~Sequence[Any]))
 static_assert(not is_assignable_to(tuple[int, ...], ~Sequence[Any]))
-
-# TODO: should pass (`tuple[int]` should be considered disjoint from `Sequence[Never]`)
-static_assert(is_assignable_to(tuple[int], ~Sequence[Any]))  # error: [static-assert-error]
+static_assert(not is_assignable_to(tuple[int], ~Sequence[Any]))
 
 # TODO: should pass (`list[int]` should be considered disjoint from `Sequence[Never]`)
 static_assert(is_assignable_to(list[int], ~Sequence[Any]))  # error: [static-assert-error]
@@ -882,10 +881,9 @@ static_assert(is_assignable_to(list[int], ~Sequence[Any]))  # error: [static-ass
 # `tuple[()]`, and `tuple[()]` is not disjoint from itself
 static_assert(not is_assignable_to(tuple[Any, ...], ~tuple[Any, ...]))
 
-# but `tuple[Any]` is assignable to `~tuple[Any]`,
-# as the bottom materialization of `tuple[Any]` is `Never`,
-# and `Never` *is* disjoint from itself
-static_assert(is_assignable_to(tuple[Any], ~tuple[Any]))
+# `tuple[Any]` also cannot be assigned to `~tuple[Any]`: its bottom
+# materialization is `tuple[Never]`, which is not disjoint from itself.
+static_assert(not is_assignable_to(tuple[Any], ~tuple[Any]))
 
 # The same principle applies for non-fully-static `list` specializations.
 # TODO: this should pass (`Bottom[list[Any]]` should simplify to `Never`)

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -252,8 +252,9 @@ static_assert(is_disjoint_from(tuple[Never], tuple[()]))
 static_assert(is_disjoint_from(tuple[Never, Never], tuple[int]))
 ```
 
-Tuple elements are covariant. Consequently, a potentially inhabited `tuple[Never]` is a common
-subtype of tuple types whose element types would otherwise be disjoint.
+`tuple[Never]` retains its shape as a non-bottom static type. Because tuple elements are covariant,
+it is a common subtype of tuple types with disjoint element types. This static overlap does not
+imply that their intersection has a runtime inhabitant.
 
 ```py
 static_assert(is_subtype_of(tuple[Never], tuple[int]))
@@ -296,12 +297,25 @@ static_assert(not is_disjoint_from(BottomTuple, tuple[str]))
 static_assert(is_disjoint_from(BottomTuple, tuple[()]))
 ```
 
-A homogeneous `tuple[Never, ...]` has no required elements and therefore simplifies to the empty
-tuple type rather than overlapping tuples with required elements.
+A homogeneous `tuple[Never, ...]` retains every possible static tuple length. It therefore overlaps
+both the empty tuple and fixed-length tuples through their corresponding `Never` element types, even
+when the fixed-length intersection has no runtime inhabitants.
 
 ```py
 static_assert(not is_disjoint_from(tuple[Never, ...], tuple[()]))
-static_assert(is_disjoint_from(tuple[Never, ...], tuple[int]))
+static_assert(not is_disjoint_from(tuple[Never, ...], tuple[int]))
+static_assert(not is_disjoint_from(tuple[Never, ...], tuple[int, str]))
+static_assert(not is_disjoint_from(tuple[Never, ...], tuple[Never]))
+static_assert(is_disjoint_from(tuple[Never, ...], str))
+```
+
+A mixed tuple with a homogeneous `Never` segment also retains all lengths compatible with its
+required prefix and suffix. Tuples shorter than that required portion remain disjoint.
+
+```py
+static_assert(not is_disjoint_from(tuple[int, Unpack[tuple[Never, ...]], str], tuple[int, str]))
+static_assert(not is_disjoint_from(tuple[int, Unpack[tuple[Never, ...]], str], tuple[int, int, str]))
+static_assert(is_disjoint_from(tuple[int, Unpack[tuple[Never, ...]], str], tuple[int]))
 ```
 
 ## Unions
@@ -1097,20 +1111,23 @@ tag identifies the `NewType` applied to a value. Neither kind of tag is visible 
 object itself, but both affect which types an inhabitant belongs to.
 
 Generic tags carry guarantees about how an object can be used. The invariant types `list[int]` and
-`list[str]` are disjoint because one reference could append a string that the other would then
-incorrectly read as an integer. These incompatible generic tags cannot describe the same object
-simultaneously in soundly typed code.
+`list[str]` cannot share a realizable typed inhabitant: one reference could append a string that the
+other would then incorrectly read as an integer. This does not by itself establish static
+disjointness. We retain `Bottom[list[Any]]` as a non-bottom common subtype, but the generic
+disjointness check does not yet account for this static overlap.
 
-Unlike incompatible invariant generic tags, distinct `NewType` tags can describe different typed
-inhabitants of the same runtime object. If `UserId` and `OrderId` are distinct integer `NewType`s,
-both `UserId(value)` and `OrderId(value)` return the same integer unchanged at runtime, but their
-tags are incompatible. The two `NewType`s are disjoint even though their values can identify the
-same runtime object. Both types still overlap `int`, which does not require either specific tag.
+Distinct `NewType` tags can describe different typed inhabitants of the same runtime object. If
+`UserId` and `OrderId` are distinct integer `NewType`s, both `UserId(value)` and `OrderId(value)`
+return the same integer unchanged at runtime, but their tags are incompatible. The two `NewType`s
+are disjoint even though their values can identify the same runtime object. Both types still overlap
+`int`, which does not require either specific tag.
 
 ### Invariant and covariant generic specializations
 
-Incompatible invariant arguments make generic specializations disjoint. Covariant specializations
-can still overlap when a common empty or bottom specialization satisfies both.
+The current implementation treats incompatible invariant arguments as proof of disjointness. The
+assertions below record this behavior, which still needs to account for non-bottom common subtypes.
+Covariant specializations already overlap when a common empty or bottom specialization satisfies
+both.
 
 ```pyi
 from collections.abc import Sequence
@@ -1118,6 +1135,8 @@ from typing import Any, Generic, TypeVar
 from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from
 
+# TODO: `Bottom[list[Any]]` is a non-bottom subtype of both specializations,
+# so their static intersection must not simplify to `Never`. This should return false.
 static_assert(is_disjoint_from(list[int], list[str]))
 
 T = TypeVar("T")
@@ -1144,16 +1163,19 @@ class InvSubA(Invariant[A]):
 class CoSubB(Covariant[B]):
     pass
 
+# TODO: Account for `Bottom[Invariant[Any]]` when checking these invariant specializations
+# and their subclasses for static overlap.
 static_assert(is_disjoint_from(Invariant[A], Invariant[B]))
 static_assert(is_disjoint_from(InvSubA, Invariant[B]))
 static_assert(not is_disjoint_from(Invariant[A], Invariant[A]))
 static_assert(not is_disjoint_from(Invariant[Any], Invariant[B]))
 static_assert(not is_disjoint_from(Invariant[B], Invariant[Any]))
-# `A | Any` cannot materialize to be equivalent to `B`.
+# The current invariant-tag check observes that `A | Any` cannot materialize to `B`.
 static_assert(is_disjoint_from(Invariant[A | Any], Invariant[B]))
 static_assert(is_disjoint_from(Invariant[B], Invariant[A | Any]))
 static_assert(is_disjoint_from(Invariant[A & Any], Invariant[B]))
 static_assert(is_disjoint_from(Invariant[B], Invariant[A & Any]))
+# TODO: These specializations share the non-bottom subtype `Bottom[InvariantPair[A, Any]]`.
 static_assert(is_disjoint_from(InvariantPair[A, A], InvariantPair[A, B]))
 static_assert(not is_disjoint_from(Covariant[A], Covariant[B]))
 static_assert(not is_disjoint_from(Covariant[A], CoSubB))
@@ -1218,6 +1240,7 @@ def _[U]():
     static_assert(not is_disjoint_from(Invariant[Id[U]], Invariant[int]))
 
 static_assert(not is_disjoint_from(Invariant[Id[int]], Invariant[int]))
+# TODO: Account for the non-bottom common subtype `Bottom[Invariant[Any]]` here as well.
 static_assert(is_disjoint_from(Invariant[Id[int]], Invariant[str]))
 
 class Mixed[T, U]:

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -230,12 +230,13 @@ static_assert(is_disjoint_from(I, J))
 
 ## Tuple types
 
-Tuple types are disjoint when their lengths or corresponding element types cannot overlap.
+Tuple types are disjoint from incompatible runtime types and from other tuples whose possible
+lengths do not overlap.
 
 ```py
-from typing_extensions import Literal, Never
+from typing_extensions import Literal, Never, NoReturn, Unpack
 from ty_extensions import static_assert
-from ty_extensions._internal import TypeOf, is_disjoint_from
+from ty_extensions._internal import TypeOf, is_disjoint_from, is_subtype_of
 
 static_assert(is_disjoint_from(tuple[()], TypeOf[object]))
 static_assert(is_disjoint_from(tuple[()], TypeOf[Literal]))
@@ -246,15 +247,61 @@ static_assert(is_disjoint_from(tuple[None], Literal["a"]))
 static_assert(is_disjoint_from(tuple[None], Literal[1]))
 static_assert(is_disjoint_from(tuple[None], Literal[True]))
 
-static_assert(is_disjoint_from(tuple[Literal[1]], tuple[Literal[2]]))
 static_assert(is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[Literal[1]]))
-static_assert(is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[Literal[1], Literal[3]]))
+static_assert(is_disjoint_from(tuple[Never], tuple[()]))
+static_assert(is_disjoint_from(tuple[Never, Never], tuple[int]))
+```
+
+Tuple elements are covariant. Consequently, a potentially inhabited `tuple[Never]` is a common
+subtype of tuple types whose element types would otherwise be disjoint.
+
+```py
+static_assert(is_subtype_of(tuple[Never], tuple[int]))
+static_assert(is_subtype_of(tuple[Never], tuple[str]))
+
+static_assert(not is_disjoint_from(tuple[Never], tuple[Never]))
+static_assert(not is_disjoint_from(tuple[Never], tuple[int]))
+static_assert(not is_disjoint_from(tuple[NoReturn], tuple[str]))
+static_assert(not is_disjoint_from(tuple[int], tuple[str]))
+static_assert(not is_disjoint_from(tuple[Literal[1]], tuple[Literal[2]]))
+static_assert(not is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[Literal[1], Literal[3]]))
 
 static_assert(not is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[Literal[1], int]))
 static_assert(not is_disjoint_from(tuple[Literal[1], Literal[2]], tuple[int, ...]))
+static_assert(not is_disjoint_from(tuple[int, int], tuple[None, ...]))
+```
 
-# TODO: should pass
-static_assert(is_disjoint_from(tuple[int, int], tuple[None, ...]))  # error: [static-assert-error]
+The same overlap exists for nested tuples and for required prefixes or suffixes of variable-length
+tuples.
+
+```py
+static_assert(not is_disjoint_from(tuple[tuple[Never]], tuple[tuple[int]]))
+static_assert(not is_disjoint_from(tuple[tuple[int]], tuple[tuple[str]]))
+
+static_assert(not is_disjoint_from(tuple[Never, Unpack[tuple[int, ...]]], tuple[str, Unpack[tuple[str, ...]]]))
+static_assert(not is_disjoint_from(tuple[Unpack[tuple[int, ...]], Never], tuple[Unpack[tuple[str, ...]], bytes]))
+static_assert(not is_disjoint_from(tuple[int, Never, Unpack[tuple[str, ...]]], tuple[str, bytes, Unpack[tuple[int, ...]]]))
+```
+
+A tuple subclass with a `Never` element must overlap itself and every compatible tuple supertype. It
+remains disjoint from tuples whose lengths cannot match.
+
+```py
+class BottomTuple(tuple[Never]): ...
+
+static_assert(not is_disjoint_from(BottomTuple, BottomTuple))
+static_assert(not is_disjoint_from(BottomTuple, tuple[Never]))
+static_assert(not is_disjoint_from(BottomTuple, tuple[int]))
+static_assert(not is_disjoint_from(BottomTuple, tuple[str]))
+static_assert(is_disjoint_from(BottomTuple, tuple[()]))
+```
+
+A homogeneous `tuple[Never, ...]` has no required elements and therefore simplifies to the empty
+tuple type rather than overlapping tuples with required elements.
+
+```py
+static_assert(not is_disjoint_from(tuple[Never, ...], tuple[()]))
+static_assert(is_disjoint_from(tuple[Never, ...], tuple[int]))
 ```
 
 ## Unions

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -353,6 +353,22 @@ static_assert(
 )
 ```
 
+## Subtyping across mixed tuple boundaries
+
+A required element at one end can satisfy a requirement at the other end when the intervening
+elements are all `Never`.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+# TODO: Align required prefixes and suffixes across the variable-length segment.
+# Both assertions should pass.
+static_assert(is_subtype_of(tuple[int, *tuple[Never, ...]], tuple[*tuple[object, ...], int]))  # error: [static-assert-error]
+static_assert(is_subtype_of(tuple[*tuple[Never, ...], int], tuple[int, *tuple[object, ...]]))  # error: [static-assert-error]
+```
+
 ## Subtyping of the gradual tuple
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -74,11 +74,11 @@ def _(bottom_callable: Bottom[Callable[[Any, Unknown], None]]):
 
 The invariant position is represented with the `Bottom` special form.
 
-There is an argument that `Bottom[list[Any]]` should simplify to `Never`, since it is the infinite
-intersection of all possible materializations of `list[Any]`, and (due to invariance) these
-materializations are disjoint types. But currently we do not make this simplification: there doesn't
-seem to be any compelling need for it, and allowing more gradual types to materialize to `Never` has
-undesirable implications for mutual assignability of seemingly-unrelated gradual types.
+`Bottom[list[Any]]` has no runtime inhabitants, but we retain it as a non-bottom static type. Its
+list shape prevents unrelated gradual types from becoming mutually assignable. As a lower bound, it
+is a subtype of every materialization of `list[Any]`, including `list[int]` and `list[str]`. The
+generic disjointness check does not yet consistently preserve that common subtype; see the
+[invariant-generic disjointness TODOs](is_disjoint_from.md#invariant-and-covariant-generic-specializations).
 
 ```py
 def _(bottom_list: Bottom[list[Any]]):
@@ -302,6 +302,20 @@ static_assert(is_equivalent_to(Bottom[tuple[Unknown, int]], tuple[Never, int]))
 static_assert(is_equivalent_to(Top[tuple[Any, int, Unknown]], tuple[object, int, object]))
 static_assert(is_equivalent_to(Bottom[tuple[Any, int, Unknown]], tuple[Never, int, Never]))
 ```
+
+Materializing tuple elements also preserves variable-length segments, even when their element type
+becomes `Never`.
+
+```py
+static_assert(is_equivalent_to(Top[tuple[Any, ...]], tuple[object, ...]))
+static_assert(is_equivalent_to(Bottom[tuple[Any, ...]], tuple[Never, ...]))
+static_assert(not is_equivalent_to(Bottom[tuple[Any, ...]], tuple[()]))
+static_assert(is_equivalent_to(Bottom[tuple[int, *tuple[Any, ...], str]], tuple[int, *tuple[Never, ...], str]))
+```
+
+TODO: Account for gradual tuple length when computing the lower bound. `tuple[Any, ...]` can
+materialize to distinct fixed lengths, so the current element-wise result is not a subtype of every
+materialization.
 
 Except for when the tuple itself is in a contravariant position, then all positions in the tuple
 inherit the contravariant position.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -356,6 +356,120 @@ def _(
     reveal_type(bottom_aiu)  # revealed: Bottom[list[tuple[Any, int, Unknown]]]
 ```
 
+## Gradual tuple length in invariant positions
+
+An unrestricted variable-length tuple with dynamic elements can materialize to an empty tuple. The
+top materialization of an enclosing invariant generic includes that specialization, and its bottom
+materialization is a subtype of it.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Any, Generic, TypeVar, TypeVarTuple
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+
+class Box(Generic[T]): ...
+
+static_assert(is_subtype_of(Box[tuple[()]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Box[tuple[()]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[()]]))
+static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[()]]))
+static_assert(not is_subtype_of(Box[tuple[()]], Bottom[Box[tuple[Any, ...]]]))
+```
+
+The same gradual-length choice also includes nonempty, fixed-length tuple specializations.
+
+```py
+static_assert(is_subtype_of(Box[tuple[int]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Box[tuple[int]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[int]]))
+static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[int]]))
+static_assert(not is_subtype_of(Box[tuple[int]], Bottom[Box[tuple[Any, ...]]]))
+```
+
+An exact tuple remains a valid materialization when its element is spelled through a type alias.
+
+```py
+from typing_extensions import TypeAliasType
+
+ItemAlias = TypeAliasType("ItemAlias", int)
+
+static_assert(is_subtype_of(Box[tuple[ItemAlias]], Top[Box[tuple[Any, ...]]]))
+```
+
+Aliases around the entire tuple still need to be resolved before comparing the materialization
+families.
+
+```py
+FixedTupleAlias = TypeAliasType("FixedTupleAlias", tuple[int])
+
+# TODO: Resolve aliases around the entire tuple in invariant subtyping.
+static_assert(is_subtype_of(Box[FixedTupleAlias], Top[Box[tuple[Any, ...]]]))  # error: [static-assert-error]
+```
+
+A gradual fixed-length tuple has a narrower materialization range than an unrestricted gradual
+tuple. Their top bounds preserve that containment, while their bottom bounds reverse it.
+
+```py
+static_assert(is_subtype_of(Top[Box[tuple[Any]]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_subtype_of(Top[Box[tuple[Any, ...]]], Top[Box[tuple[Any]]]))
+static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Bottom[Box[tuple[Any]]]))
+static_assert(not is_subtype_of(Bottom[Box[tuple[Any]]], Bottom[Box[tuple[Any, ...]]]))
+static_assert(not is_subtype_of(Top[Box[tuple[Any, ...]]], Bottom[Box[tuple[Any, ...]]]))
+```
+
+An unpacked type variable tuple is another valid exact-tuple specialization, even though its length
+is not known.
+
+```py
+def symbolic(value: Box[tuple[*Ts]]) -> None:
+    static_assert(is_subtype_of(Box[tuple[*Ts]], Top[Box[tuple[Any, ...]]]))
+    static_assert(not is_disjoint_from(Box[tuple[*Ts]], Top[Box[tuple[Any, ...]]]))
+    static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[*Ts]]))
+    static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[*Ts]]))
+    static_assert(not is_subtype_of(Box[tuple[*Ts]], Bottom[Box[tuple[Any, ...]]]))
+```
+
+A tuple subclass is not itself a materialization of the exact built-in `tuple[Any, ...]` type. The
+surrounding invariant generic must therefore keep the subclass distinct.
+
+```py
+class IntTuple(tuple[int]): ...
+
+static_assert(is_subtype_of(IntTuple, tuple[object, ...]))
+static_assert(not is_subtype_of(Box[IntTuple], Top[Box[tuple[Any, ...]]]))
+static_assert(is_disjoint_from(Box[IntTuple], Top[Box[tuple[Any, ...]]]))
+static_assert(is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[IntTuple]))
+static_assert(not is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[IntTuple]))
+```
+
+A static homogeneous tuple does not make a gradual choice of length, even though every `int` is an
+`object`.
+
+```py
+static_assert(not is_subtype_of(Box[tuple[int]], Top[Box[tuple[object, ...]]]))
+static_assert(is_disjoint_from(Box[tuple[int]], Top[Box[tuple[object, ...]]]))
+```
+
+Fixed elements in a mixed tuple must also retain their invariant identity. In particular, a `bool`
+prefix cannot replace the required `int` prefix simply because `bool` is a subtype of `int`.
+
+```py
+static_assert(not is_subtype_of(Box[tuple[bool, str]], Top[Box[tuple[int, *tuple[Any, ...]]]]))
+static_assert(is_disjoint_from(Box[tuple[bool, str]], Top[Box[tuple[int, *tuple[Any, ...]]]]))
+```
+
+TODO: Handle valid mixed gradual-length tuples without losing their required prefix and suffix
+elements. For example, `Box[tuple[int, str]]` should be a subtype of
+`Top[Box[tuple[int, *tuple[Any, ...]]]]`.
+
 ## Union
 
 All positions in a union are covariant.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/tuples_containing_never.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/tuples_containing_never.md
@@ -1,8 +1,8 @@
 # Tuples containing `Never`
 
-A heterogeneous `tuple[…]` type that contains `Never` remains distinct from `Never`. Tuple types
-include user-defined subclasses, so their element types must not be discarded solely because an
-ordinary tuple with those elements cannot be constructed.
+A heterogeneous `tuple[…]` type that contains `Never` remains distinct from `Never`. Although it has
+no runtime inhabitants, it retains its tuple length and element types. This prevents it from
+becoming assignable to unrelated types such as `str`.
 
 ```py
 from ty_extensions import static_assert

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3173,16 +3173,31 @@ impl<'db> Bindings<'db> {
                                 // iterable (it could be a Liskov-uncompliant subtype of the `Iterable` class that sets
                                 // `__iter__ = None`, for example). That would be badly written Python code, but we still
                                 // need to be able to handle it without crashing.
-                                let return_type = if let Type::Union(union) = argument {
-                                    union.map(db, env, |element| {
-                                        Type::tuple(TupleType::new(
+                                let tuple_from_iterable = |iterable: &Type<'db>| {
+                                    let spec = iterable.iterate(db, env);
+                                    if let TupleSpec::Variable(tuple) = spec.as_ref()
+                                        && matches!(
+                                            tuple.variable(),
+                                            VariableSegment::Homogeneous(Type::Never)
+                                        )
+                                    {
+                                        // A runtime tuple construction cannot consume any elements
+                                        // from a `Never` segment. Keep this result precise without
+                                        // erasing the segment from the iterable's static type.
+                                        return Type::heterogeneous_tuple(
                                             db,
                                             env,
-                                            &element.iterate(db, env),
-                                        ))
-                                    })
+                                            tuple
+                                                .iter_prefix_elements()
+                                                .chain(tuple.iter_suffix_elements()),
+                                        );
+                                    }
+                                    Type::tuple(TupleType::new(db, env, &spec))
+                                };
+                                let return_type = if let Type::Union(union) = argument {
+                                    union.map(db, env, tuple_from_iterable)
                                 } else {
-                                    Type::tuple(TupleType::new(db, env, &argument.iterate(db, env)))
+                                    tuple_from_iterable(argument)
                                 };
                                 overload.set_return_type(return_type);
                             }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2014,7 +2014,11 @@ impl<'db> ClassType<'db> {
                                 env,
                                 &[slice_bound, slice_bound, slice_bound],
                             ),
-                            Type::homogeneous_tuple(db, env, all_elements_unioned),
+                            if tuple.len().into_fixed_length() == Some(0) {
+                                Type::empty_tuple(db, env)
+                            } else {
+                                Type::homogeneous_tuple(db, env, all_elements_unioned)
+                            },
                         ));
 
                         let getitem_signature =

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2099,6 +2099,35 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_type: Type<'db>,
         target_materialization: MaterializationKind,
     ) -> ConstraintSet<'db, 'c> {
+        // `tuple[Any, ...]` can materialize to a builtin tuple type of any length. Its current
+        // element-wise bottom, `tuple[Never, ...]`, is not a subtype of every fixed-length
+        // tuple, so the endpoint comparisons below cannot establish that, for example,
+        // `Box[tuple[int]] <: Top[Box[tuple[Any, ...]]]` for an invariant `Box`.
+        // Handle this unrestricted materialization family directly. Tuple subclasses do not
+        // qualify: `Box[MyTuple]` is not a materialization of `Box[tuple[Any, ...]]`.
+        // TODO: Compare gradual tuple-length materialization families generally, including
+        // required prefixes and suffixes, without changing the static shape of `tuple[Never, ...]`.
+        if let (Some(source_tuple), Some(target_tuple)) = (
+            source_type.exact_tuple_instance_spec(db),
+            target_type.exact_tuple_instance_spec(db),
+        ) {
+            let is_unrestricted = |tuple: &TupleSpec<'db>| {
+                matches!(tuple, TupleSpec::Variable(tuple)
+                    if tuple.prefix_elements().is_empty()
+                        && tuple.suffix_elements().is_empty()
+                        && matches!(tuple.variable(), VariableSegment::Homogeneous(Type::Dynamic(_))))
+            };
+            // Top preserves family inclusion, Bottom reverses it, and Bottom-to-Top needs
+            // only an overlap, so either unrestricted family is enough in that case.
+            if (target_materialization == MaterializationKind::Top
+                && is_unrestricted(&target_tuple))
+                || (source_materialization == MaterializationKind::Bottom
+                    && is_unrestricted(&source_tuple))
+            {
+                return self.always();
+            }
+        }
+
         let source_top =
             source_type.materialize(db, MaterializationKind::Top, self.materialization_visitor);
         let source_bottom = source_type.materialize(

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -372,6 +372,32 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 )
             }),
 
+            // Preserve known empty results without collapsing the static `tuple[Never, ...]`
+            // type. Restrict this to built-in tuple specializations so operands whose static types
+            // name a tuple subclass still use normal operator dispatch.
+            (Type::NominalInstance(left), Type::NominalInstance(right), ast::Operator::Add)
+                if left
+                    .own_tuple_spec(db)
+                    .is_some_and(|tuple| tuple.len().into_fixed_length() == Some(0))
+                    && right
+                        .own_tuple_spec(db)
+                        .is_some_and(|tuple| tuple.len().into_fixed_length() == Some(0)) =>
+            {
+                Some(Type::empty_tuple(db, env))
+            }
+
+            (Type::NominalInstance(tuple), Type::LiteralValue(multiplier), ast::Operator::Mult)
+            | (Type::LiteralValue(multiplier), Type::NominalInstance(tuple), ast::Operator::Mult)
+                if matches!(
+                    multiplier.kind(),
+                    LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_)
+                ) && tuple
+                    .own_tuple_spec(db)
+                    .is_some_and(|tuple| tuple.len().into_fixed_length() == Some(0)) =>
+            {
+                Some(Type::empty_tuple(db, env))
+            }
+
             (Type::TypedDict(left_typed_dict), rhs, ast::Operator::BitOr)
                 if rhs.is_assignable_to(db, env, Type::TypedDict(left_typed_dict)) =>
             {

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -157,11 +157,11 @@ impl<'db> Type<'db> {
                     _ => None,
                 },
                 Type::Never => {
-                    // The dunder logic below would have us return `tuple[Never, ...]`, which eagerly
-                    // simplifies to `tuple[()]`. That will will cause us to emit false positives if we
-                    // index into the tuple. Using `tuple[Unknown, ...]` avoids these false positives.
-                    // TODO: Consider removing this special case, and instead hide the indexing
-                    // diagnostic in unreachable code.
+                    // Preserve a permissive iteration fallback for an expression that cannot
+                    // produce a value.
+                    // TODO: Revisit this workaround now that `tuple[Never, ...]` retains its
+                    // variable-length shape. Unreachable-code handling should suppress diagnostics
+                    // caused by impossible iteration.
                     Some(Cow::Owned(TupleSpec::homogeneous(Type::unknown())))
                 }
                 Type::TypeAlias(alias) => non_async_special_case(db, env, alias.value_type(db)),

--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -209,6 +209,16 @@ mod stable {
         forall fully_static_types t. t.is_subtype_of(db, env, t)
     );
 
+    // `tuple[T]` is a subtype of `tuple[T, ...]` for every fully static `T`, including `Never`.
+    type_property_test!(
+        fixed_length_tuple_is_subtype_of_homogeneous_tuple, db, env,
+        forall fully_static_types t. {
+            let fixed = Type::heterogeneous_tuple(db, env, [t]);
+            let homogeneous = Type::homogeneous_tuple(db, env, t);
+            fixed.is_subtype_of(db, env, homogeneous)
+        }
+    );
+
     // For any two fully static types, each type in the pair must be a subtype of their union.
     // (This is clearly not true for non-fully-static types, since their subtyping is not
     // reflexive.)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -850,18 +850,21 @@ impl<'db> Type<'db> {
         checker.check_type_pair(db, self, other)
     }
 
-    /// Return true if `self & other` should simplify to `Never`:
-    /// if the intersection of the two types could never be inhabited by any
-    /// possible runtime value.
+    /// Return true if the static intersection `self & other` should simplify to `Never`.
+    ///
+    /// Having no runtime inhabitants is not sufficient. For example, `tuple[int] & tuple[str]`
+    /// is runtime-uninhabited, but `tuple[Never]` is a common subtype of both operands. We preserve
+    /// `tuple[Never]` as a non-bottom static type to retain its tuple shape, so their intersection
+    /// must not simplify to `Never`.
     ///
     /// Our implementation of disjointness for non-fully-static types only
     /// returns true if the *top materialization* of `self` has no overlap with
     /// the *top materialization* of `other`.
     ///
-    /// For example, `list[int]` is disjoint from `list[str]`: the two types have
-    /// no overlap. But `list[Any]` is not disjoint from `list[str]`: there exists
+    /// For example, `list[int]` is disjoint from `str`: the two types have
+    /// no static overlap. But `list[Any]` is not disjoint from `list[str]`: there exists
     /// a fully static materialization of `list[Any]` (`list[str]`) that is a
-    /// subtype of `list[str]`
+    /// subtype of `list[str]`.
     ///
     /// This function aims to have no false positives, but might return wrong
     /// `false` answers in some cases.

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -445,6 +445,34 @@ fn divergent_type() {
 }
 
 #[test]
+fn unrestricted_tuple_materialization_absorbs_divergent_approximations() {
+    let db = setup_db();
+    let db = &db;
+    let env = db.program_environment();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_of = |tuple| KnownClass::List.to_specialized_instance(db, &env, &[tuple]);
+    let approximation = |element| list_of(Type::heterogeneous_tuple(db, &env, [element]));
+    let top = list_of(Type::homogeneous_tuple(db, &env, Type::any())).top_materialization(db, &env);
+
+    // This fixed top absorbs every exact-tuple approximation, including a marker nested
+    // more deeply in a later iteration. Removing the marker here therefore converges.
+    let first = approximation(div);
+    for candidate in [first, approximation(first)] {
+        assert!(candidate.is_redundant_with(db, &env, top));
+        assert_eq!(UnionType::from_elements(db, &env, [candidate, top]), top);
+        assert_eq!(UnionType::from_elements(db, &env, [top, candidate]), top);
+    }
+
+    // An unresolved marker is not itself an unrestricted gradual element type. Its
+    // homogeneous tuple must not acquire the same family as `tuple[Any, ...]`.
+    let divergent_top =
+        list_of(Type::homogeneous_tuple(db, &env, div)).top_materialization(db, &env);
+    let empty = list_of(Type::empty_tuple(db, &env));
+    assert!(!empty.is_subtype_of(db, &env, divergent_top));
+    assert!(!empty.is_redundant_with(db, &env, divergent_top));
+}
+
+#[test]
 fn type_alias_variance() {
     use crate::db::tests::TestDb;
     use crate::place::global_symbol;

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -10,8 +10,10 @@
 //!
 //! The description of which elements can appear in a `tuple` is called a [`TupleSpec`]. Other
 //! things besides `tuple` instances can be described by a tuple spec — for instance, the targets
-//! of an unpacking assignment. A `tuple` specialization can include `Never` as a fixed-length
-//! element because a user-defined tuple subclass can inhabit that type.
+//! of an unpacking assignment. `Never` elements remain part of a tuple's static shape. A required
+//! `Never` element makes the tuple runtime-uninhabited, but does not turn it into the universal
+//! bottom type. A variable-length `Never` segment also retains its possible static lengths, so
+//! `tuple[Never]` remains a subtype of `tuple[Never, ...]`.
 
 use crate::{Program, ProgramEnvironment};
 use std::cmp::Ordering;
@@ -174,19 +176,6 @@ impl<'db> TupleType<'db> {
         env: &ProgramEnvironment<'db>,
         spec: &TupleSpec<'db>,
     ) -> Self {
-        // If the variable-length portion is Never, it can only be instantiated with zero elements.
-        // That means this isn't a variable-length tuple after all!
-        if let TupleSpec::Variable(tuple) = spec
-            && matches!(tuple.variable(), VariableSegment::Homogeneous(Type::Never))
-        {
-            let tuple = TupleSpec::Fixed(FixedLengthTuple::from_elements(
-                tuple
-                    .iter_prefix_elements()
-                    .chain(tuple.iter_suffix_elements()),
-            ));
-            return TupleType::new_internal(db, env.program(db), tuple);
-        }
-
         TupleType::new_internal(db, env.program(db), spec)
     }
 
@@ -241,10 +230,7 @@ impl<'db> TupleType<'db> {
         env: &ProgramEnvironment<'db>,
         element: Type<'db>,
     ) -> Self {
-        match element {
-            Type::Never => TupleType::empty(db, env),
-            _ => TupleType::new_internal(db, env.program(db), TupleSpec::homogeneous(element)),
-        }
+        TupleType::new_internal(db, env.program(db), TupleSpec::homogeneous(element))
     }
 
     /// Packs a `TypeVarTuple` into the tuple value used for generic specialization relations.
@@ -603,6 +589,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // The overlapping parts of the prefixes and suffixes must satisfy the relation.
                 // Any remaining parts must satisfy the relation with the other tuple's
                 // variable-length part.
+                // TODO: Also align required elements across the variable-length part, as in
+                // `tuple[int, *tuple[Never, ...]] <: tuple[*tuple[object, ...], int]`.
                 let mut result = self.always();
                 let pairwise = source
                     .prenormalized_prefix_elements(db, env, source_prenormalize_variable)
@@ -711,9 +699,11 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         }
 
         // Tuple elements are covariant, so `tuple[Never]` is a common subtype of `tuple[int]` and
-        // `tuple[str]`. Unlike `Never` itself, `tuple[Never]` can be inhabited by a user-defined
-        // tuple subclass. Therefore, incompatible element types do not make tuple specializations
-        // with compatible lengths disjoint.
+        // `tuple[str]`. We preserve `tuple[Never]` as a non-bottom static type to retain its tuple
+        // shape, even though it has no runtime inhabitants. Therefore, incompatible element types
+        // do not make tuple specializations with compatible lengths statically disjoint.
+        // TODO: Use a separate runtime-disjointness check for identity comparisons and reachability
+        // after narrowing, without changing this static relation or intersection simplification.
         self.never()
     }
 }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -696,7 +696,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 
     pub(super) fn check_tuple_spec_pair(
         &self,
-        db: &'db dyn Db,
+        _db: &'db dyn Db,
         left: &TupleSpec<'db>,
         right: &TupleSpec<'db>,
     ) -> ConstraintSet<'db, 'c> {
@@ -710,46 +710,11 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             return self.always();
         }
 
-        // If any of the required elements are pairwise disjoint, the tuples are disjoint as well.
-        let any_disjoint = |a: &[Type<'db>], b: &[Type<'db>], rev: bool| {
-            if rev {
-                std::iter::zip(a.iter().rev(), b.iter().rev()).when_any(
-                    db,
-                    self.constraints,
-                    |(&left_elem, &right_elem)| self.check_type_pair(db, left_elem, right_elem),
-                )
-            } else {
-                std::iter::zip(a, b).when_any(db, self.constraints, |(&left_elem, &right_elem)| {
-                    self.check_type_pair(db, left_elem, right_elem)
-                })
-            }
-        };
-
-        match (left, right) {
-            (Tuple::Fixed(left), Tuple::Fixed(right)) => {
-                any_disjoint(left.all_elements(), right.all_elements(), false)
-            }
-
-            // Note that we don't compare the variable-length portions; two pure homogeneous tuples
-            // `tuple[A, ...]` and `tuple[B, ...]` can never be disjoint even if A and B are
-            // disjoint, because `tuple[()]` would be assignable to both.
-            (Tuple::Variable(left), Tuple::Variable(right)) => {
-                any_disjoint(left.prefix_elements(), right.prefix_elements(), false).or(
-                    db,
-                    self.constraints,
-                    || any_disjoint(left.suffix_elements(), right.suffix_elements(), true),
-                )
-            }
-
-            (Tuple::Fixed(fixed), Tuple::Variable(variable))
-            | (Tuple::Variable(variable), Tuple::Fixed(fixed)) => {
-                any_disjoint(fixed.all_elements(), variable.prefix_elements(), false).or(
-                    db,
-                    self.constraints,
-                    || any_disjoint(fixed.all_elements(), variable.suffix_elements(), true),
-                )
-            }
-        }
+        // Tuple elements are covariant, so `tuple[Never]` is a common subtype of `tuple[int]` and
+        // `tuple[str]`. Unlike `Never` itself, `tuple[Never]` can be inhabited by a user-defined
+        // tuple subclass. Therefore, incompatible element types do not make tuple specializations
+        // with compatible lengths disjoint.
+        self.never()
     }
 }
 


### PR DESCRIPTION
Preserving `tuple[Never]` in #27580 exposed an inconsistent disjointness rule: tuple specializations with compatible lengths could be considered disjoint despite having a shared non-bottom subtype. This broke the stable type-property tests.

Check static tuple disjointness by their possible lengths, and retain homogeneous and mixed `Never` segments so `tuple[Never]` remains a subtype of `tuple[Never, ...]`. Keep known-empty tuple construction, slicing, concatenation, and literal repetition precise at their operation sites.

Preserving variable-length tuple shapes also exposed an existing error in invariant-generic materialization comparisons: an exhaustive class pattern could be marked unreachable. Recognize the unrestricted gradual tuple family directly in those comparisons, including both top and bottom bounds. Leave more general gradual-length families, such as mixed tuples with required prefixes or suffixes, as a TODO.

The updated rationale distinguishes static overlap from runtime inhabitability. Broader runtime narrowing, practical assignability, invariant-generic overlap, and remaining tuple precision limitations are recorded as follow-ups rather than changed here.

Fixes astral-sh/ty#4263.

## Test plan

- Cover fixed, nested, homogeneous, and mixed tuple overlap; incompatible lengths; `Never` subtyping and materialization; and the resulting narrowing and assignability behavior.
- Cover known-empty tuple operations and ordinary/reflected tuple-subclass overrides.
- Cover invariant tuple-family bounds in both directions, symmetric overlap, aliases, tuple-subclass exclusions, and cycle-recovery approximations. Verify exhaustive class patterns for empty, nonempty, and symbolic variadic specializations.
- Add a stable property that `tuple[T]` is a subtype of `tuple[T, ...]` for every fully static `T`, including `Never`. Verify the full stable property suite at the CI sample count.
