### PR TITLE
[`pylint`] Trigger on builtins.open (`PLW1514`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unspecified_encoding.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unspecified_encoding.py
@@ -104,3 +104,12 @@ from pathlib import Path
 def format_file(file: Path):
     with file.open() as f:
         contents = f.read()
+
+# https://github.com/astral-sh/ruff/issues/28012
+import builtins
+
+# Error.
+builtins.open("test.txt")
+
+# Non-error.
+builtins.open("test.txt", encoding="utf-8")

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -155,7 +155,7 @@ impl<'a> Callee<'a> {
     fn mode_argument(&self) -> ModeArgument {
         match self {
             Callee::Qualified(qualified_name) => match qualified_name.segments() {
-                ["" | "codecs" | "_io", "open"] => ModeArgument::Supported,
+                ["" | "builtins" | "codecs" | "_io", "open"] => ModeArgument::Supported,
                 [
                     "tempfile",
                     "TemporaryFile" | "NamedTemporaryFile" | "SpooledTemporaryFile",
@@ -224,7 +224,7 @@ fn is_violation(call: &ast::ExprCall, qualified_name: &Callee) -> bool {
     }
     match qualified_name {
         Callee::Qualified(qualified_name) => match qualified_name.segments() {
-            ["" | "codecs" | "_io", "open"] => {
+            ["" | "builtins" | "codecs" | "_io", "open"] => {
                 if let Some(mode_arg) = call.arguments.find_argument_value("mode", 1) {
                     if is_binary_mode(mode_arg).unwrap_or(true) {
                         // binary mode or unknown mode is no violation

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__unspecified-encoding_unspecified_encoding.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__unspecified-encoding_unspecified_encoding.py.snap
@@ -429,3 +429,21 @@ help: Add explicit `encoding` argument
 106 |         contents = f.read()
     |
 note: This is an unsafe fix and may change runtime behavior
+
+PLW1514 [*] `builtins.open` in text mode without explicit `encoding` argument
+   --> unspecified_encoding.py:112:1
+    |
+111 | # Error.
+112 | builtins.open("test.txt")
+    | ^^^^^^^^^^^^^
+113 |
+114 | # Non-error.
+    |
+help: Add explicit `encoding` argument
+    |
+111 | # Error.
+    - builtins.open("test.txt")
+112 + builtins.open("test.txt", encoding="utf-8")
+113 |
+    |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Trigger PLW1514 on `builtins.open` usage with an unspecified encoding.

Related to #28012

## Test Plan

`cargo nextest run`
