### PR TITLE
[ty] Reject incompatible constructor context for variadic packs

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -173,6 +173,99 @@ indirect: Variadic[str] = inferred
 direct: Variadic[str] = Variadic(1)
 ```
 
+Concrete contexts do not supply missing arguments or discard extra ones.
+
+```py
+# error: [invalid-assignment]
+missing_argument: Variadic[int] = reveal_type(Variadic())  # revealed: Variadic[()]
+
+# error: [invalid-assignment]
+extra_argument: Variadic[int] = reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
+```
+
+A contextual specialization cannot supply missing constructor arguments. Empty calls infer an empty
+pack, and one argument cannot satisfy an arbitrary outer pack, even when it matches a required
+suffix. This applies with or without a fixed suffix.
+
+```py
+def empty_with_context[*Us](shape: tuple[*Us]) -> Variadic[*Us, int]:
+    # error: [invalid-return-type]
+    return reveal_type(Variadic())  # revealed: Variadic[()]
+
+def nonempty_with_context[*Us](shape: tuple[*Us]) -> Variadic[*Us, int]:
+    # error: [invalid-return-type]
+    return reveal_type(Variadic(1))  # revealed: Variadic[int]
+
+def empty_without_suffix[*Us](shape: tuple[*Us]) -> Variadic[*Us]:
+    # error: [invalid-return-type]
+    return reveal_type(Variadic())  # revealed: Variadic[()]
+```
+
+Forwarding the outer pack supplies the required arguments. A compatible context can still widen
+their element types without changing the pack's shape.
+
+```py
+widened: Variadic[object] = Variadic(1)
+
+def forward_without_suffix[*Us](shape: tuple[*Us]) -> Variadic[*Us]:
+    return Variadic(*shape)
+
+def forward_with_suffix[*Us](shape: tuple[*Us]) -> Variadic[*Us, int]:
+    return Variadic(*shape, 1)
+
+def widen_suffix[*Us](shape: tuple[*Us]) -> Variadic[*Us, object]:
+    return Variadic(*shape, 1)
+```
+
+An unpacked `tuple[Any, ...]` can match any length, so a compatible context can specialize it. The
+same gradual behavior applies when a tuple is passed as one element of the pack.
+
+```py
+from typing import Any
+
+def gradual_arguments(values: tuple[Any, ...]) -> None:
+    concrete: Variadic[int, str] = reveal_type(Variadic(*values))  # revealed: Variadic[int, str]
+    nested: Variadic[object, tuple[int]] = reveal_type(Variadic(1, values))  # revealed: Variadic[object, tuple[int]]
+
+def gradual_with_context[*Us](shape: tuple[*Us], values: tuple[Any, ...]) -> Variadic[*Us, int]:
+    return Variadic(*values)
+
+def gradual_boundaries[*Us](
+    shape: tuple[*Us],
+    prefix: tuple[int, *tuple[Any, ...]],
+    suffix: tuple[*tuple[Any, ...], str],
+) -> None:
+    first: Variadic[int, *Us, str] = Variadic(*prefix)
+    last: Variadic[int, *Us, str] = Variadic(*suffix)
+```
+
+Aliases of `Any` preserve gradual length when the context supplies a concrete specialization.
+
+```py
+type Dynamic = Any
+
+def gradual_alias_arguments(values: tuple[Dynamic, ...]) -> None:
+    concrete: Variadic[int, str] = reveal_type(Variadic(*values))  # revealed: Variadic[int, str]
+```
+
+Fixed elements still constrain the pack's length and types, even when other elements are gradual.
+
+```py
+def fixed_any_with_context[*Us](shape: tuple[*Us], values: tuple[Any]) -> Variadic[*Us, int]:
+    fixed_length: Variadic[int] = reveal_type(Variadic(*values))  # revealed: Variadic[int]
+    # error: [invalid-return-type]
+    return reveal_type(Variadic(*values))  # revealed: Variadic[Any]
+
+def incompatible_gradual_prefix[*Us](shape: tuple[*Us], values: tuple[int, *tuple[Any, ...]]) -> Variadic[*Us, int]:
+    return Variadic(*values)  # error: [invalid-return-type]
+
+def incompatible_gradual_element(values: tuple[bytes, *tuple[Any, ...]]) -> Variadic[int, str]:
+    return Variadic(*values)  # error: [invalid-return-type]
+
+def too_many_gradual_boundaries(values: tuple[int, *tuple[Any, ...], str]) -> Variadic[int]:
+    return Variadic(*values)  # error: [invalid-return-type]
+```
+
 ### Unspecified type arguments
 
 An unsubscripted variadic generic behaves as if it used an unknown-length tuple of `Any` arguments.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -6066,6 +6066,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     ///
     /// Comparing the complete argument tuple with the declared tuple preserves fixed elements,
     /// nested type variable tuples, and the unbounded shape of splatted arguments.
+    /// If requested, checks the preferred type context as well. A `false` result tells the caller
+    /// to retry inference using only argument constraints.
     ///
     /// ```py
     /// def collect[*Ts](*args: *Ts) -> tuple[*Ts]: ...
