### PR TITLE
[ty] Infer variance through nonrecursive protocol references

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
@@ -484,10 +484,9 @@ class ConstructorOnly(Protocol[T]):
 
 ## Protocol method receivers
 
-Explicit receiver annotations that reference the protocol trigger the recursion guard, so these
-examples currently skip declared-variance validation. The covariant version should be rejected
-because `send` consumes its type parameter, but it is also accepted. This demonstrates the guard's
-limitation rather than correct handling of receiver variance.
+Explicit receiver annotations do not add an input or output position to a bound method. Both
+protocols consume their type parameter through `send`, so only the contravariant declaration is
+valid.
 
 ```py
 from typing import Protocol, TypeVar
@@ -500,7 +499,7 @@ class ExplicitReceivers(Protocol[T_contra]):
     @classmethod
     def configure(cls: "type[ExplicitReceivers[T_contra]]") -> None: ...
 
-# TODO: Reject the covariant declaration; this protocol should be contravariant.
+# error: [invalid-protocol] "Type variable `T_co` in protocol `CovariantExplicitReceivers` should be contravariant, but is covariant"
 class CovariantExplicitReceivers(Protocol[T_co]):
     def send(self: "CovariantExplicitReceivers[T_co]", value: T_co) -> None: ...
     @classmethod
@@ -538,8 +537,7 @@ static_assert(not is_assignable_to(WritableProtocol[int], WritableProtocol[objec
 
 ## Protocol members referencing other protocols
 
-The recursion guard currently skips declared-variance validation whenever a member type contains a
-protocol, even if that protocol is unrelated and the interface is not recursive. `Source` should be
+An unrelated protocol in a member type does not prevent declared-variance validation. `Source` is
 covariant because only `read` uses `T`, in a return position.
 
 ```py
@@ -550,10 +548,74 @@ T = TypeVar("T")
 class Marker(Protocol):
     def ready(self) -> bool: ...
 
-# TODO: Reject the invariant declaration even though `marker` returns another protocol.
+# error: [invalid-protocol] "Type variable `T` in protocol `Source` should be covariant, but is invariant"
 class Source(Protocol[T]):
     def read(self) -> T: ...
     def marker(self) -> Marker: ...
+```
+
+## Nested protocol variance
+
+Variance composes through nonrecursive generic protocols. Returning a covariant protocol produces
+its type parameter, while accepting it as an argument consumes that parameter.
+
+```py
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class Reader(Protocol[T_co]):
+    def read(self) -> T_co: ...
+
+class NestedReader(Protocol[T_co]):
+    def reader(self) -> Reader[T_co]: ...
+
+# error: [invalid-protocol] "Type variable `T` in protocol `Source` should be covariant, but is invariant"
+class Source(Protocol[T]):
+    def reader(self) -> NestedReader[T]: ...
+
+class Sink(Protocol[T_contra]):
+    def write(self, reader: NestedReader[T_contra]) -> None: ...
+```
+
+## Recursive protocol variance
+
+Declared-variance validation still skips recursive protocol interfaces. Each protocol below exposes
+a method that consumes its type parameter, either directly or through another protocol, so a
+covariant declaration is invalid.
+
+```py
+from typing import Protocol, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+# TODO: Reject the covariant declaration even though `next` refers to this protocol.
+class Recursive(Protocol[T_co]):
+    def write(self, value: T_co) -> None: ...
+    def next(self) -> "Recursive[T_co]": ...
+```
+
+The guard also recognizes recursion when each reference changes the specialization.
+
+```py
+# TODO: Reject the covariant declaration despite the expanding recursive reference.
+class Expanding(Protocol[T_co]):
+    def write(self, value: T_co) -> None: ...
+    def next(self) -> "Expanding[list[T_co]]": ...
+```
+
+Mutually recursive interfaces are also skipped, regardless of which protocol is checked first.
+
+```py
+# TODO: Reject the covariant declarations in this recursive pair.
+class Left(Protocol[T_co]):
+    def write(self, value: T_co) -> None: ...
+    def right(self) -> "Right[T_co]": ...
+
+class Right(Protocol[T_co]):
+    def left(self) -> Left[T_co]: ...
 ```
 
 ## Inherited protocol variance

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -414,7 +414,9 @@ static_assert(not is_subtype_of(Covariant[object], Covariant[int]))
 ## Nested nonrecursive protocols
 
 Using a generic protocol inside another specialization of the same protocol is not a recursive
-definition. Covariance composes through both specializations, including through a type alias.
+definition, including through a type alias. The nested `Reader` specializations do not prevent
+structural variance inference for `Source`: its writable `_value` attribute makes it invariant.
+Returning `Source[T]` from a nominal wrapper preserves that invariance.
 
 ```py
 from typing import Protocol
