### PR TITLE
docs(search): keep Python keywords searchable

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -61,7 +61,12 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
 plugins:
-  - search
+  - search:
+      # Keep language keywords searchable (e.g. `while`), rather than dropping
+      # them as English stop words.
+      pipeline:
+        - stemmer
+        - trimmer
   - gh-admonitions
   - llmstxt:
       markdown_description: |


### PR DESCRIPTION
## Summary

> Contributor explanation (original Chinese):
>
> 我修改了`mkdocs.template.yml` 原来使用 Material for MkDocs 默认搜索 pipeline，其中包含 `stopWordFilter`，会把英文词 `while` 当成停用词丢掉。
> 我改成显式使用：`stemmer，trimmer`。这样保留普通搜索处理，但不再过滤 `while` 等 Python 关键词，因此文档搜索可以找到它们。随后我构建了搜索索引，并确认 `while` 已进入索引。
>
> English translation:
>
> I changed `mkdocs.template.yml`, which previously used Material for MkDocs' default search pipeline containing `stopWordFilter`. That treated the English word `while` as a stop word and removed it. I now explicitly use `stemmer` and `trimmer`, preserving normal search processing without filtering `while` and other Python keywords. I built the search index and confirmed that `while` is included.

This addresses #21869 by keeping programming-language keywords searchable in the documentation.

## Testing

- `python -m mkdocs build -f mkdocs.template.yml --site-dir site/search-test-nonstrict`
- Confirmed the generated search index uses the `stemmer` and `trimmer` pipeline and contains the standalone token `while`.