### PR TITLE
Use stabilized Rust pattern assertion macros

### DIFF
--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -962,6 +962,7 @@ impl BlackOptions {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::path::Path;
 
     use indoc::indoc;
@@ -982,10 +983,7 @@ mod tests {
             .unwrap()
             .to_py_format_options(Path::new("code_inline.py"));
         assert_eq!(options.line_width(), LineWidth::try_from(119).unwrap());
-        assert!(matches!(
-            options.magic_trailing_comma(),
-            MagicTrailingComma::Respect
-        ));
+        assert_matches!(options.magic_trailing_comma(), MagicTrailingComma::Respect);
     }
 
     #[test]
@@ -1001,9 +999,6 @@ mod tests {
             .unwrap()
             .to_py_format_options(Path::new("code_inline.py"));
         assert_eq!(options.line_width(), LineWidth::try_from(130).unwrap());
-        assert!(matches!(
-            options.magic_trailing_comma(),
-            MagicTrailingComma::Ignore
-        ));
+        assert_matches!(options.magic_trailing_comma(), MagicTrailingComma::Ignore);
     }
 }

--- a/crates/ruff_linter/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/fixes.rs
@@ -1,3 +1,5 @@
+use std::debug_assert_matches;
+
 use anyhow::{Context, Ok, Result};
 
 use ruff_python_ast as ast;
