### PR TITLE
Respect the pygls version bound in ruff-lsp tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,13 @@
       description: "Weekly update of prek dependencies",
     },
     {
+      matchFileNames: ["pyproject.toml"],
+      matchPackageNames: ["pygls"],
+      matchJsonata: ["depType = 'dependency-groups' and managerData.depGroup = 'ruff-lsp-test'"],
+      description: "ruff-lsp compatibility tests require the pygls 1.x server API",
+      rangeStrategy: "in-range-only",
+    },
+    {
       groupName: "NPM Development dependencies",
       matchManagers: ["npm"],
       matchDepTypes: ["devDependencies"],


### PR DESCRIPTION
## Summary

Keep Renovate updates for `pygls` in the `ruff-lsp-test` dependency group within the declared version range, preventing incompatible upgrades such as #28056.

ruff-lsp is deprecated, we don't plan on upgrading it to pygls 2

## Test Plan

Renovate 44.24.3 configuration validation passed using its JavaScript regex fallback; hooks were not run.
