### PR TITLE
[ty] Bound expanding generic constructor signatures

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -375,6 +375,56 @@ class Factory[T]:
 reveal_type(C[Factory[int]]())  # revealed: int
 ```
 
+### Growing generic constructor specializations
+
+A recursive constructor can keep growing its arguments without repeating an exact receiver type. We
+bound constructor expansion and use the gradual fallback when it reaches the limit. Finite chains
+beyond the limit also use this fallback.
+
+```py
+class C[T]:
+    __new__: type["C[list[T]]"]
+
+C[int]()
+C[tuple[int, str]]()
+C[int | str]()
+```
+
+Growth can also pass through a class that forwards construction to its type argument:
+
+```py
+class Wrapper[T]:
+    __new__: type[T]
+
+class Factory[T]:
+    __new__: type[Wrapper["Factory[list[T]]"]]
+
+Wrapper[Factory[int]]()
+```
+
+Swapping arguments can hide the growth until the constructor has been expanded more than once:
+
+```py
+class Swap[T, U]:
+    __new__: type["Swap[U, list[T]]"]
+
+Swap[int, str]()
+```
+
+### Recursive aliases in constructor arguments
+
+Unfolding a recursive alias can also keep introducing new constructor specializations. These chains
+use the same bounded-expansion fallback:
+
+```py
+class C[T]:
+    __new__: type[T]
+
+type Recursive[T] = C[Recursive[list[T]]]
+
+C[Recursive[int]]()
+```
+
 ### Descriptor-sensitive constructor receivers
 
 An exact class object and a value of `type[C]` can select different descriptor overloads. This

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6458,6 +6458,8 @@ impl<'db> Type<'db> {
         class: ClassType<'db>,
         recursion_guard: &ActiveRecursionDetector<Type<'db>>,
     ) -> Bindings<'db> {
+        const MAX_CONSTRUCTOR_DEPTH: usize = 64;
+
         fn resolve_dunder_new_callable<'db>(
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,
@@ -6583,9 +6585,17 @@ impl<'db> Type<'db> {
 
         let on_cycle = || {
             // Leave the return type unknown so the enclosing constructor supplies its own
-            // instance type, rather than the class where the cycle happened to be detected.
+            // instance type, rather than the class where expansion stopped.
             Binding::single(self_type, Signature::dynamic(Type::unknown())).into()
         };
+        // A chain such as `C[int] -> C[list[int]] -> C[list[list[int]]]` never repeats a
+        // receiver. Growth alone does not prove recursion: a finite chain can also add nesting
+        // before reaching a callable signature. Bound expansion separately from exact-cycle
+        // detection; sufficiently deep finite chains also use this fallback.
+        if recursion_guard.depth() >= MAX_CONSTRUCTOR_DEPTH {
+            return on_cycle();
+        }
+
         // Key recursion by the full receiver type. Descriptor overloads can distinguish `C` from
         // `type[C]`, and different specializations need separate expansion even if one contains
         // the other, because a constructor may ignore its nested type arguments.

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -651,6 +651,11 @@ impl<T> Default for ActiveRecursionDetector<T> {
 }
 
 impl<T: Hash + Eq + Clone> ActiveRecursionDetector<T> {
+    /// The number of active visits, excluding visits that encountered an existing key.
+    pub(super) fn depth(&self) -> usize {
+        self.seen.borrow().len()
+    }
+
     pub(crate) fn visit<R>(
         &self,
         item: &T,
@@ -687,7 +692,9 @@ impl<T: Hash + Eq> Drop for ActiveRecursionGuard<'_, T> {
 mod tests {
     use std::assert_matches;
 
-    use super::{CycleDetector, CycleDetectorVisit, Db, HasIdentity, TypeIdentity};
+    use super::{
+        ActiveRecursionDetector, CycleDetector, CycleDetectorVisit, Db, HasIdentity, TypeIdentity,
+    };
     use crate::ProgramEnvironment;
     use crate::db::tests::setup_db;
     use crate::place::global_symbol;
@@ -931,5 +938,26 @@ class RecursivePropertySetter[T](Protocol):
             panic!("the second identity should be ready after the pending visit is finished");
         };
         assert_eq!(seen, 2);
+    }
+
+    #[test]
+    fn tracks_active_recursion_depth() {
+        let detector = ActiveRecursionDetector::default();
+        assert_eq!(detector.depth(), 0);
+
+        let depth = detector.visit(
+            &1,
+            || 0,
+            || {
+                assert_eq!(detector.depth(), 1);
+                assert_eq!(detector.visit(&2, || 0, || detector.depth()), 2);
+                assert_eq!(detector.depth(), 1);
+                assert_eq!(detector.visit(&1, || detector.depth(), || 0), 1);
+                detector.depth()
+            },
+        );
+
+        assert_eq!(depth, 1);
+        assert_eq!(detector.depth(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Stacked on #27958.

Constructor signature expansion can overflow the stack without repeating an exact receiver: each
step can create a new specialization, such as `C[int] -> C[list[int]] -> C[list[list[int]]]`.

Limit the active constructor expansion depth to 64 and use the existing gradual fallback at that
boundary. `ActiveRecursionDetector` exposes its active depth, while the limit remains specific to
constructor binding. Exact receiver matching and the enclosing constructor's return-type handling
are unchanged. Sufficiently deep finite chains also use the fallback.

Descriptor calls that start a fresh binding context are not addressed by this change.

## Test plan

Add constructor mdtests for growing specializations with scalar, tuple, and union arguments;
growth through forwarding constructors; swapped type arguments; and recursive aliases. Existing
constructor coverage continues to check finite chains, descriptor-sensitive receivers, and
downstream argument validation.

Add a unit test for active depth during nested visits, exact-cycle callbacks, and after visits
return.
