### PR TITLE
[ty] Preserve gradual type context during generic call inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1634,6 +1634,16 @@ def _(xy: X | Y):
     xy.x = reveal_type([1])  # revealed: list[int]
 ```
 
+Unannotated lambda parameters do not prevent the inferred attribute type from providing context to
+the dictionary literals:
+
+```py
+class Callbacks:
+    def __init__(self):
+        self.values = [{"x": 0}, {"x": lambda x: 0}]
+        self.identities = [{"x": 0}, {"x": lambda x: x}]
+```
+
 ## Overload evaluation
 
 The type context of all matching overloads are considered during argument inference:
@@ -1807,7 +1817,7 @@ def from_or(values: list[str] | None) -> None:
         reveal_type(value)  # revealed: str
 
 def constructor_fallback(values: list[int] | None) -> None:
-    reveal_type(values or list())  # revealed: (list[int] & ~AlwaysFalsy) | list[Unknown]
+    reveal_type(values or list())  # revealed: list[int]
 
 def from_and(values: list[str]) -> None:
     reveal_type(values and [])  # revealed: list[str]
@@ -2361,6 +2371,137 @@ def non_generic(value: int) -> int:
 # error: [unresolved-reference]
 diagnostic_pair(non_generic(missing_argument), [1])
 diagnostic_pair(non_generic(suppressed_argument), [1])  # ty: ignore[unresolved-reference]
+```
+
+## Dynamic type context
+
+A lambda parameter can use type context containing `Any`:
+
+```py
+from typing import Any, Callable
+
+def callable_pair[T](pair: tuple[Callable[[T], int], list[T]]) -> None:
+    function, values = pair
+    function(values[0])
+
+def _(values: list[list[Any]]):
+    callable_pair((lambda value: len(reveal_type(value)), values))  # revealed: list[Any]
+```
+
+List literals widen based on dynamic type context contributed from a sibling argument:
+
+```py
+def append[T](items: list[T], value: T) -> None:
+    items.append(value)
+
+def example(value: str | Any) -> None:
+    append([1], value)
+```
+
+This also applies when a generic base class contributes gradual type context:
+
+```py
+class GenericBase[T]: ...
+class Specialized(GenericBase[str]): ...
+class Mixed(Specialized, GenericBase[Any]): ...
+
+def g[T](values: list[T], base: GenericBase[T]) -> list[T]:
+    return values
+
+reveal_type(g([1], Specialized()))  # revealed: list[int | str]
+reveal_type(g([1], Mixed()))  # revealed: list[int | str | Any]
+```
+
+Dynamic arguments also participate when inferring the specialization for a nested collection
+literal:
+
+```py
+from ty_extensions._internal import Unknown
+
+def merge[K, V](*maps: dict[K, V]) -> tuple[K, V]:
+    raise NotImplementedError
+
+def _(dynamic: Unknown):
+    # TODO: The key and value types should also include `Unknown`.
+    reveal_type(merge({"a": 1}, {2: "b"}, dynamic))  # revealed: tuple[str | int, int | str]
+    reveal_type(merge(dynamic, {"a": 1}, {2: "b"}))  # revealed: tuple[str | int, int | str]
+
+def _(dynamic: Any):
+    # TODO: The key and value types should also include `Any`.
+    reveal_type(merge({"a": 1}, {2: "b"}, dynamic))  # revealed: tuple[str | int, int | str]
+    reveal_type(merge(dynamic, {"a": 1}, {2: "b"}))  # revealed: tuple[str | int, int | str]
+```
+
+## Lambda parameter cycles
+
+The return context can determine the types of mutually dependent identity callbacks. Unresolved
+parameter types do not contribute `Unknown` to the inferred return type:
+
+```toml
+[environment]
+python-version = "3.13"
+
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from collections.abc import Callable
+
+def f[T, U, V](extract: Callable[[U], V], store: Callable[[V], U], key: Callable[[T], str]) -> list[V]:
+    raise NotImplementedError
+
+def _[T](key: Callable[[T], str]) -> list[T]:
+    return f(key=key, extract=lambda x: x, store=lambda x: x)
+```
+
+Gradual types from arguments still propagate through an identity lambda:
+
+```py
+from typing import Any
+from ty_extensions._internal import Unknown
+
+def apply[T, R](function: Callable[[T], R], value: T) -> R:
+    return function(value)
+
+def _(value: Any):
+    reveal_type(apply(lambda x: x, value))  # revealed: Any
+
+def _(value: Unknown):
+    reveal_type(apply(lambda x: x, value))  # revealed: Unknown
+```
+
+## Type-variable defaults as type context
+
+An explicit type-variable default can provide fallback context when arguments do not determine a
+type:
+
+```py
+from collections.abc import Callable
+
+class Base[T]: ...
+class Child[T](Base[T]): ...
+
+class Container[T = Base[str]]:
+    def __init__(self, factory: Callable[[], T] | None = None) -> None: ...
+
+reveal_type(Container())  # revealed: Container[Base[str]]
+
+x1 = Container(Child)
+reveal_type(x1)  # revealed: Container[Child[str]]
+reveal_type(Container(Child))  # revealed: Container[Child[str]]
+```
+
+An inferred argument type takes precedence over the default:
+
+```py
+reveal_type(Container(Child[int]))  # revealed: Container[Child[int]]
+
+def create[T = Base[str]](factory: Callable[[], T], value: T) -> T:
+    return factory()
+
+def _(value: Child[int]):
+    reveal_type(create(Child, value))  # revealed: Child[int]
 ```
 
 ## Dunder Calls

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -76,6 +76,17 @@ reveal_type(Foo())  # revealed: Foo
 reveal_type(Foo(1, 2))  # revealed: Foo
 ```
 
+When `__new__` is a lambda with an unknown return type, constructor calls still infer the class
+instance type:
+
+```py
+class LambdaNew:
+    __new__ = lambda cls: object.__new__(cls)
+
+reveal_type(LambdaNew())  # revealed: LambdaNew
+LambdaNew().missing_attribute  # error: [unresolved-attribute]
+```
+
 ## `__new__` with an invalid decorator and unresolved return annotation
 
 Regression test for <https://github.com/astral-sh/ty/issues/3470>.

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1414,6 +1414,15 @@ def list_caller(value: list[Any]) -> None:
     reveal_type(choose(value, [1]))  # revealed: int | list[int]
 ```
 
