### PR TITLE
[ty] Optimize inherited recursive protocol comparisons

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -863,6 +863,68 @@ fn benchmark_many_protocol_members_mismatch(criterion: &mut Criterion) {
     });
 }
 
+/// Regression benchmarks for ty#4269: constructor inference and invalid recursive protocols.
+///
+/// Without the constrained-receiver shortcut, each inherited method repeatedly expands the
+/// protocol while inferring the concrete class's specialization or collecting diagnostics.
+fn benchmark_inherited_recursive_protocol(criterion: &mut Criterion) {
+    const NUM_METHODS: usize = 8;
+
+    setup_rayon();
+
+    let mut code = "\
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Protocol
+
+class Chain[T](Protocol):
+    def value(self) -> T: ...
+"
+    .to_string();
+
+    for i in 0..NUM_METHODS {
+        writeln!(
+            &mut code,
+            "    def method_{i}[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ..."
+        )
+        .ok();
+    }
+
+    code.push_str(
+        "\n\
+class Concrete[T](Chain[T]):
+    def __init__(self, values: Iterable[T]) -> None: ...
+",
+    );
+
+    for (name, scenario, expected_diagnostics) in [
+        (
+            "ty_micro[inherited_recursive_protocol_constructor]",
+            "\nvalue: Chain[int] = Concrete(())\n",
+            0,
+        ),
+        (
+            "ty_micro[inherited_recursive_protocol_diagnostic]",
+            "\ndef diagnose[T](value: Concrete[T]) -> None:\n    invalid: Chain[int] = value\n",
+            1,
+        ),
+    ] {
+        let code = format!("{code}{scenario}");
+        criterion.bench_function(name, |b| {
+            b.iter_batched_ref(
+                || setup_micro_case(&code),
+                |case| {
+                    let Case { db } = case;
+                    let result = db.check();
+                    assert_eq!(result.len(), expected_diagnostics);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
 /// Regression benchmark for large calls to a gradual variadic tail.
 ///
 /// Without the gradual-call shortcut, every positional argument type is folded into the same
@@ -1621,6 +1683,7 @@ criterion_group!(
     benchmark_mixed_str_enum_comparison,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
+    benchmark_inherited_recursive_protocol,
     benchmark_vararg_parameter_type_accumulation,
     benchmark_very_large_tuple,
     benchmark_large_union_narrowing,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -863,10 +863,10 @@ fn benchmark_many_protocol_members_mismatch(criterion: &mut Criterion) {
     });
 }
 
-/// Regression benchmarks for ty#4269: constructor inference and invalid recursive protocols.
+/// Regression benchmarks for ty#4269: recursive protocol inference and assignment diagnostics.
 ///
-/// Without the constrained-receiver shortcut, each inherited method repeatedly expands the
-/// protocol while inferring the concrete class's specialization or collecting diagnostics.
+/// Explicit receiver annotations can repeatedly expand inherited recursive protocol members
+/// during constructor inference or diagnostic collection.
 fn benchmark_inherited_recursive_protocol(criterion: &mut Criterion) {
     const NUM_METHODS: usize = 8;
 
@@ -891,12 +891,8 @@ class Chain[T](Protocol):
         .ok();
     }
 
-    code.push_str(
-        "\n\
-class Concrete[T](Chain[T]):
-    def __init__(self, values: Iterable[T]) -> None: ...
-",
-    );
+    code.push_str("\nclass Concrete[T](Chain[T]):\n");
+    code.push_str("    def __init__(self, values: Iterable[T]) -> None: ...\n");
 
     for (name, scenario, expected_diagnostics) in [
         (
@@ -914,11 +910,7 @@ class Concrete[T](Chain[T]):
         criterion.bench_function(name, |b| {
             b.iter_batched_ref(
                 || setup_micro_case(&code),
-                |case| {
-                    let Case { db } = case;
-                    let result = db.check();
-                    assert_eq!(result.len(), expected_diagnostics);
-                },
+                |case| assert_eq!(case.db.check().len(), expected_diagnostics),
                 BatchSize::SmallInput,
             );
         });

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -1272,6 +1272,51 @@ info: └── protocol member `check` is incompatible
 info:     └── parameter `y` has an incompatible type: `str` is not assignable to `bytes`
 ```
 
+## Recursive protocol diagnostic context
+
+A value-constrained type parameter makes the recursive `child` override valid for each permitted
+specialization. The explicit receiver on `Outer.expose` preserves unresolved type variables while
+diagnostic context is collected, including the incompatible recursive member and its return type.
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Chain[T](Protocol):
+    def child(self) -> Chain[T]: ...
+    def value(self) -> T: ...
+
+class Outer[T](Protocol):
+    def expose(self: Outer[T]) -> Chain[T]: ...
+
+class Concrete[T: (str, object)](Chain[T], Outer[T]):
+    def child(self) -> Concrete[str]:
+        raise NotImplementedError
+
+    def expose(self: Outer[T]) -> Concrete[T]:
+        raise NotImplementedError
+
+def diagnose[T: (str, object)](value: Concrete[T]) -> None:
+    invalid: Outer[int] = value  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `Concrete[T@diagnose]` is not assignable to `Outer[int]`
+  --> src/mdtest_snippet.py:20:27
+   |
+20 |     invalid: Outer[int] = value  # snapshot: invalid-assignment
+   |              ----------   ^^^^^ Incompatible value of type `Concrete[T@diagnose]`
+   |              |
+   |              Declared type
+info: type `Concrete[T@diagnose]` is not assignable to protocol `Chain[int]`
+info: └── protocol member `child` is incompatible
+info:     └── incompatible return types: `Concrete[str]` is not assignable to `Chain[int]`
+info:         └── type `Concrete[str]` is not assignable to protocol `Chain[int]`
+info:             └── protocol member `value` is incompatible
+info:                 └── incompatible return types: `str` is not assignable to `int`
+```
+
 ## Protocol method parameter names
 
 Assignability errors against protocols are often caused because a method in the protocol class

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -6699,12 +6699,12 @@ python-version = "3.12"
 ```py
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from typing import Protocol
 
 class Chain[T](Protocol):
     def value(self) -> T: ...
-    def map_pairs[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
+    def combine[S](self: Chain[S], pair: tuple[S, T]) -> Chain[T]: ...
 
 class Concrete[T](Chain[T]):
     def __init__(self, values: Iterable[T]) -> None: ...
@@ -6740,13 +6740,9 @@ class Chain[T](Protocol):
 
 class Concrete[T](Chain[T]): ...
 
-def specialized(value: Concrete[int]) -> None:
-    reveal_type(value.accumulate())  # revealed: Chain[int]
-
-def symbolic[T](value: Concrete[T]) -> None:
-    reveal_type(value.accumulate())  # revealed: Chain[T@symbolic]
-
-def unspecialized() -> None:
+def check[T](concrete: Concrete[int], symbolic: Concrete[T]) -> None:
+    reveal_type(concrete.accumulate())  # revealed: Chain[int]
+    reveal_type(symbolic.accumulate())  # revealed: Chain[T@check]
     reveal_type(Concrete().accumulate())  # revealed: Chain[Unknown]
 ```
 
@@ -6767,20 +6763,17 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Protocol
 
-class RecursivePair[A, B](Protocol):
+class Recursive[A, B](Protocol):
     first: A
-    def value(self, child: RecursivePair[Any, Any]) -> B: ...
+    def value(self, child: Recursive[Any, Any]) -> B: ...
 
-class PartiallyErased[T, U](RecursivePair[T, Any]):
-    def value(self, child: RecursivePair[Any, Any]) -> U:
+class Erased[T, U](Recursive[T, Any]):
+    def value(self, child: Recursive[Any, Any]) -> U:
         raise NotImplementedError
 
-    def __init__(self, first: T, callback: Callable[[U], object]) -> None: ...
+    def __init__(self, callback: Callable[[U], object]) -> None: ...
 
-contextual: RecursivePair[int, str] = PartiallyErased(
-    1,
-    lambda value: reveal_type(value),  # revealed: str
-)
+pair: Recursive[int, str] = Erased(lambda value: reveal_type(value))  # revealed: str
 ```
 
 ### Overridden recursive protocol requirements

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5936,6 +5936,32 @@ def _(x: Foo):
         pass
 ```
 
+## Structural matches for explicitly inherited protocols
+
+A class can satisfy a different specialization of an inherited protocol by overriding one of its
+members. Constructor inference must preserve those structural solutions instead of treating the
+inherited specialization as the only possible match.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Callable
+from typing import Protocol
+
+class Consumer[T](Protocol):
+    def consume(self, value: T) -> None: ...
+
+class Permissive[T](Consumer[T]):
+    def __init__(self, callback: Callable[[T], object]) -> None: ...
+    def consume(self, value: object) -> None: ...
+
+contextual: Consumer[int] = Permissive(lambda value: reveal_type(value))  # revealed: Unknown
+also_valid: Consumer[int] = Permissive(lambda value: value.upper())
+```
+
 ## Protocols are never singleton types
 
 It *might* be possible to have a singleton protocol-instance type...?
@@ -6682,6 +6708,219 @@ class Recursive[T](Protocol):
 
 def check(value: Recursive[int]) -> None:
     rejected: Recursive[str] = value  # error: [invalid-assignment]
+```
+
+### Generic constructors inheriting recursive protocols
+
+A generic constructor can infer its specialization from an expected protocol type. Explicitly
+constrained receivers on inherited recursive methods must not repeatedly expand the protocol while
+inferring that specialization.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Protocol
+
+class Chain[T](Protocol):
+    def value(self) -> T: ...
+    def first[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
+    def second[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
+    def third[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
+    def fourth[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
+
+class Concrete[T](Chain[T]):
+    def __init__(self, values: Iterable[T]) -> None: ...
+
+contextual: Chain[int] = Concrete(())
+reveal_type(contextual)  # revealed: Concrete[int]
+
+explicit: Chain[int] = Concrete[int](())
+
+def make() -> Chain[int]:
+    return Concrete(())
+
+wrong: Chain[int] = Concrete(("wrong",))  # error: [invalid-assignment]
+```
+
+### Fully specialized sources for generic protocol inference
+
+A fully specialized source can contribute more structural inference information than its nominal
+specialization. In particular, an empty tuple's `Never` element type must not be discarded.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Iterable, Iterator
+from typing import Never
+
+class Container[T]:
+    def __init__(self, values: Iterable[T]) -> None: ...
+
+reveal_type(Container(()))  # revealed: Container[Never]
+
+def infer[T](values: Iterable[T]) -> T:
+    raise NotImplementedError
+
+def preserve_iterator(values: Iterator[Never]) -> None:
+    reveal_type(infer(values))  # revealed: Never
+
+reveal_type(infer(()))  # revealed: Never
+```
+
+### Class and static methods on recursive protocols
+
+A static method's annotated first argument is not a receiver, and a class method's receiver has
+already been bound. Neither method's first ordinary argument should enable the shortcut for
+explicitly constrained receivers or discard a fully specialized source's `Never` type argument.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Never, Protocol
+
+class Recursive[T](Protocol):
+    @classmethod
+    def classify(cls, value: object) -> None: ...
+    @staticmethod
+    def describe(value: object) -> None: ...
+    @property
+    def child(self) -> Recursive[T]: ...
+    def get(self) -> T: ...
+
+class Concrete[T](Recursive[T]): ...
+
+def infer[T](value: Recursive[T]) -> T:
+    raise NotImplementedError
+
+reveal_type(infer(Concrete[Never]()))  # revealed: Never
+```
+
+### Fully specialized sources with constrained protocol receivers
+
+A concrete class can inherit recursive methods with explicitly constrained receivers. Both concrete
+and unknown specializations must bind those receivers without repeatedly expanding the inherited
+protocol interface.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, overload
+
+class Chain[T](Protocol):
+    def value(self) -> T: ...
+    @overload
+    def accumulate[S](self: Chain[S], callback: None = None) -> Chain[S]: ...
+    @overload
+    def accumulate[I, N](self: Chain[N], callback: Callable[[I, N], I], initial: I) -> Chain[I]: ...
+
+class Concrete[T](Chain[T]): ...
+
+def specialized(value: Concrete[int]) -> None:
+    reveal_type(value.accumulate())  # revealed: Chain[int]
+
+def unspecialized() -> None:
+    reveal_type(Concrete().accumulate())  # revealed: Chain[Unknown]
+```
+
+### Structural inference from recursive protocol requirements
+
+An inherited protocol specialization can erase a class type parameter. A recursive member can still
+recover that parameter structurally, so satisfying the nominal relation is not enough to stop
+collecting protocol constraints.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol
+
+class RecursivePair[A, B](Protocol):
+    first: A
+
+    @property
+    def child(self) -> RecursivePair[A, Any]: ...
+    def value(self, child: RecursivePair[Any, Any]) -> B: ...
+
+class PartiallyErased[T, U](RecursivePair[T, Any]):
+    first: T
+
+    @property
+    def child(self) -> RecursivePair[T, Any]:
+        raise NotImplementedError
+
+    def value(self, child: RecursivePair[Any, Any]) -> U:
+        raise NotImplementedError
+
+    def __init__(self, values: Iterable[T], callback: Callable[[U], object]) -> None: ...
+
+contextual: RecursivePair[int, str] = PartiallyErased(
+    [],
+    lambda value: reveal_type(value),  # revealed: str
+)
+```
+
+### Overridden recursive protocol requirements
+
+Recursive requirements remain significant when a concrete class overrides them. Their constraints
+must still reject incompatible assignments and preserve generic inference.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Node[T](Protocol):
+    @property
+    def value(self) -> T: ...
+    @property
+    def child(self) -> Node[T]: ...
+
+class Mismatched[T](Node[object]):
+    def __init__(self, value: T) -> None: ...
+    @property
+    def value(self) -> T:
+        raise NotImplementedError
+
+    @property
+    def child(self) -> Node[str]:
+        raise NotImplementedError
+
+bad_assignment: Node[int] = Mismatched(1)  # error: [invalid-assignment]
+
+def extract[U](node: Node[U]) -> U:
+    raise NotImplementedError
+
+reveal_type(extract(Mismatched(1)))  # revealed: object
 ```
 
 ### Recursive legacy generic protocol

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5936,32 +5936,6 @@ def _(x: Foo):
         pass
 ```
 
-## Structural matches for explicitly inherited protocols
-
-A class can satisfy a different specialization of an inherited protocol by overriding one of its
-members. Constructor inference must preserve those structural solutions instead of treating the
-inherited specialization as the only possible match.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from collections.abc import Callable
-from typing import Protocol
-
-class Consumer[T](Protocol):
-    def consume(self, value: T) -> None: ...
-
-class Permissive[T](Consumer[T]):
-    def __init__(self, callback: Callable[[T], object]) -> None: ...
-    def consume(self, value: object) -> None: ...
-
-contextual: Consumer[int] = Permissive(lambda value: reveal_type(value))  # revealed: Unknown
-also_valid: Consumer[int] = Permissive(lambda value: value.upper())
-```
-
 ## Protocols are never singleton types
 
 It *might* be possible to have a singleton protocol-instance type...?
@@ -6712,9 +6686,10 @@ def check(value: Recursive[int]) -> None:
 
 ### Generic constructors inheriting recursive protocols
 
-A generic constructor can infer its specialization from an expected protocol type. Explicitly
-constrained receivers on inherited recursive methods must not repeatedly expand the protocol while
-inferring that specialization.
+A generic constructor can infer its specialization from an expected recursive protocol even when the
+protocol includes a method with an explicitly constrained receiver. Invalid constructor arguments
+are rejected. Without an expected type, the empty tuple is an `Iterable[Never]`, so the constructor
+infers `T = Never` regardless of the protocol's variance.
 
 ```toml
 [environment]
@@ -6729,58 +6704,25 @@ from typing import Protocol
 
 class Chain[T](Protocol):
     def value(self) -> T: ...
-    def first[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
-    def second[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
-    def third[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
-    def fourth[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
+    def map_pairs[A, B](self: Chain[tuple[A, B]], callback: Callable[[A, B], T]) -> Chain[T]: ...
 
 class Concrete[T](Chain[T]):
     def __init__(self, values: Iterable[T]) -> None: ...
 
 contextual: Chain[int] = Concrete(())
 reveal_type(contextual)  # revealed: Concrete[int]
-
-explicit: Chain[int] = Concrete[int](())
+wrong: Chain[int] = Concrete(("wrong",))  # error: [invalid-assignment]
+reveal_type(Concrete(()))  # revealed: Concrete[Never]
 
 def make() -> Chain[int]:
     return Concrete(())
-
-wrong: Chain[int] = Concrete(("wrong",))  # error: [invalid-assignment]
 ```
 
-### Fully specialized sources for generic protocol inference
+### Specialized sources with constrained protocol receivers
 
-A fully specialized source can contribute more structural inference information than its nominal
-specialization. In particular, an empty tuple's `Never` element type must not be discarded.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from collections.abc import Iterable, Iterator
-from typing import Never
-
-class Container[T]:
-    def __init__(self, values: Iterable[T]) -> None: ...
-
-reveal_type(Container(()))  # revealed: Container[Never]
-
-def infer[T](values: Iterable[T]) -> T:
-    raise NotImplementedError
-
-def preserve_iterator(values: Iterator[Never]) -> None:
-    reveal_type(infer(values))  # revealed: Never
-
-reveal_type(infer(()))  # revealed: Never
-```
-
-### Class and static methods on recursive protocols
-
-A static method's annotated first argument is not a receiver, and a class method's receiver has
-already been bound. Neither method's first ordinary argument should enable the shortcut for
-explicitly constrained receivers or discard a fully specialized source's `Never` type argument.
+A concrete class can inherit recursive methods with explicitly constrained receivers. Concrete,
+symbolic, and unknown specializations bind those receivers and preserve the corresponding return
+types.
 
 ```toml
 [environment]
@@ -6790,53 +6732,19 @@ python-version = "3.12"
 ```py
 from __future__ import annotations
 
-from typing import Never, Protocol
-
-class Recursive[T](Protocol):
-    @classmethod
-    def classify(cls, value: object) -> None: ...
-    @staticmethod
-    def describe(value: object) -> None: ...
-    @property
-    def child(self) -> Recursive[T]: ...
-    def get(self) -> T: ...
-
-class Concrete[T](Recursive[T]): ...
-
-def infer[T](value: Recursive[T]) -> T:
-    raise NotImplementedError
-
-reveal_type(infer(Concrete[Never]()))  # revealed: Never
-```
-
-### Fully specialized sources with constrained protocol receivers
-
-A concrete class can inherit recursive methods with explicitly constrained receivers. Both concrete
-and unknown specializations must bind those receivers without repeatedly expanding the inherited
-protocol interface.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from __future__ import annotations
-
-from collections.abc import Callable
-from typing import Protocol, overload
+from typing import Protocol
 
 class Chain[T](Protocol):
     def value(self) -> T: ...
-    @overload
-    def accumulate[S](self: Chain[S], callback: None = None) -> Chain[S]: ...
-    @overload
-    def accumulate[I, N](self: Chain[N], callback: Callable[[I, N], I], initial: I) -> Chain[I]: ...
+    def accumulate[S](self: Chain[S]) -> Chain[S]: ...
 
 class Concrete[T](Chain[T]): ...
 
 def specialized(value: Concrete[int]) -> None:
     reveal_type(value.accumulate())  # revealed: Chain[int]
+
+def symbolic[T](value: Concrete[T]) -> None:
+    reveal_type(value.accumulate())  # revealed: Chain[T@symbolic]
 
 def unspecialized() -> None:
     reveal_type(Concrete().accumulate())  # revealed: Chain[Unknown]
@@ -6856,30 +6764,21 @@ python-version = "3.12"
 ```py
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import Any, Protocol
 
 class RecursivePair[A, B](Protocol):
     first: A
-
-    @property
-    def child(self) -> RecursivePair[A, Any]: ...
     def value(self, child: RecursivePair[Any, Any]) -> B: ...
 
 class PartiallyErased[T, U](RecursivePair[T, Any]):
-    first: T
-
-    @property
-    def child(self) -> RecursivePair[T, Any]:
-        raise NotImplementedError
-
     def value(self, child: RecursivePair[Any, Any]) -> U:
         raise NotImplementedError
 
-    def __init__(self, values: Iterable[T], callback: Callable[[U], object]) -> None: ...
+    def __init__(self, first: T, callback: Callable[[U], object]) -> None: ...
 
 contextual: RecursivePair[int, str] = PartiallyErased(
-    [],
+    1,
     lambda value: reveal_type(value),  # revealed: str
 )
 ```
@@ -6887,7 +6786,7 @@ contextual: RecursivePair[int, str] = PartiallyErased(
 ### Overridden recursive protocol requirements
 
 Recursive requirements remain significant when a concrete class overrides them. Their constraints
-must still reject incompatible assignments and preserve generic inference.
+reject incompatible assignments and preserve generic inference.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -518,6 +518,20 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         self.node == ALWAYS_TRUE
     }
 
+    /// Returns whether this constraint set mentions this exact bound type-variable occurrence.
+    pub(super) fn mentions_typevar(
+        self,
+        db: &'db dyn Db,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> bool {
+        let storage = self.builder.storage.borrow();
+        storage.node_support(self.node).is_some_and(|support| {
+            support
+                .iter()
+                .any(|id| storage.typevar_data(id) == typevar.identity(db))
+        })
+    }
+
     /// Returns the constraints under which `lhs` is a subtype of `rhs`, assuming that the
     /// constraints in this constraint set hold. Panics if neither of the types being compared are
     /// a typevar. (That case is handled by `Type::has_relation_to`.)
@@ -7206,6 +7220,13 @@ mod tests {
 
         assert_eq!(mentioned, vec![t.identity(db), u.identity(db)]);
         assert!(support.is_complete());
+
+        let builder = ConstraintSetBuilder::new();
+        let constraint =
+            ConstraintSet::constrain_typevar_upper_bound(db, &env, &builder, t, actual_bound);
+        assert!(constraint.mentions_typevar(db, t));
+        assert!(constraint.mentions_typevar(db, u));
+        assert!(!constraint.mentions_typevar(db, metadata));
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -518,18 +518,12 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         self.node == ALWAYS_TRUE
     }
 
-    /// Returns whether this constraint set mentions this exact bound type-variable occurrence.
-    pub(super) fn mentions_typevar(
-        self,
-        db: &'db dyn Db,
-        typevar: BoundTypeVarInstance<'db>,
-    ) -> bool {
+    /// Returns whether this constraint set mentions the given type-variable identity.
+    pub(super) fn mentions_typevar(self, typevar: BoundTypeVarIdentity<'db>) -> bool {
         let storage = self.builder.storage.borrow();
-        storage.node_support(self.node).is_some_and(|support| {
-            support
-                .iter()
-                .any(|id| storage.typevar_data(id) == typevar.identity(db))
-        })
+        storage
+            .node_support(self.node)
+            .is_some_and(|support| support.iter().any(|id| storage.typevar_data(id) == typevar))
     }
 
     /// Returns the constraints under which `lhs` is a subtype of `rhs`, assuming that the
@@ -7224,9 +7218,9 @@ mod tests {
         let builder = ConstraintSetBuilder::new();
         let constraint =
             ConstraintSet::constrain_typevar_upper_bound(db, &env, &builder, t, actual_bound);
-        assert!(constraint.mentions_typevar(db, t));
-        assert!(constraint.mentions_typevar(db, u));
-        assert!(!constraint.mentions_typevar(db, metadata));
+        assert!(constraint.mentions_typevar(t.identity(db)));
+        assert!(constraint.mentions_typevar(u.identity(db)));
+        assert!(!constraint.mentions_typevar(metadata.identity(db)));
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -687,16 +687,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         }
 
         let env = self.env;
-        let Type::NominalInstance(source) = ty else {
-            return None;
-        };
-        let ClassType::Generic(source_alias) = source.class(db, env) else {
-            return None;
-        };
+        let source = ty.as_nominal_instance()?;
+        let source_class = source.class(db, env);
+        let source_alias = source_class.into_generic_alias()?;
 
         let source_arguments = source_alias.specialization(db).types(db);
         if !source_arguments.iter().all(|argument| match argument {
-            Type::TypeVar(typevar) => nominally_satisfied.mentions_typevar(db, *typevar),
+            Type::TypeVar(typevar) => nominally_satisfied.mentions_typevar(typevar.identity(db)),
             argument => !any_over_type_expanding_aliases(db, env, *argument, Type::is_type_var),
         }) {
             return None;
@@ -705,14 +702,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let interface = protocol.interface(db);
 
         // A concrete source normally contributes useful structural inference beyond its nominal
-        // specialization; for example, `()` must infer `Iterable[Never]`. Recursive receiver
+        // specialization; for example, `()` infers `Iterable[Never]`. Recursive receiver
         // binding is the exception: same-origin protocol sources and protocols with explicitly
         // constrained receivers can otherwise repeatedly expand the same interface.
         if !source_arguments
             .iter()
-            .any(|argument| matches!(argument, Type::TypeVar(_)))
+            .any(|argument| argument.is_type_var())
             && !protocol.class_origin(db).is_some_and(|target_origin| {
-                source.class(db, env).class_literal(db) == target_origin.class_literal(db)
+                source_class.class_literal(db) == target_origin.class_literal(db)
             })
             && !interface
                 .members(db)

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -702,6 +702,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
+        let interface = protocol.interface(db);
+
         // A concrete source normally contributes useful structural inference beyond its nominal
         // specialization; for example, `()` must infer `Iterable[Never]`. Recursive receiver
         // binding is the exception: same-origin protocol sources and protocols with explicitly
@@ -712,16 +714,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             && !protocol.class_origin(db).is_some_and(|target_origin| {
                 source.class(db, env).class_literal(db) == target_origin.class_literal(db)
             })
-            && !protocol
-                .interface(db)
+            && !interface
                 .members(db)
                 .any(|member| member.has_explicit_receiver_annotation(db))
         {
             return None;
         }
 
-        let mut members: Vec<_> = protocol
-            .interface(db)
+        let mut members: Vec<_> = interface
             .members(db)
             .map(|member| (member.structural_member_priority(db, env), member))
             .collect();
@@ -741,23 +741,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .when_all(db, self.constraints, |(_, member)| {
                     self.type_satisfies_protocol_member(db, ty, member)
                 });
-        if structurally_satisfied
-            .implies(db, self.constraints, || nominally_satisfied)
-            .is_always_satisfied(db, env)
-        {
-            return Some(structurally_satisfied);
-        }
-
         for (_, member) in recursive_members {
-            structurally_satisfied = structurally_satisfied.and(db, self.constraints, || {
-                self.type_satisfies_protocol_member(db, ty, member)
-            });
             if structurally_satisfied
                 .implies(db, self.constraints, || nominally_satisfied)
                 .is_always_satisfied(db, env)
             {
                 break;
             }
+            structurally_satisfied = structurally_satisfied.and(db, self.constraints, || {
+                self.type_satisfies_protocol_member(db, ty, member)
+            });
         }
 
         Some(structurally_satisfied)

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 use ruff_python_ast::name::Name;
 use ty_module_resolver::{ModuleName, file_to_module};
 
-use super::protocol_class::{ProtocolInterface, ProtocolInterfaceView};
+use super::protocol_class::{ProtocolInterface, ProtocolInterfaceView, StructuralMemberPriority};
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, ClassType, DivergentType, KnownClass,
     MaterializationKind, SubclassOfType, Type, TypeAliasType, TypeVarVariance,
@@ -31,7 +31,9 @@ use crate::types::relation::{
 use crate::types::signatures::SignatureRelationVisitor;
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::typevar::TypeVarSet;
-use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
+use crate::types::visitor::{
+    TypeCollector, TypeVisitor, any_over_type_expanding_aliases, walk_type_with_recursion_guard,
+};
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ErrorContext,
     FindLegacyTypeVarsVisitor, LiteralValueTypeKind, TypeContext, TypeMapping, VarianceInferable,
@@ -646,6 +648,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 source_protocol.interface(db),
                 protocol.interface(db),
             )
+        } else if let Some(structurally_satisfied) =
+            self.try_check_nominal_recursive_protocol_members(db, ty, protocol, result)
+        {
+            structurally_satisfied
         } else {
             protocol
                 .interface(db)
@@ -663,6 +669,98 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             });
         }
         result.or(db, self.constraints, || structurally_satisfied)
+    }
+
+    /// Avoid recursive requirements that cannot add solutions beyond explicit inheritance.
+    fn try_check_nominal_recursive_protocol_members(
+        &self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        protocol: ProtocolInstanceType<'db>,
+        nominally_satisfied: ConstraintSet<'db, 'c>,
+    ) -> Option<ConstraintSet<'db, 'c>> {
+        if self.typevar_evaluation != TypeVarEvaluation::Lazy
+            || self.is_context_collection_enabled()
+            || nominally_satisfied.is_trivially_never_satisfied()
+        {
+            return None;
+        }
+
+        let env = self.env;
+        let Type::NominalInstance(source) = ty else {
+            return None;
+        };
+        let ClassType::Generic(source_alias) = source.class(db, env) else {
+            return None;
+        };
+
+        let source_arguments = source_alias.specialization(db).types(db);
+        if !source_arguments.iter().all(|argument| match argument {
+            Type::TypeVar(typevar) => nominally_satisfied.mentions_typevar(db, *typevar),
+            argument => !any_over_type_expanding_aliases(db, env, *argument, Type::is_type_var),
+        }) {
+            return None;
+        }
+
+        // A concrete source normally contributes useful structural inference beyond its nominal
+        // specialization; for example, `()` must infer `Iterable[Never]`. Recursive receiver
+        // binding is the exception: same-origin protocol sources and protocols with explicitly
+        // constrained receivers can otherwise repeatedly expand the same interface.
+        if !source_arguments
+            .iter()
+            .any(|argument| matches!(argument, Type::TypeVar(_)))
+            && !protocol.class_origin(db).is_some_and(|target_origin| {
+                source.class(db, env).class_literal(db) == target_origin.class_literal(db)
+            })
+            && !protocol
+                .interface(db)
+                .members(db)
+                .any(|member| member.has_explicit_receiver_annotation(db))
+        {
+            return None;
+        }
+
+        let mut members: Vec<_> = protocol
+            .interface(db)
+            .members(db)
+            .map(|member| (member.structural_member_priority(db, env), member))
+            .collect();
+        members.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+        let first_recursive = members.partition_point(|(priority, _)| {
+            !matches!(priority, StructuralMemberPriority::Recursive)
+        });
+        let (finite_members, recursive_members) = members.split_at(first_recursive);
+        if recursive_members.is_empty() {
+            return None;
+        }
+
+        let mut structurally_satisfied =
+            finite_members
+                .iter()
+                .when_all(db, self.constraints, |(_, member)| {
+                    self.type_satisfies_protocol_member(db, ty, member)
+                });
+        if structurally_satisfied
+            .implies(db, self.constraints, || nominally_satisfied)
+            .is_always_satisfied(db, env)
+        {
+            return Some(structurally_satisfied);
+        }
+
+        for (_, member) in recursive_members {
+            structurally_satisfied = structurally_satisfied.and(db, self.constraints, || {
+                self.type_satisfies_protocol_member(db, ty, member)
+            });
+            if structurally_satisfied
+                .implies(db, self.constraints, || nominally_satisfied)
+                .is_always_satisfied(db, env)
+            {
+                break;
+            }
+        }
+
+        Some(structurally_satisfied)
     }
 
     /// Tries to relate the finite members of two specializations of the same protocol.

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1881,20 +1881,19 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         matches!(self.data.kind, ProtocolMemberKind::Method(..))
     }
 
-    /// Returns whether an instance method explicitly constrains its receiver.
+    /// Returns whether an instance method has an explicit positional receiver annotation.
     pub(super) fn has_explicit_receiver_annotation(&self, db: &'db dyn Db) -> bool {
-        let ProtocolMemberKind::Method(member, ProtocolMethodKind::Instance) = self.data.kind
-        else {
-            return false;
-        };
-        let Type::Callable(callable) = member.ty() else {
-            return false;
-        };
-
-        callable
-            .signatures(db)
-            .iter()
-            .any(Signature::has_explicit_positional_receiver_annotation)
+        match self.data.kind {
+            ProtocolMemberKind::Method(member, ProtocolMethodKind::Instance)
+                if let Type::Callable(callable) = member.ty() =>
+            {
+                callable
+                    .signatures(db)
+                    .iter()
+                    .any(Signature::has_explicit_positional_receiver_annotation)
+            }
+            _ => false,
+        }
     }
 
     /// Returns the priority for structurally comparing this member.

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1773,7 +1773,7 @@ pub(super) struct ProtocolMember<'a, 'db> {
 /// The declaration order is significant because the derived ordering is used when comparing
 /// protocol interfaces.
 #[derive(Eq, Ord, PartialEq, PartialOrd)]
-enum StructuralMemberPriority {
+pub(super) enum StructuralMemberPriority {
     /// A non-recursive member with at most one callable signature.
     Simple,
     /// A non-recursive callable member with multiple overloads.
@@ -1881,11 +1881,27 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         matches!(self.data.kind, ProtocolMemberKind::Method(..))
     }
 
+    /// Returns whether an instance method explicitly constrains its receiver.
+    pub(super) fn has_explicit_receiver_annotation(&self, db: &'db dyn Db) -> bool {
+        let ProtocolMemberKind::Method(member, ProtocolMethodKind::Instance) = self.data.kind
+        else {
+            return false;
+        };
+        let Type::Callable(callable) = member.ty() else {
+            return false;
+        };
+
+        callable
+            .signatures(db)
+            .iter()
+            .any(Signature::has_explicit_positional_receiver_annotation)
+    }
+
     /// Returns the priority for structurally comparing this member.
     ///
     /// Simple finite members are cheapest, followed by finite overloads. Recursive members and
     /// aliases that contain a protocol or are themselves recursive are compared last.
-    fn structural_member_priority(
+    pub(super) fn structural_member_priority(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1286,10 +1286,6 @@ impl<'db> Signature<'db> {
         receiver_type: Type<'db>,
         typing_self_type: Type<'db>,
     ) -> Option<Self> {
-        if !self.can_bind_self_to(db, env, receiver_type) {
-            return None;
-        }
-
         let bound_signature =
             self.bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type));
         let Some(receiver_constraints) = bound_signature.receiver_constraints.as_ref() else {
@@ -1355,6 +1351,10 @@ impl<'db> Signature<'db> {
         receiver_type: Type<'db>,
         typing_self_type: Type<'db>,
     ) -> Option<Self> {
+        if !self.can_bind_self_to(db, env, receiver_type) {
+            return None;
+        }
+
         self.specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
             .map(|signature| {
                 signature.bind_self_with_receiver(


### PR DESCRIPTION
Generic classes inheriting recursive protocols can repeatedly expand the same protocol interface when contextual constructor inference or diagnostic collection binds explicitly constrained method receivers. Programs with several inherited recursive members then become pathologically slow.

Check finite requirements first for nominally inherited protocols, and stop expanding recursive requirements once their constraints establish the inherited relationship. Preserve full structural checking when it remains necessary for erased type parameters, overridden requirements, concrete-source inference, or diagnostic explanations. Also restrict eager receiver-compatibility checks to overload selection, where they actually prune candidates, so single-method binding does not recursively re-enter the protocol.

Part of astral-sh/ty#4269.

## Ecosystem impact

Werkzeug gains two overload errors and two unused-ignore warnings because improved contextual inference preserves the actual `sorted` callback argument instead of widening it to `object`. This exposes its existing `int | None` sort key; the old lambda-line ignore no longer covers the call-level error.

## Test plan

- Protocol mdtests cover contextual constructor inference, invalid constructor arguments, empty-iterable `Never` inference, concrete/symbolic/unknown constrained receivers, erased type parameters recovered structurally, and overridden recursive requirements.
- A diagnostic snapshot preserves nested protocol-member explanations during context collection.
- A constraint-support test verifies exact type-variable identities without treating declaration-default metadata as semantic support.
- Separate benchmarks cover recursive-protocol constructor inference and diagnostic collection.
