### PR TITLE
[ty] Infer `yield from` send/return types from the iterator returned by `__iter__`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -460,6 +460,7 @@ def f[T](x: int) -> (y := 3):
 
 def _():
     # error: [invalid-syntax] "yield expression cannot be used within a generic definition"
+    # error: [invalid-base] "Invalid class base with type `None`"
     class C[T]((yield from [object])):
         pass
 ```

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/semantic_syntax_errors.md
@@ -460,7 +460,6 @@ def f[T](x: int) -> (y := 3):
 
 def _():
     # error: [invalid-syntax] "yield expression cannot be used within a generic definition"
-    # error: [invalid-base] "Invalid class base with type `None`"
     class C[T]((yield from [object])):
         pass
 ```

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -178,6 +178,72 @@ def mixed_send(value: Wrapped | Sequence) -> Generator[int, int, None]:
     yield from value
 ```
 
+## `yield from` with union send types
+
+The outer generator's send type must be accepted by every possible delegated generator. An `int`
+cannot be forwarded to an iterator that might require `str`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generator
+
+class IntBox:
+    def __iter__(self) -> Generator[int, int, None]:
+        yield 1
+
+class StrBox:
+    def __iter__(self) -> Generator[int, str, None]:
+        yield 1
+
+def incompatible_boxes(box: IntBox | StrBox) -> Generator[int, int, None]:
+    yield from box  # error: [invalid-yield]
+```
+
+The same check applies when `__iter__` itself returns a union, including through a type alias, or
+when the operand is already a union of generators:
+
+```py
+type EitherGenerator = Generator[int, int, None] | Generator[int, str, None]
+
+class UnionBox:
+    def __iter__(self) -> EitherGenerator:
+        yield 1
+
+def incompatible_iterators() -> Generator[int, int, None]:
+    yield from UnionBox()  # error: [invalid-yield]
+
+def incompatible_generators(inner: EitherGenerator) -> Generator[int, int, None]:
+    yield from inner  # error: [invalid-yield]
+```
+
+Delegation is valid when every alternative accepts the outer send type, even if the alternatives
+also accept different additional types:
+
+```py
+class OverlappingBox:
+    def __iter__(self) -> Generator[int, int | str, None] | Generator[int, int | bytes, None]:
+        yield 1
+
+def compatible_iterators() -> Generator[int, int, None]:
+    yield from OverlappingBox()
+```
+
+Gradual send types are checked against each alternative separately. `list[Any]` is assignable to
+both `list[int]` and `list[str]`, so this delegation is accepted:
+
+```py
+from typing import Any
+
+def gradual_send(
+    inner: Generator[int, list[int], None] | Generator[int, list[str], None],
+) -> Generator[int, list[Any], None]:
+    yield from inner
+```
+
 ## `yield from` with a generator that return `types.GeneratorType`
 
 `types.GeneratorType` is a nominal type that implements the `typing.Generator` protocol:

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -76,7 +76,7 @@ therefore determined by the iterator returned by `x.__iter__()`, even if `x` its
 generator:
 
 ```py
-from typing import Generator, Iterator
+from typing import Generator
 
 class Box:
     def __iter__(self) -> Generator[str, None, int]:
@@ -106,20 +106,44 @@ def outer_ok() -> Generator[int, int, None]:
     yield from SendBox()
 ```
 
-If `__iter__` returns a plain `Iterator`, the value of the `yield from` expression is `None`, just
-like for a generator annotated as returning an `Iterator`:
+## `yield from` with a plain `Iterator`
+
+An `Iterator` annotation specifies the yielded type, but not the value of `StopIteration.value`. The
+result of delegating to such an iterator is therefore `Unknown`, even when it is returned by a
+custom iterable's `__iter__` method:
 
 ```py
+from typing import Generator, Iterator
+
+class Finished:
+    def __iter__(self) -> "Finished":
+        return self
+
+    def __next__(self) -> str:
+        raise StopIteration(42)
+
 class Plain:
     def __iter__(self) -> Iterator[str]:
-        yield "a"
+        return Finished()
 
-def plain() -> Generator[str, None, None]:
+def plain() -> Generator[str, None, int]:
     result = yield from Plain()
-    reveal_type(result)  # revealed: None
+    reveal_type(result)  # revealed: Unknown
+    return result
+```
 
