### PR TITLE
[ty] Optimization: reject impossible eager protocol comparisons early

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -210,6 +210,59 @@ error[invalid-assignment]: Object of type `tuple[int, str]` is not assignable to
 info: a tuple of length 2 is not assignable to a tuple of length 3
 ```
 
+## Repeated successful comparisons before a mismatch
+
+Successful comparisons remain memoized while collecting context for a later mismatch. Fully
+expanding the first tuple element below would produce over a million leaves, but the diagnostic can
+identify the incompatible second element without visiting every repeated occurrence.
+
+```py
+type Pair[T] = tuple[T, T]
+type Quad[T] = Pair[Pair[T]]
+type Sixteen[T] = Quad[Quad[T]]
+type Nested[T] = Sixteen[Sixteen[Sixteen[Sixteen[Sixteen[T]]]]]
+
+def check(source: tuple[Nested[int], int]) -> tuple[Nested[object], str]:
+    return source  # snapshot: invalid-return-type
+```
+
+```snapshot
+error[invalid-return-type]: Return type does not match returned value
+ --> src/mdtest_snippet.py:7:12
+  |
+6 | def check(source: tuple[Nested[int], int]) -> tuple[Nested[object], str]:
+  |                                               -------------------------- Expected `tuple[Nested[object], str]` because of return type
+7 |     return source  # snapshot: invalid-return-type
+  |            ^^^^^^ expected `tuple[Nested[object], str]`, found `tuple[Nested[int], int]`
+info: the second tuple element is not compatible: `int` is not assignable to `str`
+```
+
+An explicit receiver can leave successful comparisons conditional on a type variable. Comparing the
+first parameters below produces a satisfiable constraint on `S`. We reuse that result while
+reporting the incompatible `y` parameter.
+
+```py
+from typing import Callable
+
+class Receiver:
+    def method[S](self: S, x: Nested[S], y: int) -> int:
+        return 0
+
+def check_receiver(receiver: Receiver) -> Callable[[Nested[int], str], int]:
+    return receiver.method  # snapshot: invalid-return-type
+```
+
+```snapshot
+error[invalid-return-type]: Return type does not match returned value
+  --> src/mdtest_snippet.py:15:12
+   |
+14 | def check_receiver(receiver: Receiver) -> Callable[[Nested[int], str], int]:
+   |                                           --------------------------------- Expected `(Nested[int], str, /) -> int` because of return type
+15 |     return receiver.method  # snapshot: invalid-return-type
+   |            ^^^^^^^^^^^^^^^ expected `(Nested[int], str, /) -> int`, found `bound method Receiver.method[S](x: Nested[S], y: int) -> int`
+info: the second parameter has an incompatible type: `str` is not assignable to `int`
+```
+
 ## `Callable`
 
 Assigning a function to a `Callable`
@@ -1315,6 +1368,51 @@ info:     └── incompatible return types: `Concrete[str]` is not assignable
 info:         └── type `Concrete[str]` is not assignable to protocol `Chain[int]`
 info:             └── protocol member `value` is incompatible
 info:                 └── incompatible return types: `str` is not assignable to `int`
+```
+
+## Recursive protocols in a union after overload comparison
+
+A recursive callable protocol can be incompatible with more than one member of a target union. The
+diagnostic includes the nested `payload` mismatch for `HasPacket[str]`, even if the same member
+types were already compared when checking the callable overloads.
+
+```py
+from __future__ import annotations
+
+from typing import Callable, Protocol, overload
+
+class Packet[T](Protocol):
+    payload: T
+
+class HasPacket[T](Protocol):
+    def packet(self) -> Packet[T]: ...
+
+class Source[T](HasPacket[T], Protocol):
+    @overload
+    def __call__(self, x: int) -> Source[T]: ...
+    @overload
+    def __call__(self, x: str) -> Source[tuple[T]]: ...
+
+def check(source: Source[bytes]) -> Callable[[int], Source[str]] | HasPacket[str]:
+    return source  # snapshot: invalid-return-type
+```
+
+```snapshot
+error[invalid-return-type]: Return type does not match returned value
+  --> src/mdtest_snippet.py:18:12
+   |
+17 | def check(source: Source[bytes]) -> Callable[[int], Source[str]] | HasPacket[str]:
+   |                                     --------------------------------------------- Expected `((int, /) -> Source[str]) | HasPacket[str]` because of return type
+18 |     return source  # snapshot: invalid-return-type
+   |            ^^^^^^ expected `((int, /) -> Source[str]) | HasPacket[str]`, found `Source[bytes]`
+info: type `Source[bytes]` is not assignable to any element of the union `((int, /) -> Source[str]) | HasPacket[str]`
+info: ├── type `Source[bytes]` has inferred callable type `Overload[(x: int) -> Source[bytes], (x: str) -> Source[tuple[bytes]]]`
+info: └── protocol `Source[bytes]` is not assignable to protocol `HasPacket[str]`
+info:     └── protocol member `packet` is incompatible
+info:         └── incompatible return types: `Packet[bytes]` is not assignable to `Packet[str]`
+info:             └── protocol `Packet[bytes]` is not assignable to protocol `Packet[str]`
+info:                 └── protocol member `payload` is incompatible
+info:                     └── read type `bytes` is not assignable to `str`
 ```
 
 ## Protocol method parameter names

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -6732,6 +6732,31 @@ def infer[T](outer: T, recursive: C[int]) -> None:
     accept(outer, recursive)
 ```
 
+### Recursive protocol requirements after matching finite members
+
+Matching a finite member does not prove that the whole protocol is compatible. The recursive `split`
+requirement also carries `T` in a tuple element, so these specializations are incompatible even
+though their `marker` methods match.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to
+
+class Node[T](Protocol):
+    def marker(self) -> int: ...
+    def split(self) -> tuple[T, Node[T]]: ...
+
+static_assert(not is_assignable_to(Node[str], Node[int]))
+```
+
 ### Nested protocol source members with finite targets
 
 A source specialization can contain its own protocol even when the target has no recursive
