### PR TITLE
[ty] Improve LiteralString suggestions in string annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -97,6 +97,25 @@ error[invalid-type-form]: `LiteralString` expects no type parameter
   |         Did you mean `Literal`?
 ```
 
+Aliases containing multiple literal values are also valid `Literal` arguments.
+
+```py
+MultipleValues = Literal["a", "b"]
+
+# snapshot: invalid-type-form
+multiple_values: "LiteralString[MultipleValues]"
+```
+
+```snapshot
+error[invalid-type-form]: `LiteralString` expects no type parameter
+  --> src/mdtest_snippet.py:10:19
+   |
+10 | multiple_values: "LiteralString[MultipleValues]"
+   |                   -------------^^^^^^^^^^^^^^^^
+   |                   |
+   |                   Did you mean `Literal`?
+```
+
 Ordinary variables are not valid `Literal` arguments, even if their values are strings.
 
 ```py
@@ -108,9 +127,9 @@ variable: "LiteralString[value]"
 
 ```snapshot
 error[invalid-type-form]: `LiteralString` expects no type parameter
-  --> src/mdtest_snippet.py:10:12
+  --> src/mdtest_snippet.py:14:12
    |
-10 | variable: "LiteralString[value]"
+14 | variable: "LiteralString[value]"
    |            ^^^^^^^^^^^^^^^^^^^^
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -73,6 +73,47 @@ from typing_extensions import LiteralString
 class C(LiteralString): ...  # error: [invalid-base]
 ```
 
