### PR TITLE
[`flake8-bandit`] Describe what the rule actually checks for `httpx` (`S113`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -7,13 +7,15 @@ use crate::Violation;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for uses of the Python `requests` or `httpx` module that omit the
-/// `timeout` parameter.
+/// Checks for uses of the Python `requests` module that omit the `timeout`
+/// parameter, and for `requests` or `httpx` calls that pass `timeout=None`.
 ///
 /// ## Why is this bad?
 /// The `timeout` parameter is used to set the maximum time to wait for a
-/// response from the server. By omitting the `timeout` parameter, the program
-/// may hang indefinitely while awaiting a response.
+/// response from the server. `requests` has no timeout by default, so omitting
+/// the parameter may leave the program hanging indefinitely while awaiting a
+/// response. `httpx` applies a default timeout, so only an explicit
+/// `timeout=None` disables it.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
Hi :)

## Summary

The S113 docs say it checks `requests` or `httpx` calls that omit `timeout`, but that hasn't been true for httpx sincee #12213

httpx applies a default timeout, so leaving the argument out is fine there -- only an explicit `timeout=None` gets reported

In the code the implicit case is only reported when the module is `requests`

So this rewrites "What it does" & "Why is this bad?" to match what the rule actually does

Doc comment only, no behaviour change -- closes #27868 

## Test Plan

Ran ruff 0.16.3 over three files:

- `httpx.get(url)` -> nothing reported
- `httpx.get(url, timeout=None)` -> S113, "timeout set to `None`"
- `requests.get(url)` -> S113, "without timeout"

`docs/rules` is generated rather than committed, so there's nothing to regenerate here

Drafted with AI assistance (Claude Fable 5)