### PR TITLE
[flake8-use-pathlib] Add a display-only suggestion for `os-listdir` (PTH208)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -9,6 +9,7 @@ use crate::rules::flake8_use_pathlib::{
     rules::Glob,
     violations::{Joiner, OsListdir, OsPathJoin, OsPathSplitext, PyPath},
 };
+use crate::{Edit, Fix};
 
 pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
     let Some(qualified_name) = checker.semantic().resolve_qualified_name(&call.func) else {
@@ -91,7 +92,14 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             {
                 return;
             }
-            checker.report_diagnostic_if_enabled(OsListdir, range)
+            let mut diagnostic = checker.report_diagnostic(OsListdir, range);
+            if let Some(path) = call.arguments.find_argument_value("path", 0) {
+                diagnostic.set_fix(Fix::display_only_edit(Edit::range_replacement(
+                    format!("Path({}).iterdir()", checker.locator().slice(path)),
+                    call.range(),
+                )));
+            }
+            Some(diagnostic)
         }
 
         _ => return,

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH208_PTH208.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__PTH208_PTH208.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_use_pathlib/mod.rs
 ---
-PTH208 Use `pathlib.Path.iterdir()` instead.
+PTH208 [*] Use `pathlib.Path.iterdir()` instead.
  --> PTH208.py:3:1
   |
 1 | import os
@@ -10,8 +10,15 @@ PTH208 Use `pathlib.Path.iterdir()` instead.
   | ^^^^^^^^^^
 4 | os.listdir(b'.')
   |
+  |
+2 |
+  - os.listdir('.')
+3 + Path('.').iterdir()
+4 | os.listdir(b'.')
+  |
+note: This is a display-only fix and is likely to be incorrect
 
-PTH208 Use `pathlib.Path.iterdir()` instead.
+PTH208 [*] Use `pathlib.Path.iterdir()` instead.
  --> PTH208.py:4:1
   |
 3 | os.listdir('.')
@@ -20,8 +27,15 @@ PTH208 Use `pathlib.Path.iterdir()` instead.
 5 |
 6 | string_path = '.'
   |
+  |
+3 | os.listdir('.')
+  - os.listdir(b'.')
+4 + Path(b'.').iterdir()
+5 |
+  |
+note: This is a display-only fix and is likely to be incorrect
 
-PTH208 Use `pathlib.Path.iterdir()` instead.
+PTH208 [*] Use `pathlib.Path.iterdir()` instead.
  --> PTH208.py:7:1
   |
 6 | string_path = '.'
@@ -30,30 +44,58 @@ PTH208 Use `pathlib.Path.iterdir()` instead.
 8 |
 9 | bytes_path = b'.'
   |
+  |
+6 | string_path = '.'
+  - os.listdir(string_path)
+7 + Path(string_path).iterdir()
+8 |
+  |
+note: This is a display-only fix and is likely to be incorrect
 
-PTH208 Use `pathlib.Path.iterdir()` instead.
+PTH208 [*] Use `pathlib.Path.iterdir()` instead.
   --> PTH208.py:10:1
    |
  9 | bytes_path = b'.'
 10 | os.listdir(bytes_path)
    | ^^^^^^^^^^
+   |
+9  | bytes_path = b'.'
+   - os.listdir(bytes_path)
+10 + Path(bytes_path).iterdir()
+11 |
+   |
+note: This is a display-only fix and is likely to be incorrect
 
-PTH208 Use `pathlib.Path.iterdir()` instead.
+PTH208 [*] Use `pathlib.Path.iterdir()` instead.
   --> PTH208.py:16:1
    |
 15 | path_path = Path('.')
 16 | os.listdir(path_path)
    | ^^^^^^^^^^
+   |
+15 | path_path = Path('.')
+   - os.listdir(path_path)
+16 + Path(path_path).iterdir()
+17 |
+   |
+note: This is a display-only fix and is likely to be incorrect
 
-PTH208 Use `pathlib.Path.iterdir()` instead.
+PTH208 [*] Use `pathlib.Path.iterdir()` instead.
   --> PTH208.py:19:4
    |
 19 | if os.listdir("dir"):
    |    ^^^^^^^^^^
 20 |     ...
    |
+   |
+18 |
+   - if os.listdir("dir"):
+19 + if Path("dir").iterdir():
+20 |     ...
+   |
+note: This is a display-only fix and is likely to be incorrect
 
-PTH208 Use `pathlib.Path.iterdir()` instead.
+PTH208 [*] Use `pathlib.Path.iterdir()` instead.
   --> PTH208.py:22:14
    |
 20 |     ...
@@ -62,3 +104,10 @@ PTH208 Use `pathlib.Path.iterdir()` instead.
    |              ^^^^^^^^^^
 23 |     ...
    |
+   |
+21 |
+   - if "file" in os.listdir("dir"):
+22 + if "file" in Path("dir").iterdir():
+23 |     ...
+   |
+note: This is a display-only fix and is likely to be incorrect

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
@@ -1,6 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 
-use crate::Violation;
+use crate::{FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for uses of `os.path.join`.
@@ -210,6 +210,8 @@ impl Violation for PyPath {
 pub(crate) struct OsListdir;
 
 impl Violation for OsListdir {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         "Use `pathlib.Path.iterdir()` instead.".to_string()


### PR DESCRIPTION
## Summary

- Add a display-only suggestion for PTH208, suggesting `Path(...).iterdir()` as an alternative to `os.listdir(...)`.
- Since `os.listdir()` returns string or bytes names, while `Path.iterdir()` returns `Path` objects, the suggestion may not preserve the original semantics and should be reviewed manually.

Part of #2331

## Test Plan

- `cargo test -p ruff_linter flake8_use_pathlib` (34 passed)
- `cargo fmt --all -- --check`
- `git diff --check`