### PR TITLE
[ty] Unsound intersection simplification for generic iterables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -466,6 +466,91 @@ Base[P] & Top[Sub[Any]] = Top[Sub[P & Any]]    (Base: covariant, Sub: invariant)
 Base[P] & Top[Sub[Any]] = Top[Sub[P | Any]]    (Base: contravariant, Sub: invariant)
 ```
 
+Above, we made the assumption that `Base` and `Sub` are nominal types. In general, these results do
+not hold for structural types. Consider for example:
+
+```pyi
+from typing import Protocol
+
+class BaseProtocol[T](Protocol):
+    def get1(self) -> T: ...
+
+class SubProtocol[T](BaseProtocol[T], Protocol):
+    def get2(self) -> T: ...
+```
+
+The intersection `BaseProtocol[P] & SubProtocol[object]` is not equivalent to `SubProtocol[P]`.
+Consider the following `CounterExample` class which is a subtype of the intersection, but not a
+subtype of `SubProtocol[P]`.
+
+```pyi
+class CounterExample:
+    def get1(self) -> P: ...
+    def get2(self) -> object: ...
+
+static_assert(is_subtype_of(CounterExample, BaseProtocol[P] & SubProtocol[object]))
+static_assert(not is_subtype_of(CounterExample, SubProtocol[P]))
+```
+
+This proves that `BaseProtocol[P] & SubProtocol[object]` is not equivalent to `SubProtocol[P]`:
+
+```pyi
+static_assert(not is_equivalent_to(BaseProtocol[P] & SubProtocol[object], SubProtocol[P]))
+```
+
+However, there are cases where we this simplification would be helpful. Consider narrowing something
+of type `Iterable[P]` via `isinstance(.., frozenset)`. It would be useful to get a narrowed type
+with a (read) element type `P`.
+
+```pyi
+from typing import Iterable
+
+def f(xs: Iterable[P]) -> None:
+    if isinstance(xs, frozenset):
+        for x in xs:
+            x  # we would like this to be of type `P`
+```
+
+Let's look at the (simplified) definitions of `Iterable` and `frozenset`:
+
+```ignore
+class Iterable[T_co](Protocol):
+    def __iter__(self) -> Iterator[T_co]: ...
+
+class frozenset[T_co](AbstractSet[T_co]):
+    def __iter__(self) -> Iterator[T_co]: ...
+```
+
+Just like in the counterexample above, we could construct a class that is a (nominal) subtype of
+`frozenset[object]` and a (structural) subtype of `Iterable[P]` (and therefore a subtype of the
+intersection `Iterable[P] & frozenset[object]`), but not a subtype of `frozenset[P]`:
+
+```pyi
+from typing import Iterable, Iterator
+
+class Weird(frozenset[object]):
+    def __iter__(self) -> Iterator[P]:
+        raise NotImplementedError
+```
+
+However, consider what this `__iter__` method would do. It would return an iterator over `P`, even
+though elements of that `frozenset` could be of any type. This would violate the behavioral contract
+of [iterators](https://docs.python.org/3/glossary.html#term-iterator):
+
+> Iterators are required to have an `__iter__()` method that returns the iterator object itself
+
+Therefore, it seems reasonable to make an exception for `Iterable` and its subtypes, and to assume
+that classes like `Weird` do not exist. We therefore implement the following intersection
+simplifications:
+
+```pyi
+static_assert(is_equivalent_to(Iterable[P] & Iterator[object], Iterator[P]))
+static_assert(is_equivalent_to(Iterable[P] & tuple[object, ...], tuple[P, ...]))
+static_assert(is_equivalent_to(Iterable[P] & frozenset[object], frozenset[P]))
+static_assert(is_equivalent_to(Iterable[P] & Top[list[Any]], Top[list[P & Any]]))
+static_assert(is_equivalent_to(Iterable[P] & Top[set[Any]], Top[set[P & Any]]))
+```
+
 ## Edge cases
 
 ### Multi-parameter and mixed-variance generics

--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -498,9 +498,9 @@ This proves that `BaseProtocol[P] & SubProtocol[object]` is not equivalent to `S
 static_assert(not is_equivalent_to(BaseProtocol[P] & SubProtocol[object], SubProtocol[P]))
 ```
 
-However, there are cases where we this simplification would be helpful. Consider narrowing something
-of type `Iterable[P]` via `isinstance(.., frozenset)`. It would be useful to get a narrowed type
-with a (read) element type `P`.
+However, there are cases where this simplification would be helpful. Consider narrowing something of
+type `Iterable[P]` via `isinstance(.., frozenset)`. It would be useful to get a narrowed type with a
+(read) element type `P`.
 
 ```pyi
 from typing import Iterable
@@ -529,26 +529,30 @@ intersection `Iterable[P] & frozenset[object]`), but not a subtype of `frozenset
 from typing import Iterable, Iterator
 
 class Weird(frozenset[object]):
-    def __iter__(self) -> Iterator[P]:
-        raise NotImplementedError
+    def __iter__(self) -> Iterator[P]: ...
 ```
 