@@ -125,7 +127,7 @@ pub(crate) fn remove_exception_handler_assignment(
     let preceding = tokenizer
         .next()
         .context("expected the exception name to be preceded by `as`")?;
-    debug_assert!(matches!(preceding.kind, SimpleTokenKind::As));
+    debug_assert_matches!(preceding.kind, SimpleTokenKind::As);
 
     // Lex to the end of the preceding token, which should be the exception value.
     let preceding = tokenizer
@@ -137,7 +139,7 @@ pub(crate) fn remove_exception_handler_assignment(
         .skip_trivia()
         .next()
         .context("expected the exception name to be followed by a colon")?;
-    debug_assert!(matches!(following.kind, SimpleTokenKind::Colon));
+    debug_assert_matches!(following.kind, SimpleTokenKind::Colon);
 
     Ok(Edit::deletion(preceding.end(), following.start()))
 }

--- a/crates/ruff_mdtest/src/lib.rs
+++ b/crates/ruff_mdtest/src/lib.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -69,8 +70,9 @@ fn run_test(
                 return None;
             }
 
-            assert!(
-                matches!(embedded.lang, "py" | "pyi" | "python" | "ipynb" | "toml"),
+            assert_matches!(
+                embedded.lang,
+                "py" | "pyi" | "python" | "ipynb" | "toml",
                 "Supported file types are: py (or python), pyi, ipynb, toml, and ignore"
             );
 

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -482,6 +482,7 @@ impl Eq for Notebook {}
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::path::Path;
 
     use anyhow::Result;
@@ -508,18 +509,18 @@ mod tests {
 
     #[test]
     fn test_invalid() {
-        assert!(matches!(
+        assert_matches!(
             Notebook::from_path(&notebook_path("invalid_extension.ipynb")),
             Err(NotebookError::InvalidJson(_))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             Notebook::from_path(&notebook_path("not_json.ipynb")),
             Err(NotebookError::InvalidJson(_))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             Notebook::from_path(&notebook_path("wrong_schema.ipynb")),
             Err(NotebookError::InvalidSchema(_))
-        ));
+        );
     }
 
     #[test]

--- a/crates/ruff_options_metadata/src/lib.rs
+++ b/crates/ruff_options_metadata/src/lib.rs
@@ -207,6 +207,7 @@ impl OptionSet {
     /// ### Find a nested option
     ///
     /// ```rust
+    /// # use std::assert_matches;
     /// # use ruff_options_metadata::{OptionEntry, OptionField, OptionsMetadata, Visit};
     ///
     /// static HARD_TABS: OptionField = OptionField {
@@ -244,7 +245,7 @@ impl OptionSet {
     /// }
     ///
     /// assert_eq!(Root::metadata().find("format.hard-tabs").and_then(OptionEntry::into_field), Some(HARD_TABS.clone()));
-    /// assert!(matches!(Root::metadata().find("format"), Some(OptionEntry::Set(_))));
+    /// assert_matches!(Root::metadata().find("format"), Some(OptionEntry::Set(_)));
     /// assert!(Root::metadata().find("format.spaces").is_none());
     /// assert!(Root::metadata().find("lint.hard-tabs").is_none());
     /// ```

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -10,6 +10,7 @@ use ruff_python_trivia::{
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use std::cmp::Ordering;
+use std::debug_assert_matches;
 
 use crate::comments::visitor::{CommentPlacement, DecoratedComment};
 use crate::expression::expr_slice::{ExprSliceCommentSection, assign_comment_in_slice};
@@ -1161,11 +1162,7 @@ fn handle_slice_comments<'a>(
         //     1:
         // ]
         // ```
-        debug_assert!(
-            matches!(comment.enclosing_node(), AnyNodeRef::ExprSubscript(_)),
-            "{:?}",
-            comment.enclosing_node()
-        );
+        debug_assert_matches!(comment.enclosing_node(), AnyNodeRef::ExprSubscript(_));
         return CommentPlacement::dangling(comment.enclosing_node(), comment);
     }
 
@@ -1322,10 +1319,10 @@ fn handle_dict_unpacking_comment<'a>(
     comment: DecoratedComment<'a>,
     source: &str,
 ) -> CommentPlacement<'a> {
-    debug_assert!(matches!(
+    debug_assert_matches!(
         comment.enclosing_node(),
         AnyNodeRef::ExprDict(_) | AnyNodeRef::ExprDictComp(_)
-    ));
+    );
 
     // no node after our comment so we can't be between `**` and the name (node)
     let Some(following) = comment.following_node() else {
@@ -1365,10 +1362,10 @@ fn handle_key_value_comment<'a>(
     comment: DecoratedComment<'a>,
     source: &str,
 ) -> CommentPlacement<'a> {
-    debug_assert!(matches!(
+    debug_assert_matches!(
         comment.enclosing_node(),
         AnyNodeRef::ExprDict(_) | AnyNodeRef::ExprDictComp(_)
-    ));
+    );
 
     let (Some(following), Some(preceding)) = (comment.following_node(), comment.preceding_node())
     else {
@@ -2004,10 +2001,10 @@ fn handle_bracketed_end_of_line_comment<'a>(
         let Some(paren) = lexer.next() else {
             return CommentPlacement::Default(comment);
         };
-        debug_assert!(matches!(
+        debug_assert_matches!(
             paren.kind(),
             SimpleTokenKind::LParen | SimpleTokenKind::LBrace | SimpleTokenKind::LBracket
-        ));
+        );
 
         // If there are no additional tokens between the open parenthesis and the comment, then
         // it should be attached as a dangling comment on the brackets, rather than a leading

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -1,3 +1,5 @@
+use std::assert_matches;
+
 use ruff_formatter::{FormatRuleWithOptions, format_args, write};
 use ruff_python_ast::{AnyNodeRef, Parameters};
 use ruff_python_trivia::{CommentLinePosition, SimpleToken, SimpleTokenKind, SimpleTokenizer};
@@ -671,27 +673,23 @@ fn has_trailing_comma(
     // The slash lacks its own node
     if ends_with_pos_only_argument_separator {
         let comma = tokens.next();
-        assert!(
-            matches!(
-                comma,
-                Some(SimpleToken {
-                    kind: SimpleTokenKind::Comma,
-                    ..
-                })
-            ),
-            "The last positional only argument must be separated by a `,` from the positional only parameters separator `/` but found '{comma:?}'."
+        assert_matches!(
+            comma,
+            Some(SimpleToken {
+                kind: SimpleTokenKind::Comma,
+                ..
+            }),
+            "The last positional only argument must be separated by a `,` from the positional only parameters separator `/`."
         );
 
         let slash = tokens.next();
-        assert!(
-            matches!(
-                slash,
-                Some(SimpleToken {
-                    kind: SimpleTokenKind::Slash,
-                    ..
-                })
-            ),
-            "The positional argument separator must be present for a function that has positional only parameters but found '{slash:?}'."
+        assert_matches!(
+            slash,
+            Some(SimpleToken {
+                kind: SimpleTokenKind::Slash,
+                ..
+            }),
+            "The positional argument separator must be present for a function that has positional only parameters."
         );
     }
 

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -7,6 +7,7 @@
 //! [Lexical analysis]: https://docs.python.org/3/reference/lexical_analysis.html
 
 use std::cmp::Ordering;
+use std::debug_assert_matches;
 
 use unicode_ident::{is_xid_continue, is_xid_start};
 
@@ -1048,10 +1049,7 @@ impl<'src> Lexer<'src> {
     /// Lex a hex/octal/decimal/binary number without a decimal point.
     fn lex_number_radix(&mut self, radix: Radix) -> TokenKind {
         #[cfg(debug_assertions)]
-        debug_assert!(matches!(
-            self.cursor.previous().to_ascii_lowercase(),
-            'x' | 'o' | 'b'
-        ));
+        debug_assert_matches!(self.cursor.previous().to_ascii_lowercase(), 'x' | 'o' | 'b');
 
         let number = self.radix_run(radix);
         if !number.has_digit {

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,3 +1,5 @@
+use std::assert_matches;
+
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
 
 use crate::{Mode, ParseOptions, parse, parse_expression, parse_module};
@@ -365,8 +367,8 @@ fn deep_nesting_preserves_surrounding_statements() {
     );
     let parsed = parse_module(&src).unwrap();
 
-    assert!(matches!(parsed.suite().first(), Some(Stmt::Assign(_))));
-    assert!(matches!(parsed.suite().last(), Some(Stmt::Assign(_))));
+    assert_matches!(parsed.suite().first(), Some(Stmt::Assign(_)));
+    assert_matches!(parsed.suite().last(), Some(Stmt::Assign(_)));
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/crates/ruff_python_trivia/src/whitespace.rs
+++ b/crates/ruff_python_trivia/src/whitespace.rs
@@ -125,20 +125,21 @@ impl PythonWhitespace for str {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::borrow::Cow;
 
     use super::{expand_tabs, tab_offset, tab_offset_u32};
 
     #[test]
     fn tab_expansion_borrows_unchanged_text() {
-        assert!(matches!(expand_tabs("unchanged"), Cow::Borrowed(_)));
+        assert_matches!(expand_tabs("unchanged"), Cow::Borrowed(_));
     }
 
     #[test]
     fn tab_expansion_allocates_changed_text() {
         let expanded = expand_tabs("  \tvalue");
 
-        assert!(matches!(&expanded, Cow::Owned(_)));
+        assert_matches!(&expanded, Cow::Owned(_));
         assert_eq!(expanded, "        value");
     }
 

--- a/crates/ty_ide/src/docstring/markdown/general.rs
+++ b/crates/ty_ide/src/docstring/markdown/general.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::debug_assert_matches;
 
 use ruff_text_size::TextSize;
 
@@ -315,7 +316,7 @@ impl<'source, 'output> Renderer<'source, 'output> {
     }
 
     fn finish_rest_literal(&mut self) {
-        debug_assert!(matches!(self.block_state, BlockState::RestLiteral { .. }));
+        debug_assert_matches!(self.block_state, BlockState::RestLiteral { .. });
         self.flush_pending_line();
         self.block_state = BlockState::Prose;
         self.output.push_str(FENCE);
@@ -344,7 +345,7 @@ impl<'source, 'output> Renderer<'source, 'output> {
     }
 
     fn finish_doctest(&mut self) {
-        debug_assert!(matches!(self.block_state, BlockState::Doctest));
+        debug_assert_matches!(self.block_state, BlockState::Doctest);
         self.flush_pending_line();
         self.block_state = BlockState::Prose;
         self.output.push_str(FENCE);
@@ -357,7 +358,7 @@ impl<'source, 'output> Renderer<'source, 'output> {
     }
 
     fn finish_markdown_fence(&mut self, line: &str) {
-        debug_assert!(matches!(self.block_state, BlockState::MarkdownFence(_)));
+        debug_assert_matches!(self.block_state, BlockState::MarkdownFence(_));
         self.flush_pending_line();
         self.block_state = BlockState::Prose;
         self.output.push_str(line);
@@ -461,7 +462,7 @@ impl LinePrefix {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 enum BlockState<'a> {
     #[default]
     Prose,

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::debug_assert_matches;
 use std::fmt::Formatter;
 use std::str::FromStr;
 
@@ -204,11 +205,7 @@ fn all_submodule_names_for_package<'db>(
     }
 
     let path = SystemOrVendoredPathRef::try_from_file(db, module.file(db))?;
-    debug_assert!(
-        matches!(path.file_name(), Some("__init__.py" | "__init__.pyi")),
-        "expected package file `{:?}` to be `__init__.py` or `__init__.pyi`",
-        path.file_name(),
-    );
+    debug_assert_matches!(path.file_name(), Some("__init__.py" | "__init__.pyi"));
 
     let resolver_environment = module.resolver_environment(db);
     Some(match path.parent()? {

--- a/crates/ty_module_resolver/src/module_glob.rs
+++ b/crates/ty_module_resolver/src/module_glob.rs
@@ -354,6 +354,8 @@ fn glob_to_regex(pattern: &str) -> Result<Box<str>, ModuleGlobError> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[track_caller]
@@ -527,52 +529,43 @@ mod tests {
     #[test]
     fn test_invalid_empty_pattern() {
         let result = ModuleGlobSet::from_patterns([""]);
-        assert!(matches!(result, Err(ModuleGlobError::EmptyPattern)));
+        assert_matches!(result, Err(ModuleGlobError::EmptyPattern));
     }
 
     #[test]
     fn test_invalid_just_negation() {
         let result = ModuleGlobSet::from_patterns(["!"]);
-        assert!(matches!(result, Err(ModuleGlobError::EmptyPattern)));
+        assert_matches!(result, Err(ModuleGlobError::EmptyPattern));
     }
 
     #[test]
     fn test_invalid_double_star_combined() {
         let result = ModuleGlobSet::from_patterns(["foo**"]);
-        assert!(matches!(
-            result,
-            Err(ModuleGlobError::InvalidDoubleStarUsage(_))
-        ));
+        assert_matches!(result, Err(ModuleGlobError::InvalidDoubleStarUsage(_)));
 
         let result = ModuleGlobSet::from_patterns(["**foo"]);
-        assert!(matches!(
-            result,
-            Err(ModuleGlobError::InvalidDoubleStarUsage(_))
-        ));
+        assert_matches!(result, Err(ModuleGlobError::InvalidDoubleStarUsage(_)));
 
         let result = ModuleGlobSet::from_patterns(["foo.bar**"]);
-        assert!(matches!(
-            result,
-            Err(ModuleGlobError::InvalidDoubleStarUsage(_))
-        ));
+        assert_matches!(result, Err(ModuleGlobError::InvalidDoubleStarUsage(_)));
     }
 
     #[test]
     fn test_invalid_consecutive_dots() {
         let result = ModuleGlobSet::from_patterns(["foo..bar"]);
-        assert!(matches!(result, Err(ModuleGlobError::ConsecutiveDots)));
+        assert_matches!(result, Err(ModuleGlobError::ConsecutiveDots));
     }
 
     #[test]
     fn test_invalid_leading_dot() {
         let result = ModuleGlobSet::from_patterns([".foo"]);
-        assert!(matches!(result, Err(ModuleGlobError::LeadingDot)));
+        assert_matches!(result, Err(ModuleGlobError::LeadingDot));
     }
 
     #[test]
     fn test_invalid_trailing_dot() {
         let result = ModuleGlobSet::from_patterns(["foo."]);
-        assert!(matches!(result, Err(ModuleGlobError::TrailingDot)));
+        assert_matches!(result, Err(ModuleGlobError::TrailingDot));
     }
 
     #[test]

--- a/crates/ty_module_resolver/src/path.rs
+++ b/crates/ty_module_resolver/src/path.rs
@@ -1,5 +1,6 @@
 //! Internal abstractions for differentiating between different kinds of search paths.
 
+use std::assert_matches;
 use std::fmt;
 use std::sync::Arc;
 
@@ -71,8 +72,9 @@ impl ModulePath {
                     "Extension must be `pyi`; got `{component_extension}`"
                 );
             } else {
-                assert!(
-                    matches!(component_extension, "pyi" | "py"),
+                assert_matches!(
+                    component_extension,
+                    "pyi" | "py",
                     "Extension must be `py` or `pyi`; got `{component_extension}`"
                 );
             }

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -2036,6 +2036,8 @@ mod tests {
         clippy::disallowed_methods,
         reason = "These are tests, so it's fine to do I/O by-passing System."
     )]
+    use std::assert_matches;
+
     use ruff_db::Db;
     use ruff_db::files::{File, FilePath, system_path_to_file};
     use ruff_db::system::{DbWithTestSystem as _, DbWithWritableSystem as _};
@@ -2384,8 +2386,8 @@ mod tests {
             resolve_module(&db, ImportingFile::File(importing_file, py311), &namespace).unwrap();
         let py312_namespace =
             resolve_module(&db, ImportingFile::File(importing_file, py312), &namespace).unwrap();
-        assert!(matches!(py311_namespace, Module::Namespace(_)));
-        assert!(matches!(py312_namespace, Module::Namespace(_)));
+        assert_matches!(py311_namespace, Module::Namespace(_));
+        assert_matches!(py312_namespace, Module::Namespace(_));
         assert_eq!(py311_namespace.python_version(&db), PythonVersion::PY311);
         assert_eq!(py312_namespace.python_version(&db), PythonVersion::PY312);
         assert_ne!(py311_namespace, py312_namespace);

--- a/crates/ty_project/src/files.rs
+++ b/crates/ty_project/src/files.rs
@@ -272,6 +272,7 @@ impl Drop for IndexedMut<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::time::{Duration, Instant};
 
     use rustc_hash::FxHashSet;
@@ -352,11 +353,9 @@ mod tests {
             }
             Err(cancelled) => cancelled,
         };
-        assert!(
-            matches!(
-                cancelled.downcast_ref::<salsa::Cancelled>(),
-                Some(salsa::Cancelled::PendingWrite)
-            ),
+        assert_matches!(
+            cancelled.downcast_ref::<salsa::Cancelled>(),
+            Some(salsa::Cancelled::PendingWrite),
             "file indexing did not propagate the salsa cancellation"
         );
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -654,6 +654,8 @@ pub enum ProjectMetadataError {
 mod tests {
     //! Integration tests for project discovery
 
+    use std::assert_matches;
+
     use anyhow::{Context, anyhow};
     use insta::assert_ron_snapshot;
     use ruff_db::system::{SystemPathBuf, TestSystem};
@@ -1135,18 +1137,18 @@ unclosed table, expected `]`
                 .map(RelativePathBuf::path),
             Some(environment.as_path())
         );
-        assert!(matches!(
+        assert_matches!(
             project_environment
                 .and_then(|environment| environment.python.as_ref())
                 .map(RelativePathBuf::source),
             Some(ValueSource::UvWorkspace)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             project_environment
                 .and_then(|environment| environment.python_version.as_ref())
                 .map(ruff_ranged_value::RangedValue::source),
             Some(ValueSource::UvWorkspace)
-        ));
+        );
 
         let user_config_directory = root.join("config");
         system

--- a/crates/ty_project/src/uv/metadata.rs
+++ b/crates/ty_project/src/uv/metadata.rs
@@ -177,6 +177,8 @@ struct WorkspacePython {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use ruff_db::system::{SystemPath, TestSystem};
     use ty_static::EnvVars;
 
@@ -186,10 +188,10 @@ mod tests {
     fn rejects_invalid_metadata() {
         let system = TestSystem::default();
 
-        assert!(matches!(
+        assert_matches!(
             UvWorkspace::from_metadata(b"{", &system),
             Err(UvWorkspaceError::InvalidMetadata(_))
-        ));
+        );
     }
 
     #[test]
@@ -197,11 +199,11 @@ mod tests {
         let system = TestSystem::default();
         system.set_env_var(EnvVars::UV, "/custom/uv");
 
-        assert!(matches!(
+        assert_matches!(
             UvWorkspace::discover(SystemPath::new("/app"), &system),
             Err(UvWorkspaceError::Invocation(error))
                 if error.kind() == std::io::ErrorKind::Unsupported
-        ));
+        );
     }
 
     #[test]
@@ -263,10 +265,10 @@ mod tests {
             }
         }"#;
 
-        assert!(matches!(
+        assert_matches!(
             UvWorkspace::from_metadata(metadata, &system),
             Err(UvWorkspaceError::InvalidPythonVersion(_))
-        ));
+        );
 
         Ok(())
     }

--- a/crates/ty_python_core/src/builder/except_handlers.rs
+++ b/crates/ty_python_core/src/builder/except_handlers.rs
@@ -1,3 +1,5 @@
+use std::debug_assert_matches;
+
 use crate::reachability_constraints::ScopedReachabilityConstraintId;
 use crate::use_def::{ExceptionCheckpointKey, FlowSnapshot, UseDefMapBuilder};
 
@@ -89,14 +91,14 @@ impl ExceptionContextStackManager {
     pub(super) fn finish_context_manager_context(&mut self) -> Vec<FlowSnapshot> {
         let snapshots = self.take_exception_snapshots();
         let context = self.current_exception_context_stack().pop_context();
-        debug_assert!(matches!(context.kind, ExceptionContextKind::With));
+        debug_assert_matches!(context.kind, ExceptionContextKind::With);
         snapshots
     }
 
     /// Removes the current `try` context after its handlers have been deactivated.
     pub(super) fn pop_try_context(&mut self) -> ExceptionContext {
         let context = self.current_exception_context_stack().pop_context();
-        debug_assert!(matches!(context.kind, ExceptionContextKind::Try { .. }));
+        debug_assert_matches!(context.kind, ExceptionContextKind::Try { .. });
         debug_assert!(!context.exception_handlers.is_active());
         context
     }

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -1069,6 +1069,8 @@ impl HasTrackedScope for ast::Identifier {}
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use ruff_db::{
         files::{File, system_path_to_file},
         parsed::ParsedModuleRef,
@@ -1165,10 +1167,10 @@ mod tests {
         let declaration = use_def
             .first_public_declaration(global_table.symbol_id("x").expect("symbol to exist"))
             .unwrap();
-        assert!(matches!(
+        assert_matches!(
             declaration.kind(&db),
             DefinitionKind::AnnotatedAssignment(_)
-        ));
+        );
     }
 
     #[test]
@@ -1182,7 +1184,7 @@ mod tests {
 
         let use_def = use_def_map(&db, scope);
         let binding = use_def.first_public_binding(foo).unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Import(_)));
+        assert_matches!(binding.kind(&db), DefinitionKind::Import(_));
     }
 
     #[test]
@@ -1219,7 +1221,7 @@ mod tests {
         let binding = use_def
             .first_public_binding(global_table.symbol_id("foo").expect("symbol to exist"))
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::ImportFrom(_)));
+        assert_matches!(binding.kind(&db), DefinitionKind::ImportFrom(_));
     }
 
     #[test]
@@ -1239,7 +1241,7 @@ mod tests {
         let binding = use_def
             .first_public_binding(global_table.symbol_id("x").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Assignment(_)));
+        assert_matches!(binding.kind(&db), DefinitionKind::Assignment(_));
     }
 
     #[test]
@@ -1255,10 +1257,7 @@ mod tests {
             .first_public_binding(global_table.symbol_id("x").unwrap())
             .unwrap();
 
-        assert!(matches!(
-            binding.kind(&db),
-            DefinitionKind::AugmentedAssignment(_)
-        ));
+        assert_matches!(binding.kind(&db), DefinitionKind::AugmentedAssignment(_));
     }
 
     #[test]
@@ -1298,7 +1297,7 @@ y = 2
         let binding = use_def
             .first_public_binding(class_table.symbol_id("x").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Assignment(_)));
+        assert_matches!(binding.kind(&db), DefinitionKind::Assignment(_));
     }
 
     #[test]
@@ -1337,7 +1336,7 @@ y = 2
         let binding = use_def
             .first_public_binding(function_table.symbol_id("x").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Assignment(_)));
+        assert_matches!(binding.kind(&db), DefinitionKind::Assignment(_));
     }
 
     #[test]
@@ -1372,22 +1371,22 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             let binding = use_def
                 .first_public_binding(function_table.symbol_id(name).expect("symbol exists"))
                 .unwrap();
-            assert!(matches!(binding.kind(&db), DefinitionKind::Parameter(_)));
+            assert_matches!(binding.kind(&db), DefinitionKind::Parameter(_));
         }
         let args_binding = use_def
             .first_public_binding(function_table.symbol_id("args").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(
+        assert_matches!(
             args_binding.kind(&db),
             DefinitionKind::Parameter(ParameterDefinitionNodeKind::VariadicPositionalParameter(_))
-        ));
+        );
         let kwargs_binding = use_def
             .first_public_binding(function_table.symbol_id("kwargs").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(
+        assert_matches!(
             kwargs_binding.kind(&db),
             DefinitionKind::Parameter(ParameterDefinitionNodeKind::VariadicKeywordParameter(_))
-        ));
+        );
     }
 
     #[test]
@@ -1417,37 +1416,37 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             let binding = use_def
                 .first_public_binding(lambda_table.symbol_id(name).expect("symbol exists"))
                 .unwrap();
-            assert!(matches!(
+            assert_matches!(
                 binding.kind(&db),
                 DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
                     index: _,
                     lambda: _,
                     parameter: ParameterDefinitionNodeKind::Parameter(_)
                 })
-            ));
+            );
         }
         let args_binding = use_def
             .first_public_binding(lambda_table.symbol_id("args").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(
+        assert_matches!(
             args_binding.kind(&db),
             DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
                 index: 3,
                 lambda: _,
                 parameter: ParameterDefinitionNodeKind::VariadicPositionalParameter(_)
             })
-        ));
+        );
         let kwargs_binding = use_def
             .first_public_binding(lambda_table.symbol_id("kwargs").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(
+        assert_matches!(
             kwargs_binding.kind(&db),
             DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
                 index: 5,
                 lambda: _,
                 parameter: ParameterDefinitionNodeKind::VariadicKeywordParameter(_)
             })
-        ));
+        );
     }
 
     /// Test case to validate that the comprehension scope is correctly identified and that the target
@@ -1494,10 +1493,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
                         .expect("symbol exists"),
                 )
                 .unwrap();
-            assert!(matches!(
-                binding.kind(&db),
-                DefinitionKind::Comprehension(_)
-            ));
+            assert_matches!(binding.kind(&db), DefinitionKind::Comprehension(_));
         }
     }
 
