### PR TITLE
[ty] Support tagged union with multiple tags per type

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -365,6 +365,22 @@ def _(x: tuple[Literal["a"], A] | tuple[Literal["b"], B]):
         reveal_type(x)  # revealed: tuple[Literal["a"], A]
 ```
 
+A tuple can have several literal tags. Matching a different tag rules out that tuple, while
+excluding only one of its possible tags leaves it in the union:
+
+```py
+def multiple_tags(x: tuple[Literal["a"], int] | tuple[Literal["b", "c"], str]):
+    if "a" == x[0]:
+        reveal_type(x)  # revealed: tuple[Literal["a"], int]
+    else:
+        reveal_type(x)  # revealed: tuple[Literal["b", "c"], str]
+
+    if x[0] != "b":
+        reveal_type(x)  # revealed: tuple[Literal["a"], int] | tuple[Literal["b", "c"], str]
+    else:
+        reveal_type(x)  # revealed: tuple[Literal["b", "c"], str]
+```
+
 Enum literals are supported as tuple tags, including `IntEnum` literals:
 
 ```py
@@ -403,6 +419,19 @@ def _(x: tuple[Literal["tag1"], A] | tuple[str, B]):
     else:
         # But we *can* narrow with inequality
         reveal_type(x)  # revealed: tuple[str, B]
+```
+
+This also applies when a tag is a union of literal and non-literal types. The non-literal
+alternative can compare equal to the tag being checked:
+
+```py
+class MatchesAnything:
+    def __eq__(self, other: object) -> bool:
+        return True
+
+def nonliteral_tag_union(x: tuple[Literal["a"], int] | tuple[Literal["b"] | MatchesAnything, str]):
+    if x[0] == "a":
+        reveal_type(x)  # revealed: tuple[Literal["a"], int] | tuple[Literal["b"] | MatchesAnything, str]
 ```
 
 If the index is out of bounds for any tuple in the union, we also skip narrowing (a diagnostic will

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -2605,6 +2605,10 @@ class B:
     tag: Literal["b"]
     field_b: str
 
+class X1:
+    tag: Literal["x", 1]
+    field_x1: str
+
 class Marker(Protocol):
     marked: bool
 
@@ -2619,6 +2623,12 @@ class TaggedB(Protocol):
 
     @property
     def tag(self) -> Literal["b"]: ...
+
+class TaggedXY(Protocol):
+    field_x1: str
+
+    @property
+    def tag(self) -> Literal["x", 1]: ...
 
 class Container:
     value: A | B | None
@@ -2640,6 +2650,21 @@ def _(x: A | B):
         reveal_type(x)  # revealed: B
     else:
         reveal_type(x)  # revealed: A
+
+def multiple_tags(x: A | B | X1):
+    if x.tag == "x":
+        reveal_type(x)  # revealed: X1
+        reveal_type(x.field_x1)  # revealed: str
+    elif x.tag == 1:
+        reveal_type(x)  # revealed: X1
+    else:
+        reveal_type(x)  # revealed: A | B
+
+def exclude_one_of_multiple_tags(x: A | B | X1):
+    if x.tag != "x":
+        reveal_type(x)  # revealed: A | B | X1
+    else:
+        reveal_type(x)  # revealed: X1
 
 def truthiness_guard(value: A | B | None):
     if not value:
@@ -2678,6 +2703,15 @@ def protocol_union(value: TaggedA | TaggedB):
     else:
         reveal_type(value)  # revealed: TaggedB
         reveal_type(value.field_b)  # revealed: str
+
+def protocol_union_multiple_tags(value: TaggedA | TaggedB | TaggedXY):
+    if value.tag == "x":
+        reveal_type(value)  # revealed: XY
+        reveal_type(value.field_x1)  # revealed: str
+    elif value.tag == "y":
+        reveal_type(value)  # revealed: XY
+    else:
+        reveal_type(value)  # revealed: TaggedA | TaggedB
 ```
 
 Enum literals are also supported as attribute tags:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -2718,11 +2718,12 @@ def protocol_union(value: TaggedA | TaggedB):
         reveal_type(value.field_b)  # revealed: str
 
 def protocol_union_multiple_tags(value: TaggedA | TaggedC1):
-    if value.tag == "c":
+    if value.tag == "a":
+        reveal_type(value)  # revealed: TaggedA
+        reveal_type(value.field_a)  # revealed: int
+    else:
         reveal_type(value)  # revealed: TaggedC1
         reveal_type(value.field_c1)  # revealed: str
