### PR TITLE
Fix compiler warnings seen in CI jobs

### DIFF
--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -36,7 +36,7 @@ use crate::{Applicability, FixAvailability};
 use crate::{Locator, directives};
 
 /// Represents the difference between two diagnostic runs.
-#[cfg(any(test, fuzzing))]
+#[cfg(test)]
 #[derive(Debug)]
 pub(crate) struct DiagnosticsDiff {
     /// Diagnostics that were removed (present in 'before' but not in 'after')
@@ -49,7 +49,7 @@ pub(crate) struct DiagnosticsDiff {
     settings_after: LinterSettings,
 }
 
-#[cfg(any(test, fuzzing))]
+#[cfg(test)]
 impl std::fmt::Display for DiagnosticsDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         writeln!(f, "--- Linter settings ---")?;
@@ -91,7 +91,7 @@ impl std::fmt::Display for DiagnosticsDiff {
 }
 
 /// Compare two sets of diagnostics and return the differences
-#[cfg(any(test, fuzzing))]
+#[cfg(test)]
 fn diff_diagnostics(
     before: Vec<Diagnostic>,
     after: Vec<Diagnostic>,

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -7,7 +7,6 @@
 //! [Lexical analysis]: https://docs.python.org/3/reference/lexical_analysis.html
 
 use std::cmp::Ordering;
-use std::debug_assert_matches;
 
 use unicode_ident::{is_xid_continue, is_xid_start};
 
@@ -1049,7 +1048,10 @@ impl<'src> Lexer<'src> {
     /// Lex a hex/octal/decimal/binary number without a decimal point.
     fn lex_number_radix(&mut self, radix: Radix) -> TokenKind {
         #[cfg(debug_assertions)]
-        debug_assert_matches!(self.cursor.previous().to_ascii_lowercase(), 'x' | 'o' | 'b');
+        {
+            use std::debug_assert_matches;
+            debug_assert_matches!(self.cursor.previous().to_ascii_lowercase(), 'x' | 'o' | 'b');
+        }
 
         let number = self.radix_run(radix);
         if !number.has_digit {

--- a/crates/ruff_server/src/session/options.rs
+++ b/crates/ruff_server/src/session/options.rs
@@ -491,8 +491,6 @@ impl_noop_combine!(LineLength);
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use insta::assert_debug_snapshot;
     use ruff_linter::settings::types::PreviewMode;
     use ruff_python_formatter::QuoteStyle;
@@ -746,6 +744,8 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn test_vs_code_workspace_settings_resolve() {
+        use std::str::FromStr;
+
         let options = deserialize_fixture(VS_CODE_INIT_OPTIONS_FIXTURE);
         let AllOptions {
             global,


### PR DESCRIPTION
## Summary

In CI jobs that build with `--profile=profiling`, we [see this warning](https://github.com/astral-sh/ruff/actions/runs/32965699980/job/98167573333#step:6:1236):

```
warning: unused import: `std::debug_assert_matches`
  --> crates/ruff_python_parser/src/lexer.rs:10:5
   |
10 | use std::debug_assert_matches;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
```

In CI jobs that build on Windows, we [see this warning](https://github.com/astral-sh/ruff/actions/runs/32930412034/job/98061497954#step:7:67):

```
warning: unused import: `std::str::FromStr`
   --> crates\ruff_server\src\session\options.rs:494:9
    |
494 |     use std::str::FromStr;
    |         ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
```

And in CI jobs that build with the `fuzzing` feature enabled, we [see these warnings](https://github.com/astral-sh/ruff/actions/runs/32930412034/job/98061497872#step:8:82):

```
warning: struct `DiagnosticsDiff` is never constructed
  --> /home/runner/work/ruff/ruff/crates/ruff_linter/src/test.rs:41:19
   |
41 | pub(crate) struct DiagnosticsDiff {
   |                   ^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: function `diff_diagnostics` is never used
  --> /home/runner/work/ruff/ruff/crates/ruff_linter/src/test.rs:95:4
   |
95 | fn diff_diagnostics(
   |    ^^^^^^^^^^^^^^^^
```

This PR fixes all of them

## Test Plan

Eyeballing CI jobs on this PR