+The same applies to an iterator used directly and to a built-in iterable whose `__iter__` method
+returns a plain `Iterator`:
+
+```py
+def direct(iterator: Iterator[str]) -> Generator[str, None, int]:
+    result = yield from iterator
+    reveal_type(result)  # revealed: Unknown
+    return result
+
+def builtin() -> Generator[str, None, None]:
     result = yield from ["a", "b"]
-    reveal_type(result)  # revealed: None
+    reveal_type(result)  # revealed: Unknown
 ```
 
 ## `yield from` with a generator that return `types.GeneratorType`

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -146,6 +146,38 @@ def builtin() -> Generator[str, None, None]:
     reveal_type(result)  # revealed: Unknown
 ```
 
+## `yield from` with alternative iteration protocols
+
+An iterable union can mix a generator-returning `__iter__` with the sequence protocol. The
+`__getitem__` alternative contributes to the result of `yield from`, so the return type of the
+generator alone does not describe every possible result:
+
+```py
+from typing import Generator
+
+class Wrapped:
+    def __iter__(self) -> Generator[int, int | None, str]:
+        yield 1
+        return "done"
+
+class Sequence:
+    def __getitem__(self, index: int) -> int:
+        raise IndexError
+
+def mixed(value: Wrapped | Sequence) -> Generator[int, None, object]:
+    result = yield from value
+    reveal_type(result)  # revealed: Unknown
+    return result
+```
+
+The sequence iterator does not support sending a non-`None` value, even though the generator does:
+
+```py
+def mixed_send(value: Wrapped | Sequence) -> Generator[int, int, None]:
+    # error: [invalid-yield] "Send type `None` does not match annotated send type `int`"
+    yield from value
+```
+
 ## `yield from` with a generator that return `types.GeneratorType`
 
 `types.GeneratorType` is a nominal type that implements the `typing.Generator` protocol:

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -24,8 +24,8 @@ def outer_generator():
 
 ## `yield from` with a custom iterable
 
-`yield from` can also be used with custom iterable types. In that case, the type of the `yield from`
-expression cannot be determined
+`yield from` can also be used with custom iterable types. If the iterator returned by `__iter__` is
+not a generator, the type of the `yield from` expression cannot be determined:
 
 ```py
 from typing import Generator, TypeVar, Generic
@@ -67,6 +67,59 @@ def generator() -> Generator[str]:
     # (the more common case), then the `.value` attribute of the `StopIteration` instance
     # would default to `None`.
     reveal_type(result)  # revealed: Unknown
+```
+
+## `yield from` with a custom iterable whose `__iter__` returns a generator
+
+`yield from x` delegates to `iter(x)`. The send and return types of the `yield from` expression are
+therefore determined by the iterator returned by `x.__iter__()`, even if `x` itself is not a
+generator:
+
+```py
+from typing import Generator, Iterator
+
+class Box:
+    def __iter__(self) -> Generator[str, None, int]:
+        yield "hello"
+        return 42
+
+def main() -> Generator[str, None, int]:
+    x = yield from Box()
+    reveal_type(x)  # revealed: int
+
+    y: str = yield from Box()  # error: [invalid-assignment]
+    return x
+```
+
+The send type of the inner generator is also validated against the outer generator's send type:
+
+```py
+class SendBox:
+    def __iter__(self) -> Generator[int, int, None]:
+        x = yield 1
+
+def outer() -> Generator[int, str, None]:
+    # error: [invalid-yield] "Send type `int` does not match annotated send type `str`"
+    yield from SendBox()
+
+def outer_ok() -> Generator[int, int, None]:
+    yield from SendBox()
+```
+
+If `__iter__` returns a plain `Iterator`, the value of the `yield from` expression is `None`, just
+like for a generator annotated as returning an `Iterator`:
+
+```py
+class Plain:
+    def __iter__(self) -> Iterator[str]:
+        yield "a"
+
+def plain() -> Generator[str, None, None]:
+    result = yield from Plain()
+    reveal_type(result)  # revealed: None
+
+    result = yield from ["a", "b"]
+    reveal_type(result)  # revealed: None
 ```
 
 ## `yield from` with a generator that return `types.GeneratorType`

--- a/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/yield_and_yield_from.md
@@ -344,8 +344,9 @@ def mixing_generator_async_generator() -> Generator[int, int, None] | AsyncGener
     return None
 ```
 
