### PR TITLE
[ty] Preserve class bindings for unknown decorators

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -589,14 +589,24 @@ class RegularCallableReplacementDecorated: ...
 reveal_type(RegularCallableReplacementDecorated)  # revealed: Unknown
 ```
 
-An unknown class decorator still makes the class binding unknown:
+An unknown class decorator preserves the original class binding, so instances and their operations
+remain checked even though the decorator itself is unresolved:
 
 ```py
 # error: [unresolved-reference] "Name `unknown_class_decorator` used when not defined"
 @unknown_class_decorator
-class UnknownDecorated: ...
+class UnknownDecorated:
+    def get(self, key: str) -> int:
+        return 1
 
-reveal_type(UnknownDecorated)  # revealed: Unknown
+reveal_type(UnknownDecorated)  # revealed: <class 'UnknownDecorated'>
+
+instance = UnknownDecorated()
+reveal_type(instance)  # revealed: UnknownDecorated
+reveal_type(instance.get("key"))  # revealed: int
+
+instance.get(1)  # error: [invalid-argument-type]
+instance + 1  # error: [unsupported-operator]
 ```
 
 An unannotated class decorator preserves the result of earlier decorators:

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -168,6 +168,31 @@ reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecialized))
 reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTypevar))
 ```
 
+## Decorated generic bases
+
+An unresolved class decorator should not erase a generic class's type parameters. Subclasses can
+inherit those parameters and remain generic.
+
+```py
+import collections.abc
+from typing import Generic, TypeVar
+from ty_extensions._internal import generic_context
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+# error: [unresolved-attribute] "Class `Mapping` has no attribute `register`"
+@collections.abc.Mapping.register
+class Mapping(Generic[K, V]): ...
+
+# revealed: ty_extensions._internal.GenericContext[K@Mapping, V@Mapping]
+reveal_type(generic_context(Mapping))
+
+class FrozenDict(Mapping[K, V]): ...
+
+mapping: FrozenDict[str, int]
+```
+
 ## Specializing classes with unavailable generic context
 
 When an earlier error prevents ty from determining a class's generic context, specializing the class
@@ -193,33 +218,6 @@ class Parser(typing.Generic[T]): ...
 
 # TODO: Remove this cascading error when https://github.com/astral-sh/ty/issues/1585 is fixed.
 parser: Parser[int]  # error: [invalid-type-form] "Non-generic class `Parser` cannot be specialized in a type expression"
-```
-
-### Decorated generic bases
-
-A decorator that ty cannot fully understand can obscure the generic context of a base class. A
-subclass that forwards type variables to that base remains possibly generic.
-
-```py
-import collections.abc
-from typing import Generic, TypeVar
-from ty_extensions._internal import generic_context
-
-K = TypeVar("K")
-V = TypeVar("V")
-
-# error: [unresolved-attribute] "Class `Mapping` has no attribute `register`"
-@collections.abc.Mapping.register
-class Mapping(Generic[K, V]): ...
-
-# TODO: Invalid decorator causes us to lose the generic context from the class...
-reveal_type(generic_context(Mapping))  # revealed: None
-
-class FrozenDict(Mapping[K, V]): ...
-
-# TODO: ...which then causes us to emit this
-# error: [invalid-type-form] "Non-generic class `FrozenDict` cannot be specialized in a type expression"
-mapping: FrozenDict[str, int]
 ```
 
 ### Unresolved generic bases

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -341,7 +341,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 decorated_ty => decorated_ty,
             };
             // If a class decorator application loses all precision, preserve the original class
-            // binding for decorators known to preserve unknown results.
+            // binding when the decorator's unknown-result policy permits preservation.
             let should_preserve_binding = is_unknown_decorator_result(db, decorated_ty)
                 && preserve_binding_for_unknown_result(
                     db,
@@ -606,9 +606,9 @@ fn is_unknown_class_object_decorator_result<'db>(db: &'db dyn Db, ty: Type<'db>)
 /// Policy for class decorators whose application result is unknown.
 ///
 /// This is only consulted after applying the decorator produced no useful replacement type. If the
-/// decorator itself statically suggests an unannotated identity-preserving shape, we keep the
-/// current class binding; if it explicitly promises a replacement type, or if the decorator is
-/// unknown, we let the unknown result replace the binding.
+/// decorator itself is unknown or statically suggests an unannotated identity-preserving shape,
+/// we keep the current class binding. If it explicitly promises a replacement type, we let the
+/// unknown result replace the binding.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum ClassDecoratorUnknownResultPolicy {
     /// Preserve the current class binding when the decorator result is unknown.
@@ -620,9 +620,9 @@ enum ClassDecoratorUnknownResultPolicy {
 impl ClassDecoratorUnknownResultPolicy {
     /// Infer the unknown-result policy from the decorator's own type.
     ///
-    /// Unannotated function and method decorators are treated as class-preserving when their
-    /// application result is unknown. Explicit return annotations are trusted as replacement
-    /// intent.
+    /// Unknown decorators and unannotated function and method decorators are treated as
+    /// class-preserving when their application result is unknown. Explicit return annotations are
+    /// trusted as replacement intent.
     fn from_decorator<'db>(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -630,7 +630,7 @@ impl ClassDecoratorUnknownResultPolicy {
         decorator_result_ty: Type<'db>,
     ) -> Self {
         if decorator_ty.is_unknown() {
-            return Self::ReplaceBinding;
+            return Self::PreserveBinding;
         }
 
         Self::known_from_decorator(db, env, decorator_ty, decorator_result_ty)


### PR DESCRIPTION
## Summary

This is an experimental change to ty's class-decorator preservation heuristic.

Previously, a class decorator whose own inferred type was `Unknown` replaced the class binding with `Unknown`, even though an identifiable unannotated decorator with an `Unknown` application result preserved the original class. This change treats unknown decorators like those unannotated decorators: it preserves the current class binding while still reporting the diagnostic that made the decorator unknown.

Keeping the class binding lets ty retain instance and method types, report invalid downstream operations, and preserve generic class parameters instead of producing cascading specialization errors. Decorators with explicit return annotations and other intentionally class-replacing decorators retain their existing behavior.
