### PR TITLE
Set `--preview` and `--default-index` for the `uv-lock` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,6 +117,7 @@ repos:
     hooks:
       - id: uv-lock
         priority: 0
+        args: [--preview, --default-index=https://pypi.org/simple]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 65dbdb59d2f2d9c3bdc343c566821ad3319ddaa3 # frozen: v0.16.3


### PR DESCRIPTION
Summary
--

This aligns the pre-commit hook with our release script

## Test plan

Manual test on today's release branch