### PR TITLE
[ty] Fix slot descriptor runtime metaclass classification

### DIFF
--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -209,6 +209,8 @@ impl KnownClass {
             | Self::MethodType
             | Self::MethodWrapperType
             | Self::WrapperDescriptorType
+            | Self::MemberDescriptorType
+            | Self::GetSetDescriptorType
             | Self::UnionType
             | Self::GeneratorType
             | Self::AsyncGeneratorType


### PR DESCRIPTION
## Summary

Restore the `main` build after #27730 by including `MemberDescriptorType` and `GetSetDescriptorType` in the exhaustive `KnownClass::has_known_type_metaclass` match.

Both descriptor classes have `type` as their runtime metaclass, so they belong alongside the other built-in descriptor types.
