### PR TITLE
[ty] Add a benchmark that has all rules enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,6 +3192,7 @@ dependencies = [
  "tracing",
  "ty_module_resolver",
  "ty_project",
+ "ty_python_semantic",
  "ty_static",
 ]
 

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -126,6 +126,7 @@ ignored = [
     "ruff_python_parser",
     "ruff_python_trivia",
     "ty_module_resolver",
+    "ty_python_semantic",
     "mimalloc",
     "tikv-jemallocator"
 ]

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -24,6 +24,7 @@ ruff_python_parser = { workspace = true, optional = true }
 ruff_python_trivia = { workspace = true, optional = true }
 ty_module_resolver = { workspace = true, optional = true }
 ty_project = { workspace = true, optional = true }
+ty_python_semantic = { workspace = true, optional = true }
 
 anyhow = { workspace = true }
 codspeed-criterion-compat = { workspace = true, default-features = false, optional = true }
@@ -60,7 +61,7 @@ ruff_instrumented = [
     "tikv-jemallocator",
 ]
 # Enables the ty instrumented benchmarks
-ty_instrumented = ["criterion", "ty_project", "ruff_python_trivia"]
+ty_instrumented = ["criterion", "ty_project", "ty_python_semantic", "ruff_python_trivia"]
 # Enables the module-resolution benchmark
 module_resolution = ["divan", "ty_module_resolver", "ty_project"]
 codspeed = ["codspeed-criterion-compat"]

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -13,8 +13,8 @@ use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::source::source_text;
 use ruff_db::system::{InMemorySystem, MemoryFileSystem, SystemPath, SystemPathBuf, TestSystem};
-use ruff_ranged_value::RangedValue;
-use ty_project::metadata::options::{AnalysisOptions, EnvironmentOptions, Options};
+use ruff_ranged_value::{RangedValue, ValueSource};
+use ty_project::metadata::options::{AnalysisOptions, EnvironmentOptions, Options, Rules};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::watch::{ChangeEvent, ChangedKind};
@@ -1485,6 +1485,7 @@ struct ProjectBenchmark<'a> {
     fs: MemoryFileSystem,
     max_diagnostics: usize,
     freeze_inputs: bool,
+    rules: Option<Rules>,
 }
 
 impl<'a> ProjectBenchmark<'a> {
@@ -1499,6 +1500,7 @@ impl<'a> ProjectBenchmark<'a> {
             fs,
             max_diagnostics,
             freeze_inputs: false,
+            rules: None,
         }
     }
 
@@ -1519,6 +1521,7 @@ impl<'a> ProjectBenchmark<'a> {
                 python: Some(RelativePathBuf::cli(SystemPath::new(".venv"))),
                 ..EnvironmentOptions::default()
             }),
+            rules: self.rules.clone(),
             ..Options::default()
         });
 