-    else:
-        reveal_type(value)  # revealed: TaggedA | TaggedC1
 ```
 
 Enum literals are also supported as attribute tags:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -2605,9 +2605,9 @@ class B:
     tag: Literal["b"]
     field_b: str
 
-class X1:
-    tag: Literal["x", 1]
-    field_x1: str
+class C1:
+    tag: Literal["c", 1]
+    field_c1: str
 
 class Marker(Protocol):
     marked: bool
@@ -2624,11 +2624,11 @@ class TaggedB(Protocol):
     @property
     def tag(self) -> Literal["b"]: ...
 
-class TaggedXY(Protocol):
-    field_x1: str
+class TaggedC1(Protocol):
+    field_c1: str
 
     @property
-    def tag(self) -> Literal["x", 1]: ...
+    def tag(self) -> Literal["c", 1]: ...
 
 class Container:
     value: A | B | None
@@ -2651,20 +2651,33 @@ def _(x: A | B):
     else:
         reveal_type(x)  # revealed: A
 
-def multiple_tags(x: A | B | X1):
-    if x.tag == "x":
-        reveal_type(x)  # revealed: X1
-        reveal_type(x.field_x1)  # revealed: str
-    elif x.tag == 1:
-        reveal_type(x)  # revealed: X1
+def multiple_tags(x: A | C1):
+    if x.tag == "a":
+        reveal_type(x)  # revealed: A
+        reveal_type(x.field_a)  # revealed: int
     else:
-        reveal_type(x)  # revealed: A | B
+        reveal_type(x)  # revealed: C1
+        reveal_type(x.field_c1)  # revealed: str
 
-def exclude_one_of_multiple_tags(x: A | B | X1):
-    if x.tag != "x":
-        reveal_type(x)  # revealed: A | B | X1
+    if "a" == x.tag:
+        reveal_type(x)  # revealed: A
     else:
-        reveal_type(x)  # revealed: X1
+        reveal_type(x)  # revealed: C1
+
+    if x.tag != "a":
+        reveal_type(x)  # revealed: C1
+    else:
+        reveal_type(x)  # revealed: A
+
+    if x.tag == "c":
+        reveal_type(x)  # revealed: C1
+    else:
+        reveal_type(x)  # revealed: A | C1
+
+    if x.tag != "c":
+        reveal_type(x)  # revealed: A | C1
+    else:
+        reveal_type(x)  # revealed: C1
 
 def truthiness_guard(value: A | B | None):
     if not value:
@@ -2704,14 +2717,12 @@ def protocol_union(value: TaggedA | TaggedB):
         reveal_type(value)  # revealed: TaggedB
         reveal_type(value.field_b)  # revealed: str
 
-def protocol_union_multiple_tags(value: TaggedA | TaggedB | TaggedXY):
-    if value.tag == "x":
-        reveal_type(value)  # revealed: XY
-        reveal_type(value.field_x1)  # revealed: str
-    elif value.tag == "y":
-        reveal_type(value)  # revealed: XY
+def protocol_union_multiple_tags(value: TaggedA | TaggedC1):
+    if value.tag == "c":
+        reveal_type(value)  # revealed: TaggedC1
+        reveal_type(value.field_c1)  # revealed: str
     else:
-        reveal_type(value)  # revealed: TaggedA | TaggedB
+        reveal_type(value)  # revealed: TaggedA | TaggedC1
 ```
 
 Enum literals are also supported as attribute tags:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -4066,6 +4066,20 @@ def _(x: tuple[A, Literal["tag1"]] | tuple[B, Literal["tag2"]]):
             reveal_type(x)  # revealed: Never
 ```
 
+A tuple with several literal tags can match more than one case. Failing one of those tags leaves the
+tuple available to later cases:
+
+```py
+def multiple_tags(x: tuple[Literal["a"], int] | tuple[Literal["b", "c"], str]):
+    match x[0]:
+        case "b":
+            reveal_type(x)  # revealed: tuple[Literal["b", "c"], str]
+        case "a":
+            reveal_type(x)  # revealed: tuple[Literal["a"], int]
+        case _:
+            reveal_type(x)  # revealed: tuple[Literal["b", "c"], str]
+```
+
 Narrowing is restricted to `Literal` tag elements:
 
 ```py