@@ -1620,7 +1616,7 @@ with item1 as x, item2 as y:
             let binding = use_def
                 .first_public_binding(global_table.symbol_id(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            assert!(matches!(binding.kind(&db), DefinitionKind::WithItem(_)));
+            assert_matches!(binding.kind(&db), DefinitionKind::WithItem(_));
         }
     }
 
@@ -1643,7 +1639,7 @@ with context() as (x, y):
             let binding = use_def
                 .first_public_binding(global_table.symbol_id(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            assert!(matches!(binding.kind(&db), DefinitionKind::WithItem(_)));
+            assert_matches!(binding.kind(&db), DefinitionKind::WithItem(_));
         }
     }
 
@@ -1697,7 +1693,7 @@ def func():
         let binding = use_def
             .first_public_binding(global_table.symbol_id("func").expect("symbol exists"))
             .unwrap();
-        assert!(matches!(binding.kind(&db), DefinitionKind::Function(_)));
+        assert_matches!(binding.kind(&db), DefinitionKind::Function(_));
     }
 
     #[test]
@@ -1952,7 +1948,7 @@ match subject:
             let binding = use_def
                 .first_public_binding(global_table.symbol_id(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            assert!(matches!(binding.kind(&db), DefinitionKind::MatchPattern(_)));
+            assert_matches!(binding.kind(&db), DefinitionKind::MatchPattern(_));
         }
     }
 
