### PR TITLE
[`ruff`] Remove `lint.external` hint for Ruff-specific suppressions (`RUF102`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -368,7 +368,6 @@ error[RUF102]: Invalid rule code in suppression: unknown-rule, unused-import
  9 | import sys
 10 | # ruff:enable[unused-import, unknown-rule]
    | ------------------------------------------
-help: Add non-Ruff rule codes to the `lint.external` configuration option
 help: Enable `lint.preview` to use rule names
 help: Remove the suppression comment
   |
@@ -481,7 +480,6 @@ error[RUF102]: Invalid rule code in suppression: not-a-rule
   |
 2 | # ruff:ignore[unused-import, not-a-rule]
   |                              ^^^^^^^^^^
-help: Add non-Ruff rule codes to the `lint.external` configuration option
 help: Remove the rule code `not-a-rule`
   |
 1 | # snapshot: invalid-rule-code
@@ -836,7 +834,6 @@ error[RUF102]: Invalid rule code in suppression: XYZ
   |
 3 | # ruff:ignore[XYZ] # ruff:file-ignore[F821]
   |               ^^^
-help: Add non-Ruff rule codes to the `lint.external` configuration option
 help: Remove the suppression comment
   |
 2 | # error: [invalid-suppression-comment]

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__range_suppressions.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__range_suppressions.snap
@@ -300,7 +300,6 @@ RUF102 [*] Invalid rule code in suppression: YF829
 96 |     # ruff: enable[F841, RQW320]
 97 |     # ruff: enable[YF829]
    |                    -----
-help: Add non-Ruff rule codes to the `lint.external` configuration option
 help: Remove the suppression comment
    |
 92 |     # Unknown rule codes
@@ -324,7 +323,6 @@ RUF102 [*] Invalid rule code in suppression: RQW320
    |                          ------
 97 |     # ruff: enable[YF829]
    |
-help: Add non-Ruff rule codes to the `lint.external` configuration option
 help: Remove the rule code `RQW320`
    |
 93 |     # ruff: disable[YF829]

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -241,9 +241,6 @@ struct SuppressionDiagnostic<'a> {
     disabled_codes: Vec<&'a str>,
     unused_codes: Vec<&'a str>,
 
-    /// Whether one of the invalid codes was totally unknown and may be external.
-    has_unknown_code: bool,
-
     /// Whether one of the invalid codes was a rule name with preview disabled.
     has_stable_rule_name: bool,
 }
@@ -256,7 +253,6 @@ impl<'a> SuppressionDiagnostic<'a> {
             duplicated_codes: Vec::new(),
             disabled_codes: Vec::new(),
             unused_codes: Vec::new(),
-            has_unknown_code: false,
             has_stable_rule_name: false,
         }
     }
@@ -467,11 +463,6 @@ impl Suppressions {
                         whole_comment: group.suppression.codes().len() == group.invalid_codes.len(),
                     },
                 ) {
-                    if group.has_unknown_code {
-                        diagnostic.help(
-                            "Add non-Ruff rule codes to the `lint.external` configuration option",
-                        );
-                    }
                     if group.has_stable_rule_name {
                         diagnostic.help("Enable `lint.preview` to use rule names");
                     }
@@ -524,7 +515,6 @@ impl Suppressions {
                 let (_key, group) = grouped_diagnostic
                     .get_or_insert_with(|| (key, SuppressionDiagnostic::new(suppression)));
                 group.invalid_codes.push(code_str);
-                group.has_unknown_code |= !name_is_known;
                 group.has_stable_rule_name |= name_is_known;
             } else if !suppression.used.get() {
                 // UnusedNOQA


### PR DESCRIPTION
## Summary

Remove the "Add non-Ruff rule codes to the `lint.external` configuration option" help message from the suppression path (RUF102/RUF104).

The `# ruff: ignore` directive is a Ruff-specific suppression mechanism. When a user writes an unknown code in a `# ruff: ignore` directive, it is typically a typo or a rule name with preview disabled — not a non-Ruff rule code. The help message suggesting to add the code to `lint.external` is therefore misleading in this context.

The noqa path (RUF102) still handles this tip for `# noqa` directives, which is the appropriate context for external rule codes.

Closes #27880.

## Changes

1. **suppression.rs**: Removed the `has_unknown_code` field from `SuppressionDiagnostic` and the help message that was emitted when it was set.
2. **ignore.md**: Removed the "Add non-Ruff rule codes" help lines from suppression test snapshots.
3. **range_suppressions.snap**: Updated snapshot to reflect the removal of the help message.