### PR TITLE
[ty] Reject failed calls during overload resolution

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1607,6 +1607,182 @@ def f9(func: Callable[[], Union[Awaitable[T2], T2]]) -> Future[T2]:
     return future
 ```
 
+## Failed generic calls do not match outer overloads
+
+Generic call inference currently fails when the `Child` return context conflicts with the `Parent`
+argument. The resulting `Unknown` must not make the outer overload ambiguous.
+
+```py
+from collections.abc import Callable
+from typing import overload
+
+class Parent: ...
+class Child(Parent): ...
+
+@overload
+def inner[T](value: T, key: None = None) -> T: ...
+@overload
+def inner[T](value: T, key: Callable[[T], object]) -> T: ...
+def inner[T](value: T, key: Callable[[T], object] | None = None) -> T:
+    return value
+
+@overload
+def outer(value: Child) -> Child: ...
+@overload
+def outer(value: Parent) -> Parent: ...
+def outer(value: Parent) -> Parent:
+    return value
+
+def _(value: Parent):
+    reveal_type(inner(value, lambda _: None))  # revealed: Parent
+    reveal_type(outer(inner(value, lambda _: None)))  # revealed: Parent
+```
+
+## Failed generic calls with invariant return types
+
+No specialization of the inner call can accept `list[Parent]` and return `list[Child]`. Its recovery
+type must not select the first outer overload.
+
+```py
+from collections.abc import Callable
+from typing import overload
+
+class Parent: ...
+class Child(Parent): ...
+
+@overload
+def inner[T](value: T, key: None = None) -> T: ...
+@overload
+def inner[T](value: T, key: Callable[[T], object]) -> T: ...
+def inner[T](value: T, key: Callable[[T], object] | None = None) -> T:
+    return value
+
+@overload
+def outer(value: list[Child]) -> list[Child]: ...
+@overload
+def outer(value: list[Parent]) -> list[Parent]: ...
+def outer(value: object) -> object:
+    return value
+
+def _(value: list[Parent]):
+    reveal_type(outer(inner(value, lambda _: None)))  # revealed: list[Parent]
+```
+
+The same rule applies to non-overloaded generic calls:
+
+```py
+def direct[T](value: T, key: Callable[[T], object]) -> T:
+    return value
+
+def _(value: list[Parent]):
+    reveal_type(outer(direct(value, lambda _: None)))  # revealed: list[Parent]
+```
+
+As well as calls nested in collection literals:
+
+```py
+@overload
+def outer_tuple(value: tuple[list[Child]]) -> list[Child]: ...
+@overload
+def outer_tuple(value: tuple[list[Parent]]) -> list[Parent]: ...
+def outer_tuple(value: tuple[object]) -> object:
+    return value[0]
+
+def _(value: list[Parent]):
+    reveal_type(outer_tuple((inner(value, lambda _: None),)))  # revealed: list[Parent]
+```
+
+When both contextual inferences are valid, ordinary overload declaration order still applies.
+
+```py
+@overload
+def ordered(value: list[Parent]) -> int: ...
+@overload
+def ordered(value: list[Child]) -> str: ...
+def ordered(value: object) -> int | str:
+    raise NotImplementedError
+
+reveal_type(ordered([Child()]))  # revealed: int
+```
+
+## Argument expansion preserves failures in other arguments
+
+Expanding `tag` does not change the inner call's return type. The `int` member still has no matching
+overload because `list[Parent]` is not assignable to `list[Child]`.
+
+```py
+from collections.abc import Callable
+from typing import overload
+
+class Parent: ...
+class Child(Parent): ...
+
+def inner[T](value: T, key: Callable[[T], object]) -> T:
+    return value
+
+@overload
+def outer(value: list[Child], tag: int) -> int: ...
+@overload
+def outer(value: list[Parent], tag: str) -> str: ...
+def outer(value: object, tag: int | str) -> int | str:
+    return tag
+
+def _(value: list[Parent], tag: int | str):
+    # error: [no-matching-overload]
+    reveal_type(outer(inner(value, lambda _: None), tag))  # revealed: Unknown
+```
+
+## Overload matching preserves gradual and known return types
+
+A genuine `Any` still makes overload matching ambiguous. An invalid non-generic call also retains
+its declared return type, which can select an outer overload.
+
+```py
+from typing import Any, overload
+
+@overload
+def outer(value: str) -> str: ...
+@overload
+def outer(value: int) -> int: ...
+def outer(value: str | int) -> str | int:
+    return value
+
+def inner(value: int) -> str:
+    return str(value)
+
+def _(dynamic: Any):
+    reveal_type(outer(dynamic))  # revealed: Unknown
+    # error: [invalid-argument-type]
+    reveal_type(outer(inner("wrong argument")))  # revealed: str
+```
+
+## Overload inference does not discard shared lambda bodies
+
+Lambda bodies currently obtain their parameter types through the enclosing statement. A failure in
+that shared inference must not discard both callback candidates.
+
+```py
+from collections.abc import Callable
+from typing import overload
+
+@overload
+def inner(value: int) -> int: ...
+@overload
+def inner(value: bytes) -> int: ...
+def inner(value: int | bytes) -> int:
+    return 0
+
+@overload
+def outer(callback: Callable[[str], int]) -> str: ...
+@overload
+def outer(callback: Callable[[int], int]) -> int: ...
+def outer(callback: Callable[[str], int] | Callable[[int], int]) -> str | int:
+    raise NotImplementedError
+
+# TODO: Infer the body independently for each candidate, and reveal `int`.
+reveal_type(outer(lambda value: inner(value)))  # revealed: str
+```
+
 ## Class constructor parameters
 
 The parameters of both `__init__` and `__new__` are used as type context sources for constructor

--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -420,6 +420,18 @@ def _(xs: Unknown):
     reveal_type("".join(map("{}".format, xs)))  # revealed: Unknown
 ```
 