@@ -1619,6 +1622,17 @@ fn attrs(criterion: &mut Criterion) {
     // Keep one real-world benchmark frozen to catch regressions from newly added inputs.
     let frozen_benchmark = benchmark.freeze_inputs();
     bench_project_named(&frozen_benchmark, criterion, "attrs (frozen inputs)");
+
+    let all_rules_benchmark = ProjectBenchmark {
+        freeze_inputs: false,
+        rules: Options::from_toml_str("rules.all = 'error'", ValueSource::Cli)
+            .expect("valid rule configuration")
+            .rules,
+        max_diagnostics: 100,
+        ..frozen_benchmark
+    };
+
+    bench_project_named(&all_rules_benchmark, criterion, "attrs (all rules)");
 }
 
 fn anyio(criterion: &mut Criterion) {

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -13,12 +13,13 @@ use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::source::source_text;
 use ruff_db::system::{InMemorySystem, MemoryFileSystem, SystemPath, SystemPathBuf, TestSystem};
-use ruff_ranged_value::{RangedValue, ValueSource};
+use ruff_ranged_value::RangedValue;
 use ty_project::metadata::options::{AnalysisOptions, EnvironmentOptions, Options, Rules};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::watch::{ChangeEvent, ChangedKind};
 use ty_project::{CheckMode, Db, ProjectDatabase, ProjectMetadata};
+use ty_python_semantic::lint::Level;
 
 mod ty_shared;
 
@@ -1625,9 +1626,10 @@ fn attrs(criterion: &mut Criterion) {
 
     let all_rules_benchmark = ProjectBenchmark {
         freeze_inputs: false,
-        rules: Options::from_toml_str("rules.all = 'error'", ValueSource::Cli)
-            .expect("valid rule configuration")
-            .rules,
+        rules: Some(Rules::from_iter([(
+            RangedValue::cli("all".to_owned()),
+            RangedValue::cli(Level::Error),
+        )])),
         max_diagnostics: 100,
         ..frozen_benchmark
     };


### PR DESCRIPTION
## Summary

Add an `attrs (all rules)` CodSpeed benchmark that runs the same project as the existing default-rules benchmark, with every rule enabled at error severity (`--error=all`). This gives us performance coverage for disabled-by-default rules.

## Motivation

The motivation is that I'm seeing persistent slowdowns on setuptools in the ecosystem-analyzer report on https://github.com/astral-sh/ruff/pull/27634 (and codex says it can reproduce them locally), but we currently have no codspeed coverage for disabled-by-default rules.

I picked `attrs` just because we type-check `attrs` fairly quickly and it's a pretty well-written codebase. We already use the project for our frozen-inputs benchmark. I haven't checked whether this new benchmark reproduces a slowdown on #27634, but it does seem important that we should have at least one codspeed CI benchmark giving us coverage.

## CodSpeed results

_The following section is all codex-authored._

### Benchmark cost

The [CodSpeed results for `dc560af`](https://app.codspeed.io/astral-sh/ruff/runs/6a8b3ed12dd980af0c4a25d0?q=attrs) show almost no additional per-check cost on attrs currently:

| Configuration | CPU-simulated time |
| --- | ---: |
| Default rules | 655.7 ms |
| All rules | 657.4 ms |

Enabling all rules takes approximately **1.7 ms (0.26%) longer**. Both measurements come from the same run. These are CPU-simulation measurements, not wall-clock durations.

### CI shard duration

The projects shards in [CI run 32658608739](https://github.com/astral-sh/ruff/actions/runs/32658608739) took longer than their averages across the ten preceding successful main-branch CI runs:

| Projects shard | Previous average | This PR | Increase |
| --- | ---: | ---: | ---: |
| [Simulation](https://github.com/astral-sh/ruff/actions/runs/32658608739/job/97241576324) | 7m 52.5s | 10m 07s | 2m 14.5s (28.5%) |
| [Memory](https://github.com/astral-sh/ruff/actions/runs/32658608739/job/97241576376) | 6m 00.2s | 7m 21s | 1m 20.8s (22.4%) |

Neither is the longest CodSpeed shard. Simulation projects ranks second, behind [simulation microbenchmarks at **12m 31s**](https://github.com/astral-sh/ruff/actions/runs/32658608739/job/97241576460). Memory projects ranks fourth.

The baseline covers August 21–23, 2026, and durations exclude queue time. This compares one PR run with ten historical runs, so the increases should not be interpreted as precise estimates of the change's added cost. The new benchmark itself occupies approximately **54 seconds of simulation instrumentation** and **41 seconds of memory instrumentation**, based on the consecutive frozen-input and all-rules completion timestamps in the job logs. Historical simulation-shard durations ranged from 5m 29s to 9m 06s, and memory-shard durations from 4m 41s to 6m 43s.

<details>
<summary>Baseline runs</summary>

The benchmark source and CI workflow are unchanged between the earliest and latest baseline commits. Durations are calculated from each job's `started_at` and `completed_at` timestamps.

| Main-branch CI run | Simulation projects | Memory projects |
| --- | ---: | ---: |
| [32657383200](https://github.com/astral-sh/ruff/actions/runs/32657383200) | 8m 37s | 6m 35s |
| [32657337783](https://github.com/astral-sh/ruff/actions/runs/32657337783) | 6m 54s | 5m 41s |
| [32590011112](https://github.com/astral-sh/ruff/actions/runs/32590011112) | 7m 05s | 5m 54s |
| [32573739110](https://github.com/astral-sh/ruff/actions/runs/32573739110) | 9m 03s | 4m 41s |
| [32573181418](https://github.com/astral-sh/ruff/actions/runs/32573181418) | 8m 19s | 6m 38s |
| [32532383556](https://github.com/astral-sh/ruff/actions/runs/32532383556) | 7m 53s | 6m 38s |
| [32529917638](https://github.com/astral-sh/ruff/actions/runs/32529917638) | 5m 29s | 6m 43s |
| [32525938153](https://github.com/astral-sh/ruff/actions/runs/32525938153) | 7m 43s | 5m 53s |
| [32519274517](https://github.com/astral-sh/ruff/actions/runs/32519274517) | 9m 06s | 6m 33s |
| [32516047668](https://github.com/astral-sh/ruff/actions/runs/32516047668) | 8m 36s | 4m 46s |

</details>
