### PR TITLE
[ty] Infer tuple type parameters from union arguments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -339,6 +339,7 @@ from typing import TypeVar
 class A: ...
 class B: ...
 class C: ...
+class D: ...
 
 T = TypeVar("T")
 
@@ -363,8 +364,8 @@ U = TypeVar("U")
 def swap(values: tuple[U, T]) -> tuple[T, U]:
     return values[1], values[0]
 
-def _(pairs: tuple[A, B] | tuple[B, C]):
-    reveal_type(swap(pairs))  # revealed: tuple[B | C, A | B]
+def _(pairs: tuple[A, B] | tuple[C, D]):
+    reveal_type(swap(pairs))  # revealed: tuple[B | D, A | C]
 
 def tail(values: tuple[A, *tuple[T, ...]]) -> tuple[T, ...]:
     return values[1:]

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -322,6 +322,77 @@ reveal_type(takes_homogeneous_tuple((42,)))  # revealed: Literal[42]
 reveal_type(takes_homogeneous_tuple((42, 43)))  # revealed: Literal[42, 43]
 ```
 
+## Inferring tuple parameter types from unions
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+Every member of a union argument contributes to the inferred element type of a homogeneous tuple
+parameter. Different tuple lengths do not prevent inference, and an empty tuple contributes no
+element types.
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def elements(values: tuple[T, ...]) -> tuple[T, ...]:
+    return values
+
+def _(
+    same: tuple[str, str] | tuple[str, str, str],
+    mixed: tuple[int] | tuple[str, str],
+    possibly_empty: tuple[()] | tuple[str, str],
+):
+    reveal_type(elements(same))  # revealed: tuple[str, ...]
+    reveal_type(elements(mixed))  # revealed: tuple[int | str, ...]
+    reveal_type(elements(possibly_empty))  # revealed: tuple[str, ...]
+```
+
+Fixed-length and mixed tuples infer type parameters from their corresponding element positions.
+
+```py
+U = TypeVar("U")
+
+def pair(values: tuple[T, U]) -> tuple[T, U]:
+    return values
+
+def _(pairs: tuple[int, str] | tuple[str, int]):
+    reveal_type(pair(pairs))  # revealed: tuple[int | str, str | int]
+
+def tail(values: tuple[int, *tuple[T, ...]]) -> tuple[T, ...]:
+    return values[1:]
+
+def _(tails: tuple[int, str] | tuple[int, bytes, bytes]):
+    reveal_type(tail(tails))  # revealed: tuple[str | bytes, ...]
+```
+
+Gradual elements remain gradual in the inferred result rather than being discarded in favor of the
+fully static elements from another union member.
+
+```py
+from typing import Any
+
+def _(values: tuple[str] | tuple[Any, Any]):
+    reveal_type(elements(values))  # revealed: tuple[str | Any, ...]
+```
+
+Inference still respects type-variable bounds and the required tuple length.
+
+```py
+StringT = TypeVar("StringT", bound=str)
+
+def strings(values: tuple[StringT, ...]) -> tuple[StringT, ...]:
+    return values
+
+def _(valid: tuple[str] | tuple[str, str], invalid: tuple[str] | tuple[int, int]):
+    reveal_type(strings(valid))  # revealed: tuple[str, ...]
+    strings(invalid)  # error: [invalid-argument-type]
+    pair(valid)  # error: [invalid-argument-type]
+```
+
 ## Inferring a bound typevar
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -336,19 +336,23 @@ element types.
 ```py
 from typing import TypeVar
 
+class A: ...
+class B: ...
+class C: ...
+
 T = TypeVar("T")
 
 def elements(values: tuple[T, ...]) -> tuple[T, ...]:
     return values
 
 def _(
-    same: tuple[str, str] | tuple[str, str, str],
-    mixed: tuple[int] | tuple[str, str],
-    possibly_empty: tuple[()] | tuple[str, str],
+    same: tuple[A, A] | tuple[A, A, A],
+    mixed: tuple[A] | tuple[B, B],
+    possibly_empty: tuple[()] | tuple[A, A],
 ):
-    reveal_type(elements(same))  # revealed: tuple[str, ...]
-    reveal_type(elements(mixed))  # revealed: tuple[int | str, ...]
-    reveal_type(elements(possibly_empty))  # revealed: tuple[str, ...]
+    reveal_type(elements(same))  # revealed: tuple[A, ...]
+    reveal_type(elements(mixed))  # revealed: tuple[A | B, ...]
+    reveal_type(elements(possibly_empty))  # revealed: tuple[A, ...]
 ```
 
 Fixed-length and mixed tuples infer type parameters from their corresponding element positions.
