### PR TITLE
[`flake8-datetimez`] Reject `tzinfo=None` for datetime bounds (`DTZ901`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-datetimez/datetime-min-max.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-datetimez/datetime-min-max.md
@@ -1,0 +1,27 @@
+# `datetime-min-max` (`DTZ901`)
+
+```toml
+lint.select = ["DTZ901"]
+```
+
+## Replacing the timezone with None
+
+Passing `tzinfo=None` to `replace` leaves `datetime.min` and `datetime.max` naive.
+
+```py
+from datetime import datetime
+
+datetime.min.replace(tzinfo=None)  # error: [datetime-min-max]
+datetime.max.replace(tzinfo=None)  # error: [datetime-min-max]
+```
+
+## Replacing the timezone with a timezone object
+
+Passing a timezone object produces an aware datetime.
+
+```py
+from datetime import datetime, timezone
+
+datetime.min.replace(tzinfo=timezone.utc)
+datetime.max.replace(tzinfo=timezone.utc)
+```

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/datetime_min_max.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/datetime_min_max.rs
@@ -98,7 +98,11 @@ fn usage_is_safe(semantic: &SemanticModel) -> bool {
 
     match (parent, grandparent) {
         (Expr::Attribute(ExprAttribute { attr, .. }), Expr::Call(ExprCall { arguments, .. })) => {
-            attr == "time" || (attr == "replace" && arguments.find_keyword("tzinfo").is_some())
+            attr == "time"
+                || (attr == "replace"
+                    && arguments
+                        .find_keyword("tzinfo")
+                        .is_some_and(|keyword| !keyword.value.is_none_literal_expr()))
         }
         _ => false,
     }


### PR DESCRIPTION
Only exempt replace calls with a non-None timezone argument, since passing None leaves datetime.min and datetime.max naive.

Fixes #28013.