@@ -1978,7 +1974,7 @@ match 1:
             let binding = use_def
                 .first_public_binding(global_table.symbol_id(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            assert!(matches!(binding.kind(&db), DefinitionKind::MatchPattern(_)));
+            assert_matches!(binding.kind(&db), DefinitionKind::MatchPattern(_));
         }
     }
 
@@ -1995,7 +1991,7 @@ match 1:
             .first_public_binding(global_table.symbol_id("x").unwrap())
             .unwrap();
 
-        assert!(matches!(binding.kind(&db), DefinitionKind::For(_)));
+        assert_matches!(binding.kind(&db), DefinitionKind::For(_));
     }
 
     #[test]
@@ -2014,8 +2010,8 @@ match 1:
             .first_public_binding(global_table.symbol_id("y").unwrap())
             .unwrap();
 
-        assert!(matches!(x_binding.kind(&db), DefinitionKind::For(_)));
-        assert!(matches!(y_binding.kind(&db), DefinitionKind::For(_)));
+        assert_matches!(x_binding.kind(&db), DefinitionKind::For(_));
+        assert_matches!(y_binding.kind(&db), DefinitionKind::For(_));
     }
 
     #[test]
@@ -2031,6 +2027,6 @@ match 1:
             .first_public_binding(global_table.symbol_id("a").unwrap())
             .unwrap();
 