@@ -6757,7 +6782,8 @@ static_assert(is_constraint_set_assignable_to(Consumer[Consumer[int]], Consumer[
 
 A protocol member can contain the same protocol in the source specialization but remain finite in
 the target specialization. Its structural requirements must still contribute all valid solutions,
-even when nominal inheritance alone would infer a narrower type.
+even when nominal inheritance alone would infer a narrower type. The same members also establish
+assignability when no type variables need to be inferred.
 
 ```toml
 [environment]
@@ -6767,18 +6793,36 @@ python-version = "3.12"
 ```py
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to
 
 class Consumer[T](Protocol):
     def consume(self, value: T | int) -> None: ...
     @property
     def child(self) -> Consumer[T]: ...
 
+static_assert(is_assignable_to(Consumer[Consumer[int]], Consumer[int]))
+
 def extract[T](consumer: Consumer[T]) -> T:
     raise NotImplementedError
 
 def check(value: Consumer[Consumer[int]]) -> None:
     reveal_type(extract(value))  # revealed: Consumer[int] | int
+```
+
+An explicit receiver annotation introduces constraints when comparing a bound method with a
+callable. The return types still match structurally, so union simplification retains only the
+callable.
+
+```py
+class Receiver:
+    def method[S](self: S, value: S, /) -> Consumer[Consumer[int]]:
+        raise NotImplementedError
+
+def check_union(receiver: Receiver, callback: Callable[[object], Consumer[int]], flag: bool) -> None:
+    reveal_type(receiver.method if flag else callback)  # revealed: (object, /) -> Consumer[int]
 ```
 
 ### Repeated applications of a nonrecursive alias
@@ -6897,6 +6941,44 @@ def check[T](concrete: Concrete[int], symbolic: Concrete[T]) -> None:
     reveal_type(concrete.accumulate())  # revealed: Chain[int]
     reveal_type(symbolic.accumulate())  # revealed: Chain[T@check]
     reveal_type(Concrete().accumulate())  # revealed: Chain[Unknown]
+```
+
+### Incompatible explicit receivers on recursive protocols
+
+The `value` and `write` methods make `Chain` invariant. Calling `flatten` on `Chain[list[int]]` is
+therefore invalid, even though `list[int]` is assignable to `Iterable[int]`. The incompatible
+`write` requirement rejects the receiver without expanding the recursive specializations in
+`combinations` and `product`. A receiver specialized with `Iterable[int]` remains valid and
+preserves the element type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal, Protocol, overload
+
+class Chain[T](Protocol):
+    def value(self) -> T: ...
+    @overload
+    def combinations(self, length: Literal[2]) -> Chain[tuple[T, T]]: ...
+    @overload
+    def combinations(self, length: Literal[3]) -> Chain[tuple[T, T, T]]: ...
+    @overload
+    def combinations(self, length: int) -> Chain[tuple[T, ...]]: ...
+    def product(self) -> Chain[tuple[T]]: ...
+    def flatten[U](self: Chain[Iterable[U]]) -> Chain[U]: ...
+    def write(self, items: Iterable[T]) -> None: ...
+
+def invalid(value: Chain[list[int]]) -> None:
+    value.flatten()  # error: [invalid-argument-type]
+
+def valid(value: Chain[Iterable[int]]) -> None:
+    reveal_type(value.flatten())  # revealed: Chain[int]
 ```
 
 ### Structural inference from recursive protocol requirements

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -387,19 +387,37 @@ where
     ///
     /// The caller must convert `Err(item)` into an operation-specific conservative result. An
     /// exact recursive reentry uses the detector's configured fallback and is returned as `Ok`.
+    ///
+    /// Completed results are reused only when `reuse_cached` accepts them. Otherwise, the visit
+    /// recomputes the result using the same active recursion guards, without replacing the cached
+    /// value. Results for previously uncached items are memoized as usual.
     #[inline]
     pub(super) fn try_visit(
         &self,
         db: &'db dyn Db,
         item: T,
+        reuse_cached: impl FnOnce(&R) -> bool,
         compute: impl FnOnce() -> R,
     ) -> Result<R, T> {
-        match self.begin_visit(db, item) {
+        let cached_result = self.cache.borrow().get(&item).cloned();
+        let was_cached = cached_result.is_some();
+        if let Some(result) = cached_result
+            && reuse_cached(&result)
+        {
+            return Ok(result);
+        }
+
+        match self.begin_active_visit(db, item) {
             CycleDetectorVisit::Ready(result) => Ok(result),
             CycleDetectorVisit::Cycle(item) => Err(item),
             CycleDetectorVisit::Pending(item) => {
                 let result = compute();
-                Ok(self.finish_visit(item, result))
+                if was_cached {
+                    self.finish_active_visit(&item);
+                    Ok(result)
+                } else {
+                    Ok(self.finish_visit(item, result))
+                }
             }
         }
     }
@@ -409,6 +427,10 @@ where
             return CycleDetectorVisit::Ready(result.clone());
         }
 
+        self.begin_active_visit(db, item)
+    }
+
+    fn begin_active_visit(&self, db: &'db dyn Db, item: T) -> CycleDetectorVisit<T, R> {
         let seen = self.seen.borrow();
         if seen.iter().any(|active| active.item == item) {
             return CycleDetectorVisit::Ready(self.fallback.clone());
@@ -442,12 +464,16 @@ where
 
     /// Finish a [`CycleDetectorVisit::Pending`] visit and cache its result.
     fn finish_visit(&self, item: T, result: R) -> R {
-        let active = self.seen.borrow_mut().pop();
-        debug_assert!(active.as_ref().is_some_and(|active| active.item == item));
+        self.finish_active_visit(&item);
         self.cache
             .borrow_mut()
             .insert_completed(item, result.clone());
         result
+    }
+
+    fn finish_active_visit(&self, item: &T) {
+        let active = self.seen.borrow_mut().pop();
+        debug_assert!(active.as_ref().is_some_and(|active| active.item == *item));
     }
 }
 
@@ -752,7 +778,7 @@ mod tests {
         }
     }
 
-    #[derive(Clone, Eq, Hash, PartialEq)]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     struct ConstantIdentityItem(u8);
 
     impl<'db> HasIdentity<'db> for ConstantIdentityItem {
@@ -844,6 +870,89 @@ class RecursivePropertySetter[T](Protocol):
         assert_eq!(
             detector.visit(db, 1, || detector.visit(db, 1, || 20) + 10),
             10
+        );
+    }
+
+    #[test]
+    fn selectively_reuses_cached_results() {
+        let db = setup_db();
+        let db = &db;
+        let detector = Detector::new(0);
+
+        assert_eq!(detector.try_visit(db, 1, |_| true, || 10), Ok(10));
+        assert_eq!(
+            detector.try_visit(db, 1, |&result| result == 10, || 20),
+            Ok(10)
+        );
+        assert_eq!(
+            detector.try_visit(
+                db,
+                1,
+                |&result| result == 20,
+                || {
+                    assert_eq!(detector.try_visit(db, 1, |_| false, || 30), Ok(0));
+                    detector.visit(db, 1, || 30) + 10
+                }
+            ),
+            Ok(20)
+        );
+        assert_eq!(detector.visit(db, 1, || 30), 10);
+    }
+
+    #[test]
+    fn recomputed_visits_share_exact_recursion_guards() {
+        let db = setup_db();
+        let db = &db;
+        let detector = Detector::new(0);
+
+        assert_eq!(
+            detector.try_visit(db, 1, |_| false, || detector.visit(db, 1, || 20) + 10),
+            Ok(10)
+        );
+        assert_eq!(
+            detector.visit(db, 2, || {
+                assert_eq!(detector.try_visit(db, 2, |_| false, || 20), Ok(0));
+                10
+            }),
+            10
+        );
+    }
+
+    #[test]
+    fn recomputed_visits_share_abstract_identity_guards() {
+        let db = setup_db();
+        let db = &db;
+        let detector = CycleDetector::<TestVisit, ConstantIdentityItem, u8, 1>::new(0);
+
+        assert_eq!(
+            detector.try_visit(
+                db,
+                ConstantIdentityItem(1),
+                |_| false,
+                || {
+                    assert_eq!(
+                        detector.try_visit(db, ConstantIdentityItem(2), |_| true, || 20),
+                        Err(ConstantIdentityItem(2))
+                    );
+                    10
+                }
+            ),
+            Ok(10)
+        );
+        assert_eq!(
+            detector.try_visit(
+                db,
+                ConstantIdentityItem(3),
+                |_| true,
+                || {
+                    assert_eq!(
+                        detector.try_visit(db, ConstantIdentityItem(4), |_| false, || 20),
+                        Err(ConstantIdentityItem(4))
+                    );
+                    10
+                }
+            ),
+            Ok(10)
         );
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -607,27 +607,35 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     return result;
                 }
 
-                if let Some(structurally_satisfied) = self.try_check_non_recursive_protocol_members(
-                    db,
-                    ty,
-                    protocol,
-                    source_protocol_as_nominal,
-                    nominal_instance,
-                ) {
-                    return result.or(db, self.constraints, || structurally_satisfied);
-                }
-
                 // For union simplification, failing the nominal relation between two
                 // specializations of the same protocol class is enough to keep both union elements.
                 // Falling back to the structural relation can recursively compare every protocol
                 // member even though a failed redundancy check only means that we preserve a
                 // potentially redundant union arm.
-                if matches!(self.relation, TypeRelation::Redundancy { pure: false })
-                    && source_protocol_as_nominal.is_some_and(|source_instance| {
-                        source_instance.class(db, env).class_literal(db)
-                            == nominal_instance.class(db, env).class_literal(db)
-                    })
+                let can_use_nominal_redundancy =
+                    matches!(self.relation, TypeRelation::Redundancy { pure: false })
+                        && source_protocol_as_nominal.is_some_and(|source_instance| {
+                            source_instance.class(db, env).class_literal(db)
+                                == nominal_instance.class(db, env).class_literal(db)
+                        });
+
+                // Eager finite checks can only reject. Lazy comparisons can also contribute
+                // structural solutions, so try them before using the nominal fallback.
+                if (self.typevar_evaluation == TypeVarEvaluation::Lazy
+                    || !can_use_nominal_redundancy)
+                    && let Some(structurally_satisfied) = self
+                        .try_check_non_recursive_protocol_members(
+                            db,
+                            ty,
+                            protocol,
+                            source_protocol_as_nominal,
+                            nominal_instance,
+                        )
                 {
+                    return result.or(db, self.constraints, || structurally_satisfied);
+                }
+
+                if can_use_nominal_redundancy {
                     return nominally_satisfied;
                 }
             }
@@ -802,6 +810,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ///
     /// This retains structural solutions such as `T | int`, while recursive members are the
     /// coinductive edge currently being proved. Returns `None` when the shortcut is inapplicable.
+    ///
+    /// Eager comparisons can only reject: matching the finite requirements does not prove that
+    /// the omitted recursive members are compatible.
     fn try_check_non_recursive_protocol_members(
         &self,
         db: &'db dyn Db,
@@ -810,9 +821,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source_protocol_as_nominal: Option<NominalInstanceType<'db>>,
         nominal_instance: NominalInstanceType<'db>,
     ) -> Option<ConstraintSet<'db, 'c>> {
-        if self.typevar_evaluation != TypeVarEvaluation::Lazy
-            || self.is_context_collection_enabled()
-        {
+        if self.is_context_collection_enabled() {
             return None;
         }
 
@@ -859,7 +868,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // Filter requirements, not evidence: a target-finite member can contain the same protocol
         // in the source specialization and must remain available for comparison.
-        Some(self.check_protocol_interface_pair(
+        let structurally_satisfied = self.check_protocol_interface_pair(
             db,
             ty,
             source_interface,
@@ -867,7 +876,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 target_non_recursive,
                 target_interface.materialization_kind(),
             ),
-        ))
+        );
+
+        // We run the eager comparison to reject incompatible finite requirements before
+        // expanding recursive members. If it cannot reject, the caller checks the full
+        // interface instead.
+        (self.typevar_evaluation == TypeVarEvaluation::Lazy
+            || structurally_satisfied.is_never_satisfied(db, env))
+        .then_some(structurally_satisfied)
     }
 
     /// Return whether a class-object type inhabits `type[protocol]`.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1217,10 +1217,16 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         target: Type<'db>,
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
+        let collect_context = self.is_context_collection_enabled();
         self.relation_visitor
             .try_visit(
                 db,
                 (source, target, self.relation, self.typevar_evaluation),
+                // Cached constraints do not retain explanations. When collecting context,
+                // recompute unsatisfiable comparisons while preserving the active recursion
+                // guards. Satisfiable constraints remain reusable, including those that
+                // constrain type variables.
+                |result| !collect_context || !result.is_never_satisfied(db, self.env),
                 work,
             )
             .unwrap_or_else(|item| self.recursive_type_pair_fallback(db, item.0, item.1))


### PR DESCRIPTION
Type checking could spend substantial time expanding recursive protocol members even when a finite member already made an eager comparison impossible. This is particularly costly when checking explicit receiver annotations on invariant protocols.

Extend the finite-member shortcut to eager comparisons between specializations of the same protocol. Incompatible finite requirements reject the structural relation immediately; matching finite requirements still fall back to the full interface, since recursive members may impose additional requirements. Preserve the nominal shortcut for union simplification and the existing lazy structural comparisons.

Preserve nested protocol mismatch explanations when overload checking has already compared the same types. During diagnostic generation, recompute cached unsatisfiable comparisons while reusing satisfiable constraints and keeping the existing recursion guards.

On the `Chain.flatten` reproducer, the median time across five warmed debug runs with a single worker and concise output falls from 1.674 s to 0.039 s (about 43× faster). Full and concise diagnostics are unchanged for this reproducer.

Part of https://github.com/astral-sh/ty/issues/4269.

## Test plan

- Cover an invariant recursive `Chain` protocol with an incompatible `flatten` receiver and a valid receiver that preserves its element type.
- Verify that matching finite members cannot hide incompatible recursive requirements.
- Preserve structural assignability when recursion occurs in the source specialization, including lazy bound-method comparisons during union simplification.
- Preserve nested protocol-member explanations for a recursive callable protocol assigned to a union, including the incompatible `payload` type.
- Keep repeated successful alias comparisons fast when diagnosing later tuple or callable parameter mismatches, including explicit receivers that leave type-variable constraints.
- Check cache reuse and shared recursion guards when a completed comparison is repeated.
