### PR TITLE
[ty] Fix stack overflow in recursive TypedDict dictionary compatibility

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -7697,6 +7697,17 @@ class ChildWithBadValueType(Base):
     year: NotRequired[int]
 ```
 
+Recursive items are subject to the same consistency requirement. A recursive `TypedDict` is not
+consistent with the base's `bool` extra items:
+
+```py
+class RecursiveBase(TypedDict, extra_items=bool): ...
+
+# error: [invalid-typed-dict-header]
+class RecursiveChild(RecursiveBase):
+    child: NotRequired["RecursiveChild"]
+```
+
 ### A subclass of a TypedDict with read-only `extra_items: T` may add required or non-required items assignable to `T`
 
 ```py
@@ -8424,6 +8435,68 @@ class HasReadOnly(TypedDict, extra_items=int):
     x: NotRequired[ReadOnly[int]]
 
 static_assert(not is_assignable_to(HasReadOnly, dict[str, int]))
+```
+
+### Recursive fields with mutable extra items
+
+A declared item can have a different type from the extra items, including a reference to the
+`TypedDict` itself. Such a type is compatible with `Mapping[str, object]`, but not with a mutable
+dictionary whose values must all be `bool`:
+
+```py
+from collections.abc import Mapping
+from typing_extensions import TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+class Recursive(TypedDict, total=False, extra_items=bool):
+    child: "Recursive"
+
+static_assert(is_assignable_to(Recursive, Mapping[str, object]))
+static_assert(not is_assignable_to(Recursive, dict[str, bool]))
+static_assert(not is_subtype_of(Recursive, dict[str, bool]))
+```
+
+### Mutually recursive fields with dictionary-valued extra items
+
+Recursive items can also refer to another `TypedDict`. Even when the extra items are themselves
+dictionaries, the declared items need not be consistent with them:
+
+```py
+from collections.abc import Mapping
+from typing_extensions import TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+class Left(TypedDict, total=False, extra_items=dict[str, object]):
+    child: "Right"
+
+class Right(TypedDict, total=False, extra_items=dict[str, object]):
+    child: Left
+
+static_assert(is_assignable_to(Left, Mapping[str, object]))
+static_assert(not is_assignable_to(Left, dict[str, dict[str, object]]))
+static_assert(not is_subtype_of(Right, dict[str, dict[str, object]]))
+```
+
+### Recursive functional TypedDicts with mutable extra items
+
+The functional syntax has the same dictionary compatibility rules as the class syntax:
+
+```py
+from collections.abc import Mapping
+from typing_extensions import NotRequired, TypedDict
+
+Recursive = TypedDict("Recursive", {"child": "NotRequired[Recursive]"}, extra_items=bool)
+
+def as_mapping(value: Recursive) -> Mapping[str, object]:
+    return value
+
+def as_dict(value: Recursive) -> dict[str, bool]:
+    return value  # error: [invalid-return-type]
+
+def update(value: Recursive) -> None:
+    value.update({"child": value})
 ```
 
 [closed]: https://peps.python.org/pep-0728/#disallowing-extra-items-explicitly

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2241,11 +2241,29 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (Type::TypedDict(typed_dict), _) => {
                 self.with_recursion_guard(db, source, target, || {
-                    let dict_value_type = if self.relation.is_assignability() {
-                        typed_dict.assignable_dict_value_type(db, env)
-                    } else {
-                        typed_dict.dict_value_type(db, env)
-                    };
+                    let dict_value_type =
+                        typed_dict.dict_value_type_if(db, |field_ty, extra_ty| {
+                            let result = if self.relation.is_assignability() {
+                                // Mutual assignability lets gradual field types satisfy the mutable
+                                // dict contract. Check the schema without inferring type variables or
+                                // contributing error context, but keep the active recursion guards.
+                                let checker = Self {
+                                    inferable: TypeVarSet::None,
+                                    typevar_evaluation: TypeVarEvaluation::Eager,
+                                    context_tree: None,
+                                    ..self.clone()
+                                };
+                                checker.check_type_pair(db, field_ty, extra_ty).and(
+                                    db,
+                                    self.constraints,
+                                    || checker.check_type_pair(db, extra_ty, field_ty),
+                                )
+                            } else {
+                                self.as_equivalence_checker()
+                                    .check_type_pair(db, field_ty, extra_ty)
+                            };
+                            result.is_always_satisfied(db, env)
+                        });
                     let fallback = if let Some(value_ty) = dict_value_type {
                         KnownClass::Dict.to_specialized_instance(
                             db,

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -476,41 +476,24 @@ impl<'db> TypedDictType<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Type<'db>> {
-        let extra_items = self.explicit_extra_items(db)?;
-        if extra_items.is_read_only()
-            || self.items(db).values().any(|field| {
-                field.is_required()
-                    || field.is_read_only()
-                    || !field
-                        .declared_ty
-                        .is_equivalent_to(db, env, extra_items.declared_ty)
-            })
-        {
-            return None;
-        }
-        Some(extra_items.declared_ty)
+        self.dict_value_type_if(db, |field_ty, extra_items_ty| {
+            field_ty.is_equivalent_to(db, env, extra_items_ty)
+        })
     }
 
-    /// Returns the value type if this `TypedDict` is assignable to `dict[str, VT]`.
-    ///
-    /// This uses mutual assignability rather than equivalence so gradual value types can satisfy
-    /// the mutable `dict` contract.
-    pub(crate) fn assignable_dict_value_type(
+    /// Like [`Self::dict_value_type`], but uses the caller's equivalence or mutual-assignability
+    /// check so recursive comparisons can share their cycle guards.
+    pub(super) fn dict_value_type_if(
         self,
         db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
+        types_match: impl Fn(Type<'db>, Type<'db>) -> bool,
     ) -> Option<Type<'db>> {
         let extra_items = self.explicit_extra_items(db)?;
         if extra_items.is_read_only()
             || self.items(db).values().any(|field| {
                 field.is_required()
                     || field.is_read_only()
-                    || !field
-                        .declared_ty
-                        .is_assignable_to(db, env, extra_items.declared_ty)
-                    || !extra_items
-                        .declared_ty
-                        .is_assignable_to(db, env, field.declared_ty)
+                    || !types_match(field.declared_ty, extra_items.declared_ty)
             })
         {
             return None;


### PR DESCRIPTION
Recursive `TypedDict` definitions with mutable `extra_items` can overflow the stack during class validation or dictionary compatibility checks. Preserve the active recursion guards when comparing declared field types with the extra-items type, so valid definitions are accepted and incompatible inherited fields produce a diagnostic instead of crashing.

The dictionary-compatibility helper now accepts the caller's comparison function. Relation checks reuse their existing visitors while preserving the distinction between equivalence and mutual assignability for gradual field types.

Fixes https://github.com/astral-sh/ty/issues/4346.

## Test plan

Extend the TypedDict mdtests to cover the original inheritance error, standalone and mutually recursive fields with mutable extra items, dictionary-valued extra items, and functional declarations used in mapping assignments, invalid dictionary returns, and updates. Existing gradual-field tests continue to distinguish assignability from subtyping.
