### PR TITLE
Update args for uv-lock hook in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,7 +117,7 @@ repos:
     hooks:
       - id: uv-lock
         priority: 0
-        args: [--default-index=https://pypi.org/simple]
+        args: [--default-index=https://pypi.org/simple, --check, --refresh]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: aab412d509121cb5f7533134b7e67f9fab59c682 # frozen: v0.16.4


### PR DESCRIPTION
- `--refresh` enforces our uv cooldown period: manual changes to the lockfile that violate the cooldown will not actually cause this hook to fail without `--refresh`
- `--check` means that there's a better error message when the hook fails in CI