+The `Unknown` returned by a lambda without declared parameter types is also gradual evidence:
+
+```py
+lambda_identity = lambda value: value
+
+def lambda_caller(value: Any) -> None:
+    reveal_type(identity(lambda_identity(value)))  # revealed: Unknown
+```
+
 ## Ambiguous constrained TypeVar inference from a gradual callable return
 
 Constraint-set-native inference also preserves gradual evidence nested inside a callable. As above,

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -975,7 +975,17 @@ def without_first(callback: Callback[Concatenate[object, P]]) -> Callable[P, Non
 
 def original(first: object, value: str) -> None: ...
 
-remaining = without_first(Callback(original))  # error: [invalid-argument-type]
+wrapped = Callback(original)
+remaining = without_first(wrapped)  # error: [invalid-argument-type]
+reveal_type(remaining)  # revealed: (value: str) -> None
+remaining(1)  # error: [invalid-argument-type]
+```
+
+When constructed inline, `Callback` infers the positional-only prefix based on the outer type
+context:
+
+```py
+remaining = without_first(Callback(original))
 reveal_type(remaining)  # revealed: (value: str) -> None
 remaining(1)  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -534,12 +534,14 @@ def contravariant_tail[**P, R](
 def original(first: object, value: str) -> int:
     return len(value)
 
-invariant_remaining = invariant_tail(InvariantCallback(original))  # error: [invalid-argument-type]
+invariant_callback = InvariantCallback(original)
+invariant_remaining = invariant_tail(invariant_callback)  # error: [invalid-argument-type]
 reveal_type(invariant_remaining)  # revealed: (value: str) -> int
 invariant_remaining(1)  # error: [invalid-argument-type]
 invariant_remaining("valid").missing_attribute  # error: [unresolved-attribute]
 
-contravariant_remaining = contravariant_tail(ContravariantCallback(original))  # error: [invalid-argument-type]
+contravariant_callback = ContravariantCallback(original)
+contravariant_remaining = contravariant_tail(contravariant_callback)  # error: [invalid-argument-type]
 reveal_type(contravariant_remaining)  # revealed: (value: str) -> int
 contravariant_remaining(1)  # error: [invalid-argument-type]
 contravariant_remaining("valid").missing_attribute  # error: [unresolved-attribute]
@@ -562,19 +564,36 @@ def contravariant_higher_order[**P](
 ) -> Callable[P, None]:
     raise NotImplementedError
 
-invariant_exact = invariant_higher_order(InvariantCallback(accepts_exact))  # error: [invalid-argument-type]
+invariant_exact_callback = InvariantCallback(accepts_exact)
+invariant_exact = invariant_higher_order(invariant_exact_callback)  # error: [invalid-argument-type]
 reveal_type(invariant_exact)  # revealed: (str, /) -> None
 invariant_exact(1)  # error: [invalid-argument-type]
 
-invariant_narrower = invariant_higher_order(InvariantCallback(accepts_narrower))  # error: [invalid-argument-type]
+invariant_narrower_callback = InvariantCallback(accepts_narrower)
+invariant_narrower = invariant_higher_order(invariant_narrower_callback)  # error: [invalid-argument-type]
 reveal_type(invariant_narrower)  # revealed: (str, /) -> None
 
-contravariant_exact = contravariant_higher_order(ContravariantCallback(accepts_exact))  # error: [invalid-argument-type]
+contravariant_exact_callback = ContravariantCallback(accepts_exact)
+contravariant_exact = contravariant_higher_order(contravariant_exact_callback)  # error: [invalid-argument-type]
 reveal_type(contravariant_exact)  # revealed: (str, /) -> None
 contravariant_exact(1)  # error: [invalid-argument-type]
 
-contravariant_narrower = contravariant_higher_order(ContravariantCallback(accepts_narrower))  # error: [invalid-argument-type]
+contravariant_narrower_callback = ContravariantCallback(accepts_narrower)
+contravariant_narrower = contravariant_higher_order(contravariant_narrower_callback)  # error: [invalid-argument-type]
 reveal_type(contravariant_narrower)  # revealed: (str, /) -> None
+```
+
+When constructed inline, the wrappers infer the positional-only prefix based on the outer type
+context:
+
+```py
+reveal_type(invariant_tail(InvariantCallback(original)))  # revealed: (value: str) -> int
+reveal_type(contravariant_tail(ContravariantCallback(original)))  # revealed: (value: str) -> int
+
+reveal_type(invariant_higher_order(InvariantCallback(accepts_exact)))  # revealed: (str, /) -> None
+reveal_type(invariant_higher_order(InvariantCallback(accepts_narrower)))  # revealed: (str, /) -> None
+reveal_type(contravariant_higher_order(ContravariantCallback(accepts_exact)))  # revealed: (str, /) -> None
+reveal_type(contravariant_higher_order(ContravariantCallback(accepts_narrower)))  # revealed: (str, /) -> None
 ```
 
 ## Inferring through nested callable protocols
@@ -632,13 +651,23 @@ def contravariant_tail[**P](container: ContravariantCallback[VariadicCallback[P]
 
 def original(first: object, value: str) -> None: ...
 
-invariant_remaining = invariant_tail(InvariantCallback(original))  # error: [invalid-argument-type]
+invariant_callback = InvariantCallback(original)
+invariant_remaining = invariant_tail(invariant_callback)  # error: [invalid-argument-type]
 reveal_type(invariant_remaining)  # revealed: (value: str) -> None
 invariant_remaining(1)  # error: [invalid-argument-type]
 
-contravariant_remaining = contravariant_tail(ContravariantCallback(original))  # error: [invalid-argument-type]
+contravariant_callback = ContravariantCallback(original)
+contravariant_remaining = contravariant_tail(contravariant_callback)  # error: [invalid-argument-type]
 reveal_type(contravariant_remaining)  # revealed: (value: str) -> None
 contravariant_remaining(1)  # error: [invalid-argument-type]
+```
+
+When constructed inline, the wrappers infer the positional-only prefix based on the outer type
+context:
+
+```py
+reveal_type(invariant_tail(InvariantCallback(original)))  # revealed: (value: str) -> None
+reveal_type(contravariant_tail(ContravariantCallback(original)))  # revealed: (value: str) -> None
 ```
 
 A nominal callable object's `__call__` method must likewise preserve the callback protocol's
@@ -648,13 +677,22 @@ inferred parameters under both wrapper variances.
 class CallableObject:
     def __call__(self, first: object, value: str) -> None: ...
 
-invariant_object = invariant_tail(InvariantCallback(CallableObject()))  # error: [invalid-argument-type]
+invariant_callback = InvariantCallback(CallableObject())
+invariant_object = invariant_tail(invariant_callback)  # error: [invalid-argument-type]
 reveal_type(invariant_object)  # revealed: (value: str) -> None
 invariant_object(1)  # error: [invalid-argument-type]
 
-contravariant_object = contravariant_tail(ContravariantCallback(CallableObject()))  # error: [invalid-argument-type]
+contravariant_callback = ContravariantCallback(CallableObject())
+contravariant_object = contravariant_tail(contravariant_callback)  # error: [invalid-argument-type]
 reveal_type(contravariant_object)  # revealed: (value: str) -> None
 contravariant_object(1)  # error: [invalid-argument-type]
+```
+
+Similarly, constructing the wrappers inline lets them use the `VariadicCallback` type from context:
+
+```py
+reveal_type(invariant_tail(InvariantCallback(CallableObject())))  # revealed: (value: str) -> None
+reveal_type(contravariant_tail(ContravariantCallback(CallableObject())))  # revealed: (value: str) -> None
 ```
 
 ## Bound violations inferred through protocols
@@ -1620,6 +1658,15 @@ def _(any_value: Any, unknown_value: Unknown, upper: Callable[[list[int]], None]
     reveal_type(any_result[0])  # revealed: int & Any
     reveal_type(unknown_result)  # revealed: list[int] & Unknown
     reveal_type(unknown_result[0])  # revealed: int & Unknown
+```
+
+The same restriction applies when `Unknown` is inferred from a lambda call:
+
+```py
+identity = lambda value: value
+
+def _(value: Unknown, upper: Callable[[int], None]):
+    reveal_type(infer(identity(value), upper))  # revealed: int & Unknown
 ```
 
 ## Redundant upper bounds preserve large gradual unions

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -668,21 +668,6 @@ def _(upper: Callable[[int], None]):
     reveal_type(f("x", upper))  # revealed: list[str | int]
 ```
 
-This also applies when multiple inheritance contributes both static and gradual specializations:
-
-```py
-from typing import Any
-
-class Base[T]: ...
-class Specialized(Base[str]): ...
-class Mixed(Specialized, Base[Any]): ...
-
-def g[T](values: list[T], base: Base[T]) -> list[T]:
-    return values
-
-g([1], Mixed())  # error: [invalid-argument-type]
-```
-
 ## Literal annotations from declaration are respected
 
 Literal types that are explicitly annotated when declared will not be promoted, even if they are

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2131,6 +2131,7 @@ impl<'db> Type<'db> {
             Type::Dynamic(
                 DynamicType::Unknown
                     | DynamicType::UnknownGeneric(_)
+                    | DynamicType::UnknownLambdaParameter
                     | DynamicType::AmbiguousOverload
             )
         )
@@ -2296,6 +2297,7 @@ impl<'db> Type<'db> {
             | DynamicType::InvalidConcatenateUnknown
             | DynamicType::UnknownGeneric(_)
             | DynamicType::UnspecializedTypeVar
+            | DynamicType::UnknownLambdaParameter
             | DynamicType::AmbiguousOverload => false,
             DynamicType::Todo(_) => true,
         })
@@ -3078,6 +3080,7 @@ impl<'db> Type<'db> {
                 DynamicType::Unknown
                 | DynamicType::UnknownGeneric(_)
                 | DynamicType::UnspecializedTypeVar
+                | DynamicType::UnknownLambdaParameter
                 | DynamicType::Todo(_)
                 | DynamicType::InvalidConcatenateUnknown
                 | DynamicType::AmbiguousOverload => false,
@@ -9688,6 +9691,7 @@ impl<'db> Type<'db> {
             Self::Dynamic(
                 DynamicType::Unknown
                 | DynamicType::UnknownGeneric(_)
+                | DynamicType::UnknownLambdaParameter
                 | DynamicType::AmbiguousOverload,
             ) => Type::SpecialForm(SpecialFormType::Unknown).definition(db, env),
             Self::Divergent(_) => Type::SpecialForm(SpecialFormType::Divergent).definition(db, env),
@@ -10464,6 +10468,8 @@ pub enum DynamicType<'db> {
     /// calls. For now, we replace unspecialized type variables with this marker type, and ignore them
     /// during generic inference.
     UnspecializedTypeVar,
+    /// A provisional marker inferred for a lambda parameter before access to its declared type.
+    UnknownLambdaParameter,
     /// A special variant that represents that `Unknown` was inferred due to an invalid use of
     /// `Concatenate` in a type expression.
     ///
@@ -10493,6 +10499,13 @@ impl DynamicType<'_> {
     fn is_todo(&self) -> bool {
         matches!(self, Self::Todo(_))
     }
+
+    const fn is_provisional_marker(self) -> bool {
+        matches!(
+            self,
+            Self::UnspecializedTypeVar | Self::UnknownLambdaParameter
+        )
+    }
 }
 
 impl std::fmt::Display for DynamicType<'_> {
@@ -10501,6 +10514,7 @@ impl std::fmt::Display for DynamicType<'_> {
             DynamicType::Any => f.write_str("Any"),
             DynamicType::Unknown
             | DynamicType::UnknownGeneric(_)
+            | DynamicType::UnknownLambdaParameter
             | DynamicType::InvalidConcatenateUnknown
             | DynamicType::AmbiguousOverload => f.write_str("Unknown"),
             DynamicType::UnspecializedTypeVar => f.write_str("UnspecializedTypeVar"),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -6053,21 +6053,20 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         }
 
                         // Filter out inferable typevars (cross-typevar references from
-                        // SequentMap transitivity) and unspecialized typevars (from partially
-                        // specialized contexts).
+                        // SequentMap transitivity) and provisional markers.
                         let inferred_ty = builder
                             .remove_inferable_typevar_artifacts_from_solution(
                                 binding.bound_typevar,
                                 binding.solution,
                             )
                             .filter_union(db, self.env, |ty| {
-                                if ty.has_unspecialized_type_var(db, self.env) {
+                                if ty.has_provisional_marker(db, self.env) {
                                     partially_specialized_declared_type.insert(identity);
                                     return false;
                                 }
                                 true
                             });
-                        if inferred_ty.has_unspecialized_type_var(db, self.env) {
+                        if inferred_ty.has_provisional_marker(db, self.env) {
                             continue;
                         }
 
@@ -7899,6 +7898,15 @@ impl<'db> Binding<'db> {
             }
         }
 
+        // The marker distinguishes unsolved type variables without defaults from gradual types
+        // inferred from arguments. Only the former are ignored during fixpoint iteration.
+        let argument_specialization = self.inference.map(|inference| {
+            inference.merged_specialization_with(db, |typevar, inferred| {
+                (inferred.is_none() && typevar.default_type(db).is_none())
+                    .then_some(Type::Dynamic(DynamicType::UnspecializedTypeVar))
+            })
+        });
+
         // TODO: Note that specializing parameter types for type context using this specialization is
         // not strictly correct, as it requires eagerly choosing a solution for a given type variable,
         // which may conflate upper and lower bounds when applied transitively to parameter types
@@ -7912,10 +7920,9 @@ impl<'db> Binding<'db> {
                 let identity = typevar.identity(db);
 
                 let call_expression_constraints = return_type_solutions.get(&identity).copied();
-                let argument_constraints = self
-                    .merged_specialization(db)
+                let argument_constraints = argument_specialization
                     .and_then(|specialization| specialization.get(db, typevar))
-                    .filter(|ty| !ty.has_dynamic(db, env))
+                    .filter(|ty| !ty.has_provisional_marker(db, env))
                     .map(|ty| ty.promote(db, env));
 
                 // TODO: We should similarly combine both the call expression and argument constraints

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -72,6 +72,7 @@ impl<'db> ClassBase<'db> {
             ClassBase::Dynamic(
                 DynamicType::Unknown
                 | DynamicType::UnknownGeneric(_)
+                | DynamicType::UnknownLambdaParameter
                 | DynamicType::InvalidConcatenateUnknown
                 | DynamicType::AmbiguousOverload,
             ) => "Unknown",

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2021,7 +2021,7 @@ impl<'db> ConstraintBounds<'db> {
         iter::chain(self.lower, self.upper).all(|bound| {
             let bound = bound.ty();
             !bound.has_typevar(db, env)
-                && !bound.has_unspecialized_type_var(db, env)
+                && !bound.has_provisional_marker(db, env)
                 && bound.bottom_materialization(db, env) == bound.top_materialization(db, env)
         })
     }
@@ -4182,7 +4182,7 @@ impl<'db> PathBounds<'db> {
                     let mut bounds = iter::chain(constraint.bounds.lower, constraint.bounds.upper)
                         .map(ConstraintBound::ty);
                     if bounds.any(|bound| {
-                        bound.has_typevar(db, env) || bound.has_unspecialized_type_var(db, env)
+                        bound.has_typevar(db, env) || bound.has_provisional_marker(db, env)
                     }) {
                         return ControlFlow::Continue(None);
                     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6802,8 +6802,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for binding in solution {
                 let inferred_ty = binding
                     .solution
-                    .filter_union(db, env, |ty| !ty.has_unspecialized_type_var(db, env));
-                if inferred_ty.has_unspecialized_type_var(db, env) {
+                    .filter_union(db, env, |ty| !ty.has_provisional_marker(db, env));
+                if inferred_ty.has_provisional_marker(db, env) {
                     continue;
                 }
 
@@ -8623,6 +8623,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .iter()
                 .map(|param| {
                     let parameter = Parameter::positional_only(Some(param.name().id.clone()))
+                        .with_inferred_type(Type::Dynamic(DynamicType::UnknownLambdaParameter))
                         .with_optional_default_type(param.default().map(|default_expr| {
                             self.infer_expression(default_expr, TypeContext::default())
                                 .replace_parameter_defaults(db, env)
@@ -8640,6 +8641,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .iter()
                 .map(|param| {
                     let parameter = Parameter::positional_or_keyword(param.name().id.clone())
+                        .with_inferred_type(Type::Dynamic(DynamicType::UnknownLambdaParameter))
                         .with_optional_default_type(param.default().map(|default_expr| {
                             self.infer_expression(default_expr, TypeContext::default())
                                 .replace_parameter_defaults(db, env)
@@ -8652,26 +8654,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 })
                 .collect::<Vec<_>>();
-            let variadic = parameters
-                .vararg
-                .as_ref()
-                .map(|param| Parameter::variadic(param.name().id.clone()));
+            let variadic = parameters.vararg.as_ref().map(|param| {
+                Parameter::variadic(param.name().id.clone())
+                    .with_inferred_type(Type::Dynamic(DynamicType::UnknownLambdaParameter))
+            });
             let keyword_only = parameters
                 .kwonlyargs
                 .iter()
                 .map(|param| {
-                    Parameter::keyword_only(param.name().id.clone()).with_optional_default_type(
-                        param.default().map(|default_expr| {
+                    Parameter::keyword_only(param.name().id.clone())
+                        .with_inferred_type(Type::Dynamic(DynamicType::UnknownLambdaParameter))
+                        .with_optional_default_type(param.default().map(|default_expr| {
                             self.infer_expression(default_expr, TypeContext::default())
                                 .replace_parameter_defaults(db, env)
-                        }),
-                    )
+                        }))
                 })
                 .collect::<Vec<_>>();
-            let keyword_variadic = parameters
-                .kwarg
-                .as_ref()
-                .map(|param| Parameter::keyword_variadic(param.name().id.clone()));
+            let keyword_variadic = parameters.kwarg.as_ref().map(|param| {
+                Parameter::keyword_variadic(param.name().id.clone())
+                    .with_inferred_type(Type::Dynamic(DynamicType::UnknownLambdaParameter))
+            });
 
             let parameters = positional_only
                 .into_iter()

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -426,8 +426,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             (unknown @ Type::Dynamic(DynamicType::UnknownGeneric(_)), _, _)
             | (_, unknown @ Type::Dynamic(DynamicType::UnknownGeneric(_)), _) => Some(unknown),
 
-            (typevar @ Type::Dynamic(DynamicType::UnspecializedTypeVar), _, _)
-            | (_, typevar @ Type::Dynamic(DynamicType::UnspecializedTypeVar), _) => Some(typevar),
+            (
+                placeholder @ Type::Dynamic(
+                    DynamicType::UnspecializedTypeVar | DynamicType::UnknownLambdaParameter,
+                ),
+                _,
+                _,
+            )
+            | (
+                _,
+                placeholder @ Type::Dynamic(
+                    DynamicType::UnspecializedTypeVar | DynamicType::UnknownLambdaParameter,
+                ),
+                _,
+            ) => Some(placeholder),
 
             // When both operands are the same constrained TypeVar (e.g., `T: (int, str)`),
             // we check if the operation is valid for each constraint paired with itself.

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -2,8 +2,8 @@ use crate::{
     Db, ProgramEnvironment,
     reachability::ReachabilityConstraintsExtension,
     types::{
-        KnownClass, KnownInstanceType, ParamSpecAttrKind, SubclassOfInner, SubclassOfType, Type,
-        TypeContext, TypeVarKind, UnionType,
+        DynamicType, KnownClass, KnownInstanceType, ParamSpecAttrKind, SubclassOfInner,
+        SubclassOfType, Type, TypeContext, TypeVarKind, UnionType,
         constraints::ConstraintSetBuilder,
         diagnostic::{
             ABSTRACT_AND_FINAL_METHOD, FINAL_ON_NON_METHOD, INVALID_PARAMETER_DEFAULT,
@@ -1330,19 +1330,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             node_index: _,
         } = parameter_with_default;
 
-        let default_expr = default.as_ref();
         let ty = if let Some(parameter_type) = self.annotated_lambda_parameter_type(index, lambda) {
             parameter_type
-        } else if let Some(default_expr) = default_expr {
+        } else if let Some(default_expr) = default {
             let default_ty = self.file_expression_type(default_expr);
             UnionType::from_two_elements(
                 db,
                 self.program_environment(),
-                Type::unknown(),
+                Type::Dynamic(DynamicType::UnknownLambdaParameter),
                 default_ty,
             )
         } else {
-            Type::unknown()
+            Type::Dynamic(DynamicType::UnknownLambdaParameter)
         };
 
         self.add_binding(parameter.into(), definition)
@@ -1364,7 +1363,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ty = if let Some(parameter_type) = self.annotated_lambda_parameter_type(index, lambda) {
             parameter_type
         } else {
-            Type::homogeneous_tuple(db, self.program_environment(), Type::unknown())
+            Type::homogeneous_tuple(
+                db,
+                self.program_environment(),
+                Type::Dynamic(DynamicType::UnknownLambdaParameter),
+            )
         };
         self.add_binding(parameter.into(), definition)
             .insert(self, ty);
@@ -1382,7 +1385,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let inferred_ty = KnownClass::Dict.to_specialized_instance(
             db,
             env,
-            &[KnownClass::Str.to_instance(db, env), Type::unknown()],
+            &[
+                KnownClass::Str.to_instance(db, env),
+                Type::Dynamic(DynamicType::UnknownLambdaParameter),
+            ],
         );
 
         self.add_binding(parameter.into(), definition)
@@ -1408,12 +1414,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let parameter_type = signature.parameters().as_slice()[index as usize].annotated_type();
-        if parameter_type.is_unknown()
-            || parameter_type.has_unspecialized_type_var(db, self.program_environment())
-        {
-            None
-        } else {
-            Some(parameter_type)
-        }
+        (!parameter_type.has_provisional_marker(db, self.program_environment()))
+            .then_some(parameter_type)
     }
 }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -5450,6 +5450,13 @@ impl<'db> Parameter<'db> {
         self
     }
 
+    /// Set the inferred type without displaying it as an explicit annotation.
+    pub(super) fn with_inferred_type(mut self, inferred_type: Type<'db>) -> Self {
+        self.annotated_type = inferred_type;
+        self.inferred_annotation = true;
+        self
+    }
+
     pub(crate) fn with_starred_annotation(mut self) -> Self {
         self.annotation_kind = ParameterAnnotationKind::Starred;
         self

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -128,6 +128,17 @@ impl<'db> Type<'db> {
             matches!(ty, Type::Dynamic(DynamicType::UnspecializedTypeVar))
         })
     }
+
+    pub(crate) fn has_provisional_marker(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> bool {
+        any_over_type(db, env, self, false, |ty| {
+            ty.as_dynamic()
+                .is_some_and(DynamicType::is_provisional_marker)
+        })
+    }
 }
 
 /// A specific instance of a type variable that has not been bound to a generic context yet.
@@ -707,6 +718,7 @@ impl<'db> TypeVarInstance<'db> {
                     | DynamicType::Unknown
                     | DynamicType::UnknownGeneric(_)
                     | DynamicType::UnspecializedTypeVar
+                    | DynamicType::UnknownLambdaParameter
                     | DynamicType::InvalidConcatenateUnknown
                     | DynamicType::AmbiguousOverload => Parameters::unknown(),
                 },


### PR DESCRIPTION
We currently ignore type context containing dynamic types entirely during generic call inference. This was historically necessary to avoid unsolved type variables from polluting future fixpoint iterations with `Unknown` types. This PR distinguishes unsolved type variables from dynamic types inferred from arguments with a dynamic marker type, allowing us to retain applicable type context more often. This removes a number of false positives, e.g.,
```py
from typing import Any

def append[T](items: list[T], value: T) -> None:
    items.append(value)

def example(value: str | Any) -> None:
    append([1], value)  # before: invalid-argument-type, after: ok
```