### PR TITLE
[ty] Preserve invariant materialization constraints

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -342,6 +342,59 @@ def inspect_gradual[T]() -> None:
     reveal_type(constraints.solutions_for(T, inferable=tuple[T]))  # revealed: None
 ```
 
+### Constraints introduced by recursive properties
+
+A recursive property can introduce constraints that the outer properties do not impose. Here, the
+outer `value` properties both return `str | int`, but the children return `bytes | int` and
+`T | int`. The child therefore contributes the lower bound `bytes <: T`. Its specialization stays
+unchanged on subsequent recursive steps.
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import ConstraintSet, is_constraint_set_assignable_to
+
+class Recursive[A, B](Protocol):
+    @property
+    def value(self) -> A | int: ...
+    @property
+    def child(self) -> Recursive[B, B]: ...
+
+def materialized_source[T]() -> None:
+    top = is_constraint_set_assignable_to(Top[Recursive[str | int, bytes]], Recursive[str, T])
+    static_assert(top == ConstraintSet.lower_bound(bytes, T))
+    reveal_type(top.solutions_for(T, inferable=tuple[T]))  # revealed: tuple[Solution[T=bytes]]
+
+    bottom = is_constraint_set_assignable_to(Bottom[Recursive[str | int, bytes]], Recursive[str, T])
+    static_assert(bottom == ConstraintSet.lower_bound(bytes, T))
+```
+
+Materializing the target instead preserves the same bound. These specializations contain no gradual
+types, so neither materialization changes their requirements.
+
+```py
+def materialized_target[T]() -> None:
+    top = is_constraint_set_assignable_to(Recursive[str | int, bytes], Top[Recursive[str, T]])
+    static_assert(top == ConstraintSet.lower_bound(bytes, T))
+
+    bottom = is_constraint_set_assignable_to(Recursive[str | int, bytes], Bottom[Recursive[str, T]])
+    static_assert(bottom == ConstraintSet.lower_bound(bytes, T))
+```
+
+The bound also survives opposite materializations. Combining it with an incompatible upper bound has
+no solution; the recursive comparison does not merely succeed without constraining `T`.
+
+```py
+def incompatible_bound[T]() -> None:
+    constraints = is_constraint_set_assignable_to(Top[Recursive[str | int, bytes]], Bottom[Recursive[str, T]])
+    static_assert(constraints == ConstraintSet.lower_bound(bytes, T))
+
+    incompatible = constraints & ConstraintSet.upper_bound(T, str)
+    reveal_type(incompatible.solutions_for(T, inferable=tuple[T]))  # revealed: None
+```
+
 ## Intersection
 
 The intersection of two constraint sets requires that the constraints in both sets hold. In many

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -273,6 +273,75 @@ def _[T]() -> None:
     static_assert(negated_type != negated_constraint)
 ```
 
+## Constraints from materialized types
+
+### Invariant classes
+
+Assignability between fully static specializations of an invariant class determines the type
+variable exactly.
+
+```py
+from typing import Any
+from ty_extensions import Bottom, Top
+from ty_extensions._internal import is_constraint_set_assignable_to
+
+class Invariant[T]:
+    value: T
+
+def inspect_exact[T]() -> None:
+    exact = is_constraint_set_assignable_to(Top[Invariant[str]], Top[Invariant[T]])
+    reveal_type(exact.solutions_for(T, inferable=tuple[T]))  # revealed: tuple[Solution[T=str]]
+```
+
+The top materialization of `Invariant[Any]` covers every static specialization represented by `Any`.
+No single fully static specialization of `T` can cover that range. The reverse
+bottom-materialization comparison is impossible for the same reason. Constraint inference preserves
+both ends of those ranges, so neither comparison has a solution.
+
+```py
+def inspect_gradual[T]() -> None:
+    top = is_constraint_set_assignable_to(Top[Invariant[Any]], Top[Invariant[T]])
+    reveal_type(top.solutions_for(T, inferable=tuple[T]))  # revealed: None
+
+    bottom = is_constraint_set_assignable_to(Bottom[Invariant[T]], Bottom[Invariant[Any]])
+    reveal_type(bottom.solutions_for(T, inferable=tuple[T]))  # revealed: None
+```
+
+### Recursive consuming methods
+
+A recursive consuming method imposes the opposite constraint from a covariant property. Seeing the
+type variable in the property's constraints is not enough to omit that method: both bounds are
+needed to establish the invariant specialization. The `Any` marker keeps the protocol gradual even
+when its type argument is fully static.
+
+```py
+from __future__ import annotations
+
+from typing import Any, Protocol
+from ty_extensions import Top, static_assert
+from ty_extensions._internal import ConstraintSet, is_constraint_set_assignable_to
+
+class RecursiveInvariant[T](Protocol):
+    marker: Any
+
+    @property
+    def value(self) -> T: ...
+    def consume(self, other: RecursiveInvariant[T]) -> None: ...
+
+def inspect[T]() -> None:
+    constraints = is_constraint_set_assignable_to(Top[RecursiveInvariant[str]], Top[RecursiveInvariant[T]])
+    static_assert(constraints == ConstraintSet.equality(T, str))
+```
+
+A top-materialized `Any` also contributes both bounds. Its recursive consuming requirement makes the
+relation impossible for every fully static specialization of `T`.
+
+```py
+def inspect_gradual[T]() -> None:
+    constraints = is_constraint_set_assignable_to(Top[RecursiveInvariant[Any]], Top[RecursiveInvariant[T]])
+    reveal_type(constraints.solutions_for(T, inferable=tuple[T]))  # revealed: None
+```
+
 ## Intersection
 
 The intersection of two constraint sets requires that the constraints in both sets hold. In many

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -2713,6 +2713,54 @@ def recursive_nested_materialization(
     reveal_type(nested_bottom.marker)  # revealed: Never
 ```
 
