### PR TITLE
Export `UV_DEFAULT_INDEX` in `release.sh`

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,6 +5,7 @@
 set -eu
 
 export UV_PREVIEW=1
+export UV_DEFAULT_INDEX='https://pypi.org/simple'
 
 script_root="$(realpath "$(dirname "$0")")"
 project_root="$(dirname "$script_root")"
@@ -22,7 +23,7 @@ uv run --script "$project_root/scripts/generate-crate-readmes.py"
 
 echo "Updating lockfiles..."
 cargo update -p ruff
-uv lock --default-index https://pypi.org/simple
+uv lock
 
 echo "Checking crates.io publish setup..."
-uv run --default-index https://pypi.org/simple --script "$project_root/scripts/setup-crates-io-publish.py" --quiet
+uv run --script "$project_root/scripts/setup-crates-io-publish.py" --quiet


### PR DESCRIPTION
Summary
--

Before this, running `./scripts/release.sh` produced this error on my machine:

```console
❯ ./scripts/release.sh
Updating metadata with rooster...
warning: `VIRTUAL_ENV=/Users/brw/.virtualenvs/openai` does not match the project environment path `.venv` and will be ig
nored; use `--active` to target the active environment instead
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.

hint: To update the lockfile, run `uv lock`.
```

Passing an additional `--default-index` flag to the initial `uv run` also works, but it seems easier
to export the environment variable for the whole workflow.

Test Plan
--

Manual testing in today's release