-`Iterator` has no send type or return type, It is equivalent to using `Generator` with send set to
-`None` and return type to `Unknown`.
+Within generator functions annotated as `Iterator` or `AsyncIterator`, we infer `None` for `yield`
+expressions. These annotations expose iteration with `next()` or `anext()`, not a `send` or `asend`
+method.
 
 ```py
 def iterator_send_none() -> Iterator[int]:
@@ -359,6 +360,52 @@ async def async_iterator_send_none() -> AsyncIterator[int]:
 def iterator_yield_from() -> Generator[int, None, int]:
     yield from iterator_send_none()
     return 1
+```
+
+## `yield from` with an `Iterator` return annotation
+
+An outer `Iterator` annotation does not expose a `send` method. Advancing the outer iterator with
+`next()` also advances the delegated generator with `next()`, so its send type does not restrict
+this delegation:
+
+```py
+from typing import Generator, Iterator
+
+class Wrapped:
+    def __iter__(self) -> Generator[int, str, None]:
+        yield 1
+
+def iterator() -> Iterator[int]:
+    yield from Wrapped()
+```
+
+The yielded values are still checked against the outer annotation:
+
+```py
+def invalid_yield() -> Iterator[str]:
+    # error: [invalid-yield] "Yield type `int` does not match annotated yield type `str`"
+    yield from Wrapped()
+```
+
+An explicit `Generator` annotation still constrains the values sent to the delegated generator:
+
+```py
+def invalid_send() -> Generator[int, int, None]:
+    # error: [invalid-yield] "Send type `str` does not match annotated send type `int`"
+    yield from Wrapped()
+```
+
+An `Iterator` member in a return-type union does not remove the other members' explicit send
+requirements. Here the yielded `int` values require the `Generator` alternative, whose send type
+must be compatible with the delegated generator:
+
+```py
+def mixed_annotation() -> Iterator[str] | Generator[int, int, None]:
+    # error: [invalid-yield] "Send type `str` does not match annotated send type `int`"
+    yield from Wrapped()
+
+def compatible_mixed_annotation() -> Iterator[str] | Generator[int, str, None]:
+    yield from Wrapped()
 ```
 
 ## Generator type aliases
@@ -392,6 +439,9 @@ type IteratorAlias[T] = Iterator[T]
 def invalid_iterator_return() -> IteratorAlias[int]:
     yield 42
     return "foo"  # error: [invalid-return-type]
