### PR TITLE
[ty] Recognize pytest parametrization with a known class

### DIFF
--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -163,6 +163,8 @@ pub enum KnownClass {
     PydanticConfigDict,
     PydanticRootModel,
     PydanticStrict,
+    // Pytest
+    PytestParametrizeMarkDecorator,
 }
 
 impl KnownClass {
@@ -295,7 +297,8 @@ impl KnownClass {
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel
-            | Self::PydanticStrict => Some(Truthiness::Ambiguous),
+            | Self::PydanticStrict
+            | Self::PytestParametrizeMarkDecorator => Some(Truthiness::Ambiguous),
 
             // Evaluating `NotImplementedType` in a boolean context was deprecated in Python 3.9
             // and raises a `TypeError` in Python >=3.14
@@ -418,7 +421,8 @@ impl KnownClass {
             | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
             | KnownClass::PydanticRootModel
-            | KnownClass::PydanticStrict => false,
+            | KnownClass::PydanticStrict
+            | KnownClass::PytestParametrizeMarkDecorator => false,
         }
     }
 
@@ -532,7 +536,8 @@ impl KnownClass {
             | KnownClass::PydanticBaseModel
             | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticRootModel
-            | KnownClass::PydanticStrict => false,
+            | KnownClass::PydanticStrict
+            | KnownClass::PytestParametrizeMarkDecorator => false,
 
             KnownClass::PydanticConfigDict => true,
         }
@@ -648,7 +653,8 @@ impl KnownClass {
             | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
             | KnownClass::PydanticRootModel
-            | KnownClass::PydanticStrict => false,
+            | KnownClass::PydanticStrict
+            | KnownClass::PytestParametrizeMarkDecorator => false,
         }
     }
 
@@ -775,7 +781,8 @@ impl KnownClass {
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel
-            | Self::PydanticStrict => false,
+            | Self::PydanticStrict
+            | Self::PytestParametrizeMarkDecorator => false,
         }
     }
 
@@ -891,7 +898,8 @@ impl KnownClass {
             | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
             | KnownClass::PydanticRootModel
-            | KnownClass::PydanticStrict => false,
+            | KnownClass::PydanticStrict
+            | KnownClass::PytestParametrizeMarkDecorator => false,
             KnownClass::NamedTupleFallback
             | KnownClass::TypedDictFallback
             | KnownClass::ExtensionTypedDictFallback => true,
@@ -1020,6 +1028,7 @@ impl KnownClass {
             Self::PydanticConfigDict => "ConfigDict",
             Self::PydanticRootModel => "RootModel",
             Self::PydanticStrict => "Strict",
+            Self::PytestParametrizeMarkDecorator => "_ParametrizeMarkDecorator",
         }
     }
 
@@ -1445,6 +1454,7 @@ impl KnownClass {
             Self::PydanticConfigDict => KnownModule::PydanticConfig,
             Self::PydanticRootModel => KnownModule::PydanticRootModel,
             Self::PydanticStrict => KnownModule::PydanticTypes,
+            Self::PytestParametrizeMarkDecorator => KnownModule::PytestMarkStructures,
         }
     }
 
@@ -1562,7 +1572,8 @@ impl KnownClass {
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel
-            | Self::PydanticStrict => false,
+            | Self::PydanticStrict
+            | Self::PytestParametrizeMarkDecorator => false,
         }
     }
 
@@ -1678,6 +1689,7 @@ impl KnownClass {
             "ConfigDict" => &[Self::PydanticConfigDict],
             "RootModel" => &[Self::PydanticRootModel],
             "Strict" => &[Self::PydanticStrict],
+            "_ParametrizeMarkDecorator" => &[Self::PytestParametrizeMarkDecorator],
             _ => return None,
         };
 
