### PR TITLE
[ty] Avoid duplicate bindings in multi-target assignments

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -29,9 +29,9 @@ use crate::ast_ids::node_key::ExpressionNodeKey;
 use crate::ast_ids::{AstIdsBuilder, ScopedUseId};
 use crate::ast_node_ref::AstNodeRef;
 use crate::definition::{
-    AnnotatedAssignmentDefinitionNodeRef, AssignmentDefinitionNodeRef,
-    AssignmentValueBindingsOwner, ComprehensionDefinitionNodeRef, Definition, DefinitionCategory,
-    DefinitionKind, DefinitionNodeKey, DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef,
+    AnnotatedAssignmentDefinitionNodeRef, AssignmentDefinitionNodeRef, BindingsOwner,
+    ComprehensionDefinitionNodeRef, Definition, DefinitionCategory, DefinitionKind,
+    DefinitionNodeKey, DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef,
     ExceptHandlerDefinitionNodeRef, ForStmtDefinitionNodeRef, ImportDefinitionNodeRef,
     ImportFromDefinitionNodeRef, ImportFromSubmoduleDefinitionNodeRef,
     LambdaParameterDefinitionNodeRef, LoopHeaderDefinitionNodeRef, LoopStmtRef,
@@ -1409,7 +1409,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             Some(CurrentAssignment::Assign {
                 node,
                 unpack,
-                value_bindings_owner,
+                owner,
             }) => {
                 let assignment = self.add_definition(
                     place_id,
@@ -1417,7 +1417,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         unpack,
                         value: &node.value,
                         target: expr,
-                        value_bindings_owner,
+                        owner,
                     },
                 );
 
@@ -3917,7 +3917,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.push_assignment(CurrentAssignment::Assign {
                         node,
                         unpack: None,
-                        value_bindings_owner: AssignmentValueBindingsOwner::Definition,
+                        owner: BindingsOwner::Definition,
                     });
                     self.visit_expr(target);
                     self.pop_assignment();
@@ -5787,7 +5787,7 @@ enum CurrentAssignment<'ast, 'db> {
     Assign {
         node: &'ast ast::StmtAssign,
         unpack: Option<Unpack<'db>>,
-        value_bindings_owner: AssignmentValueBindingsOwner,
+        owner: BindingsOwner,
     },
     AnnAssign {
         node: &'ast ast::StmtAnnAssign,
@@ -5888,7 +5888,7 @@ impl<'ast> Unpackable<'ast> {
             Unpackable::Assign(stmt) => CurrentAssignment::Assign {
                 node: stmt,
                 unpack,
-                value_bindings_owner: AssignmentValueBindingsOwner::Statement,
+                owner: BindingsOwner::Statement,
             },
             Unpackable::For(stmt) => CurrentAssignment::For {
                 node: stmt,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -30,8 +30,8 @@ use crate::ast_ids::{AstIdsBuilder, ScopedUseId};
 use crate::ast_node_ref::AstNodeRef;
 use crate::definition::{
     AnnotatedAssignmentDefinitionNodeRef, AssignmentDefinitionNodeRef,
-    ComprehensionDefinitionNodeRef, Definition, DefinitionCategory, DefinitionKind,
-    DefinitionNodeKey, DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef,
+    AssignmentValueBindingsOwner, ComprehensionDefinitionNodeRef, Definition, DefinitionCategory,
+    DefinitionKind, DefinitionNodeKey, DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef,
     ExceptHandlerDefinitionNodeRef, ForStmtDefinitionNodeRef, ImportDefinitionNodeRef,
     ImportFromDefinitionNodeRef, ImportFromSubmoduleDefinitionNodeRef,
     LambdaParameterDefinitionNodeRef, LoopHeaderDefinitionNodeRef, LoopStmtRef,
@@ -1406,13 +1406,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     fn record_place_definition(&mut self, place_id: ScopedPlaceId, expr: &'ast ast::Expr) {
         match self.current_assignment() {
-            Some(CurrentAssignment::Assign { node, unpack }) => {
+            Some(CurrentAssignment::Assign {
+                node,
+                unpack,
+                value_bindings_owner,
+            }) => {
                 let assignment = self.add_definition(
                     place_id,
                     AssignmentDefinitionNodeRef {
                         unpack,
                         value: &node.value,
                         target: expr,
+                        value_bindings_owner,
                     },
                 );
 
@@ -3909,7 +3914,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 if let [target] = &node.targets[..]
                     && target.is_name_expr()
                 {
-                    self.push_assignment(CurrentAssignment::Assign { node, unpack: None });
+                    self.push_assignment(CurrentAssignment::Assign {
+                        node,
+                        unpack: None,
+                        value_bindings_owner: AssignmentValueBindingsOwner::Definition,
+                    });
                     self.visit_expr(target);
                     self.pop_assignment();
 
@@ -5778,6 +5787,7 @@ enum CurrentAssignment<'ast, 'db> {
     Assign {
         node: &'ast ast::StmtAssign,
         unpack: Option<Unpack<'db>>,
+        value_bindings_owner: AssignmentValueBindingsOwner,
     },
     AnnAssign {
         node: &'ast ast::StmtAnnAssign,
@@ -5875,7 +5885,11 @@ impl<'ast> Unpackable<'ast> {
     ) -> CurrentAssignment<'ast, 'db> {
         let positioned = unpack.map(|unpack| (UnpackPosition::First, unpack));
         match self {
-            Unpackable::Assign(stmt) => CurrentAssignment::Assign { node: stmt, unpack },
+            Unpackable::Assign(stmt) => CurrentAssignment::Assign {
+                node: stmt,
+                unpack,
+                value_bindings_owner: AssignmentValueBindingsOwner::Statement,
+            },
             Unpackable::For(stmt) => CurrentAssignment::For {
                 node: stmt,
                 unpack: positioned,

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -528,7 +528,7 @@ pub(crate) struct AssignmentDefinitionNodeRef<'ast, 'db> {
     pub(crate) unpack: Option<Unpack<'db>>,
     pub(crate) value: &'ast ast::Expr,
     pub(crate) target: &'ast ast::Expr,
-    pub(crate) value_bindings_owner: AssignmentValueBindingsOwner,
+    pub(crate) owner: BindingsOwner,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -694,12 +694,12 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 unpack,
                 value,
                 target,
-                value_bindings_owner,
+                owner,
             }) => DefinitionKind::Assignment(AssignmentDefinitionKind {
                 unpack,
                 value: AstNodeRef::new(parsed, value),
                 target: AstNodeRef::new(parsed, target),
-                value_bindings_owner,
+                owner,
             }),
             DefinitionNodeRef::AnnotatedAssignment(AnnotatedAssignmentDefinitionNodeRef {
                 node,
@@ -844,7 +844,7 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 value: _,
                 unpack: _,
                 target,
-                value_bindings_owner: _,
+                owner: _,
             }) => DefinitionNodeKey(NodeKey::from_node(target)),
             Self::AnnotatedAssignment(ann_assign) => ann_assign.node.into(),
             Self::AugmentedAssignment(node) => node.into(),
@@ -1428,7 +1428,7 @@ impl ImportFromSubmoduleDefinitionKind {
 
 /// The inference region that owns bindings created while evaluating an assignment's value.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-pub enum AssignmentValueBindingsOwner {
+pub enum BindingsOwner {
     /// A simple-name assignment is represented by its definition.
     Definition,
     /// An assignment with multiple, unpacking, or non-name targets is represented by its statement.
@@ -1440,7 +1440,7 @@ pub struct AssignmentDefinitionKind<'db> {
     unpack: Option<Unpack<'db>>,
     value: AstNodeRef<ast::Expr>,
     target: AstNodeRef<ast::Expr>,
-    value_bindings_owner: AssignmentValueBindingsOwner,
+    owner: BindingsOwner,
 }
 
 impl<'db> AssignmentDefinitionKind<'db> {
@@ -1456,8 +1456,8 @@ impl<'db> AssignmentDefinitionKind<'db> {
         self.target.node(module)
     }
 
-    pub fn value_bindings_owner(&self) -> AssignmentValueBindingsOwner {
-        self.value_bindings_owner
+    pub fn owner(&self) -> BindingsOwner {
+        self.owner
     }
 }
 

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -528,6 +528,7 @@ pub(crate) struct AssignmentDefinitionNodeRef<'ast, 'db> {
     pub(crate) unpack: Option<Unpack<'db>>,
     pub(crate) value: &'ast ast::Expr,
     pub(crate) target: &'ast ast::Expr,
+    pub(crate) value_bindings_owner: AssignmentValueBindingsOwner,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -693,10 +694,12 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 unpack,
                 value,
                 target,
+                value_bindings_owner,
             }) => DefinitionKind::Assignment(AssignmentDefinitionKind {
                 unpack,
                 value: AstNodeRef::new(parsed, value),
                 target: AstNodeRef::new(parsed, target),
+                value_bindings_owner,
             }),
             DefinitionNodeRef::AnnotatedAssignment(AnnotatedAssignmentDefinitionNodeRef {
                 node,
@@ -841,6 +844,7 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 value: _,
                 unpack: _,
                 target,
+                value_bindings_owner: _,
             }) => DefinitionNodeKey(NodeKey::from_node(target)),
             Self::AnnotatedAssignment(ann_assign) => ann_assign.node.into(),
             Self::AugmentedAssignment(node) => node.into(),
@@ -1422,11 +1426,21 @@ impl ImportFromSubmoduleDefinitionKind {
     }
 }
 
+/// The inference region that owns bindings created while evaluating an assignment's value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub enum AssignmentValueBindingsOwner {
+    /// A simple-name assignment is represented by its definition.
+    Definition,
+    /// An assignment with multiple, unpacking, or non-name targets is represented by its statement.
+    Statement,
+}
+
 #[derive(Clone, Debug, get_size2::GetSize, salsa::SalsaValue)]
 pub struct AssignmentDefinitionKind<'db> {
     unpack: Option<Unpack<'db>>,
     value: AstNodeRef<ast::Expr>,
     target: AstNodeRef<ast::Expr>,
+    value_bindings_owner: AssignmentValueBindingsOwner,
 }
 
 impl<'db> AssignmentDefinitionKind<'db> {
@@ -1440,6 +1454,10 @@ impl<'db> AssignmentDefinitionKind<'db> {
 
     pub fn target<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {
         self.target.node(module)
+    }
+
+    pub fn value_bindings_owner(&self) -> AssignmentValueBindingsOwner {
+        self.value_bindings_owner
     }
 }
 

--- a/crates/ty_python_semantic/resources/mdtest/assignment/multi_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/multi_target.md
@@ -22,16 +22,6 @@ reveal_type(second)  # revealed: () -> Literal[0]
 reveal_type(named)  # revealed: () -> Literal[0]
 ```
 
-The same applies when the assignment expression and lambda are separate parts of the shared value.
-
-```py
-first = second = ((named := 0), lambda: 1)
-
-reveal_type(first)  # revealed: tuple[Literal[0], () -> Literal[1]]
-reveal_type(second)  # revealed: tuple[Literal[0], () -> Literal[1]]
-reveal_type(named)  # revealed: Literal[0]
-```
-
 ## Assignment expressions with unpacking targets
 
 An unpacking target and a simple target share both the value and any assignment expressions inside
@@ -61,17 +51,18 @@ reveal_type(named)  # revealed: () -> Literal[0]
 
 ## Contextual inference in shared lambdas
 
-Each assignment target provides its own context to a shared lambda.
+Each assignment target provides its own context to a shared lambda, even when the targets have
+different parameter types.
 
 ```py
 from collections.abc import Callable
 
 first: Callable[[int], int]
-second: Callable[[int], int]
-first = second = lambda value: value.bit_length()
+second: Callable[[str], int]
+first = second = lambda value: 0
 
-reveal_type(first)  # revealed: (value: int) -> int
-reveal_type(second)  # revealed: (value: int) -> int
+reveal_type(first)  # revealed: (value: int) -> Literal[0]
+reveal_type(second)  # revealed: (value: str) -> Literal[0]
 ```
 
 ## Contextual inference in assignment expressions

--- a/crates/ty_python_semantic/resources/mdtest/assignment/multi_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/multi_target.md
@@ -59,6 +59,21 @@ reveal_type(first)  # revealed: () -> Literal[0]
 reveal_type(named)  # revealed: () -> Literal[0]
 ```
 
+## Contextual inference in shared lambdas
+
+Each assignment target provides its own context to a shared lambda.
+
+```py
+from collections.abc import Callable
+
+first: Callable[[int], int]
+second: Callable[[int], int]
+first = second = lambda value: value.bit_length()
+
+reveal_type(first)  # revealed: (value: int) -> int
+reveal_type(second)  # revealed: (value: int) -> int
+```
+
 ## Contextual inference in assignment expressions
 
 A declared type on the assignment-expression target still supplies context to its lambda.
@@ -72,4 +87,15 @@ first = second = (named := lambda value: value.bit_length())
 reveal_type(first)  # revealed: (value: int) -> int
 reveal_type(second)  # revealed: (value: int) -> int
 reveal_type(named)  # revealed: (value: int) -> int
+```
+
+## Assignment expressions in lambda defaults
+
+A lambda default executes in the enclosing assignment, so an assignment expression in that default
+creates a binding owned by the shared assignment statement.
+
+```py
+first = second = lambda value=(named := 1): value
+
+reveal_type(named)  # revealed: Literal[1]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/assignment/multi_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/multi_target.md
@@ -7,3 +7,69 @@ x = y = 1
 reveal_type(x)  # revealed: Literal[1]
 reveal_type(y)  # revealed: Literal[1]
 ```
+
+## Assignment expressions in shared values
+
+A value assigned to multiple targets can contain an assignment expression whose value is a lambda.
+The shared assignment expression should bind its name once and give every target the same callable
+type.
+
+```py
+first = second = (named := lambda: 0)
+
+reveal_type(first)  # revealed: () -> Literal[0]
+reveal_type(second)  # revealed: () -> Literal[0]
+reveal_type(named)  # revealed: () -> Literal[0]
+```
+
+The same applies when the assignment expression and lambda are separate parts of the shared value.
+
+```py
+first = second = ((named := 0), lambda: 1)
+
+reveal_type(first)  # revealed: tuple[Literal[0], () -> Literal[1]]
+reveal_type(second)  # revealed: tuple[Literal[0], () -> Literal[1]]
+reveal_type(named)  # revealed: Literal[0]
+```
+
+## Assignment expressions with unpacking targets
+
+An unpacking target and a simple target share both the value and any assignment expressions inside
+it.
+
+```py
+(first, second) = pair = ((named := 0), lambda: 1)
+
+reveal_type(first)  # revealed: Literal[0]
+reveal_type(second)  # revealed: () -> Literal[1]
+reveal_type(pair)  # revealed: tuple[Literal[0], () -> Literal[1]]
+reveal_type(named)  # revealed: Literal[0]
+```
+
+## Assignment expressions with subscript targets
+
+Subscript targets infer the shared value separately from name targets, but its nested binding still
+belongs to the same assignment.
+
+```py
+callbacks = [lambda: 0]
+first = callbacks[0] = (named := lambda: 0)
+
+reveal_type(first)  # revealed: () -> Literal[0]
+reveal_type(named)  # revealed: () -> Literal[0]
+```
+
+## Contextual inference in assignment expressions
+
+A declared type on the assignment-expression target still supplies context to its lambda.
+
+```py
+from collections.abc import Callable
+
+named: Callable[[int], int]
+first = second = (named := lambda value: value.bit_length())
+
+reveal_type(first)  # revealed: (value: int) -> int
+reveal_type(second)  # revealed: (value: int) -> int
+reveal_type(named)  # revealed: (value: int) -> int
+```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8,7 +8,7 @@ use ruff_db::diagnostic::Span;
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
-use ruff_python_ast::helpers::{any_over_expr, is_dotted_name};
+use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
@@ -2884,9 +2884,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let shared_value = self.index.expression(value.as_ref());
 
-        if !matches!(self.region, InferenceRegion::Scope(..))
-            && any_over_expr(value, ast::Expr::is_named_expr)
-        {
+        if !matches!(self.region, InferenceRegion::Scope(..)) {
+            // The statement owns every binding created while evaluating its shared value,
+            // including assignment expressions in lambda defaults.
             let inference = infer_expression_types(self.db(), shared_value, TypeContext::default());
             if let Some(extra) = &inference.extra {
                 self.bindings.extend(extra.bindings.iter().copied());

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -127,11 +127,11 @@ use crate::types::{
 };
 use crate::{AnalysisSettings, Db, DisplaySettings, FxIndexSet, FxOrderSet};
 use ty_python_core::definition::{
-    AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
-    Definition, DefinitionKind, DefinitionNodeKey, DefinitionState, ExceptHandlerDefinitionKind,
-    ForStmtDefinitionKind, LambdaParameterDefinitionNodeKind, LoopHeaderDefinitionKind,
-    NestedBindingExecution, NestedBindingsDefinitionKind, ParameterDefinitionNodeKind, TargetKind,
-    WithItemDefinitionKind,
+    AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, AssignmentValueBindingsOwner,
+    ComprehensionDefinitionKind, Definition, DefinitionKind, DefinitionNodeKey, DefinitionState,
+    ExceptHandlerDefinitionKind, ForStmtDefinitionKind, LambdaParameterDefinitionNodeKind,
+    LoopHeaderDefinitionKind, NestedBindingExecution, NestedBindingsDefinitionKind,
+    ParameterDefinitionNodeKind, TargetKind, WithItemDefinitionKind,
 };
 use ty_python_core::expression::{Expression, ExpressionKind};
 use ty_python_core::narrowing_constraints::ConstraintKey;
@@ -3402,22 +3402,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 let value_ty = if let Some(standalone_expression) = self.index.try_expression(value)
                 {
-                    if standalone_expression
-                        .assigned_to(self.db())
-                        .is_some_and(|assignment| {
-                            !matches!(
-                                assignment.node(self.module()).targets.as_slice(),
-                                [ast::Expr::Name(_)]
-                            )
-                        })
-                    {
-                        let inference =
-                            infer_expression_types(self.db(), standalone_expression, tcx);
-                        self.extend_expression_without_bindings(inference);
-                        inference.expression_type(value)
-                    } else {
-                        self.infer_standalone_expression_impl(value, standalone_expression, tcx)
+                    let inference = infer_expression_types(self.db(), standalone_expression, tcx);
+                    match assignment.value_bindings_owner() {
+                        AssignmentValueBindingsOwner::Definition => {
+                            self.extend_expression(inference);
+                        }
+                        AssignmentValueBindingsOwner::Statement => {
+                            self.extend_expression_without_bindings(inference);
+                        }
                     }
+                    inference.expression_type(value)
                 } else if let ast::Expr::Call(call_expr) = value {
                     // If the RHS is not a standalone expression, this is a simple assignment
                     // (single target, no unpackings). That means it's a valid syntactic form

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8,7 +8,7 @@ use ruff_db::diagnostic::Span;
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
-use ruff_python_ast::helpers::is_dotted_name;
+use ruff_python_ast::helpers::{any_over_expr, is_dotted_name};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
@@ -676,6 +676,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_expression_unchecked(&mut self, inference: &ExpressionInference<'db>) {
+        self.extend_expression_without_bindings(inference);
+
+        if let Some(extra) = &inference.extra
+            && !matches!(self.region, InferenceRegion::Scope(..))
+        {
+            self.bindings.extend(extra.bindings.iter().copied());
+        }
+    }
+
+    /// Merges expression results without claiming bindings owned by their enclosing statement.
+    fn extend_expression_without_bindings(&mut self, inference: &ExpressionInference<'db>) {
         self.expressions
             .extend(inference.expressions.iter().copied());
 
@@ -700,10 +711,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .entry(*collection_def)
                     .and_modify(|this| this.extend(constraints))
                     .or_insert(constraints.clone());
-            }
-
-            if !matches!(self.region, InferenceRegion::Scope(..)) {
-                self.bindings.extend(extra.bindings.iter().copied());
             }
         }
     }
@@ -2870,17 +2877,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             value,
         } = assignment;
 
+        if let [ast::Expr::Name(name)] = targets.as_slice() {
+            self.infer_definition(name);
+            return;
+        }
+
+        let shared_value = self.index.expression(value.as_ref());
+
+        if !matches!(self.region, InferenceRegion::Scope(..))
+            && any_over_expr(value, ast::Expr::is_named_expr)
+        {
+            let inference = infer_expression_types(self.db(), shared_value, TypeContext::default());
+            if let Some(extra) = &inference.extra {
+                self.bindings.extend(extra.bindings.iter().copied());
+            }
+        }
+
         for target in targets {
             if let Some(unpack) = self.index.try_unpack(target) {
-                // Infer the standalone expression here to include its diagnostics in this region.
-                self.infer_standalone_expression(value, TypeContext::default());
+                let inference =
+                    infer_expression_types(self.db(), shared_value, TypeContext::default());
+                self.extend_expression_without_bindings(inference);
 
                 let unpacked = infer_unpack_types(self.db(), unpack);
                 self.context.extend(unpacked.diagnostics());
                 self.infer_unpacked_assignment_target(target, value, unpacked);
             } else {
                 self.infer_target(target, value, &|builder, tcx| {
-                    builder.infer_standalone_expression(value, tcx)
+                    let inference = infer_expression_types(builder.db(), shared_value, tcx);
+                    builder.extend_expression_without_bindings(inference);
+                    inference.expression_type(value.as_ref())
                 });
             }
         }
@@ -3376,7 +3402,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 let value_ty = if let Some(standalone_expression) = self.index.try_expression(value)
                 {
-                    self.infer_standalone_expression_impl(value, standalone_expression, tcx)
+                    if standalone_expression
+                        .assigned_to(self.db())
+                        .is_some_and(|assignment| {
+                            !matches!(
+                                assignment.node(self.module()).targets.as_slice(),
+                                [ast::Expr::Name(_)]
+                            )
+                        })
+                    {
+                        let inference =
+                            infer_expression_types(self.db(), standalone_expression, tcx);
+                        self.extend_expression_without_bindings(inference);
+                        inference.expression_type(value)
+                    } else {
+                        self.infer_standalone_expression_impl(value, standalone_expression, tcx)
+                    }
                 } else if let ast::Expr::Call(call_expr) = value {
                     // If the RHS is not a standalone expression, this is a simple assignment
                     // (single target, no unpackings). That means it's a valid syntactic form

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -127,7 +127,7 @@ use crate::types::{
 };
 use crate::{AnalysisSettings, Db, DisplaySettings, FxIndexSet, FxOrderSet};
 use ty_python_core::definition::{
-    AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, AssignmentValueBindingsOwner,
+    AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, BindingsOwner,
     ComprehensionDefinitionKind, Definition, DefinitionKind, DefinitionNodeKey, DefinitionState,
     ExceptHandlerDefinitionKind, ForStmtDefinitionKind, LambdaParameterDefinitionNodeKind,
     LoopHeaderDefinitionKind, NestedBindingExecution, NestedBindingsDefinitionKind,
@@ -3403,11 +3403,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let value_ty = if let Some(standalone_expression) = self.index.try_expression(value)
                 {
                     let inference = infer_expression_types(self.db(), standalone_expression, tcx);
-                    match assignment.value_bindings_owner() {
-                        AssignmentValueBindingsOwner::Definition => {
+                    match assignment.owner() {
+                        BindingsOwner::Definition => {
                             self.extend_expression(inference);
                         }
-                        AssignmentValueBindingsOwner::Statement => {
+                        BindingsOwner::Statement => {
                             self.extend_expression_without_bindings(inference);
                         }
                     }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -347,6 +347,28 @@ fn shared_assignment_statement_owns_lambda_default_bindings() -> anyhow::Result<
 }
 
 #[test]
+fn single_assignment_definition_owns_lambda_default_bindings() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/lambda_default.py",
+        "values = [lambda value=(named := 1): value]",
+    )?;
+
+    let file = system_path_to_file(&db, "/src/lambda_default.py").unwrap();
+    let values = first_public_binding(&db, file, "values");
+    let named = first_public_binding(&db, file, "named");
+
+    assert!(
+        infer_definition_types(&db, values)
+            .bindings(values)
+            .any(|(definition, _)| definition == named),
+        "the definition lost the binding created in its lambda default"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn not_literal_string() -> anyhow::Result<()> {
     let mut db = setup_db();
     let content = format!(

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -320,55 +320,6 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
 }
 
 #[test]
-fn shared_assignment_statement_owns_lambda_default_bindings() -> anyhow::Result<()> {
-    let mut db = setup_db();
-    db.write_dedented(
-        "/src/lambda_default.py",
-        "first = second = lambda value=(named := 1): value",
-    )?;
-
-    let file = system_path_to_file(&db, "/src/lambda_default.py").unwrap();
-    let named = first_public_binding(&db, file, "named");
-    let program_file = program_file(&db, file);
-    let module = parsed_module(&db, program_file.python_file(&db)).load(&db);
-    let index = semantic_index(&db, program_file);
-    let statement = index.try_statement(&module.syntax().body[0]).unwrap();
-
-    assert!(
-        matches!(
-            infer_statement_types(&db, statement),
-            StatementInference::Other(inference)
-                if inference.bindings().any(|(definition, _)| definition == named)
-        ),
-        "the statement lost the binding created in its lambda default"
-    );
-
-    Ok(())
-}
-
-#[test]
-fn single_assignment_definition_owns_lambda_default_bindings() -> anyhow::Result<()> {
-    let mut db = setup_db();
-    db.write_dedented(
-        "/src/lambda_default.py",
-        "values = [lambda value=(named := 1): value]",
-    )?;
-
-    let file = system_path_to_file(&db, "/src/lambda_default.py").unwrap();
-    let values = first_public_binding(&db, file, "values");
-    let named = first_public_binding(&db, file, "named");
-
-    assert!(
-        infer_definition_types(&db, values)
-            .bindings(values)
-            .any(|(definition, _)| definition == named),
-        "the definition lost the binding created in its lambda default"
-    );
-
-    Ok(())
-}
-
-#[test]
 fn not_literal_string() -> anyhow::Result<()> {
     let mut db = setup_db();
     let content = format!(

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -320,6 +320,33 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
 }
 
 #[test]
+fn shared_assignment_statement_owns_lambda_default_bindings() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/lambda_default.py",
+        "first = second = lambda value=(named := 1): value",
+    )?;
+
+    let file = system_path_to_file(&db, "/src/lambda_default.py").unwrap();
+    let named = first_public_binding(&db, file, "named");
+    let program_file = program_file(&db, file);
+    let module = parsed_module(&db, program_file.python_file(&db)).load(&db);
+    let index = semantic_index(&db, program_file);
+    let statement = index.try_statement(&module.syntax().body[0]).unwrap();
+
+    assert!(
+        matches!(
+            infer_statement_types(&db, statement),
+            StatementInference::Other(inference)
+                if inference.bindings().any(|(definition, _)| definition == named)
+        ),
+        "the statement lost the binding created in its lambda default"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn not_literal_string() -> anyhow::Result<()> {
     let mut db = setup_db();
     let content = format!(


### PR DESCRIPTION
## Summary

Previously, chained assignments could panic when their shared right-hand side contained both an assignment expression and a lambda:

```python
first = second = (named := lambda: 0)
```

Each target independently imported the same nested binding, violating the uniqueness invariant for inferred bindings.

We now record whether an assignment's value bindings belong to its definition or its enclosing statement during semantic indexing. Statements claim shared bindings once while individual targets retain contextual expression inference. The same ownership rule handles unpacking, subscript targets, and assignment expressions in lambda defaults:

```python
first = second = lambda value=(named := 1): value
```
