### PR TITLE
[ty] Support mixed gradual tuple assignability with TypeVarTuple

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -4915,6 +4915,19 @@ class F:
 reveal_type(F().x)  # revealed: tuple[Divergent, ...]
 ```
 
+A homogeneous tuple of `Divergent` has gradual length, so it is assignable to a fixed-length tuple.
+This allows a recursively inferred instance attribute to retain an empty tuple as its class default:
+
+```py
+class G:
+    x = ()
+
+    def f(self):
+        self.x = tuple(self.x)
+
+reveal_type(G().x)  # revealed: tuple[Divergent, ...]
+```
+
 ## Attributes of standard library modules that aren't yet defined
 
 For attributes of stdlib modules that exist in future versions, we can give better diagnostics.

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -473,11 +473,13 @@ def crossing_sources[*Ts](
 ```
 
 A scalar type variable can match itself at an aligned position, but it does not constrain the
-unrelated elements of the symbolic pack.
+unrelated elements of the symbolic pack. An aligned `T` also cannot satisfy a fixed `int` target,
+since `T` is not necessarily a subtype of `int`.
 
 ```py
 def scalar_source[T, *Ts](source: tuple[T, *tuple[Any, ...]]) -> None:
     aligned: tuple[T, *Ts] = source
+    no_specialization: tuple[int, *Ts] = source  # error: [invalid-assignment]
     crossing: tuple[*Ts, int] = source  # error: [invalid-assignment]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -320,6 +320,18 @@ def f(i: int, s: str, b: bool, t: tuple[int, str], vt: tuple[int, ...]) -> None:
     reveal_type(simple(*t))  # revealed: tuple[Unknown, ...]
 ```
 
+A gradual tuple also infers a gradual pack when the parameter allows `None`.
+
+```py
+from typing import Any
+
+def optional[*Ts](value: tuple[*Ts] | None) -> tuple[*Ts] | None:
+    return value
+
+def check_optional(value: tuple[Any, ...]) -> None:
+    reveal_type(optional(value))  # revealed: tuple[Any, ...] | None
+```
+
 ### Assignability to fixed-length tuples
 
 An unspecialized type variable tuple can contain any number of elements, so a tuple containing one
