### PR TITLE
[ty] Fix invariant gradual tuple materialization ranges

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -608,6 +608,50 @@ def no_invalid_return_diagnostic_here_either[T](x: A[T]) -> ASub[T]:
         return x
 ```
 
+## Class patterns with variadic generics
+
+A class pattern matches every specialization of its variadic generic class, including a symbolic
+type variable tuple.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Variadic(Generic[*Ts]): ...
+
+def symbolic(value: Variadic[*Ts]) -> int:
+    match value:
+        case Variadic():
+            reveal_type(value)  # revealed: Variadic[*tuple[*Ts@symbolic]]
+            return 1
+```
+
+The same pattern is exhaustive when the type variable tuple has an empty specialization.
+
+```py
+def empty(value: Variadic[()]) -> int:
+    match value:
+        case Variadic():
+            reveal_type(value)  # revealed: Variadic[()]
+            return 1
+```
+
+A nonempty specialization must also remain reachable and exhaustive.
+
+```py
+def nonempty(value: Variadic[int]) -> int:
+    match value:
+        case Variadic():
+            reveal_type(value)  # revealed: Variadic[int]
+            return 1
+```
+
 ## More `match` pattern types
 
 ### `as` patterns

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -613,11 +613,6 @@ def no_invalid_return_diagnostic_here_either[T](x: A[T]) -> ASub[T]:
 A class pattern matches every specialization of its variadic generic class, including a symbolic
 type variable tuple.
 
