### PR TITLE
[ty] Invalidate member narrowing across loop iterations

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1842,18 +1842,31 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         }
     }
 
-    /// Create loop header definitions for all places that are bound within a loop. Return the
-    /// `LoopHeaderId` referenced by those definitions, the set of bound place IDs, and the lower
-    /// bound `ScopedDefinitionId` for definitions created within the loop.
+    /// Create loop header definitions for places that are bound or invalidated within a loop.
+    /// Return the `LoopHeaderId` referenced by those definitions, the set of place IDs, and the
+    /// lower bound `ScopedDefinitionId` for definitions created within the loop.
     fn synthesize_loop_header_definitions(
         &mut self,
         loop_stmt: LoopStmtRef<'ast>,
         bound_places: Vec<PlaceExpr>,
     ) -> (LoopHeaderId, FxHashSet<ScopedPlaceId>, ScopedDefinitionId) {
         let loop_header_id = self.current_use_def_map_mut().reserve_loop_header();
+        let bound_places: Vec<_> = bound_places
+            .into_iter()
+            .map(|place| self.add_place(place))
+            .collect();
+
+        // Rebinding `x` also invalidates `x.attr` and `x[index]`. These places need their own
+        // headers so that the invalidation reaches uses before the assignment on later
+        // iterations. Register all explicit targets first to include their associated places.
+        let associated_places: Vec<_> = bound_places
+            .iter()
+            .flat_map(|place| self.current_place_table().associated_place_ids(*place))
+            .copied()
+            .map(ScopedPlaceId::from)
+            .collect();
         let mut bound_place_ids: FxHashSet<ScopedPlaceId> = FxHashSet::default();
-        for place_expr in bound_places {
-            let place_id = self.add_place(place_expr);
+        for place_id in bound_places.into_iter().chain(associated_places) {
             if bound_place_ids.insert(place_id) {
                 let loop_header_ref = LoopHeaderDefinitionNodeRef {
                     loop_stmt,

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -1081,6 +1081,10 @@ def narrowed_bound_method_attribute():
 Assigning to `self` does not assign to its method attributes. An empty loop targeting `self`
 therefore leaves method calls bound, both before the loop and outside the method containing it.
 
+This guards against a regression in implicit attribute type inference: synthetic loop-header
+definitions for attribute places such as `self.method` are not attribute assignments and must not be
+considered when inferring instance attribute types.
+
 ```py
 class C:
     def method(self) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -1076,6 +1076,24 @@ def narrowed_bound_method_attribute():
         reveal_type(method.__globals__)  # revealed: dict[str, Any]
 ```
 
+## Receiver rebinding does not shadow methods
+
+Assigning to `self` does not assign to its method attributes. An empty loop targeting `self`
+therefore leaves method calls bound, both before the loop and outside the method containing it.
+
+```py
+class C:
+    def method(self) -> None:
+        pass
+
+    def rebind(self) -> None:
+        self.method()
+        for self in []:
+            pass
+
+C().method()
+```
+
 ## Builtin functions and methods
 
 Some builtin functions and methods are heavily special-cased by ty. This mdtest checks that various

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -326,6 +326,70 @@ def _(y: Y):
     f1(**y.inner)
 ```
 
+## Known key values after loop replacements
+
+An accepted dictionary replacement contributes its known key values to subsequent iterations.
+
+```py
+def accepted():
+    values: dict[str, int] = {"a": 1}
+    for _ in range(2):
+        reveal_type(values["a"])  # revealed: Literal[1, 2]
+        values = {"a": 2}
+    reveal_type(values["a"])  # revealed: Literal[2]
+```
+
+## Rejected dictionary replacements in loops
+
+A rejected replacement instead falls back to the declared value type. An assertion after the
+replacement narrows that fallback on the next iteration, rather than preserving the original key's
+literal type or using the rejected value.
+
+```py
+def rejected(repeat: bool):
+    values: dict[str, int | None] = {"a": 1}
+    while repeat:
+        reveal_type(values["a"])  # revealed: int
+        values = {"a": "bad"}  # error: [invalid-assignment]
+        assert values["a"] is not None
+    reveal_type(values["a"])  # revealed: int
+```
+
+## Setter dictionary assignments in loops
+
+A property setter need not store the assigned dictionary. Key reads use the getter's value type,
+including when a key was already read before the loop and the setter accepts a different value type.
+
+```py
+class C:
+    @property
+    def values(self) -> dict[str, int]:
+        return {"a": 1}
+
+    @values.setter
+    def values(self, value: dict[str, str]) -> None:
+        pass
+
+def f(c: C, repeat: bool) -> int:
+    reveal_type(c.values["a"])  # revealed: int
+    while repeat:
+        reveal_type(c.values["a"])  # revealed: int
+        c.values = {"a": "bad"}
+    return c.values["a"]
+```
+
+The same applies when the assigned dictionary depends on a key read from an earlier iteration.
+Inferring that assignment must converge without using the setter's input type for getter reads.
+
+```py
+def loop_carried_value(c: C, repeat: bool) -> int:
+    reveal_type(c.values["a"])  # revealed: int
+    while repeat:
+        reveal_type(c.values["a"])  # revealed: int
+        c.values = {"a": str(c.values["a"])}
+    return c.values["a"]
+```
+
 ## Rejected annotations in stubs
 
 Annotation-only declarations in stubs are also bindings. A rejected annotation should fall back to

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -2035,7 +2035,7 @@ def _():
             nonlocal y  # error: [invalid-syntax] "name `y` is used prior to nonlocal declaration"
 ```
 
-### Loop header definitions don't shadow member bindings
+### Rebinding an object before an unconditional `break`
 
 Rebinding an object followed by an unconditional `break` does not affect its members at the start of
 the loop, because the new object never reaches another iteration.
@@ -2063,32 +2063,58 @@ for _ in range(1):
 
 ### Rebinding an object resets attribute narrowing across iterations
 
-The loop body can observe either the initial frame or a replacement from a previous iteration. A
-guard on the initial frame therefore does not narrow `fin` throughout the loop.
+The first iteration sees the initial object; later iterations see a replacement narrowed at the end
+of the previous iteration. A replacement's attribute initially has the full declared union.
 
 ```py
-class Frame:
-    fin: bool
+class Box:
+    value: int | str | None
 
-def f(frame: Frame, replacement: Frame):
-    if frame.fin:
-        return
+def example(box: Box):
+    assert isinstance(box.value, int)
+    reveal_type(box.value)  # revealed: int
 
     for _ in range(2):
-        reveal_type(frame.fin)  # revealed: bool
-        frame = replacement
+        # The first iteration sees int; subsequent iterations see str.
+        reveal_type(box.value)  # revealed: int | str
+
+        box = Box()
+        reveal_type(box.value)  # revealed: int | str | None
+
+        assert isinstance(box.value, str)
+
+    # The loop is non-empty, so the current value has been narrowed to str.
+    reveal_type(box.value)  # revealed: str
 ```
 
-Narrowing established on a replacement frame also reaches the next iteration. If each replacement
-has `fin` set to `False`, the loop body keeps that narrowing.
+### Boolean attribute narrowing after rebinding
+
+The loop body can observe either the initial object or a replacement from a previous iteration. A
+guard on the initial object therefore does not narrow `box.value` throughout the loop.
 
 ```py
-def narrowed_replacement(frame: Frame, replacement: Frame):
-    if frame.fin:
+class Box:
+    value: bool
+
+def f(box: Box, replacement: Box):
+    if box.value:
         return
 
     for _ in range(2):
-        reveal_type(frame.fin)  # revealed: Literal[False]
-        frame = replacement
-        assert not frame.fin
+        reveal_type(box.value)  # revealed: bool
+        box = replacement
+```
+
+Narrowing established on a replacement object also reaches the next iteration. If each replacement
+has `value` narrowed to `False`, the loop body keeps that narrowing.
+
+```py
+def narrowed_replacement(box: Box, replacement: Box):
+    if box.value:
+        return
+
+    for _ in range(2):
+        reveal_type(box.value)  # revealed: Literal[False]
+        box = replacement
+        assert not box.value
 ```

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -2037,6 +2037,9 @@ def _():
 
 ### Loop header definitions don't shadow member bindings
 
+Rebinding an object followed by an unconditional `break` does not affect its members at the start of
+the loop, because the new object never reaches another iteration.
+
 ```py
 class C:
     x = None
@@ -2056,4 +2059,36 @@ for _ in range(1):
     reveal_type(d[0])  # revealed: Literal[1]
     d = []
     break
+```
+
+### Rebinding an object resets attribute narrowing across iterations
+
+The loop body can observe either the initial frame or a replacement from a previous iteration. A
+guard on the initial frame therefore does not narrow `fin` throughout the loop.
+
+```py
+class Frame:
+    fin: bool
+
+def f(frame: Frame, replacement: Frame):
+    if frame.fin:
+        return
+
+    for _ in range(2):
+        reveal_type(frame.fin)  # revealed: bool
+        frame = replacement
+```
+
+Narrowing established on a replacement frame also reaches the next iteration. If each replacement
+has `fin` set to `False`, the loop body keeps that narrowing.
+
+```py
+def narrowed_replacement(frame: Frame, replacement: Frame):
+    if frame.fin:
+        return
+
+    for _ in range(2):
+        reveal_type(frame.fin)  # revealed: Literal[False]
+        frame = replacement
+        assert not frame.fin
 ```

--- a/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
@@ -634,7 +634,7 @@ while True:
     x = 1
 ```
 
-### Loop header definitions don't shadow member bindings
+### Rebinding an object before an unconditional `break`
 
 Rebinding an object followed by an unconditional `break` does not affect its members at the start of
 the loop, because the new object never reaches another iteration.
@@ -661,120 +661,148 @@ while True:
 ```
 
 The same applies to narrowing from a guard before the loop. The condition is always true on the only
-iteration, but the replacement frame's attribute is not narrowed after the `break`.
+iteration, but the replacement object's attribute is not narrowed after the `break`.
 
 ```py
-class Frame:
-    fin: bool
+class Box:
+    value: bool
 
-def f(frame: Frame):
-    if frame.fin:
+def f(box: Box):
+    if box.value:
         return
 
-    while reveal_type(not frame.fin):  # revealed: Literal[True]
-        frame = Frame()
+    while reveal_type(not box.value):  # revealed: Literal[True]
+        box = Box()
         break
 
-    reveal_type(frame.fin)  # revealed: bool
+    reveal_type(box.value)  # revealed: bool
 ```
 
 ### Rebinding an object resets attribute narrowing across iterations
 
-A guard before the loop only constrains the initial object. Rebinding `frame` can make `fin` true on
-a later iteration, so the loop condition is not always true.
+The first iteration sees the initial object's `int` value; later iterations see the replacement's
+`str` value. The type at the start of the body is therefore `int | str`. Rebinding restores the full
+declared attribute type, including `None`, until the replacement is narrowed again.
 
 ```py
-class Frame:
-    fin: bool
+class Box:
+    value: int | str | None
 
-def condition(frame: Frame, replacement: Frame):
-    if frame.fin:
-        return
+def example(box: Box):
+    assert isinstance(box.value, int)
+    reveal_type(box.value)  # revealed: int
 
-    while reveal_type(not frame.fin):  # revealed: bool
-        frame = replacement
+    while True:
+        reveal_type(box.value)  # revealed: int | str
+
+        box = Box()
+        reveal_type(box.value)  # revealed: int | str | None
+
+        assert isinstance(box.value, str)
 ```
 
-When the loop exits normally, the current frame has `fin` set to `True`.
+### Rebinding an object affects the loop condition
+
+A guard before the loop only constrains the initial object. Rebinding `box` can make `box.value`
+true on a later iteration, so the loop condition is not always true.
 
 ```py
-def normal_exit(frame: Frame, replacement: Frame):
-    if frame.fin:
+class Box:
+    value: bool
+
+def condition(box: Box, replacement: Box):
+    if box.value:
         return
 
-    while not frame.fin:
-        reveal_type(frame.fin)  # revealed: Literal[False]
-        frame = replacement
+    reveal_type(box.value)  # revealed: Literal[False]
 
-    reveal_type(frame.fin)  # revealed: Literal[True]
+    while reveal_type(not box.value):  # revealed: bool
+        box = replacement
+```
+
+When the loop exits normally, `box.value` is `True`.
+
+```py
+def normal_exit(box: Box, replacement: Box):
+    if box.value:
+        return
+
+    reveal_type(box.value)  # revealed: Literal[False]
+
+    while not box.value:
+        reveal_type(box.value)  # revealed: Literal[False]
+        box = replacement
+        reveal_type(box.value)  # revealed: bool
+
+    reveal_type(box.value)  # revealed: Literal[True]
 ```
 
 ### Rebinding an object before `continue`
 
 Rebinding also invalidates attribute narrowing when the next iteration is reached through
-`continue`. The replacement frame can end the loop.
+`continue`. A replacement whose `value` is `True` can end the loop.
 
 ```py
-class Frame:
-    fin: bool
+class Box:
+    value: bool
 
-def f(frame: Frame, replacement: Frame):
-    if frame.fin:
+def f(box: Box, replacement: Box):
+    if box.value:
         return
 
-    while not frame.fin:
-        frame = replacement
+    while not box.value:
+        box = replacement
         continue
 
-    reveal_type(frame.fin)  # revealed: Literal[True]
+    reveal_type(box.value)  # revealed: Literal[True]
 ```
 
 ### Rebinding in an inner loop reaches the next outer iteration
 
-An inner loop can rebind `frame` on one iteration, then exit through a `break` before reaching the
+An inner loop can rebind `box` on one iteration, then exit through a `break` before reaching the
 assignment again. The replacement is visible both after the inner loop and on later outer
-iterations, so the initial guard no longer narrows `frame.fin`.
+iterations, so the initial guard no longer narrows `box.value`.
 
 ```py
-class Frame:
-    fin: bool
+class Box:
+    value: bool
 
 def stop() -> bool:
     raise NotImplementedError
 
-def f(frame: Frame, replacement: Frame, repeat: bool):
-    if frame.fin:
+def f(box: Box, replacement: Box, repeat: bool):
+    if box.value:
         return
 
     while repeat:
-        reveal_type(frame.fin)  # revealed: bool
+        reveal_type(box.value)  # revealed: bool
         while True:
             if stop():
                 break
-            frame = replacement
-        reveal_type(frame.fin)  # revealed: bool
+            box = replacement
+        reveal_type(box.value)  # revealed: bool
 ```
 
 ### Rebinding a member resets nested attribute narrowing
 
-Replacing `box.frame` invalidates narrowing of `box.frame.fin` on subsequent iterations, even though
-the outer `box` object is unchanged.
+Replacing `wrapper.box` invalidates narrowing of `wrapper.box.value` on subsequent iterations, even
+though the outer `wrapper` object is unchanged.
 
 ```py
-class Frame:
-    fin: bool
-
 class Box:
-    frame: Frame
+    value: bool
 
-def f(box: Box, replacement: Frame):
-    if box.frame.fin:
+class Wrapper:
+    box: Box
+
+def f(wrapper: Wrapper, replacement: Box):
+    if wrapper.box.value:
         return
 
-    while not box.frame.fin:
-        box.frame = replacement
+    while not wrapper.box.value:
+        wrapper.box = replacement
 
-    reveal_type(box.frame.fin)  # revealed: Literal[True]
+    reveal_type(wrapper.box.value)  # revealed: Literal[True]
 ```
 
 ### Rebinding a collection resets subscript narrowing

--- a/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
@@ -636,6 +636,9 @@ while True:
 
 ### Loop header definitions don't shadow member bindings
 
+Rebinding an object followed by an unconditional `break` does not affect its members at the start of
+the loop, because the new object never reaches another iteration.
+
 ```py
 class C:
     x = None
@@ -655,6 +658,139 @@ while True:
     reveal_type(d[0])  # revealed: Literal[1]
     d = []
     break
+```
+
+The same applies to narrowing from a guard before the loop. The condition is always true on the only
+iteration, but the replacement frame's attribute is not narrowed after the `break`.
+
+```py
+class Frame:
+    fin: bool
+
+def f(frame: Frame):
+    if frame.fin:
+        return
+
+    while reveal_type(not frame.fin):  # revealed: Literal[True]
+        frame = Frame()
+        break
+
+    reveal_type(frame.fin)  # revealed: bool
+```
+
+### Rebinding an object resets attribute narrowing across iterations
+
+A guard before the loop only constrains the initial object. Rebinding `frame` can make `fin` true on
+a later iteration, so the loop condition is not always true.
+
+```py
+class Frame:
+    fin: bool
+
+def condition(frame: Frame, replacement: Frame):
+    if frame.fin:
+        return
+
+    while reveal_type(not frame.fin):  # revealed: bool
+        frame = replacement
+```
+
+When the loop exits normally, the current frame has `fin` set to `True`.
+
+```py
+def normal_exit(frame: Frame, replacement: Frame):
+    if frame.fin:
+        return
+
+    while not frame.fin:
+        reveal_type(frame.fin)  # revealed: Literal[False]
+        frame = replacement
+
+    reveal_type(frame.fin)  # revealed: Literal[True]
+```
+
+### Rebinding an object before `continue`
+
+Rebinding also invalidates attribute narrowing when the next iteration is reached through
+`continue`. The replacement frame can end the loop.
+
+```py
+class Frame:
+    fin: bool
+
+def f(frame: Frame, replacement: Frame):
+    if frame.fin:
+        return
+
+    while not frame.fin:
+        frame = replacement
+        continue
+
+    reveal_type(frame.fin)  # revealed: Literal[True]
+```
+
+### Rebinding in an inner loop reaches the next outer iteration
+
+An inner loop can rebind `frame` on one iteration, then exit through a `break` before reaching the
+assignment again. The replacement is visible both after the inner loop and on later outer
+iterations, so the initial guard no longer narrows `frame.fin`.
+
+```py
+class Frame:
+    fin: bool
+
+def stop() -> bool:
+    raise NotImplementedError
+
+def f(frame: Frame, replacement: Frame, repeat: bool):
+    if frame.fin:
+        return
+
+    while repeat:
+        reveal_type(frame.fin)  # revealed: bool
+        while True:
+            if stop():
+                break
+            frame = replacement
+        reveal_type(frame.fin)  # revealed: bool
+```
+
+### Rebinding a member resets nested attribute narrowing
+
+Replacing `box.frame` invalidates narrowing of `box.frame.fin` on subsequent iterations, even though
+the outer `box` object is unchanged.
+
+```py
+class Frame:
+    fin: bool
+
+class Box:
+    frame: Frame
+
+def f(box: Box, replacement: Frame):
+    if box.frame.fin:
+        return
+
+    while not box.frame.fin:
+        box.frame = replacement
+
+    reveal_type(box.frame.fin)  # revealed: Literal[True]
+```
+
+### Rebinding a collection resets subscript narrowing
+
+A guard on the initial tuple's element does not constrain the corresponding element of a replacement
+tuple. The replacement can therefore end the loop.
+
+```py
+def f(flags: tuple[bool], replacement: tuple[bool]):
+    if flags[0]:
+        return
+
+    while not flags[0]:
+        flags = replacement
+
+    reveal_type(flags[0])  # revealed: Literal[True]
 ```
 
 [divergent_debugging]: https://github.com/astral-sh/ruff/pull/22794#issuecomment-3852095578

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -1088,6 +1088,40 @@ class D:
         # No else: y may be unbound at runtime, but there is still an assignment path
 ```
 
+### Assignment in a loop in `__init__`
+
+An assignment in a loop body can initialize a `Final` attribute. The `break` ensures the attribute
+is assigned only once.
+
+```py
+from typing import Final
+
+class C:
+    value: Final[int]
+
+    def __init__(self) -> None:
+        while True:
+            self.value = 1
+            break
+```
+
+### Rebinding `self` does not initialize `Final` attributes
+
+Reading a `Final` attribute before a loop and then rebinding `self` does not assign a value to the
+attribute.
+
+```py
+from typing import Final
+
+class C:
+    value: Final[int]  # error: [final-without-value] "`Final` symbol `value` is not assigned a value"
+
+    def __init__(self, repeat: bool, replacement: "C") -> None:
+        self.value
+        while repeat:
+            self = replacement
+```
+
 ### Reachable `Final` declaration wins for diagnostics
 
 If an earlier `Final` declaration is statically unreachable, diagnostics should be attached to the

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -1090,8 +1090,7 @@ class D:
 
 ### Assignment in a loop in `__init__`
 
-An assignment in a loop body can initialize a `Final` attribute. The `break` ensures the attribute
-is assigned only once.
+An assignment in a loop body provides a value for a `Final` attribute declared in the class body.
 
 ```py
 from typing import Final
@@ -1100,9 +1099,8 @@ class C:
     value: Final[int]
 
     def __init__(self) -> None:
-        while True:
+        for _ in range(2):
             self.value = 1
-            break
 ```
 
 ### Rebinding `self` does not initialize `Final` attributes

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -34,8 +34,7 @@ use ty_python_core::definition::docstring_from_body;
 use ty_python_core::platform::PythonPlatform;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
-    BindingWithConstraintsIterator, DeclarationsIterator, FileScopeId, attribute_scopes,
-    semantic_index,
+    BindingWithConstraints, DeclarationsIterator, FileScopeId, attribute_scopes, semantic_index,
 };
 pub use ty_site_packages::{
     PythonEnvironment, PythonVersionFileSource, PythonVersionSource, PythonVersionWithSource,
@@ -134,20 +133,35 @@ impl Default for AnalysisSettings {
 /// Returns all attribute assignments (and their method scope IDs) with a symbol name matching
 /// the one given for a specific class body scope.
 ///
+/// Loop headers are excluded: rebinding an attribute's receiver can create a loop header for the
+/// attribute without assigning to the attribute itself.
+///
 /// Only call this when doing type inference on the same file as `class_body_scope`, otherwise it
 /// introduces a direct dependency on that file's AST.
 pub(crate) fn attribute_assignments<'db, 's>(
     db: &'db dyn Db,
     class_body_scope: ScopeId<'db>,
     name: &'s str,
-) -> impl Iterator<Item = (BindingWithConstraintsIterator<'db, 'db>, FileScopeId)> + use<'s, 'db> {
+) -> impl Iterator<
+    Item = (
+        impl Iterator<Item = BindingWithConstraints<'db, 'db>>,
+        FileScopeId,
+    ),
+> + use<'s, 'db> {
     let index = semantic_index(db, class_body_scope.program_file(db));
 
-    attribute_scopes(db, class_body_scope).filter_map(|function_scope_id| {
+    attribute_scopes(db, class_body_scope).filter_map(move |function_scope_id| {
         let place_table = index.place_table(function_scope_id);
         let member = place_table.member_id_by_instance_attribute_name(name)?;
         let use_def = index.use_def_map(function_scope_id);
-        Some((use_def.reachable_member_bindings(member), function_scope_id))
+        let assignments = use_def
+            .reachable_member_bindings(member)
+            .filter(move |binding| {
+                !binding
+                    .binding
+                    .is_defined_and(|definition| definition.kind(db).is_loop_header())
+            });
+        Some((assignments, function_scope_id))
     })
 }
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1520,6 +1520,7 @@ fn loop_header_reachability_impl<'db>(
     let place = loop_header_definition.place();
 
     let mut deleted_reachability = Truthiness::AlwaysFalse;
+    let mut deleted_narrowing_constraints = FxIndexSet::default();
     let mut reachable_bindings = FxIndexSet::default();
     let live_bindings: Vec<_> = loop_header.bindings_for_place(place).collect();
     let use_exact_reachability = use_def.reachability_constraints().used_interiors().len()
@@ -1557,6 +1558,7 @@ fn loop_header_reachability_impl<'db>(
             // necessary for prior uses in the loop to see it.
             DefinitionState::Deleted => {
                 deleted_reachability = deleted_reachability.or(reachability);
+                deleted_narrowing_constraints.insert(live_binding.narrowing_constraint());
             }
             DefinitionState::Undefined => {
                 unreachable!("loop headers only include bindings from within the loop")
@@ -1566,6 +1568,7 @@ fn loop_header_reachability_impl<'db>(
 
     LoopHeaderReachability {
         deleted_reachability,
+        deleted_narrowing_constraints: deleted_narrowing_constraints.into_iter().collect(),
         reachable_bindings,
     }
 }
@@ -1574,6 +1577,9 @@ fn loop_header_reachability_impl<'db>(
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct LoopHeaderReachability<'db> {
     pub(crate) deleted_reachability: Truthiness,
+    /// Constraints established after a deletion or an assignment that invalidated a member.
+    /// These still narrow the fallback type of the member on the next iteration.
+    pub(crate) deleted_narrowing_constraints: Box<[ScopedNarrowingConstraint]>,
     /// Reachable loop-back bindings that are not `del`s.
     pub(crate) reachable_bindings: FxIndexSet<ReachableLoopBinding<'db>>,
 }
@@ -1586,15 +1592,27 @@ impl<'db> LoopHeaderReachability<'db> {
     ) -> LoopHeaderReachability<'db> {
         // Avoid losing precision for cycles that are soon to converge.
         // See [`Type::cycle_normalized`] for more details.
-        let reachable_bindings = if cycle.iteration() <= crate::TAINTED_CYCLES {
-            self.reachable_bindings
-        } else {
-            let previous_bindings = previous.reachable_bindings.iter().copied();
-            previous_bindings.chain(self.reachable_bindings).collect()
-        };
+        if cycle.iteration() <= crate::TAINTED_CYCLES {
+            return self;
+        }
+
+        let mut reachable_bindings: FxIndexSet<_> = previous
+            .reachable_bindings
+            .iter()
+            .copied()
+            .chain(self.reachable_bindings)
+            .collect();
+        reachable_bindings.shrink_to_fit();
+        let deleted_narrowing_constraints: FxIndexSet<_> = previous
+            .deleted_narrowing_constraints
+            .iter()
+            .copied()
+            .chain(self.deleted_narrowing_constraints)
+            .collect();
 
         LoopHeaderReachability {
             deleted_reachability: self.deleted_reachability,
+            deleted_narrowing_constraints: deleted_narrowing_constraints.into_iter().collect(),
             reachable_bindings,
         }
     }

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1543,7 +1543,11 @@ fn loop_header_reachability_impl<'db>(
         }
 
         match use_def.definition(live_binding.binding()) {
-            DefinitionState::Defined(def) => {
+            // Assignment validity can depend on this header, so avoid inferring it while
+            // initializing a cycle.
+            DefinitionState::Defined(def)
+                if is_cycle_initial || !is_discarded_dict_key_assignment(db, def) =>
+            {
                 debug_assert_ne!(
                     def, definition,
                     "loop headers only include bindings from within the loop"
@@ -1556,7 +1560,9 @@ fn loop_header_reachability_impl<'db>(
             // `del` in the loop body is always visible to code after the loop via the
             // normal control flow merge. Updating `deleted_reachability` here is
             // necessary for prior uses in the loop to see it.
-            DefinitionState::Deleted => {
+            // Discarded dictionary-key bindings also require a fallback to the receiver's
+            // value type instead of contributing their assigned value.
+            DefinitionState::Defined(_) | DefinitionState::Deleted => {
                 deleted_reachability = deleted_reachability.or(reachability);
                 deleted_narrowing_constraints.insert(live_binding.narrowing_constraint());
             }
@@ -1577,10 +1583,10 @@ fn loop_header_reachability_impl<'db>(
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct LoopHeaderReachability<'db> {
     pub(crate) deleted_reachability: Truthiness,
-    /// Constraints established after a deletion or an assignment that invalidated a member.
+    /// Constraints established after a deletion, member invalidation, or discarded key assignment.
     /// These still narrow the fallback type of the member on the next iteration.
     pub(crate) deleted_narrowing_constraints: Box<[ScopedNarrowingConstraint]>,
-    /// Reachable loop-back bindings that are not `del`s.
+    /// Reachable loop-back bindings whose values contribute to inferred types.
     pub(crate) reachable_bindings: FxIndexSet<ReachableLoopBinding<'db>>,
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9926,8 +9926,34 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty
     }
 
-    /// A member invalidated on a loop-back path falls back to its receiver's member type.
-    /// Preserve constraints established after that invalidation, including through nested loops.
+    /// Compute the type for reads such as `box.value` or `items[0]` in loop iterations after
+    /// `box` or `items` has been assigned a new object.
+    ///
+    /// A check on `box.value` before `box = Box()` describes the old box, not the new one.
+    /// We start again from the type given by attribute lookup, then apply any checks made
+    /// after the assignment. For example:
+    ///
+    /// ```py
+    /// class Box:
+    ///     value: int | None
+    ///
+    /// def f(box: Box):
+    ///     assert box.value is not None
+    ///     for _ in range(2):
+    ///         reveal_type(box.value)  # revealed: int
+    ///         box = Box()
+    ///         assert box.value is not None
+    /// ```
+    ///
+    /// The first assertion gives `int` for the first iteration. After `box = Box()`, the
+    /// new box's value could be `None`; the second assertion narrows it to `int` for the
+    /// next iteration. This helper computes that contribution from the previous iteration.
+    ///
+    /// `fallback_ty` is the starting type before applying those later checks: `int | None`
+    /// here. The caller obtains it when inferring the attribute or item read being checked,
+    /// including any narrowing already applied from enclosing scopes. This helper reuses
+    /// that type; it does not look it up at the assignment or at the end of the loop.
+    /// Recursive calls preserve checks made after the assignment within nested loops as well.
     fn loop_header_fallback_type(
         &self,
         definition: Definition<'db>,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9871,6 +9871,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let reachability_constraints = bindings.reachability_constraints();
                     let predicates = bindings.predicates();
                     let mut union = UnionBuilder::new(db, env);
+                    let mut loop_header_fallbacks = FxHashMap::default();
                     for binding in bindings {
                         let static_reachability = evaluate_reachability_with_cache(
                             db,
@@ -9886,7 +9887,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             DefinitionState::Defined(definition)
                                 if !is_discarded_dict_key_assignment(db, definition) =>
                             {
-                                let binding_ty = binding_type(db, definition);
+                                let mut binding_ty = binding_type(db, definition);
+                                if definition.kind(db).is_loop_header() {
+                                    let fallback_ty = self.loop_header_fallback_type(
+                                        definition,
+                                        ty,
+                                        &mut loop_header_fallbacks,
+                                    );
+                                    binding_ty = UnionType::from_elements(
+                                        db,
+                                        env,
+                                        [binding_ty, fallback_ty],
+                                    );
+                                }
                                 union.add_in_place(
                                     binding
                                         .narrowing_constraint
@@ -9910,6 +9923,51 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
         }
+        ty
+    }
+
+    /// A member invalidated on a loop-back path falls back to its receiver's member type.
+    /// Preserve constraints established after that invalidation, including through nested loops.
+    fn loop_header_fallback_type(
+        &self,
+        definition: Definition<'db>,
+        fallback_ty: Type<'db>,
+        cache: &mut FxHashMap<Definition<'db>, Type<'db>>,
+    ) -> Type<'db> {
+        // Inner headers can be reached through multiple containing headers. The fallback type
+        // is fixed for this traversal, so each definition's contribution only needs computing once.
+        if let Some(ty) = cache.get(&definition) {
+            return *ty;
+        }
+
+        let db = self.db();
+        let env = self.program_environment();
+        let header = loop_header_reachability(db, definition);
+        let use_def = self.index.use_def_map(definition.file_scope(db));
+        let place = definition.place(db);
+        let mut union = UnionBuilder::new(db, env);
+
+        for constraint in &header.deleted_narrowing_constraints {
+            union.add_in_place(use_def.narrowing_evaluator(*constraint).narrow(
+                db,
+                env,
+                fallback_ty,
+                place,
+            ));
+        }
+        for binding in &header.reachable_bindings {
+            if binding.definition.kind(db).is_loop_header() {
+                let ty = self.loop_header_fallback_type(binding.definition, fallback_ty, cache);
+                union.add_in_place(
+                    use_def
+                        .narrowing_evaluator(binding.narrowing_constraint)
+                        .narrow(db, env, ty, place),
+                );
+            }
+        }
+
+        let ty = union.build();
+        cache.insert(definition, ty);
         ty
     }
 


### PR DESCRIPTION
Reassigning an object inside a loop leaves narrowing of its attributes or indexed elements in effect from before the loop. This can make a `while` condition appear permanently true and cause ty to treat reachable code after the loop as unreachable.

Create loop-header definitions for places invalidated by reassignment, and include their fallback member types when computing narrowing across loop-back paths. Preserve narrowing established after reassignment and the initial narrowing when a reassignment cannot reach another iteration. Propagate invalidation through nested loop headers with memoization.

Exclude synthetic loop headers from attribute-assignment discovery: rebinding a receiver does not write its attributes or initialize `Final` values. Treat discarded dictionary-key assignments as invalidations so rejected replacements and property-setter inputs do not become inferred key values on subsequent iterations.

Fixes https://github.com/astral-sh/ty/issues/4379.

## Ecosystem

The ecosystem run removes 55 false-positive Pydantic errors and one Pyodide warning. It adds three expected websockets diagnostics by making a previously unreachable `join` reachable; the existing annotations allow mixed text and binary fragments. Minimized reproductions confirm these changes are expected, with no regressions found.

## Test plan

- Extend `while` and `for` mdtests to cover condition, body, and normal-exit narrowing after object replacement, explicit `continue`, nested-loop early exits, nested attributes, and subscripts.
- Verify that break-only paths preserve initial narrowing and that assertions on replacement objects narrow the next iteration.
- Verify method binding before receiver-rebinding loops and at external calls, and distinguish actual `Final` initialization inside loops from receiver rebinding.
- Cover accepted and rejected dictionary replacements, narrowing after rejected replacements, and property setters whose input types differ from their getters, including loop-carried dictionary values.
