### PR TITLE
[ty] Preserve runtime comparison semantics when narrowing tagged unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -578,6 +578,52 @@ def unions_are_different(t1: int | str, t2: int | str) -> int | str:
     return t1 + t2
 ```
 
+## Equality with constrained typevars
+
+`False` compares equal to `0` without belonging to `Literal[0]`. Comparing it with a constrained
+type variable therefore does not imply that it has the same type as that variable:
+
+```py
+from typing import Literal, TypedDict, TypeVar
+
+T = TypeVar("T", Literal[0], Literal[2])
+
+def equal_values(value: Literal[False, 2], other: T):
+    if value == other:
+        reveal_type(value)  # revealed: Literal[False, 2]
+```
+
+Both tuple tags can match one of the type variable's constraints, so equality preserves both tuples.
+The same applies when an inequality comparison is false:
+
+```py
+def equal_tuple_tags(value: tuple[Literal[False], str] | tuple[Literal[2], int], other: T):
+    if value[0] == other:
+        reveal_type(value)  # revealed: tuple[Literal[False], str] | tuple[Literal[2], int]
+
+    if value[0] != other:
+        reveal_type(value)  # revealed: tuple[Literal[False], str] | tuple[Literal[2], int]
+    else:
+        reveal_type(value)  # revealed: tuple[Literal[False], str] | tuple[Literal[2], int]
+```
+
+Equality likewise preserves both `TypedDict` variants. Since `FalseTag` can match when `other` is
+`0`, the comparison does not make a field exclusive to `TwoTag` available:
+
+```py
+class FalseTag(TypedDict):
+    tag: Literal[False]
+
+class TwoTag(TypedDict):
+    tag: Literal[2]
+    two_only: int
+
+def equal_dictionary_tags(value: FalseTag | TwoTag, other: T):
+    if value["tag"] == other:
+        reveal_type(value)  # revealed: FalseTag | TwoTag
+        value["two_only"]  # error: [invalid-key] "Unknown key "two_only" for TypedDict `FalseTag`"
+```
+
 ## Constraints containing `Any`
 
 A heterogeneous collection can infer a union of tuple types. If every member of that union is

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -943,6 +943,53 @@ def unions_are_different(t1: int | str, t2: int | str) -> int | str:
     return t1 + t2
 ```
 
+## Equality with constrained typevars
+
+`False` compares equal to `0` without belonging to `Literal[0]`. Comparing it with a constrained
+type variable therefore does not imply that it has the same type as that variable:
+
+```py
+from typing import Literal, TypedDict
+
+def equal_values[T: (Literal[0], Literal[2])](value: Literal[False, 2], other: T):
+    if value == other:
+        reveal_type(value)  # revealed: Literal[False, 2]
+```
+
+Both tuple tags can match one of the type variable's constraints, so equality preserves both tuples.
+The same applies when an inequality comparison is false:
+
+```py
+def equal_tuple_tags[T: (Literal[0], Literal[2])](
+    value: tuple[Literal[False], str] | tuple[Literal[2], int],
+    other: T,
+):
+    if value[0] == other:
+        reveal_type(value)  # revealed: tuple[Literal[False], str] | tuple[Literal[2], int]
+
+    if value[0] != other:
+        reveal_type(value)  # revealed: tuple[Literal[False], str] | tuple[Literal[2], int]
+    else:
+        reveal_type(value)  # revealed: tuple[Literal[False], str] | tuple[Literal[2], int]
+```
+
+Equality likewise preserves both `TypedDict` variants. Since `FalseTag` can match when `other` is
+`0`, the comparison does not make a field exclusive to `TwoTag` available:
+
+```py
+class FalseTag(TypedDict):
+    tag: Literal[False]
+
+class TwoTag(TypedDict):
+    tag: Literal[2]
+    two_only: int
+
+def equal_dictionary_tags[T: (Literal[0], Literal[2])](value: FalseTag | TwoTag, other: T):
+    if value["tag"] == other:
+        reveal_type(value)  # revealed: FalseTag | TwoTag
+        value["two_only"]  # error: [invalid-key] "Unknown key "two_only" for TypedDict `FalseTag`"
+```
+
 ## Typevar inference is a unification problem
 
 When inferring typevar assignments in a generic function call, we cannot simply solve constraints

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -408,6 +408,40 @@ def _(x: tuple[Literal[IntTag.A], int] | tuple[Literal[IntTag.B], str]):
         reveal_type(x)  # revealed: tuple[Literal[IntTag.B], str]
 ```
 
+An `IntEnum` member compares equal to its integer value. A tuple whose tags are `IntTag.A` or `1`
+therefore always matches `1`, and is excluded from the other branch:
+
+```py
+def enum_tag_equal_to_integer(
+    x: tuple[Literal[IntTag.A, 1], int] | tuple[Literal[1], str] | tuple[Literal[2], bytes],
+):
+    if x[0] == 1:
+        reveal_type(x)  # revealed: tuple[Literal[IntTag.A, 1], int] | tuple[Literal[1], str]
+    else:
+        reveal_type(x)  # revealed: tuple[Literal[2], bytes]
+```
+
+An enum can customize `__ne__` independently of `__eq__`. An ambiguous inequality keeps tuples whose
+tag is that enum member in both branches, even when its literal type differs from the comparison
+value:
+
+```py
+class NeverUnequal(Enum):
+    A = 1
+    B = 2
+
+    def __ne__(self, other: object) -> bool:
+        return False
+
+def custom_inequality(
+    x: tuple[Literal[NeverUnequal.A], int] | tuple[Literal["a"], str] | tuple[Literal["b"], bytes],
+):
+    if "a" != x[0]:
+        reveal_type(x)  # revealed: tuple[Literal[NeverUnequal.A], int] | tuple[Literal["b"], bytes]
+    else:
+        reveal_type(x)  # revealed: tuple[Literal[NeverUnequal.A], int] | tuple[Literal["a"], str]
+```
+
 Narrowing is restricted to `Literal` tag elements. If any tuple has a non-literal type at the
 discriminating index, we can't safely narrow with equality:
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -442,17 +442,15 @@ def custom_inequality(
         reveal_type(x)  # revealed: tuple[Literal[NeverUnequal.A], int] | tuple[Literal["a"], str]
 ```
 
-Narrowing is restricted to `Literal` tag elements. If any tuple has a non-literal type at the
-discriminating index, we can't safely narrow with equality:
+An ambiguous tag keeps its tuple in both branches. Other tuples can still be excluded when their
+literal tags make the comparison always true or always false:
 
 ```py
-def _(x: tuple[Literal["tag1"], A] | tuple[str, B]):
-    # Can't narrow because second tuple has `str` (not literal) at index 0
+def _(x: tuple[Literal["tag1"], A] | tuple[str, B] | tuple[Literal["tag2"], C]):
     if x[0] == "tag1":
         reveal_type(x)  # revealed: tuple[Literal["tag1"], A] | tuple[str, B]
     else:
-        # But we *can* narrow with inequality
-        reveal_type(x)  # revealed: tuple[str, B]
+        reveal_type(x)  # revealed: tuple[str, B] | tuple[Literal["tag2"], C]
 ```
 
 This also applies when a tag is a union of literal and non-literal types. The non-literal
@@ -463,9 +461,24 @@ class MatchesAnything:
     def __eq__(self, other: object) -> bool:
         return True
 
-def nonliteral_tag_union(x: tuple[Literal["a"], int] | tuple[Literal["b"] | MatchesAnything, str]):
+def nonliteral_tag_union(
+    x: tuple[Literal["a"], int] | tuple[Literal["b"] | MatchesAnything, str] | tuple[Literal["c"], bytes],
+):
     if x[0] == "a":
         reveal_type(x)  # revealed: tuple[Literal["a"], int] | tuple[Literal["b"] | MatchesAnything, str]