+### Literal suggestions in string annotations
+
+A literal alias is valid as a `Literal` argument, so a parameterized `LiteralString` with a literal
+alias suggests `Literal`.
+
+```py
+from typing_extensions import Literal, LiteralString
+
+Alias = Literal["value"]
+
+# snapshot: invalid-type-form
+alias: "LiteralString[Alias]"
+```
+
+```snapshot
+error[invalid-type-form]: `LiteralString` expects no type parameter
+ --> src/mdtest_snippet.py:6:9
+  |
+6 | alias: "LiteralString[Alias]"
+  |         -------------^^^^^^^
+  |         |
+  |         Did you mean `Literal`?
+```
+
+Ordinary variables are not valid `Literal` arguments, even if their values are strings.
+
+```py
+value = "value"
+
+# snapshot: invalid-type-form
+variable: "LiteralString[value]"
+```
+
+```snapshot
+error[invalid-type-form]: `LiteralString` expects no type parameter
+  --> src/mdtest_snippet.py:10:12
+   |
+10 | variable: "LiteralString[value]"
+   |            ^^^^^^^^^^^^^^^^^^^^
+```
+
 ## Inference
 
 ### Common operations

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2602,48 +2602,55 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             SpecialFormType::LiteralString => {
                 let arguments = self.infer_expression(arguments_slice, TypeContext::default());
-                let argument_elements = if self.in_string_annotation() {
-                    let argument_expressions = match arguments_slice {
-                        ast::Expr::Tuple(tuple) => tuple.elts.as_slice(),
-                        _ => std::slice::from_ref(arguments_slice),
-                    };
-                    let mut builder = self.speculate_without_diagnostics();
-                    argument_expressions
-                        .iter()
-                        .map(|argument| {
-                            builder
-                                .infer_literal_parameter_type(argument)
-                                .unwrap_or(Type::unknown())
-                        })
-                        .collect::<Vec<_>>()
-                } else {
-                    let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
-                    arguments_as_tuple.as_ref().map_or_else(
-                        || vec![arguments],
-                        |tuple| tuple.iter_element_types(db).collect(),
-                    )
-                };
-
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                     let mut diag =
                         builder.into_diagnostic("`LiteralString` expects no type parameter");
 
-                    let probably_meant_literal = argument_elements.into_iter().all(|ty| match ty {
-                        Type::LiteralValue(literal)
-                            if matches!(
-                                literal.kind(),
-                                LiteralValueTypeKind::String(_)
-                                    | LiteralValueTypeKind::Bytes(_)
-                                    | LiteralValueTypeKind::Enum(_)
-                                    | LiteralValueTypeKind::Bool(_)
-                            ) =>
-                        {
-                            true
-                        }
-                        Type::NominalInstance(instance) => {
-                            instance.has_known_class(db, KnownClass::NoneType)
-                        }
-                        _ => false,
+                    let argument_elements = if self.in_string_annotation() {
+                        let argument_expressions = match arguments_slice {
+                            ast::Expr::Tuple(tuple) => tuple.elts.as_slice(),
+                            _ => std::slice::from_ref(arguments_slice),
+                        };
+                        let mut builder = self.speculate_without_diagnostics();
+                        argument_expressions
+                            .iter()
+                            .map(|argument| {
+                                builder
+                                    .infer_literal_parameter_type(argument)
+                                    .unwrap_or(Type::unknown())
+                            })
+                            .collect::<Vec<_>>()
+                    } else {
+                        let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
+                        arguments_as_tuple.as_ref().map_or_else(
+                            || vec![arguments],
+                            |tuple| tuple.iter_element_types(db).collect(),
+                        )
+                    };
+
+                    let probably_meant_literal = argument_elements.into_iter().all(|ty| {
+                        let elements = match ty {
+                            Type::Union(union) => union.elements(db),
+                            _ => std::slice::from_ref(&ty),
+                        };
+
+                        elements.iter().all(|ty| match ty {
+                            Type::LiteralValue(literal)
+                                if matches!(
+                                    literal.kind(),
+                                    LiteralValueTypeKind::String(_)
+                                        | LiteralValueTypeKind::Bytes(_)
+                                        | LiteralValueTypeKind::Enum(_)
+                                        | LiteralValueTypeKind::Bool(_)
+                                ) =>
+                            {
+                                true
+                            }
+                            Type::NominalInstance(instance) => {
+                                instance.has_known_class(db, KnownClass::NoneType)
+                            }
+                            _ => false,
+                        })
                     });
 
                     if probably_meant_literal {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2602,20 +2602,33 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             SpecialFormType::LiteralString => {
                 let arguments = self.infer_expression(arguments_slice, TypeContext::default());
+                let argument_elements = if self.in_string_annotation() {
+                    let argument_expressions = match arguments_slice {
+                        ast::Expr::Tuple(tuple) => tuple.elts.as_slice(),
+                        _ => std::slice::from_ref(arguments_slice),
+                    };
+                    let mut builder = self.speculate_without_diagnostics();
+                    argument_expressions
+                        .iter()
+                        .map(|argument| {
+                            builder
+                                .infer_literal_parameter_type(argument)
+                                .unwrap_or(Type::unknown())
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
+                    arguments_as_tuple.as_ref().map_or_else(
+                        || vec![arguments],
+                        |tuple| tuple.iter_element_types(db).collect(),
+                    )
+                };
 
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                     let mut diag =
                         builder.into_diagnostic("`LiteralString` expects no type parameter");
 
-                    let arguments_as_tuple = arguments.exact_tuple_instance_spec(db);
-
-                    let argument_elements = arguments_as_tuple.as_ref().map_or_else(
-                        || vec![arguments],
-                        |tuple| tuple.iter_element_types(db).collect(),
-                    );
-                    let mut argument_elements = argument_elements.into_iter();
-
-                    let probably_meant_literal = argument_elements.all(|ty| match ty {
+                    let probably_meant_literal = argument_elements.into_iter().all(|ty| match ty {
                         Type::LiteralValue(literal)
                             if matches!(
                                 literal.kind(),


### PR DESCRIPTION
## Summary

Previously, suggestions for invalid parameterized `LiteralString` annotations were based on the inferred runtime types of their arguments:

```python
from typing import Literal, LiteralString

Alias = Literal["value"]
alias: "LiteralString[Alias]"

value = "value"
variable: "LiteralString[value]"
```

We now check quoted arguments with the existing `Literal` argument validator before deciding whether to suggest `Literal`. This adds the suggestion for valid literal aliases and avoids suggesting it for ordinary variables. Evaluated annotations retain their existing behavior.
