### PR TITLE
[ty] Prefer the deepest valid search root for module names

### DIFF
--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -410,8 +410,11 @@ fn file_to_module_with_name<'db>(
     resolver_file: ResolverFile<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
-    // A containing root can give this file a name that is shadowed by another file.
-    // Only accept the name if resolving it leads back to this file.
+    // Resolve the module name to see if Python would resolve the name to the same path.
+    // If it doesn't, then that means that multiple modules have the same name in different
+    // root paths, but that the module corresponding to this file is in a lower priority search path,
+    // in which case we ignore this candidate name. Another enclosing root may still give the file
+    // a name that resolves back to it.
     let module = resolve_module(db, ImportingFile::ResolverFile(resolver_file), module_name)?;
     let module_file = module.file(db)?;
 

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -389,7 +389,11 @@ fn file_to_module_impl<'db, 'a>(
         // over `project` when naming `project/pkg/src/pkg/module.py`.
         let root_length = match candidate.as_path() {
             SystemOrVendoredPathRef::System(root) => root.as_str().len(),
-            SystemOrVendoredPathRef::Vendored(root) => root.as_str().len(),
+            SystemOrVendoredPathRef::Vendored(_) => {
+                // Vendored search roots don't overlap, so there's no other enclosing root to try.
+                let module_name = relative_path.to_module_name()?;
+                return file_to_module_with_name(db, resolver_file, &module_name);
+            }
         };
         if best_match.is_some_and(|(best_length, _)| best_length >= root_length) {
             continue;

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -2088,7 +2088,6 @@ mod tests {
     )]
     use std::assert_matches;
 
-    use anyhow::Context;
     use ruff_db::Db;
     use ruff_db::files::{File, FilePath, system_path_to_file};
     use ruff_db::system::{DbWithTestSystem as _, DbWithWritableSystem as _};
@@ -3559,76 +3558,6 @@ not_a_directory
                 .path(&db)
                 .as_str()
                 .ends_with("src/a/__init__.py"),
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn file_to_module_prefers_deepest_search_path() -> anyhow::Result<()> {
-        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
-            .with_src_files(&[
-                ("nested/package/__init__.py", ""),
-                ("nested/package/module.py", ""),
-                ("nested/package/module.pyi", ""),
-            ])
-            .build();
-        let nested = src.join("nested");
-
-        for src_roots in [vec![src.clone(), nested.clone()], vec![nested.clone(), src]] {
-            let search_paths = SearchPathSettings::new(src_roots).to_search_paths(
-                db.system(),
-                db.vendored(),
-                &FallibleStrategy,
-            )?;
-            db.set_search_paths(search_paths);
-
-            for (filename, expected_name) in [
-                ("__init__.py", "package"),
-                ("module.py", "package.module"),
-                ("module.pyi", "package.module"),
-            ] {
-                let path = nested.join("package").join(filename);
-                let module = path_to_module(&db, &FilePath::from(path.clone()))
-                    .context("File should resolve through the nested root")?;
-                assert_eq!(module.name(&db), expected_name);
-                assert_eq!(
-                    module.search_path(&db).context("Expected a search path")?,
-                    &nested
-                );
-                assert_eq!(
-                    module.file(&db).map(|file| file.path(&db)),
-                    Some(&FilePath::from(path))
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn file_to_module_falls_back_from_shadowed_deepest_name() -> anyhow::Result<()> {
-        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
-            .with_src_files(&[
-                ("package/__init__.py", ""),
-                ("package/module.py", ""),
-                ("nested/package/__init__.py", ""),
-                ("nested/package/module.py", ""),
-            ])
-            .build();
-        let search_paths = SearchPathSettings::new(vec![src.clone(), src.join("nested")])
-            .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)?;
-        db.set_search_paths(search_paths);
-
-        // `package.module` resolves to the outer file, but the inner file is still
-        // importable as `nested.package.module` through the shallower root.
-        let path = src.join("nested/package/module.py");
-        let module = path_to_module(&db, &FilePath::from(path))
-            .context("File should resolve through the shallower root")?;
-        assert_eq!(module.name(&db), "nested.package.module");
-        assert_eq!(
-            module.search_path(&db).context("Expected a search path")?,
-            &src
         );
 
         Ok(())

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -333,6 +333,7 @@ pub(crate) fn path_to_module<'db>(
 
 /// Resolves the module for the file with the given id.
 ///
+/// Prefers the deepest enclosing search path whose module name resolves back to the file.
 /// Returns `None` if the file is not a module locatable via any of the known search paths.
 ///
 /// This function can be understood as essentially resolving `import .<self>` in the file itself,
@@ -370,21 +371,48 @@ fn file_to_module_impl<'db, 'a>(
     db: &'db dyn Db,
     resolver_file: ResolverFile<'db>,
     path: SystemOrVendoredPathRef<'a>,
-    mut search_paths: impl Iterator<Item = &'a SearchPath>,
+    search_paths: impl Iterator<Item = &'a SearchPath>,
 ) -> Option<Module<'db>> {
-    let module_name = search_paths.find_map(|candidate: &SearchPath| {
+    let mut best_match: Option<(usize, Module<'db>)> = None;
+
+    for candidate in search_paths {
         let relative_path = match path {
             SystemOrVendoredPathRef::System(path) => candidate.relativize_system_path(path),
             SystemOrVendoredPathRef::Vendored(path) => candidate.relativize_vendored_path(path),
-        }?;
-        relative_path.to_module_name()
-    })?;
+        };
+        let Some(relative_path) = relative_path else {
+            continue;
+        };
 
-    // Resolve the module name to see if Python would resolve the name to the same path.
-    // If it doesn't, then that means that multiple modules have the same name in different
-    // root paths, but that the module corresponding to `path` is in a lower priority search path,
-    // in which case we ignore it.
-    let module = resolve_module(db, ImportingFile::ResolverFile(resolver_file), &module_name)?;
+        // All matching roots enclose the same file, so a longer prefix is a deeper root.
+        // For example, an editable install at `project/pkg/src` should take precedence
+        // over `project` when naming `project/pkg/src/pkg/module.py`.
+        let root_length = match candidate.as_path() {
+            SystemOrVendoredPathRef::System(root) => root.as_str().len(),
+            SystemOrVendoredPathRef::Vendored(root) => root.as_str().len(),
+        };
+        if best_match.is_some_and(|(best_length, _)| best_length >= root_length) {
+            continue;
+        }
+
+        if let Some(module_name) = relative_path.to_module_name()
+            && let Some(module) = file_to_module_with_name(db, resolver_file, &module_name)
+        {
+            best_match = Some((root_length, module));
+        }
+    }
+
+    best_match.map(|(_, module)| module)
+}
+
+fn file_to_module_with_name<'db>(
+    db: &'db dyn Db,
+    resolver_file: ResolverFile<'db>,
+    module_name: &ModuleName,
+) -> Option<Module<'db>> {
+    // A containing root can give this file a name that is shadowed by another file.
+    // Only accept the name if resolving it leads back to this file.
+    let module = resolve_module(db, ImportingFile::ResolverFile(resolver_file), module_name)?;
     let module_file = module.file(db)?;
 
     let file: File = resolver_file.file(db);
@@ -398,7 +426,7 @@ fn file_to_module_impl<'db, 'a>(
         // which would make us erroneously believe the `.py` is *not* also this module (breaking things
         // like relative imports). So here we try `resolve_real_module().file` to cover both cases.
         let module =
-            resolve_real_module(db, ImportingFile::ResolverFile(resolver_file), &module_name)?;
+            resolve_real_module(db, ImportingFile::ResolverFile(resolver_file), module_name)?;
         let module_file = module.file(db)?;
         if file_path == module_file.path(db) {
             return Some(module);
@@ -2060,6 +2088,7 @@ mod tests {
     )]
     use std::assert_matches;
 
+    use anyhow::Context;
     use ruff_db::Db;
     use ruff_db::files::{File, FilePath, system_path_to_file};
     use ruff_db::system::{DbWithTestSystem as _, DbWithWritableSystem as _};
@@ -3530,6 +3559,76 @@ not_a_directory
                 .path(&db)
                 .as_str()
                 .ends_with("src/a/__init__.py"),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn file_to_module_prefers_deepest_search_path() -> anyhow::Result<()> {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[
+                ("nested/package/__init__.py", ""),
+                ("nested/package/module.py", ""),
+                ("nested/package/module.pyi", ""),
+            ])
+            .build();
+        let nested = src.join("nested");
+
+        for src_roots in [vec![src.clone(), nested.clone()], vec![nested.clone(), src]] {
+            let search_paths = SearchPathSettings::new(src_roots).to_search_paths(
+                db.system(),
+                db.vendored(),
+                &FallibleStrategy,
+            )?;
+            db.set_search_paths(search_paths);
+
+            for (filename, expected_name) in [
+                ("__init__.py", "package"),
+                ("module.py", "package.module"),
+                ("module.pyi", "package.module"),
+            ] {
+                let path = nested.join("package").join(filename);
+                let module = path_to_module(&db, &FilePath::from(path.clone()))
+                    .context("File should resolve through the nested root")?;
+                assert_eq!(module.name(&db), expected_name);
+                assert_eq!(
+                    module.search_path(&db).context("Expected a search path")?,
+                    &nested
+                );
+                assert_eq!(
+                    module.file(&db).map(|file| file.path(&db)),
+                    Some(&FilePath::from(path))
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn file_to_module_falls_back_from_shadowed_deepest_name() -> anyhow::Result<()> {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[
+                ("package/__init__.py", ""),
+                ("package/module.py", ""),
+                ("nested/package/__init__.py", ""),
+                ("nested/package/module.py", ""),
+            ])
+            .build();
+        let search_paths = SearchPathSettings::new(vec![src.clone(), src.join("nested")])
+            .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)?;
+        db.set_search_paths(search_paths);
+
+        // `package.module` resolves to the outer file, but the inner file is still
+        // importable as `nested.package.module` through the shallower root.
+        let path = src.join("nested/package/module.py");
+        let module = path_to_module(&db, &FilePath::from(path))
+            .context("File should resolve through the shallower root")?;
+        assert_eq!(module.name(&db), "nested.package.module");
+        assert_eq!(
+            module.search_path(&db).context("Expected a search path")?,
+            &src
         );
 
         Ok(())

--- a/crates/ty_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/relative.md
@@ -301,3 +301,42 @@ from .a import A as A
 ```py
 class A: ...
 ```
+
+## Relative imports in a nested editable install
+
+The editable source root is nested inside the project, and the outer directory has the same name as
+the installed package. The file's module name must come from the editable root: `pkg.module`, not
+`pkg.src.pkg.module`.
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/4371>.
+
+```toml
+[environment]
+python = "/.venv"
+python-version = "3.13"
+```
+
+`/.venv/<path-to-site-packages>/pkg.pth`:
+
+```pth
+/src/pkg/src
+```
+
+`pkg/src/pkg/__init__.py`:
+
+```py
+```
+
+`pkg/src/pkg/utils.py`:
+
+```py
+value: int = 42
+```
+
+`pkg/src/pkg/module.py`:
+
+```py
+from . import utils
+
+reveal_type(utils.value)  # revealed: int
+```

--- a/crates/ty_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/relative.md
@@ -269,6 +269,123 @@ X: int = 42
 from .parser import X  # error: [unresolved-import]
 ```
 
+## Overlapping search roots, outer root first
+
+When both search roots give a file an importable module name, relative imports use the name from the
+deepest root. This applies to package initializers, source files, and stub files, including source
+files with a sibling stub.
+
+```toml
+[environment]
+extra-paths = ["/src", "/src/nested"]
+```
+
+`nested/package/utils.py`:
+
+```py
+```
+
+`nested/package/__init__.py`:
+
+```py
+from . import utils
+
+reveal_type(utils)  # revealed: <module 'package.utils'>
+```
+
+`nested/package/module.py`:
+
+```py
+from . import utils
+
+reveal_type(utils)  # revealed: <module 'package.utils'>
+```
+
+`nested/package/module.pyi`:
+
+```pyi
+from . import utils
+
+reveal_type(utils)  # revealed: <module 'package.utils'>
+```
+
+## Overlapping search roots, inner root first
+
+The deepest root still determines the module name when it appears before the outer root in the
+search path list.
+
+```toml
+[environment]
+extra-paths = ["/src/nested", "/src"]
+```
+
+`nested/package/utils.py`:
+
+```py
+```
+
+`nested/package/__init__.py`:
+
+```py
+from . import utils
+
+reveal_type(utils)  # revealed: <module 'package.utils'>
+```
+
+`nested/package/module.py`:
+
+```py
+from . import utils
+
+reveal_type(utils)  # revealed: <module 'package.utils'>
+```
+
+`nested/package/module.pyi`:
+
+```pyi
+from . import utils
+
+reveal_type(utils)  # revealed: <module 'package.utils'>
+```
+
+## Shadowed module name under the deepest root
+
+The inner `module.py` is importable as `nested.package.module`. Its shorter name, `package.module`,
+resolves to the outer file instead. Relative imports therefore use the name from the shallower root.
+
+```toml
+[environment]
+extra-paths = ["/src", "/src/nested"]
+```
+
+`package/__init__.py`:
+
+```py
+```
+
+`package/module.py`:
+
+```py
+```
+
+`nested/package/__init__.py`:
+
+```py
+```
+
+`nested/package/utils.py`:
+
+```py
+```
+
+`nested/package/module.py`:
+
+```py
+from . import utils
+
+reveal_type(utils)  # revealed: <module 'nested.package.utils'>
+```
+
 ## Relative imports in `site-packages`
 
 Relative imports in `site-packages` are correctly resolved even when the `site-packages` search path
@@ -305,8 +422,8 @@ class A: ...
 ## Relative imports in a nested editable install
 
 The editable source root is nested inside the project, and the outer directory has the same name as
-the installed package. The file's module name must come from the editable root: `pkg.module`, not
-`pkg.src.pkg.module`.
+the installed package. The editable root exposes `pkg` as a top-level package, so `module.py` has
+the name `pkg.module`, and its relative import finds `pkg.utils`.
 
 This is a regression test for <https://github.com/astral-sh/ty/issues/4371>.
 

--- a/crates/ty_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/relative.md
@@ -272,8 +272,7 @@ from .parser import X  # error: [unresolved-import]
 ## Overlapping search roots, outer root first
 
 When both search roots give a file an importable module name, relative imports use the name from the
-deepest root. This applies to package initializers, source files, and stub files, including source
-files with a sibling stub.
+deepest root.
 
 ```toml
 [environment]
@@ -285,25 +284,9 @@ extra-paths = ["/src", "/src/nested"]
 ```py
 ```
 
-`nested/package/__init__.py`:
-
-```py
-from . import utils
-
-reveal_type(utils)  # revealed: <module 'package.utils'>
-```
-
 `nested/package/module.py`:
 
 ```py
-from . import utils
-
-reveal_type(utils)  # revealed: <module 'package.utils'>
-```
-
-`nested/package/module.pyi`:
-
-```pyi
 from . import utils
 
 reveal_type(utils)  # revealed: <module 'package.utils'>
@@ -324,25 +307,9 @@ extra-paths = ["/src/nested", "/src"]
 ```py
 ```
 
-`nested/package/__init__.py`:
-
-```py
-from . import utils
-
-reveal_type(utils)  # revealed: <module 'package.utils'>
-```
-
 `nested/package/module.py`:
 
 ```py
-from . import utils
-
-reveal_type(utils)  # revealed: <module 'package.utils'>
-```
-
-`nested/package/module.pyi`:
-
-```pyi
 from . import utils
 
 reveal_type(utils)  # revealed: <module 'package.utils'>
@@ -350,40 +317,30 @@ reveal_type(utils)  # revealed: <module 'package.utils'>
 
 ## Shadowed module name under the deepest root
 
-The inner `module.py` is importable as `nested.package.module`. Its shorter name, `package.module`,
-resolves to the outer file instead. Relative imports therefore use the name from the shallower root.
+The inner `module.py` is importable as `nested.module`. Its shorter name, `module`, resolves to the
+outer file instead. Relative imports therefore use the name from the shallower root.
 
 ```toml
 [environment]
 extra-paths = ["/src", "/src/nested"]
 ```
 
-`package/__init__.py`:
+`module.py`:
 
 ```py
 ```
 
-`package/module.py`:
+`nested/utils.py`:
 
 ```py
 ```
 
-`nested/package/__init__.py`:
-
-```py
-```
-
-`nested/package/utils.py`:
-
-```py
-```
-
-`nested/package/module.py`:
+`nested/module.py`:
 
 ```py
 from . import utils
 
-reveal_type(utils)  # revealed: <module 'nested.package.utils'>
+reveal_type(utils)  # revealed: <module 'nested.utils'>
 ```
 
 ## Relative imports in `site-packages`

--- a/crates/ty_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/relative.md
@@ -317,8 +317,9 @@ reveal_type(utils)  # revealed: <module 'package.utils'>
 
 ## Shadowed module name under the deepest root
 
-The inner `module.py` is importable as `nested.module`. Its shorter name, `module`, resolves to the
-outer file instead. Relative imports therefore use the name from the shallower root.
+The file `/src/nested/module.py` is importable as `nested.module`. The name `module`, derived from
+the deeper root `/src/nested`, resolves to `/src/module.py` instead because `/src` is searched
+first. Relative imports therefore use `nested.module`, derived from `/src`.
 
 ```toml
 [environment]


### PR DESCRIPTION
## Summary

Prefer the deepest enclosing search root whose module name resolves back to the file, preserving source/stub handling and falling back when a deeper name is shadowed.

Fixes astral-sh/ty#4371.

## Test Plan

Testing: Resolver tests, the full semantic mdtest suite, Clippy, repository hooks, and CLI reproductions pass.
