### PR TITLE
Fix duplicated "of" in ClientOptions doc comment

### DIFF
--- a/crates/ruff_server/src/session/options.rs
+++ b/crates/ruff_server/src/session/options.rs
@@ -33,7 +33,7 @@ pub(crate) enum ConfigurationPreference {
     EditorOnly,
 }
 
-/// A direct representation of of `configuration` schema within the client settings.
+/// A direct representation of the `configuration` schema within the client settings.
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(untagged)]


### PR DESCRIPTION
## What
Fixed duplicated word 'of' in the doc comment for the client configuration struct in crates/ruff_server/src/session/options.rs

## Why
A small, objectively-verifiable improvement (typo) found during a
daily open-source maintenance pass (2026-08-22).

## How verified
Read the surrounding code; the comment read 'A direct representation of of `configuration` schema within the client settings.' with a clear duplicate word, corrected to 'of the'. Confirmed via git diff after edit.
Automated gates: 2 changed lines across 1 files (within limits); cargo check: passed (ruff_server).

---
Prepared with Claude Code assistance and reviewed by Aarush's
automation gates (diff-size, file-scope, deletion, and build checks)
before opening.