@@ -4121,6 +4135,20 @@ def _(x: A | B):
             reveal_type(x.field_b)  # revealed: str
         case _:
             reveal_type(x)  # revealed: Never
+```
+
+A class can also have several literal tags. A pattern outside that set of tags rules out the class:
+
+```py
+class MultipleTags:
+    tag: Literal["b", "c"]
+
+def multiple_tags(x: A | MultipleTags):
+    match x.tag:
+        case "a":
+            reveal_type(x)  # revealed: A
+        case _:
+            reveal_type(x)  # revealed: MultipleTags
 ```
 
 Non-literal tag arms are preserved during positive narrowing:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6160,6 +6160,37 @@ def _(u: Foo | Bar):
         reveal_type(u)  # revealed: Bar
 ```
 
+A union member can have several possible tags. Comparing against a different member's tag removes
+the multi-tag member from the matching branch, including in unions with more than two members:
+
+```py
+class MultiTag(TypedDict):
+    tag: Literal["bar", "baz"]
+
+def two_members(u: Foo | MultiTag):
+    if u["tag"] == "foo":
+        reveal_type(u)  # revealed: Foo
+    else:
+        reveal_type(u)  # revealed: MultiTag
+
+def three_members(u: Foo | MultiTag | Bar):
+    if u["tag"] != "foo":
+        reveal_type(u)  # revealed: MultiTag | Bar
+    else:
+        reveal_type(u)  # revealed: Foo
+```
+
+Matching one of several tags selects that member, but excluding just one of its tags does not remove
+it from the union:
+
+```py
+def match_one_tag(u: Foo | MultiTag):
+    if u["tag"] == "bar":
+        reveal_type(u)  # revealed: MultiTag
+    else:
+        reveal_type(u)  # revealed: Foo | MultiTag
+```
+
 Boolean tags can be narrowed by truthiness, including through a generic `TypedDict` and a type
 alias:
 
@@ -6311,6 +6342,22 @@ class WackyInt(int):
         return True
 
 _: NonLiteralTD = {"tag": WackyInt(99)}  # allowed
