### PR TITLE
[`flake8-async`, `pylint`] Recognize `builtins.open` (`ASYNC230`, `PLW1514`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-async/blocking-open-call-in-async-function.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-async/blocking-open-call-in-async-function.md
@@ -1,0 +1,42 @@
+# `blocking-open-call-in-async-function` (`ASYNC230`)
+
+```toml
+lint.select = ["ASYNC230"]
+```
+
+## Builtin imports
+
+Opening a file blocks an async function whether `open` is referenced directly, through `builtins`,
+or through an imported alias. `io.open` is also a blocking call.
+
+```py
+import builtins
+import io
+from builtins import open as builtin_open
+
+async def read_file():
+    open("data.txt")  # error: [blocking-open-call-in-async-function]
+    builtins.open("data.txt")  # error: [blocking-open-call-in-async-function]
+    builtin_open("data.txt")  # error: [blocking-open-call-in-async-function]
+    io.open("data.txt")  # error: [blocking-open-call-in-async-function]
+```
+
+## Synchronous functions
+
+The rule only checks calls in async contexts.
+
+```py
+import builtins
+
+def read_file():
+    builtins.open("data.txt")
+```
+
+## Shadowed names
+
+A parameter named `open` does not refer to the builtin.
+
+```py
+async def custom_open(open):
+    open("data.txt")
+```

--- a/crates/ruff_linter/resources/mdtest/pylint/unspecified-encoding.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/unspecified-encoding.md
@@ -1,0 +1,48 @@
+# `unspecified-encoding` (`PLW1514`)
+
+```toml
+preview = true
+lint.select = ["PLW1514"]
+```
+
+## Builtin imports
+
+Text files need an explicit encoding even when `open` is imported from `builtins`.
+
+```py
+import builtins
+from builtins import open as builtin_open
+
+builtins.open("data.txt")  # snapshot: unspecified-encoding
+builtin_open("data.txt")  # error: [unspecified-encoding]
+```
+
+```snapshot
+error[PLW1514]: `builtins.open` in text mode without explicit `encoding` argument
+ --> src/mdtest_snippet.py:4:1
+  |
+4 | builtins.open("data.txt")  # snapshot: unspecified-encoding
+  | ^^^^^^^^^^^^^
+help: Add explicit `encoding` argument
+  |
+3 |
+  - builtins.open("data.txt")  # snapshot: unspecified-encoding
+4 + builtins.open("data.txt", encoding="utf-8")  # snapshot: unspecified-encoding
+5 | builtin_open("data.txt")  # error: [unspecified-encoding]
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Explicit encodings and binary mode
+
+An explicit encoding or binary mode makes the call valid, whether passed by position or by keyword.
+
+```py
+import builtins
+from builtins import open as builtin_open
+
+builtins.open("data.txt", encoding="utf-8")
+builtin_open("data.txt", "r", -1, "utf-8")
+builtins.open("data.bin", "rb")
+builtin_open("data.bin", mode="wb")
+```

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_open_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_open_call.rs
@@ -64,7 +64,7 @@ fn is_open_call(func: &Expr, semantic: &SemanticModel) -> bool {
         .is_some_and(|qualified_name| {
             matches!(
                 qualified_name.segments(),
-                ["" | "io", "open"] | ["io", "open_code"]
+                ["" | "builtins" | "io", "open"] | ["io", "open_code"]
             )
         })
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -154,7 +154,7 @@ impl<'a> Callee<'a> {
     fn mode_argument(&self) -> ModeArgument {
         match self {
             Callee::Qualified(qualified_name) => match qualified_name.segments() {
-                ["" | "codecs" | "_io", "open"] => ModeArgument::Supported,
+                ["" | "builtins" | "codecs" | "_io", "open"] => ModeArgument::Supported,
                 [
                     "tempfile",
                     "TemporaryFile" | "NamedTemporaryFile" | "SpooledTemporaryFile",
@@ -223,7 +223,7 @@ fn is_violation(call: &ast::ExprCall, qualified_name: &Callee) -> bool {
     }
     match qualified_name {
         Callee::Qualified(qualified_name) => match qualified_name.segments() {
-            ["" | "codecs" | "_io", "open"] => {
+            ["" | "builtins" | "codecs" | "_io", "open"] => {
                 if let Some(mode_arg) = call.arguments.find_argument_value("mode", 1) {
                     if is_binary_mode(mode_arg).unwrap_or(true) {
                         // binary mode or unknown mode is no violation


### PR DESCRIPTION
Recognize explicitly qualified and imported builtin open calls when checking for blocking I/O and missing text encodings.

Fixes #28012.
