### PR TITLE
[ty] Avoid panic on unpacked kwargs in string annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
@@ -22,6 +22,21 @@ def _(x: Annotated[tuple[str, int], bytes]):
     reveal_type(x)  # revealed: tuple[str, int]
 ```
 
+## String annotations
+
+Metadata in a string annotation can include calls with unpacked dictionaries. The metadata does not
+affect the annotated type, regardless of where the annotation appears.
+
+```py
+from typing_extensions import Annotated
+
+value: "Annotated[int, dict(**{})]"
+
+def convert(value: "Annotated[str, dict(**{'name': 'value'})]") -> "Annotated[int, dict(**{})]":
+    reveal_type(value)  # revealed: str
+    return 1
+```
+
 ## Inside `type[...]`
 
 `Annotated` can wrap a class or specialized generic class inside `type[...]` without changing the

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8632,6 +8632,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         argument_type: Type<'db>,
         argument: &'ast ast::ArgOrKeyword,
     ) -> Option<Type<'db>> {
+        // Parsed string annotations are not indexed, so their keyword arguments have no
+        // use-definition information from which to narrow dictionary keys.
+        if self.in_string_annotation() {
+            return None;
+        }
+
         let env = self.program_environment();
         let db = self.db();
         let file_scope_id = self.scope().file_scope_id(db);


### PR DESCRIPTION
## Summary

Previously, `Annotated` metadata containing unpacked keyword arguments could panic when the annotation was written as a string:

```python
from typing import Annotated

value: "Annotated[int, dict(**{})]"
```

Dictionary-key narrowing attempted to look up use-definition information for the unpacked keyword argument, but parsed string-annotation nodes are not present in the semantic index.

We now skip dictionary-key narrowing inside string annotations while preserving ordinary call inference. This also handles unpacked dictionaries in parameter and return annotations.
