### PR TITLE
[ty] Add Python requirements to uv script test fixtures

### DIFF
--- a/crates/ty/tests/cli/scripts.rs
+++ b/crates/ty/tests/cli/scripts.rs
@@ -1636,8 +1636,13 @@ mod uv_metadata {
     fn synchronizes_multiple_scripts_with_one_worker() -> anyhow::Result<()> {
         assert_uv_supports_script_metadata()?;
 
-        let script =
-            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n";
+        let script = r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["attrs==25.4.0"]
+        # ///
+        from attrs import define
+        "#;
         let case = CliTest::with_files([("first.py", script), ("second.py", script)])?;
 
         assert_cmd_snapshot!(

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -10,6 +10,7 @@ use ruff_db::system::{
     file_time_now,
 };
 use ruff_python_ast::PythonVersion;
+use ruff_python_trivia::textwrap::dedent;
 use ruff_ranged_value::{RangedValue, ValueSource};
 use ty_module_resolver::{Module, ModuleName};
 use ty_project::metadata::options::{EnvironmentOptions, Options, SrcOptions};
@@ -319,7 +320,7 @@ impl<'a> SetupContext<'a> {
     ) -> anyhow::Result<()> {
         let relative_path = relative_path.as_ref();
         let absolute_path = self.join_project_path(relative_path);
-        Self::write_file_impl(absolute_path, content)
+        Self::write_file_impl(absolute_path, &dedent(content))
     }
 
     fn write_file(
@@ -2501,6 +2502,7 @@ mod uv_metadata {
     use ruff_db::diagnostic::DiagnosticId;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{OsSystem, System as _};
+    use ruff_python_trivia::textwrap::dedent;
     use ty_project::{Db, ScriptEnvironmentAvailability};
     use ty_static::EnvVars;
 
@@ -2512,14 +2514,28 @@ mod uv_metadata {
 
         let mut case = setup_script_uv([(
             "script.py",
-            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+            r#"
+            # /// script
+            # requires-python = ">=3.12"
+            # dependencies = ["attrs==25.4.0"]
+            # ///
+            from attrs import define
+            "#,
         )])?;
 
         assert!(case.db().check().is_empty());
 
         assert!(!update_and_synchronize_script(
             &mut case,
-            "\n# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\nvalue = 2\n",
+            r#"
+
+            # /// script
+            # requires-python = ">=3.12"
+            # dependencies = ["attrs==25.4.0"]
+            # ///
+            from attrs import define
+            value = 2
+            "#,
         )?);
 
         assert!(case.db().check().is_empty());
@@ -2533,14 +2549,26 @@ mod uv_metadata {
 
         let mut case = setup_script_uv([(
             "script.py",
-            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+            r#"
+            # /// script
+            # requires-python = ">=3.12"
+            # dependencies = ["attrs==25.4.0"]
+            # ///
+            from attrs import define
+            "#,
         )])?;
 
         assert!(case.db().check().is_empty());
 
         let synchronized = update_and_synchronize_script(
             &mut case,
-            "# /// script\n# requires-python = '>=3.11'\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+            r#"
+            # /// script
+            # requires-python = ">=3.11"
+            # dependencies = ["attrs==25.4.0"]
+            # ///
+            from attrs import define
+            "#,
         )?;
         assert!(synchronized);
 
@@ -2564,7 +2592,13 @@ mod uv_metadata {
 
         let synchronized = update_and_synchronize_script(
             &mut case,
-            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+            r#"
+            # /// script
+            # requires-python = ">=3.12"
+            # dependencies = ["attrs==25.4.0"]
+            # ///
+            from attrs import define
+            "#,
         )?;
         assert!(!synchronized);
 
@@ -2579,7 +2613,13 @@ mod uv_metadata {
 
         let mut case = setup_script_uv([(
             "script.py",
-            "# /// script\n# dependencies = ['not a valid requirement ???']\n# ///\nvalue = 1\n",
+            r#"
+            # /// script
+            # requires-python = ">=3.12"
+            # dependencies = ["not a valid requirement ???"]
+            # ///
+            value = 1
+            "#,
         )])?;
 
         let initial = case.db().check();
@@ -2591,7 +2631,13 @@ mod uv_metadata {
 
         let synchronized = update_and_synchronize_script(
             &mut case,
-            "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+            r#"
+            # /// script
+            # requires-python = ">=3.12"
+            # dependencies = ["attrs==25.4.0"]
+            # ///
+            from attrs import define
+            "#,
         )?;
         assert!(synchronized);
 
@@ -2630,7 +2676,7 @@ mod uv_metadata {
     }
 
     fn update_and_synchronize_script(case: &mut TestCase, source: &str) -> anyhow::Result<bool> {
-        update_file(case.project_path("script.py"), source)?;
+        update_file(case.project_path("script.py"), &dedent(source))?;
         let changes = case.take_watch_changes(event_for_file("script.py"));
         case.apply_changes(&changes);
 

--- a/crates/ty_project/src/script/environment.rs
+++ b/crates/ty_project/src/script/environment.rs
@@ -876,7 +876,13 @@ mod tests {
         #[test]
         fn initial_background_synchronization_is_pending_until_completion() -> anyhow::Result<()> {
             let mut case = UvTestCase::new(
-                "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+                r#"
+                # /// script
+                # requires-python = ">=3.12"
+                # dependencies = ["attrs==25.4.0"]
+                # ///
+                from attrs import define
+                "#,
             )?;
             let environments = case.db.script_environments().clone();
 
@@ -899,7 +905,13 @@ mod tests {
         fn existing_environment_remains_available_during_background_synchronization()
         -> anyhow::Result<()> {
             let mut case = UvTestCase::new(
-                "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n",
+                r#"
+                # /// script
+                # requires-python = ">=3.12"
+                # dependencies = ["attrs==25.4.0"]
+                # ///
+                from attrs import define
+                "#,
             )?;
             let environments = case.db.script_environments().clone();
             let environment = script_environment(&case.db, case.file)
@@ -923,7 +935,13 @@ mod tests {
 
         #[test]
         fn returning_to_previous_metadata_resynchronizes_the_environment() -> anyhow::Result<()> {
-            let initial = "# /// script\n# dependencies = ['attrs==25.4.0']\n# ///\nfrom attrs import define\n";
+            let initial = r#"
+            # /// script
+            # requires-python = ">=3.12"
+            # dependencies = ["attrs==25.4.0"]
+            # ///
+            from attrs import define
+            "#;
             let mut case = UvTestCase::new(initial)?;
             let environments = case.db.script_environments().clone();
             environments.request_sync(
@@ -935,9 +953,15 @@ mod tests {
             assert_eq!(case.wait_for_synchronizations()?, vec![case.file]);
             case.assert_can_import("attrs")?;
 
-            case.db.write_file(
-                &case.path,
-                "# /// script\n# dependencies = ['anyio']\n# ///\nfrom attrs import define\n",
+            case.db.write_dedented(
+                case.path.as_str(),
+                r#"
+                # /// script
+                # requires-python = ">=3.12"
+                # dependencies = ["anyio"]
+                # ///
+                from attrs import define
+                "#,
             )?;
             let wakeups = environments.sync_wakeups();
             environments.request_sync(
@@ -954,7 +978,7 @@ mod tests {
 
             // Restoring the original metadata must reinstall its dependencies, even though its
             // cache key matches the last synchronization whose result was applied.
-            case.db.write_file(&case.path, initial)?;
+            case.db.write_dedented(case.path.as_str(), initial)?;
             environments.request_sync(
                 &mut case.db,
                 case.file,
@@ -972,7 +996,14 @@ mod tests {
 
         #[test]
         fn background_result_cancels_snapshots_before_locking_entry() -> anyhow::Result<()> {
-            let mut case = UvTestCase::new("# /// script\n# dependencies = []\n# ///\n")?;
+            let mut case = UvTestCase::new(
+                r#"
+                # /// script
+                # requires-python = ">=3.12"
+                # dependencies = []
+                # ///
+                "#,
+            )?;
             let environments = case.db.script_environments().clone();
             environments.request_sync(
                 &mut case.db,
@@ -1043,7 +1074,7 @@ mod tests {
                 }
 
                 let path = root.join("script.py");
-                db.write_file(&path, source)?;
+                db.write_dedented(path.as_str(), source)?;
                 let file = system_path_to_file(&db, &path)?;
 
                 Ok(Self {


### PR DESCRIPTION
## Summary

uv can fail with

```
error: Failed to collect module owners
  Caused by: The current Python version (3.12.12) is not compatible with the locked Python requirement: `>=3.14`
```

if another test installs a pbs Python version while a `uv workspace metadata` command is running. This is a race within uv. 

We could fix it by pre-installing certain Python versions in CI. However, that doesn't help with running the tests locally. Luckily, this can also be mitigated by adding an explicit `requires-python` constraint, which is what I decided to do in this PR.


I also used this PR as an opportunity to migrate most script tests to use multiline rust strings, because they became rather hard to read. 

Example of a failed run

https://github.com/astral-sh/ruff/actions/runs/32978994472/job/98210845414?pr=28067

I considered whether installing uv is a security concern in CI. I don't think it is, given that these are trusted Python versions maintained by us. Disallowing installation would mean that our tests become less portable, which seemed annoying.

## Test Plan

Testing: CLI, script environment, and file watcher tests and pre-commit checks passed.
