### PR TITLE
[ty] Account for known subclasses in equality inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/byte_literals.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/byte_literals.md
@@ -1,5 +1,7 @@
 # Comparison: Byte literals
 
+## Literal comparisons
+
 These tests assert that we infer precise `Literal` types for comparisons between objects inferred as
 having `Literal` bytes types:
 
@@ -40,4 +42,19 @@ reveal_type(b"abc" is b"ab")  # revealed: Literal[False]
 
 reveal_type(b"abc" is not b"abc")  # revealed: bool
 reveal_type(b"abc" is not b"ab")  # revealed: Literal[True]
+```
+
+## Equality with sequences
+
+A `Sequence[int]` can be a `bytes` object, including an empty one, so comparing it with a bytes
+literal has an unknown result:
+
+```py
+from collections.abc import Sequence
+
+def _(value: Sequence[int]):
+    reveal_type(value == b"")  # revealed: bool
+    reveal_type(b"" == value)  # revealed: bool
+    reveal_type(value != b"")  # revealed: bool
+    reveal_type(b"" != value)  # revealed: bool
 ```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/strings.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/strings.md
@@ -37,3 +37,30 @@ def _(value: LiteralString):
     reveal_type(value == "")  # revealed: bool
     reveal_type(value != "")  # revealed: bool
 ```
