### PR TITLE
[ty] Guard recursive constructor bindings by receiver

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -266,6 +266,224 @@ class ReturnsFactory:
 ReturnsFactory()
 ```
 
+## Recursive constructor signatures
+
+When a constructor refers back to the same receiver type without reaching a callable signature, we
+fall back to an unknown signature with the nominal instance return type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+### A decorator returning the enclosing class
+
+A decorator can replace `__new__` with the type of its implicit `cls` parameter, making the
+constructor refer back to itself. Regression test for <https://github.com/astral-sh/ty/issues/4347>.
+
+```py
+from collections.abc import Callable
+
+def decorate[T](callback: Callable[[T], None]) -> T:
+    raise NotImplementedError
+
+class C:
+    @decorate
+    def __new__(cls):
+        pass
+
+reveal_type(C.__new__)  # revealed: type[C]
+reveal_type(C())  # revealed: C
+```
+
+### Mutually recursive class objects
+
+The same fallback applies when two classes use each other as their `__new__` method:
+
+```py
+class A:
+    __new__: type["B"]
+
+class B:
+    __new__: type[A]
+
+reveal_type(A())  # revealed: A
+```
+
+### Recursive generic constructors
+
+A constructor can also return to the same generic class with the same specialization:
+
+```py
+class C[T]:
+    __new__: type["C[T]"]
+
+# TODO: Default unsolved class type variables in gradual constructor signatures to `Unknown`.
+reveal_type(C())  # revealed: C[T@C]
+reveal_type(C[int]())  # revealed: C[int]
+```
+
+### Shared constructors in union branches
+
+A constructor that occurs in separate union branches is not recursive. Both branches reach the same
+finite signature:
+
+```py
+class End:
+    def __new__(cls, *args: object) -> int:
+        return 1
+
+class Left:
+    __new__ = End
+
+class Right:
+    __new__ = End
+
+class C:
+    __new__: type[Left] | type[Right]
+
+reveal_type(C())  # revealed: int
+```
+
+### Finite generic constructor chains
+
+Returning to the same generic class is safe when subsequent constructors reach a callable signature.
+Here, each step consumes a nested specialization until it reaches `End.__new__`:
+
+```py
+class End[T]:
+    def __new__(cls, *args: object) -> int:
+        return 1
+
+class C[T]:
+    __new__: type[T]
+
+reveal_type(C[C[End[int]]]())  # revealed: int
+
+type Inner = C[End[int]]
+
+reveal_type(C[Inner]())  # revealed: int
+```
+
+A finite chain can even grow its arguments. `Factory` returns to `C` with a larger argument, but
+`End` does not expand the nested `Factory` type:
+
+```py
+class Factory[T]:
+    __new__: type[C[End["Factory[T]"]]]
+
+reveal_type(C[Factory[int]]())  # revealed: int
+```
+
+### Descriptor-sensitive constructor receivers
+
+An exact class object and a value of `type[C]` can select different descriptor overloads. This
+constructor returns to `C` with a different receiver type before reaching a finite signature:
+
+```py
+from collections.abc import Callable
+from typing import overload
+from ty_extensions._internal import TypeOf
+
+class Descriptor:
+    @overload
+    def __get__(self, obj: None, owner: "TypeOf[C]") -> "type[C]": ...
+    @overload
+    def __get__(self, obj: None, owner: "type[C]") -> Callable[..., int]: ...
+    def __get__(self, obj, owner):
+        raise NotImplementedError
+
+class C:
+    __new__: Descriptor
+
+reveal_type(C())  # revealed: int
+```
+
+### Argument checks after recursive `__new__`
+
+The recursive `__new__` fallback accepts arbitrary arguments, but an ordinary `__init__` still
+validates them against the class's specialization:
+
+```py
+class C[T]:
+    __new__: type["C[T]"]
+
+    def __init__(self, x: T):
+        pass
+
+reveal_type(C[int](1))  # revealed: C[int]
+# error: [invalid-argument-type]
+C[int]("wrong")
+```
+
+### A recursive class object in place of `__init__`
+
+Class-valued `__init__` methods can also lead back to the constructor being expanded:
+
+```py
+class C:
+    __init__: type["C"]
+
+reveal_type(C())  # revealed: C
+```
+
+The fallback does not override a known non-instance return from `__new__`, which bypasses
+`__init__`:
+
+```py
+class ReturnsInt:
+    def __new__(cls) -> int:
+        return 1
+
+    __init__: type["ReturnsInt"]
+
+reveal_type(ReturnsInt())  # revealed: int
+```
+
+### A recursive class object in place of metaclass `__call__`
+
+A metaclass's `__call__` can refer back to the class being constructed:
+
+```py
+class Meta(type):
+    __call__: type["C"]
+
+class C(metaclass=Meta): ...
+
+reveal_type(C())  # revealed: C
+```
+
+### A cycle through a callable instance
+
+Constructor expansion can pass through an instance's `__call__` before returning to the original
+class:
+
+```py
+class C:
+    __new__: "Factory"
+
+class Factory:
+    __call__: type[C]
+
+reveal_type(C())  # revealed: C
+```
+
+### A metaclass bypassing a recursive `__new__`
+
+A metaclass `__call__` that returns an unrelated type bypasses `__new__`. A recursive signature in
+the unused `__new__` does not prevent us from inferring the metaclass method's return type:
+
+```py
+class Meta(type):
+    def __call__(cls) -> int:
+        return 1
+
+class C(metaclass=Meta):
+    __new__: type["C"]
+
+reveal_type(C())  # revealed: int
+```
+
 ## `__new__` is implicitly a static method, but explicitly marking it as one is harmless
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -26,6 +26,7 @@ use ty_module_resolver::{
 
 pub(crate) use self::callable::UpcastPolicy;
 use self::class::ClassInstanceFlags;
+use self::cyclic::ActiveRecursionDetector;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
 pub use self::dedicated::pytest::{FixtureBinding, fixture_bindings_for_parameter};
@@ -66,7 +67,7 @@ use crate::place::{
 use crate::suppression::check_suppressions;
 use crate::types::bound_super::BoundSuperType;
 use crate::types::call::bind::ConstructorCallableKind;
-use crate::types::call::{Binding, Bindings, CallArguments, CallableBinding, ConstructorStack};
+use crate::types::call::{Binding, Bindings, CallArguments, CallableBinding};
 pub(crate) use crate::types::callable::{CallableType, CallableTypes};
 pub(crate) use crate::types::class_base::ClassBase;
 use crate::types::constraints::ConstraintSetBuilder;
@@ -5647,17 +5648,17 @@ impl<'db> Type<'db> {
     /// elements. It's usually best to only worry about "callability" relative to a particular
     /// argument list, via [`try_call`][Self::try_call] and [`CallErrorKind::NotCallable`].
     fn bindings(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Bindings<'db> {
-        self.bindings_impl(db, env, None)
+        self.bindings_impl(db, env, &ActiveRecursionDetector::default())
     }
 
     fn bindings_impl(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        stack: Option<&ConstructorStack<'_, 'db>>,
+        recursion_guard: &ActiveRecursionDetector<Type<'db>>,
     ) -> Bindings<'db> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.bindings_impl(db, env, stack);
+            return fallback.bindings_impl(db, env, recursion_guard);
         }
 
         match self {
@@ -5670,7 +5671,7 @@ impl<'db> Type<'db> {
                 match bound_typevar.typevar(db).bound_or_constraints(db, env) {
                     None => CallableBinding::not_callable(self).into(),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        bound.bindings_impl(db, env, stack)
+                        bound.bindings_impl(db, env, recursion_guard)
                     }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Bindings::from_union(
@@ -5678,7 +5679,7 @@ impl<'db> Type<'db> {
                             constraints
                                 .elements(db)
                                 .iter()
-                                .map(|ty| ty.bindings_impl(db, env, stack)),
+                                .map(|ty| ty.bindings_impl(db, env, recursion_guard)),
                         )
                     }
                 }
@@ -5896,22 +5897,29 @@ impl<'db> Type<'db> {
                 // TODO this should be called from `constructor_bindings` for better consistency
                 .known_class_literal_bindings(db, env, class)
                 .unwrap_or_else(|| {
-                    self.constructor_bindings(db, env, ClassType::NonGeneric(class), stack)
+                    self.constructor_bindings(
+                        db,
+                        env,
+                        ClassType::NonGeneric(class),
+                        recursion_guard,
+                    )
                 }),
 
             Type::GenericAlias(alias) => {
-                self.constructor_bindings(db, env, ClassType::Generic(alias), stack)
+                self.constructor_bindings(db, env, ClassType::Generic(alias), recursion_guard)
             }
 
             Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(dynamic_type) => {
                     Binding::single(self, Signature::dynamic(Type::Dynamic(dynamic_type))).into()
                 }
-                SubclassOfInner::Class(class) => self.constructor_bindings(db, env, class, stack),
+                SubclassOfInner::Class(class) => {
+                    self.constructor_bindings(db, env, class, recursion_guard)
+                }
                 SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map_or_else(
                     || Binding::single(self, Signature::dynamic(Type::unknown())).into(),
                     |origin| {
-                        let bindings = self.constructor_bindings(db, env, *origin, stack);
+                        let bindings = self.constructor_bindings(db, env, *origin, recursion_guard);
                         if protocol.materialization_kind(db).is_some() {
                             bindings.with_constructed_instance_type(
                                 db,
@@ -5933,14 +5941,15 @@ impl<'db> Type<'db> {
                             {
                                 bindings
                             } else {
-                                constructor.bindings_impl(db, env, stack)
+                                constructor.bindings_impl(db, env, recursion_guard)
                             }
                         }
                         TypeVarBoundOrConstraints::Constraints(constraints) => {
                             Bindings::from_union(
                                 self,
                                 constraints.elements(db).iter().map(|ty| {
-                                    ty.to_meta_type(db, env).bindings_impl(db, env, stack)
+                                    ty.to_meta_type(db, env)
+                                        .bindings_impl(db, env, recursion_guard)
                                 }),
                             )
                         }
@@ -5985,7 +5994,7 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
-                        let mut bindings = dunder_callable.bindings_impl(db, env, stack);
+                        let mut bindings = dunder_callable.bindings_impl(db, env, recursion_guard);
                         bindings.replace_callable_type(dunder_callable, self);
                         if boundness == Definedness::PossiblyUndefined {
                             bindings.set_dunder_call_is_possibly_unbound();
@@ -6008,7 +6017,7 @@ impl<'db> Type<'db> {
                 union
                     .elements(db)
                     .iter()
-                    .map(|element| element.bindings_impl(db, env, stack)),
+                    .map(|element| element.bindings_impl(db, env, recursion_guard)),
             ),
 
             // A narrowed `type[T: Base] & type[Child]` still needs to construct `T & Child`,
@@ -6028,9 +6037,11 @@ impl<'db> Type<'db> {
                     && let Type::NominalInstance(lookup_instance) =
                         instance_type.flatten_typevars(db, env)
                     && let Some(bindings) = {
-                        let bindings = lookup_instance
-                            .to_meta_type(db, env)
-                            .bindings_impl(db, env, stack);
+                        let bindings = lookup_instance.to_meta_type(db, env).bindings_impl(
+                            db,
+                            env,
+                            recursion_guard,
+                        );
                         bindings.has_only_constructor_items().then_some(bindings)
                     } =>
             {
@@ -6043,12 +6054,14 @@ impl<'db> Type<'db> {
                 self,
                 intersection
                     .positive_elements_or_object(db)
-                    .map(|element| element.bindings_impl(db, env, stack)),
+                    .map(|element| element.bindings_impl(db, env, recursion_guard)),
             ),
 
-            Type::EnumComplement(complement) => complement
-                .to_intersection(db, env)
-                .bindings_impl(db, env, stack),
+            Type::EnumComplement(complement) => {
+                complement
+                    .to_intersection(db, env)
+                    .bindings_impl(db, env, recursion_guard)
+            }
 
             Type::DataclassDecorator(_) => {
                 let typevar = BoundTypeVarInstance::synthetic(
@@ -6079,7 +6092,7 @@ impl<'db> Type<'db> {
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(enum_literal) => enum_literal
                     .enum_class_instance(db, env)
-                    .bindings_impl(db, env, stack),
+                    .bindings_impl(db, env, recursion_guard),
                 _ => CallableBinding::not_callable(self).into(),
             },
 
@@ -6096,13 +6109,13 @@ impl<'db> Type<'db> {
             Type::KnownInstance(
                 KnownInstanceType::FunctoolsPartial(partial)
                 | KnownInstanceType::FunctoolsPartialCall(partial),
-            ) => Type::Callable(partial.partial(db)).bindings_impl(db, env, stack),
+            ) => Type::Callable(partial.partial(db)).bindings_impl(db, env, recursion_guard),
 
             Type::KnownInstance(known_instance) => known_instance
                 .instance_fallback(db, env)
-                .bindings_impl(db, env, stack),
+                .bindings_impl(db, env, recursion_guard),
 
-            Type::TypeAlias(alias) => alias.value_type(db).bindings_impl(db, env, stack),
+            Type::TypeAlias(alias) => alias.value_type(db).bindings_impl(db, env, recursion_guard),
 
             Type::PropertyInstance(_)
             | Type::AlwaysFalsy
@@ -6443,7 +6456,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         class: ClassType<'db>,
-        stack: Option<&ConstructorStack<'_, 'db>>,
+        recursion_guard: &ActiveRecursionDetector<Type<'db>>,
     ) -> Bindings<'db> {
         fn resolve_dunder_new_callable<'db>(
             db: &'db dyn Db,
@@ -6568,173 +6581,188 @@ impl<'db> Type<'db> {
             _ => self,
         };
 
-        let stack = ConstructorStack::new(self_type, stack);
-        if stack.is_recursive() {
-            // Leave the return type unknown so the enclosing constructor supplies its own instance
-            // type, rather than using the class where the cycle happened to be detected.
-            return Binding::single(self_type, Signature::dynamic(Type::unknown())).into();
-        }
-
-        // Check for a custom `__call__` on the metaclass (excluding `type.__call__`).
-        // We preserve its full overload set here and defer constructor branching decisions
-        // until call-time overload resolution.
-        let metaclass_dunder_call = self_type.member_lookup_with_policy(
-            db,
-            env,
-            "__call__",
-            MemberLookupPolicy::NO_INSTANCE_FALLBACK
-                | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
-        );
-
-        let Some(constructor_instance_ty) = self_type.to_instance_approximation(db, env) else {
-            return fallback_bindings();
-        };
-
-        // TypedDict classes inherit `dict.__new__`, whose gradual `**kwargs` signature cannot
-        // constrain their type variables. Their synthesized `__init__` contains the actual field
-        // types, including generic extra items, so constructor inference should start there.
-        let new_method = if class_literal.is_typed_dict(db) {
-            None
-        } else {
-            self_type.lookup_dunder_new(db, env)
-        };
-
-        let init_method_no_object = constructor_instance_ty.member_lookup_with_policy(
-            db,
-            env,
-            "__init__",
-            MemberLookupPolicy::NO_INSTANCE_FALLBACK | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-        );
-
-        let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
-            Some(place) => match resolve_dunder_new_callable(db, env, self_type, place) {
-                Some((new_callable, definedness)) => {
-                    let bindings = new_callable.bindings_impl(db, env, Some(&stack));
-                    let mut bindings = bind_constructor_new(db, env, bindings, self_type)
-                        .into_constructor_bindings(
-                            constructor_instance_ty,
-                            ConstructorCallableKind::New,
-                        )
-                        .with_constructed_instance_type(db, constructor_instance_ty);
-                    if definedness == Definedness::PossiblyUndefined {
-                        bindings.set_implicit_dunder_new_is_possibly_unbound();
-                    }
-                    (Some(bindings), true)
-                }
-                None => (None, false),
+        // Key recursion by the full receiver type. Descriptor overloads can distinguish `C` from
+        // `type[C]`, and different specializations need separate expansion even if one contains
+        // the other, because a constructor may ignore its nested type arguments.
+        recursion_guard.visit(
+            &self_type,
+            || {
+                // Leave the return type unknown so the enclosing constructor supplies its own
+                // instance type, rather than the class where the cycle happened to be detected.
+                Binding::single(self_type, Signature::dynamic(Type::unknown())).into()
             },
-            None => (None, false),
-        };
+            || {
+                // Check for a custom `__call__` on the metaclass (excluding `type.__call__`).
+                // We preserve its full overload set here and defer constructor branching decisions
+                // until call-time overload resolution.
+                let metaclass_dunder_call = self_type.member_lookup_with_policy(
+                    db,
+                    env,
+                    "__call__",
+                    MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                        | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
+                );
 
-        // Only fall back to `object.__init__` when `__new__` is absent.
-        let init_bindings = match (&init_method_no_object.place, has_any_new) {
-            (
-                Place::Defined(DefinedPlace {
-                    ty: init_method,
-                    definedness,
-                    ..
-                }),
-                _,
-            ) => {
-                let mut bindings = init_method
-                    .bindings_impl(db, env, Some(&stack))
-                    .into_constructor_bindings(
-                        constructor_instance_ty,
-                        ConstructorCallableKind::Init,
-                    )
-                    .with_constructed_instance_type(db, constructor_instance_ty);
-                if *definedness == Definedness::PossiblyUndefined {
-                    bindings.set_implicit_dunder_init_is_possibly_unbound();
-                }
-                Some(bindings)
-            }
-            (Place::Undefined, false) => {
-                let init_method_with_object = constructor_instance_ty.member_lookup_with_policy(
+                let Some(constructor_instance_ty) = self_type.to_instance_approximation(db, env)
+                else {
+                    return fallback_bindings();
+                };
+
+                // TypedDict classes inherit `dict.__new__`, whose gradual `**kwargs` signature cannot
+                // constrain their type variables. Their synthesized `__init__` contains the actual field
+                // types, including generic extra items, so constructor inference should start there.
+                let new_method = if class_literal.is_typed_dict(db) {
+                    None
+                } else {
+                    self_type.lookup_dunder_new(db, env)
+                };
+
+                let init_method_no_object = constructor_instance_ty.member_lookup_with_policy(
                     db,
                     env,
                     "__init__",
-                    MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                    MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                        | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
                 );
-                match init_method_with_object.place {
-                    Place::Defined(DefinedPlace {
-                        ty: init_method,
-                        definedness,
-                        ..
-                    }) => {
+
+                let (new_bindings, has_any_new) = match new_method
+                    .as_ref()
+                    .map(|method| method.place)
+                {
+                    Some(place) => match resolve_dunder_new_callable(db, env, self_type, place) {
+                        Some((new_callable, definedness)) => {
+                            let bindings = new_callable.bindings_impl(db, env, recursion_guard);
+                            let mut bindings = bind_constructor_new(db, env, bindings, self_type)
+                                .into_constructor_bindings(
+                                    constructor_instance_ty,
+                                    ConstructorCallableKind::New,
+                                )
+                                .with_constructed_instance_type(db, constructor_instance_ty);
+                            if definedness == Definedness::PossiblyUndefined {
+                                bindings.set_implicit_dunder_new_is_possibly_unbound();
+                            }
+                            (Some(bindings), true)
+                        }
+                        None => (None, false),
+                    },
+                    None => (None, false),
+                };
+
+                // Only fall back to `object.__init__` when `__new__` is absent.
+                let init_bindings = match (&init_method_no_object.place, has_any_new) {
+                    (
+                        Place::Defined(DefinedPlace {
+                            ty: init_method,
+                            definedness,
+                            ..
+                        }),
+                        _,
+                    ) => {
                         let mut bindings = init_method
-                            .bindings_impl(db, env, Some(&stack))
+                            .bindings_impl(db, env, recursion_guard)
                             .into_constructor_bindings(
                                 constructor_instance_ty,
                                 ConstructorCallableKind::Init,
                             )
                             .with_constructed_instance_type(db, constructor_instance_ty);
-                        if definedness == Definedness::PossiblyUndefined {
+                        if *definedness == Definedness::PossiblyUndefined {
                             bindings.set_implicit_dunder_init_is_possibly_unbound();
                         }
                         Some(bindings)
                     }
-                    Place::Undefined => {
-                        // If we are using vendored typeshed, it should be impossible to have missing
-                        // or unbound `__init__` method on a class, as all classes have `object` in MRO.
-                        // Thus the following may only trigger if a custom typeshed is used.
-                        // Custom/broken typeshed: no `__init__` available even after falling back
-                        // to `object`. Keep analysis going and surface the missing-implicit-call
-                        // lint via the builder.
-                        let mut bindings: Bindings<'db> = Binding::single(
-                            self_type,
-                            Signature::new(Parameters::gradual_form(), constructor_instance_ty),
-                        )
-                        .into();
-                        bindings = bindings
-                            .into_constructor_bindings(
-                                constructor_instance_ty,
-                                ConstructorCallableKind::Init,
-                            )
-                            .with_constructed_instance_type(db, constructor_instance_ty);
-                        bindings.set_implicit_dunder_init_is_possibly_unbound();
-                        Some(bindings)
+                    (Place::Undefined, false) => {
+                        let init_method_with_object = constructor_instance_ty
+                            .member_lookup_with_policy(
+                                db,
+                                env,
+                                "__init__",
+                                MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                            );
+                        match init_method_with_object.place {
+                            Place::Defined(DefinedPlace {
+                                ty: init_method,
+                                definedness,
+                                ..
+                            }) => {
+                                let mut bindings = init_method
+                                    .bindings_impl(db, env, recursion_guard)
+                                    .into_constructor_bindings(
+                                        constructor_instance_ty,
+                                        ConstructorCallableKind::Init,
+                                    )
+                                    .with_constructed_instance_type(db, constructor_instance_ty);
+                                if definedness == Definedness::PossiblyUndefined {
+                                    bindings.set_implicit_dunder_init_is_possibly_unbound();
+                                }
+                                Some(bindings)
+                            }
+                            Place::Undefined => {
+                                // If we are using vendored typeshed, it should be impossible to have missing
+                                // or unbound `__init__` method on a class, as all classes have `object` in MRO.
+                                // Thus the following may only trigger if a custom typeshed is used.
+                                // Custom/broken typeshed: no `__init__` available even after falling back
+                                // to `object`. Keep analysis going and surface the missing-implicit-call
+                                // lint via the builder.
+                                let mut bindings: Bindings<'db> = Binding::single(
+                                    self_type,
+                                    Signature::new(
+                                        Parameters::gradual_form(),
+                                        constructor_instance_ty,
+                                    ),
+                                )
+                                .into();
+                                bindings = bindings
+                                    .into_constructor_bindings(
+                                        constructor_instance_ty,
+                                        ConstructorCallableKind::Init,
+                                    )
+                                    .with_constructed_instance_type(db, constructor_instance_ty);
+                                bindings.set_implicit_dunder_init_is_possibly_unbound();
+                                Some(bindings)
+                            }
+                        }
                     }
-                }
-            }
-            (Place::Undefined, true) => None,
-        };
+                    (Place::Undefined, true) => None,
+                };
 
-        let constructor_bindings = if let Some(mut new_bindings) = new_bindings {
-            // Preserve the full `__new__` signature and defer `__init__` validation until we know
-            // which `__new__` overload matched at call time.
-            if let Some(init_bindings) = init_bindings.as_ref() {
-                new_bindings.set_downstream_constructor(init_bindings);
-            }
-            Some(new_bindings)
-        } else {
-            init_bindings
-        };
+                let constructor_bindings = if let Some(mut new_bindings) = new_bindings {
+                    // Preserve the full `__new__` signature and defer `__init__` validation until we know
+                    // which `__new__` overload matched at call time.
+                    if let Some(init_bindings) = init_bindings.as_ref() {
+                        new_bindings.set_downstream_constructor(init_bindings);
+                    }
+                    Some(new_bindings)
+                } else {
+                    init_bindings
+                };
 
-        let bindings = if let Place::Defined(DefinedPlace {
-            ty: metaclass_call_method,
-            ..
-        }) = metaclass_dunder_call.place
-        {
-            let mut metaclass_bindings = metaclass_call_method
-                .bindings_impl(db, env, Some(&stack))
-                .into_constructor_bindings(
-                    constructor_instance_ty,
-                    ConstructorCallableKind::MetaclassCall,
-                )
-                .with_constructed_instance_type(db, constructor_instance_ty);
-            if let Some(downstream_bindings) = constructor_bindings.as_ref() {
-                // Preserve the full metaclass `__call__` signature and defer whether constructor
-                // downstream checks apply until the matched overload is known.
-                metaclass_bindings.set_downstream_constructor(downstream_bindings);
-            }
-            metaclass_bindings
-        } else if let Some(constructor_bindings) = constructor_bindings {
-            constructor_bindings
-        } else {
-            return fallback_bindings();
-        };
+                let bindings = if let Place::Defined(DefinedPlace {
+                    ty: metaclass_call_method,
+                    ..
+                }) = metaclass_dunder_call.place
+                {
+                    let mut metaclass_bindings = metaclass_call_method
+                        .bindings_impl(db, env, recursion_guard)
+                        .into_constructor_bindings(
+                            constructor_instance_ty,
+                            ConstructorCallableKind::MetaclassCall,
+                        )
+                        .with_constructed_instance_type(db, constructor_instance_ty);
+                    if let Some(downstream_bindings) = constructor_bindings.as_ref() {
+                        // Preserve the full metaclass `__call__` signature and defer whether constructor
+                        // downstream checks apply until the matched overload is known.
+                        metaclass_bindings.set_downstream_constructor(downstream_bindings);
+                    }
+                    metaclass_bindings
+                } else if let Some(constructor_bindings) = constructor_bindings {
+                    constructor_bindings
+                } else {
+                    return fallback_bindings();
+                };
 
-        bindings.with_generic_context(db, class_generic_context)
+                bindings.with_generic_context(db, class_generic_context)
+            },
+        )
     }
 
     /// Calls `self`. Returns a [`CallError`] if `self` is (always or possibly) not callable, or if

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -66,7 +66,7 @@ use crate::place::{
 use crate::suppression::check_suppressions;
 use crate::types::bound_super::BoundSuperType;
 use crate::types::call::bind::ConstructorCallableKind;
-use crate::types::call::{Binding, Bindings, CallArguments, CallableBinding};
+use crate::types::call::{Binding, Bindings, CallArguments, CallableBinding, ConstructorStack};
 pub(crate) use crate::types::callable::{CallableType, CallableTypes};
 pub(crate) use crate::types::class_base::ClassBase;
 use crate::types::constraints::ConstraintSetBuilder;
@@ -5647,8 +5647,17 @@ impl<'db> Type<'db> {
     /// elements. It's usually best to only worry about "callability" relative to a particular
     /// argument list, via [`try_call`][Self::try_call] and [`CallErrorKind::NotCallable`].
     fn bindings(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Bindings<'db> {
+        self.bindings_impl(db, env, None)
+    }
+
+    fn bindings_impl(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        stack: Option<&ConstructorStack<'_, 'db>>,
+    ) -> Bindings<'db> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.bindings(db, env);
+            return fallback.bindings_impl(db, env, stack);
         }
 
         match self {
@@ -5660,14 +5669,16 @@ impl<'db> Type<'db> {
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db, env) {
                     None => CallableBinding::not_callable(self).into(),
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.bindings(db, env),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        bound.bindings_impl(db, env, stack)
+                    }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Bindings::from_union(
                             self,
                             constraints
                                 .elements(db)
                                 .iter()
-                                .map(|ty| ty.bindings(db, env)),
+                                .map(|ty| ty.bindings_impl(db, env, stack)),
                         )
                     }
                 }
@@ -5885,22 +5896,22 @@ impl<'db> Type<'db> {
                 // TODO this should be called from `constructor_bindings` for better consistency
                 .known_class_literal_bindings(db, env, class)
                 .unwrap_or_else(|| {
-                    self.constructor_bindings(db, env, ClassType::NonGeneric(class))
+                    self.constructor_bindings(db, env, ClassType::NonGeneric(class), stack)
                 }),
 
             Type::GenericAlias(alias) => {
-                self.constructor_bindings(db, env, ClassType::Generic(alias))
+                self.constructor_bindings(db, env, ClassType::Generic(alias), stack)
             }
 
             Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(dynamic_type) => {
                     Binding::single(self, Signature::dynamic(Type::Dynamic(dynamic_type))).into()
                 }
-                SubclassOfInner::Class(class) => self.constructor_bindings(db, env, class),
+                SubclassOfInner::Class(class) => self.constructor_bindings(db, env, class, stack),
                 SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map_or_else(
                     || Binding::single(self, Signature::dynamic(Type::unknown())).into(),
                     |origin| {
-                        let bindings = self.constructor_bindings(db, env, *origin);
+                        let bindings = self.constructor_bindings(db, env, *origin, stack);
                         if protocol.materialization_kind(db).is_some() {
                             bindings.with_constructed_instance_type(
                                 db,
@@ -5922,16 +5933,15 @@ impl<'db> Type<'db> {
                             {
                                 bindings
                             } else {
-                                constructor.bindings(db, env)
+                                constructor.bindings_impl(db, env, stack)
                             }
                         }
                         TypeVarBoundOrConstraints::Constraints(constraints) => {
                             Bindings::from_union(
                                 self,
-                                constraints
-                                    .elements(db)
-                                    .iter()
-                                    .map(|ty| ty.to_meta_type(db, env).bindings(db, env)),
+                                constraints.elements(db).iter().map(|ty| {
+                                    ty.to_meta_type(db, env).bindings_impl(db, env, stack)
+                                }),
                             )
                         }
                     };
@@ -5975,7 +5985,7 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
-                        let mut bindings = dunder_callable.bindings(db, env);
+                        let mut bindings = dunder_callable.bindings_impl(db, env, stack);
                         bindings.replace_callable_type(dunder_callable, self);
                         if boundness == Definedness::PossiblyUndefined {
                             bindings.set_dunder_call_is_possibly_unbound();
@@ -5998,7 +6008,7 @@ impl<'db> Type<'db> {
                 union
                     .elements(db)
                     .iter()
-                    .map(|element| element.bindings(db, env)),
+                    .map(|element| element.bindings_impl(db, env, stack)),
             ),
 
             // A narrowed `type[T: Base] & type[Child]` still needs to construct `T & Child`,
@@ -6018,7 +6028,9 @@ impl<'db> Type<'db> {
                     && let Type::NominalInstance(lookup_instance) =
                         instance_type.flatten_typevars(db, env)
                     && let Some(bindings) = {
-                        let bindings = lookup_instance.to_meta_type(db, env).bindings(db, env);
+                        let bindings = lookup_instance
+                            .to_meta_type(db, env)
+                            .bindings_impl(db, env, stack);
                         bindings.has_only_constructor_items().then_some(bindings)
                     } =>
             {
@@ -6031,12 +6043,12 @@ impl<'db> Type<'db> {
                 self,
                 intersection
                     .positive_elements_or_object(db)
-                    .map(|element| element.bindings(db, env)),
+                    .map(|element| element.bindings_impl(db, env, stack)),
             ),
 
-            Type::EnumComplement(complement) => {
-                complement.to_intersection(db, env).bindings(db, env)
-            }
+            Type::EnumComplement(complement) => complement
+                .to_intersection(db, env)
+                .bindings_impl(db, env, stack),
 
             Type::DataclassDecorator(_) => {
                 let typevar = BoundTypeVarInstance::synthetic(
@@ -6065,9 +6077,9 @@ impl<'db> Type<'db> {
             Type::SpecialForm(_) => CallableBinding::not_callable(self).into(),
 
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Enum(enum_literal) => {
-                    enum_literal.enum_class_instance(db, env).bindings(db, env)
-                }
+                LiteralValueTypeKind::Enum(enum_literal) => enum_literal
+                    .enum_class_instance(db, env)
+                    .bindings_impl(db, env, stack),
                 _ => CallableBinding::not_callable(self).into(),
             },
 
@@ -6084,13 +6096,13 @@ impl<'db> Type<'db> {
             Type::KnownInstance(
                 KnownInstanceType::FunctoolsPartial(partial)
                 | KnownInstanceType::FunctoolsPartialCall(partial),
-            ) => Type::Callable(partial.partial(db)).bindings(db, env),
+            ) => Type::Callable(partial.partial(db)).bindings_impl(db, env, stack),
 
-            Type::KnownInstance(known_instance) => {
-                known_instance.instance_fallback(db, env).bindings(db, env)
-            }
+            Type::KnownInstance(known_instance) => known_instance
+                .instance_fallback(db, env)
+                .bindings_impl(db, env, stack),
 
-            Type::TypeAlias(alias) => alias.value_type(db).bindings(db, env),
+            Type::TypeAlias(alias) => alias.value_type(db).bindings_impl(db, env, stack),
 
             Type::PropertyInstance(_)
             | Type::AlwaysFalsy
@@ -6431,6 +6443,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         class: ClassType<'db>,
+        stack: Option<&ConstructorStack<'_, 'db>>,
     ) -> Bindings<'db> {
         fn resolve_dunder_new_callable<'db>(
             db: &'db dyn Db,
@@ -6555,6 +6568,13 @@ impl<'db> Type<'db> {
             _ => self,
         };
 
+        let stack = ConstructorStack::new(self_type, stack);
+        if stack.is_recursive() {
+            // Leave the return type unknown so the enclosing constructor supplies its own instance
+            // type, rather than using the class where the cycle happened to be detected.
+            return Binding::single(self_type, Signature::dynamic(Type::unknown())).into();
+        }
+
         // Check for a custom `__call__` on the metaclass (excluding `type.__call__`).
         // We preserve its full overload set here and defer constructor branching decisions
         // until call-time overload resolution.
@@ -6589,13 +6609,13 @@ impl<'db> Type<'db> {
         let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
             Some(place) => match resolve_dunder_new_callable(db, env, self_type, place) {
                 Some((new_callable, definedness)) => {
-                    let mut bindings =
-                        bind_constructor_new(db, env, new_callable.bindings(db, env), self_type)
-                            .into_constructor_bindings(
-                                constructor_instance_ty,
-                                ConstructorCallableKind::New,
-                            )
-                            .with_constructed_instance_type(db, constructor_instance_ty);
+                    let bindings = new_callable.bindings_impl(db, env, Some(&stack));
+                    let mut bindings = bind_constructor_new(db, env, bindings, self_type)
+                        .into_constructor_bindings(
+                            constructor_instance_ty,
+                            ConstructorCallableKind::New,
+                        )
+                        .with_constructed_instance_type(db, constructor_instance_ty);
                     if definedness == Definedness::PossiblyUndefined {
                         bindings.set_implicit_dunder_new_is_possibly_unbound();
                     }
@@ -6617,7 +6637,7 @@ impl<'db> Type<'db> {
                 _,
             ) => {
                 let mut bindings = init_method
-                    .bindings(db, env)
+                    .bindings_impl(db, env, Some(&stack))
                     .into_constructor_bindings(
                         constructor_instance_ty,
                         ConstructorCallableKind::Init,
@@ -6642,7 +6662,7 @@ impl<'db> Type<'db> {
                         ..
                     }) => {
                         let mut bindings = init_method
-                            .bindings(db, env)
+                            .bindings_impl(db, env, Some(&stack))
                             .into_constructor_bindings(
                                 constructor_instance_ty,
                                 ConstructorCallableKind::Init,
@@ -6696,7 +6716,7 @@ impl<'db> Type<'db> {
         }) = metaclass_dunder_call.place
         {
             let mut metaclass_bindings = metaclass_call_method
-                .bindings(db, env)
+                .bindings_impl(db, env, Some(&stack))
                 .into_constructor_bindings(
                     constructor_instance_ty,
                     ConstructorCallableKind::MetaclassCall,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6581,188 +6581,178 @@ impl<'db> Type<'db> {
             _ => self,
         };
 
+        let on_cycle = || {
+            // Leave the return type unknown so the enclosing constructor supplies its own
+            // instance type, rather than the class where the cycle happened to be detected.
+            Binding::single(self_type, Signature::dynamic(Type::unknown())).into()
+        };
         // Key recursion by the full receiver type. Descriptor overloads can distinguish `C` from
         // `type[C]`, and different specializations need separate expansion even if one contains
         // the other, because a constructor may ignore its nested type arguments.
-        recursion_guard.visit(
-            &self_type,
-            || {
-                // Leave the return type unknown so the enclosing constructor supplies its own
-                // instance type, rather than the class where the cycle happened to be detected.
-                Binding::single(self_type, Signature::dynamic(Type::unknown())).into()
-            },
-            || {
-                // Check for a custom `__call__` on the metaclass (excluding `type.__call__`).
-                // We preserve its full overload set here and defer constructor branching decisions
-                // until call-time overload resolution.
-                let metaclass_dunder_call = self_type.member_lookup_with_policy(
-                    db,
-                    env,
-                    "__call__",
-                    MemberLookupPolicy::NO_INSTANCE_FALLBACK
-                        | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
-                );
+        recursion_guard.visit(&self_type, on_cycle, || {
+            // Check for a custom `__call__` on the metaclass (excluding `type.__call__`).
+            // We preserve its full overload set here and defer constructor branching decisions
+            // until call-time overload resolution.
+            let metaclass_dunder_call = self_type.member_lookup_with_policy(
+                db,
+                env,
+                "__call__",
+                MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                    | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
+            );
 
-                let Some(constructor_instance_ty) = self_type.to_instance_approximation(db, env)
-                else {
-                    return fallback_bindings();
-                };
+            let Some(constructor_instance_ty) = self_type.to_instance_approximation(db, env) else {
+                return fallback_bindings();
+            };
 
-                // TypedDict classes inherit `dict.__new__`, whose gradual `**kwargs` signature cannot
-                // constrain their type variables. Their synthesized `__init__` contains the actual field
-                // types, including generic extra items, so constructor inference should start there.
-                let new_method = if class_literal.is_typed_dict(db) {
-                    None
-                } else {
-                    self_type.lookup_dunder_new(db, env)
-                };
+            // TypedDict classes inherit `dict.__new__`, whose gradual `**kwargs` signature cannot
+            // constrain their type variables. Their synthesized `__init__` contains the actual field
+            // types, including generic extra items, so constructor inference should start there.
+            let new_method = if class_literal.is_typed_dict(db) {
+                None
+            } else {
+                self_type.lookup_dunder_new(db, env)
+            };
 
-                let init_method_no_object = constructor_instance_ty.member_lookup_with_policy(
-                    db,
-                    env,
-                    "__init__",
-                    MemberLookupPolicy::NO_INSTANCE_FALLBACK
-                        | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-                );
+            let init_method_no_object = constructor_instance_ty.member_lookup_with_policy(
+                db,
+                env,
+                "__init__",
+                MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                    | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            );
 
-                let (new_bindings, has_any_new) = match new_method
-                    .as_ref()
-                    .map(|method| method.place)
-                {
-                    Some(place) => match resolve_dunder_new_callable(db, env, self_type, place) {
-                        Some((new_callable, definedness)) => {
-                            let bindings = new_callable.bindings_impl(db, env, recursion_guard);
-                            let mut bindings = bind_constructor_new(db, env, bindings, self_type)
-                                .into_constructor_bindings(
-                                    constructor_instance_ty,
-                                    ConstructorCallableKind::New,
-                                )
-                                .with_constructed_instance_type(db, constructor_instance_ty);
-                            if definedness == Definedness::PossiblyUndefined {
-                                bindings.set_implicit_dunder_new_is_possibly_unbound();
-                            }
-                            (Some(bindings), true)
+            let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
+                Some(place) => match resolve_dunder_new_callable(db, env, self_type, place) {
+                    Some((new_callable, definedness)) => {
+                        let bindings = new_callable.bindings_impl(db, env, recursion_guard);
+                        let mut bindings = bind_constructor_new(db, env, bindings, self_type)
+                            .into_constructor_bindings(
+                                constructor_instance_ty,
+                                ConstructorCallableKind::New,
+                            )
+                            .with_constructed_instance_type(db, constructor_instance_ty);
+                        if definedness == Definedness::PossiblyUndefined {
+                            bindings.set_implicit_dunder_new_is_possibly_unbound();
                         }
-                        None => (None, false),
-                    },
+                        (Some(bindings), true)
+                    }
                     None => (None, false),
-                };
+                },
+                None => (None, false),
+            };
 
-                // Only fall back to `object.__init__` when `__new__` is absent.
-                let init_bindings = match (&init_method_no_object.place, has_any_new) {
-                    (
+            // Only fall back to `object.__init__` when `__new__` is absent.
+            let init_bindings = match (&init_method_no_object.place, has_any_new) {
+                (
+                    Place::Defined(DefinedPlace {
+                        ty: init_method,
+                        definedness,
+                        ..
+                    }),
+                    _,
+                ) => {
+                    let mut bindings = init_method
+                        .bindings_impl(db, env, recursion_guard)
+                        .into_constructor_bindings(
+                            constructor_instance_ty,
+                            ConstructorCallableKind::Init,
+                        )
+                        .with_constructed_instance_type(db, constructor_instance_ty);
+                    if *definedness == Definedness::PossiblyUndefined {
+                        bindings.set_implicit_dunder_init_is_possibly_unbound();
+                    }
+                    Some(bindings)
+                }
+                (Place::Undefined, false) => {
+                    let init_method_with_object = constructor_instance_ty
+                        .member_lookup_with_policy(
+                            db,
+                            env,
+                            "__init__",
+                            MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                        );
+                    match init_method_with_object.place {
                         Place::Defined(DefinedPlace {
                             ty: init_method,
                             definedness,
                             ..
-                        }),
-                        _,
-                    ) => {
-                        let mut bindings = init_method
-                            .bindings_impl(db, env, recursion_guard)
-                            .into_constructor_bindings(
-                                constructor_instance_ty,
-                                ConstructorCallableKind::Init,
-                            )
-                            .with_constructed_instance_type(db, constructor_instance_ty);
-                        if *definedness == Definedness::PossiblyUndefined {
-                            bindings.set_implicit_dunder_init_is_possibly_unbound();
-                        }
-                        Some(bindings)
-                    }
-                    (Place::Undefined, false) => {
-                        let init_method_with_object = constructor_instance_ty
-                            .member_lookup_with_policy(
-                                db,
-                                env,
-                                "__init__",
-                                MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-                            );
-                        match init_method_with_object.place {
-                            Place::Defined(DefinedPlace {
-                                ty: init_method,
-                                definedness,
-                                ..
-                            }) => {
-                                let mut bindings = init_method
-                                    .bindings_impl(db, env, recursion_guard)
-                                    .into_constructor_bindings(
-                                        constructor_instance_ty,
-                                        ConstructorCallableKind::Init,
-                                    )
-                                    .with_constructed_instance_type(db, constructor_instance_ty);
-                                if definedness == Definedness::PossiblyUndefined {
-                                    bindings.set_implicit_dunder_init_is_possibly_unbound();
-                                }
-                                Some(bindings)
-                            }
-                            Place::Undefined => {
-                                // If we are using vendored typeshed, it should be impossible to have missing
-                                // or unbound `__init__` method on a class, as all classes have `object` in MRO.
-                                // Thus the following may only trigger if a custom typeshed is used.
-                                // Custom/broken typeshed: no `__init__` available even after falling back
-                                // to `object`. Keep analysis going and surface the missing-implicit-call
-                                // lint via the builder.
-                                let mut bindings: Bindings<'db> = Binding::single(
-                                    self_type,
-                                    Signature::new(
-                                        Parameters::gradual_form(),
-                                        constructor_instance_ty,
-                                    ),
+                        }) => {
+                            let mut bindings = init_method
+                                .bindings_impl(db, env, recursion_guard)
+                                .into_constructor_bindings(
+                                    constructor_instance_ty,
+                                    ConstructorCallableKind::Init,
                                 )
-                                .into();
-                                bindings = bindings
-                                    .into_constructor_bindings(
-                                        constructor_instance_ty,
-                                        ConstructorCallableKind::Init,
-                                    )
-                                    .with_constructed_instance_type(db, constructor_instance_ty);
+                                .with_constructed_instance_type(db, constructor_instance_ty);
+                            if definedness == Definedness::PossiblyUndefined {
                                 bindings.set_implicit_dunder_init_is_possibly_unbound();
-                                Some(bindings)
                             }
+                            Some(bindings)
+                        }
+                        Place::Undefined => {
+                            // If we are using vendored typeshed, it should be impossible to have missing
+                            // or unbound `__init__` method on a class, as all classes have `object` in MRO.
+                            // Thus the following may only trigger if a custom typeshed is used.
+                            // Custom/broken typeshed: no `__init__` available even after falling back
+                            // to `object`. Keep analysis going and surface the missing-implicit-call
+                            // lint via the builder.
+                            let mut bindings: Bindings<'db> = Binding::single(
+                                self_type,
+                                Signature::new(Parameters::gradual_form(), constructor_instance_ty),
+                            )
+                            .into();
+                            bindings = bindings
+                                .into_constructor_bindings(
+                                    constructor_instance_ty,
+                                    ConstructorCallableKind::Init,
+                                )
+                                .with_constructed_instance_type(db, constructor_instance_ty);
+                            bindings.set_implicit_dunder_init_is_possibly_unbound();
+                            Some(bindings)
                         }
                     }
-                    (Place::Undefined, true) => None,
-                };
+                }
+                (Place::Undefined, true) => None,
+            };
 
-                let constructor_bindings = if let Some(mut new_bindings) = new_bindings {
-                    // Preserve the full `__new__` signature and defer `__init__` validation until we know
-                    // which `__new__` overload matched at call time.
-                    if let Some(init_bindings) = init_bindings.as_ref() {
-                        new_bindings.set_downstream_constructor(init_bindings);
-                    }
-                    Some(new_bindings)
-                } else {
-                    init_bindings
-                };
+            let constructor_bindings = if let Some(mut new_bindings) = new_bindings {
+                // Preserve the full `__new__` signature and defer `__init__` validation until we know
+                // which `__new__` overload matched at call time.
+                if let Some(init_bindings) = init_bindings.as_ref() {
+                    new_bindings.set_downstream_constructor(init_bindings);
+                }
+                Some(new_bindings)
+            } else {
+                init_bindings
+            };
 
-                let bindings = if let Place::Defined(DefinedPlace {
-                    ty: metaclass_call_method,
-                    ..
-                }) = metaclass_dunder_call.place
-                {
-                    let mut metaclass_bindings = metaclass_call_method
-                        .bindings_impl(db, env, recursion_guard)
-                        .into_constructor_bindings(
-                            constructor_instance_ty,
-                            ConstructorCallableKind::MetaclassCall,
-                        )
-                        .with_constructed_instance_type(db, constructor_instance_ty);
-                    if let Some(downstream_bindings) = constructor_bindings.as_ref() {
-                        // Preserve the full metaclass `__call__` signature and defer whether constructor
-                        // downstream checks apply until the matched overload is known.
-                        metaclass_bindings.set_downstream_constructor(downstream_bindings);
-                    }
-                    metaclass_bindings
-                } else if let Some(constructor_bindings) = constructor_bindings {
-                    constructor_bindings
-                } else {
-                    return fallback_bindings();
-                };
+            let bindings = if let Place::Defined(DefinedPlace {
+                ty: metaclass_call_method,
+                ..
+            }) = metaclass_dunder_call.place
+            {
+                let mut metaclass_bindings = metaclass_call_method
+                    .bindings_impl(db, env, recursion_guard)
+                    .into_constructor_bindings(
+                        constructor_instance_ty,
+                        ConstructorCallableKind::MetaclassCall,
+                    )
+                    .with_constructed_instance_type(db, constructor_instance_ty);
+                if let Some(downstream_bindings) = constructor_bindings.as_ref() {
+                    // Preserve the full metaclass `__call__` signature and defer whether constructor
+                    // downstream checks apply until the matched overload is known.
+                    metaclass_bindings.set_downstream_constructor(downstream_bindings);
+                }
+                metaclass_bindings
+            } else if let Some(constructor_bindings) = constructor_bindings {
+                constructor_bindings
+            } else {
+                return fallback_bindings();
+            };
 
-                bindings.with_generic_context(db, class_generic_context)
-            },
-        )
+            bindings.with_generic_context(db, class_generic_context)
+        })
     }
 
     /// Calls `self`. Returns a [`CallError`] if `self` is (always or possibly) not callable, or if

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -14,29 +14,6 @@ pub(super) use bind::{
     Binding, Bindings, CallDiagnosticOverride, CallableBinding, MatchedArgument,
 };
 
-/// The constructors whose signatures are currently being expanded.
-///
-/// An immutable stack keeps union and intersection branches independent and avoids allocating for
-/// ordinary constructor calls.
-pub(super) struct ConstructorStack<'a, 'db> {
-    receiver: Type<'db>,
-    parent: Option<&'a Self>,
-}
-
-impl<'a, 'db> ConstructorStack<'a, 'db> {
-    pub(super) fn new(receiver: Type<'db>, parent: Option<&'a Self>) -> Self {
-        Self { receiver, parent }
-    }
-
-    pub(super) fn is_recursive(&self) -> bool {
-        // Descriptor overloads can distinguish `C` from `type[C]`. Different specializations also
-        // need separate expansion, even if one contains the other, because a constructor may ignore
-        // its nested type arguments.
-        std::iter::successors(self.parent, |active| active.parent)
-            .any(|active| active.receiver == self.receiver)
-    }
-}
-
 /// Whether the right operand's reflected method has priority based on the possible runtime
 /// classes of both operands.
 ///

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -14,6 +14,29 @@ pub(super) use bind::{
     Binding, Bindings, CallDiagnosticOverride, CallableBinding, MatchedArgument,
 };
 
+/// The constructors whose signatures are currently being expanded.
+///
+/// An immutable stack keeps union and intersection branches independent and avoids allocating for
+/// ordinary constructor calls.
+pub(super) struct ConstructorStack<'a, 'db> {
+    receiver: Type<'db>,
+    parent: Option<&'a Self>,
+}
+
+impl<'a, 'db> ConstructorStack<'a, 'db> {
+    pub(super) fn new(receiver: Type<'db>, parent: Option<&'a Self>) -> Self {
+        Self { receiver, parent }
+    }
+
+    pub(super) fn is_recursive(&self) -> bool {
+        // Descriptor overloads can distinguish `C` from `type[C]`. Different specializations also
+        // need separate expansion, even if one contains the other, because a constructor may ignore
+        // its nested type arguments.
+        std::iter::successors(self.parent, |active| active.parent)
+            .any(|active| active.receiver == self.receiver)
+    }
+}
+
 /// Whether the right operand's reflected method has priority based on the possible runtime
 /// classes of both operands.
 ///


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4347.

Constructor signature expansion can revisit the same receiver through class-valued `__new__`, `__init__`, or metaclass `__call__`, recursively expanding bindings until ty overflows the stack. A generic decorator that replaces `__new__` with `type[C]` is one way to trigger this.

Track active constructor receivers during binding expansion and return a gradual signature when an exact receiver repeats, letting the enclosing constructor supply the instance return type. Comparing full receiver types preserves finite generic chains and descriptor overloads that distinguish `C` from `type[C]`.

## Test plan

Extend the constructor mdtests to cover:

- The reported generic decorator, mutual and generic constructor cycles, and cycles through `__init__`, metaclass `__call__`, and callable instances.
- Finite generic chains, aliases, shared constructors in union branches, and descriptor-sensitive receivers that must continue to resolve their return types.
- Downstream `__init__` argument validation and known non-instance return types from `__new__` or metaclass `__call__`.

The full `ty_python_semantic` test suite, Clippy, and applicable repository hooks pass.