@@ -6077,14 +6079,15 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     fn infer_typevartuple_argument_constraints<'c>(
         &self,
         builder: &mut SpecializationBuilder<'db, 'c>,
+        check_type_context: bool,
         specialization_errors: &mut Vec<BindingError<'db>>,
-    ) -> Result<(), (SpecializationError<'db>, Option<usize>)> {
+    ) -> bool {
         let db = self.db;
         let Some((parameter_index, parameter)) = self.signature.parameters().variadic() else {
-            return Ok(());
+            return true;
         };
         if !parameter.has_starred_annotation() {
-            return Ok(());
+            return true;
         }
 
         // An untouched variadic parameter remains available to future calls of a partial. In
@@ -6096,7 +6099,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     .any(|matched| matched.index == parameter_index)
             })
         {
-            return Ok(());
+            return true;
         }
 
         let (formal, typevartuple) = match parameter.annotated_type() {
@@ -6113,27 +6116,41 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         }
                     })
                 else {
-                    return Ok(());
+                    return true;
                 };
                 (annotation, typevartuple)
             }
         };
 
         if !self.can_infer_typevartuple_arguments(parameter_index, typevartuple) {
-            return Ok(());
+            return true;
         }
 
         let Some((actual, argument_indices)) =
             self.collect_typevartuple_arguments(parameter_index, parameter, formal)
         else {
-            return Ok(());
+            return true;
         };
 
-        builder.infer(formal, actual).map_err(|error| {
-            let argument_index =
-                argument_indices.and_then(|(first, last)| (first == last).then_some(first));
-            (error, argument_index)
-        })?;
+        if let Err(error) = builder.infer(formal, actual) {
+            // Fixed elements may already have produced the same specialization error.
+            if !specialization_errors.iter().any(|existing| {
+                matches!(
+                    existing,
+                    BindingError::SpecializationError {
+                        error: existing,
+                        ..
+                    } if existing == &error
+                )
+            }) {
+                specialization_errors.push(BindingError::SpecializationError {
+                    error,
+                    argument_index: argument_indices
+                        .and_then(|(first, last)| (first == last).then_some(first)),
+                });
+            }
+            return !check_type_context;
+        }
 
         if self.signature.generic_context.is_some() {
             let specialization = builder.build_with(|_, _| None);
@@ -6157,9 +6174,18 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     parameter_source: None,
                 });
             }
+
+            // A preferred return context can fix the pack before argument inference reaches it.
+            // Check the complete arguments against that specialization, including the empty tuple
+            // from `A()`, so an incompatible `A[*Us, int]` is retried without the context.
+            return !check_type_context
+                || self.is_partial_application
+                || actual
+                    .apply_specialization(db, specialization)
+                    .is_assignable_to(db, self.env, expected_ty);
         }
 
-        Ok(())
+        true
     }
 
     /// Returns whether a type variable tuple can be inferred from its variadic arguments.
@@ -6343,25 +6369,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             }
         }
 
-        if let Err((error, argument_index)) =
-            self.infer_typevartuple_argument_constraints(builder, specialization_errors)
-            && !specialization_errors.iter().any(|existing| {
-                matches!(
-                    existing,
-                    BindingError::SpecializationError {
-                        error: existing,
-                        ..
-                    } if existing == &error
-                )
-            })
-        {
-            specialization_errors.push(BindingError::SpecializationError {
-                error,
-                argument_index,
-            });
-        }
-
-        preferred_type_mappings
+        self.infer_typevartuple_argument_constraints(
+            builder,
+            !preferred_type_mappings.is_empty(),
+            specialization_errors,
+        ) && preferred_type_mappings
             .iter()
             .all(|(&identity, &preferred_ty)| {
                 partially_specialized_declared_type.contains(&identity)


### PR DESCRIPTION
An expected return type could determine a variadic constructor's type arguments even when its actual arguments were incompatible. In particular, returning `A()` from a function annotated with `A[*Ts, int]` could infer the expected specialization instead of `A[()]`, hiding an invalid return.

Compare the complete variadic argument tuple with the contextual specialization and retry inference without that context when they are incompatible.

Builds on #27943 for fixed-tuple rejection and pack-preserving length narrowing, with #27950 and #27957 providing missing-unpack recovery and gradual tuple assignability.

Fixes astral-sh/ty#4343.

## Test plan

- Cover missing and extra arguments under concrete contexts, and empty and nonempty constructor calls under symbolic contexts with and without a required suffix.
- Preserve compatible concrete widening and symbolic pack forwarding.
- Preserve concrete and symbolic context for gradual arguments, including nested tuples and aliases of `Any`.
- Reject incompatible fixed lengths and gradual boundaries.
