### PR TITLE
Mark ISC003 docstring-creating fixes as unsafe

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_implicit_str_concat/ISC003_docstring.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_implicit_str_concat/ISC003_docstring.py
@@ -1,0 +1,31 @@
+# https://github.com/astral-sh/ruff/issues/27979
+
+# Unsafe: the fix would create a module docstring.
+(
+    "module "
+    + "docstring"
+)
+
+
+# Unsafe: the fix would create a class docstring.
+class ClassWithExplicitConcatenation:
+    (
+        "class "
+        + "docstring"
+    )
+
+
+# Unsafe: the fix would create a function docstring.
+def function_with_explicit_concatenation():
+    (
+        "function "
+        + "docstring"
+    )
+
+
+# Safe: the concatenation isn't itself the first expression statement.
+def function_with_safe_concatenation():
+    print(
+        "hello "
+        + "world"
+    )

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -525,6 +525,10 @@ impl<'a> Checker<'a> {
         &self.semantic
     }
 
+    pub(crate) fn module_body(&self) -> &'a [Stmt] {
+        self.parsed.suite()
+    }
+
     /// The [`LinterSettings`] for the current analysis, including the enabled rules.
     pub(crate) const fn settings(&self) -> &'a LinterSettings {
         self.context.settings

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/mod.rs
@@ -32,6 +32,7 @@ mod tests {
         Path::new("ISC_syntax_error_2.py")
     )]
     #[test_case(Rule::ExplicitStringConcatenation, Path::new("ISC.py"))]
+    #[test_case(Rule::ExplicitStringConcatenation, Path::new("ISC003_docstring.py"))]
     #[test_case(
         Rule::ImplicitStringConcatenationInCollectionLiteral,
         Path::new("ISC004.py")

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/explicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/explicit.rs
@@ -1,6 +1,7 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::token::{TokenKind, parenthesized_range};
-use ruff_python_ast::{self as ast, Expr, Operator};
+use ruff_python_ast::{self as ast, Expr, Operator, Stmt};
+use ruff_python_semantic::ScopeKind;
 use ruff_python_trivia::is_python_whitespace;
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
@@ -24,6 +25,12 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 ///     + "dog"
 /// )
 /// ```
+///
+/// ## Fix safety
+/// The fix is unsafe when the concatenation is the first statement in a
+/// module, class, or function, because replacing explicit concatenation with
+/// implicit concatenation can turn the expression into a docstring and change
+/// the value of `__doc__`.
 ///
 /// Use instead:
 /// ```python
@@ -105,7 +112,7 @@ pub(crate) fn explicit(checker: &Checker, expr: &Expr) {
                     return;
                 }
 
-                if let Some(fix) = generate_fix(checker, bin_op) {
+                if let Some(fix) = generate_fix(checker, expr, bin_op) {
                     diagnostic.set_fix(fix);
                 }
             }
@@ -113,7 +120,7 @@ pub(crate) fn explicit(checker: &Checker, expr: &Expr) {
     }
 }
 