+### Recursive protocols with stable specializations
+
+These specializations have identical property types: both `value` properties return `str | int`, and
+both children have type `Recursive[str | int]`. Materializing either side leaves these fully static
+requirements unchanged, including when the materialization directions are opposite.
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_assignable_to
+
+class Recursive[T](Protocol):
+    @property
+    def value(self) -> T | int: ...
+    @property
+    def child(self) -> Recursive[T | int]: ...
+
+static_assert(is_assignable_to(Top[Recursive[str | int]], Recursive[str]))
+static_assert(is_assignable_to(Bottom[Recursive[str | int]], Recursive[str]))
+static_assert(is_assignable_to(Recursive[str | int], Top[Recursive[str]]))
+static_assert(is_assignable_to(Recursive[str | int], Bottom[Recursive[str]]))
+static_assert(is_assignable_to(Top[Recursive[str | int]], Bottom[Recursive[str]]))
+```
+
+### Recursive protocols with growing specializations
+
+Matching outer properties do not establish compatibility when a recursive child changes the
+requirements. Here, the children expose `list[str | int] | int` and `list[str] | int`, which are
+incompatible because `list` is invariant.
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+from ty_extensions import Top, static_assert
+from ty_extensions._internal import is_assignable_to
+
+class Growing[T](Protocol):
+    @property
+    def value(self) -> T | int: ...
+    @property
+    def child(self) -> Growing[list[T]]: ...
+
+static_assert(not is_assignable_to(Top[Growing[str | int]], Growing[str]))
+```
+
 ### Display
 
 Materialized protocols display `Top` and `Bottom` around the protocol class:

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2087,14 +2087,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         );
 
         let is_subtype_of = |source: Type<'db>, target: Type<'db>| {
-            // TODO:
-            // This should be removed and properly handled in the respective
+            // Lazy comparisons must record the bounds imposed on a type variable by each
+            // materialization. Otherwise, for example, `Top[Inv[Any]] <: Top[Inv[T]]` loses
+            // the incompatible requirements `object <: T` and `T <: Never`.
+            // TODO: Remove the eager workaround and handle it in the respective
             // `(Type::TypeVar(_), _) | (_, Type::TypeVar(_))` branch of
             // `TypeRelationChecker::check_type_pair`. Right now, we cannot generally
             // return `self.always()` from that branch, as that leads to union
             // simplification, which means that we lose track of type variables
             // without recording the constraints under which the relation holds.
-            if matches!(target, Type::TypeVar(_)) || matches!(source, Type::TypeVar(_)) {
+            if self.typevar_evaluation == TypeVarEvaluation::Eager
+                && (target.is_type_var() || source.is_type_var())
+            {
                 return self.always();
             }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -786,6 +786,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         if source_alias.origin(db) != target_alias.origin(db) {
             return None;
         }
+
+        // A materialized recursive member can impose bounds that finite members do not
+        // capture, even when the nominal relation is impossible. Check the full interface.
+        if source_protocol.materialization_kind(db).is_some()
+            || protocol.materialization_kind(db).is_some()
+        {
+            return None;
+        }
+
         let identity_protocol = target_alias
             .origin(db)
             .identity_specialization(db)

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -33,7 +33,8 @@ use crate::types::signatures::SignatureRelationVisitor;
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::typevar::TypeVarSet;
 use crate::types::visitor::{
-    TypeCollector, TypeVisitor, any_over_type_expanding_aliases, walk_type_with_recursion_guard,
+    TypeCollector, TypeVisitor, any_over_type_expanding_aliases, materialization_is_noop,
+    walk_type_with_recursion_guard,
 };
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ErrorContext,
@@ -670,6 +671,49 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             });
         }
         result.or(db, self.constraints, || structurally_satisfied)
