### PR TITLE
[ty] Ignore inconsistent binding decorators on overloads

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -1014,6 +1014,25 @@ def parameter_type(x: int) -> int | str:
     return 1
 ```
 
+An inconsistent implementation does not disable a consistently applied method decorator. Calls still
+use the overload signatures.
+
+```py
+class StaticMethod:
+    @overload
+    @staticmethod
+    # error: [invalid-overload] "Implementation does not accept all arguments of this overload"
+    def method(x: int) -> int: ...
+    @overload
+    @staticmethod
+    def method(x: str) -> int: ...
+    @staticmethod
+    def method(x: str) -> int:
+        return 0
+
+reveal_type(StaticMethod().method(1))  # revealed: int
+```
+
 Generic overloads are left to the full implementation-consistency check.
 
 ```py
@@ -1388,32 +1407,32 @@ from typing import Callable, overload
 
 class CheckStaticMethod:
     @overload
-    def method1(x: int) -> int: ...
+    def method1(self, x: int) -> int: ...
     @overload
-    def method1(x: str) -> str: ...
+    def method1(self, x: str) -> str: ...
     @staticmethod
     # error: [invalid-overload] "Overloaded function `method1` does not use the `@staticmethod` decorator consistently"
-    def method1(x: int | str) -> int | str:
+    def method1(self, x: int | str) -> int | str:
         return x
 
     @overload
-    def method2(x: int) -> int: ...
+    def method2(self, x: int) -> int: ...
     @overload
     @staticmethod
-    def method2(x: str) -> str: ...
+    def method2(self, x: str) -> str: ...
     @staticmethod
     # error: [invalid-overload]
-    def method2(x: int | str) -> int | str:
+    def method2(self, x: int | str) -> int | str:
         return x
 
     @overload
     @staticmethod
-    def method3(x: int) -> int: ...
+    def method3(self, x: int) -> int: ...
     @overload
     @staticmethod
-    def method3(x: str) -> str: ...
+    def method3(self, x: str) -> str: ...
     # error: [invalid-overload]
-    def method3(x: int | str) -> int | str:
+    def method3(self, x: int | str) -> int | str:
         return x
 
     @overload
@@ -1425,6 +1444,61 @@ class CheckStaticMethod:
     @staticmethod
     def method4(x: int | str) -> int | str:
         return x
+```
+
+An inconsistently applied `@staticmethod` decorator has no effect on method binding, including when
+it decorates the implementation. The consistent overload set remains a static method.
+
+```py
+instance = CheckStaticMethod()
+reveal_type(instance.method1(1))  # revealed: int
+reveal_type(instance.method2("a"))  # revealed: str
+reveal_type(instance.method3(1))  # revealed: int
+reveal_type(instance.method4("a"))  # revealed: str
+
+reveal_type(CheckStaticMethod.method1(instance, 1))  # revealed: int
+CheckStaticMethod.method1(1)  # error: [no-matching-overload]
+```
+
+#### Inconsistent `@staticmethod` decorators in stubs
+
+When a stub mixes static and instance overloads, calls bind the instance as the first argument.
+Overloads whose first parameter cannot accept that instance are filtered out. The order of the
+overloads does not affect this recovery.
+
+`widget.pyi`:
+
+```pyi
+from typing import overload
+
+class Widget:
+    @overload
+    @staticmethod
+    def method(source: str, index: int) -> int: ...
+    @overload
+    # error: [invalid-overload] "Overloaded function `method` does not use the `@staticmethod` decorator consistently"
+    def method(self, index: int) -> str: ...
+    @overload
+    def reversed(self, index: int) -> str: ...
+    @overload
+    @staticmethod
+    # error: [invalid-overload]
+    def reversed(source: str, index: int) -> int: ...
+```
+
+Accessing the method on the class leaves the receiver unbound, so its first parameter must be passed
+explicitly.
+
+`main.py`:
+
+```py
+from widget import Widget
+
+widget = Widget()
+reveal_type(widget.method(5))  # revealed: str
+reveal_type(widget.reversed(5))  # revealed: str
+reveal_type(Widget.method(widget, 5))  # revealed: str
+reveal_type(Widget.method("a", 5))  # revealed: int
 ```
 
 #### `@classmethod`
@@ -1490,7 +1564,26 @@ class CheckClassMethod:
         if isinstance(x, int):
             return cls(x)
         return None
+```
 
