### PR TITLE
[ty] Remove quantified constraints from source-order history

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -566,6 +566,66 @@ class C:
 reveal_type(C().method)  # revealed: Overload[[T](arg: T) -> None, (arg: int) -> None, (arg: str) -> None]
 ```
 
+## Recursive receiver protocols with tuple parameters
+
+The receiver's type variables can occur together in a tuple parameter and separately in the return
+type. Binding the receiver preserves both variables and the concrete overload alternatives.
+
+```py
+from typing import Protocol, overload
+
+class P[A, R](Protocol):
+    def method(self, arg: tuple[A, R]) -> R: ...
+
+@overload
+def method[A, R](obj: P[A, R], arg: tuple[A, R]) -> R: ...
+@overload
+def method(obj: object, arg: tuple[int, str]) -> str: ...
+@overload
+def method(obj: object, arg: tuple[str, int]) -> int: ...
+def method(obj, arg):
+    raise NotImplementedError
+
+class C:
+    method = method
+
+# revealed: Overload[[A, R](arg: tuple[A, R]) -> R, (arg: tuple[int, str]) -> str, (arg: tuple[str, int]) -> int]
+reveal_type(C().method)
+C().method((1, "x"))
+C().method(("x", 1))
+C().method((1,))  # error: [no-matching-overload]
+```
+
+## Recursive receiver protocols with invariant containers
+
+Type variables in invariant containers also survive receiver binding. Calls still enforce the
+parameter's container shape after the recursive receiver constraints have been resolved.
+
+```py
+from typing import Protocol, overload
+
+class P[A, R](Protocol):
+    def method(self, arg: list[A]) -> list[R]: ...
+
+@overload
+def method[A, R](obj: P[A, R], arg: list[A]) -> list[R]: ...
+@overload
+def method(obj: object, arg: list[int]) -> list[int]: ...
+@overload
+def method(obj: object, arg: list[str]) -> list[str]: ...
+def method(obj, arg):
+    raise NotImplementedError
+
+class C:
+    method = method
+
+# revealed: Overload[[A, R](arg: list[A]) -> list[R], (arg: list[int]) -> list[int], (arg: list[str]) -> list[str]]
+reveal_type(C().method)
+C().method([1])
+C().method(["x"])
+C().method(1)  # error: [no-matching-overload]
+```
+
 ## Builtin functions with recursive receiver protocols
 
 Assigning `pow` to a class's `__pow__` attribute is valid. Its overloads accept protocols describing

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -514,4 +514,66 @@ Parent().method(1)
 Child().method(1)
 ```
 
+## Recursive receiver protocols across overloads
+
+Each overload introduces its own type variables, even when two overloads have identical signatures.
+Binding the receiver preserves these variables when its protocol refers back to the same method.
+
+```py
+from typing import Protocol, overload
+
+class P[T](Protocol):
+    def method(self) -> T: ...
+
+@overload
+def method[T](obj: P[T]) -> T: ...
+@overload
+def method[U](obj: P[U]) -> U: ...
+@overload
+def method(obj: object) -> int: ...
+def method(obj):
+    raise NotImplementedError
+
+class C:
+    method = method
+
+reveal_type(C().method)  # revealed: Overload[[T]() -> T, [U]() -> U, () -> int]
+```
+
+## Concrete overload alternatives with a recursive receiver
+
+A recursive protocol-typed receiver also works with concrete overloads that accept different
+argument types. Binding the receiver preserves both concrete alternatives.
+
+```py
+from typing import Protocol, overload
+
+class P[T](Protocol):
+    def method(self, arg: T) -> None: ...
+
+@overload
+def method[T](obj: P[T], arg: T) -> None: ...
+@overload
+def method(obj: object, arg: int) -> None: ...
+@overload
+def method(obj: object, arg: str) -> None: ...
+def method(obj, arg):
+    raise NotImplementedError
+
+class C:
+    method = method
+
+reveal_type(C().method)  # revealed: Overload[[T](arg: T) -> None, (arg: int) -> None, (arg: str) -> None]
+```
+
+## Builtin functions with recursive receiver protocols
+
+Assigning `pow` to a class's `__pow__` attribute is valid. Its overloads accept protocols describing
+that same method, so receiver checking is recursive.
+
+```py
+class C:
+    __pow__ = pow
+```
+
 [`tensorbase`]: https://github.com/pytorch/pytorch/blob/f3913ea641d871f04fa2b6588a77f63efeeb9f10/torch/_tensor.py#L1084-L1092

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -425,9 +425,9 @@ assert_type(infer_return(callback), object)
 
 ## Generic inference after projection budget exhaustion
 
