### PR TITLE
[ty] Omit diffs from generated schema and rules checks

### DIFF
--- a/crates/ruff_dev/src/generate_ty_rules.rs
+++ b/crates/ruff_dev/src/generate_ty_rules.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 
 use anyhow::{Result, bail};
 use itertools::Itertools as _;
-use pretty_assertions::StrComparison;
 use regex::{Captures, Regex};
 
 use crate::ROOT_DIR;
@@ -34,8 +33,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
             if current == markdown {
                 println!("Up-to-date: {filename}");
             } else {
-                let comparison = StrComparison::new(&current, &markdown);
-                bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
+                bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`");
             }
         }
         Mode::Write => {

--- a/crates/ruff_dev/src/generate_ty_schema.rs
+++ b/crates/ruff_dev/src/generate_ty_schema.rs
@@ -2,7 +2,6 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Result, bail};
-use pretty_assertions::StrComparison;
 use schemars::generate::SchemaSettings;
 
 use crate::ROOT_DIR;
@@ -33,8 +32,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
             if current == schema_string {
                 println!("Up-to-date: {filename}");
             } else {
-                let comparison = StrComparison::new(&current, &schema_string);
-                bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
+                bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`");
             }
         }
         Mode::Write => {


### PR DESCRIPTION
## Summary

Stop printing full diffs when the checks for `ty.schema.json` and `crates/ty/docs/rules.md` fail. The errors still identify the stale file and tell contributors to run `cargo dev generate-all`.

These files are always regenerated rather than edited manually, so I don't think the diffs are helpful. Meanwhile, the diffs are huge, making it very hard to see if there are any other test failures when reading CI output.