### PR TITLE
[ty] Handle assignment expressions in string annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal.md
@@ -362,18 +362,32 @@ def _(x: Literal):
 
 ## Invalid expressions in string annotations
 
-Invalid `Literal` arguments in string annotations are rejected without evaluating their children.
-This includes invalid nested subscripts and attribute expressions whose operands contain
-assignments.
+Invalid `Literal` arguments in string annotations are checked without looking up assignment
+expressions that are absent from the semantic index. Missing names retain their diagnostics.
 
 `runtime.py`:
 
 ```py
 from typing import Literal
 
-a: "Literal[int[(name := missing)]]"  # error: [invalid-type-form]
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing` used when not defined"
+a: "Literal[int[(name := missing)]]"
 b: "Literal[(name := int)[0]]"  # error: [invalid-type-form]
 c: "Literal[(name := 0).real]"  # error: [invalid-type-form]
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_nested` used when not defined"
+value: "Literal[int[missing_nested]]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_call` used when not defined"
+call: "Literal[int[missing_call()]]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_left` used when not defined"
+# error: [unresolved-reference] "Name `missing_right` used when not defined"
+arguments: "Literal[int[(missing_left, missing_right)]]"
 
 def valid(value: "Literal[Literal[1], None]"):
     reveal_type(value)  # revealed: Literal[1] | None
@@ -386,7 +400,13 @@ The same error recovery applies in stub files.
 ```pyi
 from typing import Literal
 
-a: "Literal[int[(name := missing)]]"  # error: [invalid-type-form]
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing` used when not defined"
+a: "Literal[int[(name := missing)]]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_nested` used when not defined"
+b: "Literal[int[missing_nested]]"
 ```
 
 ## Invalid expressions in evaluated annotations

--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal.md
@@ -359,3 +359,49 @@ from typing import Literal
 def _(x: Literal):
     reveal_type(x)  # revealed: Unknown
 ```
+
+## Invalid expressions in string annotations
+
+Invalid `Literal` arguments in string annotations are rejected without evaluating their children.
+This includes invalid nested subscripts and attribute expressions whose operands contain
+assignments.
+
+`runtime.py`:
+
+```py
+from typing import Literal
+
+a: "Literal[int[(name := missing)]]"  # error: [invalid-type-form]
+b: "Literal[(name := int)[0]]"  # error: [invalid-type-form]
+c: "Literal[(name := 0).real]"  # error: [invalid-type-form]
+
+def valid(value: "Literal[Literal[1], None]"):
+    reveal_type(value)  # revealed: Literal[1] | None
+```
+
+The same error recovery applies in stub files.
+
+`stub.pyi`:
+
+```pyi
+from typing import Literal
+
+a: "Literal[int[(name := missing)]]"  # error: [invalid-type-form]
+```
+
+## Invalid expressions in evaluated annotations
+
+When an annotation is evaluated, errors in its invalid arguments are still reported.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Literal
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing` used when not defined"
+value: Literal[int[(name := missing)]]
+```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -65,18 +65,50 @@ error[invalid-type-form]: `LiteralString` expects no type parameter
 
 ### Parameterized string annotations
 
-Since `LiteralString` cannot be parameterized, invalid arguments in string annotations are not
-evaluated. They should neither panic nor produce distracting errors about their contents.
+Since `LiteralString` cannot be parameterized, its arguments are checked without looking up
+assignment expressions that are absent from the semantic index. Missing names retain their
+diagnostics.
 
 `runtime.py`:
 
 ```py
 from typing_extensions import LiteralString
 
-a: "LiteralString[(name := missing)]"  # error: [invalid-type-form]
-b: "LiteralString[int[(name := missing)]]"  # error: [invalid-type-form]
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing` used when not defined"
+a: "LiteralString[(name := missing)]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing` used when not defined"
+# error: [not-subscriptable]
+b: "LiteralString[int[(name := missing)]]"
 c: "LiteralString[(name := 0).real]"  # error: [invalid-type-form]
