### PR TITLE
[ty] Avoid recursive lambda cycles in boolean predicates

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -22,6 +22,68 @@ if not (lambda: f):
     f = 0
 ```
 
+## Recursive lambda in a boolean conditional
+
+A lambda remains truthy when combined with another condition. Branch reachability does not depend on
+its return type, even when that return type depends on an assignment in the branch.
+
+```py
+f = lambda: f
+if True and (lambda: f):
+    f = 0
+```
+
+The same applies to disjunctions and negated lambdas.
+
+```py
+g = lambda: g
+if False or not (lambda: g):
+    g = 0
+```
+
+When the other operand is not statically known, it alone determines the condition's truthiness.
+
+```py
+h = lambda: h
+if h and (lambda: h):
+    h = 0
+
+i = lambda: i
+if (lambda: i) and i:
+    i = 0
+```
+
+Additional nonconstant operands do not make the lambda's return type relevant to reachability.
+
+```py
+j = lambda: j
+condition: bool = bool()
+if j and condition and (lambda: j):
+    j = 0
+```
+
+## Recursive lambda in a boolean loop condition
+
+Combining a recursive lambda with another condition does not require its return type to determine
+whether a loop body is reachable.
+
+```py
+f = lambda: f
+while True and (lambda: f):
+    f = 0
+```
+
+## Recursive lambda in a boolean assertion
+
+Assertions use the same reachability constraints as other conditions and do not depend on a lambda's
+return type.
+
+```py
+f = lambda: f
+assert True and (lambda: f)
+f = 0
+```
+
 ## Function signature
 
 Deferred annotations can result in cycles in resolving a function signature:

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -209,8 +209,9 @@ use crate::{
         singleton_pattern_type,
     },
 };
+use ruff_db::parsed::parsed_module;
 use ruff_index::{Idx, IndexSlice};
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{self as ast, name::Name};
 use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
@@ -229,7 +230,7 @@ use ty_python_core::{
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
     scope::ScopeId,
-    use_def_map,
+    semantic_index, use_def_map,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -1589,14 +1590,108 @@ fn analyze_non_empty_iterable(db: &dyn Db, iterable: Expression) -> Truthiness {
     }
 }
 
+/// Evaluates predicate truthiness without inferring deferred bodies that cannot affect the result.
+///
+/// Inferring the body of a lambda in `condition and (lambda: value)` can depend on a binding whose
+/// visibility is guarded by that same condition, introducing a divergent Salsa cycle.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _| Truthiness::Ambiguous,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn analyze_expression_predicate<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Truthiness {
+    fn contains_deferred_expression(node: &ast::Expr) -> bool {
+        match node {
+            ast::Expr::Lambda(_) | ast::Expr::Generator(_) => true,
+            ast::Expr::BoolOp(ast::ExprBoolOp { values, .. }) => {
+                values.iter().any(contains_deferred_expression)
+            }
+            ast::Expr::UnaryOp(ast::ExprUnaryOp {
+                op: ast::UnaryOp::Not,
+                operand,
+                ..
+            }) => contains_deferred_expression(operand),
+            _ => false,
+        }
+    }
+
+    fn analyze_node<'db>(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        index: &SemanticIndex<'db>,
+        node: &ast::Expr,
+    ) -> Truthiness {
+        match node {
+            ast::Expr::Lambda(_) | ast::Expr::Generator(_) => Truthiness::AlwaysTrue,
+            ast::Expr::BooleanLiteral(ast::ExprBooleanLiteral { value, .. }) => {
+                Truthiness::from(*value)
+            }
+            ast::Expr::NoneLiteral(_) => Truthiness::AlwaysFalse,
+            ast::Expr::EllipsisLiteral(_) => Truthiness::AlwaysTrue,
+            ast::Expr::NumberLiteral(ast::ExprNumberLiteral {
+                value: ast::Number::Int(value),
+                ..
+            }) => Truthiness::from(*value != 0),
+            ast::Expr::UnaryOp(ast::ExprUnaryOp {
+                op: ast::UnaryOp::Not,
+                operand,
+                ..
+            }) if contains_deferred_expression(operand) => {
+                analyze_node(db, env, index, operand).negate()
+            }
+            ast::Expr::BoolOp(ast::ExprBoolOp { op, values, .. }) => {
+                let mut truthiness = match op {
+                    ast::BoolOp::And => Truthiness::AlwaysTrue,
+                    ast::BoolOp::Or => Truthiness::AlwaysFalse,
+                };
+
+                for value in values {
+                    let next = analyze_node(db, env, index, value);
+                    truthiness = match op {
+                        ast::BoolOp::And => truthiness.negate().or(next.negate()).negate(),
+                        ast::BoolOp::Or => truthiness.or(next),
+                    };
+
+                    if matches!(
+                        (op, truthiness),
+                        (ast::BoolOp::And, Truthiness::AlwaysFalse)
+                            | (ast::BoolOp::Or, Truthiness::AlwaysTrue)
+                    ) {
+                        break;
+                    }
+                }
+
+                truthiness
+            }
+            // Final boolean operands are not necessarily standalone expressions. Treating them as
+            // ambiguous avoids inferring their entire containing expression just for reachability.
+            _ => index
+                .try_expression(node)
+                .map_or(Truthiness::Ambiguous, |expression| {
+                    infer_same_file_expression_type(db, expression, TypeContext::default())
+                        .bool(db, env)
+                }),
+        }
+    }
+
+    let env = ProgramEnvironment::from_scope(expression.scope(db));
+    let module = parsed_module(db, expression.python_file(db)).load(db);
+    let node = expression.node_ref(db).node(&module);
+
+    if contains_deferred_expression(node) {
+        let index = semantic_index(db, expression.program_file(db));
+        analyze_node(db, &env, index, node)
+    } else {
+        infer_same_file_expression_type(db, expression, TypeContext::default()).bool(db, &env)
+    }
+}
+
 fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predicate) -> Truthiness {
     let _span = tracing::trace_span!("analyze_single", ?predicate).entered();
 
     match predicate.node {
         PredicateNode::Expression(test_expr) => {
-            infer_same_file_expression_type(db, test_expr, TypeContext::default())
-                .bool(db, env)
-                .negate_if(!predicate.is_positive)
+            analyze_expression_predicate(db, test_expr).negate_if(!predicate.is_positive)
         }
         PredicateNode::ContextManagerSuppresses {
             expression,


### PR DESCRIPTION
## Summary

Previously, a recursive lambda inside a boolean condition could cause type inference to panic:

```python
f = lambda: f

if True and (lambda: f):
    f = 0
```

Determining whether the assignment was reachable inferred the entire condition, including the lambda's return type. That return type depends on the assignment's visibility, creating a Salsa cycle that does not converge.

We now evaluate boolean predicate truthiness structurally when a condition contains a lambda or generator. Lambdas and generator expressions are recognized as always truthy, conjunctions and disjunctions preserve short-circuit behavior, and operands without standalone inference remain conservatively ambiguous.

This also handles multiple nonconstant operands, negated conditions, loop conditions, and assertions.