@@ -395,8 +407,8 @@ def gradual_packs[*Ts](dynamic: tuple[Any, ...], unknown: tuple[Unknown, ...]) -
     static_assert(not is_subtype_of(tuple[Unknown, ...], tuple[*Ts]))
 ```
 
-A gradual tuple with a fixed prefix or suffix cannot match every possible pack length, even when the
-required element is `Any`.
+A gradual tuple with a fixed prefix or suffix cannot be assigned to a bare symbolic pack, which may
+be empty. This remains true when the required element is `Any`.
 
 ```py
 def fixed_boundaries[*Ts](
@@ -405,6 +417,150 @@ def fixed_boundaries[*Ts](
 ) -> None:
     plain: tuple[*Ts] = prefix  # error: [invalid-assignment]
     plain = suffix  # error: [invalid-assignment]
+```
+
+### Mixed gradual tuple assignability to symbolic packs
+
+Fixed prefixes and suffixes are compared covariantly. The gradual segment can supply additional
+required target elements as well as the symbolic pack, but fixed source elements cannot disappear.
+
+```py
+from typing import Any
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_subtype_of
+
+def mixed_sources[*Ts](
+    prefix: tuple[bool, *tuple[Any, ...]],
+    suffix: tuple[*tuple[Unknown, ...], str],
+    both: tuple[bool, *tuple[Any, ...], str],
+) -> None:
+    prefixed: tuple[int, *Ts] = prefix
+    suffixed: tuple[*Ts, object] = suffix
+    bounded: tuple[int, *Ts, object] = both
+    longer: tuple[int, bytes, *Ts, float, object] = both
+
+    too_short: tuple[int, *Ts] = both  # error: [invalid-assignment]
+    wrong_prefix: tuple[str, *Ts, object] = both  # error: [invalid-assignment]
+    wrong_suffix: tuple[int, *Ts, int] = both  # error: [invalid-assignment]
+
+    static_assert(not is_subtype_of(tuple[bool, *tuple[Any, ...], str], tuple[int, *Ts, object]))
+```
+
+### Fixed source elements crossing symbolic packs
+
+A fixed source element that falls inside the symbolic pack must be assignable to every possible
+element type. `Any`, `Unknown`, and `Never` allow this; `int` and `Any | int` do not. Even a `Never`
+element remains a required tuple position when the pack is empty.
+
+```py
+from typing import Any, Never
+from ty_extensions._internal import Unknown
+
+def crossing_sources[*Ts](
+    any_prefix: tuple[Any, *tuple[Any, ...]],
+    unknown_suffix: tuple[*tuple[Any, ...], Unknown],
+    never_prefix: tuple[Never, *tuple[Any, ...]],
+    int_prefix: tuple[int, *tuple[Any, ...]],
+    union_suffix: tuple[*tuple[Any, ...], Any | int],
+) -> None:
+    moved_prefix: tuple[*Ts, int] = any_prefix
+    moved_suffix: tuple[int, *Ts] = unknown_suffix
+    bottom_prefix: tuple[*Ts, int] = never_prefix
+
+    too_short: tuple[*Ts] = never_prefix  # error: [invalid-assignment]
+    restricted_prefix: tuple[*Ts, int] = int_prefix  # error: [invalid-assignment]
+    restricted_suffix: tuple[int, *Ts] = union_suffix  # error: [invalid-assignment]
+```
+
+A scalar type variable can match itself at an aligned position, but it does not constrain the
+unrelated elements of the symbolic pack.
+
+```py
+def scalar_source[T, *Ts](source: tuple[T, *tuple[Any, ...]]) -> None:
+    aligned: tuple[T, *Ts] = source
+    crossing: tuple[*Ts, int] = source  # error: [invalid-assignment]
+```
+
+### Symbolic pack assignability to mixed gradual tuples
+
+Fixed source endpoints remain usable when the symbolic pack is erased to a gradual segment. The
+target boundaries must also fit when the symbolic pack is empty.
+
+```py
+from typing import Any
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_subtype_of
+
+def mixed_targets[*Ts](source: tuple[bool, *Ts, str]) -> None:
+    bounded: tuple[int, *tuple[Any, ...], object] = source
+    prefixed: tuple[int, *tuple[Unknown, ...]] = source
+    suffixed: tuple[*tuple[Any, ...], object] = source
+
+    too_long: tuple[int, bytes, *tuple[Any, ...], str] = source  # error: [invalid-assignment]
+    wrong_prefix: tuple[str, *tuple[Any, ...], object] = source  # error: [invalid-assignment]
+    wrong_suffix: tuple[int, *tuple[Any, ...], int] = source  # error: [invalid-assignment]
+
+    static_assert(not is_subtype_of(tuple[bool, *Ts, str], tuple[int, *tuple[Any, ...], object]))
+```
+
+### Fixed target elements crossing symbolic packs
+
+A fixed target element that falls inside the symbolic pack must accept every possible element type.
+`object` and `Any` allow this, but `int` and a separate scalar type variable do not. Unlike a source
+element of type `Any | int`, a target element of that type can accept any pack element by
+materializing its `Any` appropriately.
+
+```py
+from typing import Any
+
+def crossing_targets[*Ts](
+    prefix: tuple[int, *Ts],
+    suffix: tuple[*Ts, int],
+    long_suffix: tuple[*Ts, int, str],
+    plain: tuple[*Ts],
+) -> None:
+    moved_prefix: tuple[object, *tuple[Any, ...]] = suffix
+    moved_long_suffix: tuple[object, *tuple[Any, ...], str] = long_suffix
+    moved_suffix: tuple[*tuple[Any, ...], Any] = prefix
+    union_suffix: tuple[*tuple[Any, ...], Any | int] = prefix
+
+    restricted_prefix: tuple[int, *tuple[Any, ...]] = suffix  # error: [invalid-assignment]
+    restricted_suffix: tuple[*tuple[Any, ...], int] = prefix  # error: [invalid-assignment]
+    too_short: tuple[object, *tuple[Any, ...]] = plain  # error: [invalid-assignment]
+
+def scalar_target[T, *Ts](source: tuple[*Ts, int]) -> None:
+    target: tuple[T, *tuple[Any, ...]] = source  # error: [invalid-assignment]
+```
+
+### Aliases of gradual tuple elements
+
+An alias of `Any` also makes a variadic segment gradual in length. Aliases of `list[Any]` or
+`Any | int` do not have that effect, nor does a recursive container alias.
+
+```py
+from typing import Any
+
+type Dynamic = Any
+type IndirectDynamic = Dynamic
+type AnyList = list[Any]
+type PartlyDynamic = Any | int
+type Recursive = list[Recursive]
+
+def gradual_aliases[*Ts](
+    source: tuple[int, *tuple[IndirectDynamic, ...], str],
+    symbolic: tuple[int, *Ts, str],
+) -> None:
+    packed: tuple[int, *Ts, str] = source
+    erased: tuple[int, *tuple[IndirectDynamic, ...], str] = symbolic
+
+def non_gradual_aliases[*Ts](
+    containers: tuple[int, *tuple[AnyList, ...]],
+    union: tuple[int, *tuple[PartlyDynamic, ...]],
+    recursive: tuple[int, *tuple[Recursive, ...]],
+) -> None:
+    pack: tuple[int, *Ts] = containers  # error: [invalid-assignment]
+    pack = union  # error: [invalid-assignment]
+    pack = recursive  # error: [invalid-assignment]
 ```
 
 ### Starred variadic parameters

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -514,6 +514,7 @@ materializing its `Any` appropriately.
 
 ```py
 from typing import Any
+from ty_extensions._internal import Unknown
 
 def crossing_targets[*Ts](
     prefix: tuple[int, *Ts],
@@ -524,6 +525,7 @@ def crossing_targets[*Ts](
     moved_prefix: tuple[object, *tuple[Any, ...]] = suffix
     moved_long_suffix: tuple[object, *tuple[Any, ...], str] = long_suffix
     moved_suffix: tuple[*tuple[Any, ...], Any] = prefix
+    unknown_prefix: tuple[Unknown, *tuple[Any, ...]] = suffix
     union_suffix: tuple[*tuple[Any, ...], Any | int] = prefix
 
     restricted_prefix: tuple[int, *tuple[Any, ...]] = suffix  # error: [invalid-assignment]
@@ -532,6 +534,96 @@ def crossing_targets[*Ts](
 
 def scalar_target[T, *Ts](source: tuple[*Ts, int]) -> None:
     target: tuple[T, *tuple[Any, ...]] = source  # error: [invalid-assignment]
+```
+
+### Protocol target elements crossing symbolic packs
+
+A protocol used as a fixed target element must accept every possible pack element. All objects
+support `__str__`, but a pack can contain an unhashable value such as a list. A protocol that
+requires `__hash__` therefore cannot accept an arbitrary pack element at a fixed endpoint.
+
+```py
+from typing import Any, Protocol
+
+class SupportsStr(Protocol):
+    def __str__(self) -> str: ...
+
+class SupportsHash(Protocol):
+    def __hash__(self) -> int: ...
+
+def protocol_targets[*Ts](prefix: tuple[int, *Ts], suffix: tuple[*Ts, int]) -> None:
+    universal_prefix: tuple[SupportsStr, *tuple[Any, ...]] = suffix
+    universal_suffix: tuple[*tuple[Any, ...], SupportsStr] = prefix
+
+    hash_prefix: tuple[SupportsHash, *tuple[Any, ...]] = suffix  # error: [invalid-assignment]
+    hash_suffix: tuple[*tuple[Any, ...], SupportsHash] = prefix  # error: [invalid-assignment]
+```
+
+The standard-library `Hashable` protocol follows the same rule, including through an alias:
+
+```py
+from collections.abc import Hashable
+
+type HashableAlias = Hashable
+
+def hashable_targets[*Ts](prefix: tuple[int, *Ts], suffix: tuple[*Ts, int]) -> None:
+    hash_prefix: tuple[Hashable, *tuple[Any, ...]] = suffix  # snapshot: invalid-assignment
+    hash_suffix: tuple[*tuple[Any, ...], HashableAlias] = prefix  # error: [invalid-assignment]
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `tuple[*Ts@hashable_targets, int]` is not assignable to `tuple[Hashable, *tuple[Any, ...]]`
+  --> src/mdtest_snippet.py:20:54
+   |
+20 |     hash_prefix: tuple[Hashable, *tuple[Any, ...]] = suffix  # snapshot: invalid-assignment
+   |                  ---------------------------------   ^^^^^^ Incompatible value of type `tuple[*Ts@hashable_targets, int]`
+   |                  |
+   |                  Declared type
+```
+
+Fixed `object` endpoints retain their ordinary assignability to `Hashable`, which permits uses such
+as `object()` sentinels. This does not imply that arbitrary pack elements are hashable:
+
+```py
+def fixed_objects[*Ts](source: tuple[object, *Ts, object]) -> None:
+    prefix: tuple[Hashable, *tuple[Any, ...]] = source
+    suffix: tuple[*tuple[Any, ...], Hashable] = source
+```
+
+When a fixed source endpoint is unhashable, the diagnostic identifies that endpoint's type:
+
+```py
+def fixed_unhashable[*Ts](source: tuple[list[int], *Ts]) -> None:
+    target: tuple[Hashable, *tuple[Any, ...]] = source  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `tuple[list[int], *Ts@fixed_unhashable]` is not assignable to `tuple[Hashable, *tuple[Any, ...]]`
+  --> src/mdtest_snippet.py:26:49
+   |
+26 |     target: tuple[Hashable, *tuple[Any, ...]] = source  # snapshot: invalid-assignment
+   |             ---------------------------------   ^^^^^^ Incompatible value of type `tuple[list[int], *Ts@fixed_unhashable]`
+   |             |
+   |             Declared type
+info: type `list[int]` is not assignable to protocol `Hashable`
+info: └── protocol member `__hash__` is incompatible
+```
+
+### Inferring scalar target elements beside symbolic packs
+
+When assigning a generic function to a callable type, its scalar type parameter can be inferred from
+a tuple containing a symbolic pack. The inferred element type must accept every possible pack
+element. A type variable without an explicit bound can match, but one bounded by `Hashable` cannot.
+
+```py
+from collections.abc import Hashable
+from typing import Any, Callable
+
+def accept[T](value: tuple[T, *tuple[Any, ...]]) -> None: ...
+def accept_hashable[T: Hashable](value: tuple[T, *tuple[Any, ...]]) -> None: ...
+def callbacks[*Ts]() -> None:
+    unbounded: Callable[[tuple[*Ts, int]], None] = accept
+    hashable: Callable[[tuple[*Ts, int]], None] = accept_hashable  # error: [invalid-assignment]
 ```
 
 ### Aliases of gradual tuple elements

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -221,9 +221,9 @@ class Array[*Ts]:
 
 ### Constrained inference from synthetic `Self`
 
-A fixed synthetic `Self` domain should provide evidence for inferring a fresh constrained type
-variable, without making the owner's type variables inference targets. This currently fails when the
-matching constraint contains a `TypeVarTuple`.
+A fixed synthetic `Self` domain provides evidence for inferring a fresh constrained type variable,
+without making the owner's type variables inference targets. A constraint with gradual tuple
+arguments can accept a `TypeVarTuple` specialization.
 
 ```py
 from typing import Any, Generic, TypeVar
@@ -234,8 +234,6 @@ class Container[T, *Ts]:
     values: tuple[T, *Ts]
 
     def interface(self) -> "Interface[Container[Any, *tuple[Any, ...]]]":
-        # TODO: This should not error once fixed `TypeVarTuple` relations are supported.
-        # error: [invalid-argument-type] "Argument to `Interface.__init__` is incorrect"
         return Interface(self)
 
 C = TypeVar(
@@ -337,9 +335,9 @@ def middle_pack[*Ts](value: tuple[int, *Ts, str]) -> tuple[int, str]:
 
 ### Assignability involving type variable tuples
 
-A symbolic type variable tuple can be erased to a homogeneous `object` tuple, but a homogeneous
-tuple cannot be used to construct an arbitrary symbolic pack. Two independently bound packs are also
-not interchangeable.
+A symbolic type variable tuple can be erased to a homogeneous `object` tuple, but a fully static
+homogeneous tuple cannot be used to construct an arbitrary symbolic pack. Two independently bound
+packs are also not interchangeable.
 
 ```py
 def erase_pack[*Ts](values: tuple[*Ts]) -> tuple[object, ...]:
@@ -377,6 +375,36 @@ from ty_extensions._internal import is_assignable_to
 
 def materialized_default[*Ts = *tuple[Any, ...]]() -> None:
     static_assert(is_assignable_to(tuple[*Ts], Top[tuple[*Ts]]))
+```
+
+### Gradual tuple assignability to symbolic packs
+
+A fully gradual tuple can materialize to any specialization of a type variable tuple, including
+fixed elements around the pack. This permits assignment, but does not make it a subtype of the
+symbolic tuple.
+
+```py
+from typing import Any
+from ty_extensions import static_assert
+from ty_extensions._internal import Unknown, is_subtype_of
+
+def gradual_packs[*Ts](dynamic: tuple[Any, ...], unknown: tuple[Unknown, ...]) -> None:
+    plain: tuple[*Ts] = dynamic
+    plain = unknown
+    bounded: tuple[int, *Ts, str] = unknown
+    static_assert(not is_subtype_of(tuple[Unknown, ...], tuple[*Ts]))
+```
+
+A gradual tuple with a fixed prefix or suffix cannot match every possible pack length, even when the
+required element is `Any`.
+
+```py
+def fixed_boundaries[*Ts](
+    prefix: tuple[Any, *tuple[Any, ...]],
+    suffix: tuple[*tuple[Any, ...], Any],
+) -> None:
+    plain: tuple[*Ts] = prefix  # error: [invalid-assignment]
+    plain = suffix  # error: [invalid-assignment]
 ```
 
 ### Starred variadic parameters

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -684,6 +684,28 @@ static_assert(not is_assignable_to(tuple[int, *tuple[int, ...], int], tuple[int]
 static_assert(not is_assignable_to(tuple[int, *tuple[int, ...], int], tuple[int, int]))
 ```
 
+An unbounded homogeneous tuple whose element type is an alias of `Any` is also gradual. It is
+assignable to fixed-length tuples, including the empty tuple, even through a chain of aliases.
+
+```py
+type Dynamic = Any
+type DynamicAlias = Dynamic
+
+static_assert(is_assignable_to(tuple[Dynamic, ...], tuple[()]))
+static_assert(is_assignable_to(tuple[Dynamic, ...], tuple[int]))
+static_assert(is_assignable_to(tuple[DynamicAlias, ...], tuple[int, str]))
+```
+
+When unpacked into a mixed tuple, the gradual segment can supply additional elements, but the fixed
+prefix and suffix must still fit within the target and have compatible types.
+
+```py
+static_assert(is_assignable_to(tuple[int, *tuple[Dynamic, ...], str], tuple[int, bool, str]))
+static_assert(not is_assignable_to(tuple[int, *tuple[Dynamic, ...], str], tuple[int]))
+static_assert(not is_assignable_to(tuple[int, *tuple[Dynamic, ...], str], tuple[str, bool, str]))
+static_assert(not is_assignable_to(tuple[int, *tuple[Dynamic, ...], str], tuple[int, bool, int]))
+```
+
 ## Union types
 
 ```py

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -619,7 +619,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         {
                             // Conversely, the target's required elements must fit even with an
                             // empty source pack. A target endpoint extending into the pack must
-                            // accept any possible element, which we check using `object`.
+                            // accept any possible element. An empty protocol expresses this without
+                            // inheriting `object`'s permissive assignability to hash protocols.
                             if source.len().minimum() < target.len().minimum() {
                                 return self.never();
                             }
@@ -627,7 +628,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 db,
                                 source,
                                 target,
-                                Type::object(),
+                                Type::protocol_with_methods(db, env, []),
                                 target_element,
                             );
                         }
@@ -765,6 +766,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     .zip_longest(target.iter_suffix_elements().rev()),
             )
             .when_all(db, self.constraints, |pair| {
+                if let EitherOrBoth::Right(target) = pair
+                    && matches!(source.variable(), VariableSegment::TypeVarTuple(_))
+                {
+                    // The synthesized protocol stands for an arbitrary pack element. Diagnostics
+                    // should describe the original tuple types, not this internal placeholder.
+                    return self.without_context_collection(|| {
+                        self.check_type_pair(db, source_variable, target)
+                    });
+                }
                 let (source, target) = pair.or(source_variable, target_variable);
                 self.check_type_pair(db, source, target)
             })

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -28,6 +28,7 @@ use crate::types::class::{ClassType, KnownClass};
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker, TypeVarEvaluation};
 use crate::types::set_theoretic::RecursivelyDefined;
+use crate::types::visitor::any_over_type_expanding_aliases;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, ErrorContext, FindLegacyTypeVarsVisitor,
     IntersectionType, Type, TypeContext, TypeMapping, UnionBuilder, UnionType,
@@ -583,9 +584,55 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     });
                 }
 
+                if self.is_eager_assignability() {
+                    match (source.variable(), target.variable()) {
+                        (source_segment, VariableSegment::TypeVarTuple(target_pack))
+                            if !target_pack.is_inferable(db, self.inferable)
+                                && let Some(source_element) =
+                                    source_segment.gradual_element_type(db, env) =>
+                        {
+                            // The pack may be empty, so the source cannot require more elements
+                            // than the target's fixed ends. For longer packs, source endpoints
+                            // extending into the pack must be assignable to every element type,
+                            // which we check against `Never`. This also covers their overlap with
+                            // the opposite fixed end when the pack is short.
+                            if source.len().minimum() > target.len().minimum() {
+                                return self.never();
+                            }
+                            return self.check_tuple_boundaries(
+                                db,
+                                source,
+                                target,
+                                source_element,
+                                Type::Never,
+                            );
+                        }
+                        (VariableSegment::TypeVarTuple(source_pack), target_segment)
+                            if !source_pack.is_inferable(db, self.inferable)
+                                && let Some(target_element) =
+                                    target_segment.gradual_element_type(db, env) =>
+                        {
+                            // Conversely, the target's required elements must fit even with an
+                            // empty source pack. A target endpoint extending into the pack must
+                            // accept any possible element, which we check using `object`.
+                            if source.len().minimum() < target.len().minimum() {
+                                return self.never();
+                            }
+                            return self.check_tuple_boundaries(
+                                db,
+                                source,
+                                target,
+                                Type::object(),
+                                target_element,
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+
                 if matches!(target.variable(), VariableSegment::TypeVarTuple(_)) {
-                    // A fully gradual tuple can materialize to any specialization of the target
-                    // pack. Fixed source elements still constrain its length and cannot be ignored.
+                    // A fully gradual source imposes no length or element constraints, even
+                    // when the target pack is inferable.
                     return ConstraintSet::from_bool(
                         self.constraints,
                         self.is_eager_assignability()
@@ -692,6 +739,35 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 })
             }
         }
+    }
+
+    /// Compare the fixed ends, pairing any overhanging elements with the provided variable types.
+    /// Use raw endpoints: a symbolic pack cannot be prenormalized as a homogeneous `object` segment.
+    fn check_tuple_boundaries(
+        &self,
+        db: &'db dyn Db,
+        source: &VariableLengthTuple<Type<'db>, VariableSegment<'db>>,
+        target: &VariableLengthTuple<Type<'db>, VariableSegment<'db>>,
+        source_variable: Type<'db>,
+        target_variable: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        source
+            .iter_prefix_elements()
+            .zip_longest(target.iter_prefix_elements())
+            .chain(
+                source
+                    .iter_suffix_elements()
+                    .rev()
+                    .zip_longest(target.iter_suffix_elements().rev()),
+            )
+            .when_all(db, self.constraints, |pair| {
+                let (source, target) = match pair {
+                    EitherOrBoth::Both(source, target) => (source, target),
+                    EitherOrBoth::Left(source) => (source, target_variable),
+                    EitherOrBoth::Right(target) => (source_variable, target),
+                };
+                self.check_type_pair(db, source, target)
+            })
     }
 }
 
@@ -805,6 +881,22 @@ impl<'db> VariableSegment<'db> {
             Self::Homogeneous(element) => Some(element),
             Self::TypeVarTuple(_) => None,
         }
+    }
+
+    /// Return the homogeneous element type if this segment has gradual arity, including aliases.
+    fn gradual_element_type(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Type<'db>> {
+        let Self::Homogeneous(element) = self else {
+            return None;
+        };
+        // A static constructor or an alias cycle rules out gradual arity, even if it contains Any.
+        (!any_over_type_expanding_aliases(db, env, element, |ty| {
+            !matches!(ty, Type::TypeAlias(_) | Type::Dynamic(_))
+        }))
+        .then_some(element)
     }
 
     pub(crate) const fn typevartuple(self) -> Option<BoundTypeVarInstance<'db>> {

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -896,7 +896,7 @@ impl<'db> VariableSegment<'db> {
         let element = self.homogeneous_type()?;
         // A static constructor or an alias cycle rules out gradual arity, even if it contains Any.
         (!any_over_type_expanding_aliases(db, env, element, |ty| {
-            !matches!(ty, Type::TypeAlias(_) | Type::Dynamic(_))
+            !matches!(ty, Type::TypeAlias(_)) && !ty.is_dynamic()
         }))
         .then_some(element)
     }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -467,16 +467,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // (or any other dynamic type), then the `...` is the _gradual choice_ of all
                 // possible lengths. This means that `tuple[Any, ...]` can match any tuple of any
                 // length.