+Inconsistent `@classmethod` decorators likewise do not bind the class. Calls on an instance bind
+that instance, and calls on the class require an explicit receiver.
+
+```py
+instance = CheckClassMethod(1)
+reveal_type(instance.try_from1("a"))  # revealed: None
+reveal_type(instance.try_from2(1))  # revealed: CheckClassMethod
+reveal_type(CheckClassMethod.try_from3(CheckClassMethod, 1))  # revealed: CheckClassMethod
+reveal_type(CheckClassMethod.try_from1(instance, "a"))  # revealed: None
+CheckClassMethod.try_from1(1)  # error: [no-matching-overload]
+
+reveal_type(CheckClassMethod.try_from4(1))  # revealed: CheckClassMethod
+```
+
+Consistent classmethod overloads can restrict which subclasses accept each overload by annotating
+the receiver.
+
+```py
 class Base:
     @overload
     @classmethod
@@ -1510,6 +1603,43 @@ reveal_type(Child.from_value)  # revealed: Overload[(x: int) -> int, (x: str) ->
 good: Callable[[int], int] = Base.from_value
 # error: [invalid-assignment]
 bad: Callable[[str], str] = Base.from_value
+```
+
+#### Inconsistent `@classmethod` decorators in stubs
+
+An explicit class receiver annotation cannot accept an instance. Ignoring an inconsistent
+`@classmethod` decorator therefore filters out that overload when the method binds an instance,
+regardless of overload order.
+
+`factory.pyi`:
+
+```pyi
+from typing import overload
+
+class Factory:
+    @overload
+    @classmethod
+    def method(cls: type[Factory], value: int) -> int: ...
+    @overload
+    # error: [invalid-overload] "Overloaded function `method` does not use the `@classmethod` decorator consistently"
+    def method(self, value: int) -> str: ...
+    @overload
+    def reversed(self, value: int) -> str: ...
+    @overload
+    @classmethod
+    # error: [invalid-overload]
+    def reversed(cls: type[Factory], value: int) -> int: ...
+```
+
+`main.py`:
+
+```py
+from factory import Factory
+
+factory = Factory()
+reveal_type(factory.method(1))  # revealed: str
+reveal_type(factory.reversed(1))  # revealed: str
+reveal_type(Factory.method(factory, 1))  # revealed: str
 ```
 
 #### `@final`

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@classmethod`_(aaa04d4cfa3adaba).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/overloads.md_-_Overloads_-_Invalid_-_Inconsistent_decorat…_-_`@classmethod`_(aaa04d4cfa3adaba).snap
@@ -69,26 +69,33 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/overloads.md
 54 |         if isinstance(x, int):
 55 |             return cls(x)
 56 |         return None
-57 | 
-58 | class Base:
-59 |     @overload
-60 |     @classmethod
-61 |     def from_value(cls: type[Base], x: int) -> int: ...
-62 |     @overload
-63 |     @classmethod
-64 |     def from_value(cls: type[Child], x: str) -> str: ...
-65 |     @classmethod
-66 |     def from_value(cls, x: int | str) -> int | str:
-67 |         return x
-68 | 
-69 | class Child(Base): ...
-70 | 
-71 | reveal_type(Base.from_value)  # revealed: bound method <class 'Base'>.from_value(x: int) -> int
-72 | reveal_type(Child.from_value)  # revealed: Overload[(x: int) -> int, (x: str) -> str]
-73 | 
-74 | good: Callable[[int], int] = Base.from_value
-75 | # error: [invalid-assignment]
-76 | bad: Callable[[str], str] = Base.from_value
+57 | instance = CheckClassMethod(1)
+58 | reveal_type(instance.try_from1("a"))  # revealed: None
+59 | reveal_type(instance.try_from2(1))  # revealed: CheckClassMethod
+60 | reveal_type(CheckClassMethod.try_from3(CheckClassMethod, 1))  # revealed: CheckClassMethod
+61 | reveal_type(CheckClassMethod.try_from1(instance, "a"))  # revealed: None
+62 | CheckClassMethod.try_from1(1)  # error: [no-matching-overload]
+63 | 
+64 | reveal_type(CheckClassMethod.try_from4(1))  # revealed: CheckClassMethod
+65 | class Base:
+66 |     @overload
+67 |     @classmethod
+68 |     def from_value(cls: type[Base], x: int) -> int: ...
+69 |     @overload
+70 |     @classmethod
+71 |     def from_value(cls: type[Child], x: str) -> str: ...
+72 |     @classmethod
+73 |     def from_value(cls, x: int | str) -> int | str:
+74 |         return x
+75 | 
+76 | class Child(Base): ...
+77 | 
+78 | reveal_type(Base.from_value)  # revealed: bound method <class 'Base'>.from_value(x: int) -> int
+79 | reveal_type(Child.from_value)  # revealed: Overload[(x: int) -> int, (x: str) -> str]
+80 | 
+81 | good: Callable[[int], int] = Base.from_value
+82 | # error: [invalid-assignment]
+83 | bad: Callable[[str], str] = Base.from_value
 ```
 
 # Diagnostics