+## Joining sorted strings
+
+The `LiteralString` overload of `str.join` cannot accept an arbitrary `list[str]`. If inference of
+`sorted` fails under that context, its recovery type must not make the outer call ambiguous.
+
+```py
+def _(items: list[str]):
+    reveal_type(",".join(sorted(items, key=lambda item: item)))  # revealed: str
+    reveal_type(",".join(sorted(items, key=len)))  # revealed: str
+    reveal_type(",".join(sorted(items)))  # revealed: str
+```
+
 ## Mapping methods accept arbitrary object types
 
 ```toml

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -9,7 +9,7 @@ use ruff_python_ast as ast;
 
 mod arguments;
 pub(crate) mod bind;
-pub(super) use arguments::{Argument, CallArguments};
+pub(super) use arguments::{Argument, CallArgumentType, CallArguments};
 pub(super) use bind::{
     Binding, Bindings, CallDiagnosticOverride, CallableBinding, MatchedArgument,
 };

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -46,35 +46,57 @@ struct CallArgument<'a, 'db> {
     types: CallArgumentTypes<'db>,
 }
 
+/// The result of inferring an argument under a particular type context.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CallArgumentType<'db> {
+    pub(crate) ty: Type<'db>,
+    /// A failed generic or overloaded call still produces a recovery type, but that type cannot
+    /// establish a match for the overload that supplied the context.
+    pub(crate) is_valid: bool,
+}
+
+impl<'db> CallArgumentType<'db> {
+    fn valid(ty: Type<'db>) -> Self {
+        Self { ty, is_valid: true }
+    }
+}
+
 /// Inferred types for a given argument.
 ///
 /// Note that a single argument may produce multiple distinct inferred types when inferred
 /// with type context across multiple bindings.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct CallArgumentTypes<'db> {
-    fallback_type: Option<Type<'db>>,
-    types: FxHashMap<Type<'db>, Type<'db>>,
+    fallback_type: Option<CallArgumentType<'db>>,
+    types: FxHashMap<Type<'db>, CallArgumentType<'db>>,
 }
 
 impl<'db> CallArgumentTypes<'db> {
     fn new(fallback_ty: Option<Type<'db>>) -> Self {
         Self {
-            fallback_type: fallback_ty,
+            fallback_type: fallback_ty.map(CallArgumentType::valid),
             types: FxHashMap::default(),
         }
     }
 
     /// Returns the most appropriate type of this argument when there is no specific declared type.
     pub(crate) fn get_default(&self) -> Option<Type<'db>> {
-        // If this type was inferred against exactly one declared type, or was inferred against
-        // multiple, but resulted in a single inferred type, we have an exact type to return.
-        if let Ok(exact_ty) = self
+        self.default_inference().map(|inferred| inferred.ty)
+    }
+
+    fn default_inference(&self) -> Option<CallArgumentType<'db>> {
+        // If every contextual inference produced the same type, use it as the default. At least
+        // one of those inferences must have succeeded for the common type to establish a match.
+        if let Ok(ty) = self
             .types
             .values()
-            .exactly_one()
-            .or_else(|_| self.types.values().all_equal_value())
+            .map(|inferred| inferred.ty)
+            .all_equal_value()
         {
-            return Some(*exact_ty);
+            return Some(CallArgumentType {
+                ty,
+                is_valid: self.types.values().any(|inferred| inferred.is_valid),
+            });
         }
 
         self.fallback_type
@@ -82,19 +104,29 @@ impl<'db> CallArgumentTypes<'db> {
 
     /// Returns the type of this argument when inferred against the provided declared type.
     pub(crate) fn get_for_declared_type(&self, tcx: Type<'db>) -> Type<'db> {
-        self.types
-            .get(&tcx)
-            .copied()
-            .or_else(|| self.get_default())
+        self.inference_for_declared_type(tcx)
+            .map(|inferred| inferred.ty)
             .unwrap_or(Type::unknown())
     }
 
+    pub(crate) fn is_valid_for_declared_type(&self, tcx: Type<'db>) -> bool {
+        self.inference_for_declared_type(tcx)
+            .is_none_or(|inferred| inferred.is_valid)
+    }
+
+    fn inference_for_declared_type(&self, tcx: Type<'db>) -> Option<CallArgumentType<'db>> {
+        self.types
+            .get(&tcx)
+            .copied()
+            .or_else(|| self.default_inference())
+    }
+
     /// Insert the type of this argument when inferred with the provided type context.
-    fn insert(&mut self, tcx: impl Into<TypeContext<'db>>, ty: Type<'db>) {
-        match tcx.into().annotation {
-            None => self.fallback_type = Some(ty),
+    fn insert(&mut self, tcx: TypeContext<'db>, inferred: CallArgumentType<'db>) {
+        match tcx.annotation {
+            None => self.fallback_type = Some(inferred),
             Some(tcx) => {
-                self.types.insert(tcx, ty);
+                self.types.insert(tcx, inferred);
             }
         }
     }
@@ -102,8 +134,11 @@ impl<'db> CallArgumentTypes<'db> {
     fn iter(&self) -> impl Iterator<Item = (TypeContext<'db>, Type<'db>)> {
         self.types
             .iter()
-            .map(|(tcx, ty)| (TypeContext::new(Some(*tcx)), *ty))
-            .chain(self.fallback_type.map(|ty| (TypeContext::default(), ty)))
+            .map(|(tcx, inferred)| (TypeContext::new(Some(*tcx)), inferred.ty))
+            .chain(
+                self.fallback_type
+                    .map(|inferred| (TypeContext::default(), inferred.ty)),
+            )
     }
 }
 
@@ -210,13 +245,13 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         &mut self,
         index: usize,
         tcx: impl Into<TypeContext<'db>>,
-        ty: Type<'db>,
+        inferred: CallArgumentType<'db>,
     ) {
         self.items
             .get_mut(index)
             .expect("argument index should be valid")
             .types
-            .insert(tcx, ty);
+            .insert(tcx.into(), inferred);
     }
 
     pub(crate) fn clear_types(&mut self, index: usize) {
@@ -379,7 +414,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                 };
 
                 // Find the next type that can be expanded.
-                let expanded_types = loop {
+                let (expanded_types, is_valid) = loop {
                     let arg_type = self.argument_types(index)?;
                     // TODO: For types inferred multiple times with distinct type context, we currently only
                     // expand the default inference. Note that direct expansion of a type inferred against a
@@ -388,10 +423,10 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                     // argument type against the union a given subset of type contexts before expansion. However,
                     // this only shows up in very convoluted instances of generic call inference across multiple
                     // overloads, and is unlikely to happen in practice.
-                    if let Some(arg_type) = arg_type.get_default()
-                        && let Some(expanded_types) = expand_type(db, &env, arg_type)
+                    if let Some(inferred) = arg_type.default_inference()
+                        && let Some(expanded_types) = expand_type(db, &env, inferred.ty)
                     {
-                        break expanded_types;
+                        break (expanded_types, inferred.is_valid);
                     }
                     index += 1;
                 };
@@ -410,8 +445,15 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                 for pre_expanded_types in state.iter(self) {
                     for subtype in &expanded_types {
                         let mut expanded_argument = pre_expanded_types.clone();
-                        expanded_argument.items[index].types =
-                            CallArgumentTypes::new(Some(*subtype));
+                        // This argument is now checked against one member of its default type.
+                        // Contextual failures on other arguments still apply.
+                        expanded_argument.items[index].types = CallArgumentTypes {
+                            fallback_type: Some(CallArgumentType {
+                                ty: *subtype,
+                                is_valid,
+                            }),
+                            types: FxHashMap::default(),
+                        };
                         expanded_arguments.push(expanded_argument);
                     }
                 }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -31,7 +31,9 @@ use crate::lint::LintMetadata;
 use crate::place::{DefinedPlace, Definedness, Place};
 use crate::subscript::PyIndex;
 use crate::types::ProgramEnvironment;
-use crate::types::call::arguments::{CallArgumentTypes, Expansion, is_expandable_type};
+use crate::types::call::arguments::{
+    CallArgumentType, CallArgumentTypes, Expansion, is_expandable_type,
+};
 use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, PathBound, PathBounds, Solutions,
@@ -1018,6 +1020,24 @@ impl<'db> Bindings<'db> {
                 .callables()
                 .flat_map(CallableBinding::matching_overloads)
                 .any(|(_, overload)| f(overload))
+        })
+    }
+
+    /// Whether a union element has no matching signature and requires generic or overload
+    /// inference. Unlike a non-generic call's known return type, its recovery type cannot
+    /// establish an outer overload match.
+    pub(crate) fn has_failed_call_inference(&self) -> bool {
+        self.elements.iter().any(|element| {
+            element
+                .callables()
+                .all(|binding| binding.matching_overloads().next().is_none())
+                && element.callables().any(|binding| {
+                    binding.overloads.len() > 1
+                        || binding
+                            .overloads
+                            .iter()
+                            .any(|overload| overload.signature.generic_context.is_some())
+                })
         })
     }
 
@@ -3725,7 +3745,7 @@ impl<'db> CallableBinding<'db> {
         // Step 2: Evaluate each remaining overload as a regular (non-overloaded) call to determine
         // whether it is compatible with the supplied argument list.
         for (_, overload) in self.matching_overloads_mut() {
-            overload.check_types(
+            overload.check_overload_types(
                 db,
                 env,
                 constraints,
@@ -3916,7 +3936,7 @@ impl<'db> CallableBinding<'db> {
                 );
 
                 for (_, overload) in self.matching_overloads_mut() {
-                    overload.check_types(
+                    overload.check_overload_types(
                         db,
                         env,
                         constraints,
@@ -7086,7 +7106,7 @@ impl<'db> ArgumentTypeContext<'db> {
         self,
         arguments_types: &mut CallArguments<'_, 'db>,
         argument_index: usize,
-        inferred_ty: Type<'db>,
+        inferred_ty: CallArgumentType<'db>,
     ) {
         match self {
             Self::Standard {
@@ -7820,6 +7840,33 @@ impl<'db> Binding<'db> {
         self.variadic_argument_matched_to_variadic_parameter =
             matcher.variadic_argument_matched_to_variadic_parameter;
         self.argument_matches = matcher.finish(db, env);
+    }
+
+    /// Check a competing overload without allowing failed argument inference to establish a match.
+    fn check_overload_types(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        constraints: &ConstraintSetBuilder<'db>,
+        arguments: &CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+    ) {
+        self.check_types(db, env, constraints, arguments, call_expression_tcx);
+
+        if self
+            .argument_matches
+            .iter()
+            .zip(arguments.iter_types())
+            .any(|(matched, argument)| {
+                matched.iter().any(|parameter| {
+                    !argument.is_valid_for_declared_type(
+                        self.signature.parameters()[parameter.index].annotated_type(),
+                    )
+                })
+            })
+        {
+            self.mark_as_unmatched_overload();
+        }
     }
 
     fn check_types(

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -916,6 +916,9 @@ struct ScopeInferenceExtra<'db> {
     /// Metadata for type expressions in this region.
     type_expression_flags: FrozenMap<ExpressionNodeKey, TypeExpressionFlags>,
 
+    /// Generic or overloaded calls that failed to match their arguments.
+    failed_calls: FrozenSet<ExpressionNodeKey>,
+
     /// The constraints on any collection initializers that are accessed in this region.
     collection_use_constraints: CollectionUseConstraints<'db>,
 
@@ -1323,6 +1326,9 @@ struct OtherDefinitionInferenceExtra<'db> {
     /// Metadata for type expressions in this region.
     type_expression_flags: FrozenMap<ExpressionNodeKey, TypeExpressionFlags>,
 
+    /// Generic or overloaded calls that failed to match their arguments.
+    failed_calls: FrozenSet<ExpressionNodeKey>,
+
     /// The constraints on any collection initializers that are accessed in this region.
     collection_use_constraints: CollectionUseConstraints<'db>,
 
@@ -1703,6 +1709,9 @@ struct ExpressionInferenceExtra<'db> {
     /// Metadata for type expressions in this region.
     type_expression_flags: FrozenMap<ExpressionNodeKey, TypeExpressionFlags>,
 
+    /// Generic or overloaded calls that failed to match their arguments.
+    failed_calls: FrozenSet<ExpressionNodeKey>,
+
     /// The constraints on any collection initializers that are accessed in this region.
     collection_use_constraints: CollectionUseConstraints<'db>,
 
@@ -1877,6 +1886,9 @@ struct StatementInferenceInnerExtra<'db> {
 
     /// Metadata for type expressions in this region.
     type_expression_flags: FrozenMap<ExpressionNodeKey, TypeExpressionFlags>,
+
+    /// Generic or overloaded calls that failed to match their arguments.
+    failed_calls: FrozenSet<ExpressionNodeKey>,
 
     /// The constraints on any collection initializers that are accessed in this region.
     collection_use_constraints: CollectionUseConstraints<'db>,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8,7 +8,7 @@ use ruff_db::diagnostic::Span;
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
-use ruff_python_ast::helpers::is_dotted_name;
+use ruff_python_ast::helpers::{any_over_expr, is_dotted_name};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
@@ -51,7 +51,9 @@ use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attri
 use crate::types::call::bind::{
     ArgumentTypeContext, CheckTypesMode, OverloadSet, requires_overload_evaluation,
 };
-use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
+use crate::types::call::{
+    Binding, Bindings, CallArgumentType, CallArguments, CallError, CallErrorKind,
+};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::class::{
     ClassLiteral, CodeGeneratorKind, FrozenDataclassDispatch, MethodDecorator,
@@ -279,6 +281,10 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// Only populated for expressions that have non-empty flags.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
 
+    /// Calls that failed generic or overload inference. Keep these separate from diagnostics,
+    /// which can be suppressed, and from recovery types, which are still useful to other callers.
+    failed_calls: FxHashSet<ExpressionNodeKey>,
+
     /// The constraints on any collection initializers that are accessed in this region.
     //
     // TODO: Store projected constraint sets directly here instead of specialized receiver types.
@@ -486,6 +492,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             reachability_cache: OnceCell::new(),
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
+            failed_calls: FxHashSet::default(),
             collection_use_constraints: FxHashMap::default(),
             string_annotations: FxHashSet::default(),
             expected_types: FxHashMap::default(),
@@ -557,6 +564,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    /// Replace expression types and discard failures from their previous inference. A later
+    /// fixpoint iteration may successfully infer a call that failed under an earlier context.
+    fn extend_expression_types(
+        &mut self,
+        expressions: impl IntoIterator<Item = (ExpressionNodeKey, Type<'db>)>,
+    ) {
+        if self.failed_calls.is_empty() {
+            self.expressions.extend(expressions);
+        } else {
+            self.expressions
+                .extend(expressions.into_iter().inspect(|(expression, _)| {
+                    self.failed_calls.remove(expression);
+                }));
+        }
+    }
+
     fn extend_definition(
         &mut self,
         definition: Definition<'db>,
@@ -565,8 +588,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
-        self.expressions
-            .extend(inference.expressions.iter().copied());
+        self.extend_expression_types(inference.expressions.iter().copied());
         self.declarations.extend(inference.declarations(definition));
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
@@ -601,6 +623,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 DefinitionInferenceExtra::Undecorated(_)
                 | DefinitionInferenceExtra::DiscardsDictKeyAssignments => {}
                 DefinitionInferenceExtra::Other(extra) => {
+                    self.failed_calls.extend(extra.failed_calls.iter().copied());
                     self.called_functions
                         .extend(extra.called_functions.iter().copied());
                     self.extend_cycle_recovery(extra.cycle_recovery);
@@ -642,8 +665,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
-        self.expressions
-            .extend(inference.expressions.iter().copied());
+        self.extend_expression_types(inference.expressions.iter().copied());
         self.declarations.extend(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
@@ -651,6 +673,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if let Some(extra) = &inference.extra {
+            self.failed_calls.extend(extra.failed_calls.iter().copied());
             self.called_functions
                 .extend(extra.called_functions.iter().copied());
             self.return_types_and_ranges
@@ -676,10 +699,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_expression_unchecked(&mut self, inference: &ExpressionInference<'db>) {
-        self.expressions
-            .extend(inference.expressions.iter().copied());
+        self.extend_expression_types(inference.expressions.iter().copied());
 
         if let Some(extra) = &inference.extra {
+            self.failed_calls.extend(extra.failed_calls.iter().copied());
             self.context.extend(&extra.diagnostics);
             self.extend_cycle_recovery(extra.cycle_recovery);
             self.called_functions
@@ -712,8 +735,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
-        self.expressions
-            .extend(inference.expressions.iter().map(|(key, ty)| (*key, *ty)));
+        self.extend_expression_types(inference.expressions.iter().map(|(key, ty)| (*key, *ty)));
+        self.failed_calls.extend(&inference.failed_calls);
         self.context.extend(&inference.diagnostics);
         self.extend_cycle_recovery(inference.cycle_recovery);
         self.called_functions
@@ -751,9 +774,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_scope(&mut self, inference: &ScopeInference<'db>) {
-        self.expressions.extend(inference.expressions.iter());
+        self.extend_expression_types(inference.expressions.iter());
 
         if let Some(extra) = &inference.extra {
+            self.failed_calls.extend(extra.failed_calls.iter().copied());
             self.context.extend(&extra.diagnostics);
             self.extend_cycle_recovery(extra.cycle_recovery);
             self.string_annotations
@@ -6127,6 +6151,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
         mode: CallArgumentInferenceMode,
     ) {
+        let mut infer_argument = |builder: &mut Self, arg: ArgExpr<'db, '_>| {
+            let ty = infer_argument_ty(builder, arg);
+            CallArgumentType {
+                ty,
+                is_valid: !builder.expression_has_failed_call(arg.1),
+            }
+        };
+
         let insert_argument_ty =
             |argument_index,
              inferred_ty,
@@ -6162,7 +6194,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let tcx = argument_tcx
                         .map(ArgumentTypeContext::type_context)
                         .unwrap_or_default();
-                    let inferred_ty = infer_argument_ty(self, (argument_index, ast_argument, tcx));
+                    let inferred_ty = infer_argument(self, (argument_index, ast_argument, tcx));
                     insert_argument_ty(argument_index, inferred_ty, argument_tcx, argument_types);
                 }
 
@@ -6173,7 +6205,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // speculative mode, infer the argument without type context as the
                     // default inference.
                     if mode.requires_default_inference() {
-                        let inferred_ty = infer_argument_ty(
+                        let inferred_ty = infer_argument(
                             self,
                             (argument_index, ast_argument, TypeContext::default()),
                         );
@@ -6217,7 +6249,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .unwrap_or_default();
 
                         let mut speculative_builder = self.speculate();
-                        let inferred_ty = infer_argument_ty(
+                        let inferred_ty = infer_argument(
                             &mut speculative_builder,
                             (argument_index, ast_argument, tcx),
                         );
@@ -6239,6 +6271,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
         }
+    }
+
+    /// Whether this argument contains a failed generic or overloaded call in its own scope.
+    fn expression_has_failed_call(&self, expression: &ast::Expr) -> bool {
+        // Lambda bodies obtain parameter types through the enclosing statement, rather than the
+        // current speculative context. Until they can be inferred independently, failures in that
+        // separate scope cannot rule out an overload.
+        !self.failed_calls.is_empty()
+            && any_over_expr(expression, |expr| {
+                self.failed_calls.contains(&expr.into())
+                    && self.index.expression_scope_id(expr)
+                        == self.index.expression_scope_id(expression)
+            })
     }
 
     fn infer_maybe_standalone_statement(&mut self, statement: &ast::Stmt) {
@@ -6391,6 +6436,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         match cache_entry {
             Some(ExpressionCacheEntry::Small(ty)) => {
+                self.failed_calls.remove(&expression_key);
                 self.store_expression_type(expression, ty);
                 ty
             }
@@ -8928,6 +8974,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        self.failed_calls.remove(&call_expression.into());
+
         let db = self.db();
         let env = self.program_environment();
         let ast::ExprCall {
@@ -9364,6 +9412,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut bindings = match bindings_result {
             Ok(()) => bindings,
             Err(_) => {
+                if bindings.has_failed_call_inference() {
+                    self.failed_calls.insert(call_expression.into());
+                }
                 bindings.report_diagnostics(&self.context, call_expression.into());
                 return bindings.return_type(db, env);
             }
@@ -11172,6 +11223,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             qualifiers: _,
             type_expression_flags,
+            failed_calls,
             collection_use_constraints,
             string_annotations,
             expected_types,
@@ -11212,6 +11264,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         FullExpressionCacheEntry {
             expressions,
             type_expression_flags,
+            failed_calls,
             collection_use_constraints,
             string_annotations,
             expected_types,
@@ -11232,6 +11285,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             qualifiers,
             type_expression_flags,
+            failed_calls,
             mut collection_use_constraints,
             string_annotations,
             expected_types,
@@ -11269,6 +11323,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             || !return_types_and_ranges.is_empty()
             || !qualifiers.is_empty()
             || !type_expression_flags.is_empty()
+            || !failed_calls.is_empty()
             || !collection_use_constraints.is_empty())
         .then(|| {
             collection_use_constraints.shrink_to_fit();
@@ -11282,6 +11337,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .into_boxed_slice(),
                 return_types_and_ranges: return_types_and_ranges.into_boxed_slice(),
                 type_expression_flags: FrozenMap::from(type_expression_flags),
+                failed_calls: FrozenSet::from(failed_calls),
                 collection_use_constraints,
                 cycle_recovery,
                 deferred: deferred.into_boxed_slice(),
@@ -11364,6 +11420,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             cycle_recovery: _,
             qualifiers: _,
             type_expression_flags: _,
+            failed_calls: _,
         } = self;
         let diagnostics = context.finish();
 
@@ -11393,6 +11450,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             qualifiers,
             type_expression_flags,
+            failed_calls,
             mut collection_use_constraints,
             string_annotations,
             expected_types,
@@ -11424,6 +11482,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             + usize::from(!collection_use_constraints.is_empty())
             + usize::from(!called_functions.is_empty())
             + usize::from(!type_expression_flags.is_empty())
+            + usize::from(!failed_calls.is_empty())
             + usize::from(cycle_recovery.is_some())
             + usize::from(!deferred.is_empty())
             + usize::from(!diagnostics.is_empty())
@@ -11480,6 +11539,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect::<Vec<_>>()
                         .into_boxed_slice(),
                     type_expression_flags: FrozenMap::from(type_expression_flags),
+                    failed_calls: FrozenSet::from(failed_calls),
                     cycle_recovery,
                     deferred: deferred.into_boxed_slice(),
                     diagnostics,
@@ -11530,6 +11590,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             string_annotations,
             expected_types,
             type_expression_flags,
+            failed_calls,
             mut collection_use_constraints,
             expressions,
             scope,
@@ -11565,6 +11626,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             || !diagnostics.is_empty()
             || cycle_recovery.is_some()
             || !type_expression_flags.is_empty()
+            || !failed_calls.is_empty()
             || !collection_use_constraints.is_empty()
             || !qualifiers.is_empty())
         .then(|| {
@@ -11574,6 +11636,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 qualifiers: FrozenMap::from(qualifiers),
                 expected_types: FrozenMap::from(expected_types),
                 type_expression_flags: FrozenMap::from(type_expression_flags),
+                failed_calls: FrozenSet::from(failed_calls),
                 collection_use_constraints,
                 cycle_recovery,
                 diagnostics,
@@ -11624,6 +11687,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
             qualifiers: _,
             type_expression_flags: _,
+            failed_calls: _,
         } = *self;
 
         let mut builder = TypeInferenceBuilder::new(
@@ -11673,6 +11737,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             context,
             expressions,
             type_expression_flags,
+            failed_calls,
             collection_use_constraints,
             string_annotations,
             expected_types,
@@ -11711,7 +11776,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             "speculative `TypeInferenceBuilder` should only be used for expression inference"
         );
 
-        self.expressions.extend(expressions.iter());
+        self.extend_expression_types(expressions);
+        self.failed_calls.extend(failed_calls);
         self.context.extend(&diagnostics);
         self.extend_cycle_recovery(cycle_recovery);
         self.string_annotations
@@ -11825,6 +11891,7 @@ enum ExpressionCacheEntry<'db> {
 struct FullExpressionCacheEntry<'db> {
     expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
+    failed_calls: FxHashSet<ExpressionNodeKey>,
     collection_use_constraints: CollectionUseConstraints<'db>,
     string_annotations: FxHashSet<ExpressionNodeKey>,
     expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
@@ -11849,6 +11916,7 @@ impl<'db> FullExpressionCacheEntry<'db> {
         self.expressions.len() == 1
             && self.expressions.get(&expression) == Some(&ty)
             && self.type_expression_flags.is_empty()
+            && self.failed_calls.is_empty()
             && self.collection_use_constraints.is_empty()
             && self.string_annotations.is_empty()
             && self.expected_types.is_empty()
@@ -11864,6 +11932,7 @@ impl<'db> FullExpressionCacheEntry<'db> {
     ) -> ExpressionInference<'db> {
         let extra = (!self.string_annotations.is_empty()
             || !self.type_expression_flags.is_empty()
+            || !self.failed_calls.is_empty()
             || !self.collection_use_constraints.is_empty()
             || !self.expected_types.is_empty()
             || self.cycle_recovery.is_some()
@@ -11886,6 +11955,7 @@ impl<'db> FullExpressionCacheEntry<'db> {
                 string_annotations: FrozenSet::from(self.string_annotations),
                 expected_types: FrozenMap::from(self.expected_types),
                 type_expression_flags: FrozenMap::from(self.type_expression_flags),
+                failed_calls: FrozenSet::from(self.failed_calls),
                 bindings: self.bindings.into_boxed_slice(),
                 diagnostics: self.diagnostics,
                 called_functions: self.called_functions.into_iter().collect(),


### PR DESCRIPTION
Unsatisfiable generic or overloaded calls can fallback to `Unknown` for recovery. However, this can lead to imprecision when resolving an outer overload, making unsatisfied arms appear satisfied. We should track unsatisfied calls and filter them out directly during overload resolution, without losing recovery in the general case.

Resolves https://github.com/astral-sh/ty/issues/4311.