### PR TITLE
[ty] Preserve `ParamSpec` bindings inferred against type context

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -504,9 +504,8 @@ info: the first parameter is missing
 
 ## Missing parameters in nested generic calls involving `TypeVarTuple`s and `ParamSpec`s
 
-In the following example, the signature of the `callback` function does not satisfy the `fn`
-parameter of `wrapper` in the `accept()` call, because the arguments provided to `accept()`
-following `fn` indicate that it must accept the value `1` as a positional argument, and it does not.
+In the following example, the arguments provided to the `accept()` call are not accepted by the
+signature of the `callback` function, and so we report an error on the outer call.
 
 We don't currently add error context in this code path, but we could add it in the future:
 
@@ -519,20 +518,20 @@ def wrapper1[**P](fn: Callable[P, None]) -> Callable[P, None]:
 def accept1[**P](fn: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 def callback1() -> None: ...
 
-accept1(wrapper1(callback1), 1)  # snapshot: invalid-argument-type
+accept1(wrapper1(callback1), 1)  # snapshot: too-many-positional-arguments
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `wrapper1` is incorrect
- --> src/mdtest_snippet.py:9:18
+error[too-many-positional-arguments]: Too many positional arguments to function `accept1`: expected 0, got 1
+ --> src/mdtest_snippet.py:9:30
   |
-9 | accept1(wrapper1(callback1), 1)  # snapshot: invalid-argument-type
-  |                  ^^^^^^^^^ Expected `(**P@accept1) -> None`, found `def callback1() -> None`
-info: Function defined here
- --> src/mdtest_snippet.py:3:5
+9 | accept1(wrapper1(callback1), 1)  # snapshot: too-many-positional-arguments
+  |                              ^
+info: Function signature here
+ --> src/mdtest_snippet.py:6:5
   |
-3 | def wrapper1[**P](fn: Callable[P, None]) -> Callable[P, None]:
-  |     ^^^^^^^^      --------------------- Parameter declared here
+6 | def accept1[**P](fn: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
 The following case is similar, but exercises a different code path. Here, we could also add error
@@ -545,24 +544,26 @@ def wrapper2[**P](fn: Callable[P, None]) -> Callable[P, None]:
 def accept2[**P](fn: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 def callback2(**kwargs: int) -> None: ...
 
-accept2(wrapper2(callback2), 1)  # snapshot: invalid-argument-type
+accept2(wrapper2(callback2), 1)  # snapshot: too-many-positional-arguments
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `wrapper2` is incorrect
-  --> src/mdtest_snippet.py:16:18
+error[too-many-positional-arguments]: Too many positional arguments to function `accept2`: expected 0, got 1
+  --> src/mdtest_snippet.py:16:30
    |
-16 | accept2(wrapper2(callback2), 1)  # snapshot: invalid-argument-type
-   |                  ^^^^^^^^^ Expected `(**P@accept2) -> None`, found `def callback2(**kwargs: int) -> None`
-info: Function defined here
-  --> src/mdtest_snippet.py:10:5
+16 | accept2(wrapper2(callback2), 1)  # snapshot: too-many-positional-arguments
+   |                              ^
+info: Function signature here
+  --> src/mdtest_snippet.py:13:5
    |
-10 | def wrapper2[**P](fn: Callable[P, None]) -> Callable[P, None]:
-   |     ^^^^^^^^      --------------------- Parameter declared here
+13 | def accept2[**P](fn: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
-And the same applies to the following two examples too, which both use a `TypeVarTuple` instead of a
-`ParamSpec`:
+The following examples use a `TypeVarTuple` instead of a `ParamSpec`. In this case, we forward the
+specialization of the outer `TypeVarTuple` to the inner call, and so report `callback3` as being
+incompatible with the signature of `wrapper3`, instead of the provided arguments being incompatible
+with the signature of `accept3`.
 
 ```py
 def wrapper3[*Ts](fn: Callable[[*Ts], None]) -> Callable[[*Ts], None]:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -639,6 +639,78 @@ f3(1)
 f3("a", "b")
 ```
 
+### Prefer the declared parameter list
+
+We prefer the declared parameter list of a `ParamSpec` when it is compatible with the callback's
+inferred parameter list:
+
+```py
+from typing import Callable
+
+class Callback[**P]:
+    def __init__(self, callback: Callable[P, None]) -> None: ...
+
+def accepts_object(value: object, /) -> None: ...
+
+x1 = Callback(accepts_object)
+reveal_type(x1)  # revealed: Callback[(value: object, /)]
+
+x2: Callback[[int]] = Callback(accepts_object)
+reveal_type(x2)  # revealed: Callback[(int, /)]
+```
+
+If the parameter lists are incompatible, we ignore the declared type in the invalid assignment
+diagnostic:
+
+```py
+def no_args() -> None: ...
+
+# error: [invalid-assignment] "Object of type `Callback[()]` is not assignable to `Callback[(int, /)]`"
+x3: Callback[[int]] = Callback(no_args)
+reveal_type(x3)  # revealed: Callback[(int, /)]
+```
+
+When no argument constrains the `ParamSpec`, the declared type supplies its parameter list:
+
+```py
+def make[**P]() -> Callback[P]:
+    raise NotImplementedError
+
+reveal_type(make())  # revealed: Callback[(...)]
+
+x4: Callback[[int, str]] = make()
+reveal_type(x4)  # revealed: Callback[(int, str, /)]
+```
+
+### Preserve callback parameters in nested calls
+
+The outer call checks forwarded arguments against the inferred parameter list of the wrapped
+callback:
+
+```py
+from typing import Callable
+
+def wrap[**P](callback: Callable[P, None]) -> Callable[P, None]:
+    return callback
+
+def accept[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+def no_args() -> None: ...
+
+reveal_type(wrap(no_args))  # revealed: () -> None
+
+accept(wrap(no_args))  # ok
+accept(wrap(no_args), 1)  # error: [too-many-positional-arguments]
+```
+
+Keyword-only parameters are also preserved:
+
+```py
+def keyword_only(*, value: int) -> None: ...
+
+accept(wrap(keyword_only), value=1)
+accept(wrap(keyword_only), value="incorrect")  # error: [invalid-argument-type]
+```
+
 ### Preserve an unpacked required suffix
 
 A `ParamSpec` preserves a named positional prefix and the required suffix of an unpacked variadic

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -6100,6 +6100,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 for solution in solutions.as_slice() {
                     for binding in solution {
                         let identity = binding.bound_typevar.identity(db);
+                        // A `ParamSpec` keeps its first binding, so seeding it here would discard
+                        // the inferred parameter list of the argument.
+                        if binding.bound_typevar.is_paramspec(db) {
+                            continue;
+                        }
+
                         if let Some(&ty) = preferred.get(&identity) {
                             builder.add_type_mapping(
                                 binding.bound_typevar,
@@ -6198,24 +6204,25 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         };
 
         let mut choose = |typevar: BoundTypeVarInstance<'db>, bounds: Option<&PathBound<'db>>| {
-            let bounds = bounds?;
-            let lower = bounds.evidence_lower?;
+            let preferred_ty = preferred_type_mappings.get(&typevar.identity(db)).copied();
 
-            if let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(db))
-                && lower.is_assignable_to(db, self.env, preferred_ty)
-            {
-                // A contextual fallback remains incomplete when selected for the call.
-                return Some(if preferred_solutions_incomplete {
-                    PathBoundSolution::BudgetExceeded {
-                        fallback: Some(preferred_ty),
-                    }
-                } else {
-                    PathBoundSolution::Solved(preferred_ty)
-                });
+            if let Some(bounds) = bounds {
+                let lower = bounds.evidence_lower?;
+                if preferred_ty.is_none_or(|ty| !lower.is_assignable_to(db, self.env, ty)) {
+                    return maybe_promote(typevar, bounds);
+                }
             }
 
-            maybe_promote(typevar, bounds)
+            // A contextual fallback remains incomplete when selected for the call.
+            preferred_ty.map(|ty| {
+                if preferred_solutions_incomplete {
+                    PathBoundSolution::BudgetExceeded { fallback: Some(ty) }
+                } else {
+                    PathBoundSolution::Solved(ty)
+                }
+            })
         };
+
         let inference = match builder.build_inference_with(&mut choose) {
             Ok(inference) => inference,
             Err(()) => builder.build_diagnostic_inference_with(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3321,7 +3321,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let LegacyTypeMappings::Available(types) = &mut self.types else {
             return false;
         };
-        types.get_mut(&bound_typevar).is_some_and(|inferred_ty| {
+
+        // An unsolved type variable is always compatible.
+        types.get_mut(&bound_typevar).is_none_or(|inferred_ty| {
             inferred_ty
                 .get_or_build(db, self.env)
                 .is_assignable_to(db, self.env, ty)


### PR DESCRIPTION
When inferring a `ParamSpec`, we currently propagate a declared callable type as type context if provided. This causes us to discard the inferred signature of the `ParamSpec` in nested generic calls, leading to false positives and less precise diagnostics. For example, the following snippet currently errors:
```py
from typing import Callable

def wrap[**Q](callback: Callable[Q, None]) -> Callable[Q, None]:
    return callback

def accept[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
def no_args() -> None: ...

# error[invalid-argument-type]: Expected `(**P@accept) -> None`, found `def no_args() -> None`
accept(wrap(no_args))
```