### PR TITLE
fix(linter): avoid external rule hint for Ruff suppressions

### DIFF
--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -368,7 +368,6 @@ error[RUF102]: Invalid rule code in suppression: unknown-rule, unused-import
  9 | import sys
 10 | # ruff:enable[unused-import, unknown-rule]
    | ------------------------------------------
-help: Add non-Ruff rule codes to the `lint.external` configuration option
 help: Enable `lint.preview` to use rule names
 help: Remove the suppression comment
   |
@@ -481,7 +480,6 @@ error[RUF102]: Invalid rule code in suppression: not-a-rule
   |
 2 | # ruff:ignore[unused-import, not-a-rule]
   |                              ^^^^^^^^^^
-help: Add non-Ruff rule codes to the `lint.external` configuration option
 help: Remove the rule code `not-a-rule`
   |
 1 | # snapshot: invalid-rule-code
@@ -836,7 +834,6 @@ error[RUF102]: Invalid rule code in suppression: XYZ
   |
 3 | # ruff:ignore[XYZ] # ruff:file-ignore[F821]
   |               ^^^
-help: Add non-Ruff rule codes to the `lint.external` configuration option
 help: Remove the suppression comment
   |
 2 | # error: [invalid-suppression-comment]

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -241,9 +241,6 @@ struct SuppressionDiagnostic<'a> {
     disabled_codes: Vec<&'a str>,
     unused_codes: Vec<&'a str>,
 
-    /// Whether one of the invalid codes was totally unknown and may be external.
-    has_unknown_code: bool,
-
     /// Whether one of the invalid codes was a rule name with preview disabled.
     has_stable_rule_name: bool,
 }
@@ -256,7 +253,6 @@ impl<'a> SuppressionDiagnostic<'a> {
             duplicated_codes: Vec::new(),
             disabled_codes: Vec::new(),
             unused_codes: Vec::new(),
-            has_unknown_code: false,
             has_stable_rule_name: false,
         }
     }
@@ -467,11 +463,6 @@ impl Suppressions {
                         whole_comment: group.suppression.codes().len() == group.invalid_codes.len(),
                     },
                 ) {
-                    if group.has_unknown_code {
-                        diagnostic.help(
-                            "Add non-Ruff rule codes to the `lint.external` configuration option",
-                        );
-                    }
                     if group.has_stable_rule_name {
                         diagnostic.help("Enable `lint.preview` to use rule names");
                     }
@@ -524,7 +515,6 @@ impl Suppressions {
                 let (_key, group) = grouped_diagnostic
                     .get_or_insert_with(|| (key, SuppressionDiagnostic::new(suppression)));
                 group.invalid_codes.push(code_str);
-                group.has_unknown_code |= !name_is_known;
                 group.has_stable_rule_name |= name_is_known;
             } else if !suppression.used.get() {
                 // UnusedNOQA


### PR DESCRIPTION
## Summary

Fixes #27880.

RUF102 diagnostics for Ruff-specific suppression comments such as `# ruff: ignore`, `# ruff: disable`, and `# ruff: enable` no longer suggest configuring `lint.external`.

That option is intended to preserve third-party codes in `# noqa` directives, so mentioning it for Ruff suppression syntax was misleading.

The suppression behavior and fixes are unchanged. This change only removes the incorrect help item and updates the regression snapshots.

## Test Plan

- `cargo fmt --check`
- `cargo test -p ruff_linter --lib rules::ruff::tests::invalid_rule_code_external_rules`
- `cargo test -p ruff_mdtest --test mdtest -- suppression/ignore.md`