-```toml
-[environment]
-python-version = "3.11"
-```
-
 ```py
 from typing import Generic, TypeVarTuple, assert_never
 

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -619,37 +619,40 @@ python-version = "3.11"
 ```
 
 ```py
-from typing import Generic, TypeVarTuple
+from typing import Generic, TypeVarTuple, assert_never
 
 Ts = TypeVarTuple("Ts")
 
 class Variadic(Generic[*Ts]): ...
 
-def symbolic(value: Variadic[*Ts]) -> int:
+def symbolic(value: Variadic[*Ts]) -> None:
     match value:
         case Variadic():
             reveal_type(value)  # revealed: Variadic[*tuple[*Ts@symbolic]]
-            return 1
+        case _:
+            assert_never(value)
 ```
 
 The same pattern is exhaustive when the type variable tuple has an empty specialization.
 
 ```py
-def empty(value: Variadic[()]) -> int:
+def empty(value: Variadic[()]) -> None:
     match value:
         case Variadic():
             reveal_type(value)  # revealed: Variadic[()]
-            return 1
+        case _:
+            assert_never(value)
 ```
 
 A nonempty specialization must also remain reachable and exhaustive.
 
 ```py
-def nonempty(value: Variadic[int]) -> int:
+def nonempty(value: Variadic[int]) -> None:
     match value:
         case Variadic():
             reveal_type(value)  # revealed: Variadic[int]
-            return 1
+        case _:
+            assert_never(value)
 ```
 
 ## More `match` pattern types

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -342,6 +342,120 @@ def _(
     reveal_type(bottom_aiu)  # revealed: Bottom[list[tuple[Any, int, Unknown]]]
 ```
 
+## Gradual tuple length in invariant positions
+
+An unrestricted variable-length tuple with dynamic elements can materialize to an empty tuple. The
+top materialization of an enclosing invariant generic includes that specialization, and its bottom
+materialization is a subtype of it.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Any, Generic, TypeVar, TypeVarTuple
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+
+class Box(Generic[T]): ...
+
+static_assert(is_subtype_of(Box[tuple[()]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Box[tuple[()]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[()]]))
+static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[()]]))
+static_assert(not is_subtype_of(Box[tuple[()]], Bottom[Box[tuple[Any, ...]]]))
+```
+
+The same gradual-length choice also includes nonempty, fixed-length tuple specializations.
+
+```py
+static_assert(is_subtype_of(Box[tuple[int]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Box[tuple[int]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[int]]))
+static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[int]]))
+static_assert(not is_subtype_of(Box[tuple[int]], Bottom[Box[tuple[Any, ...]]]))
+```
+
+An exact tuple remains a valid materialization when its element is spelled through a type alias.
+
+```py
+from typing_extensions import TypeAliasType
+
+ItemAlias = TypeAliasType("ItemAlias", int)
+
+static_assert(is_subtype_of(Box[tuple[ItemAlias]], Top[Box[tuple[Any, ...]]]))
+```
+
+Aliases around the entire tuple still need to be resolved before comparing the materialization
+families.
+
+```py
+FixedTupleAlias = TypeAliasType("FixedTupleAlias", tuple[int])
+
+# TODO: Resolve aliases around the entire tuple in invariant subtyping.
+static_assert(is_subtype_of(Box[FixedTupleAlias], Top[Box[tuple[Any, ...]]]))  # error: [static-assert-error]
+```
+
+A gradual fixed-length tuple has a narrower materialization range than an unrestricted gradual
+tuple. Their top bounds preserve that containment, while their bottom bounds reverse it.
+
+```py
+static_assert(is_subtype_of(Top[Box[tuple[Any]]], Top[Box[tuple[Any, ...]]]))
+static_assert(not is_subtype_of(Top[Box[tuple[Any, ...]]], Top[Box[tuple[Any]]]))
+static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Bottom[Box[tuple[Any]]]))
+static_assert(not is_subtype_of(Bottom[Box[tuple[Any]]], Bottom[Box[tuple[Any, ...]]]))
+static_assert(not is_subtype_of(Top[Box[tuple[Any, ...]]], Bottom[Box[tuple[Any, ...]]]))
+```
+
+An unpacked type variable tuple is another valid exact-tuple specialization, even though its length
+is not known.
+
+```py
+def symbolic(value: Box[tuple[*Ts]]) -> None:
+    static_assert(is_subtype_of(Box[tuple[*Ts]], Top[Box[tuple[Any, ...]]]))
+    static_assert(not is_disjoint_from(Box[tuple[*Ts]], Top[Box[tuple[Any, ...]]]))
+    static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[*Ts]]))
+    static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[*Ts]]))
+    static_assert(not is_subtype_of(Box[tuple[*Ts]], Bottom[Box[tuple[Any, ...]]]))
+```
+
+A tuple subclass is not itself a materialization of the exact built-in `tuple[Any, ...]` type. The
+surrounding invariant generic must therefore keep the subclass distinct.
+
+```py
+class IntTuple(tuple[int]): ...
+
+static_assert(is_subtype_of(IntTuple, tuple[object, ...]))
+static_assert(not is_subtype_of(Box[IntTuple], Top[Box[tuple[Any, ...]]]))
+static_assert(is_disjoint_from(Box[IntTuple], Top[Box[tuple[Any, ...]]]))
+static_assert(is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[IntTuple]))
+static_assert(not is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[IntTuple]))
+```
+
+A static homogeneous tuple does not make a gradual choice of length, even though every `int` is an
+`object`.
+
+```py
+static_assert(not is_subtype_of(Box[tuple[int]], Top[Box[tuple[object, ...]]]))
+static_assert(is_disjoint_from(Box[tuple[int]], Top[Box[tuple[object, ...]]]))
+```
+
+Fixed elements in a mixed tuple must also retain their invariant identity. In particular, a `bool`
+prefix cannot replace the required `int` prefix simply because `bool` is a subtype of `int`.
+
+```py
+static_assert(not is_subtype_of(Box[tuple[bool, str]], Top[Box[tuple[int, *tuple[Any, ...]]]]))
+static_assert(is_disjoint_from(Box[tuple[bool, str]], Top[Box[tuple[int, *tuple[Any, ...]]]]))
+```
+
+TODO: Handle valid mixed gradual-length tuples without losing their required prefix and suffix
+elements. For example, `Box[tuple[int, str]]` should be a subtype of
+`Top[Box[tuple[int, *tuple[Any, ...]]]]`.
+
 ## Union
 
 All positions in a union are covariant.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -456,6 +456,79 @@ TODO: Handle valid mixed gradual-length tuples without losing their required pre
 elements. For example, `Box[tuple[int, str]]` should be a subtype of
 `Top[Box[tuple[int, *tuple[Any, ...]]]]`.
 
+## Gradual tuple length with aliased elements
+
+When `Dynamic` aliases `Any`, `tuple[Dynamic, ...]` has the same gradual-length choices as
+`tuple[Any, ...]`. These choices are preserved when the tuple is an invariant type argument.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, TypeAliasType
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_disjoint_from, is_subtype_of
+
+type Dynamic = Any
+
+static_assert(is_subtype_of(list[tuple[int]], Top[list[tuple[Dynamic, ...]]]))
+static_assert(is_subtype_of(Bottom[list[tuple[Dynamic, ...]]], list[tuple[int]]))
+static_assert(not is_disjoint_from(list[tuple[int]], Top[list[tuple[Dynamic, ...]]]))
+static_assert(not is_disjoint_from(Top[list[tuple[Dynamic, ...]]], list[tuple[int]]))
+```
+
+Alias chains, nested generic aliases, and aliases created with `TypeAliasType` preserve the same
+gradual-length choice.
+
+```py
+type IndirectDynamic = Dynamic
+type Identity[T] = T
+
+CalledDynamic = TypeAliasType("CalledDynamic", Any)
+
+static_assert(is_subtype_of(list[tuple[int]], Top[list[tuple[IndirectDynamic, ...]]]))
+static_assert(is_subtype_of(list[tuple[int]], Top[list[tuple[Identity[Identity[Any]], ...]]]))
+static_assert(is_subtype_of(list[tuple[int]], Top[list[tuple[CalledDynamic, ...]]]))
+static_assert(is_subtype_of(Bottom[list[tuple[CalledDynamic, ...]]], list[tuple[int]]))
+```
+
+An alias of a fully static element type does not make the tuple's length gradual.
+
+```py
+type Static = object
+
+static_assert(not is_subtype_of(list[tuple[int]], Top[list[tuple[Static, ...]]]))
+static_assert(is_disjoint_from(list[tuple[int]], Top[list[tuple[Static, ...]]]))
+```
+
+An unused dynamic type argument, or `Any` within a container or union, does not make the alias
+itself dynamic.
+
+```py
+type Constant[T] = object
+type Container = list[Any]
+type Recursive = list[Recursive] | Any
+
+static_assert(not is_subtype_of(list[tuple[int]], Top[list[tuple[Constant[Any], ...]]]))
+static_assert(is_disjoint_from(list[tuple[int]], Top[list[tuple[Constant[Any], ...]]]))
+static_assert(not is_subtype_of(list[tuple[int]], Top[list[tuple[Container, ...]]]))
+static_assert(not is_subtype_of(list[tuple[int]], Top[list[tuple[Recursive, ...]]]))
+```
+
+An alias cycle does not establish that the element is dynamic. Comparing these tuple specializations
+terminates without treating either alias as `Any`.
+
+```py
+Loop = TypeAliasType("Loop", "Loop")
+First = TypeAliasType("First", "Second")
+Second = TypeAliasType("Second", First)
+
+static_assert(is_disjoint_from(list[tuple[int]], list[tuple[Loop, ...]]))
+static_assert(is_disjoint_from(list[tuple[int]], list[tuple[First, ...]]))
+```
+
 ## Union
 
 All positions in a union are covariant.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -354,30 +354,27 @@ python-version = "3.11"
 ```
 
 ```py
-from typing import Any, Generic, TypeVar, TypeVarTuple
+from typing import Any, TypeVarTuple
 from ty_extensions import Bottom, Top, static_assert
 from ty_extensions._internal import is_disjoint_from, is_subtype_of
 
-T = TypeVar("T")
 Ts = TypeVarTuple("Ts")
 
-class Box(Generic[T]): ...
-
-static_assert(is_subtype_of(Box[tuple[()]], Top[Box[tuple[Any, ...]]]))
-static_assert(not is_disjoint_from(Box[tuple[()]], Top[Box[tuple[Any, ...]]]))
-static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[()]]))
-static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[()]]))
-static_assert(not is_subtype_of(Box[tuple[()]], Bottom[Box[tuple[Any, ...]]]))
+static_assert(is_subtype_of(list[tuple[()]], Top[list[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(list[tuple[()]], Top[list[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Top[list[tuple[Any, ...]]], list[tuple[()]]))
+static_assert(is_subtype_of(Bottom[list[tuple[Any, ...]]], list[tuple[()]]))
+static_assert(not is_subtype_of(list[tuple[()]], Bottom[list[tuple[Any, ...]]]))
 ```
 
 The same gradual-length choice also includes nonempty, fixed-length tuple specializations.
 
 ```py
-static_assert(is_subtype_of(Box[tuple[int]], Top[Box[tuple[Any, ...]]]))
-static_assert(not is_disjoint_from(Box[tuple[int]], Top[Box[tuple[Any, ...]]]))
-static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[int]]))
-static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[int]]))
-static_assert(not is_subtype_of(Box[tuple[int]], Bottom[Box[tuple[Any, ...]]]))
+static_assert(is_subtype_of(list[tuple[int]], Top[list[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(list[tuple[int]], Top[list[tuple[Any, ...]]]))
+static_assert(not is_disjoint_from(Top[list[tuple[Any, ...]]], list[tuple[int]]))
+static_assert(is_subtype_of(Bottom[list[tuple[Any, ...]]], list[tuple[int]]))
+static_assert(not is_subtype_of(list[tuple[int]], Bottom[list[tuple[Any, ...]]]))
 ```
 
 An exact tuple remains a valid materialization when its element is spelled through a type alias.
@@ -387,7 +384,7 @@ from typing_extensions import TypeAliasType
 
 ItemAlias = TypeAliasType("ItemAlias", int)
 
-static_assert(is_subtype_of(Box[tuple[ItemAlias]], Top[Box[tuple[Any, ...]]]))
+static_assert(is_subtype_of(list[tuple[ItemAlias]], Top[list[tuple[Any, ...]]]))
 ```
 
 Aliases around the entire tuple still need to be resolved before comparing the materialization
@@ -397,30 +394,30 @@ families.
 FixedTupleAlias = TypeAliasType("FixedTupleAlias", tuple[int])
 
 # TODO: Resolve aliases around the entire tuple in invariant subtyping.
-static_assert(is_subtype_of(Box[FixedTupleAlias], Top[Box[tuple[Any, ...]]]))  # error: [static-assert-error]
+static_assert(is_subtype_of(list[FixedTupleAlias], Top[list[tuple[Any, ...]]]))  # error: [static-assert-error]
 ```
 
 A gradual fixed-length tuple has a narrower materialization range than an unrestricted gradual
 tuple. Their top bounds preserve that containment, while their bottom bounds reverse it.
 
 ```py
-static_assert(is_subtype_of(Top[Box[tuple[Any]]], Top[Box[tuple[Any, ...]]]))
-static_assert(not is_subtype_of(Top[Box[tuple[Any, ...]]], Top[Box[tuple[Any]]]))
-static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Bottom[Box[tuple[Any]]]))
-static_assert(not is_subtype_of(Bottom[Box[tuple[Any]]], Bottom[Box[tuple[Any, ...]]]))
-static_assert(not is_subtype_of(Top[Box[tuple[Any, ...]]], Bottom[Box[tuple[Any, ...]]]))
+static_assert(is_subtype_of(Top[list[tuple[Any]]], Top[list[tuple[Any, ...]]]))
+static_assert(not is_subtype_of(Top[list[tuple[Any, ...]]], Top[list[tuple[Any]]]))
+static_assert(is_subtype_of(Bottom[list[tuple[Any, ...]]], Bottom[list[tuple[Any]]]))
+static_assert(not is_subtype_of(Bottom[list[tuple[Any]]], Bottom[list[tuple[Any, ...]]]))
+static_assert(not is_subtype_of(Top[list[tuple[Any, ...]]], Bottom[list[tuple[Any, ...]]]))
 ```
 
 An unpacked type variable tuple is another valid exact-tuple specialization, even though its length
 is not known.
 
 ```py
-def symbolic(value: Box[tuple[*Ts]]) -> None:
-    static_assert(is_subtype_of(Box[tuple[*Ts]], Top[Box[tuple[Any, ...]]]))
-    static_assert(not is_disjoint_from(Box[tuple[*Ts]], Top[Box[tuple[Any, ...]]]))
-    static_assert(not is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[tuple[*Ts]]))
-    static_assert(is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[tuple[*Ts]]))
-    static_assert(not is_subtype_of(Box[tuple[*Ts]], Bottom[Box[tuple[Any, ...]]]))
+def symbolic(value: list[tuple[*Ts]]) -> None:
+    static_assert(is_subtype_of(list[tuple[*Ts]], Top[list[tuple[Any, ...]]]))
+    static_assert(not is_disjoint_from(list[tuple[*Ts]], Top[list[tuple[Any, ...]]]))
+    static_assert(not is_disjoint_from(Top[list[tuple[Any, ...]]], list[tuple[*Ts]]))
+    static_assert(is_subtype_of(Bottom[list[tuple[Any, ...]]], list[tuple[*Ts]]))
+    static_assert(not is_subtype_of(list[tuple[*Ts]], Bottom[list[tuple[Any, ...]]]))
 ```
 
 A tuple subclass is not itself a materialization of the exact built-in `tuple[Any, ...]` type. The
@@ -430,46 +427,46 @@ surrounding invariant generic must therefore keep the subclass distinct.
 class IntTuple(tuple[int]): ...
 
 static_assert(is_subtype_of(IntTuple, tuple[object, ...]))
-static_assert(not is_subtype_of(Box[IntTuple], Top[Box[tuple[Any, ...]]]))
-static_assert(is_disjoint_from(Box[IntTuple], Top[Box[tuple[Any, ...]]]))
-static_assert(is_disjoint_from(Top[Box[tuple[Any, ...]]], Box[IntTuple]))
-static_assert(not is_subtype_of(Bottom[Box[tuple[Any, ...]]], Box[IntTuple]))
+static_assert(not is_subtype_of(list[IntTuple], Top[list[tuple[Any, ...]]]))
+static_assert(is_disjoint_from(list[IntTuple], Top[list[tuple[Any, ...]]]))
+static_assert(is_disjoint_from(Top[list[tuple[Any, ...]]], list[IntTuple]))
+static_assert(not is_subtype_of(Bottom[list[tuple[Any, ...]]], list[IntTuple]))
 ```
 
 A static homogeneous tuple does not make a gradual choice of length, even though every `int` is an
 `object`.
 
 ```py
-static_assert(not is_subtype_of(Box[tuple[int]], Top[Box[tuple[object, ...]]]))
-static_assert(is_disjoint_from(Box[tuple[int]], Top[Box[tuple[object, ...]]]))
+static_assert(not is_subtype_of(list[tuple[int]], Top[list[tuple[object, ...]]]))
+static_assert(is_disjoint_from(list[tuple[int]], Top[list[tuple[object, ...]]]))
 ```
 
 Fixed elements in a mixed tuple must also retain their invariant identity. In particular, a `bool`
 prefix cannot replace the required `int` prefix simply because `bool` is a subtype of `int`.
 
 ```py
-static_assert(not is_subtype_of(Box[tuple[bool, str]], Top[Box[tuple[int, *tuple[Any, ...]]]]))
-static_assert(is_disjoint_from(Box[tuple[bool, str]], Top[Box[tuple[int, *tuple[Any, ...]]]]))
+static_assert(not is_subtype_of(list[tuple[bool, str]], Top[list[tuple[int, *tuple[Any, ...]]]]))
+static_assert(is_disjoint_from(list[tuple[bool, str]], Top[list[tuple[int, *tuple[Any, ...]]]]))
 ```
 
 A required suffix retains its invariant identity even when there is no required prefix. A `bool`
 cannot replace the required `int` suffix.
 
 ```py
-static_assert(not is_subtype_of(Box[tuple[bool]], Top[Box[tuple[*tuple[Any, ...], int]]]))
-static_assert(is_disjoint_from(Box[tuple[bool]], Top[Box[tuple[*tuple[Any, ...], int]]]))
+static_assert(not is_subtype_of(list[tuple[bool]], Top[list[tuple[*tuple[Any, ...], int]]]))
+static_assert(is_disjoint_from(list[tuple[bool]], Top[list[tuple[*tuple[Any, ...], int]]]))
 ```
 
 A tuple with a required suffix cannot materialize to an empty tuple.
 
 ```py
-static_assert(not is_subtype_of(Box[tuple[()]], Top[Box[tuple[*tuple[Any, ...], int]]]))
-static_assert(is_disjoint_from(Box[tuple[()]], Top[Box[tuple[*tuple[Any, ...], int]]]))
+static_assert(not is_subtype_of(list[tuple[()]], Top[list[tuple[*tuple[Any, ...], int]]]))
+static_assert(is_disjoint_from(list[tuple[()]], Top[list[tuple[*tuple[Any, ...], int]]]))
 ```
 
 TODO: Handle valid mixed gradual-length tuples without losing their required prefix and suffix
-elements. For example, `Box[tuple[int, str]]` should be a subtype of
-`Top[Box[tuple[int, *tuple[Any, ...]]]]`.
+elements. For example, `list[tuple[int, str]]` should be a subtype of
+`Top[list[tuple[int, *tuple[Any, ...]]]]`.
 
 ## Gradual tuple length with aliased elements
 
@@ -509,16 +506,8 @@ static_assert(is_subtype_of(list[tuple[int]], Top[list[tuple[CalledDynamic, ...]
 static_assert(is_subtype_of(Bottom[list[tuple[CalledDynamic, ...]]], list[tuple[int]]))
 ```
 
-An alias of a fully static element type does not make the tuple's length gradual.
-
-```py
-type Static = object
-
-static_assert(not is_subtype_of(list[tuple[int]], Top[list[tuple[Static, ...]]]))
-static_assert(is_disjoint_from(list[tuple[int]], Top[list[tuple[Static, ...]]]))
-```
-
-An unused dynamic type argument, or `Any` within a container or union, does not make the alias
+An alias of a fully static element type does not make the tuple's length gradual, even with an
+unused dynamic type argument. Likewise, `Any` within a container or union does not make the alias
 itself dynamic.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -452,6 +452,21 @@ static_assert(not is_subtype_of(Box[tuple[bool, str]], Top[Box[tuple[int, *tuple
 static_assert(is_disjoint_from(Box[tuple[bool, str]], Top[Box[tuple[int, *tuple[Any, ...]]]]))
 ```
 
+A required suffix retains its invariant identity even when there is no required prefix. A `bool`
+cannot replace the required `int` suffix.
+
+```py
+static_assert(not is_subtype_of(Box[tuple[bool]], Top[Box[tuple[*tuple[Any, ...], int]]]))
+static_assert(is_disjoint_from(Box[tuple[bool]], Top[Box[tuple[*tuple[Any, ...], int]]]))
+```
+
+A tuple with a required suffix cannot materialize to an empty tuple.
+
+```py
+static_assert(not is_subtype_of(Box[tuple[()]], Top[Box[tuple[*tuple[Any, ...], int]]]))
+static_assert(is_disjoint_from(Box[tuple[()]], Top[Box[tuple[*tuple[Any, ...], int]]]))
+```
+
 TODO: Handle valid mixed gradual-length tuples without losing their required prefix and suffix
 elements. For example, `Box[tuple[int, str]]` should be a subtype of
 `Top[Box[tuple[int, *tuple[Any, ...]]]]`.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2038,8 +2038,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Handle this unrestricted materialization family directly. Tuple subclasses do not
         // qualify: `Box[MyTuple]` is not a materialization of `Box[tuple[Any, ...]]`.
         // TODO: Correct bottom materialization for gradual tuple arity, including required prefixes
-        // and suffixes, and compare these materialization families generally without changing fully
-        // static tuple shapes.
+        // and suffixes, and handle these materialization families in the general invariant comparison.
+        // Then remove this entire special-case block.
         if let (Some(source_tuple), Some(target_tuple)) = (
             source_type.exact_tuple_instance_spec(db),
             target_type.exact_tuple_instance_spec(db),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2030,6 +2030,35 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_type: Type<'db>,
         target_materialization: MaterializationKind,
     ) -> ConstraintSet<'db, 'c> {
+        // `tuple[Any, ...]` can materialize to a builtin tuple type of any length. Its
+        // element-wise bottom does not capture this gradual choice of length: it is not a
+        // subtype of every fixed-length tuple. The endpoint comparisons below therefore cannot
+        // establish `Box[tuple[int]] <: Top[Box[tuple[Any, ...]]]` for an invariant `Box`.
+        // Handle this unrestricted materialization family directly. Tuple subclasses do not
+        // qualify: `Box[MyTuple]` is not a materialization of `Box[tuple[Any, ...]]`.
+        // TODO: Compare gradual tuple-length materialization families generally, including
+        // required prefixes and suffixes, without changing static tuple shapes.
+        if let (Some(source_tuple), Some(target_tuple)) = (
+            source_type.exact_tuple_instance_spec(db),
+            target_type.exact_tuple_instance_spec(db),
+        ) {
+            let is_unrestricted = |tuple: &TupleSpec<'db>| {
+                matches!(tuple, TupleSpec::Variable(tuple)
+                    if tuple.prefix_elements().is_empty()
+                        && tuple.suffix_elements().is_empty()
+                        && matches!(tuple.variable(), VariableSegment::Homogeneous(Type::Dynamic(_))))
+            };
+            // Top preserves family inclusion, Bottom reverses it, and Bottom-to-Top needs
+            // only an overlap, so either unrestricted family is enough in that case.
+            if (target_materialization == MaterializationKind::Top
+                && is_unrestricted(&target_tuple))
+                || (source_materialization == MaterializationKind::Bottom
+                    && is_unrestricted(&source_tuple))
+            {
+                return self.always();
+            }
+        }
+
         let source_top =
             source_type.materialize(db, MaterializationKind::Top, self.materialization_visitor);
         let source_bottom = source_type.materialize(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2030,16 +2030,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_type: Type<'db>,
         target_materialization: MaterializationKind,
     ) -> ConstraintSet<'db, 'c> {
-        // `tuple[Any, ...]` can materialize to a builtin tuple type of any length. Our top and
-        // bottom materializations of it are currently incorrect: they materialize the element
-        // types but do not account for the tuple's gradual arity. The endpoint comparisons below
-        // therefore cannot establish `Box[tuple[int]] <: Top[Box[tuple[Any, ...]]]` for an
-        // invariant `Box`.
+        // `tuple[Any, ...]` can materialize to a builtin tuple type of any length. Its top
+        // materialization, `tuple[object, ...]`, is correct. Our bottom materialization is
+        // incorrect: it becomes `tuple[()]`, which is not a subtype of every fixed-length
+        // tuple. The endpoint comparisons below therefore cannot establish
+        // `Box[tuple[int]] <: Top[Box[tuple[Any, ...]]]` for an invariant `Box`.
         // Handle this unrestricted materialization family directly. Tuple subclasses do not
         // qualify: `Box[MyTuple]` is not a materialization of `Box[tuple[Any, ...]]`.
-        // TODO: Correct top and bottom materialization for gradual tuple arity, including required
-        // prefixes and suffixes, so we can remove this special case without changing fully static
-        // tuple shapes.
+        // TODO: Correct bottom materialization for gradual tuple arity, including required prefixes
+        // and suffixes, and compare these materialization families generally without changing fully
+        // static tuple shapes.
         if let (Some(source_tuple), Some(target_tuple)) = (
             source_type.exact_tuple_instance_spec(db),
             target_type.exact_tuple_instance_spec(db),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -28,7 +28,8 @@ use crate::types::tuple::{
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, TypeVarSet};
 use crate::types::visitor::{
-    TypeCollector, TypeVisitor, any_over_type, walk_type_with_recursion_guard,
+    TypeCollector, TypeVisitor, any_over_type, any_over_type_expanding_aliases,
+    walk_type_with_recursion_guard,
 };
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, CallableTypes,
@@ -2045,10 +2046,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target_type.exact_tuple_instance_spec(db),
         ) {
             let is_unrestricted = |tuple: &TupleSpec<'db>| {
-                matches!(tuple, TupleSpec::Variable(tuple)
-                    if tuple.prefix_elements().is_empty()
-                        && tuple.suffix_elements().is_empty()
-                        && matches!(tuple.variable(), VariableSegment::Homogeneous(Type::Dynamic(_))))
+                if let TupleSpec::Variable(tuple) = tuple
+                    && tuple.prefix_elements().is_empty()
+                    && tuple.suffix_elements().is_empty()
+                    && let VariableSegment::Homogeneous(element) = tuple.variable()
+                {
+                    // Follow element aliases, stopping at the first non-alias type. A non-dynamic
+                    // type or an alias cycle rules out this unrestricted materialization family.
+                    !any_over_type_expanding_aliases(db, self.env, element, |ty| {
+                        !matches!(ty, Type::TypeAlias(_) | Type::Dynamic(_))
+                    })
+                } else {
+                    false
+                }
             };
             // Top preserves family inclusion, Bottom reverses it, and Bottom-to-Top needs
             // only an overlap, so either unrestricted family is enough in that case.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2030,14 +2030,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_type: Type<'db>,
         target_materialization: MaterializationKind,
     ) -> ConstraintSet<'db, 'c> {
-        // `tuple[Any, ...]` can materialize to a builtin tuple type of any length. Its
-        // element-wise bottom does not capture this gradual choice of length: it is not a
-        // subtype of every fixed-length tuple. The endpoint comparisons below therefore cannot
-        // establish `Box[tuple[int]] <: Top[Box[tuple[Any, ...]]]` for an invariant `Box`.
+        // `tuple[Any, ...]` can materialize to a builtin tuple type of any length. Our top and
+        // bottom materializations of it are currently incorrect: they materialize the element
+        // types but do not account for the tuple's gradual arity. The endpoint comparisons below
+        // therefore cannot establish `Box[tuple[int]] <: Top[Box[tuple[Any, ...]]]` for an
+        // invariant `Box`.
         // Handle this unrestricted materialization family directly. Tuple subclasses do not
         // qualify: `Box[MyTuple]` is not a materialization of `Box[tuple[Any, ...]]`.
-        // TODO: Compare gradual tuple-length materialization families generally, including
-        // required prefixes and suffixes, without changing static tuple shapes.
+        // TODO: Correct top and bottom materialization for gradual tuple arity, including required
+        // prefixes and suffixes, so we can remove this special case without changing fully static
+        // tuple shapes.
         if let (Some(source_tuple), Some(target_tuple)) = (
             source_type.exact_tuple_instance_spec(db),
             target_type.exact_tuple_instance_spec(db),

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -495,7 +495,6 @@ fn unrestricted_tuple_materialization_absorbs_divergent_approximations() {
     // more deeply in a later iteration. Removing the marker here therefore converges.
     let first = approximation(div);
     for candidate in [first, approximation(first)] {
-        assert!(candidate.is_redundant_with(db, &env, top));
         assert_eq!(UnionType::from_elements(db, &env, [candidate, top]), top);
         assert_eq!(UnionType::from_elements(db, &env, [top, candidate]), top);
     }

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -482,6 +482,34 @@ fn divergent_type() {
 }
 
 #[test]
+fn unrestricted_tuple_materialization_absorbs_divergent_approximations() {
+    let db = setup_db();
+    let db = &db;
+    let env = db.program_environment();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_of = |tuple| KnownClass::List.to_specialized_instance(db, &env, &[tuple]);
+    let approximation = |element| list_of(Type::heterogeneous_tuple(db, &env, [element]));
+    let top = list_of(Type::homogeneous_tuple(db, &env, Type::any())).top_materialization(db, &env);
+
+    // This fixed top absorbs every exact-tuple approximation, including a marker nested
+    // more deeply in a later iteration. Removing the marker here therefore converges.
+    let first = approximation(div);
+    for candidate in [first, approximation(first)] {
+        assert!(candidate.is_redundant_with(db, &env, top));
+        assert_eq!(UnionType::from_elements(db, &env, [candidate, top]), top);
+        assert_eq!(UnionType::from_elements(db, &env, [top, candidate]), top);
+    }
+
+    // An unresolved marker is not itself an unrestricted gradual element type. Its
+    // homogeneous tuple must not acquire the same family as `tuple[Any, ...]`.
+    let divergent_top =
+        list_of(Type::homogeneous_tuple(db, &env, div)).top_materialization(db, &env);
+    let empty = list_of(Type::empty_tuple(db, &env));
+    assert!(!empty.is_subtype_of(db, &env, divergent_top));
+    assert!(!empty.is_redundant_with(db, &env, divergent_top));
+}
+
+#[test]
 fn type_alias_variance() {
     use crate::db::tests::TestDb;
     use crate::place::global_symbol;


### PR DESCRIPTION
`tuple[Any, ...]` can materialize to an exact built-in tuple of any length. Currently we bottom-materialize this type incorrectly. We give its bottom materialization as `tuple[Never, ...]`, which we currently simplify to `tuple[()]`, but neither of these types is a subtype of every possible tuple type, which the bottom materialization of `tuple[Any, ...]` should be. As a result, valid specializations can be rejected, and an exhaustive variadic-generic class pattern can appear non-exhaustive.

The full fix here (a correct bottom materialization of `tuple[Any, ...]`) will be more invasive, and I prefer to delay that until we've made some more general decisions about how we want to treat bottom materializations and their (non-?)equivalence to `Never`, and fixed the property tests.

This limited fix just special-cases `tuple[Any, ...]` inside invariant specialization type relations, avoiding using the bottom materialization of `tuple[Any, ...]` rather than fixing it. This is a pre-requisite to avoid regression in my next steps on fixing the property tests (and another fix I'm working on). The added tests here are correct, so at least this is moving us in the right direction and locking in some better behaviors, even if the implementation isn't what it should be yet.

This is an independent prerequisite for both #27920 and #27943. It does not change `Never` tuple normalization or static tuple disjointness.

## Test plan

- Add mdtests for empty, nonempty, and symbolic tuple specializations; top and bottom bounds; symmetric overlap; aliases; and tuple-subclass, static-tuple, and mixed-prefix exclusions.
- Verify class-pattern exhaustiveness for empty, nonempty, and symbolic variadic specializations, including the minimized regression exposed by #27943. Check the combined changes against #27943's fixed-tuple rejection tests.
- Cover union simplification with nested cycle-recovery approximations and ensure unresolved divergence markers do not count as unrestricted gradual elements.

The stable property suite has two existing failures involving `tuple[Never]` disjointness, reproduced both with and without this change. Those are addressed by the separate tuple-disjointness work in #27920.