+    else:
+        reveal_type(x)  # revealed: tuple[Literal["b"] | MatchesAnything, str] | tuple[Literal["c"], bytes]
+```
+
+An `int` tag can contain a subclass with custom equality, so it can match a string literal. This
+preserves the tuple with that tag without preventing narrowing of the literal tags:
+
+```py
+def integer_tag(x: tuple[int, A] | tuple[Literal["a"], B] | tuple[Literal["b"], C]):
+    if x[0] == "a":
+        reveal_type(x)  # revealed: tuple[int, A] | tuple[Literal["a"], B]
+    else:
+        reveal_type(x)  # revealed: tuple[int, A] | tuple[Literal["b"], C]
 ```
 
 If the index is out of bounds for any tuple in the union, we also skip narrowing (a diagnostic will
@@ -491,6 +504,56 @@ def _(x: tuple[Literal["tag1"], A] | tuple[Literal["tag2"], B] | list[int]):
         # compare equal to `"tag1"`, so `list[int]` cannot be narrowed out of this
         # union.
         reveal_type(x)  # revealed: tuple[Literal["tag1"], A] | list[int]
+```
+
+### Tuple tags with non-literal comparators
+
+A boolean comparison value can match either boolean tag value, but cannot match a string literal:
+
+```py
+from typing import Literal
+
+def boolean_comparator(value: tuple[bool, int] | tuple[Literal["other"], str], other: bool):
+    if value[0] == other:
+        reveal_type(value)  # revealed: tuple[bool, int]
+    else:
+        reveal_type(value)  # revealed: tuple[bool, int] | tuple[Literal["other"], str]
+```
+
+When the comparison value is a union of literals, a matching tuple can have any of those tags. An
+unequal comparison can retain every tuple because the comparison value is not fixed:
+
+```py
+def union_comparator(
+    value: tuple[Literal["a"], int] | tuple[Literal["b"], str] | tuple[Literal["c"], bytes],
+    other: Literal["a", "b"],
+):
+    if other != value[0]:
+        reveal_type(value)  # revealed: tuple[Literal["a"], int] | tuple[Literal["b"], str] | tuple[Literal["c"], bytes]
+    else:
+        reveal_type(value)  # revealed: tuple[Literal["a"], int] | tuple[Literal["b"], str]
+```
+
+An intersection can restrict an enum comparison value to some of its members. A tuple with the whole
+enum as its tag remains possible, while an excluded member cannot match:
+
+```py
+from enum import Enum
+from ty_extensions import Intersection, Not
+
+class Color(Enum):
+    RED = 0
+    GREEN = 1
+    BLUE = 2
+
+def intersection_comparator(
+    value: tuple[Literal[Color.RED], int] | tuple[Color, str] | tuple[Literal[Color.GREEN], bytes],
+    other: Intersection[Color, Not[Literal[Color.RED]]],
+):
+    if value[0] == other:
+        reveal_type(value)  # revealed: tuple[Color, str] | tuple[Literal[Color.GREEN], bytes]
+    else:
+        reveal_type(value)  # revealed: tuple[Literal[Color.RED], int] | tuple[Color, str] | tuple[Literal[Color.GREEN], bytes]
 ```
 
 ### PEP 695 type aliases

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -2830,6 +2830,121 @@ def _(x: A | B):
         reveal_type(x)  # revealed: B
 ```
 
+## Attribute tags with enum equality
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+An `IntEnum` member compares equal to its integer value, so both `EnumTag` and `IntegerTag` match
+`1`. `EnumTag` also permits a different tag, leaving it possible in both branches:
+
+```py
+from enum import Enum, IntEnum, StrEnum
+from typing import Literal
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+class EnumTag:
+    tag: Literal[Number.ONE, "other"]
+
+class IntegerTag:
+    tag: Literal[1]
+
+class OtherTag:
+    tag: Literal[2]
+
+def equal_integer_tags(value: EnumTag | IntegerTag | OtherTag):
+    if value.tag == 1:
+        reveal_type(value)  # revealed: EnumTag | IntegerTag
+    else:
+        reveal_type(value)  # revealed: EnumTag | OtherTag
+
+    if value.tag != 1:
+        reveal_type(value)  # revealed: EnumTag | OtherTag
+    else:
+        reveal_type(value)  # revealed: EnumTag | IntegerTag
+```
+
+The enum can also be the comparison value. An integer literal can match the enum member without
+having the same literal type:
+
+```py
+def enum_comparator(value: EnumTag | IntegerTag | OtherTag):
+    if Number.ONE == value.tag:
+        reveal_type(value)  # revealed: EnumTag | IntegerTag
+    else:
+        reveal_type(value)  # revealed: EnumTag | OtherTag
+```
+
+`StrEnum` members likewise compare equal to strings with the same value:
+
+```py
+class Word(StrEnum):
+    A = "a"
+    B = "b"
+
+class EnumStringTag:
+    tag: Literal[Word.A]
+
+class StringTag:
+    tag: Literal["a"]
+
+class OtherStringTag:
+    tag: Literal["b"]
+
+def equal_string_tags(value: EnumStringTag | StringTag | OtherStringTag):
+    if value.tag == "a":
+        reveal_type(value)  # revealed: EnumStringTag | StringTag
+    else:
+        reveal_type(value)  # revealed: OtherStringTag
+```
+
+Custom equality methods can make an enum member compare equal to unrelated values. An ambiguous
+comparison keeps the alternative containing that member in both branches:
+
+```py
+class Custom(Enum):
+    A = 1
+    B = 2
+
+    def __eq__(self, other: object) -> bool:
+        return True
+
+class CustomTag:
+    tag: Literal[Custom.A]
+
+def custom_equality(value: CustomTag | StringTag):
+    if value.tag == "a":
+        reveal_type(value)  # revealed: CustomTag | StringTag
+    else:
+        reveal_type(value)  # revealed: CustomTag
+```
+
+An enum can customize `__ne__` independently of `__eq__`. An ambiguous inequality keeps the
+alternative with that enum tag in both branches, including the branch where the inequality is false:
+
+```py
+class NeverUnequal(Enum):
+    A = 1
+    B = 2
+
+    def __ne__(self, other: object) -> bool:
+        return False
+
+class UnequalTag:
+    tag: Literal[NeverUnequal.A]
+
+def custom_inequality(value: UnequalTag | StringTag | OtherStringTag):
+    if value.tag != "a":
+        reveal_type(value)  # revealed: UnequalTag | OtherStringTag
+    else:
+        reveal_type(value)  # revealed: UnequalTag | StringTag
+```
+
 ## Enabling strict equality narrowing
 
 Enabling `strict-equality-semantics` accounts for builtin subclasses that override `__eq__` or

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -2784,7 +2784,8 @@ def _(x: A | B):
         reveal_type(x)  # revealed: B
 ```
 
