### PR TITLE
[ty] Optimize materialized recursive protocol comparisons

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -918,6 +918,41 @@ class Chain[T](Protocol):
     }
 }
 
+/// Regression benchmark for ty#4269: materialized recursive protocol comparisons.
+///
+/// Comparing the tuple-specific receiver with the gradual overload can repeatedly expand
+/// `child` into deeper tuple specializations. The finite `value` requirement establishes the
+/// needed constraints without that expansion.
+fn benchmark_materialized_recursive_protocol_overload(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let code = r#"
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol, overload
+
+class Chain[T](Protocol):
+    def value(self) -> T: ...
+    def child(self) -> Chain[tuple[T]]: ...
+    @overload
+    def map_star[A, B, R](self: Chain[tuple[A, B]], callback: Callable[[A, B], R]) -> Chain[R]: ...
+    @overload
+    def map_star[R](self: Chain[tuple[Any, ...]], callback: Callable[..., R]) -> Chain[R]: ...
+
+def check(value: Chain[tuple[int, str]]) -> None:
+    value.map_star(lambda first, second: 1)
+"#;
+
+    criterion.bench_function("ty_micro[materialized_recursive_protocol_overload]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(code),
+            |case| assert_eq!(case.db.check().len(), 0),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Regression benchmark for large calls to a gradual variadic tail.
 ///
 /// Without the gradual-call shortcut, every positional argument type is folded into the same
@@ -1814,6 +1849,7 @@ criterion_group!(
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
     benchmark_inherited_recursive_protocol,
+    benchmark_materialized_recursive_protocol_overload,
     benchmark_vararg_parameter_type_accumulation,
     benchmark_typed_dict_get_large_literal_union,
     benchmark_very_large_tuple,

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -7070,6 +7070,35 @@ def valid(value: Chain[Iterable[int]]) -> None:
     reveal_type(value.flatten())  # revealed: Chain[int]
 ```
 
+### Explicit receivers on overloaded recursive protocol methods
+
+An overloaded method can constrain its receiver to a tuple specialization of the same recursive
+protocol. Comparing the fixed-length overload with the gradual fallback terminates without
+repeatedly expanding the recursive requirement, and the call preserves the callback's return type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol, overload
+
+class Chain[T](Protocol):
+    def value(self) -> T: ...
+    def child(self) -> Chain[tuple[T]]: ...
+    @overload
+    def map_star[A, B, R](self: Chain[tuple[A, B]], callback: Callable[[A, B], R]) -> Chain[R]: ...
+    @overload
+    def map_star[R](self: Chain[tuple[Any, ...]], callback: Callable[..., R]) -> Chain[R]: ...
+
+def check(value: Chain[tuple[int, str]]) -> None:
+    reveal_type(value.map_star(lambda first, second: 1))  # revealed: Chain[Literal[1]]
+```
+
 ### Structural inference from recursive protocol requirements
 
 An inherited protocol specialization can erase a class type parameter. A recursive member can still

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -395,6 +395,30 @@ def incompatible_bound[T]() -> None:
     reveal_type(incompatible.solutions_for(T, inferable=tuple[T]))  # revealed: None
 ```
 
+### Opposite materializations of recursive protocols
+
+A fixed `Any` in a recursive method changes independently of the protocol's type parameter. The
+top-materialized return type `object` cannot satisfy the bottom-materialized return requirement
+`Never`. The matching nonrecursive property can constrain `T`, but no specialization satisfies the
+complete protocol.
+
+```py
+from __future__ import annotations
+
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+from ty_extensions._internal import is_constraint_set_assignable_to
+
+class RecursiveValue[T](Protocol):
+    @property
+    def value(self) -> T: ...
+    def consume(self, child: RecursiveValue[Any]) -> Any: ...
+
+def inspect[T]() -> None:
+    constraints = is_constraint_set_assignable_to(Top[RecursiveValue[str]], Bottom[RecursiveValue[T]])
+    reveal_type(constraints.solutions_for(T, inferable=tuple[T]))  # revealed: None
+```
+
 ## Intersection
 
 The intersection of two constraint sets requires that the constraints in both sets hold. In many

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -2544,6 +2544,93 @@ def recursive_materialized_overload_resolution(
     reveal_type(select_specific_recursive_value(valid))  # revealed: Literal["str"]
 ```
 
+### Generic inference through materialized recursive protocol specializations
+
+A recursive requirement can provide the only evidence for one of a materialized protocol's type
+parameters. The finite `first` property determines `First`, but inference still needs
+`recursive_second` to determine `Second`. Both materialization polarities preserve that information.
+
+```py
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class Pair[First, Second](Protocol):
+    marker: Any
+
+    @property
+    def first(self) -> First: ...
+    def recursive_second(self, child: Pair[Any, Any]) -> Second: ...
+
+def infer_second[Second](value: Top[Pair[int, Second]]) -> Second:
+    raise NotImplementedError
+
+def infer_bottom_second[Second](value: Bottom[Pair[int, Second]]) -> Second:
+    raise NotImplementedError
+
+def check(top: Top[Pair[int, str]], bottom: Bottom[Pair[int, str]]) -> None:
+    reveal_type(infer_second(top))  # revealed: str
+    reveal_type(infer_bottom_second(bottom))  # revealed: str
+```
+
+A type alias around the parameter does not remove the recursive member's contribution.
+
+```py
+type Identity[T] = T
+
+def infer_aliased_second[Second](value: Top[Pair[int, Identity[Second]]]) -> Second:
+    raise NotImplementedError
+
+def aliased(top: Top[Pair[int, str]]) -> None:
+    reveal_type(infer_aliased_second(top))  # revealed: str
+```
+
+Comparing callable parameters reverses the protocol comparison: `Pair[int, Second]` becomes the
+source type. The recursive method supplies the upper bound `object`, so `Second` is inferred as
+`object` even though the target specialization has no type variables.
+
+```py
+def infer_source_second[Second](callback: Callable[[Top[Pair[int, Second]]], None]) -> Second:
+    raise NotImplementedError
+
+def accept_pair(value: Top[Pair[int, object]]) -> None: ...
+
+reveal_type(infer_source_second(accept_pair))  # revealed: object
+```
+
+The source's `first` property can itself contain `Pair` while the target's `first` property is
+finite. That source member remains available to establish the valid covariant widening.
+
+```py
+def widen(source: Top[Pair[Pair[int, str], str]]) -> None:
+    widened: Top[Pair[object, str]] = source
+```
+
+### Opposite materializations of recursive protocols
+
+Materialization can change a fixed `Any` inside a recursive method independently of the protocol's
+type parameter. A top-materialized method returning `object` cannot satisfy the bottom-materialized
+requirement to return `Never`, even when the finite `value` property is compatible.
+
+```py
+from __future__ import annotations
+
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_assignable_to
+
+class RecursiveValue[T](Protocol):
+    @property
+    def value(self) -> T: ...
+    def consume(self, child: RecursiveValue[Any]) -> Any: ...
+
+static_assert(not is_assignable_to(Top[RecursiveValue[str]], Bottom[RecursiveValue[object]]))
+static_assert(is_assignable_to(Bottom[RecursiveValue[str]], Top[RecursiveValue[object]]))
+static_assert(is_assignable_to(Top[RecursiveValue[str]], RecursiveValue[object]))
+```
+
 ### Generator delegation
 
 `yield from` uses the same materialized yield and return types as direct generator methods. Applying

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -840,9 +840,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        // Assignability chooses Bottom for an unmaterialized source and Top for an unmaterialized
-        // target. An explicit Top -> Bottom comparison is different: materialization can make a
-        // recursive requirement incompatible even when the type arguments are compatible.
+        // Assignability chooses `Bottom` for an unmaterialized source and `Top` for an
+        // unmaterialized target. An explicit `Top -> Bottom` comparison is different:
+        // materialization can make a recursive requirement incompatible even when the type
+        // arguments are compatible.
         //
         // For example, consider:
         //
@@ -850,10 +851,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         //       def value(self) -> T: ...
         //       def consume(self, other: P[Any]) -> Any: ...
         //
-        // Comparing Top[P[str]] with Bottom[P[object]] accepts `value`, since str is a subtype of
-        // object. But `consume` returns object in the source and must return Never in the target.
-        // This fixed Any changes independently of T, so neither the finite member nor the nominal
-        // comparison detects the mismatch. Leave that direction to the full structural check.
+        // Comparing `Top[P[str]]` with `Bottom[P[object]]` accepts `value`, since `str` is a
+        // subtype of `object`. But `consume` returns `object` in the source and must return
+        // `Never` in the target. This fixed `Any` changes independently of `T`, so neither the
+        // finite member nor the nominal comparison detects the mismatch. Leave that direction
+        // to the full structural check.
         let is_materialized = match (
             source_protocol.materialization_kind(db),
             protocol.materialization_kind(db),
@@ -888,9 +890,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // Remove recursive requirements only from the target, and keep the complete source as
         // evidence that the remaining requirements are satisfied. For example, when comparing
-        // Chain[Chain[int]] with Chain[object], the target's `value() -> object` is non-recursive,
-        // but the source's `value() -> Chain[int]` refers to Chain. Filtering both interfaces would
-        // remove the source member we need to establish that valid return-type comparison.
+        // `Chain[Chain[int]]` with `Chain[object]`, the target's `value() -> object` is
+        // non-recursive, but the source's `value() -> Chain[int]` refers to `Chain`. Filtering both
+        // interfaces would remove the source member we need to establish that valid return-type
+        // comparison.
         let structurally_satisfied = self.check_protocol_interface_pair(
             db,
             ty,
@@ -910,11 +913,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         //       def first(self) -> First: ...
         //       def recursive_second(self, child: Pair[Any, Any]) -> Second: ...
         //
-        // For Top[Pair[int, str]] -> Top[Pair[int, Second]], checking `first` tells us nothing about
-        // Second; only `recursive_second` supplies str <: Second. Check variables in both source
-        // and target arguments, since contravariant callable parameters can reverse the comparison.
-        // Also look through aliases: given `type Identity[T] = T`, the argument Identity[Second]
-        // still needs evidence for Second.
+        // For `Top[Pair[int, str]] -> Top[Pair[int, Second]]`, checking `first` tells us nothing
+        // about `Second`; only `recursive_second` supplies `str <: Second`. Check variables in both
+        // source and target arguments, since contravariant callable parameters can reverse the
+        // comparison. Also look through aliases: given `type Identity[T] = T`, the argument
+        // `Identity[Second]` still needs evidence for `Second`.
         //
         // Merely mentioning a variable is not enough: a skipped member may add its other bound.
         // For example:
@@ -925,10 +928,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         //       def value(self) -> T: ...
         //       def consume(self, other: Invariant[T]) -> None: ...
         //
-        // Comparing Top[Invariant[str]] with Top[Invariant[T]], `value` supplies str <: T, but
-        // `consume` also requires T <: str. The nominal comparison requires both bounds because
-        // T is invariant. Requiring the finite constraints to imply that comparison catches the
-        // missing bound: allowing every supertype of str is not enough to prove T must equal str.
+        // Comparing `Top[Invariant[str]]` with `Top[Invariant[T]]`, `value` supplies `str <: T`,
+        // but `consume` also requires `T <: str`. The nominal comparison requires both bounds
+        // because `T` is invariant. Requiring the finite constraints to imply that comparison
+        // catches the missing bound: allowing every supertype of `str` is not enough to prove
+        // `T` must equal `str`.
         if is_materialized
             && (target_alias
                 .specialization(db)

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -560,51 +560,49 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // Check that inexpensive case first: comparing every requirement of an unrelated
             // recursive protocol can expand its interface before structural member ordering gets
             // a chance to reject an incompatible finite member.
-            let nominal_is_safe = nominally_satisfied.is_never_satisfied(db, env)
+            let nominal_can_be_added = nominally_satisfied.is_never_satisfied(db, env)
                 || (!protocol.materialization_changes_requirements(db, env, protocol)
                     && !source_protocol.is_some_and(|source| {
                         source.materialization_changes_requirements(db, env, protocol)
                     }));
 
-            if nominal_is_safe {
-                if result
+            if nominal_can_be_added
+                && result
                     .union(db, self.constraints, nominally_satisfied)
                     .is_trivially_always_satisfied()
-                {
-                    return result;
-                }
+            {
+                return result;
+            }
 
-                // For union simplification, failing the nominal relation between two
-                // specializations of the same protocol class is enough to keep both union elements.
-                // Falling back to the structural relation can recursively compare every protocol
-                // member even though a failed redundancy check only means that we preserve a
-                // potentially redundant union arm.
-                let can_use_nominal_redundancy =
-                    matches!(self.relation, TypeRelation::Redundancy { pure: false })
-                        && source_protocol_as_nominal.is_some_and(|source_instance| {
-                            source_instance.class(db, env).class_literal(db)
-                                == nominal_instance.class(db, env).class_literal(db)
-                        });
+            // For union simplification, failing the nominal relation between two
+            // specializations of the same protocol class is enough to keep both union elements.
+            // Falling back to the structural relation can recursively compare every protocol
+            // member even though a failed redundancy check only means that we preserve a
+            // potentially redundant union arm.
+            let can_use_nominal_redundancy = nominal_can_be_added
+                && matches!(self.relation, TypeRelation::Redundancy { pure: false })
+                && source_protocol_as_nominal.is_some_and(|source_instance| {
+                    source_instance.class(db, env).class_literal(db)
+                        == nominal_instance.class(db, env).class_literal(db)
+                });
 
-                // Eager finite checks can only reject. Lazy comparisons can also contribute
-                // structural solutions, so try them before using the nominal fallback.
-                if (self.typevar_evaluation == TypeVarEvaluation::Lazy
-                    || !can_use_nominal_redundancy)
-                    && let Some(structurally_satisfied) = self
-                        .try_check_non_recursive_protocol_members(
-                            db,
-                            ty,
-                            protocol,
-                            source_protocol_as_nominal,
-                            nominal_instance,
-                        )
-                {
-                    return result.or(db, self.constraints, || structurally_satisfied);
-                }
+            // Eager finite checks can only reject. Lazy comparisons can also contribute
+            // structural solutions, so try them before using the nominal fallback.
+            if (self.typevar_evaluation == TypeVarEvaluation::Lazy || !can_use_nominal_redundancy)
+                && let Some(structurally_satisfied) = self.try_check_non_recursive_protocol_members(
+                    db,
+                    ty,
+                    protocol,
+                    source_protocol_as_nominal,
+                    nominal_instance,
+                    nominally_satisfied,
+                )
+            {
+                return result.or(db, self.constraints, || structurally_satisfied);
+            }
 
-                if can_use_nominal_redundancy {
-                    return nominally_satisfied;
-                }
+            if can_use_nominal_redundancy {
+                return nominally_satisfied;
             }
         }
 
@@ -776,7 +774,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// Tries to relate the finite members of two specializations of the same protocol.
     ///
     /// This retains structural solutions such as `T | int`, while recursive members are the
-    /// coinductive edge currently being proved. Returns `None` when the shortcut is inapplicable.
+    /// coinductive edge currently being proved. Materialized protocols additionally require the
+    /// finite constraints to establish the nominal relation without losing type-variable constraints.
+    /// Returns `None` when the shortcut is inapplicable.
     ///
     /// Eager comparisons can only reject: matching the finite requirements does not prove that
     /// the omitted recursive members are compatible.
@@ -787,6 +787,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         protocol: ProtocolInstanceType<'db>,
         source_protocol_as_nominal: Option<NominalInstanceType<'db>>,
         nominal_instance: NominalInstanceType<'db>,
+        nominally_satisfied: ConstraintSet<'db, 'c>,
     ) -> Option<ConstraintSet<'db, 'c>> {
         if self.is_context_collection_enabled() {
             return None;
@@ -807,13 +808,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        // A materialized recursive member can impose bounds that finite members do not
-        // capture, even when the nominal relation is impossible. Check the full interface.
-        if source_protocol.materialization_kind(db).is_some()
-            || protocol.materialization_kind(db).is_some()
-        {
-            return None;
-        }
+        // Assignability chooses Bottom for an unmaterialized source and Top for an
+        // unmaterialized target. The opposite direction can change a fixed `Any` in an
+        // omitted recursive signature from `object` to `Never`, independently of its type
+        // parameters. Only the full structural comparison can establish that relation.
+        let is_materialized = match (
+            source_protocol.materialization_kind(db),
+            protocol.materialization_kind(db),
+        ) {
+            (None, None) => false,
+            (Some(MaterializationKind::Top), Some(MaterializationKind::Bottom)) => return None,
+            _ if self.typevar_evaluation == TypeVarEvaluation::Lazy
+                && self.relation.is_assignability() =>
+            {
+                true
+            }
+            _ => return None,
+        };
 
         let identity_protocol = target_alias
             .origin(db)
@@ -844,6 +855,28 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 target_interface.materialization_kind(),
             ),
         );
+
+        if is_materialized
+            && (target_alias
+                .specialization(db)
+                .types(db)
+                .iter()
+                .chain(source_alias.specialization(db).types(db))
+                .any(|argument| {
+                    any_over_type_expanding_aliases(db, env, *argument, |nested| {
+                        matches!(nested, Type::TypeVar(typevar)
+                            if !structurally_satisfied.mentions_typevar(typevar))
+                    })
+                })
+                || !structurally_satisfied
+                    .implies(db, self.constraints, || nominally_satisfied)
+                    .is_always_satisfied(db, env))
+        {
+            // A recursive member may supply the only constraint for a type variable, or
+            // impose the opposite bound through a consuming position. In either case the
+            // finite members alone do not prove the complete materialized relation.
+            return None;
+        }
 
         // We run the eager comparison to reject incompatible finite requirements before
         // expanding recursive members. If it cannot reject, the caller checks the full

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -556,17 +556,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
 
             let env = self.env;
-            // A nominal relation that cannot succeed cannot bypass any materialized requirement.
+            // `result` combines nominal and structural ways to satisfy the protocol. Including the
+            // nominal constraints directly is safe when materialization leaves the required members
+            // unchanged, or when the nominal relation has no solutions to add to `result`.
+            //
             // Check that inexpensive case first: comparing every requirement of an unrelated
             // recursive protocol can expand its interface before structural member ordering gets
             // a chance to reject an incompatible finite member.
-            let nominal_can_be_added = nominally_satisfied.is_never_satisfied(db, env)
+            let can_use_nominal_result_directly = nominally_satisfied.is_never_satisfied(db, env)
                 || (!protocol.materialization_changes_requirements(db, env, protocol)
                     && !source_protocol.is_some_and(|source| {
                         source.materialization_changes_requirements(db, env, protocol)
                     }));
 
-            if nominal_can_be_added
+            if can_use_nominal_result_directly
                 && result
                     .union(db, self.constraints, nominally_satisfied)
                     .is_trivially_always_satisfied()
@@ -579,13 +582,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // Falling back to the structural relation can recursively compare every protocol
             // member even though a failed redundancy check only means that we preserve a
             // potentially redundant union arm.
-            let can_use_nominal_redundancy = nominal_can_be_added
+            let can_use_nominal_redundancy = can_use_nominal_result_directly
                 && matches!(self.relation, TypeRelation::Redundancy { pure: false })
                 && source_protocol_as_nominal.is_some_and(|source_instance| {
                     source_instance.class(db, env).class_literal(db)
                         == nominal_instance.class(db, env).class_literal(db)
                 });
 
+            // Even when the nominal result cannot be accepted on its own, it can help prove
+            // that recursive requirements add no constraints. For materialized protocols, the
+            // helper first checks the actual non-recursive requirements, then checks that their
+            // constraints are enough to establish the nominal relation.
+            //
             // Eager finite checks can only reject. Lazy comparisons can also contribute
             // structural solutions, so try them before using the nominal fallback.
             if (self.typevar_evaluation == TypeVarEvaluation::Lazy || !can_use_nominal_redundancy)
@@ -771,15 +779,39 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         Some(structurally_satisfied)
     }
 
-    /// Tries to relate the finite members of two specializations of the same protocol.
+    /// Tries to relate specializations of the same protocol using only non-recursive members.
     ///
-    /// This retains structural solutions such as `T | int`, while recursive members are the
-    /// coinductive edge currently being proved. Materialized protocols additionally require the
-    /// finite constraints to establish the nominal relation without losing type-variable constraints.
-    /// Returns `None` when the shortcut is inapplicable.
+    /// In this example, `value` can be checked without comparing another `Chain`, while checking
+    /// `child` leads to another protocol comparison:
+    ///
+    /// ```python
+    /// class Chain[T](Protocol):
+    ///     def value(self) -> T: ...
+    ///     def child(self) -> Chain[tuple[T]]: ...
+    /// ```
+    ///
+    /// Expanding `child` while comparing `Chain[S]` with `Chain[T]` produces a comparison of
+    /// `Chain[tuple[S]]` with `Chain[tuple[T]]`, then another with doubly nested tuples, and so on.
+    /// Each pair is different, so checking for an already-visited pair does not stop the expansion.
+    /// Comparing `value` instead relates `S` to `T` directly. In this example, that also establishes
+    /// the relationship between their tuples, without expanding `child` at all.
+    ///
+    /// For materialized protocols, we need more than a successful check of the remaining members.
+    /// Their constraints must mention every type variable in both sets of type arguments and imply
+    /// the nominal relation: every solution they allow must also satisfy the comparison of the
+    /// type arguments, according to the protocol's variance. Together with the materialization
+    /// checks below, this establishes that the recursive members cannot add further restrictions.
+    ///
+    /// We still return the structural constraints, not the nominal result. In particular, the
+    /// unmaterialized path retains structural solutions from members such as `value() -> T | int`
+    /// that comparing type arguments alone would miss.
     ///
     /// Eager comparisons can only reject: matching the finite requirements does not prove that
-    /// the omitted recursive members are compatible.
+    /// the omitted recursive members are compatible. Materialized protocols use this shortcut only
+    /// during lazy evaluation.
+    ///
+    /// Returning `None` means that we cannot use this shortcut, not that the relation fails. The
+    /// caller continues with its usual checks, including the full recursive comparison when needed.
     fn try_check_non_recursive_protocol_members(
         &self,
         db: &'db dyn Db,
@@ -808,10 +840,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        // Assignability chooses Bottom for an unmaterialized source and Top for an
-        // unmaterialized target. The opposite direction can change a fixed `Any` in an
-        // omitted recursive signature from `object` to `Never`, independently of its type
-        // parameters. Only the full structural comparison can establish that relation.
+        // Assignability chooses Bottom for an unmaterialized source and Top for an unmaterialized
+        // target. An explicit Top -> Bottom comparison is different: materialization can make a
+        // recursive requirement incompatible even when the type arguments are compatible.
+        //
+        // For example, consider:
+        //
+        //   class P[T](Protocol):
+        //       def value(self) -> T: ...
+        //       def consume(self, other: P[Any]) -> Any: ...
+        //
+        // Comparing Top[P[str]] with Bottom[P[object]] accepts `value`, since str is a subtype of
+        // object. But `consume` returns object in the source and must return Never in the target.
+        // This fixed Any changes independently of T, so neither the finite member nor the nominal
+        // comparison detects the mismatch. Leave that direction to the full structural check.
         let is_materialized = match (
             source_protocol.materialization_kind(db),
             protocol.materialization_kind(db),
@@ -844,8 +886,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        // Filter requirements, not evidence: a target-finite member can contain the same protocol
-        // in the source specialization and must remain available for comparison.
+        // Remove recursive requirements only from the target, and keep the complete source as
+        // evidence that the remaining requirements are satisfied. For example, when comparing
+        // Chain[Chain[int]] with Chain[object], the target's `value() -> object` is non-recursive,
+        // but the source's `value() -> Chain[int]` refers to Chain. Filtering both interfaces would
+        // remove the source member we need to establish that valid return-type comparison.
         let structurally_satisfied = self.check_protocol_interface_pair(
             db,
             ty,
@@ -856,6 +901,34 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             ),
         );
 
+        // A skipped member can be the only source of information about a type variable. In this
+        // example, `marker: Any` ensures materialization changes the interface for static arguments:
+        //
+        //   class Pair[First, Second](Protocol):
+        //       marker: Any
+        //       @property
+        //       def first(self) -> First: ...
+        //       def recursive_second(self, child: Pair[Any, Any]) -> Second: ...
+        //
+        // For Top[Pair[int, str]] -> Top[Pair[int, Second]], checking `first` tells us nothing about
+        // Second; only `recursive_second` supplies str <: Second. Check variables in both source
+        // and target arguments, since contravariant callable parameters can reverse the comparison.
+        // Also look through aliases: given `type Identity[T] = T`, the argument Identity[Second]
+        // still needs evidence for Second.
+        //
+        // Merely mentioning a variable is not enough: a skipped member may add its other bound.
+        // For example:
+        //
+        //   class Invariant[T](Protocol):
+        //       marker: Any
+        //       @property
+        //       def value(self) -> T: ...
+        //       def consume(self, other: Invariant[T]) -> None: ...
+        //
+        // Comparing Top[Invariant[str]] with Top[Invariant[T]], `value` supplies str <: T, but
+        // `consume` also requires T <: str. The nominal comparison requires both bounds because
+        // T is invariant. Requiring the finite constraints to imply that comparison catches the
+        // missing bound: allowing every supertype of str is not enough to prove T must equal str.
         if is_materialized
             && (target_alias
                 .specialization(db)
@@ -872,9 +945,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     .implies(db, self.constraints, || nominally_satisfied)
                     .is_always_satisfied(db, env))
         {
-            // A recursive member may supply the only constraint for a type variable, or
-            // impose the opposite bound through a consuming position. In either case the
-            // finite members alone do not prove the complete materialized relation.
             return None;
         }
 


### PR DESCRIPTION
Comparing explicit receiver types on overloaded recursive protocol methods can repeatedly expand materialized protocol specializations until ty overflows its stack. This extends the non-recursive-member shortcut to eligible materialized assignability comparisons, avoiding that expansion while preserving inference constraints.

For two specializations of the same protocol, the shortcut checks the non-recursive target requirements against the complete source interface. It skips recursive requirements only when those constraints mention every type variable in both specializations, including through aliases, and imply the nominal type-argument relation. Opposite top-to-bottom materializations and comparisons that cannot establish this proof retain the full structural path.

On main, the added benchmark overflows the stack. With this change it completes in about 10 ms in a profiling build.

Part of [astral-sh/ty#4269](https://github.com/astral-sh/ty/issues/4269).

## Test plan

- Overloaded recursive protocol methods with tuple-specialized receivers and a gradual fallback terminate and preserve the callback's return type.
- Generic inference retains evidence supplied only by recursive members for both top and bottom materializations, including aliased parameters and variables on the source side of contravariant comparisons.
- Source members that contain the protocol remain available when the corresponding target requirement is non-recursive.
- Assignability and constraint inference reject top-to-bottom comparisons when a fixed `Any` in a recursive method becomes an incompatible return requirement.
- An added benchmark checks the expanding recursive-overload case.
