### PR TITLE
Disable uv preview for releases and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,7 +117,7 @@ repos:
     hooks:
       - id: uv-lock
         priority: 0
-        args: [--preview, --default-index=https://pypi.org/simple]
+        args: [--default-index=https://pypi.org/simple]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 65dbdb59d2f2d9c3bdc343c566821ad3319ddaa3 # frozen: v0.16.3

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,6 @@
 # All additional options are passed to `rooster release`
 set -eu
 
-export UV_PREVIEW=1
 export UV_DEFAULT_INDEX='https://pypi.org/simple'
 
 script_root="$(realpath "$(dirname "$0")")"


### PR DESCRIPTION
Summary
--

This partially reverts https://github.com/astral-sh/ruff/pull/27935 as an alternative to enabling
preview everywhere. Preview was initially enabled ~2 years ago (#11496), and we probably want to be
more selective about preview features now.

Test Plan
--

Today's release, previous errors:

- https://github.com/astral-sh/ruff/actions/runs/32390111175/job/96493893174?pr=27937
- https://github.com/astral-sh/ruff/actions/runs/32390111175/job/96493998150?pr=27937
