### PR TITLE
[ty] Experiment with disjoint equality comparisons

### DIFF
--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1580,9 +1580,8 @@ fn compare_literal_to_other<'db>(
 ///
 /// A base-class annotation can contain instances of a known subclass with a different
 /// implementation. For example, `Sequence[object]` can contain tuples, so its inherited
-/// `object.__eq__` cannot rule out equality with `tuple[()]`. Only consider known inheritance
-/// here: hypothetical multiple-inheritance subclasses should not prevent the default equality
-/// semantics from narrowing unrelated classes.
+/// `object.__eq__` cannot rule out equality with `tuple[()]`. Multiple inheritance can also
+/// allow the types to overlap, so only disjoint types are known to compare unequal.
 fn compare_different_semantics<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -1591,31 +1590,15 @@ fn compare_different_semantics<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     // NoneType is final and inherits only from object. This common case does not need
-    // ancestry checks, which would otherwise be repeated for each member of an optional enum.
+    // disjointness checks, which would otherwise be repeated for each member of an optional enum.
     if left.is_none(db) || right.is_none(db) {
         return operator.result_from_equality(false);
     }
 
-    match (left, right) {
-        (Type::Intersection(intersection), other) | (other, Type::Intersection(intersection)) => {
-            // An intersection can only compare equal if all of its positive elements can.
-            intersection
-                .positive(db)
-                .iter()
-                .map(|&element| compare_different_semantics(db, env, element, other, operator))
-                .find(|result| *result != ComparisonResult::Ambiguous)
-                .unwrap_or(ComparisonResult::Ambiguous)
-        }
-        (left, right)
-            if let (Some(left_class), Some(right_class)) =
-                (left.nominal_class(db, env), right.nominal_class(db, env))
-                && (left_class.is_subtype_of_class_literal(db, right_class.class_literal(db))
-                    || right_class
-                        .is_subtype_of_class_literal(db, left_class.class_literal(db))) =>
-        {
-            ComparisonResult::Ambiguous
-        }
-        _ => operator.result_from_equality(false),
+    if left.is_disjoint_from(db, env, right) {
+        operator.result_from_equality(false)
+    } else {
+        ComparisonResult::Ambiguous
     }
 }
 


### PR DESCRIPTION
Comparisons between unrelated non-final classes can be equal through a shared multiple-inheritance subclass. This experiment replaces the known-ancestry check in #28005 with `Type::is_disjoint_from`, keeping comparisons ambiguous when the operand types might overlap.

The PR is based on #28005 so the ecosystem report measures only this change. It retains the `None` fast path. Full type disjointness also considers type arguments and intersection exclusions, which introduce additional behavior changes beyond multiple inheritance.

## Results

The [ecosystem report](https://35f5dae9.ty-ecosystem-ext.pages.dev/diff) adds six diagnostics across three of 162 projects, with no removals:

- **dd-trace-py (+1):** an assertion comparing `int` with `EnvVariable[int]` no longer makes subsequent code unreachable. The added operator error exposes envier's dependence on a mypy plugin to describe fields replaced with their values at runtime.
- **Manticore (+4):** range membership no longer removes `Label` and `Activation` from a possible list index. The runtime stack assertion already excludes those alternatives, but `pop()`'s broad return annotation does not communicate that proof.
- **mypy (+1):** an `i64`-versus-`int` comparison no longer makes an assignment unreachable. The added assignment error exposes ty's existing lack of mypyc-specific native-integer conversions, which mypy handles specially.

[CodSpeed](https://app.codspeed.io/astral-sh/ruff/branches/cjm%2Fty-4377-disjoint-experiment) reports no detected performance change against #28005: 126 benchmarks unchanged and 84 skipped.

## Additional correctness concerns

Focused examples expose two regressions that the existing suite does not cover:

- `Sequence[str] & ~LiteralString` (or `~Literal["x"]`) can contain a string equal to `"x"`. The experiment changes that equality from `bool` to `Literal[False]` by treating the literal-origin exclusion as a runtime-value exclusion.
- Given an invariant `Base[T]` and `Child[T](dict[str, int], Base[T])`, comparing `Base[int]` with `Child[str]` changes from `bool` to `Literal[False]`. A `Child[int]` and a `Child[str]` can nevertheless be equal dictionaries.

These cases do not require hypothetical equality overrides. Full type disjointness is therefore not a drop-in replacement for the class-ancestry check.

## Test plan

The existing expectations are unchanged. The semantic suite and the full Linux debug and release suites each fail only the `Base`-versus-`tuple` assertion added in #28005 (`comparison/tuples.md:592`): its result changes from `Literal[False]` to `bool`. Those runs have no other failures. No snapshots change.

Additional probes compare possible multiple inheritance, invariant generic specializations, and excluded string-literal origins against the parent implementation. The two correctness concerns above are also checked against runtime witnesses; strict-equality mode remains unchanged for those probes. File-scoped hooks and semantic-crate Clippy pass.