+
+def aliased_iterator(inner: Generator[int, str, None]) -> IteratorAlias[int]:
+    yield from inner
 
 type AsyncGeneratorAlias[T] = AsyncGenerator[T]
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7349,6 +7349,32 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Extract explicit send constraints from a generator function's return annotation.
+    ///
+    /// An iterator annotation does not expose `send`, but its presence in a union must not
+    /// discard the send constraints from other generator alternatives.
+    fn generator_annotation_send_type(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Type<'db>> {
+        if let Some(union) = self.as_union_like(db) {
+            let mut send_types = union
+                .elements(db)
+                .iter()
+                .filter_map(|ty| ty.generator_annotation_send_type(db, env));
+            let first = send_types.next()?;
+            return Some(
+                send_types
+                    .fold(UnionBuilder::new(db, env).add(first), UnionBuilder::add)
+                    .build(),
+            );
+        }
+
+        self.generator_types(db, env, GeneratorTypeMode::GeneratorOnly)
+            .and_then(|types| types.send_ty)
+    }
+
     fn generator_return_type(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7358,6 +7358,30 @@ impl<'db> Type<'db> {
             .and_then(|generator_types| generator_types.return_ty)
     }
 
+    /// Find a delegated generator's send type that cannot accept `send_ty`.
+    ///
+    /// Check union members independently to preserve gradual assignability. Intersecting
+    /// `list[int]` and `list[str]` would give `Never`, incorrectly rejecting `list[Any]`.
+    fn incompatible_yield_from_send_type(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        send_ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        if let Some(union) = self.as_union_like(db) {
+            return union
+                .elements(db)
+                .iter()
+                .find_map(|ty| ty.incompatible_yield_from_send_type(db, env, send_ty));
+        }
+
+        let inner_send_ty = self
+            .generator_types(db, env, GeneratorTypeMode::GeneratorOnly)
+            .and_then(|generator_types| generator_types.send_ty)
+            .unwrap_or_else(|| Type::none(db, env));
+        (!send_ty.is_assignable_to(db, env, inner_send_ty)).then_some(inner_send_ty)
+    }
+
     /// Return the instance approximation, discarding whether the projection is exact.
     ///
     /// Use this only when an over-approximation is sound, such as constructor inference or a

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1762,6 +1762,30 @@ fn recursive_type_normalize_type_guard_like<'db, T: TypeGuardLike<'db>>(
     Some(guard.with_type(db, ty))
 }
 
+/// Whether generator-type extraction supplies defaults for iterator annotations.
+///
+/// `Iterator[T]` and `AsyncIterator[T]` constrain yielded values but do not declare
+/// send or return types. Defaults used to check a generator body do not describe
+/// an arbitrary iterator's termination value or establish a send requirement.
+#[derive(Clone, Copy)]
+enum GeneratorTypeMode {
+    /// Extract parameters exposed by `Generator` or `AsyncGenerator`, without
+    /// supplying defaults for plain iterators.
+    ///
+    /// Use this when inferring a delegated iterator's `yield from` result or
+    /// determining whether an outer generator annotation declares a send type.
+    /// An `Iterator[T]` can terminate with `StopIteration(42)`, so its annotation
+    /// does not imply that the `yield from` result is `None`.
+    GeneratorOnly,
+    /// Also recognize `Iterator[T]` and `AsyncIterator[T]`, using `T` as the yield
+    /// type and `None` as both the send and return types.
+    ///
+    /// These defaults support inference of `yield` expressions and validation of
+    /// `yield` and `return` statements in generator bodies. Return-type extraction
+    /// also uses this mode, including when inferring `await` expressions.
+    IteratorDefaults,
+}
+
 #[derive(Debug, Clone, Copy)]
 #[expect(clippy::struct_field_names)]
 struct GeneratorTypes<'db> {
@@ -7180,14 +7204,12 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Get the return type of a `yield from …` expression where `self` is the type of the generator.
-    ///
-    /// This corresponds to the `ReturnT` parameter of the generic `typing.Generator[YieldT, SendT, ReturnT]`
-    /// protocol.
+    /// Extract the yield, send, and return types of a generator.
     fn generator_types(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        mode: GeneratorTypeMode,
     ) -> Option<GeneratorTypes<'db>> {
         // TODO: Ideally, we would first try to upcast `self` to an instance of `Generator` and *then*
         // match on the protocol instance to get the `ReturnType` type parameter. For now, implement
@@ -7217,8 +7239,9 @@ impl<'db> Type<'db> {
                     send_ty: Some(*send_ty),
                     return_ty: None,
                 })
-            } else if (class.is_known(db, KnownClass::Iterator)
-                || class.is_known(db, KnownClass::AsyncIterator))
+            } else if matches!(mode, GeneratorTypeMode::IteratorDefaults)
+                && (class.is_known(db, KnownClass::Iterator)
+                    || class.is_known(db, KnownClass::AsyncIterator))
                 && let [yield_ty] = specialization.types(db)
             {
                 let none = Type::none(db, env);
@@ -7245,14 +7268,14 @@ impl<'db> Type<'db> {
                         .materialization_kind(db)
                         .map_or(types, |kind| types.materialize(db, env, kind))
                 }),
