### PR TITLE
[ty] Avoid panics on incomplete protocol type parameter lists

### DIFF
--- a/crates/ruff_text_size/src/size.rs
+++ b/crates/ruff_text_size/src/size.rs
@@ -106,6 +106,25 @@ impl TextSize {
     pub fn checked_sub(self, rhs: TextSize) -> Option<TextSize> {
         self.raw.checked_sub(rhs.raw).map(|raw| TextSize { raw })
     }
+
+    /// Saturating addition. Returns maximum `TextSize` if overflow occurred.
+    #[inline]
+    #[must_use]
+    pub fn saturating_add(self, rhs: TextSize) -> TextSize {
+        TextSize {
+            raw: self.raw.saturating_add(rhs.raw),
+        }
+    }
+
+    /// Saturating subtraction. Returns minimum `TextSize` if overflow
+    /// occurred.
+    #[inline]
+    #[must_use]
+    pub fn saturating_sub(self, rhs: TextSize) -> TextSize {
+        TextSize {
+            raw: self.raw.saturating_sub(rhs.raw),
+        }
+    }
 }
 
 impl From<u32> for TextSize {

--- a/crates/ruff_text_size/src/size.rs
+++ b/crates/ruff_text_size/src/size.rs
@@ -106,25 +106,6 @@ impl TextSize {
     pub fn checked_sub(self, rhs: TextSize) -> Option<TextSize> {
         self.raw.checked_sub(rhs.raw).map(|raw| TextSize { raw })
     }
-
-    /// Saturating addition. Returns maximum `TextSize` if overflow occurred.
-    #[inline]
-    #[must_use]
-    pub fn saturating_add(self, rhs: TextSize) -> TextSize {
-        TextSize {
-            raw: self.raw.saturating_add(rhs.raw),
-        }
-    }
-
-    /// Saturating subtraction. Returns minimum `TextSize` if overflow
-    /// occurred.
-    #[inline]
-    #[must_use]
-    pub fn saturating_sub(self, rhs: TextSize) -> TextSize {
-        TextSize {
-            raw: self.raw.saturating_sub(rhs.raw),
-        }
-    }
 }
 
 impl From<u32> for TextSize {

--- a/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
@@ -277,3 +277,43 @@ InvalidEmptyAnnotated = Annotated[]
 def _(a: InvalidEmptyAnnotated):
     reveal_type(a)  # revealed: Unknown
 ```
+
+## Incomplete type parameter lists
+
+A generic protocol with an empty, unclosed type parameter list produces diagnostics without
+panicking while constructing an autofix.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+# error: [invalid-syntax] "Type parameter list cannot be empty"
+# error: [invalid-generic-class]
+class P[(Protocol[T]): ...
+```
+
+## Incomplete type parameter lists with Unicode names
+
+An unclosed type parameter list can also contain a non-ASCII name. The missing closing bracket does
+not cause part of the name to be treated as a delimiter when constructing an autofix.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+# error: [invalid-syntax] "Expected `]`, found `(`"
+# error: [invalid-generic-class]
+class P[Ä(Protocol[T]): ...
+```

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -6,7 +6,7 @@ use ruff_db::{
 };
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::{self as ast, PythonVersion, name::Name};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 
 use crate::{
@@ -389,11 +389,11 @@ pub(crate) fn check_static_class_definitions<'db>(
                     );
                     if let ast::Expr::Subscript(node) = node {
                         let source = source_text(db, context.file());
-                        let type_params_range = TextRange::new(
-                            type_params.start().saturating_add(TextSize::new(1)),
-                            type_params.end().saturating_sub(TextSize::new(1)),
-                        );
-                        if source[node.slice.range()] == source[type_params_range] {
+                        // The parser can recover a type parameter list without a closing bracket.
+                        if let Some(type_params) = source[type_params.range()].strip_prefix('[')
+                            && let Some(type_params) = type_params.strip_suffix(']')
+                            && type_params == &source[node.slice.range()]
+                        {
                             diagnostic.help("Remove the type parameters from the `Protocol` base");
                             diagnostic.set_fix(Fix::unsafe_edit(Edit::range_deletion(
                                 TextRange::new(node.value.end(), node.end()),

--- a/hawk.toml
+++ b/hawk.toml
@@ -552,6 +552,22 @@ reason = "one-indexed arithmetic intentionally provides checked and saturating o
 
 [[override]]
 lint = "hawk::dead_public"
+crate = "ruff_text_size"
+item = "size::TextSize::saturating_add"
+kind = "inherent_method"
+level = "expect"
+reason = "TextSize intentionally provides both checked and saturating arithmetic"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "ruff_text_size"
+item = "size::TextSize::saturating_sub"
+kind = "inherent_method"
+level = "expect"
+reason = "TextSize intentionally provides both checked and saturating arithmetic"
+
+[[override]]
+lint = "hawk::dead_public"
 crate = "ty_project"
 item = "db::changes::ChangeResult::custom_stdlib_changed"
 kind = "inherent_method"


### PR DESCRIPTION
ty can panic when a generic protocol definition has an incomplete type parameter list. The autofix for `invalid-generic-class` assumes that the list contains both brackets, which can produce an inverted range or split a Unicode identifier when the closing bracket is missing.

Check the delimiters before comparing the type parameters with the `Protocol` subscript. Incomplete lists still produce diagnostics, but do not receive this autofix. Targeted Hawk expectations preserve the public saturating arithmetic helpers in `TextSize`.

Fixes astral-sh/ty#4397.

## Test plan

Add mdtests for an empty, unclosed type parameter list and an unclosed list containing a Unicode name. Both cases produce diagnostics without panicking. Existing protocol tests retain coverage for the autofix on complete type parameter lists.