@@ -426,12 +428,17 @@ class Reader[T](Protocol):
 
 type NestedReader[T] = Reader[Reader[T]]
 
-class Source[T]:
-    def reader(self) -> NestedReader[T]:
+class Source[T](Protocol):
+    _value: T
+
+    def reader(self) -> NestedReader[T]: ...
+
+class Wrapper[T]:
+    def source(self) -> Source[T]:
         raise NotImplementedError
 
-static_assert(is_subtype_of(Source[int], Source[object]))
-static_assert(not is_subtype_of(Source[object], Source[int]))
+static_assert(not is_subtype_of(Wrapper[int], Wrapper[object]))
+static_assert(not is_subtype_of(Wrapper[object], Wrapper[int]))
 ```
 
 ## Mutual Recursion

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -411,6 +411,29 @@ static_assert(is_subtype_of(Covariant[int], Covariant[object]))
 static_assert(not is_subtype_of(Covariant[object], Covariant[int]))
 ```
 
+## Nested nonrecursive protocols
+
+Using a generic protocol inside another specialization of the same protocol is not a recursive
+definition. Covariance composes through both specializations, including through a type alias.
+
+```py
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Reader[T](Protocol):
+    def read(self) -> T: ...
+
+type NestedReader[T] = Reader[Reader[T]]
+
+class Source[T]:
+    def reader(self) -> NestedReader[T]:
+        raise NotImplementedError
+
+static_assert(is_subtype_of(Source[int], Source[object]))
+static_assert(not is_subtype_of(Source[object], Source[int]))
+```
+
 ## Mutual Recursion
 
 This example due to Martin Huschenbett's PyCon 2025 talk,
@@ -561,10 +584,9 @@ def unsound(value: WritableProtocol[int]) -> None:
 
 ### Mutable protocol attributes with unrelated protocol members
 
