### PR TITLE
[ty] Expand ParamSpec signatures inferred from bound receivers

### DIFF
--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -393,6 +393,35 @@ mod tests {
     }
 
     #[test]
+    fn signature_help_paramspec_classmethod_docstring() {
+        let test = cursor_test(
+            r#"
+        from typing import Callable
+
+        class Factory:
+            def __init__(self, value: int) -> None:
+                """Constructor documentation."""
+
+            @classmethod
+            def make[**P](cls: Callable[P, "Factory"], *args: P.args, **kwargs: P.kwargs) -> "Factory":
+                """Factory method documentation."""
+                return cls(*args, **kwargs)
+
+        Factory.make(<CURSOR>)
+        "#,
+        );
+
+        let documentation = test
+            .signature_help()
+            .and_then(|result| result.signatures.into_iter().next())
+            .and_then(|signature| signature.documentation);
+        assert_eq!(
+            documentation.as_ref().map(Docstring::render_plaintext),
+            Some("Factory method documentation.\n".to_string())
+        );
+    }
+
+    #[test]
     fn signature_help_nested_function_calls() {
         let test = cursor_test(
             r#"

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1059,6 +1059,43 @@ wrapper.call(False)  # error: [no-matching-overload]
 wrapper.call(True, "wrong")  # error: [no-matching-overload]
 ```
 
+When the callback is overloaded, each method overload expands into multiple signatures. A failed
+call lists each method overload declaration only once.
+
+```py
+@overload
+def overloaded_callback(value: int) -> int: ...
+@overload
+def overloaded_callback(*, label: str) -> int: ...
+def overloaded_callback(value: int = 0, *, label: str = "") -> int:
+    return value
+
+overloaded_wrapper = Wrapper(overloaded_callback)
+overloaded_wrapper.call(False, b"wrong")  # snapshot: no-matching-overload
+```
+
+```snapshot
+error[no-matching-overload]: No overload of bound method `Wrapper.call` matches arguments
+  --> src/mdtest_snippet.py:34:1
+   |
+34 | overloaded_wrapper.call(False, b"wrong")  # snapshot: no-matching-overload
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+info: First overload defined here
+ --> src/mdtest_snippet.py:7:5
+  |
+7 | /     @overload
+8 | |     def call[**Q](self: "Wrapper[Q]", as_str: Literal[False], /, *args: Q.args, **kwargs: Q.kwargs) -> int: ...
+  | |_______________________________________________________________________________________________________________^ First overload defined here
+info: Possible overloads for bound method `call`:
+info:   [**Q](self: Wrapper[Q], as_str: Literal[False], /, *args: Q.args, **kwargs: Q.kwargs) -> int
+info:   [**Q](self: Wrapper[Q], as_str: Literal[True], /, *args: Q.args, **kwargs: Q.kwargs) -> str
+info: Overload implementation defined here
+  --> src/mdtest_snippet.py:11:9
+   |
+11 |     def call(self, as_str: bool, /, *args: P.args, **kwargs: P.kwargs) -> int | str:
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
 ### Classmethod receivers with overloaded constructors
 
 A classmethod forwards each constructor overload independently. A call supplies either an integer

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -966,6 +966,142 @@ class Factory[**P]:
 reveal_type(Factory[[int]].make)
 ```
 
+### `ParamSpec` inferred from classmethod receivers
+
+The class object bound to `cls` determines the constructor parameters represented by `P`. The bound
+method accepts those parameters, preserving their names, kinds, and defaults.
+
+```py
+from typing import Callable
+
+class Factory:
+    def __init__(self, value: int, *, label: str = "") -> None: ...
+    @classmethod
+    def make[**P](cls: Callable[P, "Factory"], *args: P.args, **kwargs: P.kwargs) -> "Factory":
+        return cls(*args, **kwargs)
+
+# revealed: bound method <class 'Factory'>.make(value: int, *, label: str = "") -> Factory
+reveal_type(Factory.make)
+reveal_type(Factory.make(1))  # revealed: Factory
+Factory.make(value=1, label="label")
+
+make: Callable[[int], Factory] = Factory.make
+```
+
+Calls and callback assignments are checked against the constructor signature. In particular, the
+required parameter cannot be omitted, and the optional keyword-only parameter cannot be positional.
+
+```py
+Factory.make()  # error: [missing-argument] "No argument provided for required parameter `value`"
+Factory.make("wrong")  # error: [invalid-argument-type] "Expected `int`"
+Factory.make(1, label=2)  # error: [invalid-argument-type] "Expected `str`"
+Factory.make(1, "label")  # error: [too-many-positional-arguments]
+Factory.make(1, unexpected=True)  # error: [unknown-argument]
+
+wrong_factory: Callable[[str], Factory] = Factory.make  # error: [invalid-assignment]
+```
+
+### `ParamSpec` inferred from callable instance receivers
+
+An instance method can infer `P` from the bound instance's `__call__` signature. If the callable is
+generic, its type parameters remain available for inference from the forwarded arguments.
+
+```py
+from typing import Callable
+
+class Callback:
+    def __call__[T](self, value: T) -> T:
+        return value
+
+    def call[**P, R](self: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+        return self(*args, **kwargs)
+
+callback = Callback()
+
+# revealed: bound method Callback.call[T](value: T) -> T
+reveal_type(callback.call)
+reveal_type(callback.call(value=1))  # revealed: Literal[1]
+reveal_type(callback.call("value"))  # revealed: Literal["value"]
+callback.call()  # error: [missing-argument] "No argument provided for required parameter `value`"
+callback.call(1, 2)  # error: [too-many-positional-arguments]
+```
+
+### Overloaded methods with generic receivers
+
+The mutable callback attribute makes `Wrapper` invariant in `P`, so its receiver determines each
+overload's `Q` exactly. The prepended flag determines the return type.
+
+```py
+from typing import Callable, Literal, overload
+
+class Wrapper[**P]:
+    def __init__(self, callback: Callable[P, int]) -> None:
+        self.callback = callback
+
+    @overload
+    def call[**Q](self: "Wrapper[Q]", as_str: Literal[False], /, *args: Q.args, **kwargs: Q.kwargs) -> int: ...
+    @overload
+    def call[**Q](self: "Wrapper[Q]", as_str: Literal[True], /, *args: Q.args, **kwargs: Q.kwargs) -> str: ...
+    def call(self, as_str: bool, /, *args: P.args, **kwargs: P.kwargs) -> int | str:
+        result = self.callback(*args, **kwargs)
+        return str(result) if as_str else result
+
+def callback(value: int) -> int:
+    return value
+
+wrapper = Wrapper(callback)
+
+# revealed: Overload[(as_str: Literal[False], /, value: int) -> int, (as_str: Literal[True], /, value: int) -> str]
+reveal_type(wrapper.call)
+reveal_type(wrapper.call(False, 1))  # revealed: int
+reveal_type(wrapper.call(True, value=1))  # revealed: str
+wrapper.call(False)  # error: [no-matching-overload]
+wrapper.call(True, "wrong")  # error: [no-matching-overload]
+```
+
+### Classmethod receivers with overloaded constructors
+
+A classmethod forwards each constructor overload independently. A call supplies either an integer
+value or a keyword-only string label, not both.
+
+```py
+from typing import Callable, overload
+
+class Factory:
+    @overload
+    def __init__(self, value: int) -> None: ...
+    @overload
+    def __init__(self, *, label: str) -> None: ...
+    def __init__(self, value: int = 0, *, label: str = "") -> None: ...
+    @classmethod
+    def make[**P](cls: Callable[P, "Factory"], *args: P.args, **kwargs: P.kwargs) -> "Factory":
+        return cls(*args, **kwargs)
+
+# revealed: Overload[(value: int) -> Factory, (*, label: str) -> Factory]
+reveal_type(Factory.make)
+reveal_type(Factory.make(1))  # revealed: Factory
+reveal_type(Factory.make(label="label"))  # revealed: Factory
+
+Factory.make()  # snapshot: no-matching-overload
+Factory.make(1, label="label")  # error: [no-matching-overload]
+```
+
+```snapshot
+error[no-matching-overload]: No overload of bound method `Factory.make` matches arguments
+  --> src/mdtest_snippet.py:18:1
+   |
+18 | Factory.make()  # snapshot: no-matching-overload
+   | ^^^^^^^^^^^^^^
+info: Possible overloads for bound method `make`:
+info:   (value: int) -> Factory
+info:   (*, label: str) -> Factory
+info: Overload implementation defined here
+  --> src/mdtest_snippet.py:10:9
+   |
+10 |     def make[**P](cls: Callable[P, "Factory"], *args: P.args, **kwargs: P.kwargs) -> "Factory":
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
 ### Gradual types propagate through `ParamSpec` inference
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5750,7 +5750,7 @@ impl<'db> Type<'db> {
                 } else {
                     // Solve exact receiver constraints before checking the other arguments, but
                     // retain the receiver itself for call inference and receiver diagnostics.
-                    let overloads = signature.overloads.iter().map(|overload| {
+                    let overloads = signature.overloads.iter().flat_map(|overload| {
                         if overload.has_receiver_determined_method_typevar(db, env)
                             && let Some(specialized) = overload.specialize_for_bound_receiver(
                                 db,
@@ -5759,9 +5759,9 @@ impl<'db> Type<'db> {
                                 bound_method.typing_self_type(db),
                             )
                         {
-                            specialized
+                            specialized.overloads
                         } else {
-                            overload.clone()
+                            smallvec_inline![overload.clone()]
                         }
                     });
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3613,11 +3613,12 @@ impl<'db> CallableBinding<'db> {
         })
     }
 
-    /// Returns the source overload indexes that should be shown in diagnostics.
+    /// Returns the distinct source overload indexes that should be shown in diagnostics.
     ///
-    /// Bound method overloads preserve their source indexes after receiver filtering. Method
-    /// wrapper overloads are synthesized from `__get__`, so their indexes do not correspond to
-    /// the overload declarations of the underlying function.
+    /// Bound method overloads preserve their source indexes after receiver filtering. Receiver
+    /// specialization can expand one source overload into multiple signatures. Method wrapper
+    /// overloads are synthesized from `__get__`, so their indexes do not correspond to the overload
+    /// declarations of the underlying function.
     fn diagnostic_overload_indexes(
         &self,
         db: &'db dyn Db,
@@ -3632,6 +3633,7 @@ impl<'db> CallableBinding<'db> {
         self.overloads
             .iter()
             .map(Binding::source_overload_index)
+            .unique()
             .collect()
     }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -16,7 +16,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::fmt;
 
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::{Ranged, TextRange};
@@ -4626,16 +4626,31 @@ impl<'db> CallableBinding<'db> {
                         function.name(context.db())
                     ));
 
-                    for overload in possible_overloads.iter().take(MAXIMUM_OVERLOADS) {
-                        diag.info(format_args!(
-                            "  {}",
-                            overload.signature(db).display(db, env)
-                        ));
+                    let possible_signatures = if possible_overloads.is_empty() {
+                        // Receiver specialization can introduce overloads through a `ParamSpec`
+                        // even when the method has no overload declarations of its own.
+                        Either::Left(self.overloads.iter().map(|overload| {
+                            if self.bound_type.is_some() {
+                                overload.signature.bind_self(db, env, None)
+                            } else {
+                                overload.signature.clone()
+                            }
+                        }))
+                    } else {
+                        Either::Right(
+                            possible_overloads
+                                .iter()
+                                .map(|overload| overload.signature(db)),
+                        )
+                    };
+                    let possible_overload_count = possible_signatures.len();
+                    for signature in possible_signatures.take(MAXIMUM_OVERLOADS) {
+                        diag.info(format_args!("  {}", signature.display(db, env)));
                     }
-                    if possible_overloads.len() > MAXIMUM_OVERLOADS {
+                    if possible_overload_count > MAXIMUM_OVERLOADS {
                         diag.info(format_args!(
                             "... omitted {remaining} overloads",
-                            remaining = possible_overloads.len() - MAXIMUM_OVERLOADS
+                            remaining = possible_overload_count - MAXIMUM_OVERLOADS
                         ));
                     }
 

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -171,9 +171,13 @@ impl<'db> BoundMethodType<'db> {
             }
 
             return CallableSignature::from_overloads(
-                function_signature.overloads.iter().filter_map(|signature| {
-                    signature.bind_self_if_compatible(db, env, receiver_type, typing_self_type)
-                }),
+                function_signature
+                    .overloads
+                    .iter()
+                    .filter_map(|signature| {
+                        signature.bind_self_if_compatible(db, env, receiver_type, typing_self_type)
+                    })
+                    .flat_map(|signature| signature.overloads),
             );
         };
 
@@ -183,12 +187,9 @@ impl<'db> BoundMethodType<'db> {
             None
         };
 
-        CallableSignature::single(
-            specialized
-                .as_ref()
-                .unwrap_or(signature)
-                .bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type)),
-        )
+        specialized
+            .unwrap_or_else(|| CallableSignature::single(signature.clone()))
+            .bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type))
     }
 
     pub(super) fn recursive_type_normalized_impl(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1279,7 +1279,8 @@ impl<'db> Signature<'db> {
     ///
     /// Matching the receiver can constrain type variables that occur elsewhere in the signature.
     /// Exact bounds determine an unambiguous specialization; one-sided constraints remain
-    /// available to normal call inference. The receiver remains in the returned signature so
+    /// available to normal call inference. A `ParamSpec` can capture multiple overloads, so one
+    /// signature can expand into several. The receiver remains in each returned signature so
     /// bound-method calls can still check it and report receiver-related diagnostics.
     pub(crate) fn specialize_for_bound_receiver(
         &self,
@@ -1287,11 +1288,11 @@ impl<'db> Signature<'db> {
         env: &ProgramEnvironment<'db>,
         receiver_type: Type<'db>,
         typing_self_type: Type<'db>,
-    ) -> Option<Self> {
+    ) -> Option<CallableSignature<'db>> {
         let bound_signature =
             self.bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type));
         let Some(receiver_constraints) = bound_signature.receiver_constraints.as_ref() else {
-            return Some(self.clone());
+            return Some(CallableSignature::single(self.clone()));
         };
 
         let constraints = ConstraintSetBuilder::new();
@@ -1300,17 +1301,19 @@ impl<'db> Signature<'db> {
 
         match when.solutions(db, env, inferable) {
             Ok(Solutions::Unsatisfiable) => return None,
-            Ok(Solutions::Unconstrained) | Err(_) => return Some(self.clone()),
+            Ok(Solutions::Unconstrained) | Err(_) => {
+                return Some(CallableSignature::single(self.clone()));
+            }
             // Each receiver path can leave a different type variable unconstrained. Preserve the
             // original relation instead of combining those independent solutions.
             Ok(Solutions::Constrained(solutions)) if solutions.as_slice().len() > 1 => {
-                return Some(self.clone());
+                return Some(CallableSignature::single(self.clone()));
             }
             Ok(Solutions::Constrained(_)) => {}
         }
 
         let Some(generic_context) = self.generic_context else {
-            return Some(self.clone());
+            return Some(CallableSignature::single(self.clone()));
         };
 
         let mut builder = SpecializationBuilder::new(db, env, &constraints, generic_context);
@@ -1343,7 +1346,22 @@ impl<'db> Signature<'db> {
             Some(Type::TypeVar(typevar))
         });
 
-        Some(self.apply_specialization(db, specialization))
+        let type_mapping =
+            TypeMapping::ApplySpecialization(ApplySpecialization::specialization(specialization));
+        let mut specialized = CallableSignature::single(self.clone()).apply_type_mapping_impl(
+            db,
+            &type_mapping,
+            TypeContext::default(),
+            &ApplyTypeMappingVisitor::new(env),
+        );
+
+        // The captured `ParamSpec` can carry overload indices from another callable. Keep
+        // this method's overload index so call diagnostics refer to the correct declaration.
+        for signature in &mut specialized.overloads {
+            signature.source_overload_index = self.source_overload_index;
+        }
+
+        Some(specialized)
     }
 
     /// Returns this signature bound to `receiver_type` if its explicit receiver annotation is
@@ -1354,7 +1372,7 @@ impl<'db> Signature<'db> {
         env: &ProgramEnvironment<'db>,
         receiver_type: Type<'db>,
         typing_self_type: Type<'db>,
-    ) -> Option<Self> {
+    ) -> Option<CallableSignature<'db>> {
         if !self.can_bind_self_to(db, env, receiver_type) {
             return None;
         }


### PR DESCRIPTION
A method whose `self` or `cls` annotation determines a `ParamSpec` can reject valid calls: the captured parameter list is treated as each argument's type instead of being expanded into parameters. Expand receiver-specialized signatures through the existing callable specialization code so they preserve parameter names, kinds, defaults, generic parameters, and overloads.

Overload diagnostics show the expanded signatures when the method has no overload declarations of its own, and list each source declaration once when it does.

Depends on #28016 for preserving method definitions during `ParamSpec` expansion.

Fixes astral-sh/ty#4383.

## Test plan

- Mdtests cover classmethod constructor forwarding, callable instance receivers with a generic `__call__`, overloaded methods and constructors, rejected arguments and callback assignments, and deduplicated overload diagnostics when the captured callback is also overloaded.
- A signature-help regression checks that the forwarding method's documentation is retained after receiver specialization.