+
+## Equality with sequences
+
+A `Sequence[str]` can be a string, including the empty string, so comparing it with a string literal
+has an unknown result:
+
+```py
+from collections.abc import Sequence
+
+def _(value: Sequence[str]):
+    reveal_type(value == "")  # revealed: bool
+    reveal_type("" == value)  # revealed: bool
+    reveal_type(value != "")  # revealed: bool
+    reveal_type("" != value)  # revealed: bool
+```
+
+The result is also unknown when the string's precise literal value is not known:
+
+```py
+from typing_extensions import LiteralString
+
+def _(value: Sequence[str], other: LiteralString):
+    reveal_type(value == other)  # revealed: bool
+    reveal_type(other == value)  # revealed: bool
+    reveal_type(value != other)  # revealed: bool
+    reveal_type(other != value)  # revealed: bool
+```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
@@ -543,6 +543,69 @@ def _(
     reveal_type(prefix_int_var_int < prefix_int_var_bool)  # revealed: bool
 ```
 
+## Equality with sequences
+
+A `Sequence[object]` can be an empty or nonempty tuple. Both equality and inequality comparisons
+therefore have unknown results:
+
+```py
+from collections.abc import Sequence
+
+def _(value: Sequence[object]):
+    reveal_type(value == ())  # revealed: bool
+    reveal_type(() == value)  # revealed: bool
+    reveal_type(value != ())  # revealed: bool
+    reveal_type(() != value)  # revealed: bool
+
+    reveal_type(value == (1,))  # revealed: bool
+```
+
+The operand types can overlap without either being a subtype of the other. For example, `(1,)`
+inhabits both `Sequence[int]` and `tuple[int | str]`, so these comparisons also have unknown
+results:
+
+```py
+def _(value: Sequence[int], other: tuple[int | str]):
+    reveal_type(value == other)  # revealed: bool
+    reveal_type(other == value)  # revealed: bool
+```
+
+## Equality with tuple subclasses
+
+A `Base` value can be a `Child` instance, so comparing them has an unknown result despite their
+different inherited equality methods:
+
+```py
+class Base: ...
+class Child(tuple[int, ...], Base): ...
+
+def _(value: Base, child: Child):
+    reveal_type(value == child)  # revealed: bool
+    reveal_type(child == value)  # revealed: bool
+```
+
+For unrelated operand classes, the default equality semantics still ignore possible subclasses with
+different equality methods:
+
+```py
+def _(value: Base, other: tuple[int, ...]):
+    reveal_type(value == other)  # revealed: Literal[False]
+```
+
+## Comparisons with truthy strings
+
+A nonempty string cannot compare equal to an integer. Truthiness narrowing preserves this result
+when equality is used for tuple comparisons or membership tests:
+
+```py
+def _(text: str):
+    if text:
+        reveal_type((1,) == (text,))  # revealed: Literal[False]
+        reveal_type((text,) == (1,))  # revealed: Literal[False]
+        reveal_type(text in (1,))  # revealed: Literal[False]
+        reveal_type(1 in (text,))  # revealed: Literal[False]
+```
+
 ## Chained comparisons with elements that incorrectly implement `__bool__`
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1314,7 +1314,7 @@ def narrow_final_object_equality(value: A | B, other: A):
         reveal_type(value)  # revealed: A
 ```
 
-Different inherited built-in implementations cannot compare equal:
+Final classes with different inherited built-in equality implementations cannot compare equal:
 
 ```py
 from typing import final
@@ -2462,6 +2462,40 @@ RightElement = NewType("RightElement", NeverEqualTupleElement)
 def tuple_with_erased_element_identity(value: NeverEqualTupleElement) -> None:
     reveal_type((LeftElement(value),) == (RightElement(value),))  # revealed: bool
     reveal_type((LeftElement(value),) != (RightElement(value),))  # revealed: bool
+```
+
+## Comparing sequences with tuples
+
+A `Sequence[object]` can be an empty tuple, so the equality branch remains reachable and we report
+errors inside it:
+
+```py
+from collections.abc import Sequence
+
+def _(value: Sequence[object]):
+    if value == ():
+        reveal_type(value)  # revealed: Sequence[object]
+        1 + "a"  # error: [unsupported-operator]
+```
+
+## Comparing truthy sequences with literals
+
+A truthy sequence can still be a string or bytes object. Comparing a literal on the left with such a
+sequence does not make the equality branch unreachable:
+
+```py
+from collections.abc import Sequence
+
+def _(text: Sequence[str], data: Sequence[int]):
+    if text:
+        reveal_type("x" == text)  # revealed: bool
+        reveal_type("x" != text)  # revealed: bool
+        if "x" == text:
+            1 + "a"  # error: [unsupported-operator]
+
+    if data:
+        reveal_type(b"x" == data)  # revealed: bool
+        reveal_type(b"x" != data)  # revealed: bool
 ```
 
 ## Narrowing with NewTypes

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1517,7 +1517,7 @@ fn compare_literal_to_other<'db>(
     if matches!(literal, LiteralValueTypeKind::LiteralString) {
         return match evaluator.comparison_semantics(other, operator) {
             Some(KnownComparisonSemantics::Str) => ComparisonResult::Ambiguous,
-            Some(_) => ComparisonResult::from_bool(operator == ComparisonOperator::Inequality),
+            Some(_) => compare_different_semantics(db, env, literal_type, other, operator),
             None => ComparisonResult::Ambiguous,
         };
     }
@@ -1545,7 +1545,7 @@ fn compare_literal_to_other<'db>(
 
     match evaluator.comparison_semantics(other, operator) {
         Some(other_semantics) if literal_semantics != other_semantics => {
-            ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
+            compare_different_semantics(db, env, literal_type, other, operator)
         }
         // Object equality compares identity. `NewType` operands are evaluated using their concrete
         // base before reaching this arm, so erased identities cannot make these types appear
@@ -1576,6 +1576,43 @@ fn compare_literal_to_other<'db>(
     }
 }
 