-Non-literal tag arms are preserved during positive narrowing:
+A broad `str` tag can match the comparison value or a different string, so its containing object
+remains possible in both branches:
 
 ```py
 from typing import Literal
@@ -2828,6 +2829,84 @@ def _(x: A | B):
         reveal_type(x)  # revealed: A
     else:
         reveal_type(x)  # revealed: B
+```
+
+## Attribute tags with non-literal comparators
+
+A boolean comparison value can match a boolean tag, but cannot match either of these other tags:
+
+```py
+from typing import Literal
+
+class BooleanTag:
+    tag: bool
+
+class StringTag:
+    tag: Literal["text"]
+
+class NumberTag:
+    tag: Literal[2]
+
+def boolean_comparator(value: BooleanTag | StringTag | NumberTag, other: bool):
+    if value.tag == other:
+        reveal_type(value)  # revealed: BooleanTag
+    else:
+        reveal_type(value)  # revealed: BooleanTag | StringTag | NumberTag
+```
+
+A union comparison value can match tags of different types. Neither `True` nor `"text"` equals `2`,
+so `NumberTag` is excluded from the equality branch:
+
+```py
+def union_comparator(value: BooleanTag | StringTag | NumberTag, other: Literal[True, "text"]):
+    if value.tag == other:
+        reveal_type(value)  # revealed: BooleanTag | StringTag
+    else:
+        reveal_type(value)  # revealed: BooleanTag | StringTag | NumberTag
+```
+
+## Attribute tags with ambiguous comparisons
+
+An `int` tag can contain a subclass with custom equality. This remains true when the tag is a
+non-final subclass that inherits `int.__eq__`. Both tag types stay possible when compared with a
+string, while the unrelated literal tag is excluded:
+
+```py
+from typing import Literal
+
+class OpenInt(int): ...
+
+class IntegerTag:
+    tag: int
+
+class SubclassTag:
+    tag: OpenInt
+
+class A:
+    tag: Literal["a"]
+
+class B:
+    tag: Literal["b"]
+
+def integer_tags(value: IntegerTag | SubclassTag | A | B):
+    if value.tag == "a":
+        reveal_type(value)  # revealed: IntegerTag | SubclassTag | A
+    else:
+        reveal_type(value)  # revealed: IntegerTag | SubclassTag | B
+```
+
+The comparison value can also have a subclass with custom equality. A `str` value might therefore
+match an integer tag, so neither containing object can be excluded:
+
+```py
+class One:
+    tag: Literal[1]
+
+def broad_comparator(value: A | One, other: str):
+    if value.tag == other:
+        reveal_type(value)  # revealed: A | One
+    else:
+        reveal_type(value)  # revealed: A | One
 ```
 
 ## Attribute tags with enum equality

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -4299,6 +4299,25 @@ def multiple_tags(x: tuple[Literal["a"], int] | tuple[Literal["b", "c"], str]):
             reveal_type(x)  # revealed: tuple[Literal["b", "c"], str]
 ```
 
+Integer patterns also match `IntEnum` members with the same value:
+
+```py
+from enum import IntEnum
+
+class IntTag(IntEnum):
+    A = 1
+    B = 2
+
+def enum_tag_equal_to_integer(
+    x: tuple[Literal[IntTag.A], int] | tuple[Literal[1], str] | tuple[Literal[2], bytes],
+):
+    match x[0]:
+        case 1:
+            reveal_type(x)  # revealed: tuple[Literal[IntTag.A], int] | tuple[Literal[1], str]
+        case _:
+            reveal_type(x)  # revealed: tuple[Literal[2], bytes]
+```
+
 Narrowing is restricted to `Literal` tag elements:
 
 ```py
@@ -4390,4 +4409,56 @@ def _(x: A | B | C):
             reveal_type(x)  # revealed: A | B
         case _:
             reveal_type(x)  # revealed: B | C
