### PR TITLE
[ty] Preserve list literal positions in starred unpacking

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/unsound.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/unsound.md
@@ -432,10 +432,11 @@ error[unsound-assignment]: Unsound assignment
 6 | middle: list[int]
   |         --------- Expected a subtype of `list[int]` because of this annotation
 7 | first, *middle, last = (0, 1, returns_any(), 2, 3)  # snapshot: unsound-assignment
-  |         ------             ^^^^^^^^^^^^^^^^^^^ Iterable element inferred as `Literal[1, 2] | Any` (expected a subtype of `int`)
+  |         ------             ^^^^^^^^^^^^^^^^^^^ Iterable element inferred as `int | Any` (expected a subtype of `int`)
   |         |
   |         Assigned to this variable
-info: `list[Literal[1, 2] | Any]` is assignable to `list[int]`, but not a subtype of `list[int]`
+info: `list[int | Any]` is assignable to `list[int]`, but not a subtype of `list[int]`
+info: element `Any` of union `int | Any` is not a subtype of `int`
 help: Consider using an `assert` to narrow the type before assigning it
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -710,7 +710,7 @@ class C:
 
 c_instance = C()
 reveal_type(c_instance.a)  # revealed: int
-reveal_type(c_instance.b)  # revealed: list[Literal[2, 3]]
+reveal_type(c_instance.b)  # revealed: list[int]
 ```
 
 #### Attributes defined in for-loop (unpacking)

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -609,6 +609,14 @@ x3: tuple[list[Literal[1]], ...] = 3 * ((singleton(1),) + (singleton(1),))
 reveal_type(x3)  # revealed: tuple[list[Literal[1]], ...]
 ```
 
+Type context also reaches mutable elements inside a starred list literal. Preserving their positions
+in the resulting tuple does not discard the element annotations.
+
+```py
+x4: tuple[list[Literal[1]], ...] = (*[[1], []],)
+reveal_type(x4)  # revealed: tuple[list[Literal[1]], list[Literal[1]]]
+```
+
 ## Generator expressions
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_syntactic_variants.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_assignment_syntactic_variants.md
@@ -511,13 +511,13 @@ first, *middle, last = (1, "wrong", 2)  # snapshot: invalid-assignment
 ```
 
 ```snapshot
-error[invalid-assignment]: Object of type `list[Literal["wrong"]]` is not assignable to `list[int]`
+error[invalid-assignment]: Object of type `list[str]` is not assignable to `list[int]`
  --> src/mdtest_snippet.py:2:28
   |
 1 | middle: list[int]
   |         --------- Declared type
 2 | first, *middle, last = (1, "wrong", 2)  # snapshot: invalid-assignment
-  |         ------             ^^^^^^^ Incompatible iterable element of type `Literal["wrong"]` (expected `int`)
+  |         ------             ^^^^^^^ Incompatible iterable element of type `str` (expected `int`)
   |         |
   |         Assigned to this variable
 ```
@@ -533,15 +533,16 @@ first, *middle, last = 1, 2, 3, "wrong", 4  # snapshot: invalid-assignment
 ```
 
 ```snapshot
-error[invalid-assignment]: Object of type `list[Literal[2, 3, "wrong"]]` is not assignable to `list[int]`
+error[invalid-assignment]: Object of type `list[int | str]` is not assignable to `list[int]`
  --> src/mdtest_snippet.py:2:27
   |
 1 | middle: list[int]
   |         --------- Declared type
 2 | first, *middle, last = 1, 2, 3, "wrong", 4  # snapshot: invalid-assignment
-  |         ------            ^^^^^^^^^^^^^ Incompatible iterable element of type `Literal[2, 3, "wrong"]` (expected `int`)
+  |         ------            ^^^^^^^^^^^^^ Incompatible iterable element of type `int | str` (expected `int`)
   |         |
   |         Assigned to this variable
+info: element `str` of union `int | str` is not assignable to `int`
 ```
 
 ## Opaque unpacking values

--- a/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
@@ -106,6 +106,16 @@ out = (obj.attr := obj).attr
 out = (obj[0] := obj).attr
 ```
 
+## Multiple starred assignment targets
+
+Even when a recovered assignment has more than one starred target, unpacking records types for its
+bindings without panicking.
+
+```py
+first, *left, *right = [1, 2, 3]  # error: [invalid-syntax] "Two starred expressions in assignment"
+first, *left, *right = (1, 2, 3)  # error: [invalid-syntax] "Two starred expressions in assignment"
+```
+
 ## Match-pattern alternatives binding different names
 
 A capture present in only one invalid `or` alternative is possibly undefined.

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1790,6 +1790,23 @@ for _ in range(1_000_000):
     reveal_type(x)  # revealed: int
 ```
 