-                let VariableSegment::Homogeneous(source_variable) = source.variable() else {
-                    // Unlike a dynamic homogeneous segment, a symbolic type variable tuple ranges
-                    // over all specializations rather than making a gradual choice of length.
-                    return self.never();
-                };
-                if !self.is_eager_assignability() || !source_variable.is_dynamic() {
+                //
+                // Unlike a dynamic homogeneous segment, a symbolic type variable tuple ranges
+                // over all specializations rather than making a gradual choice of length.
+                let env = self.env;
+                if !self.is_eager_assignability()
+                    || source.variable().gradual_element_type(db, env).is_none()
+                {
                     return self.never();
                 }
-
-                let env = self.env;
 
                 // In addition, the other tuple must have enough elements to match up with this
                 // tuple's prefix and suffix, and each of those elements must pairwise satisfy the

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -765,11 +765,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     .zip_longest(target.iter_suffix_elements().rev()),
             )
             .when_all(db, self.constraints, |pair| {
-                let (source, target) = match pair {
-                    EitherOrBoth::Both(source, target) => (source, target),
-                    EitherOrBoth::Left(source) => (source, target_variable),
-                    EitherOrBoth::Right(target) => (source_variable, target),
-                };
+                let (source, target) = pair.or(source_variable, target_variable);
                 self.check_type_pair(db, source, target)
             })
     }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -584,7 +584,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
 
                 if matches!(target.variable(), VariableSegment::TypeVarTuple(_)) {
-                    return self.never();
+                    // A fully gradual tuple can materialize to any specialization of the target
+                    // pack. Fixed source elements still constrain its length and cannot be ignored.
+                    return ConstraintSet::from_bool(
+                        self.constraints,
+                        self.is_eager_assignability()
+                            && source.prefix_elements().is_empty()
+                            && source.suffix_elements().is_empty()
+                            && matches!(
+                                source.variable(),
+                                VariableSegment::Homogeneous(Type::Dynamic(_))
+                            ),
+                    );
                 }
 
                 // When prenormalizing below, we assume that a dynamic variable-length portion of

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -544,6 +544,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
                 let env = self.env;
 