+```
+
+An `IntEnum` value pattern can match both an enum tag and an equal integer tag. Neither alternative
+remains in the default branch:
+
+```py
+from enum import Enum, IntEnum
+
+class IntTag(IntEnum):
+    A = 1
+    B = 2
+
+class IntegerTag:
+    tag: Literal[1]
+
+class EnumTag:
+    tag: Literal[IntTag.A]
+
+class OtherTag:
+    tag: Literal[2]
+
+def integer_tag_equal_to_enum(x: IntegerTag | EnumTag | OtherTag):
+    match x.tag:
+        case IntTag.A:
+            reveal_type(x)  # revealed: IntegerTag | EnumTag
+        case _:
+            reveal_type(x)  # revealed: OtherTag
+```
+
+A failed value pattern uses the negation of equality, not `__ne__`. An enum member whose custom
+`__ne__` always returns false can still fail to match the pattern:
+
+```py
+class NeverUnequal(Enum):
+    A = 1
+    B = 2
+
+    def __ne__(self, other: object) -> Literal[False]:
+        return False
+
+class UnequalTag:
+    tag: Literal[NeverUnequal.A]
+
+class StringTag:
+    tag: Literal["a"]
+
+def custom_inequality(x: UnequalTag | StringTag):
+    match x.tag:
+        case "a":
+            reveal_type(x)  # revealed: StringTag
+        case _:
+            reveal_type(x)  # revealed: UnequalTag
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -4318,20 +4318,20 @@ def enum_tag_equal_to_integer(
             reveal_type(x)  # revealed: tuple[Literal[2], bytes]
 ```
 
-Narrowing is restricted to `Literal` tag elements:
+A broad tag keeps its tuple possible in both branches, while other tuples can still be excluded
+based on their literal tags:
 
 ```py
-def _(x: tuple[Literal["tag1"], A] | tuple[str, B]):
+def _(x: tuple[Literal["tag1"], A] | tuple[str, B] | tuple[Literal["tag2"], C]):
     match x[0]:
         case "tag1":
-            # Can't narrow because second tuple has `str` (not literal) at index 0
             reveal_type(x)  # revealed: tuple[Literal["tag1"], A] | tuple[str, B]
         case _:
-            # But we *can* narrow with inequality
-            reveal_type(x)  # revealed: tuple[str, B]
+            reveal_type(x)  # revealed: tuple[str, B] | tuple[Literal["tag2"], C]
 ```
 
-and it is also restricted to `match` patterns that solely consist of value patterns:
+A broad value pattern can match either tag, so another alternative in the same OR pattern does not
+rule out either tuple:
 
 ```py
 class Config:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6407,6 +6407,22 @@ def match_one_tag(u: Foo | MultiTag):
         reveal_type(u)  # revealed: Foo | MultiTag
 ```
 
+A comparison value can itself be a union of literals. Only `Foo` has a tag that can match here, but
+either dictionary can fail to match when the comparison value is `"other"`:
+
+```py
+def union_comparator(u: Foo | Bing, other: Literal["foo", "other"]):
+    if u["tag"] == other:
+        reveal_type(u)  # revealed: Foo
+    else:
+        reveal_type(u)  # revealed: Foo | Bing
+
+    if other != u["tag"]:
+        reveal_type(u)  # revealed: Foo | Bing
+    else:
+        reveal_type(u)  # revealed: Foo
+```
+
 Boolean tags can be narrowed by truthiness, including through a generic `TypedDict` and a type
 alias:
 
@@ -6451,6 +6467,17 @@ class FalsyIntTag(TypedDict):
 
 def _(response: Response | TruthyIntTag | FalsyIntTag):
     if response["success"]:
+        reveal_type(response)  # revealed: Success[int] | TruthyIntTag
+    else:
+        reveal_type(response)  # revealed: Failure | FalsyIntTag
+```
+
+Boolean literals can also be compared explicitly. Since `True == 1`, both matching boolean and
+integer tags remain in the positive branch:
+
+```py
+def boolean_comparator(response: Response | TruthyIntTag | FalsyIntTag):
+    if response["success"] == True:
         reveal_type(response)  # revealed: Success[int] | TruthyIntTag
     else:
         reveal_type(response)  # revealed: Failure | FalsyIntTag
@@ -6591,8 +6618,8 @@ def _(u: Foo):
         reveal_type(u)  # revealed: Never
 ```
 
-Narrowing is restricted to `Literal` tags, though, because `x == "foo"` doesn't generally tell us
-anything about the type of `x`. Here's an example where narrowing would be tempting but unsound:
+An `int` tag can contain subclasses that compare equal to unrelated values, so that dictionary
+remains possible in the equality branch:
 
 ```py
 from ty_extensions import static_assert
@@ -6618,7 +6645,7 @@ class WackyInt(int):
 _: NonLiteralTD = {"tag": WackyInt(99)}  # allowed
 ```
 
-The same restriction applies to a tag union containing a non-literal type. The `int` alternative can
+The same reasoning applies to a tag union containing a non-literal type. The `int` alternative can
 still hold a `WackyInt` that compares equal to `"foo"`:
 
 ```py
@@ -6648,7 +6675,7 @@ def _(x: Intersection[Foo, Any]):
         reveal_type(x)  # revealed: Never
 ```
 
-But intersections with non-literal fields cannot be narrowed:
+Intersections with an `int` field remain possible in both branches:
 
 ```py
 from ty_extensions import Intersection
@@ -6677,6 +6704,66 @@ def _(x: Intersection[StrTagTD, Any]):
         reveal_type(x)  # revealed: Never
     else:
         reveal_type(x)  # revealed: StrTagTD & Any
+```
+
+A broad tag does not prevent other dictionaries from being excluded. Although `str` contains both
+literal tag types, comparing each dictionary's field separately rules out `Bing` when equality is
+true and `Foo` when it is false:
+
+```py
+def mixed_string_tags(u: Foo | Bing | StrTagTD):
+    if u["tag"] == "foo":
+        reveal_type(u)  # revealed: Foo | StrTagTD
+    else:
+        reveal_type(u)  # revealed: Bing | StrTagTD
+```
+
+A broad string tag might also contain a subclass that compares equal to an integer. The comparison
+does not establish that a field unique to the integer-tagged dictionary exists:
+
+```py
+class MatchesInteger(str):
+    def __eq__(self, other: object) -> bool:
+        return True
+
+_: StrTagTD = {"tag": MatchesInteger("other")}
+
+def broad_string_tag(u: StrTagTD | IntegerTag):
+    if u["tag"] == 1:
+        reveal_type(u)  # revealed: StrTagTD | IntegerTag
+        u["integer_only"]  # error: [invalid-key]
+    else:
+        reveal_type(u)  # revealed: StrTagTD
+```
+
+An `Any` tag remains possible in both branches, while a known literal tag can still be excluded:
+
+```py
+class DynamicTag(TypedDict):
+    tag: Any
+
+def dynamic_tag(u: Foo | Bing | DynamicTag):
+    if u["tag"] == "foo":
+        reveal_type(u)  # revealed: Foo | (DynamicTag & ~<TypedDict with items 'tag'>)
+    else:
+        reveal_type(u)  # revealed: Bing | (DynamicTag & ~<TypedDict with items 'tag'>)
+```
+
+An unknown or custom comparison value can match either literal tag, so it cannot exclude either
+dictionary:
+
+```py
+def dynamic_comparator(u: Foo | Bing, other: Any):
+    if u["tag"] == other:
+        reveal_type(u)  # revealed: Foo | Bing
+    else:
+        reveal_type(u)  # revealed: Foo | Bing
+
+def custom_comparator(u: Foo | Bing, other: MatchesInteger):
+    if other == u["tag"]:
+        reveal_type(u)  # revealed: Foo | Bing
+    else:
+        reveal_type(u)  # revealed: Foo | Bing
 ```
 
 We can still narrow `Literal` tags even when non-`TypedDict` types are present in the union:
@@ -6992,7 +7079,8 @@ def match_single(u: Foo):
             reveal_type(u)  # revealed: Never
 ```
 
-Narrowing is restricted to `Literal` tags:
+A non-literal tag can match the pattern or fail to match it, so its dictionary remains possible in
+both branches. Other dictionaries can still be excluded based on their literal tags:
 
 ```py
 from ty_extensions import static_assert
@@ -7001,17 +7089,16 @@ from ty_extensions._internal import is_assignable_to
 class NonLiteralTD(TypedDict):
     tag: int
 
-def match_non_literal(u: Foo | NonLiteralTD):
+def match_non_literal(u: Foo | Bing | NonLiteralTD):
     match u["tag"]:
         case "foo":
-            # We can't narrow the union here...
             reveal_type(u)  # revealed: Foo | NonLiteralTD
         case _:
-            # ...(but we *can* narrow here)...
-            reveal_type(u)  # revealed: NonLiteralTD
+            reveal_type(u)  # revealed: Bing | NonLiteralTD
 ```
 
-and it is also restricted to `match` patterns that solely consist of value patterns:
+A broad value pattern can match either tag, so another alternative in the same OR pattern does not
+rule out either dictionary:
 
 ```py
 class Config:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6510,6 +6510,64 @@ def _(u: WithAliasTagA | WithAliasTagAlsoA | WithAliasTagB):
         reveal_type(u)  # revealed: WithAliasTagB
 ```
 
+An `IntEnum` member compares equal to its integer value without having the same literal type. The
+enum and integer tags both match, so fields unique to one dictionary are not safe to access. The
+dictionary with the enum tag remains possible when equality is false because it also permits
+`"other"`:
+
+```py
+from enum import IntEnum
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+class EnumTag(TypedDict):
+    tag: Literal[Number.ONE, "other"]
+
+class IntegerTag(TypedDict):
+    tag: Literal[1]
+    integer_only: int
+
+def enum_tag(u: EnumTag | IntegerTag | Foo):
+    if u["tag"] == 1:
+        reveal_type(u)  # revealed: EnumTag | IntegerTag
+        u["integer_only"]  # error: [invalid-key]
+    else:
+        reveal_type(u)  # revealed: EnumTag | Foo
+```
+
+Integer tags can also match an enum member used as the comparison value:
+
+```py
+def enum_comparator(u: EnumTag | IntegerTag | Foo):
+    if u["tag"] == Number.ONE:
+        reveal_type(u)  # revealed: EnumTag | IntegerTag
+    else:
+        reveal_type(u)  # revealed: EnumTag | Foo
+```
+
+An enum can customize `__ne__` independently of `__eq__`. An ambiguous inequality keeps the
+dictionary with that enum tag in both branches, including the branch where the inequality is false:
+
+```py
+class NeverUnequal(Enum):
+    A = 1
+    B = 2
+
+    def __ne__(self, other: object) -> bool:
+        return False
+
+class UnequalTag(TypedDict):
+    tag: Literal[NeverUnequal.A]
+
+def custom_inequality(u: UnequalTag | Foo | Bar):
+    if u["tag"] != "foo":
+        reveal_type(u)  # revealed: UnequalTag | Bar
+    else:
+        reveal_type(u)  # revealed: UnequalTag | Foo
+```
+
 We can descend into intersections to discover `TypedDict` types that need narrowing:
 
 ```py
@@ -6887,6 +6945,40 @@ def match_enum_tags(u: WithEnumTagA | WithEnumTagB | WithEnumTagC):
             reveal_type(u)  # revealed: WithEnumTagB
         case _:
             reveal_type(u)  # revealed: WithEnumTagC
+```
+
+An integer pattern can match an `IntEnum` tag because matching uses runtime equality:
+
+```py
+from enum import IntEnum
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+class EnumTag(TypedDict):
+    tag: Literal[Number.ONE]
+
+class IntegerTag(TypedDict):
+    tag: Literal[1]
+
+def match_enum_and_integer_tags(u: EnumTag | IntegerTag | Foo):
+    match u["tag"]:
+        case 1:
+            reveal_type(u)  # revealed: EnumTag | IntegerTag
+        case _:
+            reveal_type(u)  # revealed: Foo
+```
+
+Conversely, an enum member used as a value pattern can match an integer tag:
+
+```py
+def match_integer_tags_with_enum(u: EnumTag | IntegerTag | Foo):
+    match u["tag"]:
+        case Number.ONE:
+            reveal_type(u)  # revealed: EnumTag | IntegerTag
+        case _:
+            reveal_type(u)  # revealed: Foo
 ```
 
 We can also narrow a single `TypedDict` type to `Never`:

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -232,6 +232,13 @@ fn evaluate_type_comparison<'db>(
             .is_some_and(|narrowed| {
                 equality_truthiness(db, env, narrowed, *constraint, soundness_policy)
                     == Truthiness::AlwaysTrue
+                    // Equal values need not have the same type: `False == 0` does not make
+                    // `Literal[False]` a valid specialization of a `Literal[0]` constraint.
+                    && IntersectionBuilder::new(db, env)
+                        .add_positive(left)
+                        .add_positive(narrowed)
+                        .build()
+                        .is_subtype_of(db, env, *constraint)
             })
         })
     {
@@ -394,7 +401,7 @@ pub(crate) struct ComparisonSoundnessPolicy {
 }
 
 impl ComparisonSoundnessPolicy {
-    const CONSERVATIVE: Self = Self {
+    pub(super) const CONSERVATIVE: Self = Self {
         allow_unsafe_equality: false,
     };
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2064,8 +2064,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         match pattern {
             PatternPredicateKind::Value(value) => {
                 let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
-                self.evaluate_expr_compare_op(subject_ty, value_ty, ast::CmpOp::Eq, true)
-                    .map(NarrowingConstraint::intersection)
+                self.evaluate_expr_compare_op(
+                    subject_ty,
+                    value_ty,
+                    ast::CmpOp::Eq,
+                    true,
+                    self.comparison_soundness_policy(),
+                )
+                .map(NarrowingConstraint::intersection)
             }
             PatternPredicateKind::Singleton(singleton) => Some(NarrowingConstraint::intersection(
                 singleton_pattern_type(db, &self.env, *singleton),
@@ -3819,6 +3825,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         rhs_ty: Type<'db>,
         op: ast::CmpOp,
         is_positive: bool,
+        soundness_policy: ComparisonSoundnessPolicy,
     ) -> Option<Type<'db>> {
         let db = self.db;
         if op == ast::CmpOp::Eq {
@@ -3828,7 +3835,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 lhs_ty,
                 rhs_ty,
                 is_positive,
-                self.comparison_soundness_policy(),
+                soundness_policy,
             );
         }
         if op == ast::CmpOp::NotEq {
@@ -3838,7 +3845,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 lhs_ty,
                 rhs_ty,
                 is_positive,
-                self.comparison_soundness_policy(),
+                soundness_policy,
             );
         }
 
@@ -4403,8 +4410,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             // - `if x not in y`
             if narrowable_ast(left)
                 && let Some(narrowable) = PlaceExpr::try_from_expr(left)
-                && let Some(ty) =
-                    self.evaluate_expr_compare_op(lhs_ty, lhs_narrowing_rhs_ty, *op, is_positive)
+                && let Some(ty) = self.evaluate_expr_compare_op(
+                    lhs_ty,
+                    lhs_narrowing_rhs_ty,
+                    *op,
+                    is_positive,
+                    self.comparison_soundness_policy(),
+                )
             {
                 let place = self.expect_place(&narrowable);
                 let constraint = NarrowingConstraint::intersection(ty);
@@ -4426,7 +4438,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             if !matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn)
                 && narrowable_ast(right)
                 && let Some(narrowable) = PlaceExpr::try_from_expr(right)
-                && let Some(ty) = self.evaluate_expr_compare_op(rhs_ty, lhs_ty, *op, is_positive)
+                && let Some(ty) = self.evaluate_expr_compare_op(
+                    rhs_ty,
+                    lhs_ty,
+                    *op,
+                    is_positive,
+                    self.comparison_soundness_policy(),
+                )
             {
                 let place = self.expect_place(&narrowable);
                 let constraint = NarrowingConstraint::intersection(ty);
@@ -4845,7 +4863,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let value_ty = infer_same_file_expression_type(db, value, TypeContext::default());
 
         let mut constraints = self
-            .evaluate_expr_compare_op(subject_ty, value_ty, ast::CmpOp::Eq, is_positive)
+            .evaluate_expr_compare_op(
+                subject_ty,
+                value_ty,
+                ast::CmpOp::Eq,
+                is_positive,
+                self.comparison_soundness_policy(),
+            )
             .map(|ty| {
                 NarrowingConstraints::from_iter([(place, NarrowingConstraint::intersection(ty))])
             })
@@ -4972,39 +4996,42 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         is_positive: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         let db = self.db;
-        // Check preconditions: we need a TypedDict, a string key, and a supported tag literal.
+        // Check preconditions: we need a TypedDict and a string key.
         if !is_or_contains_typeddict(db, subscript_value_type) {
             return None;
         }
         let subscript_place_expr = PlaceExpr::try_from_expr(subscript_value_expr)?;
         let key_literal = subscript_key_type.as_string_literal()?;
-        if !is_supported_tag_literal(rhs_type) {
-            return None;
-        }
 
-        let (tag_types, all_literal) = matching_typeddict_field_types(
+        // Compare each field before combining tag types: `str | Literal["b"]` simplifies to
+        // `str`, but a field declared as `Literal["b"]` can still be ruled out by `== "a"`.
+        // Use conservative semantics when constraining the containing dictionary, since a broad
+        // tag can contain subclasses with arbitrary comparison methods.
+        let mut excluded_tags = UnionBuilder::new(db, &self.env);
+        visit_matching_typeddict_field_types(
             db,
-            &self.env,
             subscript_value_type,
             key_literal.value(db),
+            &mut |tag_type| {
+                if let Some(constraint) = self.evaluate_expr_compare_op(
+                    tag_type,
+                    rhs_type,
+                    operator,
+                    is_positive,
+                    ComparisonSoundnessPolicy::CONSERVATIVE,
+                ) {
+                    // A constraint can be relative to this field's type, so its complement need
+                    // not describe other possible tags. Exclude only values from this domain.
+                    excluded_tags.add_in_place(
+                        IntersectionBuilder::new(db, &self.env)
+                            .add_positive(tag_type)
+                            .add_negative(constraint)
+                            .build(),
+                    );
+                }
+            },
         );
-        // A true equality or false inequality does not constrain broad fields: their subclasses
-        // can have arbitrary comparison methods. Only narrow literal tags in these branches.
-        let is_equality = is_positive == (operator == ast::CmpOp::Eq);
-        if is_equality && !all_literal {
-            return None;
-        }
-
-        // An enum literal can compare equal to an integer or string with a disjoint type.
-        // Exclude only tag values that cannot satisfy the runtime comparison in this branch.
-        // Restrict the exclusion to the observed tag types: a comparison constraint can be
-        // relative to this domain, so its complement need not describe other possible tags.
-        let constraint =
-            self.evaluate_expr_compare_op(tag_types, rhs_type, operator, is_positive)?;
-        let excluded_tags = IntersectionBuilder::new(db, &self.env)
-            .add_positive(tag_types)
-            .add_negative(constraint)
-            .build();
+        let excluded_tags = excluded_tags.build();
         if excluded_tags.is_never() {
             return None;
         }
@@ -5088,7 +5115,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
-    /// Narrow tagged unions of tuples with `Literal` elements.
+    /// Narrow unions of tuples by comparing an element's value.
     ///
     /// Given a subscript expression like `t[0]` where `t` is a union of tuple types, and a
     /// comparison value like `"foo"`, this method creates a constraint on `t` that narrows it
@@ -5121,24 +5148,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let index = subscript_index_type.as_int_literal()?;
         let index = i32::try_from(index).ok()?;
 
-        // The comparison value must be a supported literal type.
-        if !is_supported_tag_literal(rhs_type) {
-            return None;
-        }
-
         let subscript_place_expr = PlaceExpr::try_from_expr(subscript_value_expr)?;
         // Skip narrowing if any tuple in the union has an out-of-bounds index.
         // A diagnostic will be emitted elsewhere for the out-of-bounds access.
         if any_tuple_has_out_of_bounds_index(db, &self.env, union, index) {
-            return None;
-        }
-
-        // For equality constraints, all matching elements must have literal types to safely narrow.
-        // For inequality constraints, we can narrow even with non-literal element types.
-        let is_equality = is_positive == (operator == ast::CmpOp::Eq);
-        if is_equality
-            && !all_matching_tuple_elements_have_literal_types(db, &self.env, union, index)
-        {
             return None;
         }
 
@@ -5147,8 +5160,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             elem.tuple_instance_spec(db, &self.env)
                 .and_then(|spec| spec.py_index(db, &self.env, index).ok())
                 .is_none_or(|el_ty| {
-                    self.evaluate_expr_compare_op(el_ty, rhs_type, operator, is_positive)
-                        .is_none_or(|constraint| !el_ty.is_disjoint_from(db, &self.env, constraint))
+                    self.evaluate_expr_compare_op(
+                        el_ty,
+                        rhs_type,
+                        operator,
+                        is_positive,
+                        ComparisonSoundnessPolicy::CONSERVATIVE,
+                    )
+                    .is_none_or(|constraint| !el_ty.is_disjoint_from(db, &self.env, constraint))
                 })
         });
 
@@ -5175,12 +5194,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             return None;
         };
 
-        if matches!(operator, ast::CmpOp::Eq | ast::CmpOp::NotEq)
-            && !is_supported_tag_literal(rhs_type)
-        {
-            return None;
-        }
-
         let narrowed = union.filter(db, |element| {
             element
                 .resolve_type_alias(db)
@@ -5188,20 +5201,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .place
                 .ignore_possibly_undefined()
                 .is_none_or(|attribute_type| match operator {
-                    ast::CmpOp::Eq | ast::CmpOp::NotEq => {
-                        let is_equality = is_positive == (operator == ast::CmpOp::Eq);
-                        (is_equality && !is_supported_tag_literal_or_union(db, attribute_type))
-                            || self
-                                .evaluate_expr_compare_op(
-                                    attribute_type,
-                                    rhs_type,
-                                    operator,
-                                    is_positive,
-                                )
-                                .is_none_or(|constraint| {
-                                    !attribute_type.is_disjoint_from(db, &self.env, constraint)
-                                })
-                    }
+                    ast::CmpOp::Eq | ast::CmpOp::NotEq => self
+                        .evaluate_expr_compare_op(
+                            attribute_type,
+                            rhs_type,
+                            operator,
+                            is_positive,
+                            ComparisonSoundnessPolicy::CONSERVATIVE,
+                        )
+                        .is_none_or(|constraint| {
+                            !attribute_type.is_disjoint_from(db, &self.env, constraint)
+                        }),
                     ast::CmpOp::Is | ast::CmpOp::IsNot => attribute_type
                         .identity_comparison_truthiness(db, &self.env, rhs_type)
                         .negate_if(is_positive != (operator == ast::CmpOp::Is))
@@ -5387,71 +5397,36 @@ fn key_membership_contains_protocol<'db>(
     )
 }
 
-fn is_supported_tag_literal(ty: Type) -> bool {
-    matches!(
-        ty.as_literal_value_kind(),
-        Some(
-            LiteralValueTypeKind::String(_)
-                | LiteralValueTypeKind::Bytes(_)
-                | LiteralValueTypeKind::Int(_)
-                | LiteralValueTypeKind::Enum(_)
-        )
-    )
-}
-
-/// Return true if the given type is a literal type with one or more supported literal values,
-/// e.g. `Literal[1, "A", "B"]`. These types are represented as `Type::Union(_)`.
-fn is_supported_tag_literal_or_union(db: &dyn Db, ty: Type) -> bool {
-    match ty {
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .copied()
-            .all(is_supported_tag_literal),
-        _ => is_supported_tag_literal(ty),
-    }
-}
-
-/// Collect matching `TypedDict` field types and whether every field has supported literal tags.
-/// Non-`TypedDict` alternatives and missing fields do not contribute any tag types.
-fn matching_typeddict_field_types<'db>(
+/// Visit matching `TypedDict` field types, ignoring other alternatives and missing fields.
+fn visit_matching_typeddict_field_types<'db>(
     db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
     field_name: &str,
-) -> (Type<'db>, bool) {
+    visit: &mut impl FnMut(Type<'db>),
+) {
     let elements = match ty {
         Type::TypedDict(td) => {
-            return td
-                .items(db)
-                .get(field_name)
-                .map_or((Type::Never, true), |field| {
-                    (
-                        field.declared_ty,
-                        is_supported_tag_literal_or_union(db, field.declared_ty),
-                    )
-                });
+            if let Some(field) = td.items(db).get(field_name) {
+                visit(field.declared_ty);
+            }
+            return;
         }
         Type::TypeAlias(alias) => {
-            return matching_typeddict_field_types(db, env, alias.value_type(db), field_name);
+            return visit_matching_typeddict_field_types(
+                db,
+                alias.value_type(db),
+                field_name,
+                visit,
+            );
         }
         Type::Union(union) => Either::Left(union.elements(db).iter()),
         Type::Intersection(intersection) => Either::Right(intersection.positive(db).iter()),
-        _ => return (Type::Never, true),
+        _ => return,
     };
 
-    let mut tag_types = UnionBuilder::new(db, env);
-    let mut all_literal = true;
     for element in elements {
-        if !is_or_contains_typeddict(db, *element) {
-            continue;
-        }
-        let (element_tags, element_is_literal) =
-            matching_typeddict_field_types(db, env, *element, field_name);
-        tag_types = tag_types.add(element_tags);
-        all_literal &= element_is_literal;
+        visit_matching_typeddict_field_types(db, *element, field_name, visit);
     }
-    (tag_types.build(), all_literal)
 }
 
 /// Check if any tuple in the union has an out-of-bounds index.
@@ -5467,24 +5442,6 @@ fn any_tuple_has_out_of_bounds_index<'db>(
     union.elements(db).iter().any(|elem| {
         elem.tuple_instance_spec(db, env)
             .is_some_and(|spec| spec.py_index(db, env, index).is_err())
-    })
-}
-
-/// Check that all tuple elements at the given index have literal types.
-///
-/// Non-literal types (like `str` or `int`) could have subclasses that compare equal
-/// to arbitrary values. We therefore restrict equality narrowing to tuples with
-/// literal tags; their comparison semantics are checked separately.
-fn all_matching_tuple_elements_have_literal_types<'db>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    union: UnionType<'db>,
-    index: i32,
-) -> bool {
-    union.elements(db).iter().all(|elem| {
-        elem.tuple_instance_spec(db, env)
-            .and_then(|spec| spec.py_index(db, env, index).ok())
-            .is_none_or(|ty| is_supported_tag_literal_or_union(db, ty))
     })
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -5214,7 +5214,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         }),
                     ast::CmpOp::Is | ast::CmpOp::IsNot => attribute_type
                         .identity_comparison_truthiness(db, &self.env, rhs_type)
-                        .negate_if(is_positive != (operator == ast::CmpOp::Is))
+                        .negate_if(is_positive != operator.is_is())
                         .may_be_true(),
                     _ => true,
                 })

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -49,7 +49,7 @@ use super::equality::{
     evaluate_type_equality, evaluate_type_inequality,
 };
 use super::match_pattern::is_typed_dict_runtime_domain;
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
@@ -1602,12 +1602,6 @@ fn necessary_sequence_pattern_type<'db>(
             .map(|pattern| necessary_match_pattern_type(db, env, pattern));
         exact_sequence_pattern_type(db, env, element_types)
     }
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum NominalAttributeComparison {
-    Equality,
-    Identity,
 }
 
 /// A comparison with an integer length, expressed as a required or excluded ordering.
@@ -3820,7 +3814,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     }
 
     fn evaluate_expr_compare_op(
-        &mut self,
+        &self,
         lhs_ty: Type<'db>,
         rhs_ty: Type<'db>,
         op: ast::CmpOp,
@@ -4157,13 +4151,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //
         // Importantly, `my_typeddict_union["tag"]` isn't the place we're going to constrain.
         // Instead, we're going to constrain `my_typeddict_union` itself.
-        if let Some((left, op @ (ast::CmpOp::Eq | ast::CmpOp::NotEq), right)) =
+        if let Some((left, operator @ (ast::CmpOp::Eq | ast::CmpOp::NotEq), right)) =
             expr_compare.as_single()
         {
-            // For `==`, we use equality semantics on the `if` branch (is_positive=true).
-            // For `!=`, we use equality semantics on the `else` branch (is_positive=false).
-            let is_equality = is_positive == (*op == ast::CmpOp::Eq);
-
             let mut narrow_subscript = |subscript: &ast::ExprSubscript, other_type: Type<'db>| {
                 let value_type = inference.expression_type(&*subscript.value);
                 let slice_type = inference.expression_type(&*subscript.slice);
@@ -4173,7 +4163,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     &subscript.value,
                     slice_type,
                     other_type,
-                    is_equality,
+                    *operator,
+                    is_positive,
                 ) {
                     insert_narrowing_constraint(&mut constraints, place, constraint);
                 } else if let Some((place, constraint)) = self.narrow_tuple_subscript(
@@ -4181,7 +4172,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     &subscript.value,
                     slice_type,
                     other_type,
-                    is_equality,
+                    *operator,
+                    is_positive,
                 ) {
                     insert_narrowing_constraint(&mut constraints, place, constraint);
                 }
@@ -4202,14 +4194,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             right,
         )) = expr_compare.as_single()
         {
-            let comparison = if matches!(operator, ast::CmpOp::Is | ast::CmpOp::IsNot) {
-                NominalAttributeComparison::Identity
-            } else {
-                NominalAttributeComparison::Equality
-            };
-            let is_positive_comparison =
-                is_positive == matches!(operator, ast::CmpOp::Eq | ast::CmpOp::Is);
-
             let mut narrow_attribute = |attribute: &ast::ExprAttribute, other_type: Type<'db>| {
                 let value_type = inference.expression_type(&*attribute.value);
 
@@ -4218,8 +4202,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     &attribute.value,
                     attribute.attr.id(),
                     other_type,
-                    comparison,
-                    is_positive_comparison,
+                    *operator,
+                    is_positive,
                 ) {
                     insert_narrowing_constraint(&mut constraints, place, constraint);
                 }
@@ -4886,6 +4870,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 &subscript.value,
                 inference.expression_type(&*subscript.slice),
                 value_ty,
+                ast::CmpOp::Eq,
                 is_positive,
             ) {
                 constraints.insert(place, constraint);
@@ -4896,6 +4881,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 &subscript.value,
                 inference.expression_type(&*subscript.slice),
                 value_ty,
+                ast::CmpOp::Eq,
                 is_positive,
             ) {
                 constraints.insert(place, constraint);
@@ -4907,7 +4893,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 &attribute.value,
                 attribute.attr.id(),
                 value_ty,
-                NominalAttributeComparison::Equality,
+                ast::CmpOp::Eq,
                 is_positive,
             ) {
                 constraints.insert(place, constraint);
@@ -4982,7 +4968,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         subscript_value_expr: &ast::Expr,
         subscript_key_type: Type<'db>,
         rhs_type: Type<'db>,
-        is_equality: bool,
+        operator: ast::CmpOp,
+        is_positive: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         let db = self.db;
         // Check preconditions: we need a TypedDict, a string key, and a supported tag literal.
@@ -4995,40 +4982,45 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             return None;
         }
 
-        // If we have an equality constraint, we have to be careful. If all the matching fields
-        // in all the `TypedDict`s here have literal types, then yes, equality is as good as a
-        // type check. However, if any of them are e.g. `int` or `str` or some random class,
-        // then we can't narrow their type at all, because subclasses of those types can
-        // implement `__eq__` in any perverse way they like. On the other hand, if this is an
-        // *inequality* constraint, then we can go ahead and assert "you can't be this exact
-        // literal type" without worrying about what other types might be present.
-        if is_equality
-            && !all_matching_typeddict_fields_have_literal_types(
-                db,
-                &self.env,
-                subscript_value_type,
-                key_literal.value(db),
-            )
-        {
+        let (tag_types, all_literal) = matching_typeddict_field_types(
+            db,
+            &self.env,
+            subscript_value_type,
+            key_literal.value(db),
+        );
+        // A true equality or false inequality does not constrain broad fields: their subclasses
+        // can have arbitrary comparison methods. Only narrow literal tags in these branches.
+        let is_equality = is_positive == (operator == ast::CmpOp::Eq);
+        if is_equality && !all_literal {
             return None;
         }
+
+        // An enum literal can compare equal to an integer or string with a disjoint type.
+        // Exclude only tag values that cannot satisfy the runtime comparison in this branch.
+        // Restrict the exclusion to the observed tag types: a comparison constraint can be
+        // relative to this domain, so its complement need not describe other possible tags.
+        let constraint =
+            self.evaluate_expr_compare_op(tag_types, rhs_type, operator, is_positive)?;
+        let excluded_tags = IntersectionBuilder::new(db, &self.env)
+            .add_positive(tag_types)
+            .add_negative(constraint)
+            .build();
+        if excluded_tags.is_never() {
+            return None;
+        }
+
         let field_name = Name::from(key_literal.value(db));
-        // To avoid excluding non-`TypedDict` types, our constraints are always expressed
-        // as a negative intersection (i.e. "you're *not* this kind of `TypedDict`"). If
-        // `is_equality` is true, the whole constraint is going to be a double
-        // negative, i.e. "you're *not* a `TypedDict` *without* this literal field". As the
-        // first step of building that, we negate the right hand side.
-        let field_type = rhs_type.negate_if(db, &self.env, is_equality);
-        // Create the synthesized `TypedDict` with that (possibly negated) field. We don't
+        // Create a synthesized `TypedDict` describing the excluded tags. We don't
         // want to constrain the mutability or required-ness of the field, so the most
         // compatible form is not-required and read-only.
-        let field = TypedDictFieldBuilder::new(field_type)
+        let field = TypedDictFieldBuilder::new(excluded_tags)
             .required(false)
             .read_only(true)
             .build();
         let schema = TypedDictSchema::from_iter([(field_name, field)]);
         let synthesized_typeddict = TypedDictType::from_schema_items(db, schema);
-        // As mentioned above, the synthesized `TypedDict` is always negated.
+        // Negating the synthesized `TypedDict` excludes alternatives whose tags cannot match,
+        // without excluding non-`TypedDict` alternatives.
         let intersection = Type::TypedDict(synthesized_typeddict).negate(db, &self.env);
         let place = self.expect_place(&subscript_place_expr);
         Some((place, NarrowingConstraint::intersection(intersection)))
@@ -5116,7 +5108,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         subscript_value_expr: &ast::Expr,
         subscript_index_type: Type<'db>,
         rhs_type: Type<'db>,
-        is_equality: bool,
+        operator: ast::CmpOp,
+        is_positive: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         let db = self.db;
         // We need a union type for narrowing to be useful.
@@ -5142,6 +5135,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         // For equality constraints, all matching elements must have literal types to safely narrow.
         // For inequality constraints, we can narrow even with non-literal element types.
+        let is_equality = is_positive == (operator == ast::CmpOp::Eq);
         if is_equality
             && !all_matching_tuple_elements_have_literal_types(db, &self.env, union, index)
         {
@@ -5153,13 +5147,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             elem.tuple_instance_spec(db, &self.env)
                 .and_then(|spec| spec.py_index(db, &self.env, index).ok())
                 .is_none_or(|el_ty| {
-                    if is_equality {
-                        // Keep tuples where element could be equal to rhs.
-                        !el_ty.is_disjoint_from(db, &self.env, rhs_type)
-                    } else {
-                        // Keep tuples where element is not always equal to rhs.
-                        !el_ty.is_subtype_of(db, &self.env, rhs_type)
-                    }
+                    self.evaluate_expr_compare_op(el_ty, rhs_type, operator, is_positive)
+                        .is_none_or(|constraint| !el_ty.is_disjoint_from(db, &self.env, constraint))
                 })
         });
 
@@ -5178,7 +5167,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         attribute_value_expr: &ast::Expr,
         attribute_name: &str,
         rhs_type: Type<'db>,
-        comparison: NominalAttributeComparison,
+        operator: ast::CmpOp,
         is_positive: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         let db = self.db;
@@ -5186,7 +5175,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             return None;
         };
 
-        if comparison == NominalAttributeComparison::Equality && !is_supported_tag_literal(rhs_type)
+        if matches!(operator, ast::CmpOp::Eq | ast::CmpOp::NotEq)
+            && !is_supported_tag_literal(rhs_type)
         {
             return None;
         }
@@ -5197,18 +5187,26 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .member(db, &self.env, attribute_name)
                 .place
                 .ignore_possibly_undefined()
-                .is_none_or(|attribute_type| match (comparison, is_positive) {
-                    (NominalAttributeComparison::Equality, true) => {
-                        !is_supported_tag_literal_or_union(db, attribute_type)
-                            || !attribute_type.is_disjoint_from(db, &self.env, rhs_type)
+                .is_none_or(|attribute_type| match operator {
+                    ast::CmpOp::Eq | ast::CmpOp::NotEq => {
+                        let is_equality = is_positive == (operator == ast::CmpOp::Eq);
+                        (is_equality && !is_supported_tag_literal_or_union(db, attribute_type))
+                            || self
+                                .evaluate_expr_compare_op(
+                                    attribute_type,
+                                    rhs_type,
+                                    operator,
+                                    is_positive,
+                                )
+                                .is_none_or(|constraint| {
+                                    !attribute_type.is_disjoint_from(db, &self.env, constraint)
+                                })
                     }
-                    (NominalAttributeComparison::Equality, false) => {
-                        !attribute_type.is_subtype_of(db, &self.env, rhs_type)
-                    }
-                    (NominalAttributeComparison::Identity, is_positive) => attribute_type
+                    ast::CmpOp::Is | ast::CmpOp::IsNot => attribute_type
                         .identity_comparison_truthiness(db, &self.env, rhs_type)
-                        .negate_if(!is_positive)
+                        .negate_if(is_positive != (operator == ast::CmpOp::Is))
                         .may_be_true(),
+                    _ => true,
                 })
         });
 
@@ -5414,94 +5412,46 @@ fn is_supported_tag_literal_or_union(db: &dyn Db, ty: Type) -> bool {
     }
 }
 
-// Return true if the given type is a `TypedDict` whose `field_name` field has a supported tag literal
-// type, or a union in which all elements that are `TypedDict`s have a supported tag literal type
-// for that field, or an intersection in which all positive elements that are `TypedDict`s have a
-// supported tag literal type for that field, or a type alias to such a type.
-fn all_matching_typeddict_fields_have_literal_types<'db>(
+/// Collect matching `TypedDict` field types and whether every field has supported literal tags.
+/// Non-`TypedDict` alternatives and missing fields do not contribute any tag types.
+fn matching_typeddict_field_types<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
     field_name: &str,
-) -> bool {
-    let matching_field_is_literal = |typeddict: &TypedDictType<'db>| {
-        // There's no matching field to check if `.get()` returns `None`.
-        typeddict
-            .items(db)
-            .get(field_name)
-            .is_none_or(|field| is_supported_tag_literal_or_union(db, field.declared_ty))
+) -> (Type<'db>, bool) {
+    let elements = match ty {
+        Type::TypedDict(td) => {
+            return td
+                .items(db)
+                .get(field_name)
+                .map_or((Type::Never, true), |field| {
+                    (
+                        field.declared_ty,
+                        is_supported_tag_literal_or_union(db, field.declared_ty),
+                    )
+                });
+        }
+        Type::TypeAlias(alias) => {
+            return matching_typeddict_field_types(db, env, alias.value_type(db), field_name);
+        }
+        Type::Union(union) => Either::Left(union.elements(db).iter()),
+        Type::Intersection(intersection) => Either::Right(intersection.positive(db).iter()),
+        _ => return (Type::Never, true),
     };
 
-    match ty {
-        Type::TypedDict(td) => matching_field_is_literal(&td),
-        Type::Union(union) => union.elements(db).iter().all(|union_member_ty| {
-            !is_or_contains_typeddict(db, *union_member_ty)
-                || all_matching_typeddict_fields_have_literal_types(
-                    db,
-                    env,
-                    *union_member_ty,
-                    field_name,
-                )
-        }),
-        Type::TypeAlias(alias) => all_matching_typeddict_fields_have_literal_types(
-            db,
-            env,
-            alias.value_type(db),
-            field_name,
-        ),
-        Type::Intersection(intersection) => {
-            intersection
-                .positive(db)
-                .iter()
-                .all(|intersection_member_ty| {
-                    !is_or_contains_typeddict(db, *intersection_member_ty)
-                        || all_matching_typeddict_fields_have_literal_types(
-                            db,
-                            env,
-                            *intersection_member_ty,
-                            field_name,
-                        )
-                })
+    let mut tag_types = UnionBuilder::new(db, env);
+    let mut all_literal = true;
+    for element in elements {
+        if !is_or_contains_typeddict(db, *element) {
+            continue;
         }
-
-        // Only the four variants above can pass `is_or_contains_typeddict`, and this function is
-        // always guarded by that check.
-        Type::Dynamic(_)
-        | Type::Divergent(_)
-        | Type::Never
-        | Type::EnumComplement(_)
-        | Type::FunctionLiteral(_)
-        | Type::BoundMethod(_)
-        | Type::KnownBoundMethod(_)
-        | Type::WrapperDescriptor(_)
-        | Type::DataclassDecorator(_)
-        | Type::DataclassTransformer(_)
-        | Type::Callable(_)
-        | Type::ModuleLiteral(_)
-        | Type::ClassLiteral(_)
-        | Type::GenericAlias(_)
-        | Type::SubclassOf(_)
-        | Type::NominalInstance(_)
-        | Type::ProtocolInstance(_)
-        | Type::SpecialForm(_)
-        | Type::KnownInstance(_)
-        | Type::PropertyInstance(_)
-        | Type::SlotDescriptor(_)
-        | Type::AlwaysTruthy
-        | Type::AlwaysFalsy
-        | Type::LiteralValue(_)
-        | Type::TypeVar(_)
-        | Type::BoundSuper(_)
-        | Type::TypeIs(_)
-        | Type::TypeGuard(_)
-        | Type::TypeForm(_)
-        | Type::NewTypeInstance(_) => {
-            unreachable!(
-                "invalid type {} in all_matching_typeddict_fields_have_literal_types",
-                ty.display(db, env)
-            )
-        }
+        let (element_tags, element_is_literal) =
+            matching_typeddict_field_types(db, env, *element, field_name);
+        tag_types = tag_types.add(element_tags);
+        all_literal &= element_is_literal;
     }
+    (tag_types.build(), all_literal)
 }
 
 /// Check if any tuple in the union has an out-of-bounds index.
@@ -5522,10 +5472,9 @@ fn any_tuple_has_out_of_bounds_index<'db>(
 
 /// Check that all tuple elements at the given index have literal types.
 ///
-/// For equality narrowing to be safe, we need to ensure that the element types
-/// at the discriminating index are literals (which have well-defined equality).
-/// Non-literal types (like `str` or `int`) could have subclasses that override
-/// `__eq__` in unexpected ways.
+/// Non-literal types (like `str` or `int`) could have subclasses that compare equal
+/// to arbitrary values. We therefore restrict equality narrowing to tuples with
+/// literal tags; their comparison semantics are checked separately.
 fn all_matching_tuple_elements_have_literal_types<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,


### PR DESCRIPTION
Tagged union narrowing currently treats disjoint literal types as unequal runtime values. This can discard a valid alternative when an `IntEnum` tag is compared with its integer value or a `StrEnum` tag with a string, making invalid member accesses appear safe. It also treats `!=` as the inverse of `==`, which is incorrect for enums with custom `__ne__` methods.

Use the existing comparison evaluator for attribute and subscript tags, retaining the actual operator and branch polarity. Comparisons that constrain the containing object always use conservative semantics, so broad or custom tag types remain possible without preventing other alternatives from being excluded. This also supports comparison values beyond individual literals, including booleans and unions.

For `TypedDict`s, compare each field type before combining exclusions so a broad field does not erase the precision of separate literal fields. Restrict structural exclusions to tag values ruled out by the comparison. Match patterns continue to use equality, including its negation for fallthrough. Constrained type-variable correlation additionally requires compatible types: `False == 0` does not make `Literal[False]` a valid specialization of a `Literal[0]` constraint.

Using the existing comparison evaluator means this PR improves correctness but is a net reduction in Rust LOC.

## Test plan

Added mdtests cover:

- `IntEnum` and `StrEnum` tags compared with integers and strings in attributes, tuples, `TypedDict`s, and match patterns, including negative branches and reversed comparisons.
- Multi-tag alternatives, enums with custom `__eq__` or `__ne__`, and match fallthrough using negated equality rather than `__ne__`.
- Boolean, union, and intersection comparison values; mixed broad and literal tags; and ambiguous comparisons involving subclasses, custom methods, or `Any`.
- Constrained type-variable comparisons with distinct literal types that compare equal, using both legacy and PEP 695 syntax.
- Invalid `TypedDict` key access when a matching comparison leaves multiple alternatives possible.
