### PR TITLE
[`flake8-async`] Detect blocking generic HTTP requests (`ASYNC210`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-async/blocking-http-call-in-async-function.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-async/blocking-http-call-in-async-function.md
@@ -1,0 +1,65 @@
+# `blocking-http-call-in-async-function` (`ASYNC210`)
+
+```toml
+lint.select = ["ASYNC210"]
+```
+
+## Generic request functions
+
+The generic `requests.request` and `httpx.request` functions block just like the method-specific
+helpers such as `get`. Imported aliases have the same behavior.
+
+```py
+import httpx
+import requests
+from httpx import request as httpx_request
+from requests import request as requests_request
+
+async def fetch(url):
+    requests.get(url)  # error: [blocking-http-call-in-async-function]
+    requests.request("GET", url)  # error: [blocking-http-call-in-async-function]
+    requests_request("GET", url)  # error: [blocking-http-call-in-async-function]
+    httpx.get(url)  # error: [blocking-http-call-in-async-function]
+    httpx.request("GET", url)  # error: [blocking-http-call-in-async-function]
+    httpx_request("GET", url)  # error: [blocking-http-call-in-async-function]
+```
+
+## Synchronous functions
+
+The rule only checks calls in async contexts.
+
+```py
+import httpx
+import requests
+
+def fetch(url):
+    requests.request("GET", url)
+    httpx.request("GET", url)
+```
+
+## Shadowed module names
+
+Parameters named `requests` and `httpx` do not refer to the imported libraries.
+
+```py
+import httpx
+import requests
+
+async def custom_client(requests, httpx, url):
+    requests.request("GET", url)
+    httpx.request("GET", url)
+```
+
+## Requests dispatched to a worker thread
+
+Passing the request functions to `asyncio.to_thread` does not block the event loop.
+
+```py
+import asyncio
+import httpx
+import requests
+
+async def fetch_in_thread(url):
+    await asyncio.to_thread(requests.request, "GET", url)
+    await asyncio.to_thread(httpx.request, "GET", url)
+```

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
@@ -55,7 +55,8 @@ fn is_blocking_http_call(qualified_name: &QualifiedName) -> bool {
             | ["urllib3", "request"]
             | [
                 "httpx" | "requests",
-                "get"
+                "request"
+                    | "get"
                     | "post"
                     | "delete"
                     | "patch"


### PR DESCRIPTION
Recognize requests.request and httpx.request alongside their method-specific helpers when checking for blocking HTTP calls in async functions.

Fixes #28015.
