### PR TITLE
[ty] Fix TypedDict variance inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -1076,6 +1076,254 @@ static_assert(is_assignable_to(C[B], C[A]))
 static_assert(not is_assignable_to(C[A], C[B]))
 ```
 
+## Typed dictionaries
+
+### Mutable items
+
+A mutable `TypedDict` item can be read and written, so returning a `TypedDict` with an item of type
+`T` makes the enclosing class invariant in `T`.
+
+```py
+from typing import TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Item[T](TypedDict):
+    value: T
+
+class Producer[T]:
+    def get(self) -> Item[T]:
+        raise NotImplementedError
+
+static_assert(not is_subtype_of(Producer[bool], Producer[int]))
+static_assert(not is_subtype_of(Producer[int], Producer[bool]))
+```
+
+Optional items are still mutable, including items whose names start with an underscore.
+
+```py
+from typing import NotRequired
+
+class OptionalItem[T](TypedDict):
+    _value: NotRequired[T]
+
+class OptionalProducer[T]:
+    def get(self) -> OptionalItem[T]:
+        raise NotImplementedError
+
+static_assert(not is_subtype_of(OptionalProducer[bool], OptionalProducer[int]))
+static_assert(not is_subtype_of(OptionalProducer[int], OptionalProducer[bool]))
+```
+
+### Read-only items
+
+A read-only item is covariant in its value type. Returning this `TypedDict` makes a class covariant,
+while accepting it as a method argument makes a class contravariant. An unrelated mutable item does
+not affect the variance of `T`.
+
+```py
+from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Item[T](TypedDict):
+    value: ReadOnly[T]
+    tag: str
+
+class Producer[T]:
+    def get(self) -> Item[T]:
+        raise NotImplementedError
+
+class Consumer[T]:
+    def put(self, item: Item[T]) -> None: ...
+
+static_assert(is_subtype_of(Producer[bool], Producer[int]))
+static_assert(not is_subtype_of(Producer[int], Producer[bool]))
+static_assert(is_subtype_of(Consumer[int], Consumer[bool]))
+static_assert(not is_subtype_of(Consumer[bool], Consumer[int]))
+```
+
+### Nested item types
+
+Read-only items preserve the variance of their value types. A callable's argument and return types
+contribute opposite variances; using the same type variable in both positions makes it invariant.
+
+```py
+from typing import Callable
+from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Callback[P, R](TypedDict):
+    callback: ReadOnly[Callable[[P], R]]
+
+class Consumer[T]:
+    def get(self) -> Callback[T, None]:
+        raise NotImplementedError
+
+class Transformer[T]:
+    def get(self) -> Callback[T, T]:
+        raise NotImplementedError
+
+static_assert(is_subtype_of(Consumer[int], Consumer[bool]))
+static_assert(not is_subtype_of(Consumer[bool], Consumer[int]))
+static_assert(not is_subtype_of(Transformer[bool], Transformer[int]))
+static_assert(not is_subtype_of(Transformer[int], Transformer[bool]))
+```
+
+### Inherited items
+
+Inherited items contribute variance after applying the base class's specialization. Although the
+item itself is read-only, the list it contains is mutable, making the enclosing class invariant.
+
+```py
+from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Base[T](TypedDict):
+    value: ReadOnly[T]
+
+class Derived[T](Base[list[T]]): ...
+
+class Producer[T]:
+    def get(self) -> Derived[T]:
+        raise NotImplementedError
+
+static_assert(not is_subtype_of(Producer[bool], Producer[int]))
+static_assert(not is_subtype_of(Producer[int], Producer[bool]))
+```
+
+### Legacy type variables
+
+When a `TypedDict` appears in another generic class, its legacy type variables contribute their
+declared variance to the enclosing class's inferred variance, just as they do for protocols. An
+invariant legacy type variable makes the enclosing consumer invariant even when the item is
+read-only; a covariant legacy type variable makes the consumer contravariant even when the item is
+mutable.
+
+```py
+from typing import Generic, TypeVar
+from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+T_co = TypeVar("T_co", covariant=True)
+T = TypeVar("T")
+
+class InvariantItem(TypedDict, Generic[T]):
+    # TODO: The variance rules specified for Protocol would suggest an error here: T is
+    # declared invariant but used covariantly. The conformance suite does not specify this
+    # check for TypedDicts, and other type checkers do not implement it.
+    value: ReadOnly[T]
+
+class CovariantItem(TypedDict, Generic[T_co]):
+    # TODO: The variance rules specified for Protocol would suggest an error here: T_co is
+    # declared covariant but used invariantly. The conformance suite does not specify this
+    # check for TypedDicts, and other type checkers do not implement it.
+    value: T_co
+
+class InvariantConsumer[T]:
+    def put(self, item: InvariantItem[T]) -> None: ...
+
+class ContravariantConsumer[T]:
+    def put(self, item: CovariantItem[T]) -> None: ...
+
+static_assert(not is_subtype_of(InvariantConsumer[bool], InvariantConsumer[int]))
+static_assert(not is_subtype_of(InvariantConsumer[int], InvariantConsumer[bool]))
+static_assert(is_subtype_of(ContravariantConsumer[int], ContravariantConsumer[bool]))
+static_assert(not is_subtype_of(ContravariantConsumer[bool], ContravariantConsumer[int]))
+```
+
+### Extra items
+
+Extra items contribute variance just like named items, including when inherited. Mutable extra items
+are invariant in their value type, while read-only extra items are covariant.
+
+```py
+from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class MutableExtras[T](TypedDict, extra_items=T): ...
+class ReadOnlyExtras[T](TypedDict, extra_items=ReadOnly[T]): ...
+class InheritedExtras[T](ReadOnlyExtras[T]): ...
+
+class Producer[T]:
+    def get(self) -> MutableExtras[T]:
+        raise NotImplementedError
+
+class Consumer[T]:
+    def put(self, item: InheritedExtras[T]) -> None: ...
+
+static_assert(not is_subtype_of(Producer[bool], Producer[int]))
+static_assert(not is_subtype_of(Producer[int], Producer[bool]))
+static_assert(is_subtype_of(Consumer[int], Consumer[bool]))
+static_assert(not is_subtype_of(Consumer[bool], Consumer[int]))
+```
+
+### Functional syntax
+
+Items defined with functional syntax can refer to an enclosing class's type parameter. The item
+schema determines variance, including when it contains a recursive reference.
+
+```py
+from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Consumer[T]:
+    Item = TypedDict("Item", {"child": "ReadOnly[Item | None]", "value": ReadOnly[T]})
+
+    def put(self, item: Item) -> None: ...
+
+static_assert(is_subtype_of(Consumer[int], Consumer[bool]))
+static_assert(not is_subtype_of(Consumer[bool], Consumer[int]))
+```
+
+### Recursive items
+
+A recursive read-only item preserves covariance when every occurrence of the type variable is
+covariant. Accepting the recursive `TypedDict` as a method argument makes the class contravariant.
+
+```py
+from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Node[T](TypedDict):
+    child: ReadOnly["Node[T] | None"]
+    value: ReadOnly[T]
+
+class Consumer[T]:
+    def put(self, item: Node[T]) -> None: ...
+
+static_assert(is_subtype_of(Consumer[int], Consumer[bool]))
+static_assert(not is_subtype_of(Consumer[bool], Consumer[int]))
+```
+
+### Expanding recursive items
+
+Variance inference terminates even when a recursive item wraps the type argument in another type.
+Here the nested `list[T]` makes `T` invariant despite both items being read-only.
+
+```py
+from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Node[T](TypedDict):
+    child: ReadOnly["Node[list[T]] | None"]
+    value: ReadOnly[T]
+
+class Producer[T]:
+    def get(self) -> Node[T]:
+        raise NotImplementedError
+
+static_assert(not is_subtype_of(Producer[bool], Producer[int]))
+static_assert(not is_subtype_of(Producer[int], Producer[bool]))
+```
+
 ## Type aliases
 
 The variance of the type alias matches the variance of the value type (RHS type).

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -9322,6 +9322,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             Type::ProtocolInstance(protocol_instance_type) => {
                 protocol_instance_type.variance_of(db, env, typevar)
             }
+            Type::TypedDict(typed_dict) => typed_dict.variance_of(db, env, typevar),
             // unions are covariant in their disjuncts
             Type::Union(union_type) => union_type
                 .elements(db)
@@ -9387,7 +9388,6 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             | Type::AlwaysTruthy
             | Type::BoundSuper(_)
             | Type::TypeVar(_)
-            | Type::TypedDict(_)
             | Type::NewTypeInstance(_) => TypeVarVariance::Bivariant,
         };
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -3384,6 +3384,12 @@ impl<'db> StaticClassLiteral<'db> {
         typevar: BoundTypeVarIdentity<'db>,
     ) -> TypeVarVariance {
         let env = ProgramEnvironment::from_scope(self.body_scope(db));
+
+        if self.is_typed_dict(db) {
+            return TypedDictType::new(self.identity_specialization(db))
+                .variance_of_items(db, &env, typevar);
+        }
+
         let typevar_in_generic_context = self
             .generic_context(db)
             .is_some_and(|generic_context| generic_context.contains(db, typevar));
@@ -3503,23 +3509,8 @@ impl<'db> StaticClassLiteral<'db> {
                 })
             });
 
-        let extra_items_variance = TypedDictType::new(self.identity_specialization(db))
-            .explicit_extra_items(db)
-            .map(|extra_items| {
-                let polarity = if extra_items.is_read_only() {
-                    TypeVarVariance::Covariant
-                } else {
-                    TypeVarVariance::Invariant
-                };
-                extra_items
-                    .declared_ty
-                    .with_polarity(polarity)
-                    .variance_of(db, &env, typevar)
-            });
-
         attribute_variances
             .chain(explicit_bases_variances)
-            .chain(extra_items_variance)
             .collect()
     }
 }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -18,8 +18,9 @@ use super::diagnostic::{
 };
 use super::infer::{TypeExpressionFlags, infer_deferred_types};
 use super::{
-    ApplyTypeMappingVisitor, ErrorContext, IntersectionType, Type, TypeMapping, TypeQualifiers,
-    UnionBuilder, definition_expression_annotation, definition_expression_type, visitor,
+    ApplyTypeMappingVisitor, BoundTypeVarIdentity, ErrorContext, IntersectionType, Type,
+    TypeMapping, TypeQualifiers, TypeVarVariance, UnionBuilder, VarianceInferable,
+    definition_expression_annotation, definition_expression_type, visitor,
 };
 use crate::types::TypeContext;
 use crate::types::TypeDefinition;
@@ -549,6 +550,30 @@ impl<'db> TypedDictType<'db> {
             }
             Self::Synthesized(synthesized) => synthesized.items(db),
         }
+    }
+
+    pub(super) fn variance_of_items(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        self.items(db)
+            .values()
+            .map(|field| (field.declared_ty, field.is_read_only()))
+            .chain(
+                self.explicit_extra_items(db)
+                    .map(|extra_items| (extra_items.declared_ty, extra_items.is_read_only())),
+            )
+            .map(|(ty, is_read_only)| {
+                let polarity = if is_read_only {
+                    TypeVarVariance::Covariant
+                } else {
+                    TypeVarVariance::Invariant
+                };
+                ty.with_polarity(polarity).variance_of(db, env, typevar)
+            })
+            .collect()
     }
 
     pub(crate) fn apply_type_mapping_impl<'a>(
@@ -1287,6 +1312,43 @@ pub(crate) fn walk_typed_dict_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
 
     if let Some(extra_items) = typed_dict.explicit_extra_items(db) {
         visitor.visit_type(db, extra_items.declared_ty);
+    }
+}
+
+impl<'db> VarianceInferable<'db> for TypedDictType<'db> {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        match self {
+            Self::Class(class) if class.static_class_literal(db).is_some() => {
+                // Compose each type parameter's variance with its type argument. Inferred variance
+                // is computed on the unspecialized class: expanding specialized fields here would
+                // not terminate for a recursive item such as `child: Node[list[T]]`.
+                class.variance_of(db, env, typevar)
+            }
+            Self::Class(class) => {
+                #[salsa::tracked(
+                    returns(copy),
+                    cycle_initial=|_, _, _, _| TypeVarVariance::Bivariant,
+                    heap_size=ruff_memory_usage::heap_size
+                )]
+                fn functional_variance<'db>(
+                    db: &'db dyn Db,
+                    class: ClassType<'db>,
+                    typevar: BoundTypeVarIdentity<'db>,
+                ) -> TypeVarVariance {
+                    let env =
+                        ProgramEnvironment::from_file(class.class_literal(db).program_file(db));
+                    TypedDictType::new(class).variance_of_items(db, &env, typevar)
+                }
+
+                functional_variance(db, class, typevar)
+            }
+            Self::Synthesized(_) => self.variance_of_items(db, env, typevar),
+        }
     }
 }
 


### PR DESCRIPTION
TypedDict types currently contribute no constraints to variance inference, so a type parameter used only through a TypedDict is treated as unused. This can infer the wrong variance for an enclosing generic class.

Infer variance through TypedDict items and explicit extra items, composing each value type's variance with its mutability. Class definitions use the TypedDict schema, including inherited items, instead of ordinary attribute heuristics. The implementation reuses class specialization and cycle handling, preserves declared legacy variance, and handles functional and synthesized TypedDicts.

## Test plan

Added mdtests for mutable and read-only items, optional items with underscore-prefixed names, callable item types, specialized inherited items, declared legacy variance, inherited extra items, functional definitions capturing an enclosing type parameter, and recursive definitions with both unchanged and expanding type arguments.
