### PR TITLE
Install cargo tools locked

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,7 +2,7 @@
 
 rustup default < rust-toolchain
 rustup component add clippy rustfmt
-cargo install cargo-insta
+cargo install --locked cargo-insta@1.48.0
 cargo fetch
 
 pip install maturin prek

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Ruff is written in Rust. You'll need to install the
 You'll also need [Insta](https://insta.rs/docs/) to update snapshot tests:
 
 ```shell
-cargo install cargo-insta
+cargo install --locked cargo-insta
 ```
 
 You'll need [uv](https://docs.astral.sh/uv/getting-started/installation/) (or `pipx` and `pip`) to
@@ -612,7 +612,7 @@ git clone --branch 3.10 https://github.com/python/cpython.git crates/ruff_linter
 Install `hyperfine`:
 
 ```shell
-cargo install hyperfine
+cargo install --locked hyperfine
 ```
 
 To benchmark the release build:
@@ -777,7 +777,7 @@ critcmp main pr
 You must install [`critcmp`](https://github.com/BurntSushi/critcmp) for the comparison.
 
 ```bash
-cargo install critcmp
+cargo install --locked critcmp
 ```
 
 #### Tips
@@ -831,7 +831,7 @@ flamegraph --perfdata perf.data --no-inline
 Install [`cargo-instruments`](https://crates.io/crates/cargo-instruments):
 
 ```shell
-cargo install cargo-instruments
+cargo install --locked cargo-instruments
 ```
 
 Then run the profiler with

--- a/crates/ty/CONTRIBUTING.md
+++ b/crates/ty/CONTRIBUTING.md
@@ -28,7 +28,7 @@ ty is written in Rust. You'll need to install the
 You'll also need [Insta](https://insta.rs/docs/) to update snapshot tests:
 
 ```shell
-cargo install cargo-insta
+cargo install --locked cargo-insta
 ```
 
 You'll need [uv](https://docs.astral.sh/uv/getting-started/installation/) (or `pipx` and `pip`) to
@@ -45,7 +45,7 @@ We recommend [nextest](https://nexte.st/) to run ty's test suite (via `cargo nex
 though it's not strictly necessary:
 
 ```shell
-cargo install cargo-nextest --locked
+cargo install --locked cargo-nextest
 ```
 
 Throughout this guide, any usages of `cargo test` can be replaced with `cargo nextest run`,

--- a/crates/ty/docs/tracing.md
+++ b/crates/ty/docs/tracing.md
@@ -124,7 +124,7 @@ TY_LOG_PROFILE=1 ty -- --current-directory=../test -vvv
 You can convert the textual representation into a visual one using `inferno`.
 
 ```shell
-cargo install inferno
+cargo install --locked inferno
 ```
 
 ```shell

--- a/fuzz/init-fuzzer.sh
+++ b/fuzz/init-fuzzer.sh
@@ -8,7 +8,7 @@ cd "$SCRIPT_DIR"
 
 if ! cargo fuzz --help >&/dev/null; then
   echo "Installing cargo-fuzz..."
-  cargo install --git https://github.com/rust-fuzz/cargo-fuzz.git
+  cargo install --git https://github.com/rust-fuzz/cargo-fuzz.git --rev bf2fc668dafda5295aa6fd01825ee67b885f0f2b
 fi
 
 if [ ! -d corpus/common ]; then


### PR DESCRIPTION
Use `--locked` with all cargo dependencies, to harden against supply chain attacks. In scripts, additionally pin the specific version to be installed, to avoid automatic propagation of a newly released bad version.