-d: "LiteralString[lambda default=missing: None]"  # error: [invalid-type-form]
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing` used when not defined"
+d: "LiteralString[lambda default=missing: None]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_direct` used when not defined"
+direct: "LiteralString[missing_direct]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_nested` used when not defined"
+# error: [not-subscriptable]
+nested: "LiteralString[int[missing_nested]]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_call` used when not defined"
+# error: [unresolved-reference] "Name `missing_argument` used when not defined"
+call: "LiteralString[missing_call(missing_argument)]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_binary` used when not defined"
+binary: "LiteralString[missing_binary + 1]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_list` used when not defined"
+collection: "LiteralString[[missing_list]]"
 ```
 
 The same error recovery applies in stub files.
@@ -86,7 +118,13 @@ The same error recovery applies in stub files.
 ```pyi
 from typing_extensions import LiteralString
 
-value: "LiteralString[(name := missing)]"  # error: [invalid-type-form]
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing` used when not defined"
+value: "LiteralString[(name := missing)]"
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing_direct` used when not defined"
+direct: "LiteralString[missing_direct]"
 ```
 
 ### Literal suggestion in string annotations

--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -127,28 +127,6 @@ value: "LiteralString[(name := missing)]"
 direct: "LiteralString[missing_direct]"
 ```
 
-### Literal suggestion in string annotations
-
-For valid literal arguments, we still suggest `Literal` in a string annotation. Each argument is
-checked separately, so the combination of `True` and `False` does not lose the suggestion.
-
-```py
-from typing_extensions import LiteralString
-
-# snapshot: invalid-type-form
-value: "LiteralString['foo', True, False]"
-```
-
-```snapshot
-error[invalid-type-form]: `LiteralString` expects no type parameter
- --> src/mdtest_snippet.py:4:9
-  |
-4 | value: "LiteralString['foo', True, False]"
-  |         -------------^^^^^^^^^^^^^^^^^^^^
-  |         |
-  |         Did you mean `Literal`?
-```
-
 ### Parameterized evaluated annotations
 
 Evaluated annotations still report errors in their arguments.

--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -63,6 +63,71 @@ error[invalid-type-form]: `LiteralString` expects no type parameter
   |    Did you mean `Literal`?
 ```
 
+### Parameterized string annotations
+
+Since `LiteralString` cannot be parameterized, invalid arguments in string annotations are not
+evaluated. They should neither panic nor produce distracting errors about their contents.
+
+`runtime.py`:
+
+```py
+from typing_extensions import LiteralString
+
+a: "LiteralString[(name := missing)]"  # error: [invalid-type-form]
+b: "LiteralString[int[(name := missing)]]"  # error: [invalid-type-form]
+c: "LiteralString[(name := 0).real]"  # error: [invalid-type-form]
+d: "LiteralString[lambda default=missing: None]"  # error: [invalid-type-form]
+```
+
+The same error recovery applies in stub files.
+
+`stub.pyi`:
+
+```pyi
+from typing_extensions import LiteralString
+
+value: "LiteralString[(name := missing)]"  # error: [invalid-type-form]
+```
+
+### Literal suggestion in string annotations
+
+For valid literal arguments, we still suggest `Literal` in a string annotation. Each argument is
+checked separately, so the combination of `True` and `False` does not lose the suggestion.
+
+```py
+from typing_extensions import LiteralString
+
+# snapshot: invalid-type-form
+value: "LiteralString['foo', True, False]"
+```
+
+```snapshot
+error[invalid-type-form]: `LiteralString` expects no type parameter
+ --> src/mdtest_snippet.py:4:9
+  |
+4 | value: "LiteralString['foo', True, False]"
+  |         -------------^^^^^^^^^^^^^^^^^^^^
+  |         |
+  |         Did you mean `Literal`?
+```
+
+### Parameterized evaluated annotations
+
+Evaluated annotations still report errors in their arguments.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing_extensions import LiteralString
+
+# error: [invalid-type-form]
+# error: [unresolved-reference] "Name `missing` used when not defined"
+value: LiteralString[(name := missing)]
+```
+
 ### As a base class
 
 Subclassing `LiteralString` leads to a runtime error.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8392,13 +8392,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_named_expression(&mut self, named: &ast::ExprNamed) -> Type<'db> {
         // See https://peps.python.org/pep-0572/#differences-between-assignment-expressions-and-assignment-statements
