### PR TITLE
[flake8-simplify] Respect side effects in lambda defaults (SIM401)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM401.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM401.py
@@ -153,3 +153,31 @@ var = "default-1" if key not in a_dict else a_dict[key]
 
 # OK (default contains effect)
 var = a_dict[key] if key in a_dict else val1 + val2
+
+###
+# Lambda parameter defaults
+###
+
+# SIM401: literal defaults have no side effects.
+if key in a_dict:
+    var = a_dict[key]
+else:
+    var = lambda x=0, /, y=1, *, z=2: (x, y, z)
+
+# OK: dict.get would evaluate the lambda's default even when the key exists.
+if key in a_dict:
+    var = a_dict[key]
+else:
+    var = lambda value=initialize(): value
+
+# OK: positional-only defaults are also evaluated when the lambda is created.
+if key in a_dict:
+    var = a_dict[key]
+else:
+    var = lambda value=initialize(), /: value
+
+# OK: keyword-only defaults can contain nested side effects.
+if key in a_dict:
+    var = a_dict[key]
+else:
+    var = lambda *, value=(initialize(),): value

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM401_SIM401.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM401_SIM401.py.snap
@@ -157,3 +157,27 @@ help: Replace with `a_dict.get(key, "default-1")`
 153 |
     |
 note: This is an unsafe fix and may change runtime behavior
+
+SIM401 [*] Use `var = a_dict.get(key, lambda x=0, /, y=1, *, z=2: (x, y, z))` instead of an `if` block
+   --> SIM401.py:162:1
+    |
+161 |   # SIM401: literal defaults have no side effects.
+162 | / if key in a_dict:
+163 | |     var = a_dict[key]
+164 | | else:
+165 | |     var = lambda x=0, /, y=1, *, z=2: (x, y, z)
+    | |_______________________________________________^
+166 |
+167 |   # OK: dict.get would evaluate the lambda's default even when the key exists.
+    |
+help: Replace with `var = a_dict.get(key, lambda x=0, /, y=1, *, z=2: (x, y, z))`
+    |
+161 | # SIM401: literal defaults have no side effects.
+    - if key in a_dict:
+    -     var = a_dict[key]
+    - else:
+    -     var = lambda x=0, /, y=1, *, z=2: (x, y, z)
+162 + var = a_dict.get(key, lambda x=0, /, y=1, *, z=2: (x, y, z))
+163 |
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -283,7 +283,16 @@ where
                 any_over_expr(left, &mut *func) || any_over_expr(right, &mut *func)
             }
             Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => any_over_expr(operand, func),
-            Expr::Lambda(ast::ExprLambda { body, .. }) => any_over_expr(body, func),
+            Expr::Lambda(ast::ExprLambda {
+                body, parameters, ..
+            }) => {
+                parameters
+                    .iter()
+                    .flat_map(|parameters| parameters.iter_non_variadic_params())
+                    .filter_map(|parameter| parameter.default.as_deref())
+                    .any(|default| any_over_expr(default, &mut *func))
+                    || any_over_expr(body, func)
+            }
             Expr::If(ast::ExprIf {
                 test,
                 body,


### PR DESCRIPTION
## Summary

Fix `SIM401` false positives when a lambda fallback has side-effectful parameter defaults:

```python
def get_callback(callbacks: dict, key, initialize):
    if key in callbacks:
        callback = callbacks[key]
    else:
        callback = lambda value=initialize(): value
    return callback
```

Replacing the conditional with `callback = callbacks.get(key, lambda value=initialize(): value)` calls `initialize()` even when the key exists. The conditional only calls it when the key is missing.

`any_over_expr` now visits lambda parameter defaults before the body. This extracts the helper change from #27634.

The existing `SIM401` snapshot fixture now covers positional-only, positional-or-keyword, and keyword-only defaults, including a nested call and a literal-default case that still gets a diagnostic.