+                // TODO: Extend lazy inference for mixed gradual tuples: let gradual segments
+                // supply fixed target elements, and generate constraints for source packs that
+                // overlap fixed target elements.
                 if self.typevar_evaluation == TypeVarEvaluation::Lazy
                     && let VariableSegment::TypeVarTuple(typevartuple) = target.variable()
                 {
@@ -584,6 +587,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     });
                 }
 
+                // These checks must hold for every specialization of a non-inferable pack.
+                // Lazy evaluation needs to retain pack constraints for later solving; its empty
+                // `inferable` set does not imply universal quantification.
                 if self.is_eager_assignability() {
                     match (source.variable(), target.variable()) {
                         (source_segment, VariableSegment::TypeVarTuple(target_pack))
@@ -636,8 +642,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     return ConstraintSet::from_bool(
                         self.constraints,
                         self.is_eager_assignability()
-                            && source.prefix_elements().is_empty()
-                            && source.suffix_elements().is_empty()
+                            && source.len().minimum() == 0
                             && matches!(
                                 source.variable(),
                                 VariableSegment::Homogeneous(Type::Dynamic(_))
@@ -889,9 +894,7 @@ impl<'db> VariableSegment<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Type<'db>> {
-        let Self::Homogeneous(element) = self else {
-            return None;
-        };
+        let element = self.homogeneous_type()?;
         // A static constructor or an alias cycle rules out gradual arity, even if it contains Any.
         (!any_over_type_expanding_aliases(db, env, element, |ty| {
             !matches!(ty, Type::TypeAlias(_) | Type::Dynamic(_))


### PR DESCRIPTION
## Summary

Allow gradual tuple segments to materialize around fixed prefixes and suffixes when assigning to or from an already-bound `TypeVarTuple`. This includes fully gradual sources such as `tuple[Any, ...]` and `tuple[Unknown, ...]`, as well as mixed tuples with required elements.

Compare overlapping fixed endpoints covariantly and check required lengths against an empty specialization of the pack. Fixed endpoints that can fall inside the symbolic pack must remain compatible with arbitrary pack elements. Recognize aliases of dynamic element types without giving gradual arity to containers or unions that merely contain `Any`.

Tuples such as `tuple[Dynamic, ...]`, where `Dynamic` aliases `Any`, also retain gradual length when assigned to fixed-length tuples. This preserves gradual length for `Divergent` elements produced by recursive inference as well.

The new mixed-tuple rules apply only to eager assignability with non-inferable packs. Subtyping and TypeVarTuple inference paths are not changed here.

This is a pre-requisite to avoid false positives in several later PRs in this stack.

## Test plan

- Extend the TypeVarTuple mdtests with fully gradual and mixed `Any`/`Unknown` tuples in both directions, endpoint covariance, and minimum-length checks.
- Cover valid and invalid boundary crossings with `Any`, `Unknown`, `Never`, static types, unions, and scalar type variables, including multiple suffix elements.
- Reject `Hashable` and custom hash protocol endpoints that cross a symbolic pack, while accepting empty protocols. Preserve ordinary fixed `object` endpoints and scalar type-variable inference, and keep synthetic pack-element types out of diagnostics.
- Check alias chains, reject container/union/recursive-container aliases as gradual segments, and preserve the distinction between assignability and subtyping.
- Cover assignment from direct and chained aliases of `Any` to empty and nonempty fixed-length tuples, including required length and prefix/suffix compatibility for mixed tuples.
- Preserve gradual length for `Divergent` elements inferred from a recursive instance attribute with an empty tuple class default.
- Verify gradual pack inference through an optional tuple parameter remains supported. The existing constrained-inference-from-synthetic-`Self` example now succeeds without making the owner's type variables inference targets.

## Ecosystem

No ecosystem regressions found. Removes 107 errors from valid code in Home Assistant and StaticFrame and adds two warnings for unused `type: ignore` comments in StaticFrame. [Current ecosystem report](https://bc02a524.ty-ecosystem-ext.pages.dev/diff).
