### PR TITLE
[ty] Specialize Self bounds of inherited methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -664,6 +664,25 @@ reveal_type(int_container)  # revealed: Container[int]
 reveal_type(int_container.set_value(1))  # revealed: Container[int]
 ```
 
+## Unbound inherited methods on generic classes
+
+When an inherited method returns `Self`, its return type is the type of the instance passed to it.
+This includes the subclass and its type arguments, even when the call uses `Child` rather than
+`Child[int]`.
+
+```py
+from typing import Self
+
+class Parent[T]:
+    def get_self(self) -> Self:
+        return self
+
+class Child[U](Parent[U]): ...
+
+def _(child: Child[int]):
+    reveal_type(Child.get_self(child))  # revealed: Child[int]
+```
+
 ## Generic class with bounded type variable
 
 This is a regression test for <https://github.com/astral-sh/ty/issues/2467>.

--- a/crates/ty_python_semantic/resources/mdtest/generics/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/builtins.md
@@ -1,5 +1,27 @@
 # Generic builtins
 
+## Unbound inherited methods
+
+Methods inherited by `list` and `dict` can be called through the unsubscripted class, with an
+instance passed explicitly as the receiver. Their implicit `Self` bounds use the class's default
+type arguments, just as methods declared directly on the class do.
+
+```py
+def clear_containers(items: list[int], mapping: dict[str, int]) -> None:
+    list.clear(items)
+    list.reverse(items)
+    dict.clear(mapping)
+
+    list.append(items, 1)
+    dict.__setitem__(mapping, "a", 1)
+
+    list[int].clear(items)
+    dict[str, int].clear(mapping)
+
+    list[int].clear(["a"])  # error: [invalid-argument-type]
+    dict[str, int].clear({"a": "b"})  # error: [invalid-argument-type]
+```
+
 ## Variadic keyword arguments with a custom `dict`
 
 When we define `dict` in a custom typeshed, we must take care to define it as a generic class in the

--- a/crates/ty_python_semantic/resources/mdtest/generics/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/builtins.md
@@ -2,24 +2,14 @@
 
 ## Unbound inherited methods
 
-Methods inherited by `list` and `dict` can be called through the unsubscripted class, with an
-instance passed explicitly as the receiver. Their implicit `Self` bounds use the class's default
-type arguments, just as methods declared directly on the class do.
+In typeshed, `list` inherits `clear` from `MutableSequence`, and `dict` inherits it from
+`MutableMapping`. We can call these methods through `list` and `dict` without supplying type
+arguments.
 
 ```py
 def clear_containers(items: list[int], mapping: dict[str, int]) -> None:
     list.clear(items)
-    list.reverse(items)
     dict.clear(mapping)
-
-    list.append(items, 1)
-    dict.__setitem__(mapping, "a", 1)
-
-    list[int].clear(items)
-    dict[str, int].clear(mapping)
-
-    list[int].clear(["a"])  # error: [invalid-argument-type]
-    dict[str, int].clear({"a": "b"})  # error: [invalid-argument-type]
 ```
 
 ## Variadic keyword arguments with a custom `dict`

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -811,62 +811,39 @@ reveal_type(PartiallyFixed.unresolved)  # revealed: Unknown
 
 ## Unbound inherited methods
 
-An inherited instance method accessed through an unspecialized generic subclass uses the subclass's
-default type arguments in both its signature and the upper bound of its implicit `Self` parameter.
-The class type variables are not inferred from the receiver passed to the unbound method.
+An inherited method can be called through the subclass, passing the instance explicitly. Without
+type arguments, `Child.get` uses `Unknown` for `U`; it does not infer `U` from the instance.
 
 ```py
-from typing import Self
-
 class Parent[T]:
     def get(self) -> T:
         raise NotImplementedError
 
-    def copy(self) -> Self:
-        return self
-
 class Child[U](Parent[U]): ...
-class Grandchild[V](Child[V]): ...
 
-def get_values(parent: Parent[int], child: Child[int], grandchild: Grandchild[int]):
-    reveal_type(Parent.get(parent))  # revealed: Unknown
+def _(child: Child[int]):
     reveal_type(Child.get(child))  # revealed: Unknown
-    reveal_type(Grandchild.get(grandchild))  # revealed: Unknown
-    reveal_type(Child[int].get(child))  # revealed: int
-
-    Child.get(1)  # error: [invalid-argument-type]
 ```
 
-Applying default type arguments to the bound of `Self` does not replace `Self` itself: a method
-returning `Self` preserves the concrete receiver type, including its type arguments.
-
-```py
-def copy_values(child: Child[int], grandchild: Grandchild[str]):
-    reveal_type(Child.copy(child))  # revealed: Child[int]
-    reveal_type(Grandchild.copy(grandchild))  # revealed: Grandchild[str]
-```
-
-Default type arguments also propagate through nested specializations in the base class.
-
-```py
-class NestedChild[U](Parent[tuple[int, U]]): ...
-
-def get_nested(child: NestedChild[str]):
-    reveal_type(NestedChild.get(child))  # revealed: tuple[int, Unknown]
-    reveal_type(NestedChild[str].get(child))  # revealed: tuple[int, str]
-```
-
-Declared defaults also constrain the receiver of an unbound inherited method. A receiver with a
-different type argument is rejected, just as it is for an explicitly specialized class.
+An explicit default also determines which instances the method accepts. `DefaultChild.get` uses
+`int` for `U`, so it accepts a `DefaultChild[int]` but rejects a `DefaultChild[str]`.
 
 ```py
 class DefaultChild[U = int](Parent[U]): ...
 