-            Type::TypeAlias(alias) => alias.value_type(db).generator_types(db, env),
+            Type::TypeAlias(alias) => alias.value_type(db).generator_types(db, env, mode),
             Type::Union(union) => {
                 let mut yield_builder = Some(UnionBuilder::new(db, env));
                 let mut send_builder = Some(UnionBuilder::new(db, env));
                 let mut return_builder = Some(UnionBuilder::new(db, env));
 
                 for ty in union.elements(db) {
-                    let gt = ty.generator_types(db, env)?;
+                    let gt = ty.generator_types(db, env, mode)?;
                     match gt.yield_ty {
                         Some(ty) => yield_builder = yield_builder.map(|b| b.add(ty)),
                         None => yield_builder = None,
@@ -7283,7 +7306,7 @@ impl<'db> Type<'db> {
                 let mut any_success = false;
 
                 for ty in intersection.positive(db) {
-                    let Some(gt) = ty.generator_types(db, env) else {
+                    let Some(gt) = ty.generator_types(db, env, mode) else {
                         continue;
                     };
                     any_success = true;
@@ -7331,7 +7354,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Type<'db>> {
-        self.generator_types(db, env)
+        self.generator_types(db, env, GeneratorTypeMode::IteratorDefaults)
             .and_then(|generator_types| generator_types.return_ty)
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7335,15 +7335,6 @@ impl<'db> Type<'db> {
             .and_then(|generator_types| generator_types.return_ty)
     }
 
-    fn generator_send_type(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Option<Type<'db>> {
-        self.generator_types(db, env)
-            .and_then(|generator_types| generator_types.send_ty)
-    }
-
     /// Return the instance approximation, discarding whether the projection is exact.
     ///
     /// Use this only when an over-approximation is sound, such as constructor inference or a

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9715,9 +9715,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
         }
 
+        // `yield from x` delegates to `iter(x)`, so the send and return types of the
+        // expression are those of the *iterator*. If `x` is itself a generator (or iterator),
+        // that's `x`. Otherwise, e.g. for an instance of a class whose `__iter__` method is a
+        // generator function, we look at the return type of `x.__iter__()`.
+        let inner_generator_types = iterable_type.generator_types(db, env).or_else(|| {
+            let iterator_type = match iterable_type.try_call_dunder(
+                db,
+                env,
+                "__iter__",
+                CallArguments::none(),
+                TypeContext::default(),
+            ) {
+                Ok(bindings) => Some(bindings.return_type(db, env)),
+                Err(err) => err.return_type(db, env),
+            }?;
+            iterator_type.generator_types(db, env)
+        });
+
         if let Some(outer_send_ty) = outer_expected.send_ty {
-            let inner_send_ty = iterable_type
-                .generator_send_type(db, env)
+            let inner_send_ty = inner_generator_types
+                .and_then(|generator_types| generator_types.send_ty)
                 .unwrap_or_else(|| Type::none(db, env));
             if !outer_send_ty.is_assignable_to(db, env, inner_send_ty) {
                 report_invalid_generator_yield_type(
@@ -9731,8 +9749,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        iterable_type
-            .generator_return_type(db, env)
+        inner_generator_types
+            .and_then(|generator_types| generator_types.return_ty)
             .unwrap_or_else(Type::unknown)
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -116,14 +116,15 @@ use crate::types::typevar::{
 use crate::types::unpacker::UnpackResult;
 use crate::types::{
     BindingContext, BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType,
-    CallableTypes, ClassType, DynamicType, InferenceFlags, InternedConstraintSet, InternedType,
-    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, KnownUnion,
-    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter,
-    Parameters, ProgramEnvironment, SentinelInstance, Signature, SpecialFormType, SubclassOfType,
-    Type, TypeAliasType, TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints,
-    TypeVarKind, TypeVarVariance, TypingModule, UnionAccumulator, UnionBuilder, UnionType,
-    any_over_type, binding_type, extract_fixed_length_iterable_element_types,
-    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
+    CallableTypes, ClassType, DynamicType, GeneratorTypeMode, InferenceFlags,
+    InternedConstraintSet, InternedType, IntersectionBuilder, IntersectionType, KnownClass,
+    KnownInstanceType, KnownUnion, LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy,
+    ParamSpecAttrKind, Parameter, Parameters, ProgramEnvironment, SentinelInstance, Signature,
+    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
+    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypingModule,
+    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
+    extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
+    is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, DisplaySettings, FxIndexSet, FxOrderSet};
 use ty_python_core::definition::{
@@ -9636,7 +9637,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         .return_ty;
         let return_type_span = enclosing_function.spans(self.db()).return_type;
 
-        let Some(generator_type_params) = declared_return_ty.generator_types(db, env) else {
+        let Some(generator_type_params) =
+            declared_return_ty.generator_types(db, env, GeneratorTypeMode::IteratorDefaults)
+        else {
             let _ = self.infer_optional_expression(value.as_deref(), TypeContext::default());
             return Type::unknown();
         };
@@ -9684,7 +9687,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         )
         .return_ty;
 
-        let Some(outer_expected) = annotated_return_ty.generator_types(db, env) else {
+        let Some(outer_expected) =
+            annotated_return_ty.generator_types(db, env, GeneratorTypeMode::IteratorDefaults)
+        else {
             let _ = self.infer_expression(value, TypeContext::default());
             return Type::unknown();
         };
@@ -9716,22 +9721,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // `yield from x` delegates to `iter(x)`, so the send and return types of the
-        // expression are those of the *iterator*. If `x` is itself a generator (or iterator),
-        // that's `x`. Otherwise, e.g. for an instance of a class whose `__iter__` method is a
+        // expression are those of the *iterator*. If `x` is itself a generator, that's `x`.
+        // Otherwise, e.g. for an instance of a class whose `__iter__` method is a
         // generator function, we look at the return type of `x.__iter__()`.
-        let inner_generator_types = iterable_type.generator_types(db, env).or_else(|| {
-            let iterator_type = match iterable_type.try_call_dunder(
-                db,
-                env,
-                "__iter__",
-                CallArguments::none(),
-                TypeContext::default(),
-            ) {
-                Ok(bindings) => Some(bindings.return_type(db, env)),
-                Err(err) => err.return_type(db, env),
-            }?;
-            iterator_type.generator_types(db, env)
-        });
+        let inner_generator_types = iterable_type
+            .generator_types(db, env, GeneratorTypeMode::GeneratorOnly)
+            .or_else(|| {
+                let iterator_type = match iterable_type.try_call_dunder(
+                    db,
+                    env,
+                    "__iter__",
+                    CallArguments::none(),
+                    TypeContext::default(),
+                ) {
+                    Ok(bindings) => Some(bindings.return_type(db, env)),
+                    Err(err) => err.return_type(db, env),
+                }?;
+                // `Iterator` has no type parameter for `StopIteration.value`.
+                iterator_type.generator_types(db, env, GeneratorTypeMode::GeneratorOnly)
+            });
 
         if let Some(outer_send_ty) = outer_expected.send_ty {
             let inner_send_ty = inner_generator_types

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9749,7 +9749,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .map(|types| (iterator_type, types))
             });
 
-        if let Some(outer_send_ty) = outer_expected.send_ty {
+        // `Iterator` annotations constrain yielded values but do not expose a send method.
+        if let Some(outer_send_ty) = annotated_return_ty.generator_annotation_send_type(db, env) {
             let incompatible_send_ty = match inner_generator {
                 Some((iterator_type, _)) => {
                     iterator_type.incompatible_yield_from_send_type(db, env, outer_send_ty)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9735,6 +9735,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     TypeContext::default(),
                 ) {
                     Ok(bindings) => Some(bindings.return_type(db, env)),
+                    Err(CallDunderError::PossiblyUnbound { .. }) => {
+                        // Iteration can fall back to `__getitem__` where `__iter__` is absent.
+                        // The available `__iter__` bindings do not describe those alternatives.
+                        None
+                    }
                     Err(err) => err.return_type(db, env),
                 }?;
                 // `Iterator` has no type parameter for `StopIteration.value`.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9724,8 +9724,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // expression are those of the *iterator*. If `x` is itself a generator, that's `x`.
         // Otherwise, e.g. for an instance of a class whose `__iter__` method is a
         // generator function, we look at the return type of `x.__iter__()`.
-        let inner_generator_types = iterable_type
+        let inner_generator = iterable_type
             .generator_types(db, env, GeneratorTypeMode::GeneratorOnly)
+            .map(|types| (iterable_type, types))
             .or_else(|| {
                 let iterator_type = match iterable_type.try_call_dunder(
                     db,
@@ -9743,14 +9744,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     Err(err) => err.return_type(db, env),
                 }?;
                 // `Iterator` has no type parameter for `StopIteration.value`.
-                iterator_type.generator_types(db, env, GeneratorTypeMode::GeneratorOnly)
+                iterator_type
+                    .generator_types(db, env, GeneratorTypeMode::GeneratorOnly)
+                    .map(|types| (iterator_type, types))
             });
 
         if let Some(outer_send_ty) = outer_expected.send_ty {
-            let inner_send_ty = inner_generator_types
-                .and_then(|generator_types| generator_types.send_ty)
-                .unwrap_or_else(|| Type::none(db, env));
-            if !outer_send_ty.is_assignable_to(db, env, inner_send_ty) {
+            let incompatible_send_ty = match inner_generator {
+                Some((iterator_type, _)) => {
+                    iterator_type.incompatible_yield_from_send_type(db, env, outer_send_ty)
+                }
+                None => {
+                    let none = Type::none(db, env);
+                    (!outer_send_ty.is_assignable_to(db, env, none)).then_some(none)
+                }
+            };
+            if let Some(inner_send_ty) = incompatible_send_ty {
                 report_invalid_generator_yield_type(
                     &self.context,
                     value.as_ref(),
@@ -9762,8 +9771,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        inner_generator_types
-            .and_then(|generator_types| generator_types.return_ty)
+        inner_generator
+            .and_then(|(_, generator_types)| generator_types.return_ty)
             .unwrap_or_else(Type::unknown)
     }
 


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4368. This is my attempt to fix the issue by using AI. 

`yield from x` delegates to `iter(x)`, so the value of the expression (and the send type that must be compatible with the outer generator) comes from the *iterator* returned by `x.__iter__()`, not from `x` itself. Previously we only looked at `x`'s own MRO for `Generator`/`Iterator`, so for a class whose `__iter__` is a generator function we inferred `Unknown` and skipped the send-type check:

```py
class Box:
    def __iter__(self) -> Generator[str, None, int]:
        yield "hello"
        return 42

def main() -> Generator[str, None, int]:
    x = yield from Box()
    reveal_type(x)  # was: Unknown, now: int
    y: str = yield from Box()  # now: error[invalid-assignment]
    return x
```

This PR resolves the inner `GeneratorTypes` once in `infer_yield_from_expression`: if the operand itself is a generator/iterator we use that (unchanged behaviour, keeps the protocol materialization handling), otherwise we call `__iter__` and take the generator types of the returned iterator. Both the send-type validation and the expression's type now use that. The now-unused `generator_send_type` helper is removed.

`yield from` over a plain Iterator now consistently returns `Unknown`, since the `Iterator` type does not specify the return type, and an iterator implementation could raise `StopIteration` with any value, without violating any annotated type.

## Test Plan

- New mdtests in `expression/yield_and_yield_from.md` covering the issue's example, a send-type mismatch detected through `__iter__`, and the `Iterator` / list case.
- `cargo test -p ty_python_semantic`, `cargo clippy -p ty_python_semantic --all-targets -- -D warnings`, `cargo fmt --check`.
- Checked the built CLI against the repro from the issue and against a real-world codebase relying on this pattern (effecton); the expected new diagnostic appears and nothing else changes.