@@ -1783,7 +1795,10 @@ impl KnownClass {
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel
-            | Self::PydanticStrict => module == self.canonical_module(python_version),
+            | Self::PydanticStrict
+            | Self::PytestParametrizeMarkDecorator => {
+                module == self.canonical_module(python_version)
+            }
 
             // no equivalent class exists in typing_extensions, nor ever will
             Self::StdlibAlias => module == self.canonical_module(python_version),

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -51,7 +51,7 @@ use crate::types::function::{FunctionType, KnownFunction};
 use crate::types::infer::{function_known_decorators, infer_definition_types, original_class_type};
 use crate::types::signatures::Parameter as SignatureParameter;
 use crate::types::{
-    ClassBase, ClassLiteral, ProgramEnvironment, Type, definition_expression_type,
+    ClassBase, ClassLiteral, KnownClass, ProgramEnvironment, Type, definition_expression_type,
     extract_fixed_length_iterable_element_types,
 };
 
@@ -692,17 +692,8 @@ fn mark_excludes_fixture<'db>(
     let Some(call) = expression.as_call_expr() else {
         return false;
     };
-    let Some(attribute) = call.func.as_attribute_expr() else {
-        return false;
-    };
-    if attribute.attr.as_str() != "parametrize"
-        || !is_known_class_instance(
-            db,
-            definition,
-            expression_type(&attribute.value),
-            "MarkGenerator",
-            &[KnownModule::Pytest, KnownModule::PytestMarkStructures],
-        )
+    if !expression_type(&call.func)
+        .is_some_and(|ty| ty.is_instance_of(db, KnownClass::PytestParametrizeMarkDecorator))
     {
         return false;
     }
@@ -1397,6 +1388,11 @@ def test_aliased_direct(value): ...
 @aliased_mark.parametrize("value", [1], indirect=True)
 def test_aliased_indirect(value): ...
 
+parametrize = pytest.mark.parametrize
+
+@parametrize("value", [1])
+def test_bare_aliased_direct(value): ...
+
 @pytest.mark.parametrize("value", [1])
 class TestParametrized:
     def test_value(self, value): ...
@@ -1413,6 +1409,7 @@ class TestOuter:
         let test_mixed = test.function("test_mixed");
         let test_aliased_direct = test.function("test_aliased_direct");
         let test_aliased_indirect = test.function("test_aliased_indirect");
+        let test_bare_aliased_direct = test.function("test_bare_aliased_direct");
         let test_class_parametrized = test.function("TestParametrized.test_value");
         let test_outer_class_parametrized = test.function("TestOuter.TestInner.test_value");
 
@@ -1446,6 +1443,8 @@ class TestOuter:
 
         assert_snapshot!(test_mixed.fixture_resolution("other"), @"No fixture resolved for parameter `other`");
         assert_snapshot!(test_aliased_direct.fixture_resolution("value"), @"No fixture resolved for parameter `value`");
+
+        assert_snapshot!(test_bare_aliased_direct.fixture_resolution("value"), @"No fixture resolved for parameter `value`");
 
         assert_snapshot!(test_aliased_indirect.fixture_resolution("value"), @"
         info[pytest-fixture]: Resolve fixture for parameter
@@ -1615,8 +1614,10 @@ def test_use(value): ...
 class MarkDecorator:
     def __call__(self, *args: object, **kwargs: object) -> object: ...
 
+class _ParametrizeMarkDecorator(MarkDecorator): ...
+
 class MarkGenerator:
-    parametrize: MarkDecorator
+    parametrize: _ParametrizeMarkDecorator
 "#,
             )
             .with_file(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This applies a lesson that I learned from https://github.com/astral-sh/ruff/pull/27834: the [`@pytest.mark.parametrize`](https://docs.pytest.org/en/stable/how-to/parametrize.html#pytest-mark-parametrize) decorator can be recognized with a known class. This helps standardize the intepretation of that decorator in anticipation of new consumers, and also improves our ability to recognize the canonical decorator through aliases.

## Test Plan

See included tests.
<!-- How was it tested? -->
