### PR TITLE
Limit generated-file check diffs to 100 lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,7 +3269,6 @@ dependencies = [
  "itertools 0.15.0",
  "libcst",
  "markdown",
- "pretty_assertions",
  "rayon",
  "regex",
  "ruff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "colored",
  "ignore",
  "imara-diff",
  "indicatif",

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -35,7 +35,6 @@ indicatif = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
 markdown = { version = "1.0.0" }
-pretty_assertions = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 schemars = { workspace = true }

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -29,6 +29,7 @@ ty_static = { workspace = true }
 
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["wrap_help"] }
+colored = { workspace = true }
 ignore = { workspace = true }
 imara-diff = { workspace = true }
 indicatif = { workspace = true }

--- a/crates/ruff_dev/src/generate_all.rs
+++ b/crates/ruff_dev/src/generate_all.rs
@@ -1,6 +1,9 @@
 //! Run all code and documentation generation steps.
 
+use std::fmt::Write as _;
+
 use anyhow::Result;
+use colored::Colorize;
 use similar::TextDiff;
 
 use crate::{
@@ -58,31 +61,39 @@ pub(crate) fn generated_file_diff(current: &str, generated: &str) -> String {
     let diff = TextDiff::from_lines(current, generated)
         .unified_diff()
         .to_string();
-    let end: usize = diff
-        .split_inclusive('\n')
-        .take(MAX_DIFF_LINES)
-        .map(str::len)
-        .sum();
+    let mut output = String::new();
+    for (index, line) in diff.split_terminator('\n').enumerate() {
+        if index == MAX_DIFF_LINES {
+            let _ = writeln!(output, "… diff truncated after {MAX_DIFF_LINES} lines");
+            break;
+        }
 
-    if end < diff.len() {
-        format!(
-            "{}… diff truncated after {MAX_DIFF_LINES} lines\n",
-            &diff[..end]
-        )
-    } else {
-        diff
+        let line = match line.as_bytes().first() {
+            Some(b'-') => line.red(),
+            Some(b'+') => line.green(),
+            _ => line.normal(),
+        };
+        let _ = writeln!(output, "{line}");
     }
+
+    output
 }
 
 #[cfg(test)]
 mod tests {
+    use colored::Colorize;
+
     use super::generated_file_diff;
 
     #[test]
     fn short_diff() {
         assert_eq!(
             generated_file_diff("unchanged\nold\n", "unchanged\nnew\n"),
-            "@@ -1,2 +1,2 @@\n unchanged\n-old\n+new\n"
+            format!(
+                "@@ -1,2 +1,2 @@\n unchanged\n{}\n{}\n",
+                "-old".red(),
+                "+new".green()
+            )
         );
     }
 
@@ -94,7 +105,7 @@ mod tests {
                 generated_file_diff("", &generated),
                 format!(
                     "@@ -0,0 +1,{line_count} @@\n{}",
-                    "+new\n".repeat(line_count)
+                    format!("{}\n", "+new".green()).repeat(line_count)
                 )
             );
         }
@@ -108,7 +119,7 @@ mod tests {
                 generated_file_diff("", &generated),
                 format!(
                     "@@ -0,0 +1,{line_count} @@\n{}… diff truncated after 100 lines\n",
-                    "+new\n".repeat(99)
+                    format!("{}\n", "+new".green()).repeat(99)
                 )
             );
         }
@@ -119,7 +130,11 @@ mod tests {
         let prefix = "unchanged\n".repeat(150);
         assert_eq!(
             generated_file_diff(&format!("{prefix}old\n"), &format!("{prefix}new\n")),
-            "@@ -148,4 +148,4 @@\n unchanged\n unchanged\n unchanged\n-old\n+new\n"
+            format!(
+                "@@ -148,4 +148,4 @@\n unchanged\n unchanged\n unchanged\n{}\n{}\n",
+                "-old".red(),
+                "+new".green()
+            )
         );
     }
 }

--- a/crates/ruff_dev/src/generate_all.rs
+++ b/crates/ruff_dev/src/generate_all.rs
@@ -1,6 +1,7 @@
 //! Run all code and documentation generation steps.
 
 use anyhow::Result;
