### PR TITLE
[ty] Explain missing storage for declared slotted attributes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -210,6 +210,44 @@ error[unresolved-attribute]: Unresolved attribute `non_existent` on type `C`
   | ^^^^^^^^^^^^^^^^^^^^^
 ```
 
+## Attributes declared without instance storage
+
+An instance attribute annotation does not create storage. Assigning to an attribute declared on a
+slotted class explains that the class has neither a matching slot nor an instance dictionary.
+
+```py
+class Slotted:
+    value: int
+    __slots__ = ()
+
+Slotted().value = 1  # snapshot: unresolved-attribute
+```
+
+```snapshot
+error[unresolved-attribute]: Cannot assign to attribute `value`: `Slotted` has no slot or instance dictionary
+ --> src/mdtest_snippet.py:5:1
+  |
+5 | Slotted().value = 1  # snapshot: unresolved-attribute
+  | ^^^^^^^^^^^^^^^
+info: Attribute `value` is declared but is not included in `__slots__`
+```
+
+A genuinely undeclared attribute keeps the ordinary unresolved-attribute diagnostic.
+
+```py
+Slotted().missing = 1  # error: [unresolved-attribute] "Unresolved attribute `missing` on type `Slotted`"
+```
+
+An inherited annotation also does not provide storage for a slotted subclass.
+
+```py
+class SlottedChild(Slotted):
+    __slots__ = ()
+
+# error: [unresolved-attribute] "Cannot assign to attribute `value`: `SlottedChild` has no slot or instance dictionary"
+SlottedChild().value = 1
+```
+
 ## Possibly-missing attributes
 
 When trying to set an attribute that is not defined in all branches, we emit errors:

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -945,6 +945,26 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                             self.attribute,
                             self.object_ty.display(db, env)
                         ));
+                    } else if self
+                        .object_ty
+                        .nominal_class(db, env)
+                        .and_then(|class| class.static_class_literal(db))
+                        .is_some_and(|(class, _)| class.lacks_instance_storage(db, self.attribute))
+                        && !self
+                            .object_ty
+                            .class_member(db, env, self.attribute)
+                            .place
+                            .is_undefined()
+                    {
+                        let mut diagnostic = builder.into_diagnostic(format_args!(
+                            "Cannot assign to attribute `{}`: `{}` has no slot or instance dictionary",
+                            self.attribute,
+                            self.object_ty.display(db, env),
+                        ));
+                        diagnostic.info(format_args!(
+                            "Attribute `{}` is declared but is not included in `__slots__`",
+                            self.attribute,
+                        ));
                     } else {
                         builder.into_diagnostic(format_args!(
                             "Unresolved attribute `{}` on type `{}`",


### PR DESCRIPTION
## Summary

Previously, assigning to an annotated attribute on a slotted class produced a generic unresolved-attribute error, even though the attribute was declared:

```python
class Foo:
    x: int
    __slots__ = ()


Foo().x = 42
```

We now explain that `Foo` has no matching slot or instance dictionary, and attach a note that `x` is declared but not included in `__slots__`. The primary message remains useful with concise output. Inherited declarations receive the same explanation, while genuinely undeclared attributes retain the existing diagnostic.

Follow-up to #27730.