+```
+
+The same restriction applies to a tag union containing a non-literal type. The `int` alternative can
+still hold a `WackyInt` that compares equal to `"foo"`:
+
+```py
+class MixedTag(TypedDict):
+    tag: Literal["bar"] | int
+
+def mixed_tag(u: Foo | MixedTag):
+    if u["tag"] == "foo":
+        reveal_type(u)  # revealed: Foo | MixedTag
+    else:
+        reveal_type(u)  # revealed: MixedTag
+
+_: MixedTag = {"tag": WackyInt(99)}
 ```
 
 Intersections containing a TypedDict with literal fields can be narrowed with equality checks. Since
@@ -6578,6 +6625,23 @@ def match_statements(u: Foo | Bar | Baz | Bing):
             reveal_type(u)  # revealed: Baz
         case _:
             reveal_type(u)  # revealed: Bing
+```
+
+A tag can contain multiple literal values. A literal pattern selects the matching dictionary;
+failing one of its tags leaves the other tag possible in later cases:
+
+```py
+class MultiTag(TypedDict):
+    tag: Literal["bar", "baz"]
+
+def match_multiple_tags(u: Foo | MultiTag | Bar):
+    match u["tag"]:
+        case "foo":
+            reveal_type(u)  # revealed: Foo
+        case "bar":
+            reveal_type(u)  # revealed: MultiTag
+        case _:
+            reveal_type(u)  # revealed: MultiTag | Bar
 ```
 
 Enum literal tags are also supported in match statements:

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4960,7 +4960,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .ignore_possibly_undefined()
                 .is_none_or(|attribute_type| match (comparison, is_positive) {
                     (NominalAttributeComparison::Equality, true) => {
-                        !is_supported_tag_literal_annotation(db, attribute_type)
+                        !is_supported_tag_literal_or_union(db, attribute_type)
                             || !attribute_type.is_disjoint_from(db, &self.env, rhs_type)
                     }
                     (NominalAttributeComparison::Equality, false) => {
@@ -5162,17 +5162,16 @@ fn is_supported_tag_literal(ty: Type) -> bool {
     )
 }
 
-/// Return true if the given type is a literal type with one or more supported literal values of
-/// the same kind, e.g. `Literal["A", "B"]`. These types are represented as a `Type::Union(_)`.
-fn is_supported_tag_literal_annotation(db: &dyn Db, ty: Type) -> bool {
+/// Return true if the given type is a literal type with one or more supported literal values,
+/// e.g. `Literal[1, "A", "B"]`. These types are represented as `Type::Union(_)`.
+fn is_supported_tag_literal_or_union(db: &dyn Db, ty: Type) -> bool {
     match ty {
-        Type::LiteralValue(_) => is_supported_tag_literal(ty),
         Type::Union(union) => union
             .elements(db)
             .iter()
             .copied()
             .all(is_supported_tag_literal),
-        _ => false,
+        _ => is_supported_tag_literal(ty),
     }
 }
 
@@ -5191,7 +5190,7 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
         typeddict
             .items(db)
             .get(field_name)
-            .is_none_or(|field| is_supported_tag_literal_annotation(db, field.declared_ty))
+            .is_none_or(|field| is_supported_tag_literal_or_union(db, field.declared_ty))
     };
 
     match ty {
@@ -5297,7 +5296,7 @@ fn all_matching_tuple_elements_have_literal_types<'db>(
     union.elements(db).iter().all(|elem| {
         elem.tuple_instance_spec(db, env)
             .and_then(|spec| spec.py_index(db, env, index).ok())
-            .is_none_or(|ty| is_supported_tag_literal_annotation(db, ty))
+            .is_none_or(|ty| is_supported_tag_literal_or_union(db, ty))
     })
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4960,7 +4960,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .ignore_possibly_undefined()
                 .is_none_or(|attribute_type| match (comparison, is_positive) {
                     (NominalAttributeComparison::Equality, true) => {
-                        !is_supported_tag_literal(attribute_type)
+                        !is_supported_tag_literal_annotation(db, attribute_type)
                             || !attribute_type.is_disjoint_from(db, &self.env, rhs_type)
                     }
                     (NominalAttributeComparison::Equality, false) => {
@@ -5162,6 +5162,20 @@ fn is_supported_tag_literal(ty: Type) -> bool {
     )
 }
 
+/// Return true if the given type is a literal type with one or more supported literal values of
+/// the same kind, e.g. `Literal["A", "B"]`. These types are represented as a `Type::Union(_)`.
+fn is_supported_tag_literal_annotation(db: &dyn Db, ty: Type) -> bool {
+    match ty {
+        Type::LiteralValue(_) => is_supported_tag_literal(ty),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .copied()
+            .all(is_supported_tag_literal),
+        _ => false,
+    }
+}
+
 // Return true if the given type is a `TypedDict` whose `field_name` field has a supported tag literal
 // type, or a union in which all elements that are `TypedDict`s have a supported tag literal type
 // for that field, or an intersection in which all positive elements that are `TypedDict`s have a
@@ -5177,7 +5191,7 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
         typeddict
             .items(db)
             .get(field_name)
-            .is_none_or(|field| is_supported_tag_literal(field.declared_ty))
+            .is_none_or(|field| is_supported_tag_literal_annotation(db, field.declared_ty))
     };
 
     match ty {
@@ -5283,7 +5297,7 @@ fn all_matching_tuple_elements_have_literal_types<'db>(
     union.elements(db).iter().all(|elem| {
         elem.tuple_instance_spec(db, env)
             .and_then(|spec| spec.py_index(db, env, index).ok())
-            .is_none_or(is_supported_tag_literal)
+            .is_none_or(|ty| is_supported_tag_literal_annotation(db, ty))
     })
 }
 


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/4359.

## Summary

ty determines whether to narrow the type of a tagged union by checking if the tag is of a supported literal type. However, literals with multiple possible values are represented as `Type::Union`, which fails the check.

This can be fixed by checking that all values in the union are literals. Not sure if this is the best way to approach the problem, but it should at least provide a general direction.

Note: there is still one behavior that might be unwanted:
```python
def protocol_union_multiple_tags(value: TaggedA | TaggedC1):
    if value.tag == "c":
        reveal_type(value)  # revealed: TaggedC1
    elif value.tag == 1:
        reveal_type(value)  # revealed: TaggedC1
    else:
        reveal_type(value.tag)  # revealed: Literal["a"]
        reveal_type(value)  # revealed: TaggedA | TaggedC1
```
The last case could have been just `TaggedA`, but that is out of scope for this PR.

## Test Plan

Added mdtests for the new supported case.