-        assert!(matches!(binding.kind(&db), DefinitionKind::For(_)));
+        assert_matches!(binding.kind(&db), DefinitionKind::For(_));
     }
 }

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -1034,6 +1034,8 @@ fn hash_single<T: Hash>(value: &T) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -1170,7 +1172,7 @@ mod tests {
             MemberExpr::try_from_expr(ast::ExprRef::from(small_expr.expr())).unwrap();
 
         // Should use Small allocation
-        assert!(matches!(small_member.segments, Segments::Small(_)));
+        assert_matches!(small_member.segments, Segments::Small(_));
         assert_eq!(small_member.num_segments(), 7);
 
         // Test Heap allocation: 8 segments (exceeds inline capacity)
@@ -1179,7 +1181,7 @@ mod tests {
         let heap_member = MemberExpr::try_from_expr(ast::ExprRef::from(heap_expr.expr())).unwrap();
 
         // Should use Heap allocation
-        assert!(matches!(heap_member.segments, Segments::Heap(_)));
+        assert_matches!(heap_member.segments, Segments::Heap(_));
         assert_eq!(heap_member.num_segments(), 8);
 
         // Test Small allocation with relative offset limit
@@ -1189,7 +1191,7 @@ mod tests {
             MemberExpr::try_from_expr(ast::ExprRef::from(small_offset_expr.expr())).unwrap();
 
         // Should use Small allocation (3 segments, small offsets)
-        assert!(matches!(small_offset_member.segments, Segments::Small(_)));
+        assert_matches!(small_offset_member.segments, Segments::Small(_));
         assert_eq!(small_offset_member.num_segments(), 3);
 
         // Test Small allocation with maximum 63-byte relative offset limit
@@ -1200,7 +1202,7 @@ mod tests {
         let max_offset_member =
             MemberExpr::try_from_expr(ast::ExprRef::from(max_offset_expr.expr())).unwrap();
         // Should still use Small allocation (exactly at the limit)
-        assert!(matches!(max_offset_member.segments, Segments::Small(_)));
+        assert_matches!(max_offset_member.segments, Segments::Small(_));
         assert_eq!(max_offset_member.num_segments(), 2);
 
         // Test that heap allocation works for segment content that would exceed relative offset limits
@@ -1211,7 +1213,7 @@ mod tests {
         let long_expr = parse_expression(&long_expr_code).unwrap();
         let long_member = MemberExpr::try_from_expr(ast::ExprRef::from(long_expr.expr())).unwrap();
         // Should use Heap allocation due to large relative offset
-        assert!(matches!(long_member.segments, Segments::Heap(_)));
+        assert_matches!(long_member.segments, Segments::Heap(_));
         assert_eq!(long_member.num_segments(), 2);
     }
 }

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2532,6 +2532,8 @@ pub(crate) enum ConsideredDefinitions {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use crate::db::tests::{TestDb, setup_db};
 
@@ -2640,14 +2642,14 @@ mod tests {
 
     #[track_caller]
     fn assert_bound_string_symbol<'db>(db: &'db TestDb, symbol: Place<'db>) {
-        assert!(matches!(
+        assert_matches!(
             symbol,
             Place::Defined(DefinedPlace {
                 ty: Type::NominalInstance(_),
                 definedness: Definedness::AlwaysDefined,
                 ..
             })
-        ));
+        );
         assert_eq!(
             symbol.expect_type(),
             KnownClass::Str.to_instance(db, &db.program_environment())

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -7084,6 +7084,8 @@ impl SatisfiedClauses {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     use indoc::indoc;
@@ -7829,10 +7831,10 @@ class E: ...
         // Check satisfiability against each upper clause before punting on the union-bearing
         // merged upper bound. The old size heuristic returned `CannotSimplify` here before
         // discovering that `int` cannot satisfy the second upper clause.
-        assert!(matches!(
+        assert_matches!(
             left.intersect(db, &env, &mut storage, right),
             IntersectionResult::Disjoint
-        ));
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -685,6 +685,8 @@ impl<T: Hash + Eq> Drop for ActiveRecursionGuard<'_, T> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::{CycleDetector, CycleDetectorVisit, Db, HasIdentity, TypeIdentity};
     use crate::ProgramEnvironment;
     use crate::db::tests::setup_db;
@@ -806,14 +808,14 @@ class RecursivePropertySetter[T](Protocol):
             global_instance_type(&db, &env, "GenericProperty").recursive_identity(&db),
             None
         );
-        assert!(matches!(
+        assert_matches!(
             global_instance_type(&db, &env, "RecursiveProperty").recursive_identity(&db),
             Some(TypeIdentity::RecursiveProtocol(_))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             global_instance_type(&db, &env, "RecursivePropertySetter").recursive_identity(&db),
             Some(TypeIdentity::RecursiveProtocol(_))
-        ));
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::fmt::Write;
 
 use super::builder::TypeInferenceBuilder;
@@ -302,14 +303,14 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
 
     let owner_type = Type::unknown();
     let owner = DefinitionTypes::from_parts(first, vec![(first, owner_type)], vec![]);
-    assert!(matches!(owner, DefinitionTypes::Binding(ty) if ty == owner_type));
+    assert_matches!(owner, DefinitionTypes::Binding(ty) if ty == owner_type);
     assert_eq!(
         owner.bindings(first).collect::<Vec<_>>(),
         [(first, owner_type)]
     );
 
     let non_owner = DefinitionTypes::from_parts(first, vec![(second, owner_type)], vec![]);
-    assert!(matches!(non_owner, DefinitionTypes::Other(_)));
+    assert_matches!(non_owner, DefinitionTypes::Other(_));
     assert_eq!(
         non_owner.bindings(first).collect::<Vec<_>>(),
         [(second, owner_type)]

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -3,6 +3,7 @@
 use crate::ProgramEnvironment;
 use std::borrow::Cow;
 use std::cell::Cell;
+use std::debug_assert_matches;
 use std::marker::PhantomData;
 
 use ruff_python_ast::name::Name;
@@ -832,10 +833,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         protocol: ProtocolInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
-        debug_assert!(matches!(
+        debug_assert_matches!(
             meta_ty,
             Type::ClassLiteral(_) | Type::SubclassOf(_) | Type::GenericAlias(_)
-        ));
+        );
 
         let constructed_ty = meta_ty.bindings(db, env).return_type(db, env);
         self.check_type_pair(db, constructed_ty, Type::ProtocolInstance(protocol))

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -1,3 +1,5 @@
+use std::debug_assert_matches;
+
 use crate::Db;
 use crate::place::{DefinedPlace, Place, builtins_symbol, global_symbol, known_module_symbol};
 use crate::types::enums::is_single_member_enum;
@@ -259,8 +261,10 @@ impl Ty {
                 let ty = known_module_symbol(db, env, KnownModule::Dataclasses, "MISSING")
                     .place
                     .expect_type();
-                debug_assert!(
-                    matches!(ty, Type::NominalInstance(instance) if is_single_member_enum(db, instance.class_literal(db, env)))
+                debug_assert_matches!(
+                    ty,
+                    Type::NominalInstance(instance)
+                        if is_single_member_enum(db, instance.class_literal(db, env))
                 );
                 ty
             }

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -1,5 +1,6 @@
 use crate::ProgramEnvironment;
 use std::borrow::Cow;
+use std::debug_assert_matches;
 
 use ruff_db::parsed::ParsedModuleRef;
 
@@ -70,8 +71,9 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
     /// Unpack the value to the target expression.
     pub(crate) fn unpack(&mut self, target: &ast::Expr, value: UnpackValue<'db>) {
         let db = self.db();
-        debug_assert!(
-            matches!(target, ast::Expr::List(_) | ast::Expr::Tuple(_)),
+        debug_assert_matches!(
+            target,
+            ast::Expr::List(_) | ast::Expr::Tuple(_),
             "Unpacking target must be a list or tuple expression"
         );
 

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod version;
 
+use std::debug_assert_matches;
 use std::hash::{Hash, Hasher};
 use std::io;
 use std::num::NonZeroUsize;
@@ -134,9 +135,10 @@ impl SitePackagesPaths {
             .map(|c| {
                 // This should have all been validated in `site_packages.rs`
                 // when we resolved the search paths for the project.
-                debug_assert!(
-                    matches!(c, Utf8Component::Normal(_)),
-                    "Unexpected component in site-packages path `{c:?}` \
+                debug_assert_matches!(
+                    c,
+                    Utf8Component::Normal(_),
+                    "Unexpected component in site-packages path \
                     (expected `site-packages` to be an absolute path \
                     with symlinks resolved, located at \
                     `<sys.prefix>/lib/pythonX.Y/site-packages`)"
@@ -2302,6 +2304,8 @@ impl PartialEq<SystemPathBuf> for PythonHomePath {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use ruff_db::system::TestSystem;
     #[cfg(unix)]
     use ruff_db::system::{OsSystem, SystemPath};
@@ -2706,10 +2710,7 @@ mod tests {
             virtual_env: None,
         };
         let err = test.err();
-        assert!(
-            matches!(err, SitePackagesDiscoveryError::NoPyvenvCfgFile(..)),
-            "Got {err:?}",
-        );
+        assert_matches!(err, SitePackagesDiscoveryError::NoPyvenvCfgFile(..));
     }
 
     #[test]
@@ -2722,10 +2723,7 @@ mod tests {
             virtual_env: None,
         };
         let err = test.err();
-        assert!(
-            matches!(err, SitePackagesDiscoveryError::NoPyvenvCfgFile(..)),
-            "Got {err:?}",
-        );
+        assert_matches!(err, SitePackagesDiscoveryError::NoPyvenvCfgFile(..));
     }
 
     #[test]
@@ -2891,10 +2889,10 @@ mod tests {
     #[test]
     fn reject_env_that_does_not_exist() {
         let system = TestSystem::default();
-        assert!(matches!(
+        assert_matches!(
             PythonEnvironment::new("/env", SysPrefixPathOrigin::PythonCliFlag, &system),
             Err(SitePackagesDiscoveryError::PathNotExecutableOrDirectory(..))
-        ));
+        );
     }
 
     #[test]
@@ -2904,10 +2902,10 @@ mod tests {
             .memory_file_system()
             .write_file_all("/env", "")
             .unwrap();
-        assert!(matches!(
+        assert_matches!(
             PythonEnvironment::new("/env", SysPrefixPathOrigin::PythonCliFlag, &system),
             Err(SitePackagesDiscoveryError::PathNotExecutableOrDirectory(..))
-        ));
+        );
     }
 
     #[test]
@@ -2923,22 +2921,16 @@ mod tests {
             PythonEnvironment::new("/env", SysPrefixPathOrigin::PythonCliFlag, &system).unwrap();
         let site_packages = env.site_packages_paths(&system);
         if cfg!(unix) {
-            assert!(
-                matches!(
-                    site_packages,
-                    Err(SitePackagesDiscoveryError::CouldNotReadLibDirectory(..)),
-                ),
-                "Got {site_packages:?}",
+            assert_matches!(
+                site_packages,
+                Err(SitePackagesDiscoveryError::CouldNotReadLibDirectory(..))
             );
         } else {
             // On Windows, we look for `Lib/site-packages` directly instead of listing the entries
             // of `lib/...` — so we don't see the intermediate failure
-            assert!(
-                matches!(
-                    site_packages,
-                    Err(SitePackagesDiscoveryError::NoSitePackagesDirFound(..)),
-                ),
-                "Got {site_packages:?}",
+            assert_matches!(
+                site_packages,
+                Err(SitePackagesDiscoveryError::NoSitePackagesDirFound(..))
             );
         }
     }
@@ -2961,12 +2953,9 @@ mod tests {
         let env =
             PythonEnvironment::new("/env", SysPrefixPathOrigin::PythonCliFlag, &system).unwrap();
         let site_packages = env.site_packages_paths(&system);
-        assert!(
-            matches!(
-                site_packages,
-                Err(SitePackagesDiscoveryError::NoSitePackagesDirFound(..)),
-            ),
-            "Got {site_packages:?}",
+        assert_matches!(
+            site_packages,
+            Err(SitePackagesDiscoveryError::NoSitePackagesDirFound(..))
         );
     }
 
@@ -2980,14 +2969,14 @@ mod tests {
             .unwrap();
         let venv_result =
             PythonEnvironment::new("/.venv", SysPrefixPathOrigin::VirtualEnvVar, &system);
-        assert!(matches!(
+        assert_matches!(
             venv_result,
             Err(SitePackagesDiscoveryError::PyvenvCfgParseError(
                 path,
                 PyvenvCfgParseErrorKind::MalformedKeyValuePair { line_number }
             ))
             if path == pyvenv_cfg_path && Some(line_number) == NonZeroUsize::new(1)
-        ));
+        );
     }
 
     #[test]
@@ -3000,14 +2989,14 @@ mod tests {
             .unwrap();
         let venv_result =
             PythonEnvironment::new("/.venv", SysPrefixPathOrigin::VirtualEnvVar, &system);
-        assert!(matches!(
+        assert_matches!(
             venv_result,
             Err(SitePackagesDiscoveryError::PyvenvCfgParseError(
                 path,
                 PyvenvCfgParseErrorKind::MalformedKeyValuePair { line_number }
             ))
             if path == pyvenv_cfg_path && Some(line_number) == NonZeroUsize::new(1)
-        ));
+        );
     }
 
     #[test]
@@ -3018,14 +3007,14 @@ mod tests {
         memory_fs.write_file_all(&pyvenv_cfg_path, "").unwrap();
         let venv_result =
             PythonEnvironment::new("/.venv", SysPrefixPathOrigin::VirtualEnvVar, &system);
-        assert!(matches!(
+        assert_matches!(
             venv_result,
             Err(SitePackagesDiscoveryError::PyvenvCfgParseError(
                 path,
                 PyvenvCfgParseErrorKind::NoHomeKey
             ))
             if path == pyvenv_cfg_path
-        ));
+        );
     }
 
     #[test]
@@ -3070,14 +3059,14 @@ mod tests {
         let venv_result =
             PythonEnvironment::new("/.venv", SysPrefixPathOrigin::VirtualEnvVar, &system);
 
-        assert!(matches!(
+        assert_matches!(
             venv_result,
             Err(SitePackagesDiscoveryError::PyvenvCfgParseError(
                 path,
                 PyvenvCfgParseErrorKind::InvalidHomeValue(_)
             ))
             if path == pyvenv_cfg_path
-        ));
+        );
     }
 
     #[test]

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -16,6 +16,7 @@ use ruff_db::testing::{setup_logging, setup_logging_with_filter};
 use ruff_diagnostics::Applicability;
 use ruff_python_ast::PythonVersion;
 use ruff_source_file::OneIndexed;
+use std::assert_matches;
 use std::fmt::Write;
 use ty_module_resolver::{
     Module, SearchPath, SearchPathSettings, list_modules, resolve_module_confident,
@@ -169,11 +170,9 @@ fn run_test(
                 return None;
             }
 
-            assert!(
-                matches!(
-                    embedded.lang,
-                    "py" | "pyi" | "python" | "ipynb" | "text" | "cfg" | "pth"
-                ),
+            assert_matches!(
+                embedded.lang,
+                "py" | "pyi" | "python" | "ipynb" | "text" | "cfg" | "pth",
                 "Supported file types are: py (or python), pyi, ipynb, text, cfg and ignore"
             );
 


### PR DESCRIPTION
## Summary

- Use Rust 1.96's stabilized `assert_matches!` and `debug_assert_matches!` macros throughout Ruff and ty.
- Include mismatched values in assertion failures and remove redundant manual debug formatting.
- Preserve existing assertions for values that do not implement `Debug`.