+use similar::TextDiff;
 
 use crate::{
     generate_cli_help, generate_docs, generate_json_schema, generate_ty_cli_reference,
@@ -48,4 +49,77 @@ pub(crate) fn main(args: &Args) -> Result<()> {
         mode: args.mode,
     })?;
     Ok(())
+}
+
+/// Limit generated-file diffs so stale files do not overwhelm CI logs.
+pub(crate) fn generated_file_diff(current: &str, generated: &str) -> String {
+    const MAX_DIFF_LINES: usize = 100;
+
+    let diff = TextDiff::from_lines(current, generated)
+        .unified_diff()
+        .to_string();
+    let end: usize = diff
+        .split_inclusive('\n')
+        .take(MAX_DIFF_LINES)
+        .map(str::len)
+        .sum();
+
+    if end < diff.len() {
+        format!(
+            "{}… diff truncated after {MAX_DIFF_LINES} lines\n",
+            &diff[..end]
+        )
+    } else {
+        diff
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generated_file_diff;
+
+    #[test]
+    fn short_diff() {
+        assert_eq!(
+            generated_file_diff("unchanged\nold\n", "unchanged\nnew\n"),
+            "@@ -1,2 +1,2 @@\n unchanged\n-old\n+new\n"
+        );
+    }
+
+    #[test]
+    fn diff_within_limit() {
+        for line_count in [98, 99] {
+            let generated = "new\n".repeat(line_count);
+            assert_eq!(
+                generated_file_diff("", &generated),
+                format!(
+                    "@@ -0,0 +1,{line_count} @@\n{}",
+                    "+new\n".repeat(line_count)
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn truncated_diff() {
+        for line_count in [100, 200] {
+            let generated = "new\n".repeat(line_count);
+            assert_eq!(
+                generated_file_diff("", &generated),
+                format!(
+                    "@@ -0,0 +1,{line_count} @@\n{}… diff truncated after 100 lines\n",
+                    "+new\n".repeat(99)
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn diff_after_unchanged_prefix() {
+        let prefix = "unchanged\n".repeat(150);
+        assert_eq!(
+            generated_file_diff(&format!("{prefix}old\n"), &format!("{prefix}new\n")),
+            "@@ -148,4 +148,4 @@\n unchanged\n unchanged\n unchanged\n-old\n+new\n"
+        );
+    }
 }

--- a/crates/ruff_dev/src/generate_cli_help.rs
+++ b/crates/ruff_dev/src/generate_cli_help.rs
@@ -5,12 +5,11 @@ use std::{fs, str};
 
 use anyhow::{Context, Result, bail};
 use clap::CommandFactory;
-use pretty_assertions::StrComparison;
 
 use ruff::args;
 
 use crate::ROOT_DIR;
-use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
+use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND, generated_file_diff};
 
 const COMMAND_HELP_BEGIN_PRAGMA: &str = "<!-- Begin auto-generated command help. -->\n";
 const COMMAND_HELP_END_PRAGMA: &str = "<!-- End auto-generated command help. -->";
@@ -99,7 +98,7 @@ pub(super) fn main(args: &Args) -> Result<()> {
             if existing == new {
                 println!("up-to-date: {filename}");
             } else {
-                let comparison = StrComparison::new(&existing, &new);
+                let comparison = generated_file_diff(&existing, &new);
                 bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
             }
         }

--- a/crates/ruff_dev/src/generate_json_schema.rs
+++ b/crates/ruff_dev/src/generate_json_schema.rs
@@ -2,11 +2,10 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Result, bail};
-use pretty_assertions::StrComparison;
 use schemars::generate::SchemaSettings;
 
 use crate::ROOT_DIR;
-use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
+use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND, generated_file_diff};
 use ruff_workspace::options::Options;
 
 #[derive(clap::Args)]
@@ -33,7 +32,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
             if current == schema_string {
                 println!("Up-to-date: {filename}");
             } else {
-                let comparison = StrComparison::new(&current, &schema_string);
+                let comparison = generated_file_diff(&current, &schema_string);
                 bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
             }
         }

--- a/crates/ruff_dev/src/generate_ty_cli_reference.rs
+++ b/crates/ruff_dev/src/generate_ty_cli_reference.rs
@@ -5,10 +5,9 @@ use std::path::PathBuf;
 use anyhow::{Result, bail};
 use clap::{Command, CommandFactory};
 use itertools::Itertools;
-use pretty_assertions::StrComparison;
 
 use crate::ROOT_DIR;
-use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
+use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND, generated_file_diff};
 
 use ty::Cli;
 
@@ -34,7 +33,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
                 if current == reference_string {
                     println!("Up-to-date: {filename}");
                 } else {
-                    let comparison = StrComparison::new(&current, &reference_string);
+                    let comparison = generated_file_diff(&current, &reference_string);
                     bail!(
                         "{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}"
                     );

--- a/crates/ruff_dev/src/generate_ty_env_vars_reference.rs
+++ b/crates/ruff_dev/src/generate_ty_env_vars_reference.rs
@@ -5,11 +5,10 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::bail;
-use pretty_assertions::StrComparison;
 
 use ty_static::EnvVars;
 
-use crate::generate_all::Mode;
+use crate::generate_all::{Mode, generated_file_diff};
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -39,7 +38,7 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
                 if current == reference_string {
                     println!("Up-to-date: {filename}");
                 } else {
-                    let comparison = StrComparison::new(&current, &reference_string);
+                    let comparison = generated_file_diff(&current, &reference_string);
                     bail!(
                         "{filename} changed, please run `cargo dev generate-ty-env-vars-reference`:\n{comparison}"
                     );

--- a/crates/ruff_dev/src/generate_ty_options.rs
+++ b/crates/ruff_dev/src/generate_ty_options.rs
@@ -5,14 +5,13 @@ use std::{fmt::Write, path::PathBuf};
 
 use anyhow::bail;
 use itertools::Itertools;
-use pretty_assertions::StrComparison;
 use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
 use ruff_python_trivia::textwrap;
 use ty_project::metadata::Options;
 
 use crate::{
     ROOT_DIR,
-    generate_all::{Mode, REGENERATE_ALL_COMMAND},
+    generate_all::{Mode, REGENERATE_ALL_COMMAND, generated_file_diff},
 };
 
 #[derive(clap::Args)]
@@ -46,7 +45,7 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
             if output == current {
                 println!("Up-to-date: {file_name}");
             } else {
-                let comparison = StrComparison::new(&current, &output);
+                let comparison = generated_file_diff(&current, &output);
                 bail!("{file_name} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
             }
         }

--- a/crates/ruff_dev/src/generate_ty_rules.rs
+++ b/crates/ruff_dev/src/generate_ty_rules.rs
@@ -7,11 +7,10 @@ use std::path::PathBuf;
 
 use anyhow::{Result, bail};
 use itertools::Itertools as _;
-use pretty_assertions::StrComparison;
 use regex::{Captures, Regex};
 
 use crate::ROOT_DIR;
-use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
+use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND, generated_file_diff};
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -34,7 +33,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
             if current == markdown {
                 println!("Up-to-date: {filename}");
             } else {
-                let comparison = StrComparison::new(&current, &markdown);
+                let comparison = generated_file_diff(&current, &markdown);
                 bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
             }
         }

--- a/crates/ruff_dev/src/generate_ty_schema.rs
+++ b/crates/ruff_dev/src/generate_ty_schema.rs
@@ -2,11 +2,10 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Result, bail};
-use pretty_assertions::StrComparison;
 use schemars::generate::SchemaSettings;
 
 use crate::ROOT_DIR;
-use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
+use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND, generated_file_diff};
 use ty_project::metadata::options::Options;
 
 #[derive(clap::Args)]
@@ -33,7 +32,7 @@ pub(crate) fn main(args: &Args) -> Result<()> {
             if current == schema_string {
                 println!("Up-to-date: {filename}");
             } else {
-                let comparison = StrComparison::new(&current, &schema_string);
+                let comparison = generated_file_diff(&current, &schema_string);
                 bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
             }
         }


### PR DESCRIPTION
## Summary

Keep generated-file check failures readable by showing colored unified diffs with three context lines, capped at 100 lines with a truncation marker when more output remains. Apply this consistently across Ruff and ty generators while preserving the regeneration instructions.

Related to #27999.

## Test Plan

Testing: Regression tests with colors enabled and disabled, generator checks, crate-only Clippy, and hooks passed.
