### PR TITLE
[ty] Bump ecosystem-analyzer for script dependency preparation

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ dependencies = [
 [[package]]
 name = "ecosystem-analyzer"
 version = "0.1.0"
-source = { git = "https://github.com/astral-sh/ecosystem-analyzer#ef0bbe10e9e28c887e74b5a4101a511e65c783b4" }
+source = { git = "https://github.com/astral-sh/ecosystem-analyzer#799f67e1a8362eb4046d0fc37dbc55e226d034aa" }
 dependencies = [
     { name = "click" },
     { name = "gitpython" },

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ dependencies = [
 [[package]]
 name = "ecosystem-analyzer"
 version = "0.1.0"
-source = { git = "https://github.com/astral-sh/ecosystem-analyzer#799f67e1a8362eb4046d0fc37dbc55e226d034aa" }
+source = { git = "https://github.com/astral-sh/ecosystem-analyzer#74af2b661a70a3bfcf76f5bc12ba6c6296d5dc68" }
 dependencies = [
     { name = "click" },
     { name = "gitpython" },


### PR DESCRIPTION
## Summary

Bump ecosystem-analyzer to include https://github.com/astral-sh/ecosystem-analyzer/pull/169 and https://github.com/astral-sh/ecosystem-analyzer/pull/170, preparing script dependencies and warming uv's interpreter cache before timing either revision. Script dependency builds remain disabled.

## Test Plan

Lockfile structure and primer-pin consistency checks passed; the hook run was blocked because prek was unavailable in the isolated environment and downloads were disabled.