-The recursion guard currently disables structural variance inference whenever a member type contains
-a protocol, even if the interface is not recursive. The fallback to ordinary class inference treats
-`_value` as private and incorrectly infers covariance. This also makes a class that returns the
-protocol covariant, allowing callers to mutate `_value` through a wider specialization.
+An unrelated protocol in a member type does not change the invariance of a writable attribute. A
+class that returns this protocol is also invariant, preventing callers from mutating `_value`
+through a wider specialization.
 
 ```py
 from typing import Protocol
@@ -583,9 +605,8 @@ class Wrapper[T]:
     def value(self) -> WritableProtocol[T]:
         raise NotImplementedError
 
-# TODO: Both assertions should hold: the writable protocol attribute makes `Wrapper` invariant.
-static_assert(not is_subtype_of(Wrapper[int], Wrapper[object]))  # error: [static-assert-error]
-static_assert(not is_assignable_to(Wrapper[int], Wrapper[object]))  # error: [static-assert-error]
+static_assert(not is_subtype_of(Wrapper[int], Wrapper[object]))
+static_assert(not is_assignable_to(Wrapper[int], Wrapper[object]))
 ```
 
 ### Immutable Attributes

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -3400,7 +3400,7 @@ impl<'db> StaticClassLiteral<'db> {
 
         if self.is_protocol(db)
             && let Some(protocol) = self.identity_specialization(db).into_protocol_class(db)
-            && protocol.interface(db).supports_variance_inference(db)
+            && protocol.supports_variance_inference(db)
         {
             return protocol.interface(db).variance_of(db, &env, typevar);
         }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -79,7 +79,12 @@ impl<'db> ProtocolClass<'db> {
         cached_protocol_interface(db, *self)
     }
 
-    /// Whether the protocol's member types support structural variance inference.
+    /// Structural variance inference currently excludes recursive protocol and type-alias
+    /// dependencies: validating a cycle requires inferring variance independently of the
+    /// declarations being checked. Descriptor writes are also excluded when their accepted values
+    /// cannot be represented by a single type, leaving no write domain to use contravariantly.
+    ///
+    /// TODO: Support these recursive dependencies and descriptor write domains.
     pub(super) fn supports_variance_inference(self, db: &'db dyn Db) -> bool {
         self.static_class_literal(db)
             .is_some_and(|(class, _)| supports_protocol_variance_inference(db, class))
@@ -3664,8 +3669,6 @@ fn non_object_protocol_member_count<'db>(
 
 /// Check variance dependencies by definition, so expanding specializations such as `P[list[T]]`
 /// cannot hide a cycle. Nonrecursive protocol references do not prevent variance inference.
-///
-/// TODO: Support recursive interfaces and descriptor writes with unrepresentable domains.
 #[salsa::tracked(
     returns(copy),
     cycle_initial=|_, _, _| false,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -79,6 +79,12 @@ impl<'db> ProtocolClass<'db> {
         cached_protocol_interface(db, *self)
     }
 
+    /// Whether the protocol's member types support structural variance inference.
+    pub(super) fn supports_variance_inference(self, db: &'db dyn Db) -> bool {
+        self.static_class_literal(db)
+            .is_some_and(|(class, _)| supports_protocol_variance_inference(db, class))
+    }
+
     /// Returns the interface before an invariant specialization is materialized.
     ///
     /// A materialized generic origin retains its specialization for nominal identity and display.
@@ -317,7 +323,7 @@ impl<'db> ProtocolClass<'db> {
         let Some(protocol) = class.identity_specialization(db).into_protocol_class(db) else {
             return;
         };
-        if !protocol.interface(db).supports_variance_inference(db) {
+        if !protocol.supports_variance_inference(db) {
             return;
         }
 
@@ -851,26 +857,24 @@ impl<'db> ProtocolInterface<'db> {
         self.inner(db).contains_key(name)
     }
 
-    /// Return whether this interface is currently supported by structural variance inference.
-    ///
-    /// The finite-member guard conservatively rejects any member type containing a protocol,
-    /// including unrelated protocols and explicit receiver annotations that refer to this protocol.
-    /// This skips declared-variance validation and falls back to ordinary class variance inference
-    /// for inferred parameters, even when the interface is not recursive.
-    ///
-    /// TODO: Narrow the guard to actual recursion, and support recursive interfaces and descriptor
-    /// writes with unrepresentable domains.
-    pub(super) fn supports_variance_inference(self, db: &'db dyn Db) -> bool {
-        ProtocolInterfaceView::new(self, None).has_only_finite_members(db)
-            && self.members(db).all(|member| {
-                !matches!(
-                    member.data.kind,
-                    ProtocolMemberKind::Property {
-                        write: Some(ProtocolMemberWrite::Descriptor { domain: None, .. }),
-                        ..
-                    }
-                )
-            })
+    /// The exposed read and write types, with their positions in variance inference.
+    fn variance_types<'a>(
+        self,
+        db: &'db dyn Db,
+        env: &'a ProgramEnvironment<'db>,
+    ) -> impl Iterator<Item = (Type<'db>, TypeVarVariance)> + 'a {
+        self.members(db).flat_map(move |member| {
+            let capabilities = member.capabilities(db, env);
+            // Instance methods are checked only through their bound instance signature.
+            let class_access = if member.is_instance_method() {
+                ProtocolMemberAccess::NONE
+            } else {
+                capabilities.class
+            };
+            [capabilities.instance, class_access]
+                .into_iter()
+                .flat_map(|access| access.variances(db, env))
+        })
     }
 
     /// Returns whether `name` has an instance-write requirement of `type[T]`, where `T` belongs
@@ -1214,19 +1218,7 @@ impl<'db> VarianceInferable<'db> for ProtocolInterface<'db> {
         env: &ProgramEnvironment<'db>,
         typevar: BoundTypeVarIdentity<'db>,
     ) -> TypeVarVariance {
-        self.members(db)
-            .flat_map(|member| {
-                let capabilities = member.capabilities(db, env);
-                // Instance methods are checked only through their bound instance signature.
-                let class_access = if member.is_instance_method() {
-                    ProtocolMemberAccess::NONE
-                } else {
-                    capabilities.class
-                };
-                [capabilities.instance, class_access]
-                    .into_iter()
-                    .flat_map(|access| access.variances(db, env))
-            })
+        self.variance_types(db, env)
             .map(|(ty, variance)| ty.with_polarity(variance).variance_of(db, env, typevar))
             .collect()
     }
@@ -3668,6 +3660,61 @@ fn non_object_protocol_member_count<'db>(
         .filter(|name| name.as_str() != "__hash__" && interface.includes_member(db, name))
         .count();
     interface.member_count(db) - inherited_member_count
+}
+
+/// Check variance dependencies by definition, so expanding specializations such as `P[list[T]]`
+/// cannot hide a cycle. Nonrecursive protocol references do not prevent variance inference.
+///
+/// TODO: Support recursive interfaces and descriptor writes with unrepresentable domains.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial=|_, _, _| false,
+    heap_size=ruff_memory_usage::heap_size,
+)]
+fn supports_protocol_variance_inference<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> bool {
+    let Some(protocol) = class.identity_specialization(db).into_protocol_class(db) else {
+        return false;
+    };
+    let interface = protocol.interface(db);
+    if interface.members(db).any(|member| {
+        matches!(
+            member.data.kind,
+            ProtocolMemberKind::Property {
+                write: Some(ProtocolMemberWrite::Descriptor { domain: None, .. }),
+                ..
+            }
+        )
+    }) {
+        return false;
+    }
+
+    let env = ProgramEnvironment::from_scope(class.body_scope(db));
+    let supports_type = |ty| {
+        !any_over_type_expanding_aliases(db, &env, ty, |nested| {
+            matches!(nested, Type::ProtocolInstance(protocol) if protocol
+                .class_origin(db)
+                .is_none_or(|class| !class.supports_variance_inference(db)))
+        })
+    };
+    interface.variance_types(db, &env).all(|(ty, _)| {
+        if let Type::Callable(callable) = ty {
+            // Bound receivers constrain when a method can be called, but they are not input
+            // or output positions in variance inference. Match `Signature::variance_of`.
+            callable.signatures(db).iter().all(|signature| {
+                signature
+                    .parameters()
+                    .iter()
+                    .map(Parameter::annotated_type)
+                    .chain(std::iter::once(signature.return_ty))
+                    .all(supports_type)
+            })
+        } else {
+            supports_type(ty)
+        }
+    })
 }
 
 /// Inner Salsa query for [`ProtocolClass::interface`].


### PR DESCRIPTION
## Summary

Follow-up to #27531.

We now validate declared protocol variance when member types refer to nonrecursive protocols. Previously, any protocol reference disabled the check, so `marker` hid the variance mismatch in `Source`:

```python
from typing import Protocol, TypeVar

T = TypeVar("T")

class Marker(Protocol):
    def ready(self) -> bool: ...

class Source(Protocol[T]):  # error: [invalid-protocol]
    def read(self) -> T: ...
    def marker(self) -> Marker: ...
```

The variance guard now checks dependencies by protocol definition and uses the same read/write types as variance inference. Explicit receiver annotations no longer suppress validation, and unrelated protocol members no longer bypass invariance inference for writable attributes.

Direct, mutual, and expanding recursive interfaces remain deferred, as do descriptor writes whose accepted values cannot be represented by a single type.
