### PR TITLE
[ty] Preserve correlated generic-call inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -666,6 +666,25 @@ def f(val: str | bytes) -> None:
 reveal_type(accepts_callable(f))  # revealed: str | bytes
 ```
 
+When overloads exchange their input and output types, the inferred return tuple currently contains a
+union for each type variable.
+
+```py
+def infer_pair[T, U](converter: Callable[[T], U]) -> tuple[T, U]:
+    raise NotImplementedError
+
+@overload
+def swap(value: int) -> str: ...
+@overload
+def swap(value: str) -> int: ...
+def swap(value: int | str) -> int | str:
+    raise NotImplementedError
+
+# TODO: Infer the intersection of `tuple[int, str]` and `tuple[str, int]`.
+# Both specializations validate the same call, so its result satisfies both return types.
+reveal_type(infer_pair(swap))  # revealed: tuple[int | str, str | int]
+```
+
 When `T` is constrained to a union by other arguments, the overloaded callable must still be treated
 as a whole to satisfy `Callable[[T], T]`.
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -34,7 +34,8 @@ use crate::types::ProgramEnvironment;
 use crate::types::call::arguments::{CallArgumentTypes, Expansion, is_expandable_type};
 use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
-    ConstraintSet, ConstraintSetBuilder, PathBound, PathBounds, Solutions,
+    ConstraintSet, ConstraintSetBuilder, PathBound, PathBoundSolution, PathBounds, SolutionPaths,
+    Solutions,
 };
 use crate::types::context::LintDiagnosticGuardBuilder;
 use crate::types::dedicated::pydantic::{self, ConfigBoolean};
@@ -4132,8 +4133,10 @@ impl<'db> CallableBinding<'db> {
                             let raw_parameter_type = overload.signature.parameters()
                                 [matched_parameter.index]
                                 .annotated_type();
-                            let parameter_type = raw_parameter_type
-                                .apply_optional_specialization(db, overload.specialization(db));
+                            let parameter_type = raw_parameter_type.apply_optional_specialization(
+                                db,
+                                overload.merged_specialization(db),
+                            );
                             OverloadFilterSlot {
                                 parameter: parameter_type,
                                 // Argument types are cached by the raw parameter type, even when
@@ -5728,7 +5731,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             if let Type::Union(union) = declared_type.resolve_type_alias(db) {
                                 union.elements(db).iter().find_map(|candidate| {
                                     let specialized_candidate = candidate
-                                        .apply_optional_specialization(db, self.specialization());
+                                        .apply_optional_specialization(
+                                            db,
+                                            self.merged_specialization(),
+                                        );
                                     argument_type
                                         .is_assignable_to(db, env, specialized_candidate)
                                         .then_some(*candidate)
@@ -5800,9 +5806,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             })
     }
 
-    fn specialization(&self) -> Option<Specialization<'db>> {
+    fn merged_specialization(&self) -> Option<Specialization<'db>> {
         let db = self.db;
-        self.inference.map(|inference| inference.specialization(db))
+        self.inference
+            .map(|inference| inference.merged_specialization(db))
     }
 
     fn infer_specialization(&mut self, constraints: &ConstraintSetBuilder<'db>) {
@@ -5841,7 +5848,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // tension between type context preferences and argument constraints. If the combined set
         // is unsatisfiable, we will fall back to argument constraints alone (which the current
         // code does via `assignable_to_declared_type`).
-        let preferred_type_mappings = return_with_tcx
+        let (preferred_type_mappings, preferred_solutions_incomplete) = return_with_tcx
             .and_then(|(return_ty, tcx)| {
                 if !tcx
                     .filter_union(db, self.env, |ty| ty.may_prefer_declared_type(db, self.env))
@@ -5954,7 +5961,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     }
                 }
 
-                Some(preferred)
+                Some((
+                    preferred,
+                    matches!(solutions, SolutionPaths::BudgetExceeded(_)),
+                ))
             })
             .unwrap_or_default();
 
@@ -5987,7 +5997,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         self.errors.extend(specialization_errors);
 
         // Attempt to promote any promotable types assigned to the specialization.
-        // The hook receives (typevar, bounds) and returns Some(ty) to override the default
+        // The hook receives (typevar, bounds) and returns Some(solution) to override the default
         // solution, or None to keep it.
         let maybe_promote = |typevar: BoundTypeVarInstance<'db>, bounds: &PathBound<'db>| {
             let bound_or_constraints = typevar.typevar(db).bound_or_constraints(db, self.env);
@@ -6020,20 +6030,22 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 return None;
             }
 
-            // The promotion override must not select an unsatisfiable solution.
-            let solution =
-                PathBounds::default_solve(db, self.env, constraints, bounds).as_type()?;
-            let promoted = solution.promote(db, self.env);
+            // Promotion must preserve unsatisfiable outcomes and the completeness of fallbacks.
+            Some(
+                PathBounds::default_solve(db, self.env, constraints, bounds).map(|solution| {
+                    let promoted = solution.promote(db, self.env);
 
-            // If the TypeVar has an upper bound, only use the promoted type if it
-            // still satisfies the bound.
-            if let Some(TypeVarBoundOrConstraints::UpperBound(bound)) = bound_or_constraints {
-                if !promoted.is_assignable_to(db, self.env, bound) {
-                    return None;
-                }
-            }
+                    // If the TypeVar has an upper bound, only use the promoted type if it
+                    // still satisfies the bound.
+                    if let Some(TypeVarBoundOrConstraints::UpperBound(bound)) = bound_or_constraints
+                        && !promoted.is_assignable_to(db, self.env, bound)
+                    {
+                        return solution;
+                    }
 
-            Some(promoted)
+                    promoted
+                }),
+            )
         };
 
         let mut choose = |typevar: BoundTypeVarInstance<'db>, bounds: Option<&PathBound<'db>>| {
@@ -6043,7 +6055,14 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             if let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(db))
                 && lower.is_assignable_to(db, self.env, preferred_ty)
             {
-                return Some(preferred_ty);
+                // A contextual fallback remains incomplete when selected for the call.
+                return Some(if preferred_solutions_incomplete {
+                    PathBoundSolution::BudgetExceeded {
+                        fallback: Some(preferred_ty),
+                    }
+                } else {
+                    PathBoundSolution::Solved(preferred_ty)
+                });
             }
 
             maybe_promote(typevar, bounds)
@@ -6056,7 +6075,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 choose,
             ),
         };
-        let specialization = inference.specialization(db);
+        let specialization = inference.merged_specialization(db);
 
         self.return_ty = self.return_ty.apply_specialization(db, specialization);
         self.inference = Some(inference);
@@ -6136,7 +6155,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         })?;
 
         if self.signature.generic_context.is_some() {
-            let specialization = builder.build_with(|_, _| None);
+            let specialization = builder.build_merged_with(|_, _| None);
             let expected_ty = formal.apply_specialization(db, specialization);
 
             // The legacy solver keeps the first pack when another occurrence has a different length.
@@ -6409,8 +6428,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Mapper(callback, values)
         // ```
         //
-        // The overloads provide alternative, correlated solutions for `T` and `R`. The current
-        // solver merges each TypeVar's solutions separately, losing that correlation. Applying
+        // The overloads provide alternative, correlated solutions for `T` and `R`. Argument
+        // checking merges each TypeVar's solutions separately, losing that correlation. Applying
         // the merged specialization to `cls` a second time then changes the receiver from
         // `type[Mapper[frozenset[Never]]]` to
         // `type[Mapper[frozenset[frozenset[Never]]]]`, incorrectly rejecting the valid call.
