### PR TITLE
[ty] Re-enable CodSpeed cycle estimation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1278,7 +1278,6 @@ jobs:
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
         with:
           mode: ${{ matrix.mode }}
-          cycle-estimation: false
           run: cargo codspeed run --bench "${{ matrix.target }}" "${{ matrix.filter }}"
 
   benchmarks-walltime-build:


### PR DESCRIPTION
## Summary

Reverts #27706 to re-enable CodSpeed cycle estimation for instrumented ty benchmarks. The false-positive issue that prompted the workaround should now be fixed.

The first comparison may be incomparable until `main` has a baseline with cycle estimation enabled.

## Test Plan

Testing: Static diff checks passed; workflow hooks and benchmarks were not run locally.