-However, consider what this `__iter__` method would do. It would return an iterator over `P`, even
-though elements of that `frozenset` could be of any type. This would violate the behavioral contract
-of [iterators](https://docs.python.org/3/glossary.html#term-iterator):
-
-> Iterators are required to have an `__iter__()` method that returns the iterator object itself
-
-Therefore, it seems reasonable to make an exception for `Iterable` and its subtypes, and to assume
-that classes like `Weird` do not exist. We therefore implement the following intersection
-simplifications:
+The return type of `Iterator[P]` is compatible with that of `frozenset[object]` due to covariance.
+However, the returned iterator would only yield values of type `P` while the underlying `frozenset`
+may contain other values. Here, we assume that subclasses of built-in containers preserve their
+usual iteration behavior instead: iteration over a `frozenset` exposes its stored elements. Under
+this assumption, knowing the iteration element type also constrains the stored element type. This
+behavioral assumption is not enforced by the type system, so the simplification is unsound:
 
 ```pyi
-static_assert(is_equivalent_to(Iterable[P] & Iterator[object], Iterator[P]))
 static_assert(is_equivalent_to(Iterable[P] & tuple[object, ...], tuple[P, ...]))
 static_assert(is_equivalent_to(Iterable[P] & frozenset[object], frozenset[P]))
 static_assert(is_equivalent_to(Iterable[P] & Top[list[Any]], Top[list[P & Any]]))
 static_assert(is_equivalent_to(Iterable[P] & Top[set[Any]], Top[set[P & Any]]))
+```
+
+A similar justification applies to the following case. `Iterator`s are supposed to follow a
+[behavioral contract](https://docs.python.org/3/library/stdtypes.html#iterator-types): an iterator's
+`__iter__()` returns the iterator itself. Iteration and direct calls to `next()` therefore yield the
+same values. This supports simplifying `Iterable[P] & Iterator[object]` to `Iterator[P]`:
+
+```pyi
+static_assert(is_equivalent_to(Iterable[P] & Iterator[object], Iterator[P]))
 ```
 
 ## Edge cases

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -1100,7 +1100,7 @@ from typing import Iterable, Iterator
 
 def f(values: Iterable[int]):
     if isinstance(values, Iterator):
-        reveal_type(values)  # revealed: Top[Iterator[int]]
+        reveal_type(values)  # revealed: Iterator[int]
         reveal_type(next(values))  # revealed: int
     if isinstance(values, tuple):
         reveal_type(values)  # revealed: tuple[int, ...]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -1084,6 +1084,38 @@ def _(value: Concrete[int]) -> None:
         reveal_type(value.read())  # revealed: int
 ```
 
+## Narrowing iterables to containers and iterators in strict mode
+
+```toml
+[analysis]
+strict-generic-narrowing = true
+```
+
+Narrowing an `Iterable[T]` to an `Iterator`, or to a container type, retains its element type. See
+`generics/set_theoretic.md` for more details on the assumptions behind this, and for an explanation
+of the behavior of invariant containers:
+
+```py
+from typing import Iterable, Iterator
+
+def f(values: Iterable[int]):
+    if isinstance(values, Iterator):
+        reveal_type(values)  # revealed: Top[Iterator[int]]
+        reveal_type(next(values))  # revealed: int
+    if isinstance(values, tuple):
+        reveal_type(values)  # revealed: tuple[int, ...]
+        reveal_type(values[0])  # revealed: int
+    if isinstance(values, frozenset):
+        reveal_type(values)  # revealed: frozenset[int]
+        reveal_type(next(iter(values)))  # revealed: int
+    if isinstance(values, list):
+        reveal_type(values)  # revealed: Top[list[Unknown & int]]
+        reveal_type(values[0])  # revealed: int
+    if isinstance(values, set):
+        reveal_type(values)  # revealed: Top[set[Unknown & int]]
+        reveal_type(next(iter(values)))  # revealed: int
+```
+
 ## Use cases: `isinstance` narrowing and generics
 
 ### Strict mode

--- a/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
@@ -33,8 +33,7 @@ pub(super) enum GenericIntersection<'db> {
     Recursive,
 }
 
-/// Simplify the intersection of two generic specializations when one is a gradual
-/// generalization of the other.
+/// Simplify same-class gradual intersections and intersections with top-materialized subclasses.
 ///
 /// For example, `list[int] & list[Any]` simplifies to `list[int]`, while
 /// `Sequence[int] & Sequence[Any]` simplifies to `Sequence[int & Any]`.
@@ -48,8 +47,8 @@ pub(super) fn generic_gradual_intersection<'db>(
     dynamic_generalization_intersection(db, env, left, right)
         .or_else(|| dynamic_generalization_intersection(db, env, right, left))
         .map(GenericIntersection::Simplified)
-        .or_else(|| nominal_top_intersection(db, env, left, right))
-        .or_else(|| nominal_top_intersection(db, env, right, left))
+        .or_else(|| base_top_intersection(db, env, left, right))
+        .or_else(|| base_top_intersection(db, env, right, left))
 }
 
 /// Intersect a fully static nominal base with a generic subclass.
@@ -59,18 +58,38 @@ pub(super) fn generic_gradual_intersection<'db>(
 /// materializations instead of incorrectly collapsing, for example,
 /// `Sequence[int] & Top[list[Any]]` to `list[int]`.
 /// Subclass arguments that do not specialize the base retain their gradualness.
-fn nominal_top_intersection<'db>(
+///
+/// As a deliberately unsound exception, also allow `Iterable` as the base, and `Iterator`
+/// as its subclass. We assume containers and iterators obey their behavioral contracts,
+/// including agreement between iteration and indexing. Structural typing cannot enforce
+/// this: a `tuple[object, ...]` subclass can override `__iter__` to yield `int` while
+/// indexing still returns arbitrary objects.
+fn base_top_intersection<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     base: Type<'db>,
     subclass: Type<'db>,
 ) -> Option<GenericIntersection<'db>> {
-    if !base.is_nominal_instance() || !subclass.is_nominal_instance() || base.has_dynamic(db, env) {
+    if !matches!(base, Type::NominalInstance(_) | Type::ProtocolInstance(_))
+        || !matches!(
+            subclass,
+            Type::NominalInstance(_) | Type::ProtocolInstance(_)
+        )
+        || base.has_dynamic(db, env)
+    {
         return None;
     }
 
     let (base_class, base_specialization) = base.class_specialization(db, env)?;
     let (subclass_class, subclass_specialization) = subclass.class_specialization(db, env)?;
+
+    let is_iterable_special_case = base_class.known(db) == Some(KnownClass::Iterable)
+        && (subclass.is_nominal_instance()
+            || subclass_class.known(db) == Some(KnownClass::Iterator));
+    if !is_iterable_special_case && (!base.is_nominal_instance() || !subclass.is_nominal_instance())
+    {
+        return None;
+    }
 
     if base_class == subclass_class {
         return None;

--- a/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
@@ -58,12 +58,6 @@ pub(super) fn generic_gradual_intersection<'db>(
 /// materializations instead of incorrectly collapsing, for example,
 /// `Sequence[int] & Top[list[Any]]` to `list[int]`.
 /// Subclass arguments that do not specialize the base retain their gradualness.
-///
-/// As a deliberately unsound exception, also allow `Iterable` as the base, and `Iterator`
-/// as its subclass. We assume containers and iterators obey their behavioral contracts,
-/// including agreement between iteration and indexing. Structural typing cannot enforce
-/// this: a `tuple[object, ...]` subclass can override `__iter__` to yield `int` while
-/// indexing still returns arbitrary objects.
 fn base_top_intersection<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -83,6 +77,9 @@ fn base_top_intersection<'db>(
     let (base_class, base_specialization) = base.class_specialization(db, env)?;
     let (subclass_class, subclass_specialization) = subclass.class_specialization(db, env)?;
 
+    // As a deliberately unsound exception, allow `Iterable` as the base when the subclass is
+    // nominal or is the `Iterator` protocol. We assume containers and iterators obey their
+    // behavioral contracts, including agreement between iteration and indexing.
     let is_iterable_special_case = base_class.known(db) == Some(KnownClass::Iterable)
         && (subclass.is_nominal_instance()
             || subclass_class.known(db) == Some(KnownClass::Iterator));


### PR DESCRIPTION
## Summary

This PR adds an unsound extension of #26880 to `Iterable` and subtypes. In particular, we now reveal the user-expected element type in examples like:

```py
# analysis.strict-generic-narrowing = true

def f(xs: Iterable[int]):
    if isinstance(xs, list):
        reveal_type(xs[0])  # previously `object`, now `int`.
```

This is not sound: A subclass of `list[object]` could add a `def __iter__(self) -> Iterator[int]` method (in a Liskov-compatible way even, I think?), so as to satisfy `Iterable[int]`, but then yield elements of type `object` when accessed through `xs[0]`.

However, we argue that such subclasses would violate a behavioral contract of containers: iteration and indexing would not be compatible. This contract is not captured in the type system, but assuming it to hold allows us to reveal `int` in the example above (like pyright and pyrefly. mypy infers `Any`, which is certainly not ideal).

closes https://github.com/astral-sh/ty/issues/1824 (`fold_left` type-checks without errors, in strict and non-strict mode)
closes https://github.com/astral-sh/ty/issues/3890 (now reveals `tuple[int, ...]` instead of `tuple[object, ...]` in strict and non-strict mode, and the `unsupported-operator` diagnostic disappears)

## Ecosystem

10 removed false positives in `strict`-mode projects. 3 new true positives in pandas.

## Test Plan

New Markdown tests