-The literal-specific overloads below produce more alternative bindings than generic inference can
-project within its limits. The precise type of `default=0` does not replace the missing callback
-evidence: we recover with `Unknown` in either argument order.
+Each tuple element independently matches one of the callback's overloads. The combined alternative
+bindings exceed generic inference's projection limits. The precise type of `default=0` does not
+replace the missing callback evidence: we recover with `Unknown` in either argument order.
 
 ```py
 from typing import Callable, Literal, TypeVar, overload
@@ -436,8 +436,10 @@ from ty_extensions._internal import Unknown
 
 R = TypeVar("R")
 T = TypeVar("T")
+U = TypeVar("U")
+V = TypeVar("V")
 
-def infer_return(callback: Callable[[T], R], default: R) -> R:
+def infer_return(callback: tuple[Callable[[T], R], Callable[[U], R], Callable[[V], R]], default: R) -> R:
     raise NotImplementedError
 
 @overload
@@ -461,18 +463,12 @@ def callback(value: Literal[16, 17]): ...
 @overload
 def callback(value: Literal[18, 19]): ...
 @overload
-def callback(value: Literal[20, 21]): ...
-@overload
-def callback(value: Literal[22, 23]): ...
-@overload
-def callback(value: Literal[24, 25]): ...
-@overload
 def callback(value: object) -> object: ...
 def callback(value):
     raise NotImplementedError
 
-assert_type(infer_return(callback, 0), Unknown)
-assert_type(infer_return(default=0, callback=callback), Unknown)
+assert_type(infer_return((callback, callback, callback), 0), Unknown)
+assert_type(infer_return(default=0, callback=(callback, callback, callback)), Unknown)
 ```
 
 ## Multiple occurrences of a higher-order generic callable

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -324,8 +324,8 @@ impl<'db> OwnedConstraintSet<'db> {
 
     /// Returns the types in constraints that are still reachable from the decision diagram.
     ///
-    /// Source ordering also retains quantified-away constraints to preserve binding order, but
-    /// their type variables must not participate in semantic walks or callable freshening.
+    /// Source ordering can retain constraints that are no longer in the diagram, but their type
+    /// variables must not participate in semantic walks or callable freshening.
     pub(crate) fn types(&self) -> impl Iterator<Item = Type<'db>> + '_ {
         self.inner.iter().flat_map(|inner| {
             inner
@@ -694,11 +694,27 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: TypeVarSet<'db>,
     ) -> Self {
         self.verify_builder(builder);
+        if to_remove == TypeVarSet::None {
+            return self;
+        }
         let mut storage = builder.storage.borrow_mut();
         let (node, derived_source_order) =
             self.node
                 .exists(db, env, &mut storage, to_remove, self.source_order);
-        let source_order = storage.ordered_source_order(self.source_order, derived_source_order);
+        // The eliminated typevars must also leave the source-order history. Otherwise recursive
+        // relations can re-import each other's quantified constraints after their live graphs have
+        // stabilized. Keep the original order of the remaining entries and append derived facts.
+        let source_order = storage
+            .calculate_source_orders(self.source_order)
+            .into_iter()
+            .fold(None, |source_order, constraint| {
+                if storage.constraint_mentions_typevars(db, constraint, to_remove) {
+                    return source_order;
+                }
+                let constraint_source_order = storage.constraint_source_order(constraint);
+                storage.ordered_source_order(source_order, Some(constraint_source_order))
+            });
+        let source_order = storage.ordered_source_order(source_order, derived_source_order);
         Self::from_node(builder, node, source_order)
     }
 
@@ -1147,10 +1163,10 @@ impl<'db> ConstraintSetBuilder<'db> {
         let source_order = source_constraints
             .into_iter()
             .fold(None, |left, source_constraint| {
-                // Quantified-away constraints can still determine the order of related live
-                // solutions. An unrelated constraint cannot, and keeping its fresh type variables
-                // in a cached value can prevent recursive Salsa queries from reaching a fixed
-                // point. Incomplete supports may hide a relationship, so preserve those entries.
+                // Preserve ordering history for absorbed constraints related to the live graph.
+                // Unrelated history can retain fresh typevars and prevent recursive Salsa queries
+                // from reaching a fixed point. Incomplete supports may hide a relationship, so
+                // preserve those entries.
                 let constraint_support_id = storage.constraint_support_id(source_constraint);
                 let constraint_support = storage.support_data(constraint_support_id);
                 if !used_constraints[source_constraint.index()]
@@ -1587,6 +1603,17 @@ impl<'db> ConstraintSetStorage<'db> {
 
     fn constraint_support(&self, constraint: ConstraintId) -> &Support {
         self.support_data(self.constraint_support_id(constraint))
+    }
+
+    fn constraint_mentions_typevars(
+        &self,
+        db: &'db dyn Db,
+        constraint: ConstraintId,
+        typevars: TypeVarSet<'db>,
+    ) -> bool {
+        self.constraint_support(constraint)
+            .iter()
+            .any(|typevar| self.typevar_data(typevar).is_inferable(db, typevars))
     }
 
     fn node_support_id(&self, node: NodeId) -> Option<SupportId> {
@@ -4608,11 +4635,7 @@ impl InteriorNode {
             // the sequent map can propagate any derived constraints that do not mention the
             // quantified typevars.
             &mut |storage: &ConstraintSetStorage<'_>, constraint| {
-                let support = storage.constraint_support(constraint);
-                support.iter().any(|typevar| {
-                    let typevar = storage.typevar_data(typevar);
-                    typevar.is_inferable(db, bound_typevars)
-                })
+                storage.constraint_mentions_typevars(db, constraint, bound_typevars)
             },
         );
         result
@@ -7447,47 +7470,53 @@ class E: ...
     }
 
     #[test]
-    fn owned_constraint_set_preserves_related_quantified_constraint_order() {
+    fn owned_constraint_set_preserves_projected_solution_order() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
         let t = create_typevar(db, "T");
         let u = create_typevar(db, "U");
-        let v = create_typevar(db, "V");
+        let inferable = TypeVarSet::from_typevars(db, [u]);
+        let expected = Ok(Solutions::Constrained(SolutionPaths::Complete(vec![
+            vec![TypeVarSolution {
+                bound_typevar: u,
+                solution: known_instance(db, KnownClass::Int),
+            }],
+            vec![TypeVarSolution {
+                bound_typevar: u,
+                solution: known_instance(db, KnownClass::Str),
+            }],
+        ])));
 
         let owned = ConstraintSetBuilder::new().into_owned(|builder| {
-            let u_t = ConstraintSet::constrain_typevar_with_bounds(
+            let u_t = ConstraintSet::constrain_typevar(
                 db,
                 &env,
                 builder,
                 u,
-                None,
-                Some(ConstraintBound::Evidence(Type::TypeVar(t))),
+                Type::TypeVar(t),
+                Type::TypeVar(t),
             );
-            let t_v = ConstraintSet::constrain_typevar(
-                db,
-                &env,
-                builder,
-                t,
-                Type::TypeVar(v),
-                Type::TypeVar(v),
-            );
+            let t_str = create_constraint(db, builder, t, KnownClass::Str);
+            let u_int = create_constraint(db, builder, u, KnownClass::Int);
 
-            u_t.and(db, builder, || t_v).reduce_inferable(
-                db,
-                &env,
-                builder,
-                TypeVarSet::from_typevars(db, [t]),
-            )
+            // Eliminating T leaves a derived U = str alternative alongside the direct U = int.
+            let projected = u_t
+                .and(db, builder, || t_str)
+                .or(db, builder, || u_int)
+                .reduce_inferable(db, &env, builder, TypeVarSet::from_typevars(db, [t]));
+            assert_eq!(projected.solutions(db, &env, inferable), expected);
+            projected
         });
-
-        assert_eq!(
-            owned.inner.as_ref().map(|inner| inner.source_orders.len()),
-            Some(5),
-        );
 
         let reloaded =
             ConstraintSetBuilder::new().into_owned(|builder| builder.load(db, &env, &owned));
+        for constraints in [&owned, &reloaded] {
+            constraints.query(|_builder, constraints| {
+                assert_eq!(constraints.solutions(db, &env, inferable), expected);
+            });
+        }
+
         let reloaded_again =
             ConstraintSetBuilder::new().into_owned(|builder| builder.load(db, &env, &reloaded));
         assert_eq!(reloaded, reloaded_again);
@@ -7521,6 +7550,55 @@ class E: ...
         };
 
         assert_eq!(build(false), build(true));
+    }
+
+    #[test]
+    fn owned_constraint_set_preserves_order_when_reintroducing_constraints() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let t = create_typevar(db, "T");
+        let inferable = TypeVarSet::from_typevars(db, [t]);
+        let int = known_instance(db, KnownClass::Int);
+        let str = known_instance(db, KnownClass::Str);
+
+        // Absorption can remove a constraint without eliminating its typevar. Its source order
+        // still matters if it is reintroduced, including when gradual bounds affect the solutions.
+        for (lower, upper) in [(Some(str), Some(str)), (None, Some(Type::any()))] {
+            let mut expected = None;
+            let owned = ConstraintSetBuilder::new().into_owned(|builder| {
+                let earlier =
+                    ConstraintSet::constrain_typevar_lower_bound(db, &env, builder, t, int);
+                let later = ConstraintSet::constrain_typevar_with_bounds(
+                    db,
+                    &env,
+                    builder,
+                    t,
+                    lower.map(ConstraintBound::Evidence),
+                    upper.map(ConstraintBound::Evidence),
+                );
+                let absorbed = earlier.or(db, builder, || later).and(db, builder, || later);
+                expected = Some(
+                    absorbed
+                        .or(db, builder, || earlier)
+                        .solutions(db, &env, inferable),
+                );
+                absorbed
+            });
+            assert_matches!(&expected, Some(Ok(Solutions::Constrained(_))));
+
+            let builder = ConstraintSetBuilder::new();
+            let reloaded = builder.load(db, &env, &owned);
+            let earlier = ConstraintSet::constrain_typevar_lower_bound(db, &env, &builder, t, int);
+            assert_eq!(
+                Some(
+                    reloaded
+                        .or(db, &builder, || earlier)
+                        .solutions(db, &env, inferable),
+                ),
+                expected,
+            );
+        }
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -774,6 +774,10 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                 let constraint = storage.constraint_data(constraint_id);
                 constraints.push((constraint_id, constraint));
             });
+        // Mapping can intern constraints and typevars. Preserve their source order rather than
+        // letting the old diagram's variable order determine the rebuilt diagram's ordering.
+        let source_orders = storage.calculate_source_orders(self.source_order);
+        constraints.sort_unstable_by_key(|(constraint, _)| source_orders.get_index_of(constraint));
         drop(storage);
 
         let mut mapped_constraints = FxHashMap::default();
@@ -828,8 +832,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         }
 
         let mut storage = self.builder.storage.borrow_mut();
-        let source_order = storage
-            .calculate_source_orders(self.source_order)
+        let source_order = source_orders
             .into_iter()
             .fold(None, |source_order, constraint| {
                 mapped_constraints.get(&constraint).map_or(
@@ -2777,9 +2780,9 @@ impl NodeId {
     fn with_uncertain(
         storage: &mut ConstraintSetStorage<'_>,
         constraint: ConstraintId,
-        if_true: NodeId,
+        mut if_true: NodeId,
         if_uncertain: NodeId,
-        if_false: NodeId,
+        mut if_false: NodeId,
     ) -> NodeId {
         debug_assert!(
             if_true
@@ -2807,10 +2810,20 @@ impl NodeId {
             return ALWAYS_TRUE;
         }
 
-        if if_true == if_false {
-            if if_true == if_uncertain {
-                return if_true;
+        // A guarded branch covered by the uncertain branch adds no satisfying assignments.
+        // Keep the proof bounded and non-allocating: speculative intersections here can trigger
+        // further coverage checks and expand a compact disjunction exponentially.
+        if if_uncertain != ALWAYS_FALSE {
+            let mut remaining_visits = 64;
+            if if_true.is_covered_by(storage, if_uncertain, &mut remaining_visits) {
+                if_true = ALWAYS_FALSE;
             }
+            if if_false.is_covered_by(storage, if_uncertain, &mut remaining_visits) {
+                if_false = ALWAYS_FALSE;
+            }
+        }
+
+        if if_true == if_false {
             if if_true == ALWAYS_FALSE {
                 return if_uncertain;
             }
@@ -2823,20 +2836,73 @@ impl NodeId {
             // the local equality check has already engaged.
         }
 
-        if if_true == if_uncertain && if_false == ALWAYS_FALSE {
-            return if_uncertain;
-        }
-
-        if if_false == if_uncertain && if_true == ALWAYS_FALSE {
-            return if_uncertain;
-        }
-
         storage.intern_interior_node(InteriorNodeData {
             constraint,
             if_true,
             if_uncertain,
             if_false,
         })
+    }
+
+    /// Proves coverage using existing TDD branches, without constructing another diagram.
+    ///
+    /// This is deliberately incomplete: a branch must be covered by one target alternative,
+    /// rather than by a union assembled from several alternatives. Exhausting the shared
+    /// traversal budget also returns false, leaving the original branch unchanged.
+    fn is_covered_by(
+        self,
+        storage: &ConstraintSetStorage<'_>,
+        other: Self,
+        remaining_visits: &mut usize,
+    ) -> bool {
+        if self == other || self == ALWAYS_FALSE || other == ALWAYS_TRUE {
+            return true;
+        }
+        let Some(remaining) = remaining_visits.checked_sub(1) else {
+            return false;
+        };
+        *remaining_visits = remaining;
+        let (Node::Interior(left), Node::Interior(right)) = (self.node(), other.node()) else {
+            return false;
+        };
+        let left = storage.interior_node_data(left.node());
+        let right = storage.interior_node_data(right.node());
+        match left.constraint.ordering().cmp(&right.constraint.ordering()) {
+            Ordering::Less => {
+                left.if_true.is_covered_by(storage, other, remaining_visits)
+                    && left
+                        .if_uncertain
+                        .is_covered_by(storage, other, remaining_visits)
+                    && left
+                        .if_false
+                        .is_covered_by(storage, other, remaining_visits)
+            }
+            Ordering::Equal => {
+                left.if_uncertain
+                    .is_covered_by(storage, other, remaining_visits)
+                    && (left
+                        .if_true
+                        .is_covered_by(storage, right.if_true, remaining_visits)
+                        || left.if_true.is_covered_by(
+                            storage,
+                            right.if_uncertain,
+                            remaining_visits,
+                        ))
+                    && (left
+                        .if_false
+                        .is_covered_by(storage, right.if_false, remaining_visits)
+                        || left.if_false.is_covered_by(
+                            storage,
+                            right.if_uncertain,
+                            remaining_visits,
+                        ))
+            }
+            Ordering::Greater => {
+                self.is_covered_by(storage, right.if_uncertain, remaining_visits)
+                    || (self.is_covered_by(storage, right.if_true, remaining_visits)
+                        && self.is_covered_by(storage, right.if_false, remaining_visits))
+            }
+        }
     }
 }
 
@@ -3172,6 +3238,9 @@ impl NodeId {
 
     /// Returns the `and` or intersection of two BDDs.
     fn and(self, storage: &mut ConstraintSetStorage<'_>, other: Self) -> Self {
+        if self == other {
+            return self;
+        }
         match (self.node(), other.node()) {
             (Node::AlwaysFalse, _) | (_, Node::AlwaysFalse) => ALWAYS_FALSE,
             (Node::AlwaysTrue, _) => other,
@@ -4862,7 +4931,11 @@ impl InteriorNode {
             should_remove,
             limits,
         };
-        path.visit(db, env, storage, self.node(), &mut visitor)
+        let (node, derived_source_order) =
+            path.visit(db, env, storage, self.node(), &mut visitor)?;
+        let derived_source_order =
+            path.projection_source_order(storage, source_order, derived_source_order);
+        ControlFlow::Continue((node, derived_source_order))
     }
 
     fn path_assignments<'db>(
@@ -7129,6 +7202,74 @@ class E: ...
         );
     }
 
+    #[test]
+    fn tdd_uncertain_branch_absorbs_stronger_paths() {
+        let db = setup_db();
+        let db = &db;
+        let builder = ConstraintSetBuilder::new();
+        let t = create_typevar(db, "T");
+        let u = create_typevar(db, "U");
+        let v = create_typevar(db, "V");
+        let last = create_constraint(db, &builder, t, KnownClass::Int);
+        let middle = create_constraint(db, &builder, u, KnownClass::Str);
+        let first = create_constraint(db, &builder, v, KnownClass::Bytes);
+
+        // The uncertain branch already accepts every assignment of the stronger guarded path,
+        // whether that path requires or excludes the first constraint.
+        for guard in [first, first.negate(db, &builder)] {
+            let stronger = guard
+                .and(db, &builder, || middle)
+                .and(db, &builder, || last);
+            let absorbed = stronger.or(db, &builder, || middle);
+            assert_eq!(absorbed.node, middle.node);
+        }
+    }
+
+    #[test]
+    fn disjunction_of_independent_conjunctions_stays_compact() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let builder = ConstraintSetBuilder::new();
+        let count = 12;
+        let atoms = |prefix| {
+            (0..count)
+                .rev()
+                .map(|index| {
+                    let typevar = BoundTypeVarInstance::synthetic(
+                        db,
+                        &env,
+                        Name::new(format!("{prefix}{index}")),
+                        TypeVarVariance::Invariant,
+                    );
+                    create_constraint(db, &builder, typevar, KnownClass::Int)
+                })
+                .collect::<Vec<_>>()
+        };
+        // Place all X conditions before all Y conditions in the TDD ordering. The disjunction
+        // (X0 ∧ Y0) ∨ … ∨ (Xn ∧ Yn) has a small diagram without distributing its alternatives.
+        let y = atoms("Y");
+        let x = atoms("X");
+        let mut groups: Vec<_> = x
+            .into_iter()
+            .zip(y)
+            .rev()
+            .map(|(x, y)| x.and(db, &builder, || y))
+            .collect();
+        while groups.len() > 1 {
+            groups = groups
+                .chunks(2)
+                .map(|pair| {
+                    let left = pair[0];
+                    pair.get(1)
+                        .map_or(left, |right| left.or(db, &builder, || *right))
+                })
+                .collect();
+        }
+        let nodes = builder.storage.borrow().nodes.len();
+        assert!(nodes < 4 * count * count, "allocated {nodes} nodes");
+    }
+
     /// Negation always produces flat TDDs (all uncertain branches are `ALWAYS_FALSE`).
     #[test]
     fn tdd_negation_produces_flat_tdd() {
@@ -7235,7 +7376,13 @@ class E: ...
         let u_str = create_constraint(db, &builder, u, KnownClass::Str);
         let combined = t_int.and(db, &builder, || u_str);
 
-        for original in [t_int, combined] {
+        let t_bool = create_constraint(db, &builder, t, KnownClass::Bool);
+        let u_int = create_constraint(db, &builder, u, KnownClass::Int);
+        let alternatives = t_int
+            .and(db, &builder, || u_int)
+            .or(db, &builder, || u_str.and(db, &builder, || t_bool));
+
+        for original in [t_int, combined, alternatives] {
             let storage = builder.storage.borrow();
             let original_source_order_count = storage.source_orders.len();
             drop(storage);
@@ -7520,6 +7667,79 @@ class E: ...
         let reloaded_again =
             ConstraintSetBuilder::new().into_owned(|builder| builder.load(db, &env, &reloaded));
         assert_eq!(reloaded, reloaded_again);
+    }
+
+    #[test]
+    fn projected_constraint_source_order_is_independent_of_allocation_order() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let a = create_typevar(db, "A");
+        let r = create_typevar(db, "R");
+        let fresh_a = create_typevar(db, "FreshA");
+        let fresh_r = create_typevar(db, "FreshR");
+        let int = known_instance(db, KnownClass::Int);
+        let str = known_instance(db, KnownClass::Str);
+        let atoms = [
+            (fresh_r, Some(int), None),
+            (fresh_a, None, Some(int)),
+            (fresh_r, Some(str), None),
+            (fresh_a, None, Some(str)),
+            (r, Some(Type::TypeVar(fresh_r)), None),
+            (a, None, Some(Type::TypeVar(fresh_a))),
+        ];
+
+        let project = |allocation_order: &[usize]| {
+            let builder = ConstraintSetBuilder::new();
+            // Keep typevar orientation fixed while changing only the TDD variable order.
+            for typevar in [fresh_r, fresh_a, a, r] {
+                builder.storage.borrow_mut().intern_typevar(db, typevar);
+            }
+            let atom = |index: usize| {
+                let (typevar, lower, upper) = atoms[index];
+                ConstraintSet::constrain_typevar_with_bounds(
+                    db,
+                    &env,
+                    &builder,
+                    typevar,
+                    lower.map(ConstraintBound::Evidence),
+                    upper.map(ConstraintBound::Evidence),
+                )
+            };
+            for &index in allocation_order {
+                let _ = atom(index);
+            }
+            let [int_r, a_int, str_r, a_str, r_bound, a_bound] = [0, 1, 2, 3, 4, 5].map(atom);
+
+            // Eliminating FreshA and FreshR leaves both bounds of the int and str alternatives
+            // on A and R. All original constraints disappear, but their source order survives.
+            let projected = int_r
+                .and(db, &builder, || a_int)
+                .or(db, &builder, || str_r.and(db, &builder, || a_str))
+                .and(db, &builder, || r_bound)
+                .and(db, &builder, || a_bound)
+                .reduce_inferable(
+                    db,
+                    &env,
+                    &builder,
+                    TypeVarSet::from_typevars(db, [fresh_a, fresh_r]),
+                );
+            let storage = builder.storage.borrow();
+            storage
+                .calculate_source_orders(projected.source_order)
+                .into_iter()
+                .map(|constraint| storage.constraint_data(constraint))
+                .collect::<Vec<_>>()
+        };
+
+        let expected = project(&[0, 1, 2, 3, 4, 5]);
+        for allocation_order in (0..6).permutations(6) {
+            assert_eq!(
+                project(&allocation_order),
+                expected,
+                "allocation order {allocation_order:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints/paths.rs
+++ b/crates/ty_python_semantic/src/types/constraints/paths.rs
@@ -11,7 +11,8 @@ use rustc_hash::FxHashSet;
 
 use crate::types::constraints::sequents::{Sequent, SequentMap};
 use crate::types::constraints::{
-    ConstraintAssignment, ConstraintId, ConstraintSetStorage, Node, NodeId, PathVisitor, TypeVarId,
+    ConstraintAssignment, ConstraintId, ConstraintSetStorage, Node, NodeId, PathVisitor,
+    SourceOrderId, TypeVarId,
 };
 use crate::{Db, FxIndexMap, ProgramEnvironment};
 
@@ -130,6 +131,64 @@ impl Ord for AssignmentFuel {
 }
 
 impl PathAssignments {
+    /// Orders projected facts by replaying the rules already discovered during this walk.
+    ///
+    /// Projection emits derived facts in TDD branch order. Retaining that order can prevent
+    /// recursive relations from converging when an equivalent diagram is rebuilt in a different
+    /// arena. Start with the original source order and visit each rule's consequences in order,
+    /// including intermediate facts that are themselves projected away. This only replays cached
+    /// rules; it does not derive more facts or change the walk's assignments and fuel.
+    pub(super) fn projection_source_order(
+        &self,
+        storage: &mut ConstraintSetStorage<'_>,
+        original_source_order: Option<SourceOrderId>,
+        derived_source_order: Option<SourceOrderId>,
+    ) -> Option<SourceOrderId> {
+        let emitted = storage.calculate_source_orders(derived_source_order);
+        if emitted.is_empty() {
+            return None;
+        }
+        let mut ordered = storage.calculate_source_orders(original_source_order);
+        ordered.retain(|constraint| self.discovered.contains_key(constraint));
+        let mut index = 0;
+        // Once all emitted facts have positions, later appends cannot change their relative order.
+        while !emitted.is_subset(&ordered)
+            && let Some(constraint) = ordered.get_index(index).copied()
+        {
+            if self.discovered.get(&constraint) == Some(&true)
+                && let Some(map) = storage.single_sequent_cache.get(&constraint)
+            {
+                ordered.extend(
+                    map.consequents()
+                        .filter(|constraint| self.discovered.contains_key(constraint)),
+                );
+            }
+            for earlier_index in 0..index {
+                let earlier = ordered[earlier_index];
+                // Pair rules are not commutative. Replay the orientation used by this walk,
+                // which can differ from the order in which the replay reaches its inputs.
+                let pair = [(earlier, constraint), (constraint, earlier)]
+                    .into_iter()
+                    .find(|pair| self.elaborated_pairs.contains(pair));
+                if let Some(map) = pair.and_then(|pair| storage.pair_sequent_cache.get(&pair)) {
+                    ordered.extend(
+                        map.consequents()
+                            .filter(|constraint| self.discovered.contains_key(constraint)),
+                    );
+                }
+            }
+            index += 1;
+        }
+        debug_assert!(emitted.is_subset(&ordered));
+        ordered
+            .into_iter()
+            .filter(|constraint| emitted.contains(constraint))
+            .fold(None, |source_order, constraint| {
+                let next = storage.constraint_source_order(constraint);
+                storage.ordered_source_order(source_order, Some(next))
+            })
+    }
+
     pub(super) fn new(
         constraints: impl IntoIterator<Item = ConstraintId>,
         independent_typevars: FxHashSet<TypeVarId>,

--- a/crates/ty_python_semantic/src/types/constraints/sequents.rs
+++ b/crates/ty_python_semantic/src/types/constraints/sequents.rs
@@ -82,6 +82,15 @@ pub(super) enum Sequent {
 }
 
 impl SequentMap {
+    pub(super) fn consequents(&self) -> impl Iterator<Item = ConstraintId> + '_ {
+        self.sequents.iter().filter_map(|sequent| match sequent {
+            Sequent::SingleImplication { post, .. } | Sequent::PairImplication { post, .. } => {
+                Some(*post)
+            }
+            Sequent::SingleTautology { .. } | Sequent::PairImpossibility { .. } => None,
+        })
+    }
+
     /// Returns a sequent map containing the sequents that we can infer from a single constraint in
     /// isolation. This method is salsa-tracked so that we only perform this work once per
     /// constraint.


### PR DESCRIPTION
Fix non-converging recursive receiver checks, including assigning `pow` to a class's `__pow__` attribute, which can make Salsa panic with "too many cycle iterations".

Constraint sets retain both a ternary decision diagram (TDD) and source-order history. Successive iterations can represent the same constraints differently: eliminated type variables can survive in the history, and rebuilding a diagram can inherit allocation-dependent ordering or retain redundant branches. These representation changes prevent cached query results from reaching a fixed point.

This PR stabilizes constraint construction in three places:

- **Quantification:** remove history entries mentioning eliminated type variables, using the same support predicate as graph elimination. Preserve surviving entries' relative order and order derived facts by replaying already-discovered rules from the original source order, including intermediate facts that are themselves projected away. This replay does not derive additional facts or change inference fuel.
- **Type mapping:** map live constraints in source order before interning their replacements, so the old TDD's variable order does not determine allocation order in the rebuilt graph. Reuse that ordering when rebuilding the source-order history.
- **TDD reduction:** make self-intersection idempotent and absorb guarded branches whose satisfying assignments are already covered by the uncertain branch. The coverage proof is bounded and non-allocating; an inconclusive proof leaves the branch unchanged.

History for absorbed constraints that do not mention eliminated type variables remains intact, since it can affect later solution ordering when those constraints are reintroduced. The fix uses the existing TDD representation and leaves ordinary constraint-set equality and cycle recovery unchanged.

Fixes astral-sh/ty#4362.

## Test plan

- Mdtests cover recursive protocol receivers across independently generic overloads, concrete overload alternatives, tuple parameters, invariant containers, valid and invalid call shapes, and the builtin `pow` case.
- Unit tests cover projection order across 720 constraint-allocation permutations, solution ordering across ownership and reloads, reintroduction of absorbed constraints with concrete and gradual bounds, idempotent intersections, branch absorption, and compact construction of independent alternatives.
- Strengthen the projection-budget regression so it still exercises `Unknown` recovery in both argument orders after redundant paths are simplified.
- A nine-order mdtest comparison against the PR base finds no newly wobbling assertions or scenarios and no new checker panics. Existing ordering-sensitive cases remain; this is not a general solution to all constraint-order dependence.
