### PR TITLE
[ty] Fix unsound narrowing through branch-assigned conditions

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1285,23 +1285,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             let Some(alias) = self.narrowing_aliases.get(&name.id) else {
                 return;
             };
-            let Some(use_id) = self.current_ast_ids().try_use_id(leaf) else {
-                return;
-            };
-
-            // The alias may have been registered while visiting a different branch. Only use it
-            // if the sole reaching binding assigns this exact expression.
-            let use_def = self.current_use_def_map();
-            let Some(value) = use_def
-                .bindings_at_use(use_id)
-                .exactly_one()
-                .ok()
-                .and_then(|binding| use_def.definition(binding.binding()).definition())
-                .and_then(|definition| definition.kind(self.db).value(self.module))
-            else {
-                return;
-            };
-            if ExpressionNodeKey::from(value) != ExpressionNodeKey::from(alias.expression) {
+            if self.current_ast_ids().try_use_id(leaf).is_none() {
                 return;
             }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1282,9 +1282,29 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             let Some(name) = leaf.as_name_expr() else {
                 return;
             };
-            let Some(alias) = self.narrowing_aliases.get(&name.id).cloned() else {
+            let Some(alias) = self.narrowing_aliases.get(&name.id) else {
                 return;
             };
+            let Some(use_id) = self.current_ast_ids().try_use_id(leaf) else {
+                return;
+            };
+
+            // The alias may have been registered while visiting a different branch. Only use it
+            // if the sole reaching binding assigns this exact expression.
+            let use_def = self.current_use_def_map();
+            let Some(value) = use_def
+                .bindings_at_use(use_id)
+                .exactly_one()
+                .ok()
+                .and_then(|binding| use_def.definition(binding.binding()).definition())
+                .and_then(|definition| definition.kind(self.db).value(self.module))
+            else {
+                return;
+            };
+            if ExpressionNodeKey::from(value) != ExpressionNodeKey::from(alias.expression) {
+                return;
+            }
+
             let aliased_expression = Expression::new(
                 self.db,
                 self.scope_ids_by_scope[alias.expression_scope],

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -462,6 +462,36 @@ def _(value: int | str):
             reveal_type(cached)  # revealed: str
 ```
 
+## Cached alias updated when false
+
+A cached condition starts out false and is replaced by the `None` check whenever it is false. A
+later true condition therefore implies that `x` is not `None`, even across loop iterations.
+
+```py
+def _(x: int | None):
+    condition = False
+    for _ in range(2):
+        if not condition:
+            condition = x is not None
+        if condition:
+            reveal_type(x)  # revealed: int
+```
+
+## Cached alias updated when true
+
+The same reasoning applies with the outcomes reversed: a false condition can only come from the
+`None` check, so it rules out `None`.
+
+```py
+def _(x: int | None):
+    condition = True
+    for _ in range(2):
+        if condition:
+            condition = x is None
+        if not condition:
+            reveal_type(x)  # revealed: int
+```
+
 ## Alias reassigned on a loop backedge
 
 A different assignment can reach the condition from an earlier iteration. That assignment does not
@@ -479,6 +509,23 @@ def _(x: int | None, flags: list[bool], other: bool):
             reveal_type(x)  # revealed: int | None
         if other:
             condition = True
+```
+
+## Alias replaced by an independent loop-carried value
+
+When `replace` is false, the value carried from the first iteration makes `condition` true on the
+second iteration even if `x` is `None`. The condition therefore cannot narrow `x`.
+
+```py
+def _(x: int | None, replace: bool):
+    carry = False
+    for _ in range(2):
+        condition = carry
+        if replace:
+            condition = x is not None
+        if condition:
+            reveal_type(x)  # revealed: int | None
+        carry = not condition
 ```
 
 ## Nested scope can preserve alias

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -266,6 +266,94 @@ def _(x: int | None):
         reveal_type(x)  # revealed: None
 ```
 
+## Alias defined in the `if` branch
+
+Only the `if` branch relates `condition` to `x`. After the branches merge, the independent
+assignment can produce either condition outcome for any value of `x`.
+
+```py
+def _(x: int | None, flag: bool, other: bool):
+    if flag:
+        condition = x is not None
+    else:
+        condition = other
+
+    if condition:
+        reveal_type(x)  # revealed: int | None
+    else:
+        reveal_type(x)  # revealed: int | None
+```
+
+## Alias defined in the `else` branch
+
+The same applies when the `else` branch assigns the check. Its relationship to `x` does not hold for
+the independent assignment in the `if` branch.
+
+```py
+def _(x: int | None, flag: bool, other: bool):
+    if flag:
+        condition = other
+    else:
+        condition = x is not None
+
+    if condition:
+        reveal_type(x)  # revealed: int | None
+    else:
+        reveal_type(x)  # revealed: int | None
+```
+
+## Alias assigned conditionally
+
+If the branch is skipped, `condition` keeps the independent argument value. Neither outcome of the
+condition narrows `x`.
+
+```py
+def _(x: int | None, flag: bool, condition: bool):
+    if flag:
+        condition = x is not None
+
+    if condition:
+        reveal_type(x)  # revealed: int | None
+    else:
+        reveal_type(x)  # revealed: int | None
+```
+
+## Alias assigned on a terminal branch
+
+A check assigned on a branch that returns cannot describe the condition used afterward. The
+independent assignment is the only one that reaches this use, so neither outcome narrows `x`.
+
+```py
+def _(x: int | None, flag: bool, other: bool):
+    condition = other
+    if flag:
+        condition = x is not None
+        return
+
+    if condition:
+        reveal_type(x)  # revealed: int | None
+    else:
+        reveal_type(x)  # revealed: int | None
+```
+
+## Alias assigned on the only continuing branch
+
+If the other branch returns, the check is the only assignment that reaches the condition. Its
+relationship to `x` still permits narrowing after the branches merge.
+
+```py
+def _(x: int | None, flag: bool):
+    if flag:
+        condition = x is not None
+    else:
+        return
+
+    if condition:
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: None
+```
+
 ## Nested scope can preserve alias
 
 > TODO: This feature is not supported yet.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -318,6 +318,61 @@ def _(x: int | None, flag: bool, condition: bool):
         reveal_type(x)  # revealed: int | None
 ```
 
+## Possibly unbound local alias
+
+A missing local binding raises `UnboundLocalError` instead of falling back to an outer scope. If
+evaluation succeeds, `condition` comes from the narrowing expression.
+
+```py
+def _(x: int | None, flag: bool):
+    if flag:
+        condition = x is not None
+
+    if condition:  # error: [possibly-unresolved-reference]
+        reveal_type(x)  # revealed: int
+    else:
+        reveal_type(x)  # revealed: None
+```
+
+## Class-local alias with a global fallback
+
+An unbound class-local name falls back to the global binding. That independent boolean can produce
+either condition outcome without narrowing the class-local target.
+
+```py
+condition: bool = True
+
+def _(value: int | None, flag: bool):
+    class C:
+        x = value
+        if flag:
+            condition = x is not None
+
+        if condition:
+            reveal_type(x)  # revealed: int | None
+        else:
+            reveal_type(x)  # revealed: int | None
+```
+
+## Global alias assigned conditionally
+
+If the assignment is skipped, a `global` name keeps its independent module-level value. Neither
+outcome narrows the local target.
+
+```py
+condition: bool = True
+
+def _(x: int | None, flag: bool):
+    global condition
+    if flag:
+        condition = x is not None
+
+    if condition:
+        reveal_type(x)  # revealed: int | None
+    else:
+        reveal_type(x)  # revealed: int | None
+```
+
 ## Alias assigned on a terminal branch
 
 A check assigned on a branch that returns cannot describe the condition used afterward. The
@@ -352,6 +407,78 @@ def _(x: int | None, flag: bool):
         reveal_type(x)  # revealed: int
     else:
         reveal_type(x)  # revealed: None
+```
+
+## Alias assigned on an always-taken branch
+
+An alias assigned under a condition that is always true is definitely initialized. Both outcomes of
+the alias narrow its target.
+
+```py
+def get_value() -> int | str:
+    return 1
+
+x = get_value()
+if None is None:
+    is_int = isinstance(x, int)
+
+if is_int:
+    reveal_type(x)  # revealed: int
+else:
+    reveal_type(x)  # revealed: str
+```
+
+## Alias reassignment on the false branch
+
+If the final `check` is false, the `None` check ran and ruled out `None`. Otherwise, assigning
+`True` to `value` leaves a `bool` on that path too.
+
+```py
+def _(value: bool | None, check: bool):
+    if not check:
+        check = value is None
+    if check:
+        reveal_type(value)  # revealed: bool | None
+        value = True
+    reveal_type(value)  # revealed: bool
+```
+
+## Alias preserved across loop iterations
+
+The cached value and its alias are initialized together on the first iteration. Later iterations
+reuse both, so the alias still narrows the cached value.
+
+```py
+def _(value: int | str):
+    cached = None
+    for _ in range(2):
+        if cached is None:
+            cached = value
+            is_int = isinstance(cached, int)
+        # TODO: recognize that `is_int` is initialized on the first iteration.
+        if is_int:  # error: [possibly-unresolved-reference]
+            reveal_type(cached)  # revealed: int
+        else:
+            reveal_type(cached)  # revealed: str
+```
+
+## Alias reassigned on a loop backedge
+
+A different assignment can reach the condition from an earlier iteration. That assignment does not
+describe `x`, so the condition cannot narrow it.
+
+```py
+def _(x: int | None, flags: list[bool], other: bool):
+    condition = False
+    for flag in flags:
+        if flag:
+            condition = x is not None
+        if condition:
+            reveal_type(x)  # revealed: int | None
+        else:
+            reveal_type(x)  # revealed: int | None
+        if other:
+            condition = True
 ```
 
 ## Nested scope can preserve alias

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry};
 
-use crate::reachability::{narrow_type_by_constraint, type_narrowed_by_previous_patterns};
+use crate::place::loop_header_reachability;
+use crate::reachability::{
+    binding_reachability, narrow_type_by_constraint, type_narrowed_by_previous_patterns,
+};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
@@ -12,13 +15,15 @@ use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
     Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
-    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
-    class_pattern_positional_sources, definite_match_pattern_type_for_subject,
-    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, binding_type,
+    callable_pattern_type, class_pattern_positional_sources,
+    definite_match_pattern_type_for_subject, exact_sequence_pattern_type, infer_expression_types,
+    mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use crate::{Db, ProgramEnvironment};
+use ty_python_core::ast_ids::HasScopedUseId;
+use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
@@ -28,6 +33,7 @@ use ty_python_core::predicate::{
     SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
+use ty_python_core::symbol::Symbol;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
 
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
@@ -1543,10 +1549,17 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Option<NarrowingConstraints<'db>> {
         let db = self.db;
         match expression_node {
-            ast::Expr::Name(_) => {
+            ast::Expr::Name(name) => {
                 let index = semantic_index(db, expression.program_file(db));
                 let constraints = self.evaluate_simple_expr(expression_node, is_positive);
-                if let Some(alias_predicate) = index.narrowing_alias_predicate(expression_node) {
+                if let Some(alias_predicate) = index.narrowing_alias_predicate(expression_node)
+                    && self.is_valid_alias(
+                        name,
+                        expression,
+                        alias_predicate.expression,
+                        is_positive,
+                    )
+                {
                     let aliased_constraints =
                         self.evaluate_expression_predicate(alias_predicate.expression, is_positive);
                     // For example, suppose we have an alias `is_none = x is None`.
@@ -1605,6 +1618,79 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 self.evaluate_expr_named(expr_named, expression, is_positive)
             }
             _ => None,
+        }
+    }
+
+    /// Check that every binding that can produce this outcome evaluates the recorded alias.
+    /// Reachability is not yet known when aliases are recorded in the semantic index.
+    fn is_valid_alias(
+        &self,
+        name: &ast::ExprName,
+        expression: Expression<'db>,
+        alias: Expression<'db>,
+        is_positive: bool,
+    ) -> bool {
+        let db = self.db;
+        let scope = expression.scope(db);
+        let index = semantic_index(db, expression.program_file(db));
+        let use_def = index.use_def_map(scope.file_scope_id(db));
+        let alias_key = ExpressionNodeKey::from(alias.node_ref(db).node(self.module));
+
+        // An unbound local raises before the condition is evaluated. Other scopes can fall back
+        // to a different binding, such as a global with the same name in a class body.
+        let unbound_is_terminal = scope.node(db).scope_kind().is_function_like()
+            && index
+                .place_table(scope.file_scope_id(db))
+                .symbol_by_name(name.id.as_str())
+                .is_some_and(Symbol::is_local);
+
+        use_def
+            .bindings_at_use(name.scoped_use_id(db, expression.program_file(db)))
+            .all(|binding| {
+                let Some(definition) = binding.binding.definition() else {
+                    return unbound_is_terminal
+                        || binding_reachability(db, use_def, &binding).is_always_false();
+                };
+                if self.binding_assigns_alias(definition, alias_key, unbound_is_terminal)
+                    || binding_reachability(db, use_def, &binding).is_always_false()
+                {
+                    return true;
+                }
+                if matches!(definition.kind(db), DefinitionKind::LoopHeader(_)) {
+                    // Inferring a mixed loop header could depend on this predicate itself.
+                    return false;
+                }
+
+                // A different binding need not prevent narrowing if it cannot produce this
+                // outcome: `if not check: check = x is None` still narrows `x` when `check` is false.
+                let ty = binding.narrowing_constraint.narrow(
+                    db,
+                    &self.env,
+                    binding_type(db, definition),
+                    definition.place(db),
+                );
+                ty.bool(db, &self.env) == Truthiness::from(!is_positive)
+            })
+    }
+
+    fn binding_assigns_alias(
+        &self,
+        definition: Definition<'db>,
+        alias: ExpressionNodeKey,
+        unbound_is_terminal: bool,
+    ) -> bool {
+        let db = self.db;
+        match definition.kind(db) {
+            DefinitionKind::LoopHeader(_) => {
+                let loop_header = loop_header_reachability(db, definition);
+                (unbound_is_terminal || loop_header.deleted_reachability.is_always_false())
+                    && loop_header.reachable_bindings.iter().all(|binding| {
+                        self.binding_assigns_alias(binding.definition, alias, unbound_is_terminal)
+                    })
+            }
+            kind => kind
+                .value(self.module)
+                .is_some_and(|value| ExpressionNodeKey::from(value) == alias),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1669,7 +1669,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     binding_type(db, definition),
                     definition.place(db),
                 );
-                ty.bool(db, &self.env) == Truthiness::from(!is_positive)
+                // `Never` cannot produce either outcome, even though its truthiness is ambiguous.
+                ty.is_never() || ty.bool(db, &self.env) == Truthiness::from(!is_positive)
             })
     }
 


### PR DESCRIPTION
Our support for aliased narrowing conditions (i.e. `thing_is_not_none = thing is not None` followed later by `if thing_is_not_none:`) didn't properly account for control flow, meaning an aliased condition assigned only in a branch could wrongly be treated as definitely narrowing, and a check assigned on a returning branch could wrongly be treated as relevant to a later narrowing check.

Validate the condition's reaching bindings when generating narrowing constraints, after reachability is known. Apply alias narrowing only when every binding that can produce the condition's outcome evaluates the recorded alias expression. This accounts for loop-carried bindings and distinguishes unbound locals, which raise, from names that can fall back to another scope.

Fixes https://github.com/astral-sh/ty/issues/4378.

## Test plan

Adds mdtests for aliases assigned in either branch, conditional reassignment, returning branches, and always-taken branches. Also covers possibly-unbound locals, class/global fallbacks, outcome-specific narrowing, cached aliases across loop iterations (including conditions initialized to `False` or `True`), and unrelated loop-carried assignments that prevent narrowing.