-        if named.target.is_name_expr() {
+        if named.target.is_name_expr() && !self.in_string_annotation() {
             let definition = self.index.expect_single_definition(named);
             let result = infer_definition_types(self.db(), definition);
             self.extend_definition(definition, result);
             result.binding_type(definition)
         } else {
-            // For syntactically invalid targets, we still need to run type inference:
+            // String annotations have no indexed definitions, and syntactically invalid targets
+            // cannot define a name. Both sides still need inference to preserve their diagnostics.
             self.infer_expression(&named.target, TypeContext::default());
             self.infer_expression(&named.value, TypeContext::default());
             Type::unknown()

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2602,33 +2602,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             SpecialFormType::LiteralString => {
                 let arguments = self.infer_expression(arguments_slice, TypeContext::default());
-                let argument_elements = if self.in_string_annotation() {
-                    let argument_expressions = match arguments_slice {
-                        ast::Expr::Tuple(tuple) => tuple.elts.as_slice(),
-                        _ => std::slice::from_ref(arguments_slice),
-                    };
-                    let mut builder = self.speculate_without_diagnostics();
-                    argument_expressions
-                        .iter()
-                        .map(|argument| {
-                            builder
-                                .infer_literal_parameter_type(argument)
-                                .unwrap_or(Type::unknown())
-                        })
-                        .collect::<Vec<_>>()
-                } else {
-                    let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
-                    arguments_as_tuple.as_ref().map_or_else(
-                        || vec![arguments],
-                        |tuple| tuple.iter_element_types(db).collect(),
-                    )
-                };
 
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                     let mut diag =
                         builder.into_diagnostic("`LiteralString` expects no type parameter");
 
-                    let probably_meant_literal = argument_elements.into_iter().all(|ty| match ty {
+                    let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
+
+                    let argument_elements = arguments_as_tuple.as_ref().map_or_else(
+                        || vec![arguments],
+                        |tuple| tuple.iter_element_types(db).collect(),
+                    );
+                    let mut argument_elements = argument_elements.into_iter();
+
+                    let probably_meant_literal = argument_elements.all(|ty| match ty {
                         Type::LiteralValue(literal)
                             if matches!(
                                 literal.kind(),

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2601,21 +2601,37 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 Type::unknown()
             }
             SpecialFormType::LiteralString => {
-                let arguments = self.infer_expression(arguments_slice, TypeContext::default());
+                let argument_elements = if self.in_string_annotation() {
+                    // The outer form is already invalid. Check only whether its arguments could
+                    // belong to `Literal`, without evaluating arbitrary unindexed expressions or
+                    // reporting diagnostics that would distract from the original error.
+                    let arguments = match arguments_slice {
+                        ast::Expr::Tuple(tuple) => tuple.elts.as_slice(),
+                        _ => std::slice::from_ref(arguments_slice),
+                    };
+                    let mut builder = self.speculate_without_diagnostics();
+                    arguments
+                        .iter()
+                        .map(|argument| {
+                            builder
+                                .infer_literal_parameter_type(argument)
+                                .unwrap_or(Type::unknown())
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    let arguments = self.infer_expression(arguments_slice, TypeContext::default());
+                    let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
+                    arguments_as_tuple.as_ref().map_or_else(
+                        || vec![arguments],
+                        |tuple| tuple.iter_element_types(db).collect(),
+                    )
+                };
 
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                     let mut diag =
                         builder.into_diagnostic("`LiteralString` expects no type parameter");
 
-                    let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
-
-                    let argument_elements = arguments_as_tuple.as_ref().map_or_else(
-                        || vec![arguments],
-                        |tuple| tuple.iter_element_types(db).collect(),
-                    );
-                    let mut argument_elements = argument_elements.into_iter();
-
-                    let probably_meant_literal = argument_elements.all(|ty| match ty {
+                    let probably_meant_literal = argument_elements.into_iter().all(|ty| match ty {
                         Type::LiteralValue(literal)
                             if matches!(
                                 literal.kind(),
@@ -2670,7 +2686,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
         let env = self.program_environment();
         let ty = match parameters {
-            ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
+            ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. })
+                if !self.in_string_annotation() || is_dotted_name(value) =>
+            {
                 let value_ty = self.infer_expression(value, TypeContext::default());
                 if matches!(value_ty, Type::SpecialForm(SpecialFormType::Literal)) {
                     let ty = self.infer_literal_parameter_type(slice)?;
@@ -2680,7 +2698,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.store_expression_type(parameters, ty);
                     ty
                 } else {
-                    self.infer_expression(slice, TypeContext::default());
+                    if !self.in_string_annotation() {
+                        self.infer_expression(slice, TypeContext::default());
+                    }
                     self.store_expression_type(parameters, Type::unknown());
 
                     return Err(vec![parameters]);
@@ -2738,7 +2758,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ty
             }
             // enum members and aliases to literal types
-            ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
+            ast::Expr::Name(_) | ast::Expr::Attribute(_)
+                if !self.in_string_annotation() || is_dotted_name(parameters) =>
+            {
                 let subscript_ty = self.infer_expression(parameters, TypeContext::default());
                 match subscript_ty {
                     // type aliases to literal types

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2601,16 +2601,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 Type::unknown()
             }
             SpecialFormType::LiteralString => {
+                let arguments = self.infer_expression(arguments_slice, TypeContext::default());
                 let argument_elements = if self.in_string_annotation() {
-                    // The outer form is already invalid. Check only whether its arguments could
-                    // belong to `Literal`, without evaluating arbitrary unindexed expressions or
-                    // reporting diagnostics that would distract from the original error.
-                    let arguments = match arguments_slice {
+                    let argument_expressions = match arguments_slice {
                         ast::Expr::Tuple(tuple) => tuple.elts.as_slice(),
                         _ => std::slice::from_ref(arguments_slice),
                     };
                     let mut builder = self.speculate_without_diagnostics();
-                    arguments
+                    argument_expressions
                         .iter()
                         .map(|argument| {
                             builder
@@ -2619,7 +2617,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         })
                         .collect::<Vec<_>>()
                 } else {
-                    let arguments = self.infer_expression(arguments_slice, TypeContext::default());
                     let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
                     arguments_as_tuple.as_ref().map_or_else(
                         || vec![arguments],
@@ -2686,9 +2683,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
         let env = self.program_environment();
         let ty = match parameters {
-            ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. })
-                if !self.in_string_annotation() || is_dotted_name(value) =>
-            {
+            ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
                 let value_ty = self.infer_expression(value, TypeContext::default());
                 if matches!(value_ty, Type::SpecialForm(SpecialFormType::Literal)) {
                     let ty = self.infer_literal_parameter_type(slice)?;
@@ -2698,9 +2693,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.store_expression_type(parameters, ty);
                     ty
                 } else {
-                    if !self.in_string_annotation() {
-                        self.infer_expression(slice, TypeContext::default());
-                    }
+                    self.infer_expression(slice, TypeContext::default());
                     self.store_expression_type(parameters, Type::unknown());
 
                     return Err(vec![parameters]);
@@ -2758,9 +2751,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ty
             }
             // enum members and aliases to literal types
-            ast::Expr::Name(_) | ast::Expr::Attribute(_)
-                if !self.in_string_annotation() || is_dotted_name(parameters) =>
-            {
+            ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
                 let subscript_ty = self.infer_expression(parameters, TypeContext::default());
                 match subscript_ty {
                     // type aliases to literal types


### PR DESCRIPTION
## Summary

Previously, invalid `Literal` and `LiteralString` arguments inside string annotations could reach assignment expressions that are absent from the semantic index:

```python
from typing import Literal, LiteralString

value: "LiteralString[(other := 0)]"
another: "Literal[int[(other := 0)]]"
```

We now infer both sides of assignment expressions in string annotations without looking up nonexistent semantic-index definitions. This avoids the panic while preserving unresolved-reference and other nested diagnostics for invalid `Literal` and `LiteralString` arguments. Evaluated annotations retain their existing inference and runtime diagnostics.