+### Unpacking alongside a recursively growing value
+
+The first element remains precise even when its sibling's type grows on each loop iteration. Reading
+each literal element independently preserves that information during cycle recovery.
+
+```py
+x = 0
+for _ in range(10):
+    first, x = (1, (x,))
+    reveal_type(first)  # revealed: Literal[1]
+
+x = 0
+for _ in range(10):
+    first, x = [1, (x,)]
+    reveal_type(first)  # revealed: Literal[1]
+```
+
 ### Avoid oscillations
 
 We need to avoid oscillating cycles in cases like the following, where the type of one of these loop

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -497,6 +497,57 @@ def match_nested_list_of_tuples_captures(
             reveal_type(item)  # revealed: bytes
 ```
 
+## Mutable starred sequence captures
+
+A starred capture creates a new list, just like a starred assignment target. Inferred literal types
+are promoted in that list so it can be mutated, without widening the fixed captures or the original
+tuple.
+
+```py
+value = (1, "two")
+first, *assigned = value
+reveal_type(assigned)  # revealed: list[str]
+
+match value:
+    case [first, *rest]:
+        reveal_type(first)  # revealed: Literal[1]
+        reveal_type(rest)  # revealed: list[str]
+        rest.append("three")
+        reveal_type(value)  # revealed: tuple[Literal[1], Literal["two"]]
+```
+
+Singleton values follow the same promotion rules as in a list literal.
+
+```py
+match (1, None):
+    case [first, *rest]:
+        reveal_type(rest)  # revealed: list[None | Unknown]
+        rest.append(2)
+```
+
+Explicit literal annotations are preserved in the captured list.
+
+```py
+from typing import Literal
+
+def explicit_literal_capture(value: tuple[int, Literal["two"]]):
+    match value:
+        case [first, *rest]:
+            reveal_type(rest)  # revealed: list[Literal["two"]]
+```
+
+## Empty starred sequence captures
+
+When the fixed patterns consume every element, the starred capture gets an empty list with an
+unknown element type, just like an empty list literal.
+
+```py
+match (1,):
+    case [first, *rest]:
+        reveal_type(rest)  # revealed: list[Unknown]
+        rest.append(2)
+```
+
 ## Captures from unions of tuples
 
 When a union contains several tuple types, matching one element can determine the types of the other
@@ -560,6 +611,20 @@ def test_match_capture_filters_aliased_union_members(value: MatchPair) -> None:
     match value:
         case [1, item]:
             reveal_type(item)  # revealed: int
+```
+
+Promoting the starred capture does not widen the fixed elements used to select a union member.
+Matching `1` excludes the tuple beginning with `2`, so its integer element does not contribute to
+`rest`.
+
+```py
+def inferred_union_capture(flag: bool):
+    value = (1, "two") if flag else (2, 3)
+    match value:
+        case [1, *rest]:
+            reveal_type(rest)  # revealed: list[str]
+            rest.append("three")
+            reveal_type(value)  # revealed: tuple[Literal[1], Literal["two"]]
 ```
 
 ## Pattern aliases

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -715,7 +715,7 @@ expanded_64 = (*[], *[
     60, 61, 62, 63,
 ], *())
 expanded_65 = (*[
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    0, (1,), 2, 3, 4, 5, 6, 7, 8, 9,
     10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
     20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
 ], *(
@@ -731,22 +731,10 @@ reveal_type(expanded_65[0])  # revealed: int
 reveal_type(expanded_65[-1])  # revealed: int
 ```
 
-Widening also applies inside nested tuple elements contributed by a list literal.
+Widening also applies inside the nested tuple in `expanded_65`.
 
 ```py
-# fmt: off
-expanded = (*[
-    0, (1,), 2, 3, 4, 5, 6, 7, 8, 9,
-    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-    20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-    30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-    40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
-    50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-    60, 61, 62, 63, 64,
-],)
-# fmt: on
-reveal_type(expanded[0])  # revealed: int
-reveal_type(expanded[1])  # revealed: tuple[int]
+reveal_type(expanded_65[1])  # revealed: tuple[int]
 ```
 
 [not a singleton type]: https://discuss.python.org/t/should-we-specify-in-the-language-reference-that-the-empty-tuple-is-a-singleton/67957

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/tuple.md
@@ -582,6 +582,62 @@ def f(x: list[int]):
     reveal_type((42, 56, *x, 97))  # revealed: tuple[Literal[42], Literal[56], *tuple[int, ...], Literal[97]]
 ```
 
+## Tuples constructed from list literals
+
+Expanding a list literal into a tuple preserves the type and position of each element. Unpacking the
+resulting tuple therefore gives the same types as unpacking the literal directly.
+
+```py
+source = (*[1, "two"],)
+reveal_type(source)  # revealed: tuple[Literal[1], Literal["two"]]
+
+first, second = source
+reveal_type(first)  # revealed: Literal[1]
+reveal_type(second)  # revealed: Literal["two"]
+```
+
+Literal expansions can be nested, including through assignment expressions. Each assignment still
+binds the type of its own container.
+
+```py
+source = (0, *[1, *(pair := ("two", *[False]))])
+reveal_type(source)  # revealed: tuple[Literal[0], Literal[1], Literal["two"], Literal[False]]
+reveal_type(pair)  # revealed: tuple[Literal["two"], Literal[False]]
+
+source = (*[(first := 1), first], (last := "two"), last)
+reveal_type(source)  # revealed: tuple[Literal[1], Literal[1], Literal["two"], Literal["two"]]
+```
+
+An invalid expansion reports its iteration error once, while the surrounding literal elements retain
+their positions.
+
+```py
+# error: [not-iterable] "Object of type `Literal[2]` is not iterable"
+source = (*[1, *2, "two"],)
+reveal_type(source)  # revealed: tuple[Literal[1], *tuple[Unknown, ...], Literal["two"]]
+```
+
+## Literal expansions containing variable-length tuples
+
+A list literal can contain an expansion whose length is unknown. Converting that literal to a tuple
+preserves the fixed elements on either side of the expansion, including when the variable portion is
+a symbolic `TypeVarTuple`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+def homogeneous(values: tuple[float, ...]):
+    source = (*[1, *values, "two"],)
+    reveal_type(source)  # revealed: tuple[Literal[1], *tuple[float, ...], Literal["two"]]
+
+def symbolic[*Ts](values: tuple[*Ts]):
+    source = (*[1, *values, "two"],)
+    reveal_type(source)  # revealed: tuple[Literal[1], *Ts@symbolic, Literal["two"]]
+```
+
 ## `Literal` promotion for large unannotated tuples
 
 We infer `Literal` types for a tuple's elements only if it has \<=64 elements. For larger tuples, if
@@ -641,6 +697,56 @@ reveal_type(len(annotated_tuple_with_65))  # revealed: Literal[65]
 reveal_type(annotated_tuple_with_65)
 
 # fmt: on
+```
+
+The limit counts elements introduced by list and tuple literal expansions, including elements from
+several smaller literals. A 64-element expansion retains its literals; adding one more element
+widens the whole tuple. Empty expansions do not consume this budget.
+
+```py
+# fmt: off
+expanded_64 = (*[], *[
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+    30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+    40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+    50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+    60, 61, 62, 63,
+], *())
+expanded_65 = (*[
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+], *(
+    30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+    40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+    50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+    60, 61, 62, 63,
+), 64)
+# fmt: on
+reveal_type(expanded_64[0])  # revealed: Literal[0]
+reveal_type(expanded_64[-1])  # revealed: Literal[63]
+reveal_type(expanded_65[0])  # revealed: int
+reveal_type(expanded_65[-1])  # revealed: int
+```
+
+Widening also applies inside nested tuple elements contributed by a list literal.
+
+```py
+# fmt: off
+expanded = (*[
+    0, (1,), 2, 3, 4, 5, 6, 7, 8, 9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+    30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+    40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+    50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+    60, 61, 62, 63, 64,
+],)
+# fmt: on
+reveal_type(expanded[0])  # revealed: int
+reveal_type(expanded[1])  # revealed: tuple[int]
 ```
 
 [not a singleton type]: https://discuss.python.org/t/should-we-specify-in-the-language-reference-that-the-empty-tuple-is-a-singleton/67957

--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -166,10 +166,12 @@ reveal_type(f)  # revealed: Unknown
 
 ### Starred unpacking of a large tuple
 
-Unpacking preserves the literal promotion applied when inferring a tuple with more than 64 elements.
+For performance, ty widens inferred integer literal types to `int` in tuples with more than 64
+elements. Unpacking preserves that widening: this unannotated assignment infers `int` for `first`
+and `list[int]` for `rest`. Unpacking the small tuple `(0, 1, 2)` instead infers `Literal[0]` and
+`list[Literal[1, 2]]`.
 
 ```py
-rest: list[int]
 # fmt: off
 first, *rest = (
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -288,8 +290,7 @@ def _(value: list[int]):
 
 ### Starred expression with a list literal
 
-Unpacking a list literal assigns each element to its corresponding target. The starred target
-collects only the remaining elements, so their types do not affect the other targets.
+Unpacking a list literal assigns each element to its corresponding target.
 
 ```py
 first: int

--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -164,6 +164,27 @@ reveal_type(e)  # revealed: Unknown
 reveal_type(f)  # revealed: Unknown
 ```
 
+### Starred unpacking of a large tuple
+
+Unpacking preserves the literal promotion applied when inferring a tuple with more than 64 elements.
+
+```py
+rest: list[int]
+# fmt: off
+first, *rest = (
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+    30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+    40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+    50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+    60, 61, 62, 63, 64,
+)
+# fmt: on
+reveal_type(first)  # revealed: int
+reveal_type(rest)  # revealed: list[int]
+```
+
 ### Non-iterable unpacking
 
 ```py
@@ -263,6 +284,150 @@ def _(value: list[int]):
     reveal_type(a)  # revealed: int
     reveal_type(b)  # revealed: list[int]
     reveal_type(c)  # revealed: int
+```
+
+### Starred expression with a list literal
+
+Unpacking a list literal assigns each element to its corresponding target. The starred target
+collects only the remaining elements, so their types do not affect the other targets.
+
+```py
+first: int
+first, *rest = [1, "wrong"]
+reveal_type(first)  # revealed: Literal[1]
+reveal_type(rest)  # revealed: list[str]
+```
+
+The starred target can also precede the fixed targets:
+
+```py
+*rest, last = ["one", "two", 3]
+reveal_type(rest)  # revealed: list[str]
+reveal_type(last)  # revealed: Literal[3]
+```
+
+A starred target between fixed targets excludes both the prefix and the suffix from its element
+type:
+
+```py
+[first, *rest, last] = [1, "two", "three", 4]
+reveal_type(first)  # revealed: Literal[1]
+reveal_type(rest)  # revealed: list[str]
+reveal_type(last)  # revealed: Literal[4]
+```
+
+### Empty starred target with a list literal
+
+When the fixed targets consume every element, the starred target receives an empty list. As with an
+empty list literal, the element type is unknown, allowing values to be added later.
+
+```py
+first, *rest, last = [1, 2]
+reveal_type(first)  # revealed: Literal[1]
+reveal_type(rest)  # revealed: list[Unknown]
+reveal_type(last)  # revealed: Literal[2]
+rest.append(3)
+
+(*empty,) = []
+reveal_type(empty)  # revealed: list[Unknown]
+```
+
+### Nested starred unpacking of list literals
+
+Element positions are preserved when list literals are nested inside other list or tuple literals.
+
+```py
+(first, *rest), *outer_rest, (last,) = [[1, "two"], False, [3]]
+reveal_type(first)  # revealed: Literal[1]
+reveal_type(rest)  # revealed: list[str]
+reveal_type(outer_rest)  # revealed: list[bool]
+reveal_type(last)  # revealed: Literal[3]
+```
+
+Unpacking another iterable alongside a list literal does not affect the literal's element types.
+
+```py
+def nested(values: list[int]):
+    (first, *rest), (other,) = ([1, "two"], values)
+    reveal_type(first)  # revealed: Literal[1]
+    reveal_type(rest)  # revealed: list[str]
+    reveal_type(other)  # revealed: int
+```
+
+### Invalid starred assignment from a list literal
+
+An incompatible element still causes an error for its corresponding target.
+
+```py
+first: int
+# error: [invalid-assignment] "Object of type `Literal["wrong"]` is not assignable to `int`"
+first, *rest = ["wrong", 1]
+reveal_type(rest)  # revealed: list[int]
+```
+
+The starred target is checked against the list of collected elements.
+
+```py
+numbers: list[int]
+# error: [invalid-assignment] "Object of type `list[str]` is not assignable to `list[int]`"
+first, *numbers = [1, "wrong"]
+```
+
+### Mutable starred target
+
+A starred target receives a new list. Inferred literal element types are promoted, as in a list
+literal, so additional values of the same type can be appended.
+
+```py
+first, *rest = [1, "two"]
+rest.append("three")
+reveal_type(rest)  # revealed: list[str]
+```
+
+The collected elements are also compatible with an explicitly annotated list.
+
+```py
+strings: list[str]
+first, *strings = [1, "two"]
+first, *strings = [1]
+```
+
+Singleton values follow the same inference rules as in a list literal.
+
+```py
+optional: list[int | None]
+first, *optional = [1, None]
+```
+
+Explicit literal annotations are preserved when constructing the collected list.
+
+```py
+from typing import Literal
+
+def explicit_literal(value: Literal["one", "two"]):
+    first, *rest = [1, value]
+    reveal_type(rest)  # revealed: list[Literal["one", "two"]]
+```
+
+### Tuple elements collected from a list literal
+
+Homogeneous tuple literals of different lengths are promoted to a variable-length tuple element
+type, as in an ordinary list literal.
+
+```py
+rest: list[tuple[int, ...]]
+first, *rest = [(1,), (2,), (3, 4)]
+reveal_type(first)  # revealed: tuple[Literal[1]]
+reveal_type(rest)  # revealed: list[tuple[int, ...]]
+```
+
+A tuple from a variable retains its annotated shape and prevents tuple-size promotion for the
+collected elements.
+
+```py
+def annotated_tuple(value: tuple[int, int]):
+    first, *rest = [0, (1,), value]
+    reveal_type(rest)  # revealed: list[tuple[int] | tuple[int, int]]
 ```
 
 ## Homogeneous tuples

--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -168,12 +168,13 @@ reveal_type(f)  # revealed: Unknown
 
 For performance, ty widens inferred integer literal types to `int` in tuples with more than 64
 elements. Unpacking preserves that widening: this unannotated assignment infers `int` for `first`
-and `list[int]` for `rest`. Widening also applies inside nested tuple elements. Unpacking the small
-tuple `(0, (1,), 2)` instead infers `Literal[0]` and `Literal[1]` for the fixed targets.
+and `list[int]` for `rest`, including when the elements come from a list literal expansion. Widening
+also applies inside nested tuple elements. Unpacking the small tuple `(0, (1,), 2)` instead infers
+`Literal[0]` and `Literal[1]` for the fixed targets.
 
 ```py
 # fmt: off
-first, (second,), *rest = (
+first, (second,), *rest = (*[
     0, (1,), 2, 3, 4, 5, 6, 7, 8, 9,
     10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
     20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
@@ -181,7 +182,7 @@ first, (second,), *rest = (
     40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
     50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
     60, 61, 62, 63, 64,
-)
+],)
 # fmt: on
 reveal_type(first)  # revealed: int
 reveal_type(second)  # revealed: int

--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -119,7 +119,7 @@ reveal_type(d)  # revealed: Unknown
 ```py
 [a, *b, c] = (1, 2)
 reveal_type(a)  # revealed: Literal[1]
-reveal_type(b)  # revealed: list[Never]
+reveal_type(b)  # revealed: list[Unknown]
 reveal_type(c)  # revealed: Literal[2]
 ```
 
@@ -128,7 +128,7 @@ reveal_type(c)  # revealed: Literal[2]
 ```py
 [a, *b, c] = (1, 2, 3)
 reveal_type(a)  # revealed: Literal[1]
-reveal_type(b)  # revealed: list[Literal[2]]
+reveal_type(b)  # revealed: list[int]
 reveal_type(c)  # revealed: Literal[3]
 ```
 
@@ -137,7 +137,7 @@ reveal_type(c)  # revealed: Literal[3]
 ```py
 [a, *b, c, d] = (1, 2, 3, 4, 5, 6)
 reveal_type(a)  # revealed: Literal[1]
-reveal_type(b)  # revealed: list[Literal[2, 3, 4]]
+reveal_type(b)  # revealed: list[int]
 reveal_type(c)  # revealed: Literal[5]
 reveal_type(d)  # revealed: Literal[6]
 ```
@@ -148,7 +148,7 @@ reveal_type(d)  # revealed: Literal[6]
 [a, b, *c] = (1, 2, 3, 4)
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
-reveal_type(c)  # revealed: list[Literal[3, 4]]
+reveal_type(c)  # revealed: list[int]
 ```
 
 ### Starred expression (6)
@@ -168,13 +168,13 @@ reveal_type(f)  # revealed: Unknown
 
 For performance, ty widens inferred integer literal types to `int` in tuples with more than 64
 elements. Unpacking preserves that widening: this unannotated assignment infers `int` for `first`
-and `list[int]` for `rest`. Unpacking the small tuple `(0, 1, 2)` instead infers `Literal[0]` and
-`list[Literal[1, 2]]`.
+and `list[int]` for `rest`. Widening also applies inside nested tuple elements. Unpacking the small
+tuple `(0, (1,), 2)` instead infers `Literal[0]` and `Literal[1]` for the fixed targets.
 
 ```py
 # fmt: off
-first, *rest = (
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+first, (second,), *rest = (
+    0, (1,), 2, 3, 4, 5, 6, 7, 8, 9,
     10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
     20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
     30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
@@ -184,6 +184,7 @@ first, *rest = (
 )
 # fmt: on
 reveal_type(first)  # revealed: int
+reveal_type(second)  # revealed: int
 reveal_type(rest)  # revealed: list[int]
 ```
 
@@ -248,6 +249,41 @@ reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
 ```
 
+### Too few values in a list literal
+
+A list literal without starred elements has a known length. If it cannot fill all targets, we report
+the mismatch and infer `Unknown` for those targets, as with a tuple literal.
+
+```py
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
+first, last = [1]
+reveal_type(first)  # revealed: Unknown
+reveal_type(last)  # revealed: Unknown
+```
+
+A starred target does not reduce the number of elements required by the fixed targets. On a length
+mismatch, its element type is also unknown.
+
+```py
+# error: [invalid-assignment] "Not enough values to unpack: Expected at least 2"
+first, *rest, last = [1]
+reveal_type(first)  # revealed: Unknown
+reveal_type(rest)  # revealed: list[Unknown]
+reveal_type(last)  # revealed: Unknown
+```
+
+### Too many values in a list literal
+
+Without a starred target, every element needs a corresponding target. Extra elements cause an error
+and leave all targets with unknown types.
+
+```py
+# error: [invalid-assignment] "Too many values to unpack: Expected 2"
+first, last = [1, 2, 3]
+reveal_type(first)  # revealed: Unknown
+reveal_type(last)  # revealed: Unknown
+```
+
 ### Simple unpacking
 
 ```py
@@ -288,7 +324,9 @@ def _(value: list[int]):
     reveal_type(c)  # revealed: int
 ```
 
-### Starred expression with a list literal
+## List and tuple literals
+
+### Starred targets
 
 Unpacking a list literal assigns each element to its corresponding target.
 
@@ -317,7 +355,7 @@ reveal_type(rest)  # revealed: list[str]
 reveal_type(last)  # revealed: Literal[4]
 ```
 
-### Empty starred target with a list literal
+### Empty starred targets
 
 When the fixed targets consume every element, the starred target receives an empty list. As with an
 empty list literal, the element type is unknown, allowing values to be added later.
@@ -333,12 +371,22 @@ rest.append(3)
 reveal_type(empty)  # revealed: list[Unknown]
 ```
 
-### Nested starred unpacking of list literals
+### Nested list literals
 
 Element positions are preserved when list literals are nested inside other list or tuple literals.
 
 ```py
 (first, *rest), *outer_rest, (last,) = [[1, "two"], False, [3]]
+reveal_type(first)  # revealed: Literal[1]
+reveal_type(rest)  # revealed: list[str]
+reveal_type(outer_rest)  # revealed: list[bool]
+reveal_type(last)  # revealed: Literal[3]
+```
+
+The same nested lists retain their element positions when the outer literal is a tuple.
+
+```py
+(first, *rest), *outer_rest, (last,) = ([1, "two"], False, [3])
 reveal_type(first)  # revealed: Literal[1]
 reveal_type(rest)  # revealed: list[str]
 reveal_type(outer_rest)  # revealed: list[bool]
@@ -355,7 +403,33 @@ def nested(values: list[int]):
     reveal_type(other)  # revealed: int
 ```
 
-### Invalid starred assignment from a list literal
+If a nested list has too few elements, only the targets unpacked from that list get unknown types.
+The sibling target retains its corresponding element's type.
+
+```py
+# error: [invalid-assignment] "Not enough values to unpack: Expected at least 2"
+(first, *rest, last), other = [[1], 2]
+reveal_type(first)  # revealed: Unknown
+reveal_type(rest)  # revealed: list[Unknown]
+reveal_type(last)  # revealed: Unknown
+reveal_type(other)  # revealed: Literal[2]
+```
+
+A starred outer target does not hide a length mismatch inside either kind of literal.
+
+```py
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
+(first, last), *rest = ([1],)
+reveal_type(first)  # revealed: Unknown
+reveal_type(last)  # revealed: Unknown
+
+# error: [invalid-assignment] "Not enough values to unpack: Expected 2"
+(first, last), *rest = [[1]]
+reveal_type(first)  # revealed: Unknown
+reveal_type(last)  # revealed: Unknown
+```
+
+### Incompatible targets
 
 An incompatible element still causes an error for its corresponding target.
 
@@ -374,7 +448,7 @@ numbers: list[int]
 first, *numbers = [1, "wrong"]
 ```
 
-### Mutable starred target
+### Capture-list inference
 
 A starred target receives a new list. Inferred literal element types are promoted, as in a list
 literal, so additional values of the same type can be appended.
@@ -383,6 +457,14 @@ literal, so additional values of the same type can be appended.
 first, *rest = [1, "two"]
 rest.append("three")
 reveal_type(rest)  # revealed: list[str]
+
+first, *rest = (1, "two")
+rest.append("three")
+reveal_type(rest)  # revealed: list[str]
+
+first, *rest = (1,)
+rest.append("three")
+reveal_type(rest)  # revealed: list[Unknown]
 ```
 
 The collected elements are also compatible with an explicitly annotated list.
@@ -398,6 +480,7 @@ Singleton values follow the same inference rules as in a list literal.
 ```py
 optional: list[int | None]
 first, *optional = [1, None]
+first, *optional = (1, None)
 ```
 
 Explicit literal annotations are preserved when constructing the collected list.
@@ -408,9 +491,11 @@ from typing import Literal
 def explicit_literal(value: Literal["one", "two"]):
     first, *rest = [1, value]
     reveal_type(rest)  # revealed: list[Literal["one", "two"]]
+    first, *rest = (1, value)
+    reveal_type(rest)  # revealed: list[Literal["one", "two"]]
 ```
 
-### Tuple elements collected from a list literal
+### Collected tuple elements
 
 Homogeneous tuple literals of different lengths are promoted to a variable-length tuple element
 type, as in an ordinary list literal.
@@ -418,6 +503,10 @@ type, as in an ordinary list literal.
 ```py
 rest: list[tuple[int, ...]]
 first, *rest = [(1,), (2,), (3, 4)]
+reveal_type(first)  # revealed: tuple[Literal[1]]
+reveal_type(rest)  # revealed: list[tuple[int, ...]]
+
+first, *rest = ((1,), (2,), (3, 4))
 reveal_type(first)  # revealed: tuple[Literal[1]]
 reveal_type(rest)  # revealed: list[tuple[int, ...]]
 ```
@@ -429,6 +518,139 @@ collected elements.
 def annotated_tuple(value: tuple[int, int]):
     first, *rest = [0, (1,), value]
     reveal_type(rest)  # revealed: list[tuple[int] | tuple[int, int]]
+    first, *rest = (0, (1,), value)
+    reveal_type(rest)  # revealed: list[tuple[int] | tuple[int, int]]
+```
+
+Tuple literals collected between multiple expansions remain eligible for tuple-size promotion.
+
+```py
+def expanded_tuples(values: list[str]):
+    first, *rest, last = (0, *values, (1,), *values, (2, 3), False)
+    reveal_type(first)  # revealed: Literal[0]
+    reveal_type(rest)  # revealed: list[str | tuple[int, ...]]
+    reveal_type(last)  # revealed: Literal[False]
+
+    first, *rest, last = [0, *values, (1,), *values, (2, 3), False]
+    reveal_type(first)  # revealed: Literal[0]
+    reveal_type(rest)  # revealed: list[str | tuple[int, ...]]
+    reveal_type(last)  # revealed: Literal[False]
+```
+
+### Starred expressions on the right-hand side
+
+A starred element can contribute an unknown number of values. The literal's AST length does not
+determine whether it can fill the targets.
+
+```py
+def unpack(values: list[int]):
+    first, *rest, last = [*values]
+    reveal_type(first)  # revealed: int
+    reveal_type(rest)  # revealed: list[int]
+    reveal_type(last)  # revealed: int
+```
+
+Known elements before and after a starred expression keep their positions, for both tuple and list
+literals. Only the starred target collects the elements supplied by `values`.
+
+```py
+def fixed_ends(values: list[str]):
+    first: int
+    first, *rest, last = (1, *values, 2)
+    reveal_type(first)  # revealed: Literal[1]
+    reveal_type(rest)  # revealed: list[str]
+    reveal_type(last)  # revealed: Literal[2]
+
+    first, *rest, last = [1, *values, 2]
+    reveal_type(first)  # revealed: Literal[1]
+    reveal_type(rest)  # revealed: list[str]
+    reveal_type(last)  # revealed: Literal[2]
+```
+
+### Ambiguous positions around an expansion
+
+When an expansion may be empty, a fixed target can receive either one of its elements or a value
+from the other side of the expansion. We combine those possibilities without losing the types of the
+unambiguous targets.
+
+```py
+def ambiguous(values: list[str]):
+    first, second, *rest = (0, *values, 1)
+    reveal_type(first)  # revealed: Literal[0]
+    reveal_type(second)  # revealed: str | Literal[1]
+    reveal_type(rest)  # revealed: list[str | int]
+
+    first, second, *rest = [0, *values, 1]
+    reveal_type(first)  # revealed: Literal[0]
+    reveal_type(second)  # revealed: str | Literal[1]
+    reveal_type(rest)  # revealed: list[str | int]
+```
+
+### Unpacking literal expansions
+
+Expanding a literal preserves its elements and length. These assignments fail even though their
+right-hand sides contain starred expressions.
+
+```py
+# error: [invalid-assignment] "Not enough values to unpack: Expected at least 2"
+first, *rest, last = (*(1,),)
+reveal_type(first)  # revealed: Unknown
+reveal_type(rest)  # revealed: list[Unknown]
+reveal_type(last)  # revealed: Unknown
+
+# error: [invalid-assignment] "Not enough values to unpack: Expected at least 2"
+first, *rest, last = [*[1]]
+reveal_type(first)  # revealed: Unknown
+reveal_type(rest)  # revealed: list[Unknown]
+reveal_type(last)  # revealed: Unknown
+```
+
+A dictionary literal with a single key supplies one element.
+
+```py
+# error: [invalid-assignment] "Not enough values to unpack: Expected at least 2"
+first, *rest, last = (*{"key": 1},)
+# error: [invalid-assignment] "Not enough values to unpack: Expected at least 2"
+first, *rest, last = [*{"key": 1}]
+```
+
+### Unpacking a named expression
+
+A named expression preserves the structure of its value when unpacked immediately. The bound list
+itself still has an ordinary list type.
+
+```py
+first: int
+first, *rest = (items := (1, "two"))
+reveal_type(first)  # revealed: Literal[1]
+reveal_type(rest)  # revealed: list[str]
+
+first, *rest = (items := [1, "two"])
+reveal_type(first)  # revealed: Literal[1]
+reveal_type(rest)  # revealed: list[str]
+reveal_type(items)  # revealed: list[int | str]
+```
+
+### Aliases in unpacked values
+
+Collected lists retain aliases in their element types.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Element = int | str
+
+def aliases(value: Element):
+    first, *rest = (value, value)
+    reveal_type(first)  # revealed: int | str
+    reveal_type(rest)  # revealed: list[Element]
+
+    first, *rest = [value, value]
+    reveal_type(first)  # revealed: int | str
+    reveal_type(rest)  # revealed: list[Element]
 ```
 
 ## Homogeneous tuples
@@ -626,7 +848,7 @@ def f(x: HeterogeneousTupleSubclass):
     reveal_type(o)  # revealed: I0
     reveal_type(p)  # revealed: I1
     reveal_type(q)  # revealed: I2
-    reveal_type(r)  # revealed: list[Never]
+    reveal_type(r)  # revealed: list[Unknown]
 
     # error: [invalid-assignment] "Not enough values to unpack: Expected at least 4"
     [s, t, u, v, *w] = x
@@ -738,7 +960,7 @@ reveal_type(d)  # revealed: Unknown
 ```py
 a, *b, c = "ab"
 reveal_type(a)  # revealed: Literal["a"]
-reveal_type(b)  # revealed: list[Never]
+reveal_type(b)  # revealed: list[Unknown]
 reveal_type(c)  # revealed: Literal["b"]
 ```
 
@@ -747,7 +969,7 @@ reveal_type(c)  # revealed: Literal["b"]
 ```py
 a, *b, c = "abc"
 reveal_type(a)  # revealed: Literal["a"]
-reveal_type(b)  # revealed: list[Literal["b"]]
+reveal_type(b)  # revealed: list[str]
 reveal_type(c)  # revealed: Literal["c"]
 ```
 
@@ -756,7 +978,7 @@ reveal_type(c)  # revealed: Literal["c"]
 ```py
 a, *b, c, d = "abcdef"
 reveal_type(a)  # revealed: Literal["a"]
-reveal_type(b)  # revealed: list[Literal["b", "c", "d"]]
+reveal_type(b)  # revealed: list[str]
 reveal_type(c)  # revealed: Literal["e"]
 reveal_type(d)  # revealed: Literal["f"]
 ```
@@ -767,7 +989,7 @@ reveal_type(d)  # revealed: Literal["f"]
 a, b, *c = "abcd"
 reveal_type(a)  # revealed: Literal["a"]
 reveal_type(b)  # revealed: Literal["b"]
-reveal_type(c)  # revealed: list[Literal["c", "d"]]
+reveal_type(c)  # revealed: list[str]
 ```
 
 ### Starred expression (6)
@@ -885,7 +1107,7 @@ reveal_type(d)  # revealed: Unknown
 ```py
 a, *b, c = b"ab"
 reveal_type(a)  # revealed: Literal[97]
-reveal_type(b)  # revealed: list[Never]
+reveal_type(b)  # revealed: list[Unknown]
 reveal_type(c)  # revealed: Literal[98]
 ```
 
@@ -894,7 +1116,7 @@ reveal_type(c)  # revealed: Literal[98]
 ```py
 a, *b, c = b"abc"
 reveal_type(a)  # revealed: Literal[97]
-reveal_type(b)  # revealed: list[Literal[98]]
+reveal_type(b)  # revealed: list[int]
 reveal_type(c)  # revealed: Literal[99]
 ```
 
@@ -903,7 +1125,7 @@ reveal_type(c)  # revealed: Literal[99]
 ```py
 a, *b, c, d = b"abcdef"
 reveal_type(a)  # revealed: Literal[97]
-reveal_type(b)  # revealed: list[Literal[98, 99, 100]]
+reveal_type(b)  # revealed: list[int]
 reveal_type(c)  # revealed: Literal[101]
 reveal_type(d)  # revealed: Literal[102]
 ```
@@ -914,7 +1136,7 @@ reveal_type(d)  # revealed: Literal[102]
 a, b, *c = b"abcd"
 reveal_type(a)  # revealed: Literal[97]
 reveal_type(b)  # revealed: Literal[98]
-reveal_type(c)  # revealed: list[Literal[99, 100]]
+reveal_type(c)  # revealed: list[int]
 ```
 
 ### Very long literal

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2925,6 +2925,36 @@ impl<'db> Type<'db> {
         )
     }
 
+    /// Finalizes the element type of a mutable collection after combining its element evidence.
+    /// Literal types supplied by explicit annotations remain unpromotable. Without contextual
+    /// constraints, singleton types also widen: `[None]` permits later mutation, as does the list
+    /// created by `*rest, = (None,)`.
+    /// Evidence from later collection uses also passes through this helper, since those types
+    /// have not necessarily undergone the promotion applied to literal elements during inference.
+    fn promote_collection_element_type(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        allow_tuple_size_promotion: bool,
+        unconstrained: bool,
+    ) -> Type<'db> {
+        let ty = if unconstrained {
+            self.promote(db, env)
+        } else {
+            self
+        };
+        let ty = if allow_tuple_size_promotion {
+            ty.promote_tuple_size_in_union(db, env)
+        } else {
+            ty
+        };
+        if unconstrained {
+            ty.promote_singletons_recursively(db, env)
+        } else {
+            ty
+        }
+    }
+
     /// Promote a top-level singleton type (like `None`, `EllipsisType`) to `T | Unknown`.
     pub(crate) fn promote_singletons(
         self,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -108,13 +108,16 @@ use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope};
 use crate::types::special_form::TypeQualifier;
 use crate::types::subclass_of::SubclassOfInner;
 use crate::types::tuple::promotion::TupleSizePromotionConstraints;
-use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType, VariableSegment};
+use crate::types::tuple::{
+    MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE, Tuple, TupleLength, TupleSpecBuilder,
+    TupleType, VariableSegment,
+};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
 use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{
     BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity, TypeVarInstance, TypeVarSet,
 };
-use crate::types::unpacker::{UnpackResult, fixed_sequence_elements};
+use crate::types::unpacker::{UnpackResult, fixed_sequence_elements, literal_iterable_length};
 use crate::types::{
     BindingContext, BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType,
     CallableTypes, ClassType, DynamicType, GeneratorTypeMode, InferenceFlags,
@@ -6991,10 +6994,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         tuple: &ast::ExprTuple,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        /// If a tuple literal has more elements than this constant,
-        /// we promote `Literal` types when inferring the elements of the tuple.
-        /// This provides a huge speedup on files that have very large unannotated tuple literals.
-        const MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE: usize = 64;
         let db = self.db();
 
         let env = self.program_environment();
@@ -7087,20 +7086,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // emitted in the `infer_element` call above.
                 let mut spec = element_type.iterate(db, env).into_owned();
 
-                let known_length = match &*starred.value {
-                    ast::Expr::List(ast::ExprList { elts, .. })
-                    | ast::Expr::Set(ast::ExprSet { elts, .. }) => elts
-                        .iter()
-                        .all(|elt| !elt.is_starred_expr())
-                        .then_some(elts.len()),
-                    ast::Expr::Dict(ast::ExprDict { items, .. }) => items
-                        .iter()
-                        .all(|item| item.key.is_some())
-                        .then_some(items.len()),
-                    _ => None,
-                };
-
-                if let Some(known_length) = known_length {
+                if let Some(known_length) = literal_iterable_length(&starred.value) {
                     spec = spec
                         .resize(db, env, TupleLength::Fixed(known_length))
                         .unwrap_or(spec);
@@ -7879,31 +7865,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 builder.build_merged_with(|current_typevar, bounds| {
                     let lower = bounds?.evidence_lower?;
 
-                    let lower = if is_empty_collection_type_context(tcx) {
-                        // Constraints learned from later collection uses follow the same promotion
-                        // policy as literal elements: promote element literal types in invariant
-                        // position unless an explicit annotation made them unpromotable.
-                        lower.promote(db, env)
-                    } else {
-                        lower
-                    };
-
-                    let lower = if tuple_size_promotion_constraints
-                        .allow(current_typevar.identity(self.db()))
-                    {
-                        lower.promote_tuple_size_in_union(db, env)
-                    } else {
-                        lower
-                    };
-
-                    let lower = if is_empty_collection_type_context(tcx) {
-                        lower
-                            // Promote singleton types to `T | Unknown` in inferred type parameters,
-                            // so that e.g. `[None]` is inferred as `list[None | Unknown]`.
-                            .promote_singletons_recursively(db, env)
-                    } else {
-                        lower
-                    };
+                    let lower = lower.promote_collection_element_type(
+                        db,
+                        env,
+                        tuple_size_promotion_constraints.allow(current_typevar.identity(self.db())),
+                        is_empty_collection_type_context(tcx),
+                    );
 
                     Some(lower)
                 })

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -108,16 +108,16 @@ use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope};
 use crate::types::special_form::TypeQualifier;
 use crate::types::subclass_of::SubclassOfInner;
 use crate::types::tuple::promotion::TupleSizePromotionConstraints;
-use crate::types::tuple::{
-    MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE, Tuple, TupleLength, TupleSpecBuilder,
-    TupleType, VariableSegment,
-};
+use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType, VariableSegment};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
 use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{
     BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity, TypeVarInstance, TypeVarSet,
 };
-use crate::types::unpacker::{UnpackResult, fixed_sequence_elements, literal_iterable_length};
+use crate::types::unpacker::{
+    UnpackResult, fixed_sequence_elements, sequence_from_literal_elements,
+    tuple_literal_needs_promotion,
+};
 use crate::types::{
     BindingContext, BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType,
     CallableTypes, ClassType, DynamicType, GeneratorTypeMode, InferenceFlags,
@@ -7054,7 +7054,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .unwrap_or_default();
         let mut annotated_elt_tys = annotated_elt_tys.into_iter();
 
-        let mut infer_element = |elt: &ast::Expr| {
+        for elt in elts {
             let annotated_elt_ty = annotated_elt_tys.by_ref().next();
             let element_tcx = if can_use_type_context {
                 let expected = if elt.is_starred_expr() {
@@ -7067,38 +7067,32 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 TypeContext::default()
             };
-            if tuple.len() > MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE {
-                // Promote literals for very large unannotated tuples,
-                // to avoid pathological performance issues
-                self.infer_expression(elt, element_tcx).promote(db, env)
-            } else {
-                self.infer_expression(elt, element_tcx)
-            }
-        };
-
-        let mut builder = TupleSpecBuilder::with_capacity(elts.len());
-
-        for element in elts {
-            if let ast::Expr::Starred(starred) = element {
-                let element_type = infer_element(element);
-                // Fine to use `iterate` rather than `try_iterate` here:
-                // errors from iterating over something not iterable will have been
-                // emitted in the `infer_element` call above.
-                let mut spec = element_type.iterate(db, env).into_owned();
-
-                if let Some(known_length) = literal_iterable_length(&starred.value) {
-                    spec = spec
-                        .resize(db, env, TupleLength::Fixed(known_length))
-                        .unwrap_or(spec);
-                }
-
-                builder = builder.concat(db, env, &spec);
-            } else {
-                builder.push(infer_element(element));
-            }
+            self.infer_expression(elt, element_tcx);
         }
 
-        Type::tuple(TupleType::new(db, env, &builder.build()))
+        // Infer expressions once, in evaluation order and with their type context, before
+        // recovering literal positions. For `(*[(item := 1), item],)`, both list elements
+        // must be inferred before the traversal reads their types.
+        let inferred_type = |expression: &ast::Expr, promote| {
+            let ty = self.expression_type(expression);
+            if promote { ty.promote(db, env) } else { ty }
+        };
+        let spec = sequence_from_literal_elements(
+            elts,
+            tuple_literal_needs_promotion(elts),
+            &inferred_type,
+            &|expression, promote, known_length| {
+                // Starred-expression inference has already reported iteration errors.
+                let spec = inferred_type(expression, promote)
+                    .iterate(db, env)
+                    .into_owned();
+                known_length
+                    .and_then(|length| spec.resize(db, env, TupleLength::Fixed(length)).ok())
+                    .unwrap_or(spec)
+            },
+            &|builder, unpacked| builder.concat(db, env, unpacked),
+        );
+        Type::tuple(TupleType::new(db, env, &spec))
     }
 
     fn infer_list_expression(&mut self, list: &ast::ExprList, tcx: TypeContext<'db>) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -9,8 +9,9 @@ use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
-use crate::types::tuple::{TupleLength, TupleSpec, TupleSpecBuilder, TupleType, TupleUnpacker};
+use crate::types::tuple::{TupleElement, TupleLength, TupleSpec, TupleSpecBuilder, TupleType};
 use crate::types::typed_dict::{TypedDictFieldBuilder, TypedDictSchema, TypedDictType};
+use crate::types::unpacker::collected_list_type;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -3086,9 +3087,32 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     },
                 ))
             });
-        let mut unpacker = TupleUnpacker::new(db, &self.env, target_len);
-        unpacker.unpack_tuple(tuple.as_ref()).ok()?;
-        Some((narrowed_subject_ty, unpacker.into_types().collect()))
+        let unpacked = tuple
+            .unpack(
+                target_len,
+                |segment| vec![segment.element_type(db)],
+                |elements| {
+                    UnionType::from_elements_leave_aliases(db, &self.env, elements.iter().copied())
+                },
+            )
+            .ok()?;
+        let element_types = unpacked
+            .into_all_elements_with_kind()
+            .map(|element| match element {
+                // `case [1, *rest]:` still needs the precise first element to select matching
+                // tuple union members. Only the fresh list for `rest` undergoes promotion.
+                TupleElement::Variable(elements) => {
+                    collected_list_type(db, &self.env, elements.into_iter().map(|ty| (ty, None)))
+                }
+                TupleElement::Fixed(ty) | TupleElement::Prefix(ty) | TupleElement::Suffix(ty) => {
+                    UnionBuilder::new(db, &self.env)
+                        .add(ty)
+                        .try_build()
+                        .unwrap_or_else(Type::unknown)
+                }
+            })
+            .collect();
+        Some((narrowed_subject_ty, element_types))
     }
 
     fn analyze_matched_subject_arms(

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -39,9 +39,6 @@ use ty_python_core::definition::Definition;
 
 pub(crate) mod promotion;
 
-/// Limit literal precision in large tuple expressions to avoid pathological inference costs.
-pub(crate) const MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE: usize = 64;
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum TupleLength {
     Fixed(usize),
@@ -1111,7 +1108,7 @@ impl<T, V> VariableLengthTuple<T, V> {
         }
     }
 
-    fn mixed(
+    pub(super) fn mixed(
         prefix: impl IntoIterator<Item = T>,
         variable: V,
         suffix: impl IntoIterator<Item = T>,
@@ -2347,12 +2344,28 @@ impl<T, V> Tuple<T, V> {
         }
     }
 
-    /// Matches sequence elements to an unpacking target's shape.
+    /// Matches the source sequence `self` to the target shape specified by `length`.
     ///
-    /// The returned variable segment contains all elements that may be collected by the starred
-    /// target. Keeping them separate lets callers retain source expressions and choose how to
-    /// infer the new list. `combine` is only needed when a fixed target has several possible
-    /// sources, as for `a, b, *rest = (1, *items, "last")`.
+    /// For `a, b = (1, "two")`, `length` is `TupleLength::Fixed(2)`, and each target gets one
+    /// element. For `first, *rest, last = [1, "two", 3, 4]`, `length` is
+    /// `TupleLength::Variable(1, 1)`: the returned prefix and suffix contain `1` and `4`, while
+    /// the variable segment keeps `"two"` and `3` separate. The caller uses those elements to
+    /// infer the new list for `rest`, retaining their source expressions when available.
+    ///
+    /// The source can itself have an unknown-length segment:
+    ///
+    /// ```python
+    /// def example(items: list[int]):
+    ///     first, second, *rest = (0, *items, "last")
+    /// ```
+    ///
+    /// `variable_elements` exposes the possible elements represented by that source segment.
+    /// For type inference in this example, it supplies `[int]`. `combine` produces one element
+    /// for a fixed target with multiple possible sources: `second` can receive an integer from
+    /// `items` or `"last"` when `items` is empty, so its type is `int | Literal["last"]`.
+    /// The returned variable segment still keeps the candidates for `rest` separate.
+    ///
+    /// A length error means the source's known length bounds cannot fit the targets.
     pub(crate) fn unpack(
         &self,
         length: TupleLength,
@@ -2362,14 +2375,20 @@ impl<T, V> Tuple<T, V> {
     where
         T: Clone,
     {
-        match (self, length) {
-            (Self::Fixed(values), TupleLength::Fixed(length)) => match values.len().cmp(&length) {
+        match (length, self) {
+            // Both lengths are fixed, as in `a, b = (1, "two")`; every target needs one value.
+            (TupleLength::Fixed(length), Self::Fixed(values)) => match values.len().cmp(&length) {
+                // `a, b = (1,)` leaves a target without a value.
                 Ordering::Less => Err(ResizeTupleError::TooFewValues),
+                // `a, b = (1, 2, 3)` leaves a value without a target.
                 Ordering::Greater => Err(ResizeTupleError::TooManyValues),
+                // `a, b = (1, "two")` pairs both targets with their corresponding values.
                 Ordering::Equal => Ok(Tuple::Fixed(values.clone())),
             },
-            (Self::Fixed(values), TupleLength::Variable(prefix, suffix)) => {
-                // `first, *rest, last = [1]` cannot fill both fixed targets.
+            // `first, *rest, last = [1, "two", 3, 4]` reserves `1` and `4` for the fixed
+            // targets and collects `"two"` and `3`. With `[1, 4]`, the capture is empty.
+            // `first, *rest, last = [1]` cannot fill both fixed targets.
+            (TupleLength::Variable(prefix, suffix), Self::Fixed(values)) => {
                 let Some(end) = values
                     .len()
                     .checked_sub(suffix)
@@ -2383,8 +2402,17 @@ impl<T, V> Tuple<T, V> {
                     values.0[end..].iter().cloned(),
                 ))
             }
-            (Self::Variable(values), TupleLength::Fixed(length)) => {
-                // In `a, b = (1, *items, 2, 3)`, even an empty `items` leaves too many values.
+            // The fixed ends supply `a` and `d`; a successful unpacking must take both
+            // `b` and `c` from `items`:
+            //
+            // ```python
+            // def example(items: list[str]):
+            //     a, b, c, d = (1, *items, 2)
+            // ```
+            //
+            // The source's length is unknown, but its fixed elements impose a minimum.
+            // With `a, b = (1, *items, 2, 3)` instead, even an empty `items` leaves too many values.
+            (TupleLength::Fixed(length), Self::Variable(values)) => {
                 let Some(count) = length.checked_sub(values.len().minimum()) else {
                     return Err(ResizeTupleError::TooManyValues);
                 };
@@ -2398,15 +2426,26 @@ impl<T, V> Tuple<T, V> {
                         .chain(values.suffix_elements().iter().cloned()),
                 ))
             }
-            (Self::Variable(values), TupleLength::Variable(prefix, suffix)) => {
-                // Overflow elements join the capture; underflow targets receive a combination
-                // of the possible elements in the variable portion.
+            // Extra fixed values overflow into the capture. Here `a` and `b` receive `1`
+            // and `4`, while `rest` collects `2`, the elements of `items`, and `3`:
+            //
+            // ```python
+            // def overflow(items: list[int]):
+            //     a, *rest, b = (1, 2, *items, 3, 4)
+            // ```
+            //
+            // Conversely, targets beyond the source's known prefix or suffix underflow
+            // into the variable portion. Such a target can also receive a fixed value
+            // that shifts across that portion when it is empty. Here `b` can be `"last"`:
+            //
+            // ```python
+            // def underflow(items: list[int]):
+            //     a, b, *rest = (1, *items, "last")
+            // ```
+            (TupleLength::Variable(prefix, suffix), Self::Variable(values)) => {
                 let prefix_underflow = prefix.saturating_sub(values.prefix_elements().len());
                 let suffix_overflow = values.suffix_elements().len().saturating_sub(suffix);
                 let suffix_underflow = suffix.saturating_sub(values.suffix_elements().len());
-                // An underflow position can receive an element from the variable portion or
-                // a fixed element that shifts across it when the variable portion is empty.
-                // For `a, b, *rest = (1, *items, "last")`, `b` can therefore be `"last"`.
                 let collected: Vec<_> = values
                     .prefix_elements()
                     .iter()
@@ -2894,7 +2933,36 @@ impl<T, V> TupleBuilder<T, V> {
         }
     }
 
-    /// Concatenates sequences, combining their middle portions only when both have unknown length.
+    /// Appends `other`, preserving the elements whose positions are known from either end.
+    ///
+    /// A literal expansion preserves every position:
+    ///
+    /// ```python
+    /// result = (1, *[2, 3])
+    /// ```
+    ///
+    /// An expansion of unknown length leaves the enclosing prefix and suffix fixed:
+    ///
+    /// ```python
+    /// def example(items: list[str]):
+    ///     return (1, *items, 2)
+    /// ```
+    ///
+    /// Here `1` and `2` remain fixed around the variable segment contributed by `items`.
+    ///
+    /// When both sequences have variable segments, they must share one in the result:
+    ///
+    /// ```python
+    /// def example(xs: list[int], ys: list[str]):
+    ///     return (1, *xs, 2, *(3, *ys, 4))
+    /// ```
+    ///
+    /// At the final expansion, the builder holds `(1, *xs, 2)` and `other` represents
+    /// `(3, *ys, 4)`. `merge` receives the left suffix `[2]`, the mutable left segment for
+    /// `xs`, the right segment for `ys`, and the right prefix `[3]`, in that order. It folds
+    /// the suffix, prefix, and right segment into the left segment. Only `1` and `4` remain
+    /// fixed in the result. The caller decides how to combine the segments' types or source
+    /// expressions; `merge` is not called unless both sequences have variable segments.
     pub(crate) fn concat_with(
         mut self,
         other: &Tuple<T, V>,
@@ -2905,10 +2973,22 @@ impl<T, V> TupleBuilder<T, V> {
         V: Clone,
     {
         match (&mut self, other) {
+            // Expanding the literal appends two known positions to the fixed prefix `1`:
+            //
+            // ```python
+            // result = (1, *[2, 3])
+            // ```
             (Self::Fixed(left), Tuple::Fixed(right)) => {
                 left.extend_from_slice(right.elements_slice());
                 self
             }
+            // The outer expansion extends the fixed prefix to `1, 2`, with the variable
+            // segment from `items` followed by the suffix `3`:
+            //
+            // ```python
+            // def example(items: list[str]):
+            //     return (1, *(2, *items, 3))
+            // ```
             (Self::Fixed(left), Tuple::Variable(right)) => {
                 left.extend_from_slice(right.prefix_elements());
                 Self::Variable {
@@ -2917,10 +2997,25 @@ impl<T, V> TupleBuilder<T, V> {
                     suffix: right.suffix_elements().to_vec(),
                 }
             }
+            // The final expansion extends the existing suffix `2` to `2, 3, 4`, without
+            // changing the prefix or variable segment:
+            //
+            // ```python
+            // def example(items: list[str]):
+            //     return (1, *items, 2, *[3, 4])
+            // ```
             (Self::Variable { suffix, .. }, Tuple::Fixed(right)) => {
                 suffix.extend_from_slice(right.elements_slice());
                 self
             }
+            // Neither `2` nor `3` has a fixed offset from either end, because both `xs`
+            // and `ys` have unknown length. They join the combined variable segment,
+            // leaving the outer prefix `1` and suffix `4`:
+            //
+            // ```python
+            // def example(xs: list[int], ys: list[str]):
+            //     return (1, *xs, 2, *(3, *ys, 4))
+            // ```
             (
                 Self::Variable {
                     segment, suffix, ..

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -31,13 +31,16 @@ use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::visitor::any_over_type_expanding_aliases;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, ErrorContext, FindLegacyTypeVarsVisitor,
-    IntersectionType, Type, TypeContext, TypeMapping, UnionBuilder, UnionType,
+    IntersectionType, Type, TypeContext, TypeMapping, UnionType,
 };
 use crate::{Db, FxOrderSet};
 use ty_python_core::Truthiness;
 use ty_python_core::definition::Definition;
 
 pub(crate) mod promotion;
+
+/// Limit literal precision in large tuple expressions to avoid pathological inference costs.
+pub(crate) const MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE: usize = 64;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum TupleLength {
@@ -975,44 +978,6 @@ impl<T> FixedLengthTuple<T> {
 }
 
 impl<'db> FixedLengthTuple<Type<'db>> {
-    fn resize(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        new_length: TupleLength,
-    ) -> Result<TupleSpec<'db>, ResizeTupleError> {
-        match new_length {
-            TupleLength::Fixed(new_length) => match self.len().cmp(&new_length) {
-                Ordering::Less => Err(ResizeTupleError::TooFewValues),
-                Ordering::Greater => Err(ResizeTupleError::TooManyValues),
-                Ordering::Equal => Ok(Tuple::Fixed(self.clone())),
-            },
-
-            TupleLength::Variable(prefix, suffix) => {
-                // The number of rhs values that will be consumed by the starred target.
-                let Some(variable) = self.len().checked_sub(prefix + suffix) else {
-                    return Err(ResizeTupleError::TooFewValues);
-                };
-
-                // Extract rhs values into the prefix, then into the starred target, then into the
-                // suffix.
-                let mut elements = self.iter_all_elements();
-                let prefix: Vec<_> = elements.by_ref().take(prefix).collect();
-                let variable = UnionType::from_elements_leave_aliases(
-                    db,
-                    env,
-                    elements.by_ref().take(variable),
-                );
-                let suffix = elements.by_ref().take(suffix);
-                Ok(VariableLengthTuple::mixed(
-                    prefix,
-                    VariableSegment::Homogeneous(variable),
-                    suffix,
-                ))
-            }
-        }
-    }
-
     fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
@@ -1225,10 +1190,6 @@ impl<T, V> VariableLengthTuple<T, V> {
         self.variable_segment
     }
 
-    fn variable_element_mut(&mut self) -> &mut V {
-        &mut self.variable_segment
-    }
-
     pub(crate) fn prefix_elements(&self) -> &[T] {
         &self.fixed_elements[..self.prefix_len]
     }
@@ -1240,10 +1201,6 @@ impl<T, V> VariableLengthTuple<T, V> {
         self.prefix_elements().iter().copied()
     }
 
-    fn prefix_elements_mut(&mut self) -> &mut [T] {
-        &mut self.fixed_elements[..self.prefix_len]
-    }
-
     pub(crate) fn suffix_elements(&self) -> &[T] {
         &self.fixed_elements[self.prefix_len..]
     }
@@ -1253,10 +1210,6 @@ impl<T, V> VariableLengthTuple<T, V> {
         T: Copy,
     {
         self.suffix_elements().iter().copied()
-    }
-
-    fn suffix_elements_mut(&mut self) -> &mut [T] {
-        &mut self.fixed_elements[self.prefix_len..]
     }
 
     fn fixed_elements(&self) -> impl Iterator<Item = &T> + '_ {
@@ -2182,64 +2135,6 @@ impl<'db> VariableLengthTuple<Type<'db>, VariableSegment<'db>> {
             .skip_while(move |element| element.is_equivalent_to(db, env, variable))
     }
 
-    fn resize(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        new_length: TupleLength,
-    ) -> Result<TupleSpec<'db>, ResizeTupleError> {
-        match new_length {
-            TupleLength::Fixed(new_length) => {
-                // The number of elements that will get their value from our variable-length
-                // portion.
-                let Some(variable_count) = new_length.checked_sub(self.len().minimum()) else {
-                    return Err(ResizeTupleError::TooManyValues);
-                };
-                Ok(Tuple::Fixed(FixedLengthTuple::from_elements(
-                    (self.iter_prefix_elements())
-                        .chain(std::iter::repeat_n(
-                            self.variable().element_type(db),
-                            variable_count,
-                        ))
-                        .chain(self.iter_suffix_elements()),
-                )))
-            }
-
-            TupleLength::Variable(prefix_length, suffix_length) => {
-                // "Overflow" are elements of our prefix/suffix that will be folded into the
-                // result's variable-length portion. "Underflow" are elements of the result
-                // prefix/suffix that will come from our variable-length portion.
-                let self_prefix_length = self.prefix_elements().len();
-                let prefix_underflow = prefix_length.saturating_sub(self_prefix_length);
-                let self_suffix_length = self.suffix_elements().len();
-                let suffix_overflow = self_suffix_length.saturating_sub(suffix_length);
-                let suffix_underflow = suffix_length.saturating_sub(self_suffix_length);
-                // Compute the variable element first, since underflow positions can
-                // receive any element that could appear in the variable portion.
-                // For example, `tuple[I0, *tuple[I1, ...], I2]` unpacked as
-                // `[a, b, *c]` means `b` could be `I1` (variable non-empty) or
-                // `I2` (variable empty, suffix shifts left), so it should be `I1 | I2`.
-                let variable = UnionType::from_elements_leave_aliases(
-                    db,
-                    env,
-                    self.iter_prefix_elements()
-                        .skip(prefix_length)
-                        .chain(std::iter::once(self.variable().element_type(db)))
-                        .chain(self.iter_suffix_elements().take(suffix_overflow)),
-                );
-                let prefix = (self.iter_prefix_elements().take(prefix_length))
-                    .chain(std::iter::repeat_n(variable, prefix_underflow));
-                let suffix = std::iter::repeat_n(variable, suffix_underflow)
-                    .chain(self.iter_suffix_elements().skip(suffix_overflow));
-                Ok(VariableLengthTuple::mixed(
-                    prefix,
-                    VariableSegment::Homogeneous(variable),
-                    suffix,
-                ))
-            }
-        }
-    }
-
     fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
@@ -2440,6 +2335,113 @@ pub enum Tuple<T, V = T> {
 }
 
 impl<T, V> Tuple<T, V> {
+    /// Maps the variable segment without changing the fixed elements or their positions.
+    fn map_variable<W>(self, map: impl FnOnce(V) -> W) -> Tuple<T, W> {
+        match self {
+            Self::Fixed(fixed) => Tuple::Fixed(fixed),
+            Self::Variable(variable) => Tuple::Variable(VariableLengthTuple {
+                fixed_elements: variable.fixed_elements,
+                prefix_len: variable.prefix_len,
+                variable_segment: map(variable.variable_segment),
+            }),
+        }
+    }
+
+    /// Matches sequence elements to an unpacking target's shape.
+    ///
+    /// The returned variable segment contains all elements that may be collected by the starred
+    /// target. Keeping them separate lets callers retain source expressions and choose how to
+    /// infer the new list. `combine` is only needed when a fixed target has several possible
+    /// sources, as for `a, b, *rest = (1, *items, "last")`.
+    pub(crate) fn unpack(
+        &self,
+        length: TupleLength,
+        variable_elements: impl Fn(&V) -> Vec<T>,
+        combine: impl Fn(&[T]) -> T,
+    ) -> Result<Tuple<T, Vec<T>>, ResizeTupleError>
+    where
+        T: Clone,
+    {
+        match (self, length) {
+            (Self::Fixed(values), TupleLength::Fixed(length)) => match values.len().cmp(&length) {
+                Ordering::Less => Err(ResizeTupleError::TooFewValues),
+                Ordering::Greater => Err(ResizeTupleError::TooManyValues),
+                Ordering::Equal => Ok(Tuple::Fixed(values.clone())),
+            },
+            (Self::Fixed(values), TupleLength::Variable(prefix, suffix)) => {
+                // `first, *rest, last = [1]` cannot fill both fixed targets.
+                let Some(end) = values
+                    .len()
+                    .checked_sub(suffix)
+                    .filter(|end| *end >= prefix)
+                else {
+                    return Err(ResizeTupleError::TooFewValues);
+                };
+                Ok(VariableLengthTuple::mixed(
+                    values.0[..prefix].iter().cloned(),
+                    values.0[prefix..end].to_vec(),
+                    values.0[end..].iter().cloned(),
+                ))
+            }
+            (Self::Variable(values), TupleLength::Fixed(length)) => {
+                // In `a, b = (1, *items, 2, 3)`, even an empty `items` leaves too many values.
+                let Some(count) = length.checked_sub(values.len().minimum()) else {
+                    return Err(ResizeTupleError::TooManyValues);
+                };
+                let variable = combine(&variable_elements(&values.variable_segment));
+                Ok(Tuple::heterogeneous(
+                    values
+                        .prefix_elements()
+                        .iter()
+                        .cloned()
+                        .chain(std::iter::repeat_n(variable, count))
+                        .chain(values.suffix_elements().iter().cloned()),
+                ))
+            }
+            (Self::Variable(values), TupleLength::Variable(prefix, suffix)) => {
+                // Overflow elements join the capture; underflow targets receive a combination
+                // of the possible elements in the variable portion.
+                let prefix_underflow = prefix.saturating_sub(values.prefix_elements().len());
+                let suffix_overflow = values.suffix_elements().len().saturating_sub(suffix);
+                let suffix_underflow = suffix.saturating_sub(values.suffix_elements().len());
+                // An underflow position can receive an element from the variable portion or
+                // a fixed element that shifts across it when the variable portion is empty.
+                // For `a, b, *rest = (1, *items, "last")`, `b` can therefore be `"last"`.
+                let collected: Vec<_> = values
+                    .prefix_elements()
+                    .iter()
+                    .skip(prefix)
+                    .cloned()
+                    .chain(variable_elements(&values.variable_segment))
+                    .chain(
+                        values
+                            .suffix_elements()
+                            .iter()
+                            .take(suffix_overflow)
+                            .cloned(),
+                    )
+                    .collect();
+                let variable = combine(&collected);
+                Ok(VariableLengthTuple::mixed(
+                    values
+                        .prefix_elements()
+                        .iter()
+                        .take(prefix)
+                        .cloned()
+                        .chain(std::iter::repeat_n(variable.clone(), prefix_underflow)),
+                    collected,
+                    std::iter::repeat_n(variable, suffix_underflow).chain(
+                        values
+                            .suffix_elements()
+                            .iter()
+                            .skip(suffix_overflow)
+                            .cloned(),
+                    ),
+                ))
+            }
+        }
+    }
+
     /// Returns the inner fixed-length tuple if this is a `Tuple::Fixed` variant.
     pub(crate) fn as_fixed_length(&self) -> Option<&FixedLengthTuple<T>> {
         match self {
@@ -2464,7 +2466,7 @@ impl<T, V> Tuple<T, V> {
         }
     }
 
-    fn into_all_elements_with_kind(self) -> impl Iterator<Item = TupleElement<T, V>> {
+    pub(crate) fn into_all_elements_with_kind(self) -> impl Iterator<Item = TupleElement<T, V>> {
         match self {
             Tuple::Fixed(tuple) => {
                 Either::Left(tuple.owned_elements().into_iter().map(TupleElement::Fixed))
@@ -2579,10 +2581,19 @@ impl<'db> Tuple<Type<'db>, VariableSegment<'db>> {
         env: &ProgramEnvironment<'db>,
         new_length: TupleLength,
     ) -> Result<Self, ResizeTupleError> {
-        match self {
-            Tuple::Fixed(tuple) => tuple.resize(db, env, new_length),
-            Tuple::Variable(tuple) => tuple.resize(db, env, new_length),
-        }
+        Ok(self
+            .unpack(
+                new_length,
+                |segment| vec![segment.element_type(db)],
+                |elements| {
+                    UnionType::from_elements_leave_aliases(db, env, elements.iter().copied())
+                },
+            )?
+            .map_variable(|elements| {
+                VariableSegment::Homogeneous(UnionType::from_elements_leave_aliases(
+                    db, env, elements,
+                ))
+            }))
     }
 
     fn recursive_type_normalized_impl(
@@ -2845,124 +2856,11 @@ impl<'db> PyIndex<'db> for &TupleSpec<'db> {
     }
 }
 
-enum TupleElement<T, V = T> {
+pub(crate) enum TupleElement<T, V = T> {
     Fixed(T),
     Prefix(T),
     Variable(V),
     Suffix(T),
-}
-
-/// Unpacks tuple values in an unpacking assignment.
-///
-/// You provide a [`TupleLength`] specifying how many assignment targets there are, and which one
-/// (if any) is a starred target. You then call [`unpack_tuple`][TupleUnpacker::unpack_tuple] to
-/// unpack the values from a rhs tuple into those targets. If the rhs is a union, call
-/// `unpack_tuple` separately for each element of the union. We will automatically wrap the types
-/// assigned to the starred target in `list`.
-pub(crate) struct TupleUnpacker<'db> {
-    db: &'db dyn Db,
-    env: ProgramEnvironment<'db>,
-    targets: Tuple<UnionBuilder<'db>>,
-}
-
-impl<'db> TupleUnpacker<'db> {
-    pub(crate) fn new(db: &'db dyn Db, env: &ProgramEnvironment<'db>, len: TupleLength) -> Self {
-        let new_builders =
-            |len: usize| std::iter::repeat_with(|| UnionBuilder::new(db, env)).take(len);
-        let targets = match len {
-            TupleLength::Fixed(len) => {
-                Tuple::Fixed(FixedLengthTuple::from_elements(new_builders(len)))
-            }
-            TupleLength::Variable(prefix, suffix) => VariableLengthTuple::mixed(
-                new_builders(prefix),
-                UnionBuilder::new(db, env),
-                new_builders(suffix),
-            ),
-        };
-        Self {
-            db,
-            env: env.clone(),
-            targets,
-        }
-    }
-
-    /// Unpacks a single rhs tuple into the target tuple that we are building. If you want to
-    /// unpack a single type into each target, call this method with a homogeneous tuple.
-    ///
-    /// The lengths of the targets and the rhs have to be compatible, but not necessarily
-    /// identical. The lengths only have to be identical if both sides are fixed-length; if either
-    /// side is variable-length, we will pull multiple values out of the rhs variable-length
-    /// portion, and assign multiple values to the starred target, as needed.
-    pub(crate) fn unpack_tuple(&mut self, values: &TupleSpec<'db>) -> Result<(), ResizeTupleError> {
-        let db = self.db;
-        let values = values.resize(db, &self.env, self.targets.len())?;
-        match (&mut self.targets, &values) {
-            (Tuple::Fixed(targets), Tuple::Fixed(values)) => {
-                targets.unpack_tuple(values);
-            }
-            (Tuple::Variable(targets), Tuple::Variable(values)) => {
-                targets.unpack_tuple(db, &self.env, values);
-            }
-            _ => panic!("should have ensured that tuples are the same length"),
-        }
-        Ok(())
-    }
-
-    /// Returns the unpacked types for each target. If you called
-    /// [`unpack_tuple`][TupleUnpacker::unpack_tuple] multiple times, each target type will be the
-    /// union of the type unpacked into that target from each of the rhs tuples. If there is a
-    /// starred target, we will each unpacked type in `list`.
-    pub(crate) fn into_types(self) -> impl Iterator<Item = Type<'db>> {
-        let Self { db, env, targets } = self;
-        targets
-            .into_all_elements_with_kind()
-            .map(move |builder| match builder {
-                TupleElement::Variable(builder) => builder.try_build().unwrap_or_else(|| {
-                    KnownClass::List.to_specialized_instance(db, &env, &[Type::unknown()])
-                }),
-                TupleElement::Fixed(builder)
-                | TupleElement::Prefix(builder)
-                | TupleElement::Suffix(builder) => {
-                    builder.try_build().unwrap_or_else(Type::unknown)
-                }
-            })
-    }
-}
-
-impl<'db> FixedLengthTuple<UnionBuilder<'db>> {
-    fn unpack_tuple(&mut self, values: &FixedLengthTuple<Type<'db>>) {
-        // We have already verified above that the two tuples have the same length.
-        for (target, value) in self.0.iter_mut().zip(values.iter_all_elements()) {
-            target.add_in_place(value);
-        }
-    }
-}
-
-impl<'db> VariableLengthTuple<UnionBuilder<'db>> {
-    fn unpack_tuple(
-        &mut self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        values: &VariableLengthTuple<Type<'db>, VariableSegment<'db>>,
-    ) {
-        // We have already verified above that the two tuples have the same length.
-        for (target, value) in
-            (self.prefix_elements_mut().iter_mut()).zip(values.iter_prefix_elements())
-        {
-            target.add_in_place(value);
-        }
-        self.variable_element_mut()
-            .add_in_place(KnownClass::List.to_specialized_instance(
-                db,
-                env,
-                &[values.variable().element_type(db)],
-            ));
-        for (target, value) in
-            (self.suffix_elements_mut().iter_mut()).zip(values.iter_suffix_elements())
-        {
-            target.add_in_place(value);
-        }
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2971,29 +2869,90 @@ pub(crate) enum ResizeTupleError {
     TooManyValues,
 }
 
-/// A builder for creating a new [`TupleSpec`]
+/// A builder for a fixed or variable-length sequence.
 #[derive(Clone)]
-pub(crate) enum TupleSpecBuilder<'db> {
-    Fixed(Vec<Type<'db>>),
+pub(crate) enum TupleBuilder<T, V = T> {
+    Fixed(Vec<T>),
     Variable {
-        prefix: Vec<Type<'db>>,
-        segment: VariableSegment<'db>,
-        suffix: Vec<Type<'db>>,
+        prefix: Vec<T>,
+        segment: V,
+        suffix: Vec<T>,
     },
 }
 
-impl<'db> TupleSpecBuilder<'db> {
+pub(crate) type TupleSpecBuilder<'db> = TupleBuilder<Type<'db>, VariableSegment<'db>>;
+
+impl<T, V> TupleBuilder<T, V> {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
-        TupleSpecBuilder::Fixed(Vec::with_capacity(capacity))
+        Self::Fixed(Vec::with_capacity(capacity))
     }
 
-    pub(crate) fn push(&mut self, element: Type<'db>) {
+    pub(crate) fn push(&mut self, element: T) {
         match self {
-            TupleSpecBuilder::Fixed(elements) => elements.push(element),
-            TupleSpecBuilder::Variable { suffix, .. } => suffix.push(element),
+            Self::Fixed(elements) => elements.push(element),
+            Self::Variable { suffix, .. } => suffix.push(element),
         }
     }
 
+    /// Concatenates sequences, combining their middle portions only when both have unknown length.
+    pub(crate) fn concat_with(
+        mut self,
+        other: &Tuple<T, V>,
+        merge: impl FnOnce(&[T], &mut V, &V, &[T]),
+    ) -> Self
+    where
+        T: Clone,
+        V: Clone,
+    {
+        match (&mut self, other) {
+            (Self::Fixed(left), Tuple::Fixed(right)) => {
+                left.extend_from_slice(right.elements_slice());
+                self
+            }
+            (Self::Fixed(left), Tuple::Variable(right)) => {
+                left.extend_from_slice(right.prefix_elements());
+                Self::Variable {
+                    prefix: std::mem::take(left),
+                    segment: right.variable_segment.clone(),
+                    suffix: right.suffix_elements().to_vec(),
+                }
+            }
+            (Self::Variable { suffix, .. }, Tuple::Fixed(right)) => {
+                suffix.extend_from_slice(right.elements_slice());
+                self
+            }
+            (
+                Self::Variable {
+                    segment, suffix, ..
+                },
+                Tuple::Variable(right),
+            ) => {
+                merge(
+                    suffix,
+                    segment,
+                    &right.variable_segment,
+                    right.prefix_elements(),
+                );
+                suffix.clear();
+                suffix.extend_from_slice(right.suffix_elements());
+                self
+            }
+        }
+    }
+
+    pub(super) fn build(self) -> Tuple<T, V> {
+        match self {
+            Self::Fixed(elements) => Tuple::Fixed(FixedLengthTuple(elements.into_boxed_slice())),
+            Self::Variable {
+                prefix,
+                segment,
+                suffix,
+            } => Tuple::Variable(VariableLengthTuple::new_from_vec(prefix, segment, suffix)),
+        }
+    }
+}
+
+impl<'db> TupleSpecBuilder<'db> {
     /// Concatenates an unpacked `TypeVarTuple` as the variable-length portion of this tuple.
     pub(crate) fn concat_variadic_typevar(
         self,
@@ -3008,63 +2967,22 @@ impl<'db> TupleSpecBuilder<'db> {
 
     /// Concatenates another tuple to the end of this tuple, returning a new tuple.
     pub(crate) fn concat(
-        mut self,
+        self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         other: &TupleSpec<'db>,
     ) -> Self {
-        match (&mut self, other) {
-            (TupleSpecBuilder::Fixed(left_tuple), TupleSpec::Fixed(right_tuple)) => {
-                left_tuple.extend_from_slice(&right_tuple.0);
-                self
-            }
-
-            (TupleSpecBuilder::Fixed(left_tuple), TupleSpec::Variable(variable_tuple)) => {
-                left_tuple.extend_from_slice(variable_tuple.prefix_elements());
-                TupleSpecBuilder::Variable {
-                    prefix: std::mem::take(left_tuple),
-                    segment: variable_tuple.variable(),
-                    suffix: variable_tuple.suffix_elements().to_vec(),
-                }
-            }
-
-            (
-                TupleSpecBuilder::Variable {
-                    prefix: _,
-                    segment: _,
-                    suffix,
-                },
-                TupleSpec::Fixed(right),
-            ) => {
-                suffix.extend_from_slice(&right.0);
-                self
-            }
-
-            (
-                TupleSpecBuilder::Variable {
-                    prefix: left_prefix,
-                    segment: left_segment,
-                    suffix: left_suffix,
-                },
-                TupleSpec::Variable(right),
-            ) => {
-                let variable = UnionType::from_elements_leave_aliases(
-                    db,
-                    env,
-                    left_suffix
-                        .iter()
-                        .copied()
-                        .chain(std::iter::once(left_segment.element_type(db)))
-                        .chain(std::iter::once(right.variable().element_type(db)))
-                        .chain(right.iter_prefix_elements()),
-                );
-                TupleSpecBuilder::Variable {
-                    prefix: std::mem::take(left_prefix),
-                    segment: VariableSegment::Homogeneous(variable),
-                    suffix: right.suffix_elements().to_vec(),
-                }
-            }
-        }
+        self.concat_with(other, |suffix, left, right, prefix| {
+            *left = VariableSegment::Homogeneous(UnionType::from_elements_leave_aliases(
+                db,
+                env,
+                suffix
+                    .iter()
+                    .copied()
+                    .chain([left.element_type(db), right.element_type(db)])
+                    .chain(prefix.iter().copied()),
+            ));
+        })
     }
 
     fn iter_element_types(&self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> + '_ {
@@ -3162,7 +3080,7 @@ impl<'db> TupleSpecBuilder<'db> {
             // Fixed-length tuples with different lengths cannot intersect.
             (TupleSpecBuilder::Fixed(_), TupleSpec::Fixed(_)) => None,
 
-            (TupleSpecBuilder::Fixed(our_elements), TupleSpec::Variable(var)) => var
+            (TupleSpecBuilder::Fixed(our_elements), TupleSpec::Variable(_)) => other
                 .resize(db, env, TupleLength::Fixed(our_elements.len()))
                 .ok()
                 .and_then(|tuple| self.intersect(db, env, &tuple)),
@@ -3210,7 +3128,8 @@ impl<'db> TupleSpecBuilder<'db> {
 
                 let self_built = self.clone().build();
                 let self_len = self_built.len();
-                var.resize(db, env, self_len)
+                other
+                    .resize(db, env, self_len)
                     .ok()
                     .and_then(|resized| self.intersect(db, env, &resized))
                     .or_else(|| {
@@ -3222,19 +3141,6 @@ impl<'db> TupleSpecBuilder<'db> {
                             })
                     })
             }
-        }
-    }
-
-    pub(super) fn build(self) -> TupleSpec<'db> {
-        match self {
-            TupleSpecBuilder::Fixed(elements) => {
-                TupleSpec::Fixed(FixedLengthTuple(elements.into_boxed_slice()))
-            }
-            TupleSpecBuilder::Variable {
-                prefix,
-                segment,
-                suffix,
-            } => TupleSpec::Variable(VariableLengthTuple::new_from_vec(prefix, segment, suffix)),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -30,8 +30,8 @@ impl<'db> TupleSizePromotionConstraints<'db> {
         expression: &ast::Expr,
         ty: Type<'db>,
     ) {
-        if !Self::is_promotable_tuple_literal(db, env, expression, ty) {
-            self.record_unpromotable_type(db, env, typevar_identity, ty);
+        if !Self::allows_expression(db, env, expression, ty) {
+            self.blocked_typevars.insert(typevar_identity);
         }
     }
 
@@ -55,6 +55,27 @@ impl<'db> TupleSizePromotionConstraints<'db> {
     /// of the constraints recorded on this object.
     pub(crate) fn allow(&self, typevar_identity: BoundTypeVarIdentity<'db>) -> bool {
         !self.blocked_typevars.contains(&typevar_identity)
+    }
+
+    /// Reports whether an inferred collection element allows tuple size promotion. Tuple types
+    /// from annotations or nonliteral expressions keep their shape.
+    ///
+    /// For `items = [(1,), (2, 3)]`, both tuple literals are eligible, so their differing lengths
+    /// may be widened to `tuple[int, ...]`. With `pair = (2, 3)` followed by
+    /// `items = [(1,), pair]`, the nonliteral `pair` blocks promotion for the collection.
+    ///
+    /// The supplied `ty` should already have undergone literal promotion, so `(2, 3)` has the
+    /// homogeneous type `tuple[int, int]` when checking its eligibility.
+    pub(crate) fn allows_expression(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        expression: &ast::Expr,
+        ty: Type<'db>,
+    ) -> bool {
+        Self::is_promotable_tuple_literal(db, env, expression, ty)
+            || !any_over_type(db, env, ty, true, |ty| {
+                ty.tuple_instance_spec(db, env).is_some()
+            })
     }
 
     /// Returns true if the given expression is either a non-starred homogeneous tuple literal or the

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -44,9 +44,7 @@ impl<'db> TupleSizePromotionConstraints<'db> {
         typevar_identity: BoundTypeVarIdentity<'db>,
         ty: Type<'db>,
     ) {
-        if any_over_type(db, env, ty, true, |ty| {
-            ty.tuple_instance_spec(db, env).is_some()
-        }) {
+        if !Self::allows_expression(db, env, None, ty) {
             self.blocked_typevars.insert(typevar_identity);
         }
     }

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -30,7 +30,7 @@ impl<'db> TupleSizePromotionConstraints<'db> {
         expression: &ast::Expr,
         ty: Type<'db>,
     ) {
-        if !Self::allows_expression(db, env, expression, ty) {
+        if !Self::allows_expression(db, env, Some(expression), ty) {
             self.blocked_typevars.insert(typevar_identity);
         }
     }
@@ -66,13 +66,15 @@ impl<'db> TupleSizePromotionConstraints<'db> {
     ///
     /// The supplied `ty` should already have undergone literal promotion, so `(2, 3)` has the
     /// homogeneous type `tuple[int, int]` when checking its eligibility.
+    /// If no source expression is available, any tuple type blocks tuple-size promotion.
     pub(crate) fn allows_expression(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        expression: &ast::Expr,
+        expression: Option<&ast::Expr>,
         ty: Type<'db>,
     ) -> bool {
-        Self::is_promotable_tuple_literal(db, env, expression, ty)
+        expression
+            .is_some_and(|expression| Self::is_promotable_tuple_literal(db, env, expression, ty))
             || !any_over_type(db, env, ty, true, |ty| {
                 ty.tuple_instance_spec(db, env).is_some()
             })

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -12,8 +12,11 @@ use ruff_text_size::Ranged;
 
 use crate::Db;
 use crate::types::infer::{ExpressionInference, FrozenMap};
+use crate::types::tuple::promotion::TupleSizePromotionConstraints;
 use crate::types::tuple::{ResizeTupleError, TupleLength, TupleSpec, TupleUnpacker};
-use crate::types::{Type, TypeCheckDiagnostics, TypeContext, infer_expression_types};
+use crate::types::{
+    KnownClass, Type, TypeCheckDiagnostics, TypeContext, UnionBuilder, infer_expression_types,
+};
 use ty_python_core::ExpressionNodeKey;
 use ty_python_core::ProgramFile;
 use ty_python_core::scope::ScopeId;
@@ -133,9 +136,9 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
         self.unpack_inner(target, value_expr.into(), value_type);
     }
 
-    /// In regular tuple assignments like `a, b = 1, 2` {or even `a, (b, c) = 1, (2, 3)`}, map each
-    /// expression on the left individually to the corresponding element type on the right, rather
-    /// than trying to walk the tuple type of the entire RHS.
+    /// In assignments from tuple or list literals, map each target to the corresponding element
+    /// types on the right, including the elements collected by a starred target. This preserves
+    /// element positions in list literals, whose inferred type combines all element types.
     ///
     /// We avoid infinitely growing types in cycle resolution by preserving only the
     /// topmost/outermost part of types that have `Divergent` components. For example, if the
@@ -166,15 +169,12 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
             }
             ast::Expr::List(ast::ExprList { elts, .. })
             | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-                let Some(values) = fixed_sequence_elements(value_expr, elts.len()) else {
+                let Some(values) = sequence_elts(value_expr) else {
+                    // `first, *rest = items` has no literal elements to match against the
+                    // targets. Unpack the inferred type of `items` instead.
                     return false;
                 };
-
-                if elts.iter().any(ast::Expr::is_starred_expr) {
-                    return false;
-                }
-
-                self.unpack_fixed_sequence_from_inference(elts, values, value_inference)
+                self.unpack_fixed_sequence_from_inference(elts, values, value_expr, value_inference)
             }
             _ => false,
         }
@@ -184,16 +184,106 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
         &mut self,
         targets: &[ast::Expr],
         values: &[ast::Expr],
+        value_expr: &ast::Expr,
         value_inference: &ExpressionInference<'db>,
     ) -> bool {
-        // Even `a, b = 1, 2` recurses through this helper. `.all()` short-circuits,
-        // so in nested cases an earlier element may update `self.targets` before a
-        // later element falls back to the general unpacking path. That's harmless
-        // because the fallback recomputes the full unpacking and overwrites any
-        // partial entries.
-        targets.iter().zip(values).all(|(target, value_expr)| {
-            self.unpack_assignment_sequence_from_inference(target, value_expr, value_inference)
-        })
+        // For `first, *rest = [*items, "last"]`, `*items` can contribute zero or more
+        // elements, so AST positions alone cannot tell us which value is assigned to
+        // `first`. Fall back to unpacking the inferred sequence type.
+        if values.iter().any(ast::Expr::is_starred_expr) {
+            return false;
+        }
+
+        if let Some((starred_index, starred)) = targets
+            .iter()
+            .enumerate()
+            .find_map(|(index, target)| target.as_starred_expr().map(|starred| (index, starred)))
+        {
+            // `first, *rest = (1, 2, 3)` uses the inferred tuple type, which already retains
+            // element positions and the promotion applied during tuple inference. Only list
+            // literals need this path for starred targets.
+            if !value_expr.is_list_expr() {
+                return false;
+            }
+
+            let prefix_targets = &targets[..starred_index];
+            let suffix_targets = &targets[starred_index + 1..];
+
+            // `first, *rest, last = [1]` cannot fill both fixed targets. Recovered invalid
+            // syntax such as `first, *left, *right = [1, 2, 3]` has no unique starred target
+            // to collect the remaining values. Leave both cases to the general unpacker.
+            if values.len() < prefix_targets.len() + suffix_targets.len()
+                || suffix_targets.iter().any(ast::Expr::is_starred_expr)
+            {
+                return false;
+            }
+
+            let (prefix_values, remaining_values) = values.split_at(prefix_targets.len());
+            let (starred_values, suffix_values) =
+                remaining_values.split_at(remaining_values.len() - suffix_targets.len());
+            let db = self.db();
+            let env = self.context.program_environment();
+            // Preserve the promotion applied by list-literal inference, but restrict the element
+            // type to the values collected by this target.
+            let mut element_types = UnionBuilder::new(db, env).unpack_aliases(false);
+            let mut allow_tuple_size_promotion = true;
+            for value in starred_values {
+                let value_type = value_inference.expression_type(value).promote(db, env);
+                allow_tuple_size_promotion = allow_tuple_size_promotion
+                    && TupleSizePromotionConstraints::allows_expression(db, env, value, value_type);
+                element_types.add_in_place(value_type);
+            }
+            let element_type = if starred_values.is_empty() {
+                // `first, *rest = [1]` creates an empty list. As with `rest = []`, no captured
+                // value constrains its element type.
+                Type::unknown()
+            } else {
+                element_types.build()
+            };
+            let element_type = if allow_tuple_size_promotion {
+                element_type.promote_tuple_size_in_union(db, env)
+            } else {
+                element_type
+            };
+            let element_type = element_type.promote_singletons_recursively(db, env);
+            let list_type = KnownClass::List.to_specialized_instance(db, env, &[element_type]);
+            self.unpack_inner(&starred.value, value_expr.into(), list_type);
+
+            // `first, *rest, last = [1, 2, 3, 4]` is valid despite the different lengths.
+            // Once `rest` is handled, only the matching prefix and suffix remain.
+            return self.unpack_fixed_sequence_from_inference(
+                prefix_targets,
+                prefix_values,
+                value_expr,
+                value_inference,
+            ) && self.unpack_fixed_sequence_from_inference(
+                suffix_targets,
+                suffix_values,
+                value_expr,
+                value_inference,
+            );
+        }
+
+        // Without a starred target, `a, b = (1,)` and `a, b = (1, 2, 3)` cannot pair every
+        // target with exactly one value. Fall back to unpacking the inferred sequence type.
+        if targets.len() != values.len() {
+            return false;
+        }
+
+        for (target, value_expr) in targets.iter().zip(values) {
+            if !self.unpack_assignment_sequence_from_inference(target, value_expr, value_inference)
+            {
+                // In `(first, *rest), (other,) = ([1, "two"], items)`, the second element
+                // needs type-based unpacking. Fall back only for that element, preserving
+                // the precise mapping of `first` and `rest` from the nested list literal.
+                self.unpack_inner(
+                    target,
+                    value_expr.into(),
+                    value_inference.expression_type(value_expr),
+                );
+            }
+        }
+        true
     }
 
     /// Records `Unknown` for a malformed unpack target and all of its descendant expressions.

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -14,8 +14,8 @@ use crate::Db;
 use crate::types::infer::{ExpressionInference, FrozenMap};
 use crate::types::tuple::promotion::TupleSizePromotionConstraints;
 use crate::types::tuple::{
-    MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE, ResizeTupleError, Tuple, TupleBuilder,
-    TupleElement, TupleLength, TupleSpec,
+    ResizeTupleError, Tuple, TupleBuilder, TupleElement, TupleLength, TupleSpec,
+    VariableLengthTuple,
 };
 use crate::types::{
     KnownClass, Type, TypeCheckDiagnostics, TypeContext, UnionBuilder, UnionType,
@@ -503,12 +503,7 @@ fn assignment_values_for_target<'ast>(
             if let Some(length) = known_length {
                 Tuple::heterogeneous(std::iter::repeat_n(None, length))
             } else {
-                TupleBuilder::Variable {
-                    prefix: vec![],
-                    segment: vec![None],
-                    suffix: vec![],
-                }
-                .build()
+                VariableLengthTuple::mixed([], vec![None], [])
             }
         },
     )?;
@@ -575,18 +570,11 @@ fn sequence_from_type<'db, 'ast>(
         Tuple::Fixed(values) => {
             Tuple::heterogeneous(values.iter_all_elements().map(UnpackElement::from_type))
         }
-        Tuple::Variable(values) => TupleBuilder::Variable {
-            prefix: values
-                .iter_prefix_elements()
-                .map(UnpackElement::from_type)
-                .collect(),
-            segment: vec![UnpackElement::from_type(values.variable().element_type(db))],
-            suffix: values
-                .iter_suffix_elements()
-                .map(UnpackElement::from_type)
-                .collect(),
-        }
-        .build(),
+        Tuple::Variable(values) => VariableLengthTuple::mixed(
+            values.iter_prefix_elements().map(UnpackElement::from_type),
+            vec![UnpackElement::from_type(values.variable().element_type(db))],
+            values.iter_suffix_elements().map(UnpackElement::from_type),
+        ),
     }
 }
 
@@ -658,6 +646,9 @@ fn literal_sequence_elements(
 /// Other starred iterables count as one item because their elements are not recovered from
 /// literal syntax. Stop counting as soon as the limit is exceeded.
 pub(super) fn tuple_literal_needs_promotion(values: &[ast::Expr]) -> bool {
+    /// Limit literal precision in large tuple expressions to avoid pathological inference costs.
+    const MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE: usize = 64;
+
     fn remaining_budget(values: &[ast::Expr], remaining: usize) -> Option<usize> {
         values.iter().try_fold(remaining, |remaining, value| {
             if let ast::Expr::Starred(starred) = value
@@ -701,12 +692,10 @@ pub(super) fn sequence_from_literal_elements<'ast, T, V>(
 }
 
 /// The literal element count used when inferring expansions such as `(*{"key": 1},)`.
-/// An expansion within the literal, as in `[*items]` or `{**items}`, makes that count unknown.
+/// An expansion within a set or dictionary, as in `{*items}` or `{**items}`, makes that count unknown.
 fn literal_iterable_length(expression: &ast::Expr) -> Option<usize> {
     match expression {
-        ast::Expr::List(ast::ExprList { elts, .. })
-        | ast::Expr::Tuple(ast::ExprTuple { elts, .. })
-        | ast::Expr::Set(ast::ExprSet { elts, .. }) => elts
+        ast::Expr::Set(ast::ExprSet { elts, .. }) => elts
             .iter()
             .all(|element| !element.is_starred_expr())
             .then_some(elts.len()),

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -203,7 +203,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
             literal_sequence(
                 expression,
                 value.promote_literals,
-                &mut |expression, promote| {
+                &|expression, promote| {
                     let ty = value_inference.expression_type(expression);
                     UnpackElement {
                         ty: if promote { ty.promote(db, env) } else { ty },
@@ -211,7 +211,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                         promote_literals: promote,
                     }
                 },
-                &mut |expression, promote, known_length| {
+                &|expression, promote, known_length| {
                     // The starred expression's inference has already reported iteration errors.
                     // For `a, *rest = [1, *items]`, retain the shape of `items`' iterator even
                     // though the enclosing list's type has erased positions and length.
@@ -498,8 +498,8 @@ fn assignment_values_for_target<'ast>(
     let values = literal_sequence(
         value,
         false,
-        &mut |expression, _| Some(expression),
-        &mut |_, _, known_length| {
+        &|expression, _| Some(expression),
+        &|_, _, known_length| {
             if let Some(length) = known_length {
                 Tuple::heterogeneous(std::iter::repeat_n(None, length))
             } else {
@@ -621,39 +621,88 @@ pub(super) fn collected_list_type<'db, 'ast>(
 /// recursively; other starred expressions contribute the shape supplied by the caller. For
 /// `first, *rest, last = [1, *items, 2]`, the unknown width of `items` leaves both ends intact.
 fn literal_sequence<'ast, T: Clone>(
-    mut expression: &'ast ast::Expr,
+    expression: &'ast ast::Expr,
     promote: bool,
-    element: &mut impl FnMut(&'ast ast::Expr, bool) -> T,
-    spread: &mut impl FnMut(&'ast ast::Expr, bool, Option<usize>) -> Tuple<T, Vec<T>>,
+    element: &impl Fn(&'ast ast::Expr, bool) -> T,
+    spread: &impl Fn(&'ast ast::Expr, bool, Option<usize>) -> Tuple<T, Vec<T>>,
 ) -> Option<Tuple<T, Vec<T>>> {
-    // `a, *rest = (items := [1, "two"])` has the same elements as the list itself.
-    while let ast::Expr::Named(named) = expression {
-        expression = &named.value;
-    }
-    let values = sequence_elts(expression)?;
-    let promote = promote
-        || (expression.is_tuple_expr()
-            && values.len() > MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE);
-    let mut builder = TupleBuilder::with_capacity(values.len());
-    for value in values {
-        if let ast::Expr::Starred(starred) = value {
-            let unpacked = literal_sequence(&starred.value, promote, element, spread)
-                .unwrap_or_else(|| spread(value, promote, literal_iterable_length(&starred.value)));
-            builder = builder.concat_with(&unpacked, |suffix, left, right, prefix| {
+    let (values, promote) = literal_sequence_elements(expression, promote)?;
+    Some(sequence_from_literal_elements(
+        values,
+        promote,
+        element,
+        spread,
+        &|builder, unpacked| {
+            builder.concat_with(unpacked, |suffix, left, right, prefix| {
                 // For `[*a, *b, *c, ...]`, retain the accumulated elements instead of copying
                 // them again for every expansion. Positions within this segment are unknown.
                 left.extend(suffix.iter().chain(prefix).chain(right).cloned());
-            });
+            })
+        },
+    ))
+}
+
+fn literal_sequence_elements(
+    expression: &ast::Expr,
+    promote: bool,
+) -> Option<(&[ast::Expr], bool)> {
+    // `a, *rest = (items := [1, "two"])` has the same elements as the list itself.
+    let expression = expression.expression_value();
+    let values = sequence_elts(expression)?;
+    let promote = promote || (expression.is_tuple_expr() && tuple_literal_needs_promotion(values));
+    Some((values, promote))
+}
+
+/// Applies the tuple precision limit after expanding literal elements. For `(*[1, 2], 3)`,
+/// all three positions count, even though the outer tuple has only two AST elements.
+/// Other starred iterables count as one item because their elements are not recovered from
+/// literal syntax. Stop counting as soon as the limit is exceeded.
+pub(super) fn tuple_literal_needs_promotion(values: &[ast::Expr]) -> bool {
+    fn remaining_budget(values: &[ast::Expr], remaining: usize) -> Option<usize> {
+        values.iter().try_fold(remaining, |remaining, value| {
+            if let ast::Expr::Starred(starred) = value
+                && let Some(values) = sequence_elts(starred.value.expression_value())
+            {
+                remaining_budget(values, remaining)
+            } else {
+                remaining.checked_sub(1)
+            }
+        })
+    }
+
+    remaining_budget(values, MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE).is_none()
+}
+
+/// Builds a literal's sequence shape from already-inferred elements and iterable shapes.
+/// In `source = (*[1, "two"],)`, expanding the list syntax preserves both tuple positions.
+/// The caller chooses the variable-segment representation and how to concatenate it: tuple
+/// inference retains symbolic `TypeVarTuple` segments, while unpacking retains source expressions.
+pub(super) fn sequence_from_literal_elements<'ast, T, V>(
+    values: &'ast [ast::Expr],
+    promote: bool,
+    element: &impl Fn(&'ast ast::Expr, bool) -> T,
+    spread: &impl Fn(&'ast ast::Expr, bool, Option<usize>) -> Tuple<T, V>,
+    concat: &impl Fn(TupleBuilder<T, V>, &Tuple<T, V>) -> TupleBuilder<T, V>,
+) -> Tuple<T, V> {
+    let mut builder = TupleBuilder::with_capacity(values.len());
+    for value in values {
+        if let ast::Expr::Starred(starred) = value {
+            let unpacked = literal_sequence_elements(&starred.value, promote)
+                .map(|(values, promote)| {
+                    sequence_from_literal_elements(values, promote, element, spread, concat)
+                })
+                .unwrap_or_else(|| spread(value, promote, literal_iterable_length(&starred.value)));
+            builder = concat(builder, &unpacked);
         } else {
             builder.push(element(value, promote));
         }
     }
-    Some(builder.build())
+    builder.build()
 }
 
 /// The literal element count used when inferring expansions such as `(*{"key": 1},)`.
 /// An expansion within the literal, as in `[*items]` or `{**items}`, makes that count unknown.
-pub(super) fn literal_iterable_length(expression: &ast::Expr) -> Option<usize> {
+fn literal_iterable_length(expression: &ast::Expr) -> Option<usize> {
     match expression {
         ast::Expr::List(ast::ExprList { elts, .. })
         | ast::Expr::Tuple(ast::ExprTuple { elts, .. })

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -13,9 +13,13 @@ use ruff_text_size::Ranged;
 use crate::Db;
 use crate::types::infer::{ExpressionInference, FrozenMap};
 use crate::types::tuple::promotion::TupleSizePromotionConstraints;
-use crate::types::tuple::{ResizeTupleError, TupleLength, TupleSpec, TupleUnpacker};
+use crate::types::tuple::{
+    MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE, ResizeTupleError, Tuple, TupleBuilder,
+    TupleElement, TupleLength, TupleSpec,
+};
 use crate::types::{
-    KnownClass, Type, TypeCheckDiagnostics, TypeContext, UnionBuilder, infer_expression_types,
+    KnownClass, Type, TypeCheckDiagnostics, TypeContext, UnionBuilder, UnionType,
+    infer_expression_types,
 };
 use ty_python_core::ExpressionNodeKey;
 use ty_python_core::ProgramFile;
@@ -88,12 +92,6 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
         );
         let value_expr = value.expression().node_ref(self.db()).node(self.module());
 
-        if matches!(value.kind(), UnpackKind::Assign)
-            && self.unpack_assignment_sequence_from_inference(target, value_expr, value_inference)
-        {
-            return;
-        }
-
         let value_type = value_inference.expression_type(value_expr);
 
         let value_type = match value.kind() {
@@ -133,7 +131,24 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
             }
         };
 
-        self.unpack_inner(target, value_expr.into(), value_type);
+        self.unpack_inner(
+            target,
+            value_expr.into(),
+            UnpackElement {
+                ty: value_type,
+                expression: matches!(value.kind(), UnpackKind::Assign).then_some(value_expr),
+                promote_literals: false,
+            },
+            value_inference,
+        );
+    }
+
+    /// Records `Unknown` for a malformed unpack target and all of its descendant expressions.
+    fn record_unknown_target_subtree(&mut self, target: &ast::Expr) {
+        UnknownTargetCollector {
+            targets: &mut self.targets,
+        }
+        .visit_expr(target);
     }
 
     /// In assignments from tuple or list literals, map each target to the corresponding element
@@ -155,230 +170,179 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
     /// This function avoids that problem by walking the AST on the RHS and looking directly at the
     /// individual element types. That gives us one more level of structure for those types, which
     /// is enough to resolve a lot of common cycles.
-    fn unpack_assignment_sequence_from_inference(
-        &mut self,
-        target: &ast::Expr,
-        value_expr: &ast::Expr,
-        value_inference: &ExpressionInference<'db>,
-    ) -> bool {
-        let targets = match target {
-            ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
-                self.targets
-                    .insert(target.into(), value_inference.expression_type(value_expr));
-                return true;
-            }
-            ast::Expr::List(ast::ExprList { elts, .. })
-            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => elts,
-            _ => return false,
-        };
-
-        let Some(values) = sequence_elts(value_expr) else {
-            // `first, *rest = items` has no literal elements to match against the
-            // targets. Unpack the inferred type of `items` instead.
-            return false;
-        };
-
-        // For `first, *rest = [*items, "last"]`, `*items` can contribute zero or more
-        // elements, so AST positions alone cannot tell us which value is assigned to
-        // `first`. Fall back to unpacking the inferred sequence type.
-        if values.iter().any(ast::Expr::is_starred_expr) {
-            return false;
-        }
-
-        if let Some((starred_index, starred)) = targets
-            .iter()
-            .enumerate()
-            .find_map(|(index, target)| target.as_starred_expr().map(|starred| (index, starred)))
-        {
-            // `first, *rest = (1, 2, 3)` uses the inferred tuple type, which already retains
-            // element positions and the promotion applied during tuple inference. Only list
-            // literals need this path for starred targets.
-            if !value_expr.is_list_expr() {
-                return false;
-            }
-
-            let prefix_targets = &targets[..starred_index];
-            let suffix_targets = &targets[starred_index + 1..];
-
-            // `first, *rest, last = [1]` cannot fill both fixed targets. Recovered invalid
-            // syntax such as `first, *left, *right = [1, 2, 3]` has no unique starred target
-            // to collect the remaining values. Leave both cases to the general unpacker.
-            if values.len() < prefix_targets.len() + suffix_targets.len()
-                || suffix_targets.iter().any(ast::Expr::is_starred_expr)
-            {
-                return false;
-            }
-
-            let (prefix_values, remaining_values) = values.split_at(prefix_targets.len());
-            let (starred_values, suffix_values) =
-                remaining_values.split_at(remaining_values.len() - suffix_targets.len());
-            let db = self.db();
-            let env = self.context.program_environment();
-            // Preserve the promotion applied by list-literal inference, but restrict the element
-            // type to the values collected by this target.
-            let mut element_types = UnionBuilder::new(db, env).unpack_aliases(false);
-            let mut allow_tuple_size_promotion = true;
-            for value in starred_values {
-                let value_type = value_inference.expression_type(value).promote(db, env);
-                allow_tuple_size_promotion = allow_tuple_size_promotion
-                    && TupleSizePromotionConstraints::allows_expression(db, env, value, value_type);
-                element_types.add_in_place(value_type);
-            }
-            let element_type = if starred_values.is_empty() {
-                // `first, *rest = [1]` creates an empty list. As with `rest = []`, no captured
-                // value constrains its element type.
-                Type::unknown()
-            } else {
-                element_types.build()
-            };
-            let element_type = if allow_tuple_size_promotion {
-                element_type.promote_tuple_size_in_union(db, env)
-            } else {
-                element_type
-            };
-            let element_type = element_type.promote_singletons_recursively(db, env);
-            let list_type = KnownClass::List.to_specialized_instance(db, env, &[element_type]);
-            self.unpack_inner(&starred.value, value_expr.into(), list_type);
-
-            // `first, *rest, last = [1, 2, 3, 4]` is valid despite the different lengths.
-            // Once `rest` is handled, only the matching prefix and suffix remain.
-            for (targets, values) in [
-                (prefix_targets, prefix_values),
-                (suffix_targets, suffix_values),
-            ] {
-                self.unpack_fixed_sequence_from_inference(targets, values, value_inference);
-            }
-            return true;
-        }
-
-        // Without a starred target, `a, b = (1,)` and `a, b = (1, 2, 3)` cannot pair every
-        // target with exactly one value. Fall back to unpacking the inferred sequence type.
-        if targets.len() != values.len() {
-            return false;
-        }
-
-        self.unpack_fixed_sequence_from_inference(targets, values, value_inference);
-        true
-    }
-
-    fn unpack_fixed_sequence_from_inference(
-        &mut self,
-        targets: &[ast::Expr],
-        values: &[ast::Expr],
-        value_inference: &ExpressionInference<'db>,
-    ) {
-        debug_assert_eq!(targets.len(), values.len());
-
-        for (target, value_expr) in targets.iter().zip(values) {
-            if !self.unpack_assignment_sequence_from_inference(target, value_expr, value_inference)
-            {
-                // In `(first, *rest), (other,) = ([1, "two"], items)`, the second element
-                // needs type-based unpacking. Fall back only for that element, preserving
-                // the precise mapping of `first` and `rest` from the nested list literal.
-                self.unpack_inner(
-                    target,
-                    value_expr.into(),
-                    value_inference.expression_type(value_expr),
-                );
-            }
-        }
-    }
-
-    /// Records `Unknown` for a malformed unpack target and all of its descendant expressions.
-    fn record_unknown_target_subtree(&mut self, target: &ast::Expr) {
-        UnknownTargetCollector {
-            targets: &mut self.targets,
-        }
-        .visit_expr(target);
-    }
-
     fn unpack_inner(
         &mut self,
         target: &ast::Expr,
         value_expr: AnyNodeRef<'_>,
-        value_ty: Type<'db>,
+        value: UnpackElement<'db, 'ast>,
+        value_inference: &ExpressionInference<'db>,
     ) {
         let db = self.db();
-        match target {
+        let env = self.context.program_environment();
+        let targets = match target {
             ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
-                self.targets.insert(target.into(), value_ty);
+                self.targets.insert(target.into(), value.ty);
+                return;
             }
-            ast::Expr::Starred(ast::ExprStarred { value, .. }) => {
-                self.unpack_inner(value, value_expr, value_ty);
+            ast::Expr::Starred(starred) => {
+                self.unpack_inner(&starred.value, value_expr, value, value_inference);
+                return;
             }
             ast::Expr::List(ast::ExprList { elts, .. })
-            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-                let target_len = match elts.iter().position(ast::Expr::is_starred_expr) {
-                    Some(starred_index) => {
-                        TupleLength::Variable(starred_index, elts.len() - (starred_index + 1))
-                    }
-                    None => TupleLength::Fixed(elts.len()),
-                };
-                let env = self.context.program_environment();
-                let mut unpacker = TupleUnpacker::new(db, env, target_len);
-
-                // N.B. `Type::try_iterate` internally handles unions, but in a lossy way.
-                // For our purposes here, we get better error messages and more precise inference
-                // if we manually map over the union and call `try_iterate` on each union element.
-                // See <https://github.com/astral-sh/ruff/pull/20377#issuecomment-3401380305>
-                // for more discussion.
-                let unpack_types = match value_ty {
-                    Type::Union(union_ty) => union_ty.elements(self.db()),
-                    _ => std::slice::from_ref(&value_ty),
-                };
-
-                for ty in unpack_types.iter().copied() {
-                    let tuple = ty.try_iterate(db, env).unwrap_or_else(|err| {
-                        err.report_diagnostic(&self.context, ty, value_expr);
-                        Cow::Owned(TupleSpec::homogeneous(err.fallback_element_type(db, env)))
-                    });
-
-                    if let Err(err) = unpacker.unpack_tuple(tuple.as_ref()) {
-                        unpacker
-                            .unpack_tuple(&TupleSpec::homogeneous(Type::unknown()))
-                            .expect("adding a homogeneous tuple should always succeed");
-                        if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target)
-                        {
-                            match err {
-                                ResizeTupleError::TooManyValues => {
-                                    let mut diag =
-                                        builder.into_diagnostic("Too many values to unpack");
-                                    diag.set_primary_annotation_message(format_args!(
-                                        "Expected {}",
-                                        target_len.display_minimum(),
-                                    ));
-                                    diag.annotate(self.context.secondary(value_expr).message(
-                                        format_args!("Got {}", tuple.len().display_minimum()),
-                                    ));
-                                }
-                                ResizeTupleError::TooFewValues => {
-                                    let mut diag =
-                                        builder.into_diagnostic("Not enough values to unpack");
-                                    diag.set_primary_annotation_message(format_args!(
-                                        "Expected {}",
-                                        target_len.display_minimum(),
-                                    ));
-                                    diag.annotate(self.context.secondary(value_expr).message(
-                                        format_args!("Got {}", tuple.len().display_maximum()),
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // We constructed unpacker above using the length of elts, so the zip should
-                // consume the same number of elements from each.
-                for (target, value_ty) in elts.iter().zip(unpacker.into_types()) {
-                    self.unpack_inner(target, value_expr, value_ty);
-                }
-            }
+            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => elts,
             _ => {
                 // Recovered syntax can still create assignment definitions for descendants of
                 // malformed targets. Give the whole subtree an unknown type so later lookups
                 // don't panic.
                 self.record_unknown_target_subtree(target);
+                return;
             }
+        };
+        let target_len = target_length(targets);
+        let literal = value.expression.and_then(|expression| {
+            literal_sequence(
+                expression,
+                value.promote_literals,
+                &mut |expression, promote| {
+                    let ty = value_inference.expression_type(expression);
+                    UnpackElement {
+                        ty: if promote { ty.promote(db, env) } else { ty },
+                        expression: Some(expression),
+                        promote_literals: promote,
+                    }
+                },
+                &mut |expression, promote, known_length| {
+                    // The starred expression's inference has already reported iteration errors.
+                    // For `a, *rest = [1, *items]`, retain the shape of `items`' iterator even
+                    // though the enclosing list's type has erased positions and length.
+                    let ty = value_inference.expression_type(expression);
+                    let ty = if promote { ty.promote(db, env) } else { ty };
+                    let mut tuple = ty.iterate(db, env);
+                    if let Some(length) = known_length
+                        && let Ok(resized) = tuple.resize(db, env, TupleLength::Fixed(length))
+                    {
+                        tuple = Cow::Owned(resized);
+                    }
+                    sequence_from_type(db, &tuple)
+                },
+            )
+        });
+
+        let sequences = if let Some(literal) = literal {
+            vec![literal]
+        } else {
+            // N.B. `Type::try_iterate` internally handles unions, but in a lossy way.
+            // For our purposes here, we get better error messages and more precise inference
+            // if we manually map over the union and call `try_iterate` on each union element.
+            // See <https://github.com/astral-sh/ruff/pull/20377#issuecomment-3401380305>
+            // for more discussion.
+            let unpack_types = match value.ty {
+                Type::Union(union_ty) => union_ty.elements(db),
+                _ => std::slice::from_ref(&value.ty),
+            };
+            unpack_types
+                .iter()
+                .map(|ty| {
+                    let tuple = ty.try_iterate(db, env).unwrap_or_else(|err| {
+                        err.report_diagnostic(&self.context, *ty, value_expr);
+                        Cow::Owned(TupleSpec::homogeneous(err.fallback_element_type(db, env)))
+                    });
+                    sequence_from_type(db, &tuple)
+                })
+                .collect()
+        };
+
+        let mut inferred_targets: Vec<_> = targets
+            .iter()
+            .map(|_| {
+                (
+                    UnionBuilder::new(db, env).unpack_aliases(false),
+                    None,
+                    false,
+                )
+            })
+            .collect();
+        for sequence in sequences {
+            let matched = sequence.unpack(target_len, Clone::clone, |elements| {
+                UnpackElement::from_type(UnionType::from_elements_leave_aliases(
+                    db,
+                    env,
+                    elements.iter().map(|element| element.ty),
+                ))
+            });
+            match matched {
+                Ok(matched) => {
+                    for ((inferred, expression, promote_literals), element) in inferred_targets
+                        .iter_mut()
+                        .zip(matched.into_all_elements_with_kind())
+                    {
+                        let element = match element {
+                            TupleElement::Fixed(value)
+                            | TupleElement::Prefix(value)
+                            | TupleElement::Suffix(value) => value,
+                            TupleElement::Variable(values) => {
+                                UnpackElement::from_type(collected_list_type(
+                                    db,
+                                    env,
+                                    values.into_iter().map(|value| (value.ty, value.expression)),
+                                ))
+                            }
+                        };
+                        inferred.add_in_place(element.ty);
+                        // Literal sources contribute exactly one sequence. Only the type-based
+                        // path combines multiple union arms, and those have no source expressions.
+                        *expression = element.expression;
+                        *promote_literals = element.promote_literals;
+                    }
+                }
+                Err(err) => {
+                    // A length mismatch has no valid correspondence, e.g. `a, *b, c = [1]`.
+                    // Recover every target at this level, without discarding sibling literals
+                    // handled by the enclosing recursive call.
+                    for (target, (inferred, _, _)) in targets.iter().zip(&mut inferred_targets) {
+                        inferred.add_in_place(if target.is_starred_expr() {
+                            KnownClass::List.to_specialized_instance(db, env, &[Type::unknown()])
+                        } else {
+                            Type::unknown()
+                        });
+                    }
+                    if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target) {
+                        let (message, actual) = match err {
+                            ResizeTupleError::TooManyValues => (
+                                "Too many values to unpack",
+                                sequence.len().display_minimum(),
+                            ),
+                            ResizeTupleError::TooFewValues => (
+                                "Not enough values to unpack",
+                                sequence.len().display_maximum(),
+                            ),
+                        };
+                        let mut diag = builder.into_diagnostic(message);
+                        diag.set_primary_annotation_message(format_args!(
+                            "Expected {}",
+                            target_len.display_minimum()
+                        ));
+                        diag.annotate(
+                            self.context
+                                .secondary(value_expr)
+                                .message(format_args!("Got {actual}")),
+                        );
+                    }
+                }
+            }
+        }
+
+        for (target, (ty, expression, promote_literals)) in targets.iter().zip(inferred_targets) {
+            self.unpack_inner(
+                target,
+                expression.map(AnyNodeRef::from).unwrap_or(value_expr),
+                UnpackElement {
+                    ty: ty.build(),
+                    expression,
+                    promote_literals,
+                },
+                value_inference,
+            );
         }
     }
 
@@ -474,45 +438,46 @@ pub(super) fn fixed_sequence_elements(
 /// Find the expression assigned to one target in a tuple or list unpacking.
 ///
 /// For `first, (second, third) = (0, (1, 2))`, this associates `second` with `1`.
-/// Explicit values before or after a starred element remain unambiguous, but a starred target or
-/// an element supplied by a starred value has no single corresponding source expression.
+/// Explicit values before or after a starred element remain unambiguous. Literal expansions
+/// retain their source expressions too; values supplied by arbitrary iterables do not.
 pub(super) fn unpacked_assignment_value<'ast>(
     unpack_target: &ast::Expr,
     value: &'ast ast::Expr,
     requested_target: &ast::Expr,
 ) -> Option<&'ast ast::Expr> {
     assignment_values_for_target(unpack_target, value, requested_target)
-        .and_then(UnpackedAssignmentValues::as_single)
+        .and_then(UnpackedAssignmentValues::into_single)
 }
 
 /// Return the explicit values collected by a starred assignment target.
 ///
 /// For `first, *middle, last = (0, 1, 2, 3)`, `middle` collects the expressions `1` and `2`.
-/// Values containing their own starred expressions have no unambiguous collected slice.
+/// Literal expansions are flattened; an unknown source in the collected portion makes the
+/// correspondence ambiguous.
 pub(super) fn starred_assignment_values<'ast>(
     unpack_target: &ast::Expr,
     value: &'ast ast::Expr,
     requested_target: &ast::Expr,
-) -> Option<&'ast [ast::Expr]> {
+) -> Option<Vec<&'ast ast::Expr>> {
     assignment_values_for_target(unpack_target, value, requested_target)
-        .and_then(UnpackedAssignmentValues::as_collected)
+        .and_then(UnpackedAssignmentValues::into_collected)
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum UnpackedAssignmentValues<'ast> {
     Single(&'ast ast::Expr),
-    Collected(&'ast [ast::Expr]),
+    Collected(Vec<&'ast ast::Expr>),
 }
 
 impl<'ast> UnpackedAssignmentValues<'ast> {
-    fn as_single(self) -> Option<&'ast ast::Expr> {
+    fn into_single(self) -> Option<&'ast ast::Expr> {
         match self {
             Self::Single(value) => Some(value),
             Self::Collected(_) => None,
         }
     }
 
-    fn as_collected(self) -> Option<&'ast [ast::Expr]> {
+    fn into_collected(self) -> Option<Vec<&'ast ast::Expr>> {
         match self {
             Self::Single(_) => None,
             Self::Collected(values) => Some(values),
@@ -530,77 +495,178 @@ fn assignment_values_for_target<'ast>(
     }
 
     let targets = sequence_elts(unpack_target)?;
-    let values = sequence_elts(value)?;
-    let requested_range = requested_target.range();
-    let (index, target) = targets
+    let values = literal_sequence(
+        value,
+        false,
+        &mut |expression, _| Some(expression),
+        &mut |_, _, known_length| {
+            if let Some(length) = known_length {
+                Tuple::heterogeneous(std::iter::repeat_n(None, length))
+            } else {
+                TupleBuilder::Variable {
+                    prefix: vec![],
+                    segment: vec![None],
+                    suffix: vec![],
+                }
+                .build()
+            }
+        },
+    )?;
+    let matched = values
+        .unpack(target_length(targets), Clone::clone, |_| None)
+        .ok()?;
+    let (target, source) = targets
         .iter()
-        .enumerate()
-        .find(|(_, target)| target.range().contains_range(requested_range))?;
-
-    if let ast::Expr::Starred(starred) = target {
-        if ExpressionNodeKey::from(starred.value.as_ref())
-            != ExpressionNodeKey::from(requested_target)
-            || values.iter().any(ast::Expr::is_starred_expr)
-        {
-            return None;
+        .zip(matched.into_all_elements_with_kind())
+        .find(|(target, _)| target.range().contains_range(requested_target.range()))?;
+    match source {
+        TupleElement::Variable(values) => {
+            let ast::Expr::Starred(starred) = target else {
+                return None;
+            };
+            if ExpressionNodeKey::from(starred.value.as_ref())
+                != ExpressionNodeKey::from(requested_target)
+            {
+                return None;
+            }
+            Some(UnpackedAssignmentValues::Collected(
+                values.into_iter().collect::<Option<Vec<_>>>()?,
+            ))
         }
-
-        let suffix_length = targets.len().checked_sub(index + 1)?;
-        let collected_end = values.len().checked_sub(suffix_length)?;
-        return values
-            .get(index..collected_end)
-            .map(UnpackedAssignmentValues::Collected);
+        TupleElement::Fixed(value) | TupleElement::Prefix(value) | TupleElement::Suffix(value) => {
+            assignment_values_for_target(target, value?, requested_target)
+        }
     }
-
-    let nested_value = sequence_value_for_target(targets, values, index)?;
-    assignment_values_for_target(target, nested_value, requested_target)
 }
 
-/// Match fixed prefix and suffix elements without guessing the width of a starred expression.
-fn sequence_value_for_target<'ast>(
-    targets: &[ast::Expr],
-    values: &'ast [ast::Expr],
-    target_index: usize,
-) -> Option<&'ast ast::Expr> {
-    let target_starred_index = targets.iter().position(ast::Expr::is_starred_expr);
-    let first_value_starred_index = values.iter().position(ast::Expr::is_starred_expr);
-    let last_value_starred_index = values.iter().rposition(ast::Expr::is_starred_expr);
+fn target_length(targets: &[ast::Expr]) -> TupleLength {
+    match targets.iter().position(ast::Expr::is_starred_expr) {
+        Some(index) => TupleLength::Variable(index, targets.len() - index - 1),
+        None => TupleLength::Fixed(targets.len()),
+    }
+}
 
-    match (target_starred_index, first_value_starred_index) {
-        (None, None) if targets.len() != values.len() => return None,
-        (Some(_), None) if values.len() < targets.len().saturating_sub(1) => return None,
-        (None, Some(_))
-            if values
-                .iter()
-                .filter(|value| !value.is_starred_expr())
-                .count()
-                > targets.len() =>
-        {
-            return None;
+/// A source expression accompanies a type only when its position is unambiguous. We keep this
+/// transient information while unpacking, without giving mutable lists fixed-length types.
+#[derive(Clone, Copy)]
+struct UnpackElement<'db, 'ast> {
+    ty: Type<'db>,
+    expression: Option<&'ast ast::Expr>,
+    /// Widening a large tuple also widens nested tuple elements. Do not undo that widening
+    /// when following the source expression during nested unpacking.
+    promote_literals: bool,
+}
+
+impl<'db> UnpackElement<'db, '_> {
+    fn from_type(ty: Type<'db>) -> Self {
+        Self {
+            ty,
+            expression: None,
+            promote_literals: false,
         }
-        _ => {}
     }
+}
 
-    let target_prefix_length = target_starred_index.unwrap_or(targets.len());
-    let value_prefix_length = first_value_starred_index.unwrap_or(values.len());
-
-    if target_index < target_prefix_length && target_index < value_prefix_length {
-        return values.get(target_index);
+fn sequence_from_type<'db, 'ast>(
+    db: &'db dyn Db,
+    tuple: &TupleSpec<'db>,
+) -> Tuple<UnpackElement<'db, 'ast>, Vec<UnpackElement<'db, 'ast>>> {
+    match tuple {
+        Tuple::Fixed(values) => {
+            Tuple::heterogeneous(values.iter_all_elements().map(UnpackElement::from_type))
+        }
+        Tuple::Variable(values) => TupleBuilder::Variable {
+            prefix: values
+                .iter_prefix_elements()
+                .map(UnpackElement::from_type)
+                .collect(),
+            segment: vec![UnpackElement::from_type(values.variable().element_type(db))],
+            suffix: values
+                .iter_suffix_elements()
+                .map(UnpackElement::from_type)
+                .collect(),
+        }
+        .build(),
     }
+}
 
-    let target_suffix_length = target_starred_index
-        .map(|index| targets.len() - index - 1)
-        .unwrap_or(targets.len());
-    let value_suffix_length = last_value_starred_index
-        .map(|index| values.len() - index - 1)
-        .unwrap_or(values.len());
-    let suffix_index = targets.len() - target_index - 1;
-
-    if suffix_index < target_suffix_length && suffix_index < value_suffix_length {
-        return values.get(values.len() - suffix_index - 1);
+/// Infers the fresh list made by a starred assignment target or sequence-pattern capture.
+/// Both `first, *rest = values` and `case [first, *rest]:` create a new list whose inferred
+/// literal elements can widen without changing the type of the original sequence.
+pub(super) fn collected_list_type<'db, 'ast>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    values: impl ExactSizeIterator<Item = (Type<'db>, Option<&'ast ast::Expr>)>,
+) -> Type<'db> {
+    let is_empty = values.len() == 0;
+    let mut elements = UnionBuilder::new(db, env).unpack_aliases(false);
+    let mut allow_tuple_size_promotion = true;
+    for (ty, expression) in values {
+        let ty = ty.promote(db, env);
+        allow_tuple_size_promotion &=
+            TupleSizePromotionConstraints::allows_expression(db, env, expression, ty);
+        elements.add_in_place(ty);
     }
+    // `first, *rest = (1,)` constructs an empty list, just as `rest = []` does.
+    let ty = if is_empty {
+        Type::unknown()
+    } else {
+        elements.build()
+    };
+    let ty = ty.promote_collection_element_type(db, env, allow_tuple_size_promotion, true);
+    KnownClass::List.to_specialized_instance(db, env, &[ty])
+}
 
-    None
+/// Describes literal positions for both inference and diagnostics. A starred literal is expanded
+/// recursively; other starred expressions contribute the shape supplied by the caller. For
+/// `first, *rest, last = [1, *items, 2]`, the unknown width of `items` leaves both ends intact.
+fn literal_sequence<'ast, T: Clone>(
+    mut expression: &'ast ast::Expr,
+    promote: bool,
+    element: &mut impl FnMut(&'ast ast::Expr, bool) -> T,
+    spread: &mut impl FnMut(&'ast ast::Expr, bool, Option<usize>) -> Tuple<T, Vec<T>>,
+) -> Option<Tuple<T, Vec<T>>> {
+    // `a, *rest = (items := [1, "two"])` has the same elements as the list itself.
+    while let ast::Expr::Named(named) = expression {
+        expression = &named.value;
+    }
+    let values = sequence_elts(expression)?;
+    let promote = promote
+        || (expression.is_tuple_expr()
+            && values.len() > MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE);
+    let mut builder = TupleBuilder::with_capacity(values.len());
+    for value in values {
+        if let ast::Expr::Starred(starred) = value {
+            let unpacked = literal_sequence(&starred.value, promote, element, spread)
+                .unwrap_or_else(|| spread(value, promote, literal_iterable_length(&starred.value)));
+            builder = builder.concat_with(&unpacked, |suffix, left, right, prefix| {
+                // For `[*a, *b, *c, ...]`, retain the accumulated elements instead of copying
+                // them again for every expansion. Positions within this segment are unknown.
+                left.extend(suffix.iter().chain(prefix).chain(right).cloned());
+            });
+        } else {
+            builder.push(element(value, promote));
+        }
+    }
+    Some(builder.build())
+}
+
+/// The literal element count used when inferring expansions such as `(*{"key": 1},)`.
+/// An expansion within the literal, as in `[*items]` or `{**items}`, makes that count unknown.
+pub(super) fn literal_iterable_length(expression: &ast::Expr) -> Option<usize> {
+    match expression {
+        ast::Expr::List(ast::ExprList { elts, .. })
+        | ast::Expr::Tuple(ast::ExprTuple { elts, .. })
+        | ast::Expr::Set(ast::ExprSet { elts, .. }) => elts
+            .iter()
+            .all(|element| !element.is_starred_expr())
+            .then_some(elts.len()),
+        ast::Expr::Dict(ast::ExprDict { items, .. }) => items
+            .iter()
+            .all(|item| item.key.is_some())
+            .then_some(items.len()),
+        _ => None,
+    }
 }
 
 /// Extract the element slice from a list or tuple expression.

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -161,32 +161,23 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
         value_expr: &ast::Expr,
         value_inference: &ExpressionInference<'db>,
     ) -> bool {
-        match target {
+        let targets = match target {
             ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
                 self.targets
                     .insert(target.into(), value_inference.expression_type(value_expr));
-                true
+                return true;
             }
             ast::Expr::List(ast::ExprList { elts, .. })
-            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-                let Some(values) = sequence_elts(value_expr) else {
-                    // `first, *rest = items` has no literal elements to match against the
-                    // targets. Unpack the inferred type of `items` instead.
-                    return false;
-                };
-                self.unpack_fixed_sequence_from_inference(elts, values, value_expr, value_inference)
-            }
-            _ => false,
-        }
-    }
+            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => elts,
+            _ => return false,
+        };
 
-    fn unpack_fixed_sequence_from_inference(
-        &mut self,
-        targets: &[ast::Expr],
-        values: &[ast::Expr],
-        value_expr: &ast::Expr,
-        value_inference: &ExpressionInference<'db>,
-    ) -> bool {
+        let Some(values) = sequence_elts(value_expr) else {
+            // `first, *rest = items` has no literal elements to match against the
+            // targets. Unpack the inferred type of `items` instead.
+            return false;
+        };
+
         // For `first, *rest = [*items, "last"]`, `*items` can contribute zero or more
         // elements, so AST positions alone cannot tell us which value is assigned to
         // `first`. Fall back to unpacking the inferred sequence type.
@@ -251,17 +242,13 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
 
             // `first, *rest, last = [1, 2, 3, 4]` is valid despite the different lengths.
             // Once `rest` is handled, only the matching prefix and suffix remain.
-            return self.unpack_fixed_sequence_from_inference(
-                prefix_targets,
-                prefix_values,
-                value_expr,
-                value_inference,
-            ) && self.unpack_fixed_sequence_from_inference(
-                suffix_targets,
-                suffix_values,
-                value_expr,
-                value_inference,
-            );
+            for (targets, values) in [
+                (prefix_targets, prefix_values),
+                (suffix_targets, suffix_values),
+            ] {
+                self.unpack_fixed_sequence_from_inference(targets, values, value_inference);
+            }
+            return true;
         }
 
         // Without a starred target, `a, b = (1,)` and `a, b = (1, 2, 3)` cannot pair every
@@ -269,6 +256,18 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
         if targets.len() != values.len() {
             return false;
         }
+
+        self.unpack_fixed_sequence_from_inference(targets, values, value_inference);
+        true
+    }
+
+    fn unpack_fixed_sequence_from_inference(
+        &mut self,
+        targets: &[ast::Expr],
+        values: &[ast::Expr],
+        value_inference: &ExpressionInference<'db>,
+    ) {
+        debug_assert_eq!(targets.len(), values.len());
 
         for (target, value_expr) in targets.iter().zip(values) {
             if !self.unpack_assignment_sequence_from_inference(target, value_expr, value_inference)
@@ -283,7 +282,6 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                 );
             }
         }
-        true
     }
 
     /// Records `Unknown` for a malformed unpack target and all of its descendant expressions.


### PR DESCRIPTION
## Summary

Fix false-positive `invalid-assignment` diagnostics when unpacking list literals, and consolidate the sequence matching, expansion, and capture-list inference used for tuples and lists:

```python
first: int
first, *rest = [1, "wrong"]
```

Previously, unpacking the inferred `list[int | str]` lost the positions of the individual elements and checked `int | str` against the annotation on `first`. Preserving the literal's positions gives `Literal[1]` for `first` and `list[str]` for `rest`.

The implementation shares the underlying operations across their consumers:

- `Tuple::unpack` matches fixed and variable source sequences to fixed and starred targets. Assignment unpacking, tuple resizing, and sequence-pattern analysis use this matching logic.
- `TupleBuilder<T, V>` generalizes tuple construction and provides shared concatenation through `concat_with`. Tuple inference can retain symbolic `TypeVarTuple` segments, while assignment unpacking can retain source expressions.
- A shared literal-expansion traversal serves assignment inference, tuple-expression inference, and source-expression lookup for diagnostics. It preserves nested literal positions and known prefixes and suffixes around expansions without assigning persistent fixed-length types to mutable lists.
- Starred assignments and sequence-pattern captures use the same helper to infer their new lists, sharing literal and tuple-size promotion rules with ordinary mutable-collection inference.

List literals now receive the same length-mismatch diagnostics and unknown-type recovery as tuples. Starred captures from tuples also follow mutable-list promotion rules, including `list[Unknown]` for empty captures. The existing large-tuple precision limit counts elements contributed by literal expansions, and its widening is preserved through nested unpacking.

## Out of scope: contextual inference for unpacking

Unpacking does not currently use annotations on assignment targets as type context when inferring the right-hand side. This is a pre-existing limitation for both tuple and list right-hand sides. For example, these valid assignments still produce false positives:

```python
from typing import Literal

value: list[Literal[1]]
value, other = ([1], 0)  # Inferred list[int] is rejected.
value, other = [[1], 0]  # Inferred list[int] is rejected.
```

In both cases, the nested list is inferred without the target's annotation. Fixing this missing contextual inference is out of scope for this PR.