+    }
+
+    /// Try a nominal proof when a materialized recursive protocol changes specialization.
+    ///
+    /// A recursive child can stabilize at a specialization that relates nominally even when its
+    /// parent only relates structurally. Keep the child's constraints without retrying the
+    /// structural comparison that reached the recursion guard.
+    pub(super) fn try_check_nominal_protocol_cycle(
+        &self,
+        db: &'db dyn Db,
+        source: Type<'db>,
+        target: Type<'db>,
+    ) -> Option<ConstraintSet<'db, 'c>> {
+        let source = source.as_protocol_instance()?;
+        let target = target.as_protocol_instance()?;
+        if source.materialization_kind(db).is_none() && target.materialization_kind(db).is_none() {
+            return None;
+        }
+        let source_origin = source.class_origin(db)?;
+        let target_origin = target.class_origin(db)?;
+        if source_origin.class_literal(db) != target_origin.class_literal(db) {
+            return None;
+        }
+
+        // Nominal arguments alone do not describe materialized requirements such as a fixed
+        // `Any` member. Only use the nominal proof when the pending wrappers are harmless.
+        for protocol in [source, target] {
+            if let Some(origin) = protocol.materialized_origin(db)
+                && !materialization_is_noop(
+                    db,
+                    self.env,
+                    Type::ProtocolInstance(ProtocolInstanceType::from_class(origin)),
+                )
+            {
+                return None;
+            }
+        }
+
+        Some(self.check_type_pair(
+            db,
+            Type::NominalInstance(source.nominal_origin_instance(db)?),
+            Type::NominalInstance(target.nominal_origin_instance(db)?),
+        ))
     }
 
     /// Avoid recursive requirements that cannot add solutions beyond explicit inheritance.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1222,14 +1222,20 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 (source, target, self.relation, self.typevar_evaluation),
                 work,
             )
-            .unwrap_or_else(|item| self.recursive_type_pair_fallback(item.0, item.1))
+            .unwrap_or_else(|item| self.recursive_type_pair_fallback(db, item.0, item.1))
     }
 
     fn recursive_type_pair_fallback(
         &self,
-        _source: Type<'db>,
-        _target: Type<'db>,
+        db: &'db dyn Db,
+        source: Type<'db>,
+        target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if let Some(nominally_satisfied) = self.try_check_nominal_protocol_cycle(db, source, target)
+        {
+            return nominally_satisfied;
+        }
+
         // TODO: Recursively-specialized structural types can encode context-free languages,
         // whose inclusion and equivalence are undecidable. No complete fallback exists, but
         // more decidable cases can be recognized here before conservatively rejecting the pair.

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -404,7 +404,7 @@ pub(super) enum DynamicContent {
     Absent,
     /// The type contains a matching dynamic type.
     Present,
-    /// Recursive specialization prevented the type from being fully inspected.
+    /// Lazy type information or recursive specialization prevented a complete inspection.
     Indeterminate,
 }
 
@@ -414,13 +414,34 @@ impl DynamicContent {
     }
 }
 
