### PR TITLE
[ty] Avoid unnecessary Salsa queries during pytest fixture lookup

### DIFF
--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -822,11 +822,18 @@ fn fixture_candidates_from_definition<'db>(
         }
     }
 
+    let kind = definition.kind(db);
+    if !matches!(
+        &kind,
+        DefinitionKind::Function(_) | DefinitionKind::ImportFrom(_) | DefinitionKind::StarImport(_)
+    ) {
+        return Vec::new();
+    }
     if !exists_at_runtime(db, definition) {
         return Vec::new();
     }
 
-    match definition.kind(db) {
+    match kind {
         DefinitionKind::Function(_) => vec![definition],
         DefinitionKind::ImportFrom(import) => {
             let parsed = parsed_module(db, definition.python_file(db)).load(db);

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -751,8 +751,8 @@ fn fixture_declaration<'db>(
     };
     let module = parsed_module(db, definition.python_file(db)).load(db);
     let function = function_ref.node(&module);
-    let inference = function_known_decorators(db, definition);
     let first_decorator = &function.decorator_list.first()?.expression;
+    let inference = function_known_decorators(db, definition);
     let expression = if definition.scope(db).node(db).scope_kind() == ScopeKind::Class
         && matches!(
             inference.expression_type(first_decorator),

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -1107,17 +1107,19 @@ fn directly_parametrized<'db>(
     index: &ty_python_core::SemanticIndex<'_>,
     parameter_name: &str,
 ) -> bool {
-    let decorators = function_known_decorators(db, function_definition);
-    if function.decorator_list.iter().any(|decorator| {
-        mark_excludes_fixture(
-            db,
-            function_definition,
-            &decorator.expression,
-            parameter_name,
-            |expression| decorators.expression_type(expression),
-        )
-    }) {
-        return true;
+    if !function.decorator_list.is_empty() {
+        let decorators = function_known_decorators(db, function_definition);
+        if function.decorator_list.iter().any(|decorator| {
+            mark_excludes_fixture(
+                db,
+                function_definition,
+                &decorator.expression,
+                parameter_name,
+                |expression| decorators.expression_type(expression),
+            )
+        }) {
+            return true;
+        }
     }
 
     std::iter::successors(class_scope, |class_scope| {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

In anticipation of ["find references" for pytest fixtures](https://github.com/astral-sh/ruff/pull/28075), which introduces many more speculative attempts at resolving pytest fixtures, this PR helps preserve efficiency by short-circuiting a few Salsa queries:

- Return from `fixture_declaration` before calling `function_known_decorators` when a function has no decorators.
- Return from `fixture_candidates_from_definition` before calling `exists_at_runtime` when the definition kind cannot expose a fixture.
- Return from `directly_parametrized` before calling `function_known_decorators` when the test function has no decorators (while still checking parametrization from an enclosing class).

These are all behavior-preserving early exits.

## Test Plan

This is a refactor that relies on existing test coverage.
<!-- How was it tested? -->