-def get_defaults(int_child: DefaultChild[int], str_child: DefaultChild[str]):
+def _(int_child: DefaultChild[int], str_child: DefaultChild[str]):
     reveal_type(DefaultChild.get(int_child))  # revealed: int
-    reveal_type(DefaultChild[str].get(str_child))  # revealed: str
     DefaultChild.get(str_child)  # error: [invalid-argument-type]
-    DefaultChild[int].get(str_child)  # error: [invalid-argument-type]
+```
+
+Defaults also apply when a type parameter appears inside a base class's type argument. Only `U`
+becomes `Unknown` below; the `int` in `tuple[int, U]` is unchanged.
+
+```py
+class NestedChild[U](Parent[tuple[int, U]]): ...
+
+def _(child: NestedChild[str]):
+    reveal_type(NestedChild.get(child))  # revealed: tuple[int, Unknown]
 ```
 
 ## Generic methods

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -809,6 +809,66 @@ reveal_type(PartiallyFixed.fixed)  # revealed: int
 reveal_type(PartiallyFixed.unresolved)  # revealed: Unknown
 ```
 
+## Unbound inherited methods
+
+An inherited instance method accessed through an unspecialized generic subclass uses the subclass's
+default type arguments in both its signature and the upper bound of its implicit `Self` parameter.
+The class type variables are not inferred from the receiver passed to the unbound method.
+
+```py
+from typing import Self
+
+class Parent[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def copy(self) -> Self:
+        return self
+
+class Child[U](Parent[U]): ...
+class Grandchild[V](Child[V]): ...
+
+def get_values(parent: Parent[int], child: Child[int], grandchild: Grandchild[int]):
+    reveal_type(Parent.get(parent))  # revealed: Unknown
+    reveal_type(Child.get(child))  # revealed: Unknown
+    reveal_type(Grandchild.get(grandchild))  # revealed: Unknown
+    reveal_type(Child[int].get(child))  # revealed: int
+
+    Child.get(1)  # error: [invalid-argument-type]
+```
+
+Applying default type arguments to the bound of `Self` does not replace `Self` itself: a method
+returning `Self` preserves the concrete receiver type, including its type arguments.
+
+```py
+def copy_values(child: Child[int], grandchild: Grandchild[str]):
+    reveal_type(Child.copy(child))  # revealed: Child[int]
+    reveal_type(Grandchild.copy(grandchild))  # revealed: Grandchild[str]
+```
+
+Default type arguments also propagate through nested specializations in the base class.
+
+```py
+class NestedChild[U](Parent[tuple[int, U]]): ...
+
+def get_nested(child: NestedChild[str]):
+    reveal_type(NestedChild.get(child))  # revealed: tuple[int, Unknown]
+    reveal_type(NestedChild[str].get(child))  # revealed: tuple[int, str]
+```
+
+Declared defaults also constrain the receiver of an unbound inherited method. A receiver with a
+different type argument is rejected, just as it is for an explicitly specialized class.
+
+```py
+class DefaultChild[U = int](Parent[U]): ...
+
+def get_defaults(int_child: DefaultChild[int], str_child: DefaultChild[str]):
+    reveal_type(DefaultChild.get(int_child))  # revealed: int
+    reveal_type(DefaultChild[str].get(str_child))  # revealed: str
+    DefaultChild.get(str_child)  # error: [invalid-argument-type]
+    DefaultChild[int].get(str_child)  # error: [invalid-argument-type]
+```
+
 ## Generic methods
 
 Generic classes can contain methods that are themselves generic. The generic methods can refer to

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1381,7 +1381,11 @@ impl<'db> StaticClassLiteral<'db> {
                     let member =
                         self.class_member_from_mro(db, env, name, policy, self.iter_mro(db, None));
                     let specialization = generic_context.default_specialization(db, self.known(db));
-                    member.map_type(|ty| ty.apply_specialization(db, specialization))
+                    // An inherited method's `Self` bound can still contain this class's type
+                    // variables, so the default arguments must also specialize that bound.
+                    member.map_type(|ty| {
+                        ty.apply_optional_owner_specialization_to_member(db, Some(specialization))
+                    })
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

Previously, we rejected calls to inherited methods through unsubscripted generic classes:

```python
def clear_containers(items: list[int], mapping: dict[str, int]) -> None:
    list.clear(items)
    list.reverse(items)
    dict.clear(mapping)
```

Inherited member lookup applied the subclass's default type arguments to ordinary signature types, but left class-scoped type variables inside the upper bound of `Self`. For example, `list.clear` retained a bound of `MutableSequence[_T@list]`, even though `_T@list` is not inferable at the call site.

We now apply the owner's default specialization to `Self` bounds as well. This accepts compatible receivers while preserving declared defaults, incompatible-receiver errors, and concrete return types for methods returning `Self`. Constructor inference remains unchanged.

Closes https://github.com/astral-sh/ty/issues/4353.
