### PR TITLE
[ty] Preserve bounds of non-literal metaclasses

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -1019,6 +1019,32 @@ reveal_type(D)  # revealed: <class 'D'>
 reveal_type(D.__class__)  # revealed: <class 'SignatureMismatch'>
 ```
 
+## Metaclass bounds
+
+With a metaclass annotated as `type[Meta]`, the resulting class and its subclasses are instances of
+`Meta`, and therefore of `type`. Matching a `type[C]` value against `type()` is exhaustive, but
+returning it as `int` is invalid.
+
+```py
+from typing_extensions import assert_never
+
+class Meta(type): ...
+
+def _(meta: type[Meta]):
+    class C(metaclass=meta): ...
+
+    def check(cls: type[C]) -> None:
+        reveal_type(cls.__class__)  # revealed: type[Meta]
+        match cls:
+            case type():
+                pass
+            case _:
+                assert_never(cls)
+
+    def as_int(cls: type[C]) -> int:
+        return cls  # error: [invalid-return-type]
+```
+
 ## Diagnostic range
 
 ```py

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -335,12 +335,15 @@ impl<'db> SubclassOfType<'db> {
             SubclassOfInner::Dynamic(dynamic) => {
                 SubclassOfType::from(db, env, SubclassOfInner::Dynamic(dynamic))
             }
-            SubclassOfInner::Class(class) => SubclassOfType::try_from_type(
-                db,
-                env,
-                class.inferred_metaclass(db).for_inheritance(db, env),
-            )
-            .unwrap_or(SubclassOfType::subclass_of_unknown()),
+            // A metaclass selected at runtime can already have a type such as `type[M]`,
+            // rather than being a class literal. Projecting to instances preserves this
+            // constraint when computing its possible subclasses.
+            SubclassOfInner::Class(class) => class
+                .inferred_metaclass(db)
+                .for_inheritance(db, env)
+                .to_instance_approximation(db, env)
+                .map(|instance| instance.to_meta_type(db, env))
+                .unwrap_or(SubclassOfType::subclass_of_unknown()),
             // Structural implementations of a protocol can have arbitrary metaclasses. The only
             // guaranteed upper bound is therefore `type`, not the protocol origin's metaclass.
             SubclassOfInner::Protocol(_) => KnownClass::Type.to_subclass_of(db, env),


### PR DESCRIPTION
Class-object values can lose their metaclass bound when the metaclass is known as `type[M]` rather than a single class literal. This prevents ty from recognizing that `type[C]` values are still instances of `type`, producing false errors in exhaustive `type()` matches and incorrectly accepting returns as unrelated types such as `int`.

Preserve the bound in `SubclassOfType::to_meta_type` by projecting the inferred metaclass to its instance type before rebuilding the metatype. The lookup-only typeshed protocol fallback remains excluded from inheritance guarantees.

Fixes astral-sh/ty#4370.

## Test plan

Add a metaclass mdtest using an explicit `type[Meta]` parameter. It checks the preserved `type[Meta]` metatype for subclasses, exhaustive `case type()` narrowing, and rejection of an invalid `int` return.