+#[derive(Clone, Copy)]
+enum DynamicContentMode {
+    All,
+    NonAny,
+    /// Require enough information to prove that materialization preserves type requirements.
+    Materialization,
+}
+
 /// Determine whether `ty` contains any dynamic type.
 pub(super) fn dynamic_content<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
 ) -> DynamicContent {
-    dynamic_content_impl(db, env, ty, true)
+    dynamic_content_impl(db, env, ty, DynamicContentMode::All)
+}
+
+/// Whether both materializations preserve the requirements described by `ty`.
+///
+/// Unlike ordinary static-content checks, this proof cannot ignore lazy function signatures or
+/// the wrapped callable of a partial. It does not compare metadata such as parameter-default types,
+/// which do not affect whether one callable satisfies another's requirements.
+pub(super) fn materialization_is_noop<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+) -> bool {
+    dynamic_content_impl(db, env, ty, DynamicContentMode::Materialization).is_absent()
 }
 
 /// Determine whether `ty` contains a dynamic type other than `Any`.
@@ -444,14 +465,14 @@ pub(super) fn non_any_dynamic_content<'db>(
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
 ) -> DynamicContent {
-    dynamic_content_impl(db, env, ty, false)
+    dynamic_content_impl(db, env, ty, DynamicContentMode::NonAny)
 }
 
 fn dynamic_content_impl<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
-    include_any: bool,
+    mode: DynamicContentMode,
 ) -> DynamicContent {
     struct DynamicContentVisitor<'a, 'db> {
         env: &'a ProgramEnvironment<'db>,
@@ -460,7 +481,7 @@ fn dynamic_content_impl<'db>(
         active_class_typed_dicts: ActiveRecursionDetector<StaticClassLiteral<'db>>,
         active_type_aliases: ActiveRecursionDetector<Definition<'db>>,
         content: Cell<DynamicContent>,
-        include_any: bool,
+        mode: DynamicContentMode,
     }
 
     impl DynamicContentVisitor<'_, '_> {
@@ -485,8 +506,13 @@ fn dynamic_content_impl<'db>(
                 return;
             }
 
+            if matches!(self.mode, DynamicContentMode::Materialization) && ty.is_divergent() {
+                self.record(DynamicContent::Indeterminate);
+                return;
+            }
+
             if ty.is_dynamic()
-                && (self.include_any
+                && (!matches!(self.mode, DynamicContentMode::NonAny)
                     || !matches!(ty, Type::Dynamic(crate::types::DynamicType::Any)))
             {
                 self.record(DynamicContent::Present);
@@ -494,6 +520,34 @@ fn dynamic_content_impl<'db>(
             }
 
             walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+        }
+
+        fn visit_function_type(&self, db: &'db dyn Db, function: FunctionType<'db>) {
+            if !self.content.get().is_absent() {
+                return;
+            }
+
+            if matches!(self.mode, DynamicContentMode::Materialization) {
+                // The ordinary walker only visits updated signatures. Inferring an original
+                // signature here could re-enter recursive `TypeOf` evaluation, so do not claim
+                // that materialization leaves this function's requirements unchanged.
+                self.record(DynamicContent::Indeterminate);
+            } else {
+                walk_function_type(db, function, self);
+            }
+        }
+
+        fn visit_known_instance_type(&self, db: &'db dyn Db, known: KnownInstanceType<'db>) {
+            if matches!(self.mode, DynamicContentMode::Materialization)
+                && let KnownInstanceType::FunctoolsPartial(partial)
+                | KnownInstanceType::FunctoolsPartialCall(partial) = known
+            {
+                // Materialization maps both the reduced signature and the wrapped callable.
+                self.visit_type(db, partial.wrapped(db).inner(db));
+            }
+            if self.content.get().is_absent() {
+                walk_known_instance_type(db, known, self);
+            }
         }
 
         fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
@@ -572,7 +626,7 @@ fn dynamic_content_impl<'db>(
         active_class_typed_dicts: ActiveRecursionDetector::default(),
         active_type_aliases: ActiveRecursionDetector::default(),
         content: Cell::new(DynamicContent::Absent),
-        include_any,
+        mode,
     };
     visitor.visit_type(db, ty);
     visitor.content.get()
