### PR TITLE
[ty] Retain bound type-variable instances in constraint arenas

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -260,7 +260,7 @@ struct OwnedConstraintSetInner<'db> {
     constraints: Box<[Constraint<'db>]>,
     constraint_supports: Box<[SupportId]>,
     constraint_indices: RankBitBox,
-    typevars: IndexVec<TypeVarId, BoundTypeVarIdentity<'db>>,
+    typevars: IndexVec<TypeVarId, BoundTypeVarInstance<'db>>,
     nodes: Box<[InteriorNodeData]>,
     node_supports: Box<[SupportId]>,
     node_indices: RankBitBox,
@@ -522,7 +522,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     }
 
     /// Returns whether this constraint set mentions the given type-variable identity.
-    pub(super) fn mentions_typevar(self, typevar: BoundTypeVarIdentity<'db>) -> bool {
+    pub(super) fn mentions_typevar(self, typevar: BoundTypeVarInstance<'db>) -> bool {
         let storage = self.builder.storage.borrow();
         storage
             .node_support(self.node)
@@ -967,7 +967,7 @@ struct ConstraintSetStorage<'db> {
     ///
     /// The ordering of typevars within this arena defines which typevars can be the lower/upper
     /// bounds of another (e.g., whether we encode `T ≤ U` as `Never ≤ T ≤ U` or `T ≤ U ≤ object`).
-    typevars: IndexVec<TypeVarId, BoundTypeVarIdentity<'db>>,
+    typevars: IndexVec<TypeVarId, BoundTypeVarInstance<'db>>,
 
     /// The BDD nodes that appear in any of the constraint sets constructed in this builder.
     nodes: IndexVec<NodeId, InteriorNodeData>,
@@ -1011,7 +1011,7 @@ struct ConstraintSetStorage<'db> {
     constraint_set_subtype_cache: FxHashMap<(Type<'db>, Type<'db>), bool>,
 }
 
-impl ConstraintSetStorage<'_> {
+impl<'db> ConstraintSetStorage<'db> {
     fn ensure_overlay_identity_caches(&mut self) {
         let Some(compacted) = &self.compacted else {
             return;
@@ -1020,12 +1020,6 @@ impl ConstraintSetStorage<'_> {
             return;
         }
 
-        self.typevar_cache.extend(
-            compacted
-                .typevars
-                .iter_enumerated()
-                .map(|(id, typevar)| (*typevar, id)),
-        );
         self.constraint_cache.extend(
             compacted
                 .constraint_indices
@@ -1047,6 +1041,23 @@ impl ConstraintSetStorage<'_> {
                 .copied()
                 .enumerate()
                 .map(|(index, source_order)| (source_order, SourceOrderId::from_usize(index))),
+        );
+    }
+
+    // This is a separate method from `ensure_overlay_identity_caches` because it requires a `db`.
+    fn ensure_overlay_typevar_identity_cache(&mut self, db: &'db dyn Db) {
+        let Some(compacted) = &self.compacted else {
+            return;
+        };
+        if !self.typevar_cache.is_empty() {
+            return;
+        }
+
+        self.typevar_cache.extend(
+            compacted
+                .typevars
+                .iter_enumerated()
+                .map(|(id, typevar)| (typevar.identity(db), id)),
         );
     }
 
@@ -1262,15 +1273,13 @@ impl<'db> ConstraintSetBuilder<'db> {
 impl<'db> ConstraintSetStorage<'db> {
     /// Interns a single typevar, giving it a stable order in this builder
     fn intern_typevar(&mut self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
-        self.intern_typevar_identity(typevar.identity(db))
-    }
-
-    fn intern_typevar_identity(&mut self, identity: BoundTypeVarIdentity<'db>) -> TypeVarId {
         self.ensure_overlay_identity_caches();
+        self.ensure_overlay_typevar_identity_cache(db);
+        let identity = typevar.identity(db);
         if let Some(id) = self.typevar_cache.get(&identity) {
             return *id;
         }
-        let id = self.typevars.push(identity);
+        let id = self.typevars.push(typevar);
         let id = self.adjusted_typevar_id(id);
         self.typevar_cache.insert(identity, id);
         id
@@ -1397,6 +1406,7 @@ impl<'db> ConstraintSetStorage<'db> {
     fn typevar_id(&mut self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
         let identity = typevar.identity(db);
         self.ensure_overlay_identity_caches();
+        self.ensure_overlay_typevar_identity_cache(db);
         self.typevar_cache
             .get(&identity)
             .copied()
@@ -1578,7 +1588,7 @@ impl<'db> ConstraintSetStorage<'db> {
         self.adjusted_support_id(id)
     }
 
-    fn typevar_data(&self, typevar: TypeVarId) -> BoundTypeVarIdentity<'db> {
+    fn typevar_data(&self, typevar: TypeVarId) -> BoundTypeVarInstance<'db> {
         if let Some(compacted) = &self.compacted {
             let index = typevar.index();
             let split = compacted.typevars.len();
@@ -1699,7 +1709,7 @@ impl<'db> ConstraintSetStorage<'db> {
             referenced_typevars |= &inner.supports[inner.retained_support_index(*support)];
         }
         for typevar in referenced_typevars.iter() {
-            self.intern_typevar_identity(inner.typevars[typevar]);
+            self.intern_typevar(db, inner.typevars[typevar]);
         }
 
         // Rebuild constraints in their saved order, using the destination's typevar ordering.
@@ -7190,15 +7200,15 @@ mod tests {
             .map(|typevar| storage.typevar_data(typevar))
             .collect::<Vec<_>>();
 
-        assert_eq!(mentioned, vec![t.identity(db), u.identity(db)]);
+        assert_eq!(mentioned, vec![t, u]);
         assert!(support.is_complete());
 
         let builder = ConstraintSetBuilder::new();
         let constraint =
             ConstraintSet::constrain_typevar_upper_bound(db, &env, &builder, t, actual_bound);
-        assert!(constraint.mentions_typevar(t.identity(db)));
-        assert!(constraint.mentions_typevar(u.identity(db)));
-        assert!(!constraint.mentions_typevar(metadata.identity(db)));
+        assert!(constraint.mentions_typevar(t));
+        assert!(constraint.mentions_typevar(u));
+        assert!(!constraint.mentions_typevar(metadata));
     }
 
     #[test]
@@ -7245,7 +7255,7 @@ mod tests {
                 .map(|typevar| storage.typevar_data(typevar))
                 .collect::<Vec<_>>();
 
-            assert_eq!(mentioned, vec![t.identity(db), u.identity(db)]);
+            assert_eq!(mentioned, vec![t, u]);
             assert!(support.is_complete());
         }
     }
@@ -9095,7 +9105,7 @@ class E: ...
                 .inner
                 .as_ref()
                 .map(|inner| inner.typevars.iter().copied().collect::<Vec<_>>()),
-            Some(vec![t.identity(db), u.identity(db)]),
+            Some(vec![t, u]),
         );
         let reloaded_again =
             ConstraintSetBuilder::new().into_owned(|builder| builder.load(db, &env, &reloaded));

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -693,7 +693,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         let source_arguments = source_alias.specialization(db).types(db);
         if !source_arguments.iter().all(|argument| match argument {
-            Type::TypeVar(typevar) => nominally_satisfied.mentions_typevar(typevar.identity(db)),
+            Type::TypeVar(typevar) => nominally_satisfied.mentions_typevar(*typevar),
             argument => !any_over_type_expanding_aliases(db, env, *argument, Type::is_type_var),
         }) {
             return None;


### PR DESCRIPTION
In https://github.com/astral-sh/ruff/pull/27652, we will need to access the declared upper bounds and constraints of the typevars mentioned in a constraint set. To do that, we need to operate on `BoundTypeVarInstance`, not `BoundTypeVarIdentity`. This is a small refactoring PR that updates our interned arenas with this in mind.

Note that we still deduplicate by `BoundTypeVarIdentity`, but we _store_ the `BoundTypeVarInstance`. Multiple instances might have the same identity, but those will only differ in whether the declared upper bounds/constraints have been evaluated yet.