### PR TITLE
[ty] `collections.abc.Callable` is an instance of `type`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -236,13 +236,17 @@ reveal_type(CollectionsAbcCallable)  # revealed: <special-form 'collections.abc.
 
 ## Class-pattern behavior for `typing.Callable` and `collections.abc.Callable`
 
-At runtime, `collections.abc.Callable` is supported in `match` statement class patterns, however
-`typing.Callable` is not.
+At runtime, `collections.abc.Callable` is an instance of `type` and is supported in `match`
+statement class patterns; however, `typing.Callable` is not.
 
 ### `collections.abc.Callable`
 
 ```py
 from collections import abc
+
+def accepts_type(x: type): ...
+
+accepts_type(abc.Callable)  # no diagnostic
 
 def _(subj: None | abc.Callable[..., str]) -> None:
     match subj:
@@ -272,6 +276,10 @@ def _(subj: abc.Callable[..., str]) -> None:
 
 ```py
 import typing
+
+def accepts_type(x: type): ...
+
+accepts_type(typing.Callable)  # error: [invalid-argument-type]
 
 def _(subj: None | typing.Callable[..., str]) -> None:
     match subj:

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -148,7 +148,6 @@ impl SpecialFormType {
             | Self::TypeForm
             | Self::TypingSelf
             | Self::TypingCallable
-            | Self::CollectionsAbcCallable
             | Self::Concatenate
             | Self::Unpack
             | Self::TypeAlias
@@ -175,7 +174,7 @@ impl SpecialFormType {
             // as being valid.
             Self::Protocol => KnownClass::ProtocolMeta,
 
-            Self::Generic | Self::Any => KnownClass::Type,
+            Self::Generic | Self::Any | Self::CollectionsAbcCallable => KnownClass::Type,
 
             Self::LegacyStdlibAlias(_) => KnownClass::StdlibAlias,
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1215. We now model `collections.abc.Callable` as an instance of `type`, since it is at runtime.

We originally closed that issue because:
- It would have required some special-casing from ty to support the feature being requested
- It wasn't clear what problems the bug was actually causing

Since then, however:
- We added the necessary special-casing anyway, to support other features
- It is now clear that it does actually cause problems to not model `collections.abc.Callable` as an instance of `type`: it's causing false positives to show up in the ecosystem report for https://github.com/astral-sh/ruff/pull/27634

## Test Plan

mdtests