### PR TITLE
[ty] Refresh uv project metadata in the background

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -6,6 +6,7 @@ mod rule;
 mod server;
 mod version;
 
+use std::fmt::Display;
 use std::io::{BufWriter, Write};
 use std::process::{ExitCode, Termination};
 use std::sync::Mutex;
@@ -27,7 +28,9 @@ use ruff_diagnostics::Applicability;
 use salsa::Database;
 use ty_project::metadata::settings::TerminalSettings;
 use ty_project::watch::ProjectWatcher;
-use ty_project::{CollectReporter, Db, ScriptEnvironmentAvailability, UvSyncProgress, watch};
+use ty_project::{
+    CollectReporter, Db, Project, ScriptEnvironmentAvailability, UvSyncProgress, watch,
+};
 use ty_project::{ProjectDatabase, ProjectMetadata};
 use ty_python_semantic::{fix_all_diagnostics, suppress_all_diagnostics};
 use ty_static::EnvVars;
@@ -502,7 +505,9 @@ impl MainLoop {
 
                     revision += 1;
                     // Automatically cancels any pending queries and waits for them to complete.
-                    db.apply_changes(&changes);
+                    db.apply_changes_with_progress(&changes, &|db, project| {
+                        self.progress.for_project(db, project)
+                    });
 
                     let environments = db.uv_environments().clone();
                     for file in environments.files() {
@@ -726,17 +731,24 @@ impl ProgressDisplay {
         }
     }
 
+    fn for_project(&self, db: &dyn Db, project: Project) -> Option<Box<dyn UvSyncProgress>> {
+        self.start("Refreshing", format_args!("{} metadata", project.name(db)))
+    }
+
     fn for_script(&self, db: &dyn Db, file: File) -> Option<Box<dyn UvSyncProgress>> {
+        let path = file.path(db).as_system_path()?;
+        let path = path.strip_prefix(db.project().root(db)).unwrap_or(path);
+        self.start("Syncing", path)
+    }
+
+    fn start(&self, action: &str, target: impl Display) -> Option<Box<dyn UvSyncProgress>> {
         if self.bars.is_hidden() {
             return None;
         }
 
-        let path = file.path(db).as_system_path()?;
-        let path = path.strip_prefix(db.project().root(db)).unwrap_or(path);
-
         let bar = self.bars.insert(0, indicatif::ProgressBar::hidden());
         bar.set_style(indicatif::ProgressStyle::with_template("{wide_msg}").unwrap());
-        bar.set_message(format!("   {} {path}", "Syncing".bold().cyan()));
+        bar.set_message(format!("   {} {target}", action.bold().cyan()));
         Some(Box::new(UvSyncProgressBar { bar }))
     }
 

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -341,7 +341,7 @@ impl MainLoop {
         tracing::debug!("Starting main loop");
 
         let mut revision = 0u64;
-        let script_sync_wakeups = db.script_environments().sync_wakeups();
+        let script_sync_wakeups = db.uv_environments().sync_wakeups();
         let (check_sender, check_receiver) = crossbeam_channel::bounded(1);
         request_check(db, &check_sender);
 
@@ -349,7 +349,7 @@ impl MainLoop {
         // cancels the running check.
         while let Ok(message) = crossbeam_channel::select_biased! {
             recv(script_sync_wakeups) -> wakeup => {
-                wakeup.map(|()| MainLoopMessage::PollScriptEnvironments)
+                wakeup.map(|()| MainLoopMessage::PollUvEnvironments)
             }
             recv(self.receiver) -> message => message,
             recv(check_receiver) -> request => request.map(|()| MainLoopMessage::CheckWorkspace),
@@ -357,7 +357,7 @@ impl MainLoop {
             match message {
                 MainLoopMessage::CheckWorkspace => {
                     // Synchronization may have started after this request was queued.
-                    if db.script_environments().has_pending_synchronizations() {
+                    if db.uv_environments().has_pending_synchronizations() {
                         tracing::debug!("Deferring check until script synchronization completes");
                         continue;
                     }
@@ -487,8 +487,8 @@ impl MainLoop {
                     return Ok(exit_status);
                 }
 
-                MainLoopMessage::PollScriptEnvironments => {
-                    let environments = db.script_environments().clone();
+                MainLoopMessage::PollUvEnvironments => {
+                    let environments = db.uv_environments().clone();
                     if !environments.poll_sync(db).is_empty() {
                         revision += 1;
                     }
@@ -504,7 +504,7 @@ impl MainLoop {
                     // Automatically cancels any pending queries and waits for them to complete.
                     db.apply_changes(&changes);
 
-                    let environments = db.script_environments().clone();
+                    let environments = db.uv_environments().clone();
                     for file in environments.files() {
                         environments.request_sync(
                             db,
@@ -785,13 +785,13 @@ enum MainLoopMessage {
         result: Vec<Diagnostic>,
         revision: u64,
     },
-    PollScriptEnvironments,
+    PollUvEnvironments,
     ApplyChanges(Vec<watch::ChangeEvent>),
     Exit,
 }
 
 fn request_check(db: &dyn Db, sender: &crossbeam_channel::Sender<()>) {
-    if db.script_environments().has_pending_synchronizations() {
+    if db.uv_environments().has_pending_synchronizations() {
         return;
     }
 

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -27,7 +27,7 @@ use ruff_diagnostics::Applicability;
 use salsa::Database;
 use ty_project::metadata::settings::TerminalSettings;
 use ty_project::watch::ProjectWatcher;
-use ty_project::{CollectReporter, Db, ScriptEnvironmentAvailability, ScriptSyncProgress, watch};
+use ty_project::{CollectReporter, Db, ScriptEnvironmentAvailability, UvSyncProgress, watch};
 use ty_project::{ProjectDatabase, ProjectMetadata};
 use ty_python_semantic::{fix_all_diagnostics, suppress_all_diagnostics};
 use ty_static::EnvVars;
@@ -155,12 +155,6 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         None => ProjectMetadata::discover(&project_path, &system)?,
     };
 
-    if watch && project_metadata.has_uv_workspace() {
-        return Err(anyhow!(
-            "`--watch` is not supported with uv workspace integration"
-        ));
-    }
-
     project_metadata.apply_configuration_files(&system)?;
 
     project_metadata.apply_override_options(args.into_options());
@@ -280,7 +274,7 @@ struct MainLoop {
     /// The file system watcher, if running in watch mode.
     watcher: Option<ProjectWatcher>,
 
-    /// Progress bars shared by project checks and background script synchronization.
+    /// Progress bars shared by project checks and background uv synchronization.
     progress: ProgressDisplay,
 
     /// Interface for displaying information to the user.
@@ -341,14 +335,14 @@ impl MainLoop {
         tracing::debug!("Starting main loop");
 
         let mut revision = 0u64;
-        let script_sync_wakeups = db.uv_environments().sync_wakeups();
+        let uv_sync_wakeups = db.uv_environments().sync_wakeups();
         let (check_sender, check_receiver) = crossbeam_channel::bounded(1);
         request_check(db, &check_sender);
 
         // Apply all queued changes before starting a pending check because every applied change
         // cancels the running check.
         while let Ok(message) = crossbeam_channel::select_biased! {
-            recv(script_sync_wakeups) -> wakeup => {
+            recv(uv_sync_wakeups) -> wakeup => {
                 wakeup.map(|()| MainLoopMessage::PollUvEnvironments)
             }
             recv(self.receiver) -> message => message,
@@ -358,7 +352,7 @@ impl MainLoop {
                 MainLoopMessage::CheckWorkspace => {
                     // Synchronization may have started after this request was queued.
                     if db.uv_environments().has_pending_synchronizations() {
-                        tracing::debug!("Deferring check until script synchronization completes");
+                        tracing::debug!("Deferring check until uv synchronization completes");
                         continue;
                     }
                     let db = db.clone();
@@ -489,8 +483,14 @@ impl MainLoop {
 
                 MainLoopMessage::PollUvEnvironments => {
                     let environments = db.uv_environments().clone();
-                    if !environments.poll_sync(db).is_empty() {
+                    let changes = environments.poll_sync(db);
+                    if !changes.is_empty() {
                         revision += 1;
+                    }
+                    if changes.project.is_some()
+                        && let Some(watcher) = self.watcher.as_mut()
+                    {
+                        watcher.update(db);
                     }
                     request_check(db, &check_sender);
                 }
@@ -691,7 +691,7 @@ impl ty_project::ProgressReporter for IndicatifReporter {
         self.checking_bar.tick();
     }
 
-    fn for_script(&self, db: &dyn Db, file: File) -> Option<Box<dyn ScriptSyncProgress>> {
+    fn for_script(&self, db: &dyn Db, file: File) -> Option<Box<dyn UvSyncProgress>> {
         self.progress.for_script(db, file)
     }
 
@@ -711,7 +711,7 @@ impl Drop for IndicatifReporter {
     }
 }
 
-/// Coordinates the file-checking bar and per-script synchronization messages.
+/// Coordinates the file-checking bar and uv synchronization messages.
 #[derive(Clone)]
 struct ProgressDisplay {
     bars: indicatif::MultiProgress,
@@ -726,7 +726,7 @@ impl ProgressDisplay {
         }
     }
 
-    fn for_script(&self, db: &dyn Db, file: File) -> Option<Box<dyn ScriptSyncProgress>> {
+    fn for_script(&self, db: &dyn Db, file: File) -> Option<Box<dyn UvSyncProgress>> {
         if self.bars.is_hidden() {
             return None;
         }
@@ -737,8 +737,7 @@ impl ProgressDisplay {
         let bar = self.bars.insert(0, indicatif::ProgressBar::hidden());
         bar.set_style(indicatif::ProgressStyle::with_template("{wide_msg}").unwrap());
         bar.set_message(format!("   {} {path}", "Syncing".bold().cyan()));
-
-        Some(Box::new(ScriptSyncProgressBar { bar }))
+        Some(Box::new(UvSyncProgressBar { bar }))
     }
 
     fn finish_checking(&self, bar: &indicatif::ProgressBar) {
@@ -751,13 +750,13 @@ impl ProgressDisplay {
     }
 }
 
-struct ScriptSyncProgressBar {
+struct UvSyncProgressBar {
     bar: indicatif::ProgressBar,
 }
 
-impl ScriptSyncProgress for ScriptSyncProgressBar {}
+impl UvSyncProgress for UvSyncProgressBar {}
 
-impl Drop for ScriptSyncProgressBar {
+impl Drop for UvSyncProgressBar {
     fn drop(&mut self) {
         self.bar.finish_and_clear();
     }

--- a/crates/ty/tests/cli/uv_workspace.rs
+++ b/crates/ty/tests/cli/uv_workspace.rs
@@ -403,13 +403,27 @@ fn warns_when_uv_workspace_metadata_cannot_be_loaded() -> anyhow::Result<()> {
         .env("TY_OUTPUT_FORMAT", "concise");
 
     assert_cmd_snapshot!(command, @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    pyproject.toml: warning[uv-metadata] Failed to invoke `uv workspace metadata`: failed to resolve uv executable: cannot find binary path
+    Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    command.env_remove("TY_OUTPUT_FORMAT");
+    command.arg("--exit-zero-on-warning");
+    assert_cmd_snapshot!(command, @"
     success: true
     exit_code: 0
     ----- stdout -----
-    All checks passed!
+    warning[uv-metadata]: Failed to invoke `uv workspace metadata`: failed to resolve uv executable: cannot find binary path
+    --> pyproject.toml:1:1
+
+    Found 1 diagnostic
 
     ----- stderr -----
-    WARN Failed to invoke `uv workspace metadata`: failed to resolve uv executable: cannot find binary path
     ");
 
     Ok(())

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -553,7 +553,7 @@ fn isolate_environment(system: &TestSystem) {
     }
 }
 
-/// Updates the content of a file and ensures that the last modified file time is updated.
+/// Dedents and updates a file's content, ensuring that its last modified time changes.
 fn update_file(path: impl AsRef<SystemPath>, content: &str) -> anyhow::Result<()> {
     let path = path.as_ref().as_std_path();
 
@@ -565,7 +565,7 @@ fn update_file(path: impl AsRef<SystemPath>, content: &str) -> anyhow::Result<()
         .write(true)
         .truncate(true)
         .open(path)?;
-    file.write_all(content.as_bytes())?;
+    file.write_all(dedent(content).as_bytes())?;
 
     loop {
         file.sync_all()?;
@@ -2502,26 +2502,125 @@ mod uv_metadata {
     use ruff_db::diagnostic::DiagnosticId;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{OsSystem, System as _};
-    use ruff_python_trivia::textwrap::dedent;
-    use ty_project::{Db, ScriptEnvironmentAvailability};
+    use ty_project::{Db, ScriptEnvironmentAvailability, UseUv, UvSyncChanges};
     use ty_static::EnvVars;
 
-    use super::{Setup, TestCase, event_for_file, setup_with_system, update_file};
+    use super::{SetupContext, TestCase, event_for_file, setup_with_system, update_file};
+
+    const MANIFEST: &str = r#"
+    [project]
+    name = "example"
+    version = "0.1.0"
+    requires-python = ">=3.8"
+    "#;
+
+    #[test]
+    fn project_refresh_applies_settings_despite_uv_errors() -> anyhow::Result<()> {
+        let mut case = setup_uv(
+            UseUv::On,
+            &[
+                ("pyproject.toml", MANIFEST),
+                ("main.py", "value: int = 'wrong'\n"),
+            ],
+        )?;
+        let project = case.db().project();
+        let program_settings = project.program_settings(case.db()).clone();
+        assert_eq!(case.db().check()[0].id().as_str(), "invalid-assignment");
+
+        // uv rejects this setting, but ty must still apply its rule configuration.
+        update_and_synchronize_project(
+            &mut case,
+            r#"
+            [project]
+            name = "example"
+            version = "0.1.0"
+            requires-python = ">=3.8"
+
+            [tool.uv]
+            package = "invalid"
+
+            [tool.ty.rules]
+            invalid-assignment = "ignore"
+            "#,
+        )?;
+        let diagnostics = case.db().check();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].id(), DiagnosticId::UvMetadata);
+        assert_eq!(project.program_settings(case.db()), &program_settings);
+
+        // If ordinary discovery also fails, keep the last applied settings and warning.
+        update_and_synchronize_project(&mut case, "[project\n")?;
+        assert_eq!(case.db().check(), diagnostics);
+
+        update_and_synchronize_project(
+            &mut case,
+            r#"
+            [project]
+            name = "example"
+            version = "0.1.0"
+            requires-python = ">=3.8"
+
+            [tool.ty.rules]
+            invalid-assignment = "ignore"
+            "#,
+        )?;
+        assert!(case.db().check().is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn project_refresh_uses_the_returned_workspace_root() -> anyhow::Result<()> {
+        let mut case = setup_uv(
+            UseUv::On,
+            &[
+                (
+                    "../pyproject.toml",
+                    r#"
+                    [tool.uv.workspace]
+                    members = ["project"]
+                    "#,
+                ),
+                (
+                    "pyproject.toml",
+                    r#"
+                    [project]
+                    name = "example"
+                    version = "0.1.0"
+                    requires-python = ">=3.8"
+
+                    [tool.ty]
+                    "#,
+                ),
+            ],
+        )?;
+        let project = case.db().project();
+        assert_eq!(
+            project.root(case.db()),
+            case.root_path().join("project").as_path()
+        );
+
+        // Without its own ty configuration, the member belongs to the enclosing workspace.
+        update_and_synchronize_project(&mut case, MANIFEST)?;
+        assert_eq!(case.db().project(), project);
+        assert_eq!(project.root(case.db()), case.root_path());
+        Ok(())
+    }
 
     #[test]
     fn unchanged_script_environment_is_reused_after_source_edits() -> anyhow::Result<()> {
-        assert_uv_supports_script_metadata()?;
-
-        let mut case = setup_script_uv([(
-            "script.py",
-            r#"
-            # /// script
-            # requires-python = ">=3.12"
-            # dependencies = ["attrs==25.4.0"]
-            # ///
-            from attrs import define
-            "#,
-        )])?;
+        let mut case = setup_uv(
+            UseUv::Scripts,
+            &[(
+                "script.py",
+                r#"
+                # /// script
+                # requires-python = ">=3.12"
+                # dependencies = []
+                # ///
+                value = 1
+                "#,
+            )],
+        )?;
 
         assert!(case.db().check().is_empty());
 
@@ -2531,9 +2630,8 @@ mod uv_metadata {
 
             # /// script
             # requires-python = ">=3.12"
-            # dependencies = ["attrs==25.4.0"]
+            # dependencies = []
             # ///
-            from attrs import define
             value = 2
             "#,
         )?);
@@ -2545,26 +2643,29 @@ mod uv_metadata {
 
     #[test]
     fn metadata_changes_resynchronize_the_script_environment() -> anyhow::Result<()> {
-        assert_uv_supports_script_metadata()?;
+        let mut case = setup_uv(
+            UseUv::Scripts,
+            &[(
+                "script.py",
+                r#"
+                # /// script
+                # requires-python = ">=3.12"
+                # dependencies = []
+                # ///
+                from attrs import define
+                "#,
+            )],
+        )?;
 
-        let mut case = setup_script_uv([(
-            "script.py",
-            r#"
-            # /// script
-            # requires-python = ">=3.12"
-            # dependencies = ["attrs==25.4.0"]
-            # ///
-            from attrs import define
-            "#,
-        )])?;
-
-        assert!(case.db().check().is_empty());
+        let diagnostics = case.db().check();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].id().as_str(), "unresolved-import");
 
         let synchronized = update_and_synchronize_script(
             &mut case,
             r#"
             # /// script
-            # requires-python = ">=3.11"
+            # requires-python = ">=3.12"
             # dependencies = ["attrs==25.4.0"]
             # ///
             from attrs import define
@@ -2579,9 +2680,10 @@ mod uv_metadata {
 
     #[test]
     fn ordinary_files_becoming_scripts_initialize_their_environments() -> anyhow::Result<()> {
-        assert_uv_supports_script_metadata()?;
-
-        let mut case = setup_script_uv([("script.py", "from attrs import define\n")])?;
+        let mut case = setup_uv(
+            UseUv::Scripts,
+            &[("script.py", "from attrs import define\n")],
+        )?;
 
         let ordinary = case.db().check();
         assert!(
@@ -2609,18 +2711,19 @@ mod uv_metadata {
 
     #[test]
     fn corrected_script_dependencies_replace_initialization_errors() -> anyhow::Result<()> {
-        assert_uv_supports_script_metadata()?;
-
-        let mut case = setup_script_uv([(
-            "script.py",
-            r#"
-            # /// script
-            # requires-python = ">=3.12"
-            # dependencies = ["not a valid requirement ???"]
-            # ///
-            value = 1
-            "#,
-        )])?;
+        let mut case = setup_uv(
+            UseUv::Scripts,
+            &[(
+                "script.py",
+                r#"
+                # /// script
+                # requires-python = ">=3.12"
+                # dependencies = ["not a valid requirement ???"]
+                # ///
+                value = 1
+                "#,
+            )],
+        )?;
 
         let initial = case.db().check();
         assert!(
@@ -2650,33 +2753,51 @@ mod uv_metadata {
         Ok(())
     }
 
-    fn assert_uv_supports_script_metadata() -> anyhow::Result<()> {
-        let output = Command::new("uv")
-            .args(["workspace", "metadata", "--help"])
-            .output()
-            .context("failed to inspect uv workspace metadata support")?;
+    fn setup_uv(use_uv: UseUv, files: &[(&str, &str)]) -> anyhow::Result<TestCase> {
+        let uv = OsSystem::default().which("uv")?;
+        setup_with_system(
+            |context: &mut SetupContext| {
+                for (path, content) in files {
+                    context.write_project_file(path, content)?;
+                }
+                if use_uv == UseUv::On {
+                    let output = Command::new(uv.as_std_path())
+                        .current_dir(context.project_path())
+                        .args(["sync", "--offline"])
+                        .output()?;
+                    anyhow::ensure!(
+                        output.status.success(),
+                        "uv sync failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
+                Ok(())
+            },
+            |system| {
+                system.set_env_var(
+                    EnvVars::TY_UV,
+                    match use_uv {
+                        UseUv::Off => "0",
+                        UseUv::Scripts => "scripts",
+                        UseUv::On => "1",
+                    },
+                );
+                system.set_env_var(EnvVars::UV, uv.as_str());
+            },
+        )
+    }
 
-        assert!(
-            output.status.success() && String::from_utf8_lossy(&output.stdout).contains("--script"),
-            "installed uv does not support script metadata"
-        );
+    fn update_and_synchronize_project(case: &mut TestCase, source: &str) -> anyhow::Result<()> {
+        update_file(case.project_path("pyproject.toml"), source)?;
+        let changes = case.take_watch_changes(event_for_file("pyproject.toml"));
+        case.apply_changes(&changes);
 
+        wait_for_synchronizations(case)?;
         Ok(())
     }
 
-    fn setup_script_uv<F>(setup_files: F) -> anyhow::Result<TestCase>
-    where
-        F: Setup,
-    {
-        let uv = OsSystem::default().which("uv")?;
-        setup_with_system(setup_files, move |system| {
-            system.set_env_var(EnvVars::TY_UV, "scripts");
-            system.set_env_var(EnvVars::UV, uv.as_str());
-        })
-    }
-
     fn update_and_synchronize_script(case: &mut TestCase, source: &str) -> anyhow::Result<bool> {
-        update_file(case.project_path("script.py"), &dedent(source))?;
+        update_file(case.project_path("script.py"), source)?;
         let changes = case.take_watch_changes(event_for_file("script.py"));
         case.apply_changes(&changes);
 
@@ -2685,24 +2806,36 @@ mod uv_metadata {
         if !environments.files().contains(&file) {
             return Ok(false);
         }
-        let wakeups = environments.sync_wakeups();
         environments.request_sync(
             &mut case.db,
             file,
             ScriptEnvironmentAvailability::Pending,
             &|_, _| None,
         );
-        if !environments.has_pending_synchronizations() {
-            return Ok(false);
-        }
-        let mut changed = Vec::new();
+
+        Ok(!wait_for_synchronizations(case)?.scripts.is_empty())
+    }
+
+    fn wait_for_synchronizations(case: &mut TestCase) -> anyhow::Result<UvSyncChanges> {
+        let environments = case.db().uv_environments().clone();
+        let wakeups = environments.sync_wakeups();
+        let mut changes = UvSyncChanges::default();
         while environments.has_pending_synchronizations() {
             wakeups
                 .recv_timeout(Duration::from_secs(30))
-                .context("script synchronization did not finish")?;
-            changed.extend(environments.poll_sync(&mut case.db));
+                .context("uv synchronization did not finish")?;
+            let completed = environments.poll_sync(&mut case.db);
+            changes.scripts.extend(completed.scripts);
+            changes.project = completed.project.or(changes.project);
         }
 
-        Ok(!changed.is_empty())
+        if changes.project.is_some()
+            && let Some(watcher) = &mut case.watcher
+        {
+            watcher.update(&case.db);
+            assert!(!watcher.has_errored_paths());
+        }
+
+        Ok(changes)
     }
 }

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -2681,7 +2681,7 @@ mod uv_metadata {
         case.apply_changes(&changes);
 
         let file = system_path_to_file(case.db(), case.project_path("script.py"))?;
-        let environments = case.db().script_environments().clone();
+        let environments = case.db().uv_environments().clone();
         if !environments.files().contains(&file) {
             return Ok(false);
         }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -6,7 +6,8 @@ use std::{cmp, fmt};
 pub use self::changes::ChangeResult;
 use crate::CollectReporter;
 use crate::metadata::settings::file_settings;
-use crate::script::{Script, ScriptEnvironments};
+use crate::script::Script;
+use crate::uv::UvEnvironments;
 use crate::{ProgressReporter, Project, ProjectMetadata};
 use get_size2::StandardTracker;
 use ruff_db::Db as SourceDb;
@@ -27,7 +28,7 @@ mod changes;
 pub trait Db: SemanticDb {
     fn project(&self) -> Project;
 
-    fn script_environments(&self) -> &ScriptEnvironments;
+    fn uv_environments(&self) -> &UvEnvironments;
 
     fn dyn_clone(&self) -> Box<dyn Db>;
 }
@@ -55,7 +56,7 @@ fn program_file(db: &dyn Db, file: File) -> ProgramFile<'_> {
     }
 
     let program = db
-        .script_environments()
+        .uv_environments()
         .files()
         .into_iter()
         .filter_map(|script| Script::for_file(db, script))
@@ -90,7 +91,7 @@ pub struct ProjectDatabase {
     // setters instead of swapping in a freshly constructed handle.
     project: Option<Project>,
     files: Files,
-    script_environments: ScriptEnvironments,
+    uv_environments: UvEnvironments,
 
     // IMPORTANT: Never return clones of `system` outside `ProjectDatabase` (only return references)
     // or the "trick" to get a mutable `Arc` in `Self::system_mut` is no longer guaranteed to work.
@@ -146,7 +147,7 @@ impl ProjectDatabase {
     where
         S: System + 'static + Send + Sync + RefUnwindSafe,
     {
-        let script_environments = ScriptEnvironments::new(project_metadata.use_uv());
+        let uv_environments = UvEnvironments::new(project_metadata.use_uv());
         let mut db = Self {
             project: None,
             storage: salsa::Storage::new(if tracing::enabled!(tracing::Level::TRACE) {
@@ -163,7 +164,7 @@ impl ProjectDatabase {
                 None
             }),
             files: Files::default(),
-            script_environments,
+            uv_environments,
             system: Arc::new(system),
         };
 
@@ -645,8 +646,8 @@ impl Db for ProjectDatabase {
         self.project.unwrap()
     }
 
-    fn script_environments(&self) -> &ScriptEnvironments {
-        &self.script_environments
+    fn uv_environments(&self) -> &UvEnvironments {
+        &self.uv_environments
     }
 
     fn dyn_clone(&self) -> Box<dyn Db> {
@@ -694,7 +695,8 @@ pub(crate) mod testing {
 
     use crate::db::Db;
     use crate::metadata::settings::file_settings;
-    use crate::script::{Script, ScriptEnvironments};
+    use crate::script::Script;
+    use crate::uv::UvEnvironments;
     use crate::{Project, ProjectMetadata};
 
     type Events = Arc<Mutex<Vec<salsa::Event>>>;
@@ -705,7 +707,7 @@ pub(crate) mod testing {
         storage: salsa::Storage<Self>,
         events: Events,
         files: Files,
-        script_environments: ScriptEnvironments,
+        uv_environments: UvEnvironments,
         system: TestSystem,
         vendored: VendoredFileSystem,
         project: Option<Project>,
@@ -714,7 +716,7 @@ pub(crate) mod testing {
     impl TestDb {
         pub fn new(project: ProjectMetadata) -> Self {
             let events = Events::default();
-            let script_environments = ScriptEnvironments::new(project.use_uv());
+            let uv_environments = UvEnvironments::new(project.use_uv());
             let mut db = Self {
                 storage: salsa::Storage::new(Some(Box::new({
                     let events = events.clone();
@@ -726,7 +728,7 @@ pub(crate) mod testing {
                 system: TestSystem::default(),
                 vendored: ty_vendored::file_system().clone(),
                 files: Files::default(),
-                script_environments,
+                uv_environments,
                 events,
                 project: None,
             };
@@ -875,8 +877,8 @@ pub(crate) mod testing {
             self.project.unwrap()
         }
 
-        fn script_environments(&self) -> &ScriptEnvironments {
-            &self.script_environments
+        fn uv_environments(&self) -> &UvEnvironments {
+            &self.uv_environments
         }
 
         fn dyn_clone(&self) -> Box<dyn Db> {

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -240,7 +240,30 @@ impl ProjectDatabase {
         Files::sync_all_recursive(self, sync_recursively);
 
         if reload_project {
-            match project.rediscover(self) {
+            // The active project root may have been deleted. Start rediscovery from the closest
+            // existing ancestor so ty can fall back to an enclosing project.
+            let path = project_root
+                .ancestors()
+                .find(|path| self.system().is_directory(path))
+                .unwrap_or(&project_root);
+            let metadata = project.metadata(self);
+            let uv_workspace = if metadata.use_uv().workspace_discovery_enabled()
+                && metadata.config_file_override().is_none()
+            {
+                match self.uv_environments().workspace_metadata(self, path) {
+                    Ok(metadata) => Some(metadata),
+                    Err(error) => {
+                        // A failed refresh must not discard the last working uv metadata.
+                        tracing::warn!("{error}");
+                        metadata.uv_workspace().cloned()
+                    }
+                }
+            } else {
+                // No uv refresh is needed, so preserve the applied environment while
+                // rediscovering the project configuration.
+                metadata.uv_workspace().cloned()
+            };
+            match project.rediscover(self, path, uv_workspace) {
                 Ok(ProjectReloadResult::Unchanged) => {}
                 Ok(ProjectReloadResult::Changed { files_changed }) => {
                     result.project_changed = true;

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -1,4 +1,5 @@
 use crate::db::{Db, ProjectDatabase};
+use crate::uv::ProjectEnvironment;
 use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
 use crate::{ProjectMetadata, ProjectReloadResult};
 use std::collections::BTreeSet;
@@ -247,23 +248,26 @@ impl ProjectDatabase {
                 .find(|path| self.system().is_directory(path))
                 .unwrap_or(&project_root);
             let metadata = project.metadata(self);
-            let uv_workspace = if metadata.use_uv().workspace_discovery_enabled()
+            let environment = if metadata.use_uv().workspace_discovery_enabled()
                 && metadata.config_file_override().is_none()
             {
                 match self.uv_environments().workspace_metadata(self, path) {
-                    Ok(metadata) => Some(metadata),
-                    Err(error) => {
-                        // A failed refresh must not discard the last working uv metadata.
-                        tracing::warn!("{error}");
-                        metadata.uv_workspace().cloned()
-                    }
+                    Ok(metadata) => ProjectEnvironment {
+                        metadata: Some(metadata),
+                        error: None,
+                    },
+                    // Keep the last working uv metadata so a failed refresh does not change
+                    // the environment used for checking. Report the new error instead.
+                    Err(error) => ProjectEnvironment {
+                        error: Some(error.to_string().into_boxed_str()),
+                        ..metadata.environment().clone()
+                    },
                 }
             } else {
-                // No uv refresh is needed, so preserve the applied environment while
-                // rediscovering the project configuration.
-                metadata.uv_workspace().cloned()
+                // We're not refreshing uv metadata, so use the existing environment.
+                metadata.environment().clone()
             };
-            match project.rediscover(self, path, uv_workspace) {
+            match project.rediscover(self, path, environment) {
                 Ok(ProjectReloadResult::Unchanged) => {}
                 Ok(ProjectReloadResult::Changed { files_changed }) => {
                     result.project_changed = true;

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -1,7 +1,6 @@
 use crate::db::{Db, ProjectDatabase};
-use crate::uv::ProjectEnvironment;
 use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
-use crate::{ProjectMetadata, ProjectReloadResult};
+use crate::{ProjectMetadata, ProjectReloadResult, ProjectSyncProgressFactory};
 use std::collections::BTreeSet;
 
 use crate::walk::{ProjectFilesWalker, create_walker_builder};
@@ -30,8 +29,17 @@ impl ChangeResult {
 }
 
 impl ProjectDatabase {
-    #[tracing::instrument(level = "debug", skip(self, changes))]
     pub fn apply_changes(&mut self, changes: &[ChangeEvent]) -> ChangeResult {
+        self.apply_changes_with_progress(changes, &|_, _| None)
+    }
+
+    /// Applies file changes, reporting progress if project metadata must be refreshed.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub fn apply_changes_with_progress(
+        &mut self,
+        changes: &[ChangeEvent],
+        make_progress: &ProjectSyncProgressFactory<'_>,
+    ) -> ChangeResult {
         let project = self.project();
         let project_root = project.root(self).to_path_buf();
         let configuration_paths = ConfigurationPaths::from_metadata(project.metadata(self));
@@ -248,43 +256,33 @@ impl ProjectDatabase {
                 .find(|path| self.system().is_directory(path))
                 .unwrap_or(&project_root);
             let metadata = project.metadata(self);
-            let environment = if metadata.use_uv().workspace_discovery_enabled()
+            if metadata.use_uv().workspace_discovery_enabled()
                 && metadata.config_file_override().is_none()
             {
-                match self.uv_environments().workspace_metadata(self, path) {
-                    Ok(metadata) => ProjectEnvironment {
-                        metadata: Some(metadata),
-                        error: None,
-                    },
-                    // Keep the last working uv metadata so a failed refresh does not change
-                    // the environment used for checking. Report the new error instead.
-                    Err(error) => ProjectEnvironment {
-                        error: Some(error.to_string().into_boxed_str()),
-                        ..metadata.environment().clone()
-                    },
-                }
+                self.uv_environments()
+                    .request_project_sync(self, path, make_progress);
             } else {
                 // We're not refreshing uv metadata, so use the existing environment.
-                metadata.environment().clone()
-            };
-            match project.rediscover(self, path, environment) {
-                Ok(ProjectReloadResult::Unchanged) => {}
-                Ok(ProjectReloadResult::Changed { files_changed }) => {
-                    result.project_changed = true;
-                    if files_changed {
-                        // The project file set has already been rebuilt; continuing would
-                        // run incremental discovery from paths collected before the reload.
-                        return result;
+                let environment = metadata.environment().clone();
+                match project.rediscover(self, path, environment) {
+                    Ok(ProjectReloadResult::Unchanged) => {}
+                    Ok(ProjectReloadResult::Changed { files_changed }) => {
+                        result.project_changed = true;
+                        if files_changed {
+                            // The project file set has already been rebuilt; continuing would
+                            // run incremental discovery from paths collected before the reload.
+                            return result;
+                        }
                     }
-                }
-                Err(error) => {
-                    let error = anyhow::Error::new(error);
-                    tracing::error!(
-                        "Failed to load project, keeping old project configuration: {error:#}"
-                    );
-                    if reload_project_files {
-                        project.reload_files(self);
-                        return result;
+                    Err(error) => {
+                        let error = anyhow::Error::new(error);
+                        tracing::error!(
+                            "Failed to load project, keeping old project configuration: {error:#}"
+                        );
+                        if reload_project_files {
+                            project.reload_files(self);
+                            return result;
+                        }
                     }
                 }
             }

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -240,66 +240,14 @@ impl ProjectDatabase {
         Files::sync_all_recursive(self, sync_recursively);
 
         if reload_project {
-            let new_project_metadata = project.metadata(self).rediscover(self.system());
-            match new_project_metadata {
-                Ok(mut metadata) => {
-                    if let Err(error) = metadata.apply_configuration_files(self.system()) {
-                        let error = anyhow::Error::new(error);
-                        tracing::error!(
-                            "Failed to apply configuration files, \
-                            continuing without applying them: {error:#}"
-                        );
-                    }
-
-                    metadata.try_add_project_root(self);
-                    let merged_options = metadata.to_merged_options();
-
-                    let program_settings_diagnostics = match merged_options.to_program_settings(
-                        self.system(),
-                        self.vendored(),
-                        &FallibleStrategy,
-                    ) {
-                        Ok((program_settings, diagnostics)) => {
-                            project.update_program(self, program_settings);
-                            diagnostics
-                        }
-                        Err(error) => {
-                            tracing::error!(
-                                "Failed to convert metadata to program settings, \
-                                continuing without applying them: {error}"
-                            );
-                            Vec::new()
-                        }
-                    };
-
-                    let (settings, mut settings_diagnostics) =
-                        match merged_options.to_settings(self, &FallibleStrategy) {
-                            Ok((settings, diagnostics)) => (Some(settings), diagnostics),
-                            Err(error) => {
-                                tracing::warn!(
-                                    "Keeping old project configuration because loading the new \
-                                     settings failed with: {error}"
-                                );
-                                (None, vec![error.into_diagnostic()])
-                            }
-                        };
-                    settings_diagnostics.extend(
-                        program_settings_diagnostics
-                            .into_iter()
-                            .map(|diagnostic| diagnostic.into_diagnostic(self)),
-                    );
-
-                    tracing::debug!("Reloading project after structural change");
-                    match project.reload(self, metadata, settings, settings_diagnostics) {
-                        ProjectReloadResult::Unchanged => {}
-                        ProjectReloadResult::Changed { files_changed } => {
-                            result.project_changed = true;
-                            if files_changed {
-                                // The project file set has already been rebuilt; continuing would
-                                // run incremental discovery from paths collected before the reload.
-                                return result;
-                            }
-                        }
+            match project.rediscover(self) {
+                Ok(ProjectReloadResult::Unchanged) => {}
+                Ok(ProjectReloadResult::Changed { files_changed }) => {
+                    result.project_changed = true;
+                    if files_changed {
+                        // The project file set has already been rebuilt; continuing would
+                        // run incremental discovery from paths collected before the reload.
+                        return result;
                     }
                 }
                 Err(error) => {

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -30,7 +30,7 @@ use std::iter::FusedIterator;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 use ty_python_core::ProgramFile;
-use ty_python_core::program::{Program, ProgramSettings};
+use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
 pub use ty_python_semantic::Db as SemanticDb;
 use ty_python_semantic::lint::RuleSelection;
 pub use uv::{ScriptEnvironmentAvailability, UseUv, UvEnvironments};
@@ -306,6 +306,60 @@ impl Project {
                 .is_directory_included(path, GlobFilterCheckMode::Adhoc),
             IncludeResult::Included { .. }
         )
+    }
+
+    /// Rediscovers this project and applies its metadata and settings.
+    fn rediscover(
+        self,
+        db: &mut dyn Db,
+    ) -> Result<ProjectReloadResult, ProjectMetadataError> {
+        let mut metadata = self.metadata(db).rediscover(db.system())?;
+        if let Err(error) = metadata.apply_configuration_files(db.system()) {
+            let error = anyhow::Error::new(error);
+            tracing::error!(
+                "Failed to apply configuration files, \
+                continuing without applying them: {error:#}"
+            );
+        }
+
+        metadata.try_add_project_root(db);
+        let merged_options = metadata.to_merged_options();
+
+        let program_settings_diagnostics =
+            match merged_options.to_program_settings(db.system(), db.vendored(), &FallibleStrategy)
+            {
+                Ok((program_settings, diagnostics)) => {
+                    self.update_program(db, program_settings);
+                    diagnostics
+                }
+                Err(error) => {
+                    tracing::error!(
+                        "Failed to convert metadata to program settings, \
+                         continuing without applying them: {error}"
+                    );
+                    Vec::new()
+                }
+            };
+
+        let (settings, mut settings_diagnostics) =
+            match merged_options.to_settings(db, &FallibleStrategy) {
+                Ok((settings, diagnostics)) => (Some(settings), diagnostics),
+                Err(error) => {
+                    tracing::warn!(
+                        "Keeping old project configuration because loading the new \
+                         settings failed with: {error}"
+                    );
+                    (None, vec![error.into_diagnostic()])
+                }
+            };
+        settings_diagnostics.extend(
+            program_settings_diagnostics
+                .into_iter()
+                .map(|diagnostic| diagnostic.into_diagnostic(db)),
+        );
+
+        tracing::debug!("Reloading project after structural change");
+        Ok(self.reload(db, metadata, settings, settings_diagnostics))
     }
 
     /// Reload the project after its metadata or settings have changed.

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -279,7 +279,7 @@ impl Project {
         self.metadata(db).root()
     }
 
-    fn name(self, db: &dyn Db) -> &str {
+    pub fn name(self, db: &dyn Db) -> &str {
         self.metadata(db).name()
     }
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -33,7 +33,7 @@ use ty_python_core::ProgramFile;
 use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
 pub use ty_python_semantic::Db as SemanticDb;
 use ty_python_semantic::lint::RuleSelection;
-pub use uv::{ScriptEnvironmentAvailability, UseUv, UvEnvironments};
+pub use uv::{ScriptEnvironmentAvailability, UseUv, UvEnvironments, UvSyncChanges};
 
 mod db;
 mod files;
@@ -143,7 +143,7 @@ pub trait ProgressReporter: Send + Sync {
     /// Creates an owned progress guard for synchronizing `file`'s standalone-script environment.
     ///
     /// Returns `None` when synchronization progress should not be displayed.
-    fn for_script(&self, _db: &dyn Db, _file: File) -> Option<Box<dyn ScriptSyncProgress>> {
+    fn for_script(&self, _db: &dyn Db, _file: File) -> Option<Box<dyn UvSyncProgress>> {
         None
     }
 
@@ -156,13 +156,17 @@ pub trait ProgressReporter: Send + Sync {
     fn report_diagnostics(&mut self, db: &ProjectDatabase, diagnostics: Vec<Diagnostic>);
 }
 
-/// An owned progress guard for synchronizing a standalone script's environment.
+/// An owned progress guard for a project or standalone-script uv metadata request.
 ///
 /// Creating the guard starts progress reporting and dropping it finishes progress reporting. A
 /// background synchronization may move the guard between threads and outlive the operation that
 /// scheduled it. Implementations must not retain a database because doing so could keep a cancelled
 /// database snapshot alive until synchronization finishes.
-pub trait ScriptSyncProgress: Send {}
+pub trait UvSyncProgress: Send {}
+
+/// Creates progress reporting when a project metadata refresh is scheduled.
+pub type ProjectSyncProgressFactory<'a> =
+    dyn Fn(&dyn Db, Project) -> Option<Box<dyn UvSyncProgress>> + 'a;
 
 /// Reporter that collects all diagnostics into a `Vec`.
 #[derive(Default)]

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -314,11 +314,11 @@ impl Project {
         self,
         db: &mut dyn Db,
         path: &SystemPath,
-        uv_workspace: Option<uv::UvMetadata>,
+        environment: uv::ProjectEnvironment,
     ) -> Result<ProjectReloadResult, ProjectMetadataError> {
         let mut metadata = self
             .metadata(db)
-            .rediscover(db.system(), path, uv_workspace)?;
+            .rediscover(db.system(), path, environment)?;
         if let Err(error) = metadata.apply_configuration_files(db.system()) {
             let error = anyhow::Error::new(error);
             tracing::error!(
@@ -436,11 +436,7 @@ impl Project {
             name = self.name(db)
         );
 
-        let mut diagnostics: Vec<Diagnostic> = self
-            .settings_diagnostics(db)
-            .iter()
-            .map(OptionDiagnostic::to_diagnostic)
-            .collect();
+        let mut diagnostics = self.check_settings(db);
 
         let files = ProjectFiles::new(db, self);
         reporter.set_files(files.len());
@@ -735,6 +731,7 @@ impl Project {
         self.settings_diagnostics(db)
             .iter()
             .map(OptionDiagnostic::to_diagnostic)
+            .chain(self.metadata(db).uv_diagnostic(db))
             .collect()
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -23,7 +23,7 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use rustc_hash::FxHashSet;
 use salsa::{Database, Durability, Setter};
-pub use script::{ScriptEnvironmentAvailability, ScriptEnvironments, script_tag};
+pub use script::script_tag;
 use std::backtrace::BacktraceStatus;
 use std::collections::{BTreeSet, hash_set};
 use std::iter::FusedIterator;
@@ -33,7 +33,7 @@ use ty_python_core::ProgramFile;
 use ty_python_core::program::{Program, ProgramSettings};
 pub use ty_python_semantic::Db as SemanticDb;
 use ty_python_semantic::lint::RuleSelection;
-pub use uv::UseUv;
+pub use uv::{ScriptEnvironmentAvailability, UseUv, UvEnvironments};
 
 mod db;
 mod files;
@@ -404,9 +404,7 @@ impl Project {
                 let check_file_span =
                     tracing::debug_span!(parent: &project_span, "check_file", ?file);
                 let _entered = check_file_span.entered();
-                let initialization = db
-                    .script_environments()
-                    .initialize_blocking(db, file, reporter);
+                let initialization = db.uv_environments().initialize_blocking(db, file, reporter);
                 if initialization.is_pending() {
                     // The CLI watch loop or language server already scheduled this script's first
                     // synchronization in the background. Until it completes, there is no
@@ -706,7 +704,7 @@ pub fn should_check_semantics(db: &dyn Db, file: File) -> bool {
         return true;
     };
 
-    script.has_valid_settings(db) && !db.script_environments().is_initialization_pending(db, file)
+    script.has_valid_settings(db) && !db.uv_environments().is_initialization_pending(db, file)
 }
 
 /// Returns `true` if the file should be checked.

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -308,12 +308,17 @@ impl Project {
         )
     }
 
-    /// Rediscovers this project and applies its metadata and settings.
+    /// Rediscovers this project from `path` and applies its metadata and settings.
+    /// If discovery fails, the project is left unchanged.
     fn rediscover(
         self,
         db: &mut dyn Db,
+        path: &SystemPath,
+        uv_workspace: Option<uv::UvMetadata>,
     ) -> Result<ProjectReloadResult, ProjectMetadataError> {
-        let mut metadata = self.metadata(db).rediscover(db.system())?;
+        let mut metadata = self
+            .metadata(db)
+            .rediscover(db.system(), path, uv_workspace)?;
         if let Err(error) = metadata.apply_configuration_files(db.system()) {
             let error = anyhow::Error::new(error);
             tracing::error!(

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -1,6 +1,8 @@
 use compact_str::CompactString;
 use configuration_file::{ConfigurationFile, ConfigurationFileError};
+use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
 use ruff_db::files::FileRootKind;
+use ruff_db::files::system_path_to_file;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_ranged_value::ValueSource;
@@ -18,7 +20,7 @@ use crate::metadata::options::{
 use crate::metadata::pyproject::{Project, PyProject, PyProjectError, ResolveRequiresPythonError};
 use crate::metadata::settings::Settings;
 use crate::metadata::value::RelativePathBuf;
-use crate::uv::{self, UseUv};
+use crate::uv::{self, ProjectEnvironment, UseUv};
 pub use options::Options;
 use options::TyTomlError;
 mod configuration_file;
@@ -70,7 +72,7 @@ pub struct ProjectMetadata {
     config_file_override: Option<SystemPathBuf>,
 
     #[cfg_attr(test, serde(skip))]
-    uv_workspace: Option<uv::UvMetadata>,
+    environment: ProjectEnvironment,
 
     #[cfg_attr(test, serde(skip))]
     use_uv: UseUv,
@@ -88,7 +90,7 @@ impl ProjectMetadata {
             user_configuration: None,
             fallback_options: None,
             config_file_override: None,
-            uv_workspace: None,
+            environment: ProjectEnvironment::default(),
             use_uv: UseUv::Off,
         }
     }
@@ -128,7 +130,7 @@ impl ProjectMetadata {
             user_configuration: None,
             fallback_options: None,
             config_file_override: Some(path),
-            uv_workspace: None,
+            environment: ProjectEnvironment::default(),
             use_uv,
         })
     }
@@ -176,7 +178,7 @@ impl ProjectMetadata {
             user_configuration: None,
             fallback_options: None,
             config_file_override: None,
-            uv_workspace: None,
+            environment: ProjectEnvironment::default(),
             use_uv: UseUv::Off,
         })
     }
@@ -203,7 +205,7 @@ impl ProjectMetadata {
         system: &dyn System,
         use_uv: UseUv,
     ) -> Result<ProjectMetadata, ProjectMetadataError> {
-        let uv_workspace = if use_uv.workspace_discovery_enabled() {
+        let environment = if use_uv.workspace_discovery_enabled() {
             let metadata = uv::Uv::new(system)
                 .map_err(uv::uv_executable_error)
                 .map_err(uv::UvMetadataError::Invocation)
@@ -212,17 +214,20 @@ impl ProjectMetadata {
                 });
 
             match metadata {
-                Ok(metadata) => Some(metadata),
-                Err(error) => {
-                    tracing::warn!("{error}");
-                    None
-                }
+                Ok(metadata) => ProjectEnvironment {
+                    metadata: Some(metadata),
+                    error: None,
+                },
+                Err(error) => ProjectEnvironment {
+                    metadata: None,
+                    error: Some(error.to_string().into_boxed_str()),
+                },
             }
         } else {
-            None
+            ProjectEnvironment::default()
         };
 
-        Self::discover_with_uv_workspace(path, system, uv_workspace)
+        Self::discover_with_uv_workspace(path, system, environment)
             .map(|metadata| metadata.with_use_uv(use_uv))
     }
 
@@ -231,14 +236,14 @@ impl ProjectMetadata {
         path: &SystemPath,
         system: &dyn System,
     ) -> Result<ProjectMetadata, ProjectMetadataError> {
-        Self::discover_with_uv_workspace(path, system, None)
+        Self::discover_with_uv_workspace(path, system, ProjectEnvironment::default())
             .map(|metadata| metadata.with_use_uv(UseUv::from_system(system)))
     }
 
     fn discover_with_uv_workspace(
         path: &SystemPath,
         system: &dyn System,
-        uv_workspace: Option<uv::UvMetadata>,
+        environment: ProjectEnvironment,
     ) -> Result<ProjectMetadata, ProjectMetadataError> {
         tracing::debug!("Searching for a project in '{path}'");
 
@@ -248,7 +253,10 @@ impl ProjectMetadata {
 
         let mut closest_project: Option<ProjectMetadata> = None;
         let mut uv_project: Option<ProjectMetadata> = None;
-        let uv_workspace_root = uv_workspace.as_ref().map(uv::UvMetadata::workspace_root);
+        let uv_workspace_root = environment
+            .metadata
+            .as_ref()
+            .map(uv::UvMetadata::workspace_root);
 
         for project_root in path.ancestors() {
             let is_uv_workspace_root = uv_workspace_root == Some(project_root);
@@ -265,7 +273,7 @@ impl ProjectMetadata {
 
             if has_ty_configuration {
                 tracing::debug!("Found project at '{}'", project_root);
-                return Ok(metadata.with_uv_workspace(uv_workspace));
+                return Ok(metadata.with_environment(environment));
             }
 
             if is_uv_workspace_root {
@@ -311,7 +319,7 @@ impl ProjectMetadata {
             Self::new(path.file_name().unwrap_or("root"), path.to_path_buf())
         };
 
-        Ok(metadata.with_uv_workspace(uv_workspace))
+        Ok(metadata.with_environment(environment))
     }
 
     fn discover_in(
@@ -398,8 +406,8 @@ impl ProjectMetadata {
     }
 
     #[must_use]
-    fn with_uv_workspace(mut self, uv_workspace: Option<uv::UvMetadata>) -> Self {
-        self.uv_workspace = uv_workspace;
+    fn with_environment(mut self, environment: ProjectEnvironment) -> Self {
+        self.environment = environment;
         self
     }
 
@@ -415,7 +423,7 @@ impl ProjectMetadata {
         &self,
         system: &dyn System,
         path: &SystemPath,
-        uv_workspace: Option<uv::UvMetadata>,
+        environment: ProjectEnvironment,
     ) -> Result<Self, ProjectMetadataError> {
         let mut metadata = if let Some(config_file) = self.config_file_override() {
             Self::from_config_file_with_uv(
@@ -424,9 +432,9 @@ impl ProjectMetadata {
                 system,
                 self.use_uv,
             )?
-            .with_uv_workspace(uv_workspace)
+            .with_environment(environment)
         } else {
-            Self::discover_with_uv_workspace(path, system, uv_workspace)?.with_use_uv(self.use_uv)
+            Self::discover_with_uv_workspace(path, system, environment)?.with_use_uv(self.use_uv)
         };
 
         metadata.override_options.clone_from(&self.override_options);
@@ -491,11 +499,28 @@ impl ProjectMetadata {
     }
 
     pub fn has_uv_workspace(&self) -> bool {
-        self.uv_workspace.is_some()
+        self.environment.metadata.is_some()
     }
 
-    pub(crate) fn uv_workspace(&self) -> Option<&uv::UvMetadata> {
-        self.uv_workspace.as_ref()
+    pub(crate) fn environment(&self) -> &ProjectEnvironment {
+        &self.environment
+    }
+
+    pub(crate) fn uv_diagnostic(&self, db: &dyn Db) -> Option<Diagnostic> {
+        let error = self.environment.error.as_deref()?;
+        let path = self
+            .environment
+            .metadata
+            .as_ref()
+            .map_or(self.root(), uv::UvMetadata::workspace_root)
+            .join("pyproject.toml");
+        let mut diagnostic = Diagnostic::new(DiagnosticId::UvMetadata, Severity::Warning, error);
+        if let Ok(file) = system_path_to_file(db, &path) {
+            let mut annotation = Annotation::primary(Span::from(file));
+            annotation.hide_snippet(true);
+            diagnostic.annotate(annotation);
+        }
+        Some(diagnostic)
     }
 
     /// Applies lower-precedence options to this project.
@@ -564,7 +589,7 @@ impl ProjectMetadata {
             self.user_configuration = Some(Box::new((user.path().to_owned(), user.into_options())));
         }
 
-        self.uv_workspace_options = self.uv_workspace.as_ref().map(|uv_workspace| {
+        self.uv_workspace_options = self.environment.metadata.as_ref().map(|uv_workspace| {
             Box::new(Options {
                 environment: Some(EnvironmentOptions {
                     python_version: uv_workspace.python_version().cloned(),
@@ -705,6 +730,7 @@ mod tests {
     use ty_static::EnvVars;
 
     use crate::metadata::{Options, uv::UvMetadata, value::RelativePathBuf};
+    use crate::uv::ProjectEnvironment;
     use crate::{ProjectMetadata, ProjectMetadataError};
 
     #[test]
@@ -980,9 +1006,8 @@ unclosed table, expected `]`
             ),
         ])?;
 
-        let uv_workspace = uv_workspace(&root, &system)?;
-        let project =
-            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+        let environment = uv_workspace(&root, &system)?;
+        let project = ProjectMetadata::discover_with_uv_workspace(&member, &system, environment)?;
 
         assert_eq!(project.root(), &*root);
 
@@ -1015,9 +1040,8 @@ unclosed table, expected `]`
             ),
         ])?;
 
-        let uv_workspace = uv_workspace(&root, &system)?;
-        let project =
-            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+        let environment = uv_workspace(&root, &system)?;
+        let project = ProjectMetadata::discover_with_uv_workspace(&member, &system, environment)?;
 
         assert_eq!(project.root(), &*root);
 
@@ -1063,9 +1087,9 @@ unclosed table, expected `]`
             ),
         ])?;
 
-        let uv_workspace = uv_workspace(&root, &system)?;
+        let environment = uv_workspace(&root, &system)?;
         let mut project =
-            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+            ProjectMetadata::discover_with_uv_workspace(&member, &system, environment)?;
         project.apply_configuration_files(&system)?;
 
         assert_eq!(project.root(), &*member);
@@ -1109,9 +1133,8 @@ unclosed table, expected `]`
             ),
         ])?;
 
-        let uv_workspace = uv_workspace(&workspace, &system)?;
-        let project =
-            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+        let environment = uv_workspace(&workspace, &system)?;
+        let project = ProjectMetadata::discover_with_uv_workspace(&member, &system, environment)?;
 
         assert_eq!(project.root(), &*root);
 
@@ -1149,9 +1172,15 @@ unclosed table, expected `]`
                 },
             },
         });
-        let uv_workspace = UvMetadata::from_metadata(metadata.to_string().as_bytes(), &system)?;
+        let uv_environment = ProjectEnvironment {
+            metadata: Some(UvMetadata::from_metadata(
+                metadata.to_string().as_bytes(),
+                &system,
+            )?),
+            error: None,
+        };
         let mut project =
-            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+            ProjectMetadata::discover_with_uv_workspace(&member, &system, uv_environment)?;
         project.apply_fallback_options(Options::from_toml_str(
             r#"
             [environment]
@@ -1682,15 +1711,21 @@ unclosed table, expected `]`
         assert_eq!(format!("{error:#}").replace('\\', "/"), message);
     }
 
-    fn uv_workspace(root: &SystemPathBuf, system: &TestSystem) -> anyhow::Result<UvMetadata> {
+    fn uv_workspace(
+        root: &SystemPathBuf,
+        system: &TestSystem,
+    ) -> anyhow::Result<ProjectEnvironment> {
         let metadata = serde_json::json!({
             "workspace_root": root,
         });
 
-        Ok(UvMetadata::from_metadata(
-            metadata.to_string().as_bytes(),
-            system,
-        )?)
+        Ok(ProjectEnvironment {
+            metadata: Some(UvMetadata::from_metadata(
+                metadata.to_string().as_bytes(),
+                system,
+            )?),
+            error: None,
+        })
     }
 
     fn with_escaped_paths<R>(f: impl FnOnce() -> R) -> R {

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -207,7 +207,9 @@ impl ProjectMetadata {
             let metadata = uv::Uv::new(system)
                 .map_err(uv::uv_executable_error)
                 .map_err(uv::UvMetadataError::Invocation)
-                .and_then(|uv| uv.metadata(system, uv::MetadataTarget::Workspace(path)));
+                .and_then(|uv| {
+                    uv.metadata(system, &uv::MetadataTarget::Workspace(path.to_path_buf()))
+                });
 
             match metadata {
                 Ok(metadata) => Some(metadata),

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -498,10 +498,6 @@ impl ProjectMetadata {
         }
     }
 
-    pub fn has_uv_workspace(&self) -> bool {
-        self.environment.metadata.is_some()
-    }
-
     pub(crate) fn environment(&self) -> &ProjectEnvironment {
         &self.environment
     }

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -410,8 +410,13 @@ impl ProjectMetadata {
         self
     }
 
-    /// Rediscovers the project, while preserving applied options.
-    pub(crate) fn rediscover(&self, system: &dyn System) -> Result<Self, ProjectMetadataError> {
+    /// Rediscovers the project from `path`, while preserving applied options.
+    pub(crate) fn rediscover(
+        &self,
+        system: &dyn System,
+        path: &SystemPath,
+        uv_workspace: Option<uv::UvMetadata>,
+    ) -> Result<Self, ProjectMetadataError> {
         let mut metadata = if let Some(config_file) = self.config_file_override() {
             Self::from_config_file_with_uv(
                 config_file.to_path_buf(),
@@ -419,15 +424,9 @@ impl ProjectMetadata {
                 system,
                 self.use_uv,
             )?
+            .with_uv_workspace(uv_workspace)
         } else {
-            // The active project root may have been deleted. Start rediscovery from the closest
-            // existing ancestor so ty can fall back to an enclosing project.
-            let rediscovery_path = self
-                .root()
-                .ancestors()
-                .find(|path| system.is_directory(path))
-                .unwrap_or_else(|| self.root());
-            Self::discover_with_uv(rediscovery_path, system, self.use_uv)?
+            Self::discover_with_uv_workspace(path, system, uv_workspace)?.with_use_uv(self.use_uv)
         };
 
         metadata.override_options.clone_from(&self.override_options);
@@ -493,6 +492,10 @@ impl ProjectMetadata {
 
     pub fn has_uv_workspace(&self) -> bool {
         self.uv_workspace.is_some()
+    }
+
+    pub(crate) fn uv_workspace(&self) -> Option<&uv::UvMetadata> {
+        self.uv_workspace.as_ref()
     }
 
     /// Applies lower-precedence options to this project.

--- a/crates/ty_project/src/script.rs
+++ b/crates/ty_project/src/script.rs
@@ -17,14 +17,8 @@ use crate::metadata::options::{EnvironmentOptions, Options, OptionsContext};
 use crate::metadata::pyproject::Tool;
 use crate::metadata::settings::Settings;
 use crate::metadata::value::RelativePathBuf;
-use crate::uv::UvMetadata;
+use crate::uv::{UvMetadata, script_environment};
 use crate::{Db, ProjectMetadata};
-
-mod environment;
-
-pub(crate) use environment::ScriptEnvironmentCacheKey;
-use environment::script_environment;
-pub use environment::{ScriptEnvironmentAvailability, ScriptEnvironments};
 
 /// A standalone PEP 723 script and its resolved settings.
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]

--- a/crates/ty_project/src/uv.rs
+++ b/crates/ty_project/src/uv.rs
@@ -6,9 +6,11 @@ use ty_static::EnvVars;
 
 pub(crate) use command::{MetadataTarget, Uv, uv_executable_error};
 pub(crate) use environments::{ProjectEnvironment, ScriptEnvironmentCacheKey, script_environment};
-pub use environments::{ScriptEnvironmentAvailability, UvEnvironments};
+pub use environments::{ScriptEnvironmentAvailability, UvEnvironments, UvSyncChanges};
 pub(crate) use metadata::{UvMetadata, UvMetadataError};
-pub(crate) use service::{ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, UvMetadataService};
+pub(crate) use service::{
+    ScriptSyncRequest, ScriptSyncTask, UvMetadataResult, UvMetadataService, UvSyncTask,
+};
 
 mod command;
 mod environments;

--- a/crates/ty_project/src/uv.rs
+++ b/crates/ty_project/src/uv.rs
@@ -1,16 +1,16 @@
 //! Runs uv commands and manages background script synchronization.
 
-use std::process::Output;
-
-use ruff_db::system::{Command, CommandExecutor, System, SystemPath, WhichError};
+use ruff_db::system::System;
 use ty_combine::Combine;
 use ty_static::EnvVars;
 
+pub(crate) use command::{MetadataTarget, Uv, uv_executable_error};
 pub use environments::{ScriptEnvironmentAvailability, UvEnvironments};
 pub(crate) use environments::{ScriptEnvironmentCacheKey, script_environment};
 pub(crate) use metadata::{UvMetadata, UvMetadataError};
 pub(crate) use service::{ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, UvMetadataService};
 
+mod command;
 mod environments;
 mod metadata;
 mod service;
@@ -67,128 +67,12 @@ impl Combine for UseUv {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct Uv {
-    executable: String,
-}
-
-impl Uv {
-    pub(crate) fn new(system: &dyn System) -> Result<Self, WhichError> {
-        let executable = match system.env_var(EnvVars::UV) {
-            Ok(executable) => executable,
-            Err(_) => system.which("uv")?.into_string(),
-        };
-
-        Ok(Self { executable })
-    }
-
-    /// Executes `uv workspace metadata` and parses and validates its output.
-    pub(crate) fn metadata(
-        &self,
-        system: &dyn System,
-        target: MetadataTarget<'_>,
-    ) -> Result<UvMetadata, UvMetadataError> {
-        let output = system
-            .command_executor()
-            .ok_or_else(unsupported_command_execution)
-            .and_then(|executor| self.execute(executor, target));
-        Self::parse_metadata_output(system, output)
-    }
-
-    /// Executes `uv workspace metadata` without interpreting its output.
-    ///
-    /// This operation only requires a detached command executor, so it can run on a background
-    /// worker.
-    #[tracing::instrument(name = "Uv::execute", level = "debug", skip(self, executor))]
-    fn execute(
-        &self,
-        executor: &dyn CommandExecutor,
-        target: MetadataTarget<'_>,
-    ) -> std::io::Result<Output> {
-        let mut command = Command::new(self.executable.as_str());
-        command.args(["workspace", "metadata", "--quiet"]);
-
-        match target {
-            MetadataTarget::Workspace(path) => {
-                // `uv check` has already selected and synchronized the environment. Keep this
-                // query read-only so package selection and `--isolated` aren't overwritten.
-                command.args(["--frozen", "--active"]).current_dir(path);
-            }
-            MetadataTarget::Script { path, python } => {
-                command.args(["--sync", "--script", path.as_str()]);
-                if let Some(python) = python {
-                    command.args(["--python", python.as_str()]);
-                }
-                if let Some(parent) = path.parent() {
-                    command.current_dir(parent);
-                }
-            }
-        }
-
-        tracing::debug!(
-            "Running `{} {}`",
-            command.get_executable(),
-            command.get_args().join(" ")
-        );
-
-        let start = ruff_db::Instant::now();
-        let output = executor.execute(command);
-
-        tracing::debug!(
-            "uv metadata completed in {:.3}s",
-            start.elapsed().as_secs_f64()
-        );
-
-        output
-    }
-
-    /// Parses and validates the output returned by [`Self::execute`].
-    pub(crate) fn parse_metadata_output(
-        system: &dyn System,
-        output: std::io::Result<Output>,
-    ) -> Result<UvMetadata, UvMetadataError> {
-        let output = output.map_err(UvMetadataError::Invocation)?;
-
-        if !output.status.success() {
-            return Err(UvMetadataError::CommandFailed {
-                status: output.status,
-                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            });
-        }
-
-        UvMetadata::from_metadata(&output.stdout, system)
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum MetadataTarget<'path> {
-    Workspace(&'path SystemPath),
-    Script {
-        path: &'path SystemPath,
-        python: Option<&'path SystemPath>,
-    },
-}
-
-pub(crate) fn uv_executable_error(error: WhichError) -> std::io::Error {
-    std::io::Error::new(
-        std::io::ErrorKind::NotFound,
-        format!("failed to resolve uv executable: {error}"),
-    )
-}
-
-fn unsupported_command_execution() -> std::io::Error {
-    std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "running commands is not supported by this system",
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use ruff_db::system::TestSystem;
     use ty_static::EnvVars;
 
-    use super::{UseUv, Uv};
+    use super::UseUv;
 
     #[test]
     fn use_uv_from_system() {
@@ -203,17 +87,5 @@ mod tests {
 
         system.set_env_var(EnvVars::TY_UV, "off");
         assert_eq!(UseUv::from_system(&system), UseUv::Off);
-    }
-
-    #[test]
-    fn explicit_uv_override_skips_path_lookup() -> anyhow::Result<()> {
-        let system = TestSystem::default();
-        system.set_env_var(EnvVars::UV, "custom-uv");
-
-        let uv = Uv::new(&system)?;
-
-        assert_eq!(uv.executable, "custom-uv");
-
-        Ok(())
     }
 }

--- a/crates/ty_project/src/uv.rs
+++ b/crates/ty_project/src/uv.rs
@@ -6,11 +6,14 @@ use ruff_db::system::{Command, CommandExecutor, System, SystemPath, WhichError};
 use ty_combine::Combine;
 use ty_static::EnvVars;
 
+pub use environments::{ScriptEnvironmentAvailability, UvEnvironments};
+pub(crate) use environments::{ScriptEnvironmentCacheKey, script_environment};
 pub(crate) use metadata::{UvMetadata, UvMetadataError};
-pub(crate) use sync::{ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, UvSyncService};
+pub(crate) use service::{ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, UvMetadataService};
 
+mod environments;
 mod metadata;
-mod sync;
+mod service;
 
 /// Controls which uv integrations ty uses.
 #[derive(
@@ -53,7 +56,7 @@ impl UseUv {
         matches!(self, Self::On)
     }
 
-    pub(super) const fn script_environments_enabled(self) -> bool {
+    const fn script_environments_enabled(self) -> bool {
         matches!(self, Self::Scripts | Self::On)
     }
 }

--- a/crates/ty_project/src/uv.rs
+++ b/crates/ty_project/src/uv.rs
@@ -5,8 +5,8 @@ use ty_combine::Combine;
 use ty_static::EnvVars;
 
 pub(crate) use command::{MetadataTarget, Uv, uv_executable_error};
+pub(crate) use environments::{ProjectEnvironment, ScriptEnvironmentCacheKey, script_environment};
 pub use environments::{ScriptEnvironmentAvailability, UvEnvironments};
-pub(crate) use environments::{ScriptEnvironmentCacheKey, script_environment};
 pub(crate) use metadata::{UvMetadata, UvMetadataError};
 pub(crate) use service::{ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, UvMetadataService};
 

--- a/crates/ty_project/src/uv.rs
+++ b/crates/ty_project/src/uv.rs
@@ -1,4 +1,4 @@
-//! Runs uv commands and manages background script synchronization.
+//! Runs uv commands and coordinates project and script environments.
 
 use ruff_db::system::System;
 use ty_combine::Combine;

--- a/crates/ty_project/src/uv/command.rs
+++ b/crates/ty_project/src/uv/command.rs
@@ -1,0 +1,144 @@
+//! Constructs and executes uv metadata commands.
+
+use std::process::Output;
+
+use ruff_db::system::{Command, CommandExecutor, System, SystemPath, WhichError};
+use ty_static::EnvVars;
+
+use super::{UvMetadata, UvMetadataError};
+
+#[derive(Clone)]
+pub(crate) struct Uv {
+    executable: String,
+}
+
+impl Uv {
+    pub(crate) fn new(system: &dyn System) -> Result<Self, WhichError> {
+        let executable = match system.env_var(EnvVars::UV) {
+            Ok(executable) => executable,
+            Err(_) => system.which("uv")?.into_string(),
+        };
+
+        Ok(Self { executable })
+    }
+
+    /// Executes `uv workspace metadata` and parses and validates its output.
+    pub(crate) fn metadata(
+        &self,
+        system: &dyn System,
+        target: MetadataTarget<'_>,
+    ) -> Result<UvMetadata, UvMetadataError> {
+        let output = system
+            .command_executor()
+            .ok_or_else(unsupported_command_execution)
+            .and_then(|executor| self.execute(executor, target));
+        Self::parse_metadata_output(system, output)
+    }
+
+    /// Executes `uv workspace metadata` without interpreting its output.
+    ///
+    /// This operation only requires a detached command executor, so it can run on a background
+    /// worker.
+    #[tracing::instrument(name = "Uv::execute", level = "debug", skip(self, executor))]
+    pub(crate) fn execute(
+        &self,
+        executor: &dyn CommandExecutor,
+        target: MetadataTarget<'_>,
+    ) -> std::io::Result<Output> {
+        let mut command = Command::new(self.executable.as_str());
+        command.args(["workspace", "metadata", "--quiet"]);
+
+        match target {
+            MetadataTarget::Workspace(path) => {
+                // `uv check` has already selected and synchronized the environment. Keep this
+                // query read-only so package selection and `--isolated` aren't overwritten.
+                command.args(["--frozen", "--active"]).current_dir(path);
+            }
+            MetadataTarget::Script { path, python } => {
+                command.args(["--sync", "--script", path.as_str()]);
+                if let Some(python) = python {
+                    command.args(["--python", python.as_str()]);
+                }
+                if let Some(parent) = path.parent() {
+                    command.current_dir(parent);
+                }
+            }
+        }
+
+        tracing::debug!(
+            "Running `{} {}`",
+            command.get_executable(),
+            command.get_args().join(" ")
+        );
+
+        let start = ruff_db::Instant::now();
+        let output = executor.execute(command);
+
+        tracing::debug!(
+            "uv metadata completed in {:.3}s",
+            start.elapsed().as_secs_f64()
+        );
+
+        output
+    }
+
+    /// Parses and validates the output returned by [`Self::execute`].
+    pub(crate) fn parse_metadata_output(
+        system: &dyn System,
+        output: std::io::Result<Output>,
+    ) -> Result<UvMetadata, UvMetadataError> {
+        let output = output.map_err(UvMetadataError::Invocation)?;
+
+        if !output.status.success() {
+            return Err(UvMetadataError::CommandFailed {
+                status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+
+        UvMetadata::from_metadata(&output.stdout, system)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum MetadataTarget<'path> {
+    Workspace(&'path SystemPath),
+    Script {
+        path: &'path SystemPath,
+        python: Option<&'path SystemPath>,
+    },
+}
+
+pub(crate) fn uv_executable_error(error: WhichError) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("failed to resolve uv executable: {error}"),
+    )
+}
+
+pub(super) fn unsupported_command_execution() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "running commands is not supported by this system",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::system::TestSystem;
+    use ty_static::EnvVars;
+
+    use super::Uv;
+
+    #[test]
+    fn explicit_uv_override_skips_path_lookup() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        system.set_env_var(EnvVars::UV, "custom-uv");
+
+        let uv = Uv::new(&system)?;
+
+        assert_eq!(uv.executable, "custom-uv");
+
+        Ok(())
+    }
+}

--- a/crates/ty_project/src/uv/command.rs
+++ b/crates/ty_project/src/uv/command.rs
@@ -2,7 +2,7 @@
 
 use std::process::Output;
 
-use ruff_db::system::{Command, CommandExecutor, System, SystemPath, WhichError};
+use ruff_db::system::{Command, CommandExecutor, System, SystemPathBuf, WhichError};
 use ty_static::EnvVars;
 
 use super::{UvMetadata, UvMetadataError};
@@ -26,7 +26,7 @@ impl Uv {
     pub(crate) fn metadata(
         &self,
         system: &dyn System,
-        target: MetadataTarget<'_>,
+        target: &MetadataTarget,
     ) -> Result<UvMetadata, UvMetadataError> {
         let output = system
             .command_executor()
@@ -43,7 +43,7 @@ impl Uv {
     pub(crate) fn execute(
         &self,
         executor: &dyn CommandExecutor,
-        target: MetadataTarget<'_>,
+        target: &MetadataTarget,
     ) -> std::io::Result<Output> {
         let mut command = Command::new(self.executable.as_str());
         command.args(["workspace", "metadata", "--quiet"]);
@@ -100,12 +100,17 @@ impl Uv {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum MetadataTarget<'path> {
-    Workspace(&'path SystemPath),
+/// The workspace or standalone script for which to request uv metadata.
+#[derive(Debug)]
+pub(crate) enum MetadataTarget {
+    /// The directory from which uv discovers the workspace, not necessarily the workspace root.
+    Workspace(SystemPathBuf),
+    /// A standalone Python script.
     Script {
-        path: &'path SystemPath,
-        python: Option<&'path SystemPath>,
+        /// The script file passed to `--script`.
+        path: SystemPathBuf,
+        /// The optional `--python` argument.
+        python: Option<SystemPathBuf>,
     },
 }
 

--- a/crates/ty_project/src/uv/environments.rs
+++ b/crates/ty_project/src/uv/environments.rs
@@ -1,4 +1,4 @@
-//! Manages uv environments for standalone Python scripts.
+//! Manages the Python environments used to check projects and standalone scripts.
 //!
 //! A script can declare its Python requirements and dependencies in an inline metadata block.
 //! Synchronizing that metadata with uv produces an environment whose Python version and installed
@@ -53,12 +53,13 @@ use parking_lot::{Condvar, Mutex, MutexGuard};
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_db::FxDashMap;
 use ruff_db::files::{File, Files};
-use ruff_db::system::SystemPathBuf;
+use ruff_db::system::{SystemPath, SystemPathBuf};
 use salsa::Setter;
 
 use crate::script::script_tag;
 use crate::uv::{
-    ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, Uv, UvMetadata, UvMetadataService,
+    MetadataTarget, ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, Uv, UvMetadata,
+    UvMetadataError, UvMetadataService,
 };
 use crate::{Db, ProgressReporter, ScriptSyncProgress, UseUv};
 
@@ -86,7 +87,7 @@ pub(crate) fn script_environment(db: &dyn Db, file: File) -> Option<ScriptEnviro
     db.uv_environments().environment(db, file)
 }
 
-/// Manages and synchronizes PEP 723 script environments using `uv metadata`.
+/// Coordinates project and PEP 723 script environments using `uv metadata`.
 #[derive(Clone, Default)]
 pub struct UvEnvironments {
     inner: Arc<UvEnvironmentsInner>,
@@ -100,6 +101,20 @@ impl UvEnvironments {
                 ..UvEnvironmentsInner::default()
             }),
         }
+    }
+
+    /// Reads workspace metadata through the same worker pool used by scripts.
+    #[expect(dead_code, reason = "Project reloads will use this in a follow-up")]
+    pub(crate) fn workspace_metadata(
+        &self,
+        db: &dyn Db,
+        path: &SystemPath,
+    ) -> Result<UvMetadata, UvMetadataError> {
+        let output = self
+            .inner
+            .sync_service
+            .run_blocking(db, MetadataTarget::Workspace(path.to_path_buf()));
+        Uv::parse_metadata_output(db.system(), output)
     }
 
     /// Returns a receiver for background synchronization wakeups.
@@ -194,7 +209,9 @@ impl UvEnvironments {
                     // Run uv and show progress until the synchronization finishes.
                     let output = {
                         let _progress = reporter.for_script(db, file);
-                        self.inner.sync_service.run_blocking(db, task)
+                        self.inner
+                            .sync_service
+                            .run_blocking(db, task.request.to_metadata_target())
                     };
 
                     // Create the `ScriptEnvironment` input from uv's output, retaining its cache key

--- a/crates/ty_project/src/uv/environments.rs
+++ b/crates/ty_project/src/uv/environments.rs
@@ -56,9 +56,9 @@ use ruff_db::files::{File, Files};
 use ruff_db::system::SystemPathBuf;
 use salsa::Setter;
 
-use super::script_tag;
+use crate::script::script_tag;
 use crate::uv::{
-    ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, Uv, UvMetadata, UvSyncService,
+    ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, Uv, UvMetadata, UvMetadataService,
 };
 use crate::{Db, ProgressReporter, ScriptSyncProgress, UseUv};
 
@@ -82,22 +82,22 @@ type ProgressFactory<'factory> =
 /// a second [`ScriptEnvironment`] input.
 ///
 /// Returns `None` if script integration is disabled or the script is not an actual file on disk.
-pub(super) fn script_environment(db: &dyn Db, file: File) -> Option<ScriptEnvironment> {
-    db.script_environments().environment(db, file)
+pub(crate) fn script_environment(db: &dyn Db, file: File) -> Option<ScriptEnvironment> {
+    db.uv_environments().environment(db, file)
 }
 
 /// Manages and synchronizes PEP 723 script environments using `uv metadata`.
 #[derive(Clone, Default)]
-pub struct ScriptEnvironments {
-    inner: Arc<ScriptEnvironmentsInner>,
+pub struct UvEnvironments {
+    inner: Arc<UvEnvironmentsInner>,
 }
 
-impl ScriptEnvironments {
+impl UvEnvironments {
     pub(crate) fn new(use_uv: UseUv) -> Self {
         Self {
-            inner: Arc::new(ScriptEnvironmentsInner {
+            inner: Arc::new(UvEnvironmentsInner {
                 use_uv,
-                ..ScriptEnvironmentsInner::default()
+                ..UvEnvironmentsInner::default()
             }),
         }
     }
@@ -416,7 +416,7 @@ impl ScriptEnvironments {
     ///
     /// Can be used to delay checking until all requested synchronizations have completed.
     pub fn has_pending_synchronizations(&self) -> bool {
-        self.inner.by_file.iter().any(|entry| {
+        self.inner.scripts.iter().any(|entry| {
             matches!(
                 *entry.state.lock(),
                 ScriptEnvironmentState::InitializingBlocking { .. }
@@ -428,7 +428,7 @@ impl ScriptEnvironments {
     /// Returns every file for which a `ScriptEnvironment` input has been created.
     pub fn files(&self) -> Vec<File> {
         self.inner
-            .by_file
+            .scripts
             .iter()
             .filter_map(|entry| entry.state.lock().environment().map(|_| *entry.key()))
             .collect()
@@ -465,18 +465,18 @@ impl ScriptEnvironments {
     }
 
     fn existing_entry(&self, file: File) -> Option<Arc<ScriptEnvironmentEntry>> {
-        let entry = self.inner.by_file.get(&file)?;
+        let entry = self.inner.scripts.get(&file)?;
         Some(Arc::clone(entry.value()))
     }
 
     fn entry(&self, file: File) -> Arc<ScriptEnvironmentEntry> {
         // Return an owned entry so the map's shard lock is released before the caller waits
         // for synchronization. Otherwise, unrelated scripts in the same shard would also be blocked.
-        Arc::clone(self.inner.by_file.entry(file).or_default().value())
+        Arc::clone(self.inner.scripts.entry(file).or_default().value())
     }
 }
 
-impl std::panic::RefUnwindSafe for ScriptEnvironments {}
+impl std::panic::RefUnwindSafe for UvEnvironments {}
 
 /// Whether a script environment is suitable for operations that depend on its dependencies.
 ///
@@ -520,7 +520,7 @@ pub(crate) type ScriptEnvironmentCacheKey = u64;
 /// environment when its Python version, module search paths, or initialization error changes.
 #[salsa::input(heap_size=ruff_memory_usage::heap_size)]
 #[derive(Debug)]
-pub(super) struct ScriptEnvironment {
+pub(crate) struct ScriptEnvironment {
     /// The cache key of the most recently completed synchronization.
     ///
     /// `None` means the environment has not been synchronized yet. Both successful and failed
@@ -534,31 +534,31 @@ pub(super) struct ScriptEnvironment {
     /// `None` means the environment has not been synchronized or synchronization failed.
     /// [`initialization_error`](Self::initialization_error) distinguishes those cases.
     #[returns(as_ref)]
-    pub(super) uv_metadata: Option<UvMetadata>,
+    pub(crate) uv_metadata: Option<UvMetadata>,
 
     /// The error from the most recent synchronization.
     ///
     /// `None` if synchronization has not completed or completed successfully.
     #[returns(as_deref)]
-    pub(super) initialization_error: Option<Box<str>>,
+    pub(crate) initialization_error: Option<Box<str>>,
 }
 
-struct ScriptEnvironmentsInner {
+struct UvEnvironmentsInner {
     use_uv: UseUv,
-    by_file: FxDashMap<File, Arc<ScriptEnvironmentEntry>>,
-    sync_service: UvSyncService,
+    scripts: FxDashMap<File, Arc<ScriptEnvironmentEntry>>,
+    sync_service: UvMetadataService,
     sync_results: Receiver<ScriptSyncResult>,
     sync_wakeups: Receiver<()>,
 }
 
-impl Default for ScriptEnvironmentsInner {
+impl Default for UvEnvironmentsInner {
     fn default() -> Self {
         let (results_sender, sync_results) = crossbeam::channel::unbounded();
         let (wake_sender, sync_wakeups) = crossbeam::channel::bounded(1);
         Self {
             use_uv: UseUv::default(),
-            by_file: FxDashMap::default(),
-            sync_service: UvSyncService::new(results_sender, wake_sender),
+            scripts: FxDashMap::default(),
+            sync_service: UvMetadataService::new(results_sender, wake_sender),
             sync_results,
             sync_wakeups,
         }
@@ -870,7 +870,7 @@ mod tests {
         let mut db = TestDb::new(metadata);
         db.write_file(&path, "# /// script\n# dependencies = []\n# ///\n")?;
         let file = system_path_to_file(&db, &path)?;
-        let environments = db.script_environments().clone();
+        let environments = db.uv_environments().clone();
 
         // Semantic queries can reach a script before its environment has been synchronized. They
         // create one stable Salsa input with no uv metadata or initialization error.
@@ -914,7 +914,7 @@ mod tests {
                 from attrs import define
                 "#,
             )?;
-            let environments = case.db.script_environments().clone();
+            let environments = case.db.uv_environments().clone();
 
             environments.request_sync(
                 &mut case.db,
@@ -943,7 +943,7 @@ mod tests {
                 from attrs import define
                 "#,
             )?;
-            let environments = case.db.script_environments().clone();
+            let environments = case.db.uv_environments().clone();
             let environment = script_environment(&case.db, case.file)
                 .context("expected a default script environment")?;
 
@@ -973,7 +973,7 @@ mod tests {
             from attrs import define
             "#;
             let mut case = UvTestCase::new(initial)?;
-            let environments = case.db.script_environments().clone();
+            let environments = case.db.uv_environments().clone();
             environments.request_sync(
                 &mut case.db,
                 case.file,
@@ -1034,7 +1034,7 @@ mod tests {
                 # ///
                 "#,
             )?;
-            let environments = case.db.script_environments().clone();
+            let environments = case.db.uv_environments().clone();
             environments.request_sync(
                 &mut case.db,
                 case.file,
@@ -1116,7 +1116,7 @@ mod tests {
             }
 
             fn wait_for_synchronizations(&mut self) -> anyhow::Result<Vec<File>> {
-                let environments = self.db.script_environments().clone();
+                let environments = self.db.uv_environments().clone();
                 let wakeups = environments.sync_wakeups();
                 let mut changed = Vec::new();
 

--- a/crates/ty_project/src/uv/environments.rs
+++ b/crates/ty_project/src/uv/environments.rs
@@ -1,47 +1,52 @@
 //! Manages the Python environments used to check projects and standalone scripts.
 //!
-//! A script can declare its Python requirements and dependencies in an inline metadata block.
-//! Synchronizing that metadata with uv produces an environment whose Python version and installed
-//! packages determine how ty checks the script.
+//! ty needs to know which Python version and packages are available when checking a file. For
+//! project files, uv provides metadata about the workspace's environment. Standalone scripts can
+//! declare their own requirements in inline metadata, so uv may need to create and synchronize
+//! separate environments for them.
 //!
-//! Discovering which files need synchronization requires reading their contents. Initializing every
-//! script before checking a project would therefore require inspecting every candidate file upfront.
+//! The project environment is resolved during initial discovery. Discovering which Python files need
+//! synchronization, however, requires reading their contents to look for inline script metadata.
+//! Initializing every script before checking a project would therefore require inspecting every
+//! candidate file upfront.
 //! This is particularly problematic for language-server latency: a single filesystem event can
 //! represent an entire directory, requiring ty to traverse the directory, read every file, and
 //! initialize its script environments before handling the next editor request. We also want to
 //! avoid initializing environments for files that never need checking.
 //!
-//! Instead, project checks discover and initialize script environments lazily. When checking first
-//! encounters a script without an environment, it runs uv and waits for the result before continuing.
+//! Instead, ty discovers and initializes script environments lazily during checking. When it
+//! encounters a script without an environment, it runs uv and waits before continuing.
 //! Waiting is necessary because the script's dependencies and Python version must be known to
 //! produce accurate diagnostics.
 //!
 //! The language server cannot use the same blocking behavior when opening or updating documents.
-//! Synchronization creates virtual environments and installs packages as needed; waiting for those
+//! Synchronizing scripts can create environments and install packages; waiting for those
 //! operations would increase the latency of other editor requests. For example, semantic tokens
 //! should remain available while synchronization is running. The language server therefore
-//! schedules synchronization in the background when a script is opened or saved, or when a
-//! file-watcher event reports a change to a closed script.
-//!
-//! Until synchronization completes, an existing script continues using its most recently
-//! synchronized environment. For a newly opened script without a synchronized environment, ty
-//! defers semantic diagnostics rather than reporting incorrect missing-dependency errors. Other
-//! operations, such as semantic tokens, are never deferred and use the available environment.
+//! requests project metadata in the background when configuration changes, and schedules script
+//! synchronization when a script is opened or saved, or when a file-watcher event reports a change
+//! to a closed script.
 //! This avoids a rust-analyzer-like experience where editor operations wait for `cargo check` to
 //! complete before becoming available.
 //!
-//! Unsaved edits require different handling. If an edit turns an ordinary file into a script, ty
-//! uses a temporary environment derived from the script's settings. This allows checking to
-//! continue until the file is saved and synchronization is requested, rather than making existing
-//! diagnostics disappear.
+//! While uv runs in the background, existing projects and scripts continue using their most
+//! recently applied environments.
+//! For a newly opened script without a synchronized environment, ty defers semantic diagnostics
+//! rather than reporting incorrect missing-dependency errors.
 //!
-//! CLI watch mode also schedules synchronization in the background after filesystem changes, but
-//! delays the next check until those synchronizations have completed. Scripts discovered during
-//! the subsequent check are initialized lazily. Repeated changes to a script are combined so only
-//! the latest requested synchronization runs after the current one.
+//! uv reads files from disk, not from the editor. If a user adds a script metadata block to an
+//! open file, ty does not request synchronization until the file is saved. It keeps checking the
+//! file using ty's settings, so existing diagnostics stay visible. Once the file is saved and uv
+//! finishes synchronization, ty checks it again using the environment returned by uv.
 //!
-//! Each script's virtual environment is represented by a stable [`ScriptEnvironment`] Salsa input.
-//! Updating that input invalidates semantic queries that depend on the script's Python version or
+//! CLI watch mode also schedules requests in the background after filesystem changes, but delays
+//! the next check until those requests have completed. Scripts discovered during the subsequent
+//! check are initialized lazily. Repeated changes to a project or script are combined so only the
+//! latest requested update runs after the current one.
+//!
+//! The main loop applies project metadata by rediscovering the existing project, including when uv
+//! fails. Each script's virtual environment is represented by a stable [`ScriptEnvironment`] Salsa
+//! input. Updating these inputs invalidates semantic queries that depend on the Python version or
 //! module search paths, ensuring that checks are rerun after synchronization.
 
 use std::hash::Hasher;
@@ -58,15 +63,17 @@ use salsa::Setter;
 
 use crate::script::script_tag;
 use crate::uv::{
-    MetadataTarget, ScriptSyncRequest, ScriptSyncResult, ScriptSyncTask, Uv, UvMetadata,
-    UvMetadataError, UvMetadataService,
+    ScriptSyncRequest, ScriptSyncTask, Uv, UvMetadata, UvMetadataResult, UvMetadataService,
+    UvSyncTask,
 };
-use crate::{Db, ProgressReporter, ScriptSyncProgress, UseUv};
+use crate::{
+    Db, ProgressReporter, ProjectReloadResult, ProjectSyncProgressFactory, UseUv, UvSyncProgress,
+};
 
 const CANCELLATION_CHECK_INTERVAL: Duration = Duration::from_millis(1);
 
 type ProgressFactory<'factory> =
-    dyn Fn(&dyn Db, File) -> Option<Box<dyn ScriptSyncProgress>> + 'factory;
+    dyn Fn(&dyn Db, File) -> Option<Box<dyn UvSyncProgress>> + 'factory;
 
 /// Returns the Salsa input representing `file`'s script environment.
 ///
@@ -103,17 +110,31 @@ impl UvEnvironments {
         }
     }
 
-    /// Reads workspace metadata through the same worker pool used by scripts.
-    pub(crate) fn workspace_metadata(
+    /// Requests fresh workspace metadata for project rediscovery.
+    pub(crate) fn request_project_sync(
         &self,
         db: &dyn Db,
         path: &SystemPath,
-    ) -> Result<UvMetadata, UvMetadataError> {
-        let output = self
-            .inner
-            .sync_service
-            .run_blocking(db, MetadataTarget::Workspace(path.to_path_buf()));
-        Uv::parse_metadata_output(db.system(), output)
+        make_progress: &ProjectSyncProgressFactory<'_>,
+    ) {
+        let progress = {
+            let mut project = self.inner.project.lock();
+            if let Some(sync) = project.as_mut() {
+                sync.next_request = Some(path.to_path_buf());
+                return;
+            }
+
+            let progress = make_progress(db, db.project());
+            *project = Some(ProjectSync { next_request: None });
+            progress
+        };
+
+        tracing::debug!("Requested workspace metadata for `{path}`");
+        self.inner.sync_service.schedule_one(
+            db.system(),
+            UvSyncTask::Workspace(path.to_path_buf()),
+            progress,
+        );
     }
 
     /// Returns a receiver for background synchronization wakeups.
@@ -123,8 +144,8 @@ impl UvEnvironments {
     /// multiple completed synchronizations.
     ///
     /// The CLI and language-server main loops wait on this receiver alongside their other events.
-    /// When signaled, they call [`poll_sync`](Self::poll_sync) to update script environments and
-    /// recheck the affected files.
+    /// When signaled, they call [`poll_sync`](Self::poll_sync) to apply project and script results
+    /// and refresh the affected diagnostics.
     pub fn sync_wakeups(&self) -> Receiver<()> {
         self.inner.sync_wakeups.clone()
     }
@@ -341,10 +362,10 @@ impl UvEnvironments {
 
         self.inner
             .sync_service
-            .schedule_one(db.system(), task, progress);
+            .schedule_one(db.system(), UvSyncTask::Script(task), progress);
     }
 
-    /// Processes completed background synchronizations and updates their script environments.
+    /// Applies completed background requests to their projects or script environments.
     ///
     /// Background workers cannot apply their results because updating an existing Salsa input
     /// requires mutable access to the database. The CLI and language-server main loops call this
@@ -354,91 +375,142 @@ impl UvEnvironments {
     /// outdated result and schedules the newer request instead, transferring the existing progress
     /// indicator. Scheduling can block while the worker queue is full.
     ///
-    /// Returns the files whose environments were updated so callers can recheck them.
-    pub fn poll_sync(&self, db: &mut dyn Db) -> Vec<File> {
+    /// Reports project completions and changed scripts so callers can refresh diagnostics.
+    pub fn poll_sync(&self, db: &mut dyn Db) -> UvSyncChanges {
         // Updating a Salsa input waits for outstanding snapshots to be dropped. Cancel
         // them before taking an entry lock, which their queries may need to finish.
         db.trigger_cancellation();
-        let mut changed_files = Vec::new();
+        let mut changes = UvSyncChanges::default();
 
         while let Ok(result) = self.inner.sync_results.try_recv() {
-            let ScriptSyncResult {
+            let UvMetadataResult {
                 task,
                 output,
                 progress,
             } = result;
-            let file = task.file;
-            let request = task.request;
-            let Some(entry) = self.existing_entry(file) else {
-                panic!(
-                    "received a synchronization result for unknown script `{}`",
-                    request.path(),
-                );
-            };
+            match task {
+                UvSyncTask::Workspace(path) => {
+                    let next = self
+                        .inner
+                        .project
+                        .lock()
+                        .as_mut()
+                        .and_then(|sync| sync.next_request.take());
+                    if let Some(next) = next {
+                        tracing::debug!("Discarded superseded workspace metadata for `{path}`");
+                        self.inner.sync_service.schedule_one(
+                            db.system(),
+                            UvSyncTask::Workspace(next),
+                            progress,
+                        );
+                        continue;
+                    }
+                    let project = db.project();
+                    let environment = match Uv::parse_metadata_output(db.system(), output) {
+                        Ok(metadata) => ProjectEnvironment {
+                            metadata: Some(metadata),
+                            error: None,
+                        },
+                        // Keep the last working uv metadata so a failed refresh does not change
+                        // the environment used for checking. Report the new error instead.
+                        Err(error) => ProjectEnvironment {
+                            error: Some(error.to_string().into_boxed_str()),
+                            ..project.metadata(db).environment().clone()
+                        },
+                    };
+                    changes.project = Some(match project.rediscover(db, &path, environment) {
+                        Ok(result) => result,
+                        Err(error) => {
+                            let error = anyhow::Error::new(error);
+                            tracing::error!(
+                                "Failed to load project, keeping old project configuration: {error:#}"
+                            );
+                            ProjectReloadResult::Unchanged
+                        }
+                    });
+                    *self.inner.project.lock() = None;
+                }
+                UvSyncTask::Script(task) => {
+                    let file = task.file;
+                    let request = task.request;
+                    let Some(entry) = self.existing_entry(file) else {
+                        panic!(
+                            "received a synchronization result for unknown script `{}`",
+                            request.path(),
+                        );
+                    };
 
-            let mut state = entry.state.lock();
-            let ScriptEnvironmentState::SynchronizingInBackground {
-                environment, sync, ..
-            } = &mut *state
-            else {
-                panic!(
-                    "synchronization result for `{}` does not match any task currently in flight",
-                    request.path(),
-                );
-            };
-            assert_eq!(
-                sync.active_cache_key,
-                request.cache_key(),
-                "synchronization result for `{}` does not match the task currently in flight",
-                request.path()
-            );
+                    let mut state = entry.state.lock();
+                    let ScriptEnvironmentState::SynchronizingInBackground {
+                        environment, sync, ..
+                    } = &mut *state
+                    else {
+                        panic!(
+                            "synchronization result for `{}` does not match any task currently in flight",
+                            request.path(),
+                        );
+                    };
+                    assert_eq!(
+                        sync.active_cache_key,
+                        request.cache_key(),
+                        "synchronization result for `{}` does not match the task currently in flight",
+                        request.path()
+                    );
 
-            if let Some(next) = sync.next_request.take() {
-                // uv updates the same environment on disk for every version of this script. If the
-                // metadata changes A -> B -> A, the B synchronization may already have modified the
-                // environment. Run A again even though its cache key matches the last completed
-                // synchronization.
-                sync.active_cache_key = next.cache_key();
+                    if let Some(next) = sync.next_request.take() {
+                        // uv updates the same environment on disk for every version of this script. If the
+                        // metadata changes A -> B -> A, the B synchronization may already have modified the
+                        // environment. Run A again even though its cache key matches the last completed
+                        // synchronization.
+                        sync.active_cache_key = next.cache_key();
 
-                tracing::debug!(
-                    "Discarded superseded script environment synchronization result for `{}`",
-                    request.path()
-                );
+                        tracing::debug!(
+                            "Discarded superseded script environment synchronization result for `{}`",
+                            request.path()
+                        );
 
-                // Scheduling can block while the worker queue is full; release the entry lock first.
-                drop(state);
+                        // Scheduling can block while the worker queue is full; release the entry lock first.
+                        drop(state);
 
-                self.inner.sync_service.schedule_one(
-                    db.system(),
-                    ScriptSyncTask {
-                        file,
-                        request: next,
-                    },
-                    progress,
-                );
-                continue;
+                        self.inner.sync_service.schedule_one(
+                            db.system(),
+                            UvSyncTask::Script(ScriptSyncTask {
+                                file,
+                                request: next,
+                            }),
+                            progress,
+                        );
+                        continue;
+                    }
+
+                    let environment = *environment;
+                    apply_sync_result(db, environment, &request, output);
+                    *state = ScriptEnvironmentState::Current { environment };
+                    changes.scripts.push(file);
+                }
             }
-
-            let environment = *environment;
-            apply_sync_result(db, environment, &request, output);
-            *state = ScriptEnvironmentState::Current { environment };
-            changed_files.push(file);
         }
 
-        changed_files
+        changes
     }
 
-    /// Returns whether any script environment is being initialized or synchronized.
+    /// Returns whether any project or script synchronization is pending.
     ///
     /// Can be used to delay checking until all requested synchronizations have completed.
+    ///
+    /// Other database handles can start or finish script synchronization at any time,
+    /// including between this call and using its result. To avoid this race, call
+    /// after `trigger_cancellation` returns and do not create another database handle
+    /// until you have used the result.
     pub fn has_pending_synchronizations(&self) -> bool {
-        self.inner.scripts.iter().any(|entry| {
-            matches!(
-                *entry.state.lock(),
-                ScriptEnvironmentState::InitializingBlocking { .. }
-                    | ScriptEnvironmentState::SynchronizingInBackground { .. }
-            )
-        })
+        self.inner.project.lock().is_some()
+            || self.inner.scripts.iter().any(|entry| {
+                matches!(
+                    *entry.state.lock(),
+                    ScriptEnvironmentState::InitializingBlocking { .. }
+                        | ScriptEnvironmentState::SynchronizingInBackground { .. }
+                )
+            })
     }
 
     /// Returns every file for which a `ScriptEnvironment` input has been created.
@@ -493,6 +565,20 @@ impl UvEnvironments {
 }
 
 impl std::panic::RefUnwindSafe for UvEnvironments {}
+
+/// Changes applied by polling completed uv metadata requests.
+#[derive(Debug, Default)]
+pub struct UvSyncChanges {
+    pub scripts: Vec<File>,
+    /// `Some` also reports completion when rediscovery leaves the project unchanged or fails.
+    pub project: Option<ProjectReloadResult>,
+}
+
+impl UvSyncChanges {
+    pub fn is_empty(&self) -> bool {
+        self.scripts.is_empty() && self.project.is_none()
+    }
+}
 
 /// Applied workspace metadata and the error from its latest request.
 /// Both fields are absent when no workspace metadata has been requested.
@@ -569,9 +655,10 @@ pub(crate) struct ScriptEnvironment {
 
 struct UvEnvironmentsInner {
     use_uv: UseUv,
+    project: Mutex<Option<ProjectSync>>,
     scripts: FxDashMap<File, Arc<ScriptEnvironmentEntry>>,
     sync_service: UvMetadataService,
-    sync_results: Receiver<ScriptSyncResult>,
+    sync_results: Receiver<UvMetadataResult>,
     sync_wakeups: Receiver<()>,
 }
 
@@ -581,12 +668,17 @@ impl Default for UvEnvironmentsInner {
         let (wake_sender, sync_wakeups) = crossbeam::channel::bounded(1);
         Self {
             use_uv: UseUv::default(),
+            project: Mutex::default(),
             scripts: FxDashMap::default(),
             sync_service: UvMetadataService::new(results_sender, wake_sender),
             sync_results,
             sync_wakeups,
         }
     }
+}
+
+struct ProjectSync {
+    next_request: Option<SystemPathBuf>,
 }
 
 #[derive(Default)]
@@ -892,7 +984,14 @@ mod tests {
         let path = root.join("script.py");
         let metadata = ProjectMetadata::new("test", root).with_use_uv(UseUv::Scripts);
         let mut db = TestDb::new(metadata);
-        db.write_file(&path, "# /// script\n# dependencies = []\n# ///\n")?;
+        db.write_dedented(
+            path.as_str(),
+            r#"
+            # /// script
+            # dependencies = []
+            # ///
+            "#,
+        )?;
         let file = system_path_to_file(&db, &path)?;
         let environments = db.uv_environments().clone();
 
@@ -923,13 +1022,80 @@ mod tests {
         use salsa::Database as _;
         use ty_static::EnvVars;
 
-        use super::super::{ScriptEnvironmentAvailability, script_environment};
+        use super::super::{ScriptEnvironmentAvailability, UvSyncChanges, script_environment};
         use crate::db::testing::TestDb;
         use crate::{Db as _, ProjectMetadata, UseUv};
 
         #[test]
+        fn newer_project_refresh_discards_old_metadata() -> anyhow::Result<()> {
+            let mut case = UvTestCase::project(
+                r#"
+                [project]
+                name = 'example'
+                version = '0.1.0'
+                requires-python = '>=3.8'
+                "#,
+            )?;
+            let root = case.db.project().root(&case.db).to_path_buf();
+            let environments = case.db.uv_environments().clone();
+            environments.request_project_sync(&case.db, &root, &|_, _| None);
+
+            // Leave the first result unapplied, then add a dependency-free workspace member.
+            environments
+                .sync_wakeups()
+                .recv_timeout(Duration::from_secs(30))?;
+            assert!(environments.has_pending_synchronizations());
+            let member_root = root.join("member");
+            case.db.write_dedented(
+                member_root.join("pyproject.toml").as_str(),
+                r#"
+                [project]
+                name = 'member'
+                version = '0.1.0'
+                requires-python = '>=3.8'
+                "#,
+            )?;
+            case.db.write_dedented(
+                case.path.as_str(),
+                r#"
+                [project]
+                name = 'example'
+                version = '0.1.0'
+                requires-python = '>=3.8'
+
+                [tool.uv.workspace]
+                members = ['member']
+                "#,
+            )?;
+            case.sync_workspace()?;
+            environments.request_project_sync(&case.db, &root, &|_, _| None);
+
+            let mut changes = environments.poll_sync(&mut case.db);
+            if changes.project.is_none() {
+                changes = case.wait_for_synchronizations()?;
+            }
+            assert!(changes.project.is_some());
+            assert!(!environments.has_pending_synchronizations());
+
+            let environment = case.db.project().metadata(&case.db).environment();
+            assert_eq!(environment.error, None);
+            assert_eq!(
+                environment
+                    .metadata
+                    .as_ref()
+                    .context("missing uv metadata")?
+                    .members()
+                    .iter()
+                    .find(|member| member.name.as_ref() == "member")
+                    .map(|member| member.path.as_path()),
+                Some(member_root.as_path())
+            );
+            Ok(())
+        }
+
+        #[test]
         fn initial_background_synchronization_is_pending_until_completion() -> anyhow::Result<()> {
-            let mut case = UvTestCase::new(
+            let mut case = UvTestCase::script(
                 r#"
                 # /// script
                 # requires-python = ">=3.12"
@@ -948,7 +1114,7 @@ mod tests {
             );
             assert!(environments.is_initialization_pending(&case.db, case.file));
 
-            assert_eq!(case.wait_for_synchronizations()?, vec![case.file]);
+            assert_eq!(case.wait_for_synchronizations()?.scripts, vec![case.file]);
             assert!(!environments.is_initialization_pending(&case.db, case.file));
             case.assert_can_import("attrs")?;
 
@@ -958,7 +1124,7 @@ mod tests {
         #[test]
         fn existing_environment_remains_available_during_background_synchronization()
         -> anyhow::Result<()> {
-            let mut case = UvTestCase::new(
+            let mut case = UvTestCase::script(
                 r#"
                 # /// script
                 # requires-python = ">=3.12"
@@ -980,7 +1146,7 @@ mod tests {
             assert_eq!(script_environment(&case.db, case.file), Some(environment));
             assert!(!environments.is_initialization_pending(&case.db, case.file));
 
-            assert_eq!(case.wait_for_synchronizations()?, vec![case.file]);
+            assert_eq!(case.wait_for_synchronizations()?.scripts, vec![case.file]);
             assert_eq!(script_environment(&case.db, case.file), Some(environment));
             case.assert_can_import("attrs")?;
 
@@ -996,7 +1162,7 @@ mod tests {
             # ///
             from attrs import define
             "#;
-            let mut case = UvTestCase::new(initial)?;
+            let mut case = UvTestCase::script(initial)?;
             let environments = case.db.uv_environments().clone();
             environments.request_sync(
                 &mut case.db,
@@ -1004,7 +1170,7 @@ mod tests {
                 ScriptEnvironmentAvailability::Pending,
                 &|_, _| None,
             );
-            assert_eq!(case.wait_for_synchronizations()?, vec![case.file]);
+            assert_eq!(case.wait_for_synchronizations()?.scripts, vec![case.file]);
             case.assert_can_import("attrs")?;
 
             case.db.write_dedented(
@@ -1040,8 +1206,8 @@ mod tests {
                 &|_, _| None,
             );
 
-            let mut changed = environments.poll_sync(&mut case.db);
-            changed.extend(case.wait_for_synchronizations()?);
+            let mut changed = environments.poll_sync(&mut case.db).scripts;
+            changed.extend(case.wait_for_synchronizations()?.scripts);
             assert_eq!(changed, vec![case.file]);
             case.assert_can_import("attrs")?;
 
@@ -1050,7 +1216,7 @@ mod tests {
 
         #[test]
         fn background_result_cancels_snapshots_before_locking_entry() -> anyhow::Result<()> {
-            let mut case = UvTestCase::new(
+            let mut case = UvTestCase::script(
                 r#"
                 # /// script
                 # requires-python = ">=3.12"
@@ -1090,7 +1256,10 @@ mod tests {
                 drop(snapshot);
             });
 
-            assert_eq!(environments.poll_sync(&mut case.db), vec![case.file]);
+            assert_eq!(
+                environments.poll_sync(&mut case.db).scripts,
+                vec![case.file]
+            );
             reader
                 .join()
                 .map_err(|_| anyhow::anyhow!("reader panicked"))?;
@@ -1105,53 +1274,44 @@ mod tests {
         }
 
         impl UvTestCase {
-            fn new(source: &str) -> anyhow::Result<Self> {
-                let temp_dir = tempfile::tempdir()?;
-                let root = SystemPath::from_std_path(temp_dir.path())
-                    .context("temporary directory is not a valid UTF-8 path")?
-                    .to_path_buf();
-                let metadata =
-                    ProjectMetadata::new("test", root.clone()).with_use_uv(UseUv::Scripts);
-                let mut db = TestDb::new(metadata);
-                db.use_system(OsSystem::new(&root));
-
-                let uv = OsSystem::default().which("uv")?;
-                db.test_system().set_env_var(EnvVars::UV, uv.as_str());
-                for name in [
-                    EnvVars::VIRTUAL_ENV,
-                    EnvVars::CONDA_PREFIX,
-                    EnvVars::CONDA_DEFAULT_ENV,
-                    EnvVars::CONDA_ROOT,
-                    EnvVars::PYTHONPATH,
-                ] {
-                    db.test_system().remove_env_var(name);
-                }
-
-                let path = root.join("script.py");
-                db.write_dedented(path.as_str(), source)?;
-                let file = system_path_to_file(&db, &path)?;
-
-                Ok(Self {
-                    _temp_dir: temp_dir,
-                    db,
-                    file,
-                    path,
-                })
+            fn script(source: &str) -> anyhow::Result<Self> {
+                Self::new("script.py", source, UseUv::Scripts)
             }
 
-            fn wait_for_synchronizations(&mut self) -> anyhow::Result<Vec<File>> {
+            fn project(source: &str) -> anyhow::Result<Self> {
+                let case = Self::new("pyproject.toml", source, UseUv::On)?;
+                case.sync_workspace()?;
+                Ok(case)
+            }
+
+            fn wait_for_synchronizations(&mut self) -> anyhow::Result<UvSyncChanges> {
                 let environments = self.db.uv_environments().clone();
                 let wakeups = environments.sync_wakeups();
-                let mut changed = Vec::new();
+                let mut changes = UvSyncChanges::default();
 
                 while environments.has_pending_synchronizations() {
                     wakeups
                         .recv_timeout(Duration::from_secs(30))
-                        .context("script synchronization did not finish")?;
-                    changed.extend(environments.poll_sync(&mut self.db));
+                        .context("uv synchronization did not finish")?;
+                    let completed = environments.poll_sync(&mut self.db);
+                    changes.scripts.extend(completed.scripts);
+                    changes.project = completed.project.or(changes.project);
                 }
 
-                Ok(changed)
+                Ok(changes)
+            }
+
+            fn sync_workspace(&self) -> anyhow::Result<()> {
+                let output = Command::new(self.db.test_system().env_var(EnvVars::UV)?)
+                    .current_dir(self.db.project().root(&self.db))
+                    .args(["sync", "--offline"])
+                    .output()?;
+                anyhow::ensure!(
+                    output.status.success(),
+                    "uv sync failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                Ok(())
             }
 
             fn assert_can_import(&self, module: &str) -> anyhow::Result<()> {
@@ -1182,6 +1342,40 @@ mod tests {
                 );
 
                 Ok(())
+            }
+
+            fn new(file_name: &str, source: &str, use_uv: UseUv) -> anyhow::Result<Self> {
+                let temp_dir = tempfile::tempdir()?;
+                let root = SystemPath::from_std_path(temp_dir.path())
+                    .context("temporary directory is not a valid UTF-8 path")?;
+                // uv resolves symlinks, including macOS's symlinked temporary directory.
+                let root = OsSystem::default().canonicalize_path(root)?;
+                let metadata = ProjectMetadata::new("test", root.clone()).with_use_uv(use_uv);
+                let mut db = TestDb::new(metadata);
+                db.use_system(OsSystem::new(&root));
+
+                let uv = OsSystem::default().which("uv")?;
+                db.test_system().set_env_var(EnvVars::UV, uv.as_str());
+                for name in [
+                    EnvVars::VIRTUAL_ENV,
+                    EnvVars::CONDA_PREFIX,
+                    EnvVars::CONDA_DEFAULT_ENV,
+                    EnvVars::CONDA_ROOT,
+                    EnvVars::PYTHONPATH,
+                ] {
+                    db.test_system().remove_env_var(name);
+                }
+
+                let path = root.join(file_name);
+                db.write_dedented(path.as_str(), source)?;
+                let file = system_path_to_file(&db, &path)?;
+
+                Ok(Self {
+                    _temp_dir: temp_dir,
+                    db,
+                    file,
+                    path,
+                })
             }
         }
     }

--- a/crates/ty_project/src/uv/environments.rs
+++ b/crates/ty_project/src/uv/environments.rs
@@ -104,7 +104,6 @@ impl UvEnvironments {
     }
 
     /// Reads workspace metadata through the same worker pool used by scripts.
-    #[expect(dead_code, reason = "Project reloads will use this in a follow-up")]
     pub(crate) fn workspace_metadata(
         &self,
         db: &dyn Db,

--- a/crates/ty_project/src/uv/environments.rs
+++ b/crates/ty_project/src/uv/environments.rs
@@ -494,6 +494,14 @@ impl UvEnvironments {
 
 impl std::panic::RefUnwindSafe for UvEnvironments {}
 
+/// Applied workspace metadata and the error from its latest request.
+/// Both fields are absent when no workspace metadata has been requested.
+#[derive(Debug, Default, Clone, PartialEq, Eq, get_size2::GetSize)]
+pub(crate) struct ProjectEnvironment {
+    pub(crate) metadata: Option<UvMetadata>,
+    pub(crate) error: Option<Box<str>>,
+}
+
 /// Whether a script environment is suitable for operations that depend on its dependencies.
 ///
 /// When opening a script, the initial environment lacks its declared dependencies and can produce

--- a/crates/ty_project/src/uv/metadata.rs
+++ b/crates/ty_project/src/uv/metadata.rs
@@ -11,6 +11,7 @@ use crate::metadata::python_version::SupportedPythonVersion;
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
 pub(crate) struct UvMetadata {
     workspace_root: SystemPathBuf,
+    members: Box<[WorkspaceMember]>,
     environment: Option<SystemPathBuf>,
     python_version: Option<RangedValue<SupportedPythonVersion>>,
 }
@@ -18,6 +19,12 @@ pub(crate) struct UvMetadata {
 impl UvMetadata {
     pub(crate) fn workspace_root(&self) -> &SystemPath {
         &self.workspace_root
+    }
+
+    /// Workspace members returned by uv. Empty for standalone scripts.
+    #[cfg(test)]
+    pub(crate) fn members(&self) -> &[WorkspaceMember] {
+        &self.members
     }
 
     pub(crate) fn environment(&self) -> Option<&SystemPath> {
@@ -51,10 +58,18 @@ impl UvMetadata {
 
         Ok(Self {
             workspace_root,
+            members: metadata.members,
             environment,
             python_version,
         })
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, get_size2::GetSize)]
+pub(crate) struct WorkspaceMember {
+    pub(crate) name: Box<str>,
+    /// Directory containing the member's `pyproject.toml`.
+    pub(crate) path: SystemPathBuf,
 }
 
 #[derive(Debug, Error)]
@@ -119,6 +134,8 @@ fn resolve_python_version(
 #[derive(Deserialize)]
 struct WorkspaceMetadata {
     workspace_root: PathBuf,
+    #[serde(default)]
+    members: Box<[WorkspaceMember]>,
     environment: Option<WorkspaceEnvironment>,
 }
 
@@ -165,6 +182,7 @@ mod tests {
 
         assert!(workspace.environment().is_none());
         assert!(workspace.python_version().is_none());
+        assert!(workspace.members().is_empty());
 
         Ok(())
     }

--- a/crates/ty_project/src/uv/service.rs
+++ b/crates/ty_project/src/uv/service.rs
@@ -10,7 +10,7 @@ use super::command::unsupported_command_execution;
 use super::{MetadataTarget, ScriptEnvironmentCacheKey, Uv, uv_executable_error};
 use crate::{Db, ScriptSyncProgress};
 
-/// Synchronizes standalone script environments with uv.
+/// Runs workspace and standalone-script metadata requests with uv.
 ///
 /// A project stores one service in its shared `UvEnvironments`, so every database snapshot uses
 /// the same bounded request queue and workers. The queue applies backpressure to producers, while
@@ -47,7 +47,7 @@ impl UvMetadataService {
         }
     }
 
-    /// Synchronizes one script and waits for its result.
+    /// Requests workspace or script metadata and waits for its result.
     ///
     /// Blocks the calling thread, periodically checking for Salsa cancellation.
     ///
@@ -57,7 +57,7 @@ impl UvMetadataService {
     pub(crate) fn run_blocking(
         &self,
         db: &dyn Db,
-        task: ScriptSyncTask,
+        target: MetadataTarget,
     ) -> std::io::Result<Output> {
         let workers = self.worker_pool(db.system())?;
 
@@ -69,7 +69,7 @@ impl UvMetadataService {
         let (result_sender, result_receiver) = crossbeam::channel::bounded(1);
 
         let mut job = UvJob {
-            task,
+            target,
             mode: UvJobMode::Blocking {
                 result_sender,
                 cancellation,
@@ -125,8 +125,9 @@ impl UvMetadataService {
 
         let path = task.request.path().to_path_buf();
         let job = UvJob {
-            task,
+            target: task.request.to_metadata_target(),
             mode: UvJobMode::Background {
+                task,
                 result_sender: self.results_sender.clone(),
                 wake_sender: self.wake_sender.clone(),
                 progress,
@@ -139,21 +140,18 @@ impl UvMetadataService {
         tracing::debug!("Queuing script synchronization for `{path}`");
         match workers.jobs.send(job) {
             Ok(()) => tracing::debug!("Queued script synchronization for `{path}`"),
-            Err(error) => {
-                let UvJob { task, mode, .. } = error.into_inner();
-                match mode {
-                    UvJobMode::Blocking { result_sender, .. } => {
-                        let _ = result_sender.send(Err(worker_disconnected()));
-                    }
-                    UvJobMode::Background { progress, .. } => {
-                        self.publish_result(ScriptSyncResult {
-                            task,
-                            output: Err(worker_disconnected()),
-                            progress,
-                        });
-                    }
+            Err(error) => match error.into_inner().mode {
+                UvJobMode::Blocking { result_sender, .. } => {
+                    let _ = result_sender.send(Err(worker_disconnected()));
                 }
-            }
+                UvJobMode::Background { task, progress, .. } => {
+                    self.publish_result(ScriptSyncResult {
+                        task,
+                        output: Err(worker_disconnected()),
+                        progress,
+                    });
+                }
+            },
         }
     }
 
@@ -224,9 +222,11 @@ impl ScriptSyncRequest {
         &self.0.path
     }
 
-    /// The `--python` argument
-    fn python(&self) -> Option<&ruff_db::system::SystemPath> {
-        self.0.python.as_deref()
+    pub(crate) fn to_metadata_target(&self) -> MetadataTarget {
+        MetadataTarget::Script {
+            path: self.0.path.clone(),
+            python: self.0.python.clone(),
+        }
     }
 
     pub(crate) fn cache_key(&self) -> ScriptEnvironmentCacheKey {
@@ -255,7 +255,7 @@ const MAX_QUEUED_UV_TASKS: usize = 8;
 /// Maximum time to block before checking for Salsa cancellation.
 const POLL_TIMEOUT: Duration = Duration::from_millis(1);
 
-/// A bounded worker pool for synchronizing standalone script environments with uv.
+/// A bounded worker pool for workspace and script metadata requests.
 struct UvWorkerPool {
     /// Disconnects when the pool is dropped so workers abandon buffered jobs.
     ///
@@ -335,34 +335,42 @@ impl UvWorker {
             if let UvJobMode::Blocking { cancellation, .. } = &job.mode
                 && cancellation.is_cancelled()
             {
-                tracing::debug!(
-                    "Discarded cancelled script synchronization for `{}`",
-                    job.task.request.path()
-                );
+                match &job.target {
+                    MetadataTarget::Workspace(path) => {
+                        tracing::debug!(
+                            "Discarded cancelled workspace metadata request for `{path}`"
+                        );
+                    }
+                    MetadataTarget::Script { path, .. } => {
+                        tracing::debug!("Discarded cancelled script synchronization for `{path}`");
+                    }
+                }
                 continue;
             }
 
             // Run the job
             let output = {
                 let _span = job.span.enter();
-                tracing::info!("Synchronizing script `{}`", job.task.request.path());
-
-                let target = MetadataTarget::Script {
-                    path: job.task.request.path(),
-                    python: job.task.request.python(),
-                };
-
+                let target = &job.target;
+                match target {
+                    MetadataTarget::Workspace(path) => {
+                        tracing::info!("Reading workspace metadata for `{path}`");
+                    }
+                    MetadataTarget::Script { path, .. } => {
+                        tracing::info!("Synchronizing script `{path}`");
+                    }
+                }
                 self.uv.execute(&*self.executor, target)
             };
 
             // Send the result
-            let UvJob { task, mode, .. } = job;
-            match mode {
+            match job.mode {
                 UvJobMode::Blocking { result_sender, .. } => {
                     // The receiver disappears when the blocking caller is cancelled.
                     let _ = result_sender.send(output);
                 }
                 UvJobMode::Background {
+                    task,
                     result_sender,
                     wake_sender,
                     progress,
@@ -386,7 +394,7 @@ impl UvWorker {
 }
 
 struct UvJob {
-    task: ScriptSyncTask,
+    target: MetadataTarget,
     mode: UvJobMode,
     span: tracing::Span,
 }
@@ -402,6 +410,9 @@ enum UvJobMode {
     /// The job runs as a background task.
     ///
     Background {
+        /// The script identity and request to return with the synchronization result.
+        task: ScriptSyncTask,
+
         /// The sender end of the channel communicating with the sync service.
         result_sender: Sender<ScriptSyncResult>,
 

--- a/crates/ty_project/src/uv/service.rs
+++ b/crates/ty_project/src/uv/service.rs
@@ -6,10 +6,8 @@ use crossbeam::channel::{Receiver, RecvTimeoutError, SendTimeoutError, Sender, T
 use ruff_db::files::File;
 use ruff_db::system::{CommandExecutor, System, SystemPathBuf};
 
-use super::{
-    MetadataTarget, ScriptEnvironmentCacheKey, Uv, unsupported_command_execution,
-    uv_executable_error,
-};
+use super::command::unsupported_command_execution;
+use super::{MetadataTarget, ScriptEnvironmentCacheKey, Uv, uv_executable_error};
 use crate::{Db, ScriptSyncProgress};
 
 /// Synchronizes standalone script environments with uv.

--- a/crates/ty_project/src/uv/service.rs
+++ b/crates/ty_project/src/uv/service.rs
@@ -8,7 +8,7 @@ use ruff_db::system::{CommandExecutor, System, SystemPathBuf};
 
 use super::command::unsupported_command_execution;
 use super::{MetadataTarget, ScriptEnvironmentCacheKey, Uv, uv_executable_error};
-use crate::{Db, ScriptSyncProgress};
+use crate::{Db, UvSyncProgress};
 
 /// Runs workspace and standalone-script metadata requests with uv.
 ///
@@ -28,7 +28,7 @@ pub(crate) struct UvMetadataService {
     workers: OnceLock<std::io::Result<UvWorkerPool>>,
 
     /// Channel, where to send the background results to.
-    results_sender: Sender<ScriptSyncResult>,
+    results_sender: Sender<UvMetadataResult>,
 
     /// Signals when new background results are available.
     ///
@@ -39,7 +39,7 @@ pub(crate) struct UvMetadataService {
 }
 
 impl UvMetadataService {
-    pub(crate) fn new(results_sender: Sender<ScriptSyncResult>, wake_sender: Sender<()>) -> Self {
+    pub(crate) fn new(results_sender: Sender<UvMetadataResult>, wake_sender: Sender<()>) -> Self {
         Self {
             workers: OnceLock::new(),
             results_sender,
@@ -108,13 +108,13 @@ impl UvMetadataService {
     pub(crate) fn schedule_one(
         &self,
         system: &dyn System,
-        task: ScriptSyncTask,
-        progress: Option<Box<dyn ScriptSyncProgress>>,
+        task: UvSyncTask,
+        progress: Option<Box<dyn UvSyncProgress>>,
     ) {
         let workers = match self.worker_pool(system) {
             Ok(workers) => workers,
             Err(error) => {
-                self.publish_result(ScriptSyncResult {
+                self.publish_result(UvMetadataResult {
                     task,
                     output: Err(error),
                     progress,
@@ -123,39 +123,40 @@ impl UvMetadataService {
             }
         };
 
-        let path = task.request.path().to_path_buf();
+        let (path, description) = match &task {
+            UvSyncTask::Workspace(path) => (path.as_path(), "workspace metadata"),
+            UvSyncTask::Script(task) => (task.request.path(), "script synchronization"),
+        };
+        let span = tracing::debug_span!("uv_metadata", path = %path);
+        tracing::debug!("Queuing {description} for `{path}`");
+
         let job = UvJob {
-            target: task.request.to_metadata_target(),
+            target: task.to_metadata_target(),
             mode: UvJobMode::Background {
                 task,
                 result_sender: self.results_sender.clone(),
                 wake_sender: self.wake_sender.clone(),
                 progress,
             },
-            span: tracing::debug_span!(
-                "script_environment_sync",
-                script = %path,
-            ),
+            span,
         };
-        tracing::debug!("Queuing script synchronization for `{path}`");
-        match workers.jobs.send(job) {
-            Ok(()) => tracing::debug!("Queued script synchronization for `{path}`"),
-            Err(error) => match error.into_inner().mode {
+        if let Err(error) = workers.jobs.send(job) {
+            match error.into_inner().mode {
                 UvJobMode::Blocking { result_sender, .. } => {
                     let _ = result_sender.send(Err(worker_disconnected()));
                 }
                 UvJobMode::Background { task, progress, .. } => {
-                    self.publish_result(ScriptSyncResult {
+                    self.publish_result(UvMetadataResult {
                         task,
                         output: Err(worker_disconnected()),
                         progress,
                     });
                 }
-            },
+            }
         }
     }
 
-    fn publish_result(&self, result: ScriptSyncResult) {
+    fn publish_result(&self, result: UvMetadataResult) {
         self.results_sender
             .send(result)
             .expect("the uv synchronization result receiver must remain connected");
@@ -241,13 +242,29 @@ struct ScriptSyncRequestData {
     cache_key: ScriptEnvironmentCacheKey,
 }
 
-/// The result of synchronizing a standalone script environment.
+/// Identifies a background workspace or script request.
+#[derive(Debug)]
+pub(crate) enum UvSyncTask {
+    Workspace(SystemPathBuf),
+    Script(ScriptSyncTask),
+}
+
+impl UvSyncTask {
+    fn to_metadata_target(&self) -> MetadataTarget {
+        match self {
+            Self::Workspace(path) => MetadataTarget::Workspace(path.clone()),
+            Self::Script(task) => task.request.to_metadata_target(),
+        }
+    }
+}
+
+/// The result of a background uv metadata request.
 ///
 /// This owns the progress guard so progress remains active until the result is consumed.
-pub(crate) struct ScriptSyncResult {
-    pub(crate) task: ScriptSyncTask,
+pub(crate) struct UvMetadataResult {
+    pub(crate) task: UvSyncTask,
     pub(crate) output: std::io::Result<Output>,
-    pub(crate) progress: Option<Box<dyn ScriptSyncProgress>>,
+    pub(crate) progress: Option<Box<dyn UvSyncProgress>>,
 }
 
 const MAX_UV_WORKERS: usize = 2;
@@ -377,7 +394,7 @@ impl UvWorker {
                 } => {
                     // The receiver disappears when the owning project is dropped.
                     if result_sender
-                        .send(ScriptSyncResult {
+                        .send(UvMetadataResult {
                             task,
                             output,
                             progress,
@@ -410,15 +427,15 @@ enum UvJobMode {
     /// The job runs as a background task.
     ///
     Background {
-        /// The script identity and request to return with the synchronization result.
-        task: ScriptSyncTask,
+        /// The request to return with the synchronization result.
+        task: UvSyncTask,
 
         /// The sender end of the channel communicating with the sync service.
-        result_sender: Sender<ScriptSyncResult>,
+        result_sender: Sender<UvMetadataResult>,
 
         /// The wake signal that notifies that there's a new result to process.
         wake_sender: Sender<()>,
-        progress: Option<Box<dyn ScriptSyncProgress>>,
+        progress: Option<Box<dyn UvSyncProgress>>,
     },
 }
 

--- a/crates/ty_project/src/uv/service.rs
+++ b/crates/ty_project/src/uv/service.rs
@@ -6,13 +6,15 @@ use crossbeam::channel::{Receiver, RecvTimeoutError, SendTimeoutError, Sender, T
 use ruff_db::files::File;
 use ruff_db::system::{CommandExecutor, System, SystemPathBuf};
 
-use super::{MetadataTarget, Uv, unsupported_command_execution, uv_executable_error};
-use crate::script::ScriptEnvironmentCacheKey;
+use super::{
+    MetadataTarget, ScriptEnvironmentCacheKey, Uv, unsupported_command_execution,
+    uv_executable_error,
+};
 use crate::{Db, ScriptSyncProgress};
 
 /// Synchronizes standalone script environments with uv.
 ///
-/// A project stores one service in its shared `ScriptEnvironments`, so every database snapshot uses
+/// A project stores one service in its shared `UvEnvironments`, so every database snapshot uses
 /// the same bounded request queue and workers. The queue applies backpressure to producers, while
 /// the number of workers limits concurrent uv processes.
 ///
@@ -22,9 +24,9 @@ use crate::{Db, ScriptSyncProgress};
 /// retain only the configured uv executable and a detached command executor.
 ///
 /// The service only owns scheduling of `uv metadata` calls.
-/// [`ScriptEnvironments`](crate::ScriptEnvironments) is the higher level abstraction that
+/// [`UvEnvironments`](crate::UvEnvironments) is the higher level abstraction that
 /// application code should use.
-pub(crate) struct UvSyncService {
+pub(crate) struct UvMetadataService {
     workers: OnceLock<std::io::Result<UvWorkerPool>>,
 
     /// Channel, where to send the background results to.
@@ -34,11 +36,11 @@ pub(crate) struct UvSyncService {
     ///
     /// This overlaps with `results_sender`, but the main difference is that it doesn't expose the
     /// sync result. The LSP and CLI use it as a wake up signal for when to call
-    /// [`ScriptEnvironments::poll_sync`](crate::ScriptEnvironments::poll_sync).
+    /// [`UvEnvironments::poll_sync`](crate::UvEnvironments::poll_sync).
     wake_sender: Sender<()>,
 }
 
-impl UvSyncService {
+impl UvMetadataService {
     pub(crate) fn new(results_sender: Sender<ScriptSyncResult>, wake_sender: Sender<()>) -> Self {
         Self {
             workers: OnceLock::new(),
@@ -184,7 +186,7 @@ impl UvSyncService {
     }
 }
 
-impl std::panic::RefUnwindSafe for UvSyncService {}
+impl std::panic::RefUnwindSafe for UvMetadataService {}
 
 /// A standalone script environment that should be synchronized by uv.
 #[derive(Debug)]

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -22,7 +22,9 @@ mod schedule;
 
 use crate::session::client::Client;
 pub(crate) use api::Error;
-pub(crate) use api::{publish_diagnostics_if_needed, publish_settings_diagnostics};
+pub(crate) use api::{
+    publish_all_document_diagnostics, publish_diagnostics_if_needed, publish_settings_diagnostics,
+};
 pub(crate) use lazy_work_done_progress::LazyWorkDoneProgress;
 pub(crate) use main_loop::{
     Action, ConnectionSender, Event, MainLoopReceiver, MainLoopSender, SendRequest,

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -18,7 +18,9 @@ mod type_hierarchy;
 use self::traits::{NotificationHandler, RequestHandler};
 use super::{Result, schedule::BackgroundSchedule};
 use crate::session::client::Client;
-pub(crate) use diagnostics::{publish_diagnostics_if_needed, publish_settings_diagnostics};
+pub(crate) use diagnostics::{
+    publish_all_document_diagnostics, publish_diagnostics_if_needed, publish_settings_diagnostics,
+};
 use ruff_db::panic::PanicError;
 
 /// Processes a request from the client to the server.

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -208,6 +208,13 @@ impl LspDiagnostics {
     }
 }
 
+/// Publishes diagnostics for all open files that need push diagnostics.
+pub(crate) fn publish_all_document_diagnostics(session: &Session, client: &Client) {
+    for document in session.file_document_handles() {
+        publish_diagnostics_if_needed(&document, session, client);
+    }
+}
+
 /// Publishes the diagnostics for the given document snapshot using the [publish diagnostics
 /// notification] .
 ///

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -399,7 +399,7 @@ pub(super) fn compute_diagnostics(
     // The first uv result supplies the module paths needed for correct diagnostics. Do not analyze
     // the script until that result is available. Waiting would not help: publishing the environment
     // advances the database revision and cancels this snapshot, so the request must retry anyway.
-    if db.script_environments().is_initialization_pending(db, file) {
+    if db.uv_environments().is_initialization_pending(db, file) {
         return None;
     }
 

--- a/crates/ty_server/src/server/api/notifications/did_change.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change.rs
@@ -37,7 +37,7 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
             .with_failure_code(ErrorCode::InternalError)?;
 
         document
-            .update_text_document(session, content_changes, version)
+            .update_text_document(session, client, content_changes, version)
             .with_failure_code(ErrorCode::InternalError)?;
 
         publish_diagnostics_if_needed(&document, session, client);

--- a/crates/ty_server/src/server/api/notifications/did_change_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_notebook.rs
@@ -28,7 +28,7 @@ impl SyncNotificationHandler for DidChangeNotebookHandler {
             .with_failure_code(ErrorCode::InternalError)?;
 
         document
-            .update_notebook_document(session, cells, metadata, version)
+            .update_notebook_document(session, client, cells, metadata, version)
             .with_failure_code(ErrorCode::InternalError)?;
 
         // Always publish diagnostics because notebooks only support publish diagnostics.

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -69,22 +69,20 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
             return Ok(());
         }
 
+        let client_capabilities = session.client_capabilities();
         let roots: Vec<_> = session
             .workspaces()
             .into_iter()
             .map(|(root, _)| root.clone())
             .collect();
-
         for root in roots {
             tracing::debug!("Applying changes to `{root}`");
 
-            session.apply_changes(&AnySystemPath::System(root.clone()), &changes);
+            session.apply_changes(client, &AnySystemPath::System(root.clone()), &changes);
             publish_settings_diagnostics(session, client, root);
         }
 
         session.synchronize_closed_scripts(client);
-
-        let client_capabilities = session.client_capabilities();
 
         if client_capabilities.supports_workspace_diagnostic_refresh() {
             client.send_request::<types::DiagnosticRefreshRequest>(session, (), |_, ()| {});

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -1,7 +1,7 @@
 use crate::document::DocumentKey;
 use crate::server::Result;
 use crate::server::api::diagnostics::{
-    publish_diagnostics_if_needed, publish_settings_diagnostics,
+    publish_all_document_diagnostics, publish_settings_diagnostics,
 };
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
@@ -9,7 +9,6 @@ use crate::session::client::Client;
 use crate::system::AnySystemPath;
 use lsp_types::FileChangeType;
 use lsp_types::{self as types, DidChangeWatchedFilesNotification};
-use ty_project::Db as _;
 use ty_project::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind, ExistingPathKind};
 
 pub(crate) struct DidChangeWatchedFiles;
@@ -71,8 +70,9 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         }
 
         let roots: Vec<_> = session
-            .project_dbs()
-            .map(|db| db.project().root(db).to_owned())
+            .workspaces()
+            .into_iter()
+            .map(|(root, _)| root.clone())
             .collect();
 
         for root in roots {
@@ -89,9 +89,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         if client_capabilities.supports_workspace_diagnostic_refresh() {
             client.send_request::<types::DiagnosticRefreshRequest>(session, (), |_, ()| {});
         } else {
-            for document in session.file_document_handles() {
-                publish_diagnostics_if_needed(&document, session, client);
-            }
+            publish_all_document_diagnostics(session, client);
         }
 
         if client_capabilities.supports_inlay_hint_refresh() {

--- a/crates/ty_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/ty_server/src/server/api/notifications/did_open_notebook.rs
@@ -34,7 +34,7 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
             NotebookDocument::new(notebook_uri, version, cells, metadata.unwrap_or_default())
                 .with_failure_code(ErrorCode::InternalError)?;
 
-        let document = session.open_notebook_document(notebook);
+        let document = session.open_notebook_document(client, notebook);
         let notebook_path = document.notebook_or_file_path();
 
         for cell in params.cell_text_documents {

--- a/crates/ty_server/src/server/api/notifications/did_save.rs
+++ b/crates/ty_server/src/server/api/notifications/did_save.rs
@@ -2,7 +2,7 @@ use lsp_types::{DidSaveTextDocumentNotification, DidSaveTextDocumentParams};
 use ty_project::ScriptEnvironmentAvailability;
 
 use crate::server::Result;
-use crate::server::api::diagnostics::publish_diagnostics_if_needed;
+use crate::server::api::diagnostics::publish_all_document_diagnostics;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
@@ -24,9 +24,7 @@ impl SyncNotificationHandler for DidSaveTextDocumentHandler {
             document.synchronize_script(session, client, ScriptEnvironmentAvailability::Available);
         }
 
-        for document in session.file_document_handles() {
-            publish_diagnostics_if_needed(&document, session, client);
-        }
+        publish_all_document_diagnostics(session, client);
 
         Ok(())
     }

--- a/crates/ty_server/src/server/lazy_work_done_progress.rs
+++ b/crates/ty_server/src/server/lazy_work_done_progress.rs
@@ -190,7 +190,7 @@ enum ProgressCreation {
     TryQueue,
 }
 
-impl ty_project::ScriptSyncProgress for LazyWorkDoneProgress {}
+impl ty_project::UvSyncProgress for LazyWorkDoneProgress {}
 
 struct Inner {
     token: std::sync::OnceLock<ProgressToken>,

--- a/crates/ty_server/src/server/main_loop.rs
+++ b/crates/ty_server/src/server/main_loop.rs
@@ -158,7 +158,7 @@ impl Server {
                     }
                 },
                 Event::PollUvEnvironments { project_root } => {
-                    self.session.poll_script_sync(&client, &project_root);
+                    self.session.poll_uv_sync(&client, &project_root);
                 }
             }
         }
@@ -188,8 +188,8 @@ impl Server {
             return Ok(Some(Event::Message(deferred)));
         }
 
-        let script_sync = ScriptSyncWakeups(self.session.script_sync_wakeups());
-        script_sync.select(&self.connection.receiver, &self.main_loop_receiver)
+        let uv_sync = UvSyncWakeups(self.session.uv_sync_wakeups());
+        uv_sync.select(&self.connection.receiver, &self.main_loop_receiver)
     }
 
     fn initialize(&mut self, client: &Client) {
@@ -244,10 +244,10 @@ impl std::fmt::Debug for SendRequest {
     }
 }
 
-/// Script-environment wakeups for the currently active project databases.
-struct ScriptSyncWakeups(Vec<(SystemPathBuf, crossbeam::channel::Receiver<()>)>);
+/// Uv-environment wakeups for the currently active project databases.
+struct UvSyncWakeups(Vec<(SystemPathBuf, crossbeam::channel::Receiver<()>)>);
 
-impl ScriptSyncWakeups {
+impl UvSyncWakeups {
     /// Waits for a project wakeup, client message, or main-loop action.
     fn select(
         &self,

--- a/crates/ty_server/src/server/main_loop.rs
+++ b/crates/ty_server/src/server/main_loop.rs
@@ -157,7 +157,7 @@ impl Server {
                         // self.try_register_file_watcher(&client);
                     }
                 },
-                Event::PollScriptEnvironments { project_root } => {
+                Event::PollUvEnvironments { project_root } => {
                     self.session.poll_script_sync(&client, &project_root);
                 }
             }
@@ -224,7 +224,7 @@ pub(crate) enum Event {
 
     Action(Action),
 
-    PollScriptEnvironments {
+    PollUvEnvironments {
         project_root: SystemPathBuf,
     },
 }
@@ -265,7 +265,7 @@ impl ScriptSyncWakeups {
 
         if let Some((project_root, receiver)) = self.0.get(index) {
             return operation.recv(receiver).map(|()| {
-                Some(Event::PollScriptEnvironments {
+                Some(Event::PollUvEnvironments {
                     project_root: project_root.clone(),
                 })
             });

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -27,7 +27,7 @@ use ty_project::metadata::Options;
 use ty_project::watch::ChangeEvent;
 use ty_project::{
     ChangeResult, Db as _, ProjectDatabase, ProjectMetadata, ScriptEnvironmentAvailability,
-    SemanticDb as _, UseUv,
+    SemanticDb as _, UseUv, UvSyncChanges,
 };
 
 use index::DocumentError;
@@ -40,7 +40,8 @@ use crate::capabilities::{ResolvedClientCapabilities, server_diagnostic_options}
 use crate::db::Db as _;
 use crate::document::{DocumentKey, DocumentVersion, LanguageId, NotebookDocument};
 use crate::server::{
-    Action, LazyWorkDoneProgress, publish_diagnostics_if_needed, publish_settings_diagnostics,
+    Action, LazyWorkDoneProgress, publish_all_document_diagnostics, publish_diagnostics_if_needed,
+    publish_settings_diagnostics,
 };
 use crate::session::client::Client;
 use crate::session::index::Document;
@@ -255,10 +256,8 @@ impl Session {
             });
     }
 
-    /// Returns each project's background script synchronization wakeups.
-    pub(crate) fn script_sync_wakeups(
-        &self,
-    ) -> Vec<(SystemPathBuf, crossbeam::channel::Receiver<()>)> {
+    /// Returns each project's background uv synchronization wakeups.
+    pub(crate) fn uv_sync_wakeups(&self) -> Vec<(SystemPathBuf, crossbeam::channel::Receiver<()>)> {
         self.projects
             .iter()
             .map(|(root, state)| (root.clone(), state.db.uv_environments().sync_wakeups()))
@@ -288,29 +287,32 @@ impl Session {
         }
     }
 
-    /// Gives one project's script environments an opportunity to make progress.
-    pub(crate) fn poll_script_sync(&mut self, client: &Client, project_root: &SystemPath) {
+    /// Gives one project's uv environments an opportunity to make progress.
+    pub(crate) fn poll_uv_sync(&mut self, client: &Client, project_root: &SystemPath) {
         let Some(project) = self.projects.get_mut(project_root) else {
             tracing::debug!(
-                "Ignored script synchronization wakeup for removed project `{project_root}`"
+                "Ignored uv synchronization wakeup for removed project `{project_root}`"
             );
             return;
         };
         let db = &mut project.db;
         let environments = db.uv_environments().clone();
-        let changed_files = environments.poll_sync(db);
-
-        self.uv_environments_changed(client, project_root, changed_files);
+        let changes = environments.poll_sync(db);
+        self.uv_environments_changed(client, project_root, changes);
     }
 
     fn uv_environments_changed(
         &mut self,
         client: &Client,
         project_root: &SystemPath,
-        changed_files: Vec<File>,
+        changes: UvSyncChanges,
     ) {
-        if changed_files.is_empty() {
+        if changes.is_empty() {
             return;
+        }
+
+        if changes.project.is_some() {
+            publish_settings_diagnostics(self, client, project_root.to_path_buf());
         }
 
         self.bump_revision();
@@ -320,8 +322,10 @@ impl Session {
         let capabilities = self.client_capabilities();
         if capabilities.supports_workspace_diagnostic_refresh() {
             client.send_request::<lsp_types::DiagnosticRefreshRequest>(self, (), |_, ()| {});
+        } else if changes.project.is_some() {
+            publish_all_document_diagnostics(self, client);
         } else if let Some(project) = self.projects.get(project_root) {
-            for file in changed_files {
+            for file in changes.scripts {
                 if let Some(document) = project.db.document(file) {
                     let document = DocumentHandle::from_document(document);
                     publish_diagnostics_if_needed(&document, self, client);

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -539,12 +539,21 @@ impl Session {
 
     pub(crate) fn apply_changes(
         &mut self,
+        client: &Client,
         path: &AnySystemPath,
         changes: &[ChangeEvent],
     ) -> ChangeResult {
         self.bump_revision();
 
-        self.project_db_mut(path).apply_changes(changes)
+        let capabilities = self.resolved_client_capabilities;
+        self.project_db_mut(path)
+            .apply_changes_with_progress(changes, &|db, project| {
+                Some(Box::new(LazyWorkDoneProgress::new_on_main_loop(
+                    client,
+                    &format!("Refreshing {} metadata", project.name(db)),
+                    capabilities,
+                )))
+            })
     }
 
     /// Returns a mutable iterator over all project databases.
@@ -1334,9 +1343,13 @@ impl Session {
     /// If a document is already open here, it will be overwritten.
     ///
     /// Returns a handle to the opened document.
-    pub(crate) fn open_notebook_document(&mut self, document: NotebookDocument) -> DocumentHandle {
+    pub(crate) fn open_notebook_document(
+        &mut self,
+        client: &Client,
+        document: NotebookDocument,
+    ) -> DocumentHandle {
         let handle = self.index_mut().open_notebook_document(document);
-        self.open_document_in_db(&handle, None);
+        self.open_document_in_db(client, &handle, None);
         handle
     }
 
@@ -1382,11 +1395,16 @@ impl Session {
             }
         }
         let handle = self.index_mut().open_text_document(document);
-        self.open_document_in_db(&handle, Some(language_id));
+        self.open_document_in_db(client, &handle, Some(language_id));
         handle
     }
 
-    fn open_document_in_db(&mut self, document: &DocumentHandle, language_id: Option<LanguageId>) {
+    fn open_document_in_db(
+        &mut self,
+        client: &Client,
+        document: &DocumentHandle,
+        language_id: Option<LanguageId>,
+    ) {
         let path = document.notebook_or_file_path();
 
         // When we know the document isn't a Python source file
@@ -1396,7 +1414,7 @@ impl Session {
 
         match path {
             AnySystemPath::System(system_path) => {
-                self.apply_changes(path, &[ChangeEvent::Opened(system_path.clone())]);
+                self.apply_changes(client, path, &[ChangeEvent::Opened(system_path.clone())]);
 
                 if is_not_python {
                     return;
@@ -1988,6 +2006,7 @@ impl DocumentHandle {
     pub(crate) fn update_text_document(
         &mut self,
         session: &mut Session,
+        client: &Client,
         content_changes: Vec<TextDocumentContentChangeEvent>,
         new_version: DocumentVersion,
     ) -> crate::Result<()> {
@@ -2010,7 +2029,7 @@ impl DocumentHandle {
             self.set_version(document.version());
         }
 
-        self.update_in_db(session);
+        self.update_in_db(session, client);
 
         Ok(())
     }
@@ -2018,6 +2037,7 @@ impl DocumentHandle {
     pub(crate) fn update_notebook_document(
         &mut self,
         session: &mut Session,
+        client: &Client,
         cells: Option<lsp_types::NotebookDocumentCellChanges>,
         metadata: Option<lsp_types::LspObject>,
         new_version: DocumentVersion,
@@ -2037,11 +2057,11 @@ impl DocumentHandle {
             self.set_version(new_version);
         }
 
-        self.update_in_db(session);
+        self.update_in_db(session, client);
         Ok(())
     }
 
-    fn update_in_db(&self, session: &mut Session) {
+    fn update_in_db(&self, session: &mut Session, client: &Client) {
         let path = self.notebook_or_file_path();
         let changes = match path {
             AnySystemPath::System(system_path) => {
@@ -2052,7 +2072,7 @@ impl DocumentHandle {
             }
         };
 
-        session.apply_changes(path, &changes);
+        session.apply_changes(client, path, &changes);
     }
 
     fn set_version(&mut self, version: DocumentVersion) {

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -261,7 +261,7 @@ impl Session {
     ) -> Vec<(SystemPathBuf, crossbeam::channel::Receiver<()>)> {
         self.projects
             .iter()
-            .map(|(root, state)| (root.clone(), state.db.script_environments().sync_wakeups()))
+            .map(|(root, state)| (root.clone(), state.db.uv_environments().sync_wakeups()))
             .collect()
     }
 
@@ -270,7 +270,7 @@ impl Session {
         let capabilities = self.resolved_client_capabilities;
         for state in self.projects.values_mut() {
             let db = &mut state.db;
-            for file in db.script_environments().files() {
+            for file in db.uv_environments().files() {
                 // Open documents are synchronized when opened or saved. Ignore watcher events
                 // for them because the file on disk may differ from the open document.
                 if db.is_open_file(file) {
@@ -297,13 +297,13 @@ impl Session {
             return;
         };
         let db = &mut project.db;
-        let environments = db.script_environments().clone();
+        let environments = db.uv_environments().clone();
         let changed_files = environments.poll_sync(db);
 
-        self.script_environments_changed(client, project_root, changed_files);
+        self.uv_environments_changed(client, project_root, changed_files);
     }
 
-    fn script_environments_changed(
+    fn uv_environments_changed(
         &mut self,
         client: &Client,
         project_root: &SystemPath,
@@ -345,7 +345,7 @@ impl Session {
         capabilities: ResolvedClientCapabilities,
         availability: ScriptEnvironmentAvailability,
     ) {
-        let environments = db.script_environments().clone();
+        let environments = db.uv_environments().clone();
         environments.request_sync(db, file, availability, &|db, file| {
             let file_path = file.path(db);
             let display_path = file_path.as_system_path().map_or_else(

--- a/crates/ty_server/tests/e2e/goto_definition.rs
+++ b/crates/ty_server/tests/e2e/goto_definition.rs
@@ -65,7 +65,7 @@ mod uv_metadata {
         TextDocumentContentChangeEvent, TextDocumentContentChangeWholeDocument,
         WorkspaceDocumentDiagnosticReport,
     };
-    use ruff_db::system::{OsSystem, System as _, SystemPath, SystemPathBuf};
+    use ruff_db::system::{SystemPath, SystemPathBuf};
     use ty_project::UseUv;
     use ty_server::{ClientOptions, DiagnosticMode};
 
@@ -85,29 +85,14 @@ from attrs import define
         let mut server = TestServerBuilder::new()?
             .with_workspace(workspace_root, None)?
             .with_file(script, source)?
-            .with_use_uv(UseUv::Scripts)
-            .with_env_var("UV", uv_executable()?)
+            .with_real_uv(UseUv::Scripts)?
             .enable_work_done_progress(true)
             .build()
             .wait_until_workspaces_are_initialized();
 
         server.open_text_document(script, source, 1);
 
-        let (request_id, progress) =
-            server.await_request::<lsp_types::WorkDoneProgressCreateRequest>();
-        server.send(lsp_server::Message::Response(lsp_server::Response::new_ok(
-            request_id,
-            (),
-        )));
-
-        let begin = server.await_notification::<lsp_types::ProgressNotification>();
-        assert_eq!(begin.token, progress.token);
-        let begin: lsp_types::WorkDoneProgressBegin = serde_json::from_value(begin.value)?;
-        assert_eq!(begin.title, "Syncing script.py");
-
-        let end = server.await_notification::<lsp_types::ProgressNotification>();
-        assert_eq!(end.token, progress.token);
-        let _: lsp_types::WorkDoneProgressEnd = serde_json::from_value(end.value)?;
+        server.assert_work_done_progress("Syncing script.py")?;
 
         let definition = server
             .goto_definition_request(script, Position::new(4, 18))
@@ -174,8 +159,7 @@ from attrs import define
             .with_workspace(second_workspace, None)?
             .with_file(first_script, first_source)?
             .with_file(second_script, second_source)?
-            .with_use_uv(UseUv::Scripts)
-            .with_env_var("UV", uv_executable()?)
+            .with_real_uv(UseUv::Scripts)?
             .enable_workspace_diagnostic_refresh(true)
             .build()
             .wait_until_workspaces_are_initialized();
@@ -233,8 +217,7 @@ from idna import encode
         let mut server = TestServerBuilder::new()?
             .with_workspace(workspace_root, None)?
             .with_file(script, initial)?
-            .with_use_uv(UseUv::Scripts)
-            .with_env_var("UV", uv_executable()?)
+            .with_real_uv(UseUv::Scripts)?
             .enable_workspace_diagnostic_refresh(true)
             .build()
             .wait_until_workspaces_are_initialized();
@@ -310,8 +293,7 @@ from attrs import define
         let mut server = TestServerBuilder::new()?
             .with_workspace(SystemPath::new("src"), None)?
             .with_file(script, initial)?
-            .with_use_uv(UseUv::Scripts)
-            .with_env_var("UV", uv_executable()?)
+            .with_real_uv(UseUv::Scripts)?
             .enable_workspace_diagnostic_refresh(true)
             .build()
             .wait_until_workspaces_are_initialized();
@@ -357,8 +339,7 @@ print(define)
                 Some(ClientOptions::default().with_diagnostic_mode(DiagnosticMode::Workspace)),
             )?
             .with_file(script, ordinary)?
-            .with_use_uv(UseUv::Scripts)
-            .with_env_var("UV", uv_executable()?)
+            .with_real_uv(UseUv::Scripts)?
             .enable_workspace_diagnostic_refresh(true)
             .build()
             .wait_until_workspaces_are_initialized();
@@ -409,8 +390,7 @@ from attrs import define
         let mut server = TestServerBuilder::new()?
             .with_workspace(workspace_root, None)?
             .with_file(script, initial)?
-            .with_use_uv(UseUv::Scripts)
-            .with_env_var("UV", uv_executable()?)
+            .with_real_uv(UseUv::Scripts)?
             .enable_workspace_diagnostic_refresh(true)
             .build()
             .wait_until_workspaces_are_initialized();
@@ -494,8 +474,7 @@ from idna import encode
         let mut server = TestServerBuilder::new()?
             .with_workspace(workspace_root, None)?
             .with_file(script, initial)?
-            .with_use_uv(UseUv::Scripts)
-            .with_env_var("UV", uv_executable()?)
+            .with_real_uv(UseUv::Scripts)?
             .enable_workspace_diagnostic_refresh(true)
             .build()
             .wait_until_workspaces_are_initialized();
@@ -523,9 +502,5 @@ from idna import encode
         );
 
         Ok(())
-    }
-
-    fn uv_executable() -> Result<String> {
-        Ok(OsSystem::default().which("uv")?.into_string())
     }
 }

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -80,6 +80,8 @@ use lsp_types::{
     WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticRequest,
     WorkspaceEdit, WorkspaceFolder, WorkspaceFoldersChangeEvent, WorkspaceFoldersInitializeParams,
 };
+#[cfg(feature = "test-uv")]
+use ruff_db::system::System as _;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf, SystemVirtualPath, TestSystem};
 use rustc_hash::FxHashMap;
 use serde_json::{Value, json};
@@ -599,6 +601,25 @@ impl TestServer {
     pub(crate) fn await_diagnostic_refresh(&mut self) {
         let (id, ()) = self.await_request::<lsp_types::DiagnosticRefreshRequest>();
         self.send(Message::Response(Response::new_ok(id, ())));
+    }
+
+    /// Checks server-created progress with a begin and end notification and no intermediate reports.
+    #[cfg(feature = "test-uv")]
+    #[track_caller]
+    pub(crate) fn assert_work_done_progress(&mut self, expected_title: &str) -> Result<()> {
+        let (request_id, progress) =
+            self.await_request::<lsp_types::WorkDoneProgressCreateRequest>();
+        self.send(Message::Response(Response::new_ok(request_id, ())));
+
+        let begin = self.await_notification::<lsp_types::ProgressNotification>();
+        assert_eq!(begin.token, progress.token);
+        let begin: lsp_types::WorkDoneProgressBegin = serde_json::from_value(begin.value)?;
+        assert_eq!(begin.title, expected_title);
+
+        let end = self.await_notification::<lsp_types::ProgressNotification>();
+        assert_eq!(end.token, progress.token);
+        let _: lsp_types::WorkDoneProgressEnd = serde_json::from_value(end.value)?;
+        Ok(())
     }
 
     /// Wait for a request of the specified type from the server and return the request ID and
@@ -1263,6 +1284,13 @@ impl TestServerBuilder {
     pub(crate) fn with_raw_initialization_options(mut self, options: Value) -> Self {
         self.initialization_options = Some(options);
         self
+    }
+
+    /// Enable uv integration using the uv executable on the test process's PATH.
+    #[cfg(feature = "test-uv")]
+    pub(crate) fn with_real_uv(self, use_uv: UseUv) -> Result<Self> {
+        let uv = OsSystem::default().which("uv")?;
+        Ok(self.with_use_uv(use_uv).with_env_var("UV", uv.as_str()))
     }
 
     /// Configure which uv integrations the test server enables.

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -960,13 +960,66 @@ fn collect_publish_diagnostic_notifications_with_versions(
 }
 
 mod uv_metadata {
+    #[cfg(feature = "test-uv")]
+    use std::process::Command;
+
     use anyhow::Result;
     use lsp_types::{Code, PublishDiagnosticsNotification};
     use ruff_db::system::SystemPath;
+    #[cfg(feature = "test-uv")]
+    use ruff_db::system::{OsSystem, System as _};
     use serde_json::json;
     use ty_project::UseUv;
 
     use crate::TestServerBuilder;
+
+    #[cfg(feature = "test-uv")]
+    #[test]
+    fn project_refresh_clears_errors() -> Result<()> {
+        let manifest =
+            "[project]\nname = 'example'\nversion = '0.1.0'\nrequires-python = '>=3.8'\n";
+        let uv = OsSystem::default().which("uv")?;
+        let mut server = TestServerBuilder::new()?
+            .with_workspace(SystemPath::new("src"), None)?
+            .with_file(
+                "src/pyproject.toml",
+                format!("{manifest}\n[tool.uv]\npackage = 'invalid'\n"),
+            )?
+            .with_use_uv(UseUv::On)
+            .with_env_var("UV", uv.as_str())
+            .build()
+            .wait_until_workspaces_are_initialized();
+        let event = lsp_types::FileEvent {
+            uri: server.file_uri("src/pyproject.toml"),
+            kind: lsp_types::FileChangeType::Changed,
+        };
+        let diagnostics = server.collect_publish_diagnostic_notifications(1);
+        assert_eq!(diagnostics[&event.uri].len(), 1);
+        assert_eq!(
+            diagnostics[&event.uri][0].code,
+            Some(Code::String("uv-metadata".into()))
+        );
+
+        server.write_file("src/pyproject.toml", manifest)?;
+        let output = Command::new(uv.as_std_path())
+            .current_dir(server.file_path("src"))
+            .args(["lock", "--offline"])
+            .output()?;
+        anyhow::ensure!(
+            output.status.success(),
+            "uv lock failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        server.did_change_watched_files(vec![event.clone()]);
+
+        // The existing warning is republished while the refresh is pending, then cleared.
+        assert_eq!(
+            server.collect_publish_diagnostic_notifications(1),
+            diagnostics
+        );
+        assert!(server.collect_publish_diagnostic_notifications(1)[&event.uri].is_empty());
+        Ok(())
+    }
 
     #[test]
     fn untrusted_workspace_keeps_semantic_diagnostics() -> Result<()> {

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -966,8 +966,6 @@ mod uv_metadata {
     use anyhow::Result;
     use lsp_types::{Code, PublishDiagnosticsNotification};
     use ruff_db::system::SystemPath;
-    #[cfg(feature = "test-uv")]
-    use ruff_db::system::{OsSystem, System as _};
     use serde_json::json;
     use ty_project::UseUv;
 
@@ -975,18 +973,26 @@ mod uv_metadata {
 
     #[cfg(feature = "test-uv")]
     #[test]
-    fn project_refresh_clears_errors() -> Result<()> {
-        let manifest =
-            "[project]\nname = 'example'\nversion = '0.1.0'\nrequires-python = '>=3.8'\n";
-        let uv = OsSystem::default().which("uv")?;
+    fn project_refresh_reports_progress_and_clears_errors() -> Result<()> {
+        let manifest = r#"
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.8"
+"#;
         let mut server = TestServerBuilder::new()?
             .with_workspace(SystemPath::new("src"), None)?
             .with_file(
                 "src/pyproject.toml",
-                format!("{manifest}\n[tool.uv]\npackage = 'invalid'\n"),
+                format!(
+                    r#"{manifest}
+[tool.uv]
+package = "invalid"
+"#
+                ),
             )?
-            .with_use_uv(UseUv::On)
-            .with_env_var("UV", uv.as_str())
+            .with_real_uv(UseUv::On)?
+            .enable_work_done_progress(true)
             .build()
             .wait_until_workspaces_are_initialized();
         let event = lsp_types::FileEvent {
@@ -1001,16 +1007,18 @@ mod uv_metadata {
         );
 
         server.write_file("src/pyproject.toml", manifest)?;
-        let output = Command::new(uv.as_std_path())
+        let output = Command::new("uv")
             .current_dir(server.file_path("src"))
-            .args(["lock", "--offline"])
+            .args(["sync", "--offline"])
             .output()?;
         anyhow::ensure!(
             output.status.success(),
-            "uv lock failed: {}",
+            "uv sync failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
         server.did_change_watched_files(vec![event.clone()]);
+
+        server.assert_work_done_progress("Refreshing example metadata")?;
 
         // The existing warning is republished while the refresh is pending, then cleared.
         assert_eq!(


### PR DESCRIPTION
## Summary

This refactors the project's `uv workspace metadata` call to run in the background, the same as for scripts. This ensures that the watch command and the LSP remain responsive and show a progress indicator while uv is running. 

It should also make it easier to run `uv workspace metadata --sync` for projects. Although, that does require some work so that we can surface progress from the initial uv call (during project discovery) and not have the LSP blocked until the command completes.

This PR does not change when we run `uv workspace metadata`. That is, it doesn't add logic to detect when uv needs to rerun. The same as before, `uv workspace metadata` is only called when the `pyproject.toml` changed. It isn't run when a `uv.toml` or the virtual environment changes. We should do so, but this should be its own PR.

This PR enables `TY_UV=1 ty check --watch`

## Review

I recommending reviewing this PR commit by commit and with whitespace changes disabled.


## Test Plan

LSP:


https://github.com/user-attachments/assets/8c1ab9df-8209-44d5-b0b2-ba06cb824625



1. Simulate a long `uv metadata` command (e.g. when `uv sync` is holding the lock for multiple seconds). You can see the progress report
2. Changes to a `pyproject.toml` trigger a refresh

CLI

https://github.com/user-attachments/assets/b3cde596-c7f5-4f2e-880b-d3885c02dcb8