-fn generate_fix(checker: &Checker, expr_bin_op: &ast::ExprBinOp) -> Option<Fix> {
+fn generate_fix(checker: &Checker, expr: &Expr, expr_bin_op: &ast::ExprBinOp) -> Option<Fix> {
     let ast::ExprBinOp { left, right, .. } = expr_bin_op;
 
     let between_operands_range = TextRange::new(left.end(), right.start());
@@ -141,8 +148,40 @@ fn generate_fix(checker: &Checker, expr_bin_op: &ast::ExprBinOp) -> Option<Fix> 
         before_plus.trim_end_matches(is_python_whitespace)
     };
 
-    Some(Fix::safe_edit(Edit::range_replacement(
-        format!("{before_plus}{after_plus}"),
-        between_operands_range,
-    )))
+    let edit =
+        Edit::range_replacement(format!("{before_plus}{after_plus}"), between_operands_range);
+
+    let creates_docstring = matches!(
+        (left.as_ref(), right.as_ref()),
+        (Expr::StringLiteral(_), Expr::StringLiteral(_))
+    ) && is_docstring_position(checker, expr);
+
+    Some(if creates_docstring {
+        Fix::unsafe_edit(edit)
+    } else {
+        Fix::safe_edit(edit)
+    })
+}
+
+fn is_docstring_position(checker: &Checker, expr: &Expr) -> bool {
+    let statement = checker.semantic().current_statement();
+
+    let Stmt::Expr(ast::StmtExpr { value, .. }) = statement else {
+        return false;
+    };
+
+    // The concatenation must be the entire expression statement.
+    if !std::ptr::eq(value.as_ref(), expr) {
+        return false;
+    }
+
+    let body = match checker.semantic().current_scope().kind {
+        ScopeKind::Module => checker.module_body(),
+        ScopeKind::Class(class_def) => class_def.body.as_slice(),
+        ScopeKind::Function(function_def) => function_def.body.as_slice(),
+        _ => return false,
+    };
+
+    body.first()
+        .is_some_and(|first| std::ptr::eq(first, statement))
 }

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__ISC003_ISC003_docstring.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/snapshots/ruff_linter__rules__flake8_implicit_str_concat__tests__ISC003_ISC003_docstring.py.snap
@@ -1,0 +1,77 @@
+---
+source: crates/ruff_linter/src/rules/flake8_implicit_str_concat/mod.rs
+---
+ISC003 [*] Explicitly concatenated string should be implicitly concatenated
+ --> ISC003_docstring.py:5:5
+  |
+3 |   # Unsafe: the fix would create a module docstring.
+4 |   (
+5 | /     "module "
+6 | |     + "docstring"
+  | |_________________^
+7 |   )
+  |
+help: Remove redundant '+' operator to implicitly concatenate
+  |
+5 |     "module "
+  -     + "docstring"
+6 +      "docstring"
+7 | )
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+ISC003 [*] Explicitly concatenated string should be implicitly concatenated
+  --> ISC003_docstring.py:13:9
+   |
+11 |   class ClassWithExplicitConcatenation:
+12 |       (
+13 | /         "class "
+14 | |         + "docstring"
+   | |_____________________^
+15 |       )
+   |
+help: Remove redundant '+' operator to implicitly concatenate
+   |
+13 |         "class "
+   -         + "docstring"
+14 +          "docstring"
+15 |     )
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+ISC003 [*] Explicitly concatenated string should be implicitly concatenated
+  --> ISC003_docstring.py:21:9
+   |
+19 |   def function_with_explicit_concatenation():
+20 |       (
+21 | /         "function "
+22 | |         + "docstring"
+   | |_____________________^
+23 |       )
+   |
+help: Remove redundant '+' operator to implicitly concatenate
+   |
+21 |         "function "
+   -         + "docstring"
+22 +          "docstring"
+23 |     )
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+ISC003 [*] Explicitly concatenated string should be implicitly concatenated
+  --> ISC003_docstring.py:29:9
+   |
+27 |   def function_with_safe_concatenation():
+28 |       print(
+29 | /         "hello "
+30 | |         + "world"
+   | |_________________^
+31 |       )
+   |
+help: Remove redundant '+' operator to implicitly concatenate
+   |
+29 |         "hello "
+   -         + "world"
+30 +          "world"
+31 |     )
+   |


### PR DESCRIPTION
## Fixes #27979.

`ISC003` previously treated removing an explicit `+` between string literals as a safe fix in all cases. However, when the concatenation is the first statement in a module, class, or function, removing the `+` can turn the expression into a docstring and change the value of `__doc__`.

This change marks the fix as **unsafe only when it would create a docstring**. Other `ISC003` fixes remain safe.

It also adds regression coverage for module, class, and function docstring positions, along with a case that verifies concatenations nested inside another expression remain safe.

## Test Plan

* Added a dedicated `ISC003_docstring.py` fixture and snapshot tests.
* Verified module, class, and function docstring-creating fixes are marked unsafe.
* Verified a normal nested concatenation remains a safe fix.
* Ran:

  * `cargo test -p ruff_linter flake8_implicit_str_concat`
  * `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings`
  * `cargo fmt --all`
  * `git diff --check`