### PR TITLE
[ty] Propagate deletions through nested loop headers

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1758,6 +1758,28 @@ for _ in iterable():
 x
 ```
 
+### Deletions in nested loops reach the outer loop
+
+A deletion followed by `continue` in an inner loop can remain visible after a later `break`. The
+variable can be unbound on the next outer iteration, even when exhausting the inner loop returns
+from the function.
+
+```py
+def f(flags: list[bool]):
+    x = 0
+    for _ in flags:
+        x  # error: [possibly-unresolved-reference]
+        for stop in flags:
+            if stop:
+                break
+            x = 0
+            del x
+            continue
+        else:
+            return
+        x  # error: [possibly-unresolved-reference]
+```
+
 ### Bindings in a loop are possibly-unbound after the loop
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
@@ -411,6 +411,74 @@ while x < 10:
     reveal_type(x)  # revealed: Literal[1]
 ```
 
+### Deletions in nested loops reach the outer loop
+
+An inner loop can delete a variable on one iteration, then exit through `break` on a later
+iteration. The variable can therefore be unbound both after the inner loop and at the start of the
+next outer iteration.
+
+```py
+def stop() -> bool:
+    raise NotImplementedError
+
+def f(repeat: bool):
+    x = 0
+    while repeat:
+        x  # error: [possibly-unresolved-reference]
+        while True:
+            if stop():
+                break
+            x = 0
+            del x
+        x  # error: [possibly-unresolved-reference]
+```
+
+### Rebinding after an inner loop restores boundness
+
+An inner loop's deletion does not make a variable possibly unbound on later outer iterations if the
+variable is reassigned before reaching the next iteration.
+
+```py
+def stop() -> bool:
+    raise NotImplementedError
+
+def f(repeat: bool):
+    x = 0
+    while repeat:
+        reveal_type(x)  # revealed: Literal[0]
+        while True:
+            if stop():
+                break
+            x = 0
+            del x
+        x = 0
+```
+
+### Statically unreachable deletions in nested loops preserve boundness
+
+A deletion guarded by an impossible comparison does not make the variable possibly unbound, even
+through several nested loops. Evaluating the loop conditions and comparison depends on bindings from
+the enclosing loops.
+
+```py
+def stop() -> bool:
+    raise NotImplementedError
+
+def f(repeat: bool):
+    x = 1
+    while repeat:
+        reveal_type(x)  # revealed: Literal[1]
+        while x:
+            if stop():
+                break
+            while x:
+                if stop():
+                    break
+                if x == 4:
+                    del x
+        reveal_type(x)  # revealed: Literal[1]
+```
+
 ### Bindings in a loop are possibly-unbound after the loop
 
 ```py

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -4,6 +4,7 @@ use crate::ProgramEnvironment;
 use itertools::Either;
 use ruff_index::IndexSlice;
 use ruff_python_ast::PythonVersion;
+use rustc_hash::FxHashMap;
 use ty_module_resolver::{
     KnownModule, Module, ModuleName, file_to_module, resolve_module_confident,
 };
@@ -1479,7 +1480,7 @@ fn symbol_impl<'db>(
 #[salsa::tracked(
     returns(clone),
     cycle_initial=|db, _, definition: Definition<'db>| {
-        loop_header_reachability_impl(db, definition, true)
+        loop_header_reachability_impl(db, definition, Some(&mut FxHashMap::default()))
     },
     cycle_fn=loop_header_reachability_cycle_recover,
     heap_size = ruff_memory_usage::heap_size,
@@ -1488,7 +1489,7 @@ pub(crate) fn loop_header_reachability<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> LoopHeaderReachability<'db> {
-    loop_header_reachability_impl(db, definition, false)
+    loop_header_reachability_impl(db, definition, None)
 }
 
 fn loop_header_reachability_cycle_recover<'db>(
@@ -1504,7 +1505,7 @@ fn loop_header_reachability_cycle_recover<'db>(
 fn loop_header_reachability_impl<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
-    is_cycle_initial: bool,
+    mut cycle_initial_cache: Option<&mut FxHashMap<Definition<'db>, Truthiness>>,
 ) -> LoopHeaderReachability<'db> {
     // This cutoff was chosen by benchmarking real isort to keep loop analysis
     // overhead minimal while preserving diagnostics.
@@ -1525,7 +1526,7 @@ fn loop_header_reachability_impl<'db>(
     let use_exact_reachability = use_def.reachability_constraints().used_interiors().len()
         <= MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES;
     for live_binding in live_bindings {
-        let reachability = if is_cycle_initial {
+        let reachability = if cycle_initial_cache.is_some() {
             Truthiness::Ambiguous
         } else if use_exact_reachability {
             evaluate_reachability(db, use_def, live_binding.reachability_constraint())
@@ -1547,6 +1548,33 @@ fn loop_header_reachability_impl<'db>(
                     def, definition,
                     "loop headers only include bindings from within the loop"
                 );
+                if def.kind(db).is_loop_header() {
+                    // An inner loop can reach a `break` with a header binding that carries a
+                    // deletion from an earlier iteration. That deletion also affects boundness
+                    // in the enclosing loop.
+                    let nested_deleted_reachability =
+                        if let Some(cache) = cycle_initial_cache.as_deref_mut() {
+                            // Cycle initialization cannot evaluate predicates that could re-enter
+                            // the cycle. Memoize this structural walk because a descendant header
+                            // can be reached through several containing headers.
+                            cache.get(&def).copied().unwrap_or_else(|| {
+                                let deleted_reachability =
+                                    loop_header_reachability_impl(db, def, Some(cache))
+                                        .deleted_reachability;
+                                cache.insert(def, deleted_reachability);
+                                deleted_reachability
+                            })
+                        } else {
+                            loop_header_reachability(db, def).deleted_reachability
+                        };
+                    // This binding is reachable, but a conditional loop-back path can make a
+                    // definitely reachable nested deletion only possibly reachable here.
+                    deleted_reachability =
+                        deleted_reachability.or(match nested_deleted_reachability {
+                            Truthiness::AlwaysTrue => reachability,
+                            other => other,
+                        });
+                }
                 reachable_bindings.insert(ReachableLoopBinding {
                     definition: def,
                     narrowing_constraint: live_binding.narrowing_constraint(),
@@ -1573,6 +1601,7 @@ fn loop_header_reachability_impl<'db>(
 /// Result of [`loop_header_reachability`]: pre-computed reachability info for loop-back bindings.
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct LoopHeaderReachability<'db> {
+    /// Reachability of deletions, including those carried by nested loop headers.
     pub(crate) deleted_reachability: Truthiness,
     /// Reachable loop-back bindings that are not `del`s.
     pub(crate) reachable_bindings: FxIndexSet<ReachableLoopBinding<'db>>,


### PR DESCRIPTION
An inner loop can delete a variable on one iteration and then exit through `break` on a later iteration. The variable can remain unbound after the inner loop and on subsequent outer iterations, but ty did not propagate deletions carried by nested loop headers into the enclosing loop's boundness analysis.

Include nested headers' deletion reachability when computing an enclosing header's reachability. Keep the loop-back bindings intact for type inference, and memoize the structural traversal used during Salsa cycle initialization so shared descendant headers are only visited once.

Related to #28009.

## Test plan

- Add `while` and `for` mdtests for deletions that survive an inner-loop iteration and a later `break`, including an explicit `continue` and a `for`-`else` that returns.
- Verify that reassignment after the inner loop restores boundness on subsequent outer iterations.
- Verify that statically unreachable deletions preserve boundness and literal types through several nested loops.