@@ -713,9 +767,74 @@ where
 
 #[cfg(test)]
 mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::DbWithWritableSystem as _;
+    use ty_python_core::ProgramFile;
+
+    use crate::db::tests::setup_db;
+    use crate::place::global_symbol;
     use crate::types::{DynamicType, SpecialFormType, Type};
 
-    use super::CollectedTypes;
+    use super::{CollectedTypes, materialization_is_noop};
+
+    #[test]
+    fn materialization_noop_checks_hidden_function_types() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+            from __future__ import annotations
+            from functools import partial
+            from typing import Any, Protocol
+            from ty_extensions._internal import TypeOf
+
+            def gradual_callback(value: Any) -> None: ...
+
+            class Callbacks(Protocol):
+                @property
+                def callback(self) -> TypeOf[gradual_callback]: ...
+
+            class Recursive[T](Protocol):
+                @property
+                def value(self) -> T: ...
+                @property
+                def child(self) -> Recursive[T]: ...
+
+            plain: Recursive[int]
+            callbacks: Recursive[Callbacks]
+            partial_callback = partial(gradual_callback, 0)
+            partial_call = partial_callback.__call__
+            "#,
+        )?;
+        let env = db.program_environment();
+        let file = system_path_to_file(&db, "/src/a.py")?;
+        let module = ProgramFile::new(&db, file, env.program(&db));
+        for (name, expected) in [
+            ("plain", true),
+            ("callbacks", false),
+            ("partial_callback", false),
+            ("partial_call", false),
+        ] {
+            let ty = global_symbol(&db, module, name).place.expect_type();
+            assert_eq!(materialization_is_noop(&db, &env, ty), expected, "{name}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn materialization_noop_rejects_divergent_markers() {
+        let db = setup_db();
+        let env = db.program_environment();
+        let divergent = Type::divergent(salsa::plumbing::Id::from_bits(1));
+
+        for ty in [
+            divergent,
+            divergent.top_materialization(&db, &env),
+            divergent.bottom_materialization(&db, &env),
+        ] {
+            assert!(!materialization_is_noop(&db, &env, ty));
+        }
+    }
 
     #[test]
     fn collected_types_spills_without_losing_deduplication() {


### PR DESCRIPTION
Type inference can lose type-variable bounds when comparing materializations of invariant generic types. For example, assigning `Top[Invariant[Any]]` to `Top[Invariant[T]]` requires both `object <: T` and `T <: Never`, so there is no fully static solution for `T`. Skipping these comparisons incorrectly makes the relation appear satisfiable.

Preserve both endpoint constraints during lazy type-variable evaluation. Materialized recursive protocols also check their recursive members, which can impose bounds absent from their non-recursive members.

When a recursive protocol stabilizes at a new specialization, retain its nominal constraints if the source and target share an origin and the pending materializations leave their requirements unchanged. This check remains conservative for lazy function signatures, wrapped partial callables, and divergent markers.

## Ecosystem impact

The three Expression warning rewrites expose an existing solver limitation tracked in [astral-sh/ty#3467](https://github.com/astral-sh/ty/issues/3467): existential projection can discard return-type information involving an unsolved callback-local type variable. This PR removes an invalid inferred relationship that previously masked that limitation, so `Parser[Any]` becomes `Unknown` in those warnings. Fixing the solver limitation is outside the scope of this PR.

## Test plan

- Cover exact invariant specializations and impossible top/bottom comparisons involving `Any`.
- Check bounds contributed by recursive consuming methods and recursive properties, including source-only, target-only, and opposite materializations and incompatible combined bounds.
- Accept stable recursive specializations while rejecting growing incompatible specializations; check that hidden function types, partial callables, and divergent markers cannot establish a no-op materialization.