@@ -145,10 +152,34 @@ error[call-non-callable]: Object of type `CheckClassMethod` is not callable
 ```
 
 ```
-error[invalid-assignment]: Object of type `bound method <class 'Base'>.from_value(x: int) -> int` is not assignable to `(str, /) -> str`
-  --> src/mdtest_snippet.py:76:29
+error[no-matching-overload]: No overload of function `CheckClassMethod.try_from1` matches arguments
+  --> src/mdtest_snippet.py:62:1
    |
-76 | bad: Callable[[str], str] = Base.from_value
+62 | CheckClassMethod.try_from1(1)  # error: [no-matching-overload]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+info: First overload defined here
+  --> src/mdtest_snippet.py:9:5
+   |
+ 9 | /     @overload
+10 | |     @classmethod
+11 | |     def try_from1(cls, x: int) -> CheckClassMethod: ...
+   | |_______________________________________________________^ First overload defined here
+info: Possible overloads for function `try_from1`:
+info:   (cls, x: int) -> CheckClassMethod
+info:   (cls, x: str) -> None
+info: Overload implementation defined here
+  --> src/mdtest_snippet.py:16:9
+   |
+16 |     def try_from1(cls, x: int | str) -> CheckClassMethod | None:
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+```
+
+```
+error[invalid-assignment]: Object of type `bound method <class 'Base'>.from_value(x: int) -> int` is not assignable to `(str, /) -> str`
+  --> src/mdtest_snippet.py:83:29
+   |
+83 | bad: Callable[[str], str] = Base.from_value
    |      --------------------   ^^^^^^^^^^^^^^^ Incompatible value of type `bound method <class 'Base'>.from_value(x: int) -> int`
    |      |
    |      Declared type

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1389,18 +1389,26 @@ impl<'db> FunctionType<'db> {
         self.literal(db).has_known_decorator(db, decorator)
     }
 
-    /// Returns true if this method is decorated with `@classmethod`, or if it is implicitly a
-    /// classmethod.
+    /// Returns true if every definition of this method uses `@classmethod`, or is implicitly a
+    /// classmethod. An inconsistently applied decorator does not affect method binding.
     pub(crate) fn is_classmethod(self, db: &'db dyn Db) -> bool {
-        self.iter_overloads_and_implementation(db)
-            .any(|overload| overload.is_classmethod(db))
+        let mut overloads = self.iter_overloads_and_implementation(db);
+        // Overload discovery can return no definitions during cycle recovery.
+        overloads
+            .next()
+            .is_some_and(|overload| overload.is_classmethod(db))
+            && overloads.all(|overload| overload.is_classmethod(db))
     }
 
-    /// Returns true if this method is decorated with `@staticmethod`, or if it is implicitly a
-    /// static method.
+    /// Returns true if every definition of this method uses `@staticmethod`, or is implicitly a
+    /// static method. An inconsistently applied decorator does not affect method binding.
     pub(crate) fn is_staticmethod(self, db: &'db dyn Db) -> bool {
-        self.iter_overloads_and_implementation(db)
-            .any(|overload| overload.is_staticmethod(db))
+        let mut overloads = self.iter_overloads_and_implementation(db);
+        // Overload discovery can return no definitions during cycle recovery.
+        overloads
+            .next()
+            .is_some_and(|overload| overload.is_staticmethod(db))
+            && overloads.all(|overload| overload.is_staticmethod(db))
     }
 
     /// Returns true if this function has an implicit `self` or `cls` receiver parameter.


### PR DESCRIPTION
When an overload set applies `@staticmethod` inconsistently, ty reports the invalid declaration but also treats every overload as static. This leaves `self` unbound on instance overloads and causes a cascading `no-matching-overload` error.

If a decorator's application to an overload is invalid, and we report that error, it makes more sense to ignore that invalid decorator than to implicitly apply it to every overload, as we did before.

Ignore a `@staticmethod` or `@classmethod` binding decorator unless it applies consistently across every overload and any implementation. Keep the `invalid-overload` diagnostic, per-definition receiver annotations and body checking, and implicit special-method binding. Preserve the existing fallback when overload discovery encounters a cycle.

Fixes astral-sh/ty#4388.

## Test plan

- Extend overload mdtests with imported staticmethod and classmethod stubs in both declaration orders, instance and class access, and receiver-incompatible overloads.
- Cover mismatches involving implementations and verify that consistently applied decorators retain their behavior, including when an unrelated overload error is present.
