### PR TITLE
[ty] Fix Self binding in ParamSpec protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -933,6 +933,39 @@ reveal_type(foo.method)  # revealed: bound method Foo[(int, str, /)].method(int,
 reveal_type(foo.method(1, "a"))  # revealed: str
 ```
 
+### Specializing explicit instance receivers with `ParamSpec`
+
+Specializing a `ParamSpec` preserves inference from an explicit receiver annotation. The writable
+`value` attribute makes `Box` invariant in `T`, so binding `get` to a `Box[int, [str]]` instance
+fixes `U` to `int` before the method is called.
+
+```py
+class Box[T, **P]:
+    value: T
+
+    def get[U](self: "Box[U, P]", *args: P.args, **kwargs: P.kwargs) -> U:
+        return self.value
+
+def check(box: Box[int, [str]]) -> None:
+    reveal_type(box.get)  # revealed: bound method Box[int, (str, /)].get(str, /) -> int
+```
+
+### Specializing explicit class method receivers with `ParamSpec`
+
+A class method's explicit `cls` annotation also determines a method-scoped type variable when the
+method is bound. Specializing `Factory` with a concrete parameter list preserves that binding, so
+`make` returns the specialized `Factory` type.
+
+```py
+class Factory[**P]:
+    @classmethod
+    def make[T](cls: type[T], *args: P.args, **kwargs: P.kwargs) -> T:
+        return cls()
+
+# revealed: bound method <class 'Factory[(int, /)]'>.make(int, /) -> Factory[(int, /)]
+reveal_type(Factory[[int]].make)
+```
+
 ### Gradual types propagate through `ParamSpec` inference
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4452,6 +4452,70 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ```
 
+## `Self`-returning instance methods in `ParamSpec` protocols
+
+Specializing a protocol's `ParamSpec` preserves the meaning of `Self`: the return type names the
+structural implementation, even when the specialized parameter list is empty.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, Self
+
+class Copier[**P](Protocol):
+    def copy(self, *args: P.args, **kwargs: P.kwargs) -> Self: ...
+
+class Copyable:
+    def copy(self) -> Self:
+        return self
+
+copier: Copier[[]] = Copyable()
+copier_class: type[Copier[[]]] = Copyable
+```
+
+## `Self`-returning class methods in `ParamSpec` protocols
+
+A class method returning `Self` also satisfies a specialized protocol, whether the implementation is
+assigned as an instance or as a class object. The implementation does not need to inherit from the
+protocol.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, Self
+
+class FactoryP[**P](Protocol):
+    @classmethod
+    def bind(cls, *args: P.args, **kwargs: P.kwargs) -> Self: ...
+
+class Factory:
+    @classmethod
+    def bind(cls, value: int) -> Self:
+        return cls()
+
+factory: FactoryP[[int]] = Factory()
+factory_class: type[FactoryP[[int]]] = Factory
+```
+
+A matching parameter list is not enough: returning an unrelated type does not satisfy the protocol's
+`Self` return type.
+
+```py
+class BadFactory:
+    @classmethod
+    def bind(cls, value: int) -> int:
+        return value
+
+bad_factory: FactoryP[[int]] = BadFactory()  # error: [invalid-assignment]
+bad_factory_class: type[FactoryP[[int]]] = BadFactory  # error: [invalid-assignment]
+```
+
 ## Module objects with static-method protocol members
 
 Module objects implement protocols through their public interface. A module-level function can

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -379,7 +379,9 @@ impl<'db> CallableSignature<'db> {
                                     type_mapping.update_signature_generic_context(db, env, context)
                                 }),
                             ),
-                            definition: signature.definition,
+                            // Keep the enclosing method's definition for binding `Self` and
+                            // other receiver type variables after specializing its parameters.
+                            definition: self_signature.definition,
                             source_overload_index: signature.source_overload_index,
                             receiver_constraints: {
                                 let mapped = self_signature.map_receiver_constraints(


### PR DESCRIPTION
Specializing a protocol's `ParamSpec` could leave a method's `Self` return type unbound, incorrectly rejecting structural implementations. This change restores `Self` binding for both instance and class methods, including assignments to `type[Protocol]`.

Preserve the enclosing signature's definition when expanding a concrete `ParamSpec`. The definition provides the binding context for `Self` and other receiver type variables; the substituted parameter list does not provide a replacement method definition. Parameter and overload-source metadata remain unchanged.

Fixes https://github.com/astral-sh/ty/issues/4369.

## Test plan

Add mdtests for `Self`-returning instance and class methods in specialized `ParamSpec` protocols. Cover empty and concrete parameter lists, instance and class-object assignments, and rejection of implementations returning an unrelated type.
