### PR TITLE
Reduce configuration deserialization code size

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -1015,7 +1015,7 @@ impl TypedValueParser for ConfigArgumentParser {
         let _guard = ValueSourceGuard::new(ValueSource::Cli, false);
 
         let config_parse_error = match toml::Table::from_str(value) {
-            Ok(table) => match table.try_into::<Options>() {
+            Ok(table) => match Options::from_toml_table(table) {
                 Ok(option) => {
                     if option.extend.is_none() {
                         return Ok(SingleConfigArgument::SettingsOverride(Arc::new(option)));

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -114,7 +114,7 @@ impl TryFrom<ClientConfiguration> for ResolvedConfiguration {
             )),
             ClientConfiguration::Object(map) => {
                 let _guard = ValueSourceGuard::new(ValueSource::Editor, false);
-                let options = toml::Table::try_from(map)?.try_into::<Options>()?;
+                let options = Options::from_toml_table(toml::Table::try_from(map)?)?;
                 if options.extend.is_some() {
                     Err(ResolvedConfigurationError::ExtendNotSupported)
                 } else {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -516,6 +516,13 @@ pub struct Options {
     pub analyze: Option<AnalyzeOptions>,
 }
 
+impl Options {
+    /// Deserialize inline configuration in one crate, avoiding repeated code generation.
+    pub fn from_toml_table(table: toml::Table) -> Result<Self, toml::de::Error> {
+        table.try_into()
+    }
+}
+
 /// Configures how Ruff checks your code.
 ///
 /// Options specified in the `lint` section take precedence over the deprecated top-level settings.

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -33,9 +33,7 @@ pub struct Pyproject {
     project: Option<Project>,
 }
 
-fn parse_toml<P: AsRef<Path>, T: DeserializeOwned>(path: P, table_path: &[&str]) -> Result<T> {
-    let path = path.as_ref();
-
+fn parse_toml<T: DeserializeOwned>(path: &Path, table_path: &[&str]) -> Result<T> {
     let _guard = ValueSourceGuard::new(
         ValueSource::File(Arc::new(SystemPathBuf::from_path_buf_lossy(
             path.to_path_buf(),
@@ -66,18 +64,18 @@ fn parse_toml<P: AsRef<Path>, T: DeserializeOwned>(path: P, table_path: &[&str])
 }
 
 /// Parse a `ruff.toml` file.
-fn parse_ruff_toml<P: AsRef<Path>>(path: P) -> Result<Options> {
+fn parse_ruff_toml(path: &Path) -> Result<Options> {
     parse_toml(path, &[])
 }
 
 /// Parse a `pyproject.toml` file.
-fn parse_pyproject_toml<P: AsRef<Path>>(path: P) -> Result<Pyproject> {
+fn parse_pyproject_toml(path: &Path) -> Result<Pyproject> {
     parse_toml(path, &["tool", "ruff"])
 }
 
 /// Return `true` if a `pyproject.toml` contains a `[tool.ruff]` section.
 fn ruff_enabled<P: AsRef<Path>>(path: P) -> Result<bool> {
-    let pyproject = parse_pyproject_toml(path)?;
+    let pyproject = parse_pyproject_toml(path.as_ref())?;
     Ok(pyproject.tool.and_then(|tool| tool.ruff).is_some())
 }
 
@@ -547,7 +545,7 @@ per-file-ignores = { "__init__.py" = ["F401"] }
 
         let pyproject =
             find_settings_toml(tempdir.path())?.context("Failed to find pyproject.toml")?;
-        let pyproject = parse_pyproject_toml(pyproject)?;
+        let pyproject = parse_pyproject_toml(&pyproject)?;
         let config = pyproject
             .tool
             .context("Expected to find [tool] field")?


### PR DESCRIPTION
## Summary

Share TOML-to-`Options` conversion across the CLI and server, and remove unnecessary path-type monomorphizations from the configuration readers.
Matched Linux x86-64 Maturin release builds without PGO shrink the executable from 26.48 MiB to 24.00 MiB (9.37%) and the wheel by 8.18%; the changes independently save 1.49% and 5.44% of the executable.

## Test Plan

Testing: Focused configuration tests and release-wheel behavior and installation checks passed.