@@ -356,41 +360,17 @@ Fixed-length and mixed tuples infer type parameters from their corresponding ele
 ```py
 U = TypeVar("U")
 
-def pair(values: tuple[T, U]) -> tuple[T, U]:
-    return values
+def swap(values: tuple[U, T]) -> tuple[T, U]:
+    return values[1], values[0]
 
-def _(pairs: tuple[int, str] | tuple[str, int]):
-    reveal_type(pair(pairs))  # revealed: tuple[int | str, str | int]
+def _(pairs: tuple[A, B] | tuple[B, C]):
+    reveal_type(swap(pairs))  # revealed: tuple[B | C, A | B]
 
-def tail(values: tuple[int, *tuple[T, ...]]) -> tuple[T, ...]:
+def tail(values: tuple[A, *tuple[T, ...]]) -> tuple[T, ...]:
     return values[1:]
 
-def _(tails: tuple[int, str] | tuple[int, bytes, bytes]):
-    reveal_type(tail(tails))  # revealed: tuple[str | bytes, ...]
-```
-
-Gradual elements remain gradual in the inferred result rather than being discarded in favor of the
-fully static elements from another union member.
-
-```py
-from typing import Any
-
-def _(values: tuple[str] | tuple[Any, Any]):
-    reveal_type(elements(values))  # revealed: tuple[str | Any, ...]
-```
-
-Inference still respects type-variable bounds and the required tuple length.
-
-```py
-StringT = TypeVar("StringT", bound=str)
-
-def strings(values: tuple[StringT, ...]) -> tuple[StringT, ...]:
-    return values
-
-def _(valid: tuple[str] | tuple[str, str], invalid: tuple[str] | tuple[int, int]):
-    reveal_type(strings(valid))  # revealed: tuple[str, ...]
-    strings(invalid)  # error: [invalid-argument-type]
-    pair(valid)  # error: [invalid-argument-type]
+def _(tails: tuple[A, B] | tuple[A, C, C]):
+    reveal_type(tail(tails))  # revealed: tuple[B | C, ...]
 ```
 
 ## Inferring a bound typevar

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -326,7 +326,7 @@ reveal_type(takes_homogeneous_tuple((42, 43)))  # revealed: Literal[42, 43]
 
 ```toml
 [environment]
-python-version = "3.12"
+python-version = "3.11"
 ```
 
 Every member of a union argument contributes to the inferred element type of a homogeneous tuple

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -729,55 +729,37 @@ parameter. Different tuple lengths do not prevent inference, and an empty tuple 
 element types.
 
 ```py
+class A: ...
+class B: ...
+class C: ...
+
 def elements[T](values: tuple[T, ...]) -> tuple[T, ...]:
     return values
 
 def _(
-    same: tuple[str, str] | tuple[str, str, str],
-    mixed: tuple[int] | tuple[str, str],
-    possibly_empty: tuple[()] | tuple[str, str],
+    same: tuple[A, A] | tuple[A, A, A],
+    mixed: tuple[A] | tuple[B, B],
+    possibly_empty: tuple[()] | tuple[A, A],
 ):
-    reveal_type(elements(same))  # revealed: tuple[str, ...]
-    reveal_type(elements(mixed))  # revealed: tuple[int | str, ...]
-    reveal_type(elements(possibly_empty))  # revealed: tuple[str, ...]
+    reveal_type(elements(same))  # revealed: tuple[A, ...]
+    reveal_type(elements(mixed))  # revealed: tuple[A | B, ...]
+    reveal_type(elements(possibly_empty))  # revealed: tuple[A, ...]
 ```
 
 Fixed-length and mixed tuples infer type parameters from their corresponding element positions.
 
 ```py
-def pair[T, U](values: tuple[T, U]) -> tuple[T, U]:
-    return values
+def swap[T, U](values: tuple[U, T]) -> tuple[T, U]:
+    return values[1], values[0]
 
-def _(pairs: tuple[int, str] | tuple[str, int]):
-    reveal_type(pair(pairs))  # revealed: tuple[int | str, str | int]
+def _(pairs: tuple[A, B] | tuple[B, C]):
+    reveal_type(swap(pairs))  # revealed: tuple[B | C, A | B]
 
-def tail[T](values: tuple[int, *tuple[T, ...]]) -> tuple[T, ...]:
+def tail[T](values: tuple[A, *tuple[T, ...]]) -> tuple[T, ...]:
     return values[1:]
 
-def _(tails: tuple[int, str] | tuple[int, bytes, bytes]):
-    reveal_type(tail(tails))  # revealed: tuple[str | bytes, ...]
-```
-
-Gradual elements remain gradual in the inferred result rather than being discarded in favor of the
-fully static elements from another union member.
-
-```py
-from typing import Any
-
-def _(values: tuple[str] | tuple[Any, Any]):
-    reveal_type(elements(values))  # revealed: tuple[str | Any, ...]
-```
-
-Inference still respects type-variable bounds and the required tuple length.
-
-```py
-def strings[T: str](values: tuple[T, ...]) -> tuple[T, ...]:
-    return values
-
-def _(valid: tuple[str] | tuple[str, str], invalid: tuple[str] | tuple[int, int]):
-    reveal_type(strings(valid))  # revealed: tuple[str, ...]
-    strings(invalid)  # error: [invalid-argument-type]
-    pair(valid)  # error: [invalid-argument-type]
+def _(tails: tuple[A, B] | tuple[A, C, C]):
+    reveal_type(tail(tails))  # revealed: tuple[B | C, ...]
 ```
 
 ## Inferring a bound typevar

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -722,6 +722,64 @@ reveal_type(takes_homogeneous_tuple((42,)))  # revealed: Literal[42]
 reveal_type(takes_homogeneous_tuple((42, 43)))  # revealed: Literal[42, 43]
 ```
 
+## Inferring tuple parameter types from unions
+
+Every member of a union argument contributes to the inferred element type of a homogeneous tuple
+parameter. Different tuple lengths do not prevent inference, and an empty tuple contributes no
+element types.
+
+```py
+def elements[T](values: tuple[T, ...]) -> tuple[T, ...]:
+    return values
+
+def _(
+    same: tuple[str, str] | tuple[str, str, str],
+    mixed: tuple[int] | tuple[str, str],
+    possibly_empty: tuple[()] | tuple[str, str],
+):
+    reveal_type(elements(same))  # revealed: tuple[str, ...]
+    reveal_type(elements(mixed))  # revealed: tuple[int | str, ...]
+    reveal_type(elements(possibly_empty))  # revealed: tuple[str, ...]
+```
+
+Fixed-length and mixed tuples infer type parameters from their corresponding element positions.
+
+```py
+def pair[T, U](values: tuple[T, U]) -> tuple[T, U]:
+    return values
+
+def _(pairs: tuple[int, str] | tuple[str, int]):
+    reveal_type(pair(pairs))  # revealed: tuple[int | str, str | int]
+
+def tail[T](values: tuple[int, *tuple[T, ...]]) -> tuple[T, ...]:
+    return values[1:]
+
+def _(tails: tuple[int, str] | tuple[int, bytes, bytes]):
+    reveal_type(tail(tails))  # revealed: tuple[str | bytes, ...]
+```
+
+Gradual elements remain gradual in the inferred result rather than being discarded in favor of the
+fully static elements from another union member.
+
+```py
+from typing import Any
+
+def _(values: tuple[str] | tuple[Any, Any]):
+    reveal_type(elements(values))  # revealed: tuple[str | Any, ...]
+```
+
+Inference still respects type-variable bounds and the required tuple length.
+
+```py
+def strings[T: str](values: tuple[T, ...]) -> tuple[T, ...]:
+    return values
+
+def _(valid: tuple[str] | tuple[str, str], invalid: tuple[str] | tuple[int, int]):
+    reveal_type(strings(valid))  # revealed: tuple[str, ...]
+    strings(invalid)  # error: [invalid-argument-type]
+    pair(valid)  # error: [invalid-argument-type]
+```
+
 ## Inferring a bound typevar
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -732,6 +732,7 @@ element types.
 class A: ...
 class B: ...
 class C: ...
+class D: ...
 
 def elements[T](values: tuple[T, ...]) -> tuple[T, ...]:
     return values
@@ -752,8 +753,8 @@ Fixed-length and mixed tuples infer type parameters from their corresponding ele
 def swap[T, U](values: tuple[U, T]) -> tuple[T, U]:
     return values[1], values[0]
 
-def _(pairs: tuple[A, B] | tuple[B, C]):
-    reveal_type(swap(pairs))  # revealed: tuple[B | C, A | B]
+def _(pairs: tuple[A, B] | tuple[C, D]):
+    reveal_type(swap(pairs))  # revealed: tuple[B | D, A | C]
 
 def tail[T](values: tuple[A, *tuple[T, ...]]) -> tuple[T, ...]:
     return values[1:]

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -4090,6 +4090,20 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
+            // Each alternative in a tuple union contributes constraints. The element-wise
+            // tuple path below only accepts a single actual tuple, while the constraint solver
+            // handles the entire union. Variadic type parameters still require legacy inference.
+            (formal @ Type::NominalInstance(formal_instance), actual @ Type::Union(_))
+                if formal_instance.tuple_spec(db, self.env).is_some()
+                    && !self
+                        .inferable
+                        .iter(db)
+                        .any(|typevar| typevar.is_paramspec(db) || typevar.is_typevartuple(db)) =>
+            {
+                let when = self.constraint_for_relation(formal, actual, relation_polarity);
+                return self.infer_from_constraint_set(when);
+            }
+
             // Special case: `formal` and `actual` are both tuples.
             (Type::NominalInstance(formal), Type::NominalInstance(actual))
                 if let Some(formal_tuple) = formal.tuple_spec(db, self.env)


### PR DESCRIPTION
## Summary

Infer tuple type parameters from every alternative of a union of tuples:

```python
def elements[T](values: tuple[T, ...]) -> tuple[T, ...]:
    return values

def f(values: tuple[str, str] | tuple[str, str, str]):
    reveal_type(elements(values))  # tuple[str, ...]
```

Previously, this inferred `tuple[Unknown, ...]`.

This came up while working on https://github.com/astral-sh/ruff/pull/26880. The conformance suite example here requires proper type inference for the `is_two_element_tuple` function from showing up. 

## Ecosystem

Two new true positives. `CodecOptions` uses an invariant type parameter, despite inheriting from covariant `tuple`. Previously ty inferred `Unknown` which prevented the error. mypy/pyright also reject this call.

## Test plan

New Markdown tests