@@ -6421,7 +6440,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // `U`, independently checking the class against `type[U]` again would reject the call
         // solely because `U` remains unsolved.
         //
-        // TODO: Remove this special case once solution extraction preserves correlations between
+        // TODO: Remove this special case once argument checking preserves correlations between
         // TypeVars across alternative inference paths and constructor calls are solved in a single
         // constraint set, so decorator-scoped receiver variables are not rechecked independently.
         let constructor_receiver = matches!(argument, Argument::Synthetic)
@@ -6432,7 +6451,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             );
 
         let mut expected_ty = declared_type;
-        if let Some(specialization) = self.specialization() {
+        if let Some(specialization) = self.merged_specialization() {
             if !constructor_receiver {
                 argument_type = argument_type.apply_specialization(db, specialization);
             }
@@ -6542,7 +6561,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     }
 
     // TODO: Remove this workaround once call binding can infer a `TypeVarTuple` from `*args` and
-    // callable inference preserves correlations across overloads.
+    // callable argument checking preserves correlations across overloads.
     fn should_defer_typevartuple_callable_check(
         &self,
         declared_type: Type<'db>,
@@ -6728,7 +6747,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     ) -> bool {
         let db = self.db;
         let Some(Type::Callable(callable)) = self
-            .specialization()
+            .merged_specialization()
             .and_then(|specialization| specialization.get(db, paramspec))
         else {
             return false;
@@ -7472,7 +7491,7 @@ impl<'db> Binding<'db> {
             [specialized_parameter.index]
             .annotated_type();
         let parameter_type = specialized_overload
-            .specialization(db)
+            .merged_specialization(db)
             .map_or(parameter_type, |specialization| {
                 parameter_type.apply_specialization(db, specialization)
             });
@@ -7580,7 +7599,7 @@ impl<'db> Binding<'db> {
             .unwrap_or(original_parameter_type);
         let paramspec_callable = |paramspec| {
             let Type::Callable(callable) = self
-                .specialization(db)
+                .merged_specialization(db)
                 .and_then(|specialization| specialization.get(db, paramspec))
                 .or_else(|| {
                     specialization.and_then(|specialization| specialization.get(db, paramspec))
@@ -7726,7 +7745,7 @@ impl<'db> Binding<'db> {
 
                 let call_expression_constraints = return_type_solutions.get(&identity).copied();
                 let argument_constraints = self
-                    .specialization(db)
+                    .merged_specialization(db)
                     .and_then(|specialization| specialization.get(db, typevar))
                     .filter(|ty| !ty.has_dynamic(db, env))
                     .map(|ty| ty.promote(db, env));
@@ -8179,8 +8198,9 @@ impl<'db> Binding<'db> {
         &self.argument_matches
     }
 
-    pub(crate) fn specialization(&self, db: &'db dyn Db) -> Option<Specialization<'db>> {
-        self.inference.map(|inference| inference.specialization(db))
+    pub(crate) fn merged_specialization(&self, db: &'db dyn Db) -> Option<Specialization<'db>> {
+        self.inference
+            .map(|inference| inference.merged_specialization(db))
     }
 
     pub(crate) fn errors(&self) -> &[BindingError<'db>] {
@@ -9771,4 +9791,132 @@ fn all_arguments_range(node: AnyNodeRef) -> TextRange {
             )
         })
         .unwrap_or(node.range())
+}
+
+// TODO: Replace these tests with mdtests once correlated alternatives affect call inference's
+// return types or diagnostics, making retained correlations and completeness observable.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::DbWithWritableSystem;
+
+    use crate::db::tests::{TestDb, setup_db};
+    use crate::place::global_symbol;
+    use crate::types::generics::TypeVarInferenceSolutions;
+
+    fn call_inference<'db>(
+        db: &'db TestDb,
+        callable: Type<'db>,
+        arguments: impl IntoIterator<Item = Type<'db>>,
+        type_context: TypeContext<'db>,
+    ) -> anyhow::Result<TypeVarInference<'db>> {
+        let env = db.program_environment();
+        let arguments = CallArguments::positional(arguments);
+        let constraints = ConstraintSetBuilder::new();
+        let bindings = callable
+            .bindings(db, &env)
+            .match_parameters(db, &env, &arguments)
+            .check_types(db, &env, &constraints, &arguments, type_context, &[])
+            .map_err(|error| anyhow::anyhow!("call binding failed: {error:?}"))?;
+        let (_, binding) = bindings
+            .iter_flat()
+            .flat_map(CallableBinding::matching_overloads)
+            .exactly_one()
+            .map_err(|_| anyhow::anyhow!("expected one matching call binding"))?;
+        binding
+            .inference
+            .ok_or_else(|| anyhow::anyhow!("expected generic call inference"))
+    }
+
+    #[test]
+    fn overloaded_argument_retains_correlated_inference() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+from typing import Callable, overload
+
+# Restrict T to the overload inputs, excluding the vacuous T = Never solution.
+def infer_pair[T: (int, str), U](converter: Callable[[T], U]) -> tuple[T, U]:
+    raise NotImplementedError
+
+@overload
+def swap(value: int) -> str: ...
+@overload
+def swap(value: str) -> int: ...
+def swap(value: int | str) -> int | str:
+    raise NotImplementedError
+"#,
+        )?;
+        let db = &db;
+        let env = db.program_environment();
+        let file = system_path_to_file(db, "/src/a.py")?;
+        let file = ProgramFile::new(db, file, env.program(db));
+        let callable = global_symbol(db, file, "infer_pair").place.expect_type();
+        let argument = global_symbol(db, file, "swap").place.expect_type();
+        let inference = call_inference(db, callable, [argument], TypeContext::default())?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!(
+                "expected correlated alternatives, got {:?}",
+                inference.solutions(db)
+            );
+        };
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+
+        assert_eq!(
+            paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+            FxHashSet::from_iter([
+                [Some(int), Some(str)].as_slice(),
+                [Some(str), Some(int)].as_slice(),
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn contextual_preference_preserves_incomplete_inference() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+class E: ...
+
+def make[T, U](value: T) -> tuple[list[T], U, U]:
+    raise NotImplementedError
+
+expected: tuple[list[object], A | B, C | D | E]
+"#,
+        )?;
+        let db = &db;
+        let env = db.program_environment();
+        let file = system_path_to_file(db, "/src/a.py")?;
+        let file = ProgramFile::new(db, file, env.program(db));
+        let callable = global_symbol(db, file, "make").place.expect_type();
+        let expected = global_symbol(db, file, "expected").place.expect_type();
+        let int = KnownClass::Int.to_instance(db, &env);
+
+        // The contextual upper bound for U is (A | B) & (C | D | E): six non-disjoint
+        // terms exceed the four-term construction budget. T still has the preferred type object.
+        // Selecting that preference must preserve the contextual family's incompleteness,
+        // even though only one argument-inference alternative remains.
+        let inference = call_inference(db, callable, [int], expected.into())?;
+        let TypeVarInferenceSolutions::Incomplete(paths) = inference.solutions(db) else {
+            anyhow::bail!(
+                "expected incomplete inference, got {:?}",
+                inference.solutions(db)
+            );
+        };
+        assert_eq!(
+            paths.iter().map(AsRef::as_ref).collect::<Vec<_>>(),
+            [[Some(Type::object()), None].as_slice()]
+        );
+        Ok(())
+    }
 }

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -398,7 +398,7 @@ impl<'db> ConstructorBinding<'db> {
             let self_parameter_specialization = static_class_literal.and_then(|lit| {
                 let self_param_ty = overload.signature.parameters().get(0)?.annotated_type();
                 let resolved_self_param_ty = overload
-                    .specialization(db)
+                    .merged_specialization(db)
                     .map_or(self_param_ty, |specialization| {
                         self_param_ty.apply_specialization(db, specialization)
                     });
@@ -434,7 +434,11 @@ impl<'db> ConstructorBinding<'db> {
             } else {
                 refined_self_parameter_specialization
                     .or(return_specialization)
-                    .or_else(|| overload.specialization(db)?.restrict(db, class_context))
+                    .or_else(|| {
+                        overload
+                            .merged_specialization(db)?
+                            .restrict(db, class_context)
+                    })
             };
             // end TODO
 
@@ -561,7 +565,7 @@ impl<'db> ConstructorBinding<'db> {
             .unspecialized_return_type(db)
             .apply_optional_specialization(
                 db,
-                overload.specialization(db).map(|specialization| {
+                overload.merged_specialization(db).map(|specialization| {
                     self.unspecialize_class_type_variables(db, env, specialization)
                 }),
             );

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3737,6 +3737,17 @@ pub(crate) enum PathBoundSolution<'db> {
 }
 
 impl<'db> PathBoundSolution<'db> {
+    /// Transforms a selected type without losing whether it is only a budget-exhaustion fallback.
+    pub(crate) fn map(self, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Self {
+        match self {
+            Self::Solved(ty) => Self::Solved(f(ty)),
+            Self::BudgetExceeded { fallback } => Self::BudgetExceeded {
+                fallback: fallback.map(f),
+            },
+            Self::Unsolved | Self::Unsatisfiable => self,
+        }
+    }
+
     /// Returns the selected type, including a fallback when the budget was exceeded.
     /// Match the outcome directly when completeness or the reason no type was selected matters.
     pub(crate) fn as_type(self) -> Option<Type<'db>> {
@@ -8283,6 +8294,41 @@ mod tests {
             PathBoundSolution::Solved(Type::Never).as_type(),
             Some(Type::Never)
         );
+    }
+
+    #[test]
+    fn promoting_solutions_preserves_completeness() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let literal = Type::int_literal(1);
+        let int = known_instance(db, KnownClass::Int);
+
+        for (solution, expected) in [
+            (
+                PathBoundSolution::Solved(literal),
+                PathBoundSolution::Solved(int),
+            ),
+            (
+                PathBoundSolution::BudgetExceeded {
+                    fallback: Some(literal),
+                },
+                PathBoundSolution::BudgetExceeded {
+                    fallback: Some(int),
+                },
+            ),
+            (PathBoundSolution::Unsolved, PathBoundSolution::Unsolved),
+            (
+                PathBoundSolution::Unsatisfiable,
+                PathBoundSolution::Unsatisfiable,
+            ),
+            (
+                PathBoundSolution::BudgetExceeded { fallback: None },
+                PathBoundSolution::BudgetExceeded { fallback: None },
+            ),
+        ] {
+            assert_eq!(solution.map(|ty| ty.promote(db, &env)), expected);
+        }
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -11,11 +11,11 @@ use smallvec::SmallVec;
 use crate::types::callable::walk_callable_type;
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
-use crate::types::constraints::projection::{SolutionBudget, SolutionProjection};
+use crate::types::constraints::projection::{ProjectionError, SolutionBudget, SolutionProjection};
 use crate::types::constraints::{
     ConstraintBound, ConstraintBounds, ConstraintSet, ConstraintSetBuilder,
     IteratorConstraintsExtension, PathBound, PathBoundSolution, PathBounds, SolutionPaths,
-    Solutions,
+    Solutions, TypeVarSolution,
 };
 use crate::types::infer::original_class_type;
 use crate::types::relation::{
@@ -2378,24 +2378,32 @@ enum LegacyTypeMappings<'db> {
     BudgetExceeded,
 }
 
-/// The result of type variable inference before choosing how to handle unsolved type variables.
+/// Correlated type-variable inference, together with the merged projection used by consumers
+/// that still require a single specialization.
 ///
-/// A `Some` entry means inference solved the corresponding type variable to that type. A `None`
-/// entry means the type variable was not solved and should be projected according to the use site.
+/// A `None` entry means no type was inferred for that variable. Defaults are applied only when a
+/// consumer requests a specialization, after selecting its projection.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub(crate) struct TypeVarInference<'db> {
     #[returns(copy)]
     pub(crate) generic_context: GenericContext<'db>,
+    /// Inferred types in generic-context order. Multiple solutions are union-merged per variable,
+    /// including fallback types from incomplete solution families. This projection loses
+    /// correlations and completeness; `solutions` retains that information. When correlated
+    /// solutions are unavailable, this holds the compatibility or diagnostic recovery mapping.
     #[returns(deref)]
-    types: Box<[Option<Type<'db>>]>,
+    merged_types: Box<[Option<Type<'db>>]>,
+    #[returns(ref)]
+    pub(crate) solutions: TypeVarInferenceSolutions<'db>,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for TypeVarInference<'_> {}
 
 impl<'db> TypeVarInference<'db> {
-    /// Project this inference result into a closed specialization.
-    pub(crate) fn specialization(self, db: &'db dyn Db) -> Specialization<'db> {
+    /// Merge the alternatives into one closed specialization, discarding their correlations and
+    /// completeness. Compatibility and diagnostic results use their recovery mapping.
+    pub(crate) fn merged_specialization(self, db: &'db dyn Db) -> Specialization<'db> {
         #[salsa::tracked(
             returns(copy),
             cycle_initial=|db, _, inference: TypeVarInference<'db>| {
@@ -2411,23 +2419,23 @@ impl<'db> TypeVarInference<'db> {
                 }
             }
         )]
-        fn specialization_inner<'db>(
+        fn merged_specialization_inner<'db>(
             db: &'db dyn Db,
             inference: TypeVarInference<'db>,
         ) -> Specialization<'db> {
-            inference.specialization_with(db, |_, _| None)
+            inference.merged_specialization_with(db, |_, _| None)
         }
 
-        specialization_inner(db, self)
+        merged_specialization_inner(db, self)
     }
 
-    /// Project this inference result into a specialization with explicit handling for each
-    /// type variable.
+    /// Project the merged inference result into a specialization with explicit handling for each
+    /// type variable. Alternatives are merged before applying defaults or the projection hook.
     ///
     /// The hook receives the type variable and its inferred type, if any. Returning `Some` overrides
     /// the projection for that variable. Returning `None` uses the inferred type if present,
     /// otherwise the type variable's default.
-    pub(crate) fn specialization_with(
+    pub(crate) fn merged_specialization_with(
         self,
         db: &'db dyn Db,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<Type<'db>>) -> Option<Type<'db>>,
@@ -2435,11 +2443,57 @@ impl<'db> TypeVarInference<'db> {
         let types = self
             .generic_context(db)
             .variables(db)
-            .zip(self.types(db).iter().copied())
+            .zip(self.merged_types(db).iter().copied())
             .map(|(typevar, inferred)| choose(typevar, inferred).or(inferred));
 
         self.generic_context(db).specialize_recursive(db, types)
     }
+}
+
+/// The alternatives retained when solving the pending constraints, before merging each
+/// variable's inferred types.
+///
+/// These describe the constraints recorded in `SpecializationBuilder::pending`. Argument inference
+/// can simplify argument and parameter types first: for example, it drops `None` when comparing
+/// `list[int] | None` with `list[T]`. A complete solve of the resulting constraints does not imply
+/// that the original argument is assignable to the parameter.
+///
+/// Each alternative stores types in the generic context's variable order, like `merged_types`,
+/// with `None` when no evidence selects a type. Completeness means all retained paths were solved
+/// without budget-exhaustion fallback, not that every variable has an inferred type. Defaults for
+/// variables without evidence are applied only when a consumer creates a specialization.
+///
+/// If a retained path exhausts its budget, the family is incomplete even if its siblings were
+/// solved without fallback. Such a family cannot be treated as an exhaustive account of the
+/// constraint set's specializations.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub(crate) enum TypeVarInferenceSolutions<'db> {
+    /// The sole solution is already stored in `merged_types`.
+    Single,
+    /// Two or more correlated alternatives, none relying on budget-exhaustion fallback.
+    /// A variable may still be `None` if the constraints provide no evidence for its type.
+    Alternatives(Box<[Box<[Option<Type<'db>>]>]>),
+    /// Retained alternatives, including fallback bindings from budget-exhausted solutions.
+    /// Siblings solved without fallback are kept, but the family as a whole is incomplete.
+    Incomplete(Box<[Box<[Option<Type<'db>>]>]>),
+    /// Only a compatibility or diagnostic mapping is available, not correlated solutions.
+    Unavailable(TypeVarInferenceFallback),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub(crate) enum TypeVarInferenceFallback {
+    Unconstrained,
+    Variadic,
+    Unsatisfiable,
+    ExpandingCycle,
+    BudgetExceeded,
+}
+
+/// An owned projection before allocating a cached inference result. Correlated callers retain
+/// `SolutionPaths`; merged-only callers use `()` and never allocate an alternative family.
+struct PendingInference<'db, T> {
+    merged_types: FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>,
+    solutions: Result<T, TypeVarInferenceFallback>,
 }
 
 /// The available solutions of a constraint set, or evidence for why it is unsatisfiable.
@@ -2588,8 +2642,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         self.infer_from_constraint_set(set)
     }
 
-    /// Build a specialization, using a caller-provided hook to select the solution for each
-    /// typevar.
+    /// Build a merged specialization, using a caller-provided hook to select the solution for
+    /// each typevar. This compatibility API discards correlations and solving completeness.
     ///
     /// The `choose` hook is called for each typevar on the generic context with the typevar's
     /// explicit lower and upper bounds.
@@ -2598,38 +2652,84 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     ///
     /// The hook should return `Some(ty)` to use `ty` as the specialization for this typevar, or
     /// `None` to use the inferred type unchanged.
-    pub(crate) fn build_with(
+    pub(crate) fn build_merged_with(
         &mut self,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> Specialization<'db> {
         let db = self.db;
-        let generic_context = self.generic_context;
+        let mut choose_solution = |typevar, bounds: Option<&PathBound<'db>>| {
+            choose(typevar, bounds).map(PathBoundSolution::Solved)
+        };
+        let inference = self
+            .solve_pending_projection(&mut choose_solution, |builder, choose| {
+                builder.pending.try_fold_solutions(
+                    db,
+                    builder.env,
+                    builder.inferable,
+                    SolutionBudget::default(),
+                    |_variance, path_bound| {
+                        let outcome = choose(path_bound.bound_typevar, Some(path_bound))
+                            .unwrap_or_else(|| {
+                                PathBounds::default_solve(
+                                    db,
+                                    builder.env,
+                                    builder.constraints,
+                                    path_bound,
+                                )
+                            });
+                        // Only this explicitly merged projection accepts fallback bindings as
+                        // ordinary types. Correlated inference retains their incomplete outcome.
+                        match outcome {
+                            PathBoundSolution::BudgetExceeded { fallback } => fallback
+                                .map_or(PathBoundSolution::Unsolved, PathBoundSolution::Solved),
+                            outcome => outcome,
+                        }
+                    },
+                    PendingInference {
+                        merged_types: FxHashMap::default(),
+                        solutions: Ok(()),
+                    },
+                    |mut inference, solution, budget| {
+                        for binding in solution {
+                            budget.charge_type(db, binding.solution)?;
+                        }
+                        builder.merge_solution(&mut inference.merged_types, solution);
+                        Ok(inference)
+                    },
+                )
+            })
+            .unwrap_or_else(|()| {
+                self.compatibility_inference_with(
+                    TypeVarInferenceFallback::Unsatisfiable,
+                    &mut choose_solution,
+                )
+            });
         let types = self
-            .solve_pending_with(generic_context, &mut choose)
-            .unwrap_or_else(|()| self.solve_hash_map_with(generic_context, &mut choose));
-        let specialization =
-            generic_context
-                .variables_inner(db)
-                .iter()
-                .map(|(identity, variable)| {
-                    types
-                        .get(identity)
-                        .copied()
-                        .or_else(|| choose(*variable, None))
-                });
-
-        generic_context.specialize_recursive(db, specialization)
+            .generic_context
+            .variables_inner(db)
+            .iter()
+            .map(|(identity, variable)| {
+                inference
+                    .merged_types
+                    .get(identity)
+                    .copied()
+                    .or_else(|| choose(*variable, None))
+            });
+        self.generic_context.specialize_recursive(db, types)
     }
 
-    /// Build raw type-variable inference, preserving which type variables were left unsolved.
+    /// Build correlated type-variable inference, preserving missing evidence and incomplete
+    /// solutions. The hook must retain whether an override is only a fallback.
     ///
     /// Returns an error if the call-wide pending constraints are unsatisfiable.
     pub(crate) fn build_inference_with(
         &mut self,
-        mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
+        mut choose: impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<&PathBound<'db>>,
+        ) -> Option<PathBoundSolution<'db>>,
     ) -> Result<TypeVarInference<'db>, ()> {
-        let types = self.solve_pending_with(self.generic_context, &mut choose)?;
-        Ok(self.typevar_inference(self.generic_context, &types))
+        self.solve_pending_with(SolutionBudget::default(), &mut choose)
     }
 
     /// Build a diagnostic specialization after the call-wide constraints were unsatisfiable.
@@ -2640,7 +2740,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     pub(crate) fn build_diagnostic_inference_with(
         &mut self,
         argument_relations: impl IntoIterator<Item = (Type<'db>, Type<'db>)>,
-        mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
+        mut choose: impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<&PathBound<'db>>,
+        ) -> Option<PathBoundSolution<'db>>,
     ) -> TypeVarInference<'db> {
         let db = self.db;
         for (formal, actual) in argument_relations {
@@ -2650,43 +2753,158 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             self.project_for_legacy_fallback(&analysis);
         }
 
-        let types = self.solve_hash_map_with(self.generic_context, &mut choose);
-        self.typevar_inference(self.generic_context, &types)
+        let inference =
+            self.compatibility_inference_with(TypeVarInferenceFallback::Unsatisfiable, &mut choose);
+        self.finish_inference(inference)
+    }
+
+    /// Builds a recovery mapping from the already accumulated per-relation solutions. This must
+    /// not rerun the call-wide solver or present a merged legacy mapping as a correlated solution.
+    fn compatibility_inference_with<T>(
+        &mut self,
+        reason: TypeVarInferenceFallback,
+        choose: &mut impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<&PathBound<'db>>,
+        ) -> Option<PathBoundSolution<'db>>,
+    ) -> PendingInference<'db, T> {
+        let merged_types = self
+            .solve_hash_map_with(self.generic_context, &mut |typevar, bounds| {
+                choose(typevar, bounds).and_then(PathBoundSolution::as_type)
+            });
+        PendingInference {
+            merged_types,
+            solutions: Err(reason),
+        }
     }
 
     fn typevar_inference(
         &self,
-        generic_context: GenericContext<'db>,
         types: &FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>,
+        solutions: TypeVarInferenceSolutions<'db>,
     ) -> TypeVarInference<'db> {
+        TypeVarInference::new(
+            self.db,
+            self.generic_context,
+            self.types_in_context_order(types),
+            solutions,
+        )
+    }
+
+    fn types_in_context_order(
+        &self,
+        types: &FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>,
+    ) -> Box<[Option<Type<'db>>]> {
         let db = self.db;
-        let inferred: Box<[_]> = generic_context
+        self.generic_context
             .variables_inner(db)
             .keys()
             .map(|identity| types.get(identity).copied())
-            .collect();
-
-        TypeVarInference::new(db, generic_context, inferred)
+            .collect()
     }
 
-    /// Produces the merged mapping used by existing inference consumers.
-    ///
-    /// Preference and promotion overrides can themselves return fallback types, so this legacy
-    /// projection deliberately discards completeness. A path-preserving consumer must retain
-    /// `PathBoundSolution` through its overrides instead.
+    /// Solves the call once, retaining correlated alternatives and deriving their compatibility
+    /// projection from the same bindings.
     fn solve_pending_with(
         &mut self,
-        generic_context: GenericContext<'db>,
-        choose: &mut impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
-    ) -> Result<FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>, ()> {
+        budget: SolutionBudget,
+        choose: &mut impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<&PathBound<'db>>,
+        ) -> Option<PathBoundSolution<'db>>,
+    ) -> Result<TypeVarInference<'db>, ()> {
         let db = self.db;
+        let inference = self.solve_pending_projection(choose, |builder, choose| {
+            let solutions = builder.pending.solutions_with(
+                db,
+                builder.env,
+                builder.inferable,
+                budget,
+                |_variance, path_bound| {
+                    choose(path_bound.bound_typevar, Some(path_bound)).unwrap_or_else(|| {
+                        PathBounds::default_solve(db, builder.env, builder.constraints, path_bound)
+                    })
+                },
+            )?;
+            Ok(match solutions {
+                Solutions::Unsatisfiable => SolutionProjection::Unsatisfiable,
+                Solutions::Unconstrained => SolutionProjection::Unconstrained,
+                Solutions::Constrained(solutions) => {
+                    let mut merged_types = FxHashMap::default();
+                    for solution in solutions.as_slice() {
+                        builder.merge_solution(&mut merged_types, solution);
+                    }
+
+                    // Solving charges only present bindings, but context-aligned alternatives
+                    // also allocate slots for unsolved variables. Bound those slots before
+                    // allocating any arrays; a complete single solution reuses `merged_types`.
+                    let solutions = if matches!(&solutions, SolutionPaths::Complete(paths) if paths.len() == 1)
+                        || solutions
+                            .as_slice()
+                            .len()
+                            .checked_mul(builder.generic_context.len(db))
+                            .is_some_and(|slots| slots <= budget.type_terms)
+                    {
+                        Ok(solutions)
+                    } else {
+                        // The merged projection is still valid when only alternative storage
+                        // exceeds its limit.
+                        Err(TypeVarInferenceFallback::BudgetExceeded)
+                    };
+                    SolutionProjection::Constrained(PendingInference {
+                        merged_types,
+                        solutions,
+                    })
+                }
+            })
+        })?;
+        Ok(self.finish_inference(inference))
+    }
+
+    fn merge_solution(
+        &self,
+        types: &mut FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>,
+        solution: &[TypeVarSolution<'db>],
+    ) {
+        let db = self.db;
+        for binding in solution {
+            types
+                .entry(binding.bound_typevar.identity(db))
+                .and_modify(|existing| {
+                    *existing =
+                        UnionType::from_two_elements(db, self.env, *existing, binding.solution);
+                })
+                .or_insert(binding.solution);
+        }
+    }
+
+    /// Shares recovery and normalization between streaming merged projection and correlated
+    /// solution collection. The projection decides which solved evidence it needs to retain.
+    fn solve_pending_projection<T, Choose>(
+        &mut self,
+        choose: &mut Choose,
+        project: impl FnOnce(
+            &Self,
+            &mut Choose,
+        )
+            -> Result<SolutionProjection<PendingInference<'db, T>>, ProjectionError>,
+    ) -> Result<PendingInference<'db, T>, ()>
+    where
+        Choose: FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<&PathBound<'db>>,
+        ) -> Option<PathBoundSolution<'db>>,
+    {
+        let db = self.db;
+        let generic_context = self.generic_context;
         // TODO: Move `ParamSpec` and `TypeVarTuple` handling to the new constraint solver.
         if generic_context
-            .variables_inner(db)
-            .values()
+            .variables(db)
             .any(|typevar| typevar.is_paramspec(db) || typevar.is_typevartuple(db))
         {
-            return Ok(self.solve_hash_map_with(generic_context, choose));
+            return Ok(
+                self.compatibility_inference_with(TypeVarInferenceFallback::Variadic, choose)
+            );
         }
 
         // TODO: This projection / solve can be expensive for large-union collection-literal type
@@ -2701,56 +2919,25 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // was not enough: `solutions_with` still performed the expensive path traversal, and the
         // skipped projection changed precision in LiteralString tests. See the
         // `ty_micro[pydantic_core_schema_dict]` benchmark for a minimized reproducer.
-        let mut types = match self.pending.try_fold_solutions(
-            db,
-            self.env,
-            self.inferable,
-            SolutionBudget::default(),
-            |_variance, path_bound| {
-                let typevar = path_bound.bound_typevar;
-                if let Some(ty) = choose(typevar, Some(path_bound)) {
-                    return PathBoundSolution::Solved(ty);
-                }
-
-                // The legacy projection accepts per-variable fallback bindings.
-                match PathBounds::default_solve(db, self.env, self.constraints, path_bound) {
-                    PathBoundSolution::BudgetExceeded { fallback } => {
-                        fallback.map_or(PathBoundSolution::Unsolved, PathBoundSolution::Solved)
-                    }
-                    outcome => outcome,
-                }
-            },
-            FxHashMap::default(),
-            |mut types: FxHashMap<_, _>, solution, budget| {
-                for binding in solution {
-                    budget.charge_type(db, binding.solution)?;
-                    let identity = binding.bound_typevar.identity(db);
-                    types
-                        .entry(identity)
-                        .and_modify(|existing| {
-                            *existing = UnionType::from_two_elements(
-                                db,
-                                self.env,
-                                *existing,
-                                binding.solution,
-                            );
-                        })
-                        .or_insert(binding.solution);
-                }
-                Ok(types)
-            },
-        ) {
+        let mut inference = match project(self, choose) {
             Ok(SolutionProjection::Unsatisfiable) => return Err(()),
             Ok(SolutionProjection::Unconstrained) => {
-                return Ok(self.solve_hash_map_with(generic_context, choose));
+                return Ok(self.compatibility_inference_with(
+                    TypeVarInferenceFallback::Unconstrained,
+                    choose,
+                ));
             }
             Err(_) => {
                 // A partial mapping may be narrower than the unvisited alternatives. Recover
                 // without choosing a witness or repeating the exhausted traversal/construction.
-                return Ok(self.unknown_type_mappings(generic_context));
+                return Ok(PendingInference {
+                    merged_types: self.unknown_type_mappings(generic_context),
+                    solutions: Err(TypeVarInferenceFallback::BudgetExceeded),
+                });
             }
-            Ok(SolutionProjection::Constrained(types)) => types,
+            Ok(SolutionProjection::Constrained(inference)) => inference,
         };
+        let types = &mut inference.merged_types;
 
         // Sequent-map transitivity can add relationships between inferable typevars to path
         // bounds. Those relationships are important while solving, but should not become recursive
@@ -2770,14 +2957,79 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // solution layer.
         if types
             .iter()
-            .any(|(identity, ty)| self.has_expanding_cycle(generic_context, &types, *identity, *ty))
+            .any(|(identity, ty)| self.has_expanding_cycle(generic_context, types, *identity, *ty))
         {
             // Recursive specialization cannot reach a fixed point when a cycle grows through an
             // embedded generic type, such as `SupportsAdd[T, S]`.
-            Ok(self.solve_hash_map_with(generic_context, choose))
-        } else {
-            Ok(types)
+            return Ok(
+                self.compatibility_inference_with(TypeVarInferenceFallback::ExpandingCycle, choose)
+            );
         }
+
+        Ok(inference)
+    }
+
+    fn finish_inference(
+        &self,
+        inference: PendingInference<'db, SolutionPaths<'db>>,
+    ) -> TypeVarInference<'db> {
+        let db = self.db;
+        let generic_context = self.generic_context;
+        let PendingInference {
+            merged_types: types,
+            solutions,
+        } = inference;
+        let solutions = match solutions {
+            Ok(solutions) => solutions,
+            Err(reason) => {
+                return self
+                    .typevar_inference(&types, TypeVarInferenceSolutions::Unavailable(reason));
+            }
+        };
+        let complete = matches!(solutions, SolutionPaths::Complete(_));
+        if complete && solutions.as_slice().len() == 1 {
+            return self.typevar_inference(&types, TypeVarInferenceSolutions::Single);
+        }
+
+        // The compatibility projection must be cleaned after merging, independently of these
+        // alternatives: a bare `U` survives on one path, but is removed from a merged `U | int`.
+        let mut paths = Vec::with_capacity(solutions.as_slice().len());
+        for path in solutions.into_vec() {
+            let path_types: FxHashMap<_, _> = path
+                .into_iter()
+                .filter_map(|binding| {
+                    let identity = binding.bound_typevar.identity(db);
+                    generic_context.contains(db, identity).then(|| {
+                        (
+                            identity,
+                            self.remove_inferable_typevar_artifacts_from_solution(
+                                binding.bound_typevar,
+                                binding.solution,
+                            ),
+                        )
+                    })
+                })
+                .collect();
+            if path_types.iter().any(|(identity, ty)| {
+                self.has_expanding_cycle(generic_context, &path_types, *identity, *ty)
+            }) {
+                return self.typevar_inference(
+                    &types,
+                    TypeVarInferenceSolutions::Unavailable(
+                        TypeVarInferenceFallback::ExpandingCycle,
+                    ),
+                );
+            }
+            paths.push(self.types_in_context_order(&path_types));
+        }
+
+        let paths = paths.into_boxed_slice();
+        let solutions = if complete {
+            TypeVarInferenceSolutions::Alternatives(paths)
+        } else {
+            TypeVarInferenceSolutions::Incomplete(paths)
+        };
+        self.typevar_inference(&types, solutions)
     }
 
     fn has_expanding_cycle(
@@ -3121,7 +3373,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     /// after they have accepted the corresponding relation.
     /// Omitting an accepted relation makes the legacy mapping unavailable for precise recovery.
     ///
-    /// TODO: Remove this compatibility path once [`build_with`][Self::build_with] and all other
+    /// TODO: Remove this compatibility path once [`build_merged_with`][Self::build_merged_with] and all other
     /// inference consumers can build specializations solely from the call-wide constraint set.
     fn project_for_legacy_fallback(&mut self, analysis: &ConstraintSetAnalysis<'db>) {
         if matches!(analysis, ConstraintSetAnalysis::BudgetExceeded) {
@@ -4286,9 +4538,449 @@ impl<'db> SpecializationError<'db> {
 mod tests {
     use super::*;
 
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::DbWithWritableSystem;
     use ruff_python_ast::name::Name;
+    use ty_python_core::ProgramFile;
 
-    use crate::db::tests::setup_db;
+    use crate::db::tests::{TestDb, setup_db};
+    use crate::place::global_symbol;
+
+    fn create_typevars<'db, const N: usize>(
+        db: &'db TestDb,
+        names: [&'static str; N],
+    ) -> [BoundTypeVarInstance<'db>; N] {
+        let env = db.program_environment();
+        names.map(|name| {
+            BoundTypeVarInstance::synthetic(
+                db,
+                &env,
+                Name::new_static(name),
+                TypeVarVariance::Invariant,
+            )
+        })
+    }
+
+    fn exact_alternatives<'db, 'c, const N: usize>(
+        db: &'db TestDb,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        typevars: [BoundTypeVarInstance<'db>; N],
+        alternatives: impl IntoIterator<Item = [Type<'db>; N]>,
+    ) -> ConstraintSet<'db, 'c> {
+        let env = db.program_environment();
+        alternatives.into_iter().when_any(db, constraints, |types| {
+            typevars
+                .into_iter()
+                .zip(types)
+                .when_all(db, constraints, |(typevar, ty)| {
+                    ConstraintSet::constrain_typevar(db, &env, constraints, typevar, ty, ty)
+                })
+        })
+    }
+
+    #[test]
+    fn inference_preserves_correlated_alternatives() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let typevars = create_typevars(db, ["T", "U"]);
+        let context = GenericContext::from_typevar_instances(db, &env, typevars);
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        let union = UnionType::from_two_elements(db, &env, int, str);
+
+        for alternatives in [[[int, str], [str, int]], [[str, int], [int, str]]] {
+            let constraints = ConstraintSetBuilder::new();
+            let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+            builder.record_constraint_set(exact_alternatives(
+                db,
+                &constraints,
+                typevars,
+                alternatives,
+            ));
+
+            let inference = builder
+                .build_inference_with(|_, _| None)
+                .map_err(|()| anyhow::anyhow!("expected satisfiable alternatives"))?;
+            let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+                anyhow::bail!(
+                    "expected complete alternatives, got {:?}",
+                    inference.solutions(db)
+                );
+            };
+            assert_eq!(
+                paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+                FxHashSet::from_iter([
+                    [Some(int), Some(str)].as_slice(),
+                    [Some(str), Some(int)].as_slice(),
+                ])
+            );
+
+            // Only the explicit merged projection admits the crossed pairings.
+            for ty in inference.merged_specialization(db).types(db) {
+                assert!(ty.is_equivalent_to(db, &env, union));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn incomplete_inference_preserves_complete_siblings() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let typevars @ [t, _] = create_typevars(db, ["T", "U"]);
+        let context = GenericContext::from_typevar_instances(db, &env, typevars);
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        let union = UnionType::from_two_elements(db, &env, int, str);
+
+        for alternatives in [[[int, str], [str, int]], [[str, int], [int, str]]] {
+            for fallback in [Some(str), None] {
+                let constraints = ConstraintSetBuilder::new();
+                let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+                builder.record_constraint_set(exact_alternatives(
+                    db,
+                    &constraints,
+                    typevars,
+                    alternatives,
+                ));
+
+                let inference = builder
+                    .build_inference_with(|typevar, bounds| {
+                        (typevar == t
+                            && bounds.is_some_and(|bound| bound.evidence_lower == Some(str)))
+                        .then_some(PathBoundSolution::BudgetExceeded { fallback })
+                    })
+                    .map_err(|()| anyhow::anyhow!("incomplete alternatives remain satisfiable"))?;
+                let TypeVarInferenceSolutions::Incomplete(paths) = inference.solutions(db) else {
+                    anyhow::bail!(
+                        "expected incomplete alternatives, got {:?}",
+                        inference.solutions(db)
+                    );
+                };
+                assert_eq!(
+                    paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+                    FxHashSet::from_iter([
+                        [Some(int), Some(str)].as_slice(),
+                        [fallback, Some(int)].as_slice(),
+                    ])
+                );
+
+                let expected = [if fallback.is_some() { union } else { int }, union];
+                for (ty, expected) in inference
+                    .merged_specialization(db)
+                    .types(db)
+                    .iter()
+                    .zip(expected)
+                {
+                    assert!(ty.is_equivalent_to(db, &env, expected));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn single_inference_defers_unsolved_defaults() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let typevars @ [t, u] = create_typevars(db, ["T", "U"]);
+        let context = GenericContext::from_typevar_instances(db, &env, typevars);
+        let constraints = ConstraintSetBuilder::new();
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        builder.record_constraint_set(ConstraintSet::constrain_typevar(
+            db,
+            &env,
+            &constraints,
+            t,
+            int,
+            int,
+        ));
+
+        // A complete single solution reuses the merged array, so its unsolved slots do not
+        // require any additional storage budget.
+        let inference = builder
+            .solve_pending_with(
+                SolutionBudget {
+                    type_terms: 1,
+                    ..SolutionBudget::default()
+                },
+                &mut |_, _| None,
+            )
+            .map_err(|()| anyhow::anyhow!("expected a single solution"))?;
+        assert_eq!(inference.solutions(db), &TypeVarInferenceSolutions::Single);
+        assert_eq!(inference.merged_types(db), [Some(int), None]);
+        assert_eq!(
+            inference.merged_specialization(db).types(db),
+            [int, Type::unknown()]
+        );
+
+        let specialization = inference.merged_specialization_with(db, |typevar, inferred| {
+            (typevar == u && inferred.is_none()).then_some(str)
+        });
+        assert_eq!(specialization.types(db), [int, str]);
+        Ok(())
+    }
+
+    #[test]
+    fn recovery_inference_is_not_a_complete_solution() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let [t] = create_typevars(db, ["T"]);
+        let context = GenericContext::from_typevar_instances(db, &env, [t]);
+        let constraints = ConstraintSetBuilder::new();
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+
+        let unconstrained = builder
+            .build_inference_with(|_, _| None)
+            .map_err(|()| anyhow::anyhow!("unconstrained inference should recover"))?;
+        assert_eq!(
+            unconstrained.solutions(db),
+            &TypeVarInferenceSolutions::Unavailable(TypeVarInferenceFallback::Unconstrained)
+        );
+        assert_eq!(unconstrained.merged_types(db), [None]);
+
+        for ty in [int, str] {
+            builder.record_constraint_set(ConstraintSet::constrain_typevar(
+                db,
+                &env,
+                &constraints,
+                t,
+                ty,
+                ty,
+            ));
+        }
+        assert!(builder.build_inference_with(|_, _| None).is_err());
+
+        let diagnostic = builder.build_diagnostic_inference_with(
+            [(Type::TypeVar(t), int), (Type::TypeVar(t), str)],
+            |_, _| None,
+        );
+        assert_eq!(
+            diagnostic.solutions(db),
+            &TypeVarInferenceSolutions::Unavailable(TypeVarInferenceFallback::Unsatisfiable)
+        );
+        assert_eq!(
+            diagnostic.merged_types(db),
+            [Some(UnionType::from_two_elements(db, &env, int, str))]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn inference_budget_exhaustion_discards_partial_mappings() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let [t] = create_typevars(db, ["T"]);
+        let context = GenericContext::from_typevar_instances(db, &env, [t]);
+        let constraints = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        let relation = [int, str].into_iter().when_any(db, &constraints, |ty| {
+            ConstraintSet::constrain_typevar(db, &env, &constraints, t, ty, ty)
+        });
+
+        for (budget, expected_choices) in [
+            (
+                SolutionBudget {
+                    paths: 1,
+                    ..SolutionBudget::default()
+                },
+                0,
+            ),
+            (
+                SolutionBudget {
+                    visits: 0,
+                    ..SolutionBudget::default()
+                },
+                0,
+            ),
+            (
+                SolutionBudget {
+                    type_terms: 1,
+                    ..SolutionBudget::default()
+                },
+                2,
+            ),
+        ] {
+            let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+            builder.record_constraint_set(relation);
+            let mut choices = 0;
+            let inference = builder
+                .solve_pending_with(budget, &mut |_, _| {
+                    choices += 1;
+                    None
+                })
+                .map_err(|()| anyhow::anyhow!("budget exhaustion should recover"))?;
+
+            assert_eq!(choices, expected_choices);
+            assert_eq!(
+                inference.solutions(db),
+                &TypeVarInferenceSolutions::Unavailable(TypeVarInferenceFallback::BudgetExceeded)
+            );
+            assert_eq!(inference.merged_types(db), [Some(Type::unknown())]);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn alternative_storage_budget_preserves_merged_inference() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let [t, unused] = create_typevars(db, ["T", "Unused"]);
+        // The context order differs from the variable creation order, and the first slot
+        // remains unsolved on both alternatives.
+        let context = GenericContext::from_typevar_instances(db, &env, [unused, t]);
+        let constraints = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        let relation = [int, str].into_iter().when_any(db, &constraints, |ty| {
+            ConstraintSet::constrain_typevar(db, &env, &constraints, t, ty, ty)
+        });
+
+        // Both budgets allow solving the two present bindings, but storing the complete
+        // alternatives requires four slots, including the unsolved ones.
+        for type_terms in [2, 4] {
+            let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+            builder.record_constraint_set(relation);
+            let inference = builder
+                .solve_pending_with(
+                    SolutionBudget {
+                        type_terms,
+                        ..SolutionBudget::default()
+                    },
+                    &mut |_, _| None,
+                )
+                .map_err(|()| anyhow::anyhow!("alternative storage exhaustion should recover"))?;
+
+            assert_eq!(
+                inference.merged_types(db),
+                [None, Some(UnionType::from_two_elements(db, &env, int, str))]
+            );
+            if type_terms == 2 {
+                assert_eq!(
+                    inference.solutions(db),
+                    &TypeVarInferenceSolutions::Unavailable(
+                        TypeVarInferenceFallback::BudgetExceeded
+                    )
+                );
+            } else {
+                let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+                    anyhow::bail!("expected alternatives within the storage budget");
+                };
+                assert_eq!(
+                    paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+                    FxHashSet::from_iter([
+                        [None, Some(int)].as_slice(),
+                        [None, Some(str)].as_slice(),
+                    ])
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn inference_cleans_merged_types_independently_of_alternatives() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented("/src/a.py", "def f[T, U](): ...")?;
+        let db = &db;
+        let env = db.program_environment();
+        let file = system_path_to_file(db, "/src/a.py")?;
+        let file = ProgramFile::new(db, file, env.program(db));
+        let context = global_symbol(db, file, "f")
+            .place
+            .expect_type()
+            .as_function_literal()
+            .and_then(|function| function.signature(db).overloads.first()?.generic_context)
+            .ok_or_else(|| anyhow::anyhow!("expected a generic function"))?;
+        let (t, u) = context
+            .variables(db)
+            .collect_tuple()
+            .ok_or_else(|| anyhow::anyhow!("expected two type variables"))?;
+        let constraints = ConstraintSetBuilder::new();
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        builder.record_constraint_set([str, int].into_iter().when_any(db, &constraints, |ty| {
+            ConstraintSet::constrain_typevar(db, &env, &constraints, t, ty, ty)
+        }));
+
+        let inference = builder
+            .build_inference_with(|typevar, bounds| {
+                (typevar == t && bounds.is_some_and(|bound| bound.evidence_lower == Some(str)))
+                    .then_some(PathBoundSolution::Solved(Type::TypeVar(u)))
+            })
+            .map_err(|()| anyhow::anyhow!("expected satisfiable alternatives"))?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!(
+                "expected complete alternatives, got {:?}",
+                inference.solutions(db)
+            );
+        };
+
+        // A bare U is preserved in its own alternative, but removed from the merged U | int.
+        assert_eq!(
+            paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+            FxHashSet::from_iter([
+                [Some(Type::TypeVar(u)), None].as_slice(),
+                [Some(int), None].as_slice(),
+            ])
+        );
+        assert_eq!(inference.merged_types(db), [Some(int), None]);
+        Ok(())
+    }
+
+    #[test]
+    fn inference_detects_expanding_cycles_hidden_by_merging() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let typevars @ [t, u] = create_typevars(db, ["T", "U"]);
+        let context = GenericContext::from_typevar_instances(db, &env, typevars);
+        let constraints = ConstraintSetBuilder::new();
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        let list_of_u = KnownClass::List.to_specialized_instance(db, &env, &[Type::TypeVar(u)]);
+        builder.record_constraint_set(exact_alternatives(
+            db,
+            &constraints,
+            typevars,
+            [[int, str], [str, int]],
+        ));
+
+        // Select T = list[U], U = T on one path and T = U = object on the other. Only the
+        // individual path still contains the cycle after merging with object.
+        let inference = builder
+            .build_inference_with(|typevar, bounds| {
+                let ty = match (typevar, bounds?.evidence_lower) {
+                    (typevar, Some(lower)) if typevar == t && lower == int => list_of_u,
+                    (typevar, Some(lower)) if typevar == u && lower == str => Type::TypeVar(t),
+                    _ => Type::object(),
+                };
+                Some(PathBoundSolution::Solved(ty))
+            })
+            .map_err(|()| anyhow::anyhow!("an expanding cycle should recover"))?;
+        assert_eq!(
+            inference.solutions(db),
+            &TypeVarInferenceSolutions::Unavailable(TypeVarInferenceFallback::ExpandingCycle)
+        );
+        assert_eq!(
+            inference.merged_types(db),
+            [Some(Type::object()), Some(Type::object())]
+        );
+        Ok(())
+    }
 
     #[test]
     fn recording_constraints_does_not_project_legacy_mappings() {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1366,7 +1366,7 @@ impl<'db> CallSignatureDetails<'db> {
         binding: &crate::types::call::Binding<'db>,
     ) -> Self {
         let argument_to_parameter_mapping = binding.argument_matches().to_vec();
-        let specialization = binding.specialization(db);
+        let specialization = binding.merged_specialization(db);
         let signature = binding.signature.clone();
         let display_details = signature.display(db, env).to_string_parts();
         let (parameters, parameter_to_displayed_parameter_mapping) =

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7874,7 +7874,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class_type = collection_alias
             .origin(self.db())
             .apply_specialization(db, |_| {
-                builder.build_with(|current_typevar, bounds| {
+                builder.build_merged_with(|current_typevar, bounds| {
                     let lower = bounds?.evidence_lower?;
 
                     let lower = if is_empty_collection_type_context(tcx) {
@@ -9517,7 +9517,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     for call_specialization in identity_bindings
                         .iter_flat()
                         .flat_map(CallableBinding::matching_overloads)
-                        .filter_map(|(_, identity_overload)| identity_overload.specialization(db))
+                        .filter_map(|(_, identity_overload)| {
+                            identity_overload.merged_specialization(db)
+                        })
                     {
                         // Record the constraints on the receiver's generic context formed by
                         // the arguments to this bound method call.

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1663,7 +1663,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     for call_specialization in identity_bindings
                         .iter_flat()
                         .flat_map(CallableBinding::matching_overloads)
-                        .filter_map(|(_, identity_overload)| identity_overload.specialization(db))
+                        .filter_map(|(_, identity_overload)| {
+                            identity_overload.merged_specialization(db)
+                        })
                     {
                         // Record the constraints on the receiver's generic context formed by
                         // the arguments to this dunder call.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1315,7 +1315,7 @@ impl<'db> Signature<'db> {
         builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
-        let specialization = builder.build_with(|typevar, bounds| {
+        let specialization = builder.build_merged_with(|typevar, bounds| {
             if let Some(bounds) = bounds
                 && let Some(lower) = bounds.evidence_lower
                 && bounds.has_upper_evidence()
@@ -1758,14 +1758,16 @@ impl<'db> Signature<'db> {
             .collect();
 
         if promoted_typevars.is_empty() {
-            return Some(inference.specialization(db));
+            return Some(inference.merged_specialization(db));
         }
 
-        Some(inference.specialization_with(db, |typevar, inferred| {
-            promoted_typevars
-                .contains(&typevar.identity(db))
-                .then(|| inferred.map_or(Type::TypeVar(typevar), |ty| ty.promote(db, env)))
-        }))
+        Some(
+            inference.merged_specialization_with(db, |typevar, inferred| {
+                promoted_typevars
+                    .contains(&typevar.identity(db))
+                    .then(|| inferred.map_or(Type::TypeVar(typevar), |ty| ty.promote(db, env)))
+            }),
+        )
     }
 
     fn needs_self_mapping(


### PR DESCRIPTION
Generic-call inference currently unions each type variable's solutions independently. This loses correlations between alternative specializations and whether a solve relied on a budget-exhaustion fallback.

Retain correlated, context-aligned alternatives and their completeness in `TypeVarInference`, alongside the union-merged mapping used by existing consumers. Argument checking, return types, constructors, partial signatures, and IDE signature help continue to use the explicit merged projection for now; this prepares call inference to consume alternatives in a future PR, while intentionally preserving the current visible behavior.

Preserve incomplete outcomes through contextual preferences and promotion, bound alternative storage, and keep diagnostic and compatibility recovery mappings separate from correlated solutions.

Part of astral-sh/ty#3557.

## Test plan

Rust tests cover correlated and incomplete solution families, unsolved defaults, context ordering, budget exhaustion, recovery mappings, independent merged and per-path cleanup, expanding cycles, and preservation through real call binding and type promotion. Some of these tests should be promoted to mdtests once the behavior they test is exposed in a visible way in a future PR.

An mdtest covers overloads that exchange their input and output types, preserving the current union-merged return tuple and documenting the eventual intersection of return types.