+/// Compare types that inherit different builtin comparison implementations.
+///
+/// A base-class annotation can contain instances of a known subclass with a different
+/// implementation. For example, `Sequence[object]` can contain tuples, so its inherited
+/// `object.__eq__` cannot rule out equality with `tuple[()]`. Only consider known inheritance
+/// here: hypothetical multiple-inheritance subclasses should not prevent the default equality
+/// semantics from narrowing unrelated classes.
+fn compare_different_semantics<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    left: Type<'db>,
+    right: Type<'db>,
+    operator: ComparisonOperator,
+) -> ComparisonResult<'db> {
+    match (left, right) {
+        (Type::Intersection(intersection), other) | (other, Type::Intersection(intersection)) => {
+            // An intersection can only compare equal if all of its positive elements can.
+            intersection
+                .positive(db)
+                .iter()
+                .map(|&element| compare_different_semantics(db, env, element, other, operator))
+                .find(|result| *result != ComparisonResult::Ambiguous)
+                .unwrap_or(ComparisonResult::Ambiguous)
+        }
+        (left, right)
+            if let (Some(left_class), Some(right_class)) =
+                (left.nominal_class(db, env), right.nominal_class(db, env))
+                && (left_class.is_subtype_of_class_literal(db, right_class.class_literal(db))
+                    || right_class
+                        .is_subtype_of_class_literal(db, left_class.class_literal(db))) =>
+        {
+            ComparisonResult::Ambiguous
+        }
+        _ => operator.result_from_equality(false),
+    }
+}
+
 /// Compare nominal instances when their inherited comparison implementations are known.
 ///
 /// The result is definite only when the implementations cannot compare equal, or when both types
@@ -1597,10 +1634,11 @@ fn compare_nominal_instances<'db>(
         return ComparisonResult::Ambiguous;
     };
 
-    if left_semantics != right_semantics
-        || (left_semantics == KnownComparisonSemantics::Object
-            && left.is_disjoint_from(db, env, right))
-    {
+    if left_semantics != right_semantics {
+        return compare_different_semantics(db, env, left, right, operator);
+    }
+
+    if left_semantics == KnownComparisonSemantics::Object && left.is_disjoint_from(db, env, right) {
         return ComparisonResult::from_bool(operator == ComparisonOperator::Inequality);
     }
 
@@ -1701,8 +1739,10 @@ impl ComparisonOperator {
 
 /// A known builtin implementation that determines the runtime behavior of a comparison.
 ///
-/// Two types with different known semantics cannot compare equal. Types with custom or otherwise
-/// unknown comparison methods are not assigned a value of this enum.
+/// Runtime values with different known semantics cannot compare equal. The implementation inferred
+/// for a static type may differ from that of a known subclass; see
+/// [`compare_different_semantics`]. Types with custom or otherwise unknown comparison methods are not
+/// assigned a value of this enum.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, get_size2::GetSize)]
 enum KnownComparisonSemantics {
     Object,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1590,6 +1590,12 @@ fn compare_different_semantics<'db>(
     right: Type<'db>,
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
+    // NoneType is final and inherits only from object. This common case does not need
+    // ancestry checks, which would otherwise be repeated for each member of an optional enum.
+    if left.is_none(db) || right.is_none(db) {
+        return operator.result_from_equality(false);
+    }
+
     match (left, right) {
         (Type::Intersection(intersection), other) | (other, Type::Intersection(intersection)) => {
             // An intersection can only compare equal if all of its positive elements can.


### PR DESCRIPTION
ty can infer `Literal[False]` for `Sequence[object] == ()`, even though the sequence can be an empty tuple. This can also make reachable branches disappear and hide errors.

Keep comparisons ambiguous when the operands' known classes have a base/subclass relationship, even if their inherited equality implementations differ. Apply the same reasoning to literals and truthiness-narrowed intersections while retaining the default behavior for unrelated classes.

Fixes astral-sh/ty#4377.

## Test plan

Added mdtests cover sequence comparisons with empty and nonempty tuples, strings, bytes, and `LiteralString`; both operand orders and equality operators; partial generic overlap; and custom base/tuple subclass relationships. Narrowing regressions check branch reachability and preserve tuple-comparison and membership precision for unrelated types.

The added Ibis diagnostics in the ecosystem are correct.
