### PR TITLE
[ty] Preserve parentheses when removing redundant casts

### DIFF
--- a/crates/ruff_python_ast/src/token/parentheses.rs
+++ b/crates/ruff_python_ast/src/token/parentheses.rs
@@ -1,4 +1,4 @@
-use ruff_text_size::{Ranged, TextLen, TextRange};
+use ruff_text_size::{Ranged, TextRange};
 
 use super::{TokenKind, Tokens};
 use crate::{AnyNodeRef, ExprRef};
@@ -16,16 +16,20 @@ pub fn parentheses_iterator<'a>(
     tokens: &'a Tokens,
 ) -> impl Iterator<Item = TextRange> + 'a {
     let after_tokens = if let Some(parent) = parent {
+        let after_tokens = tokens.in_range(TextRange::new(expr.end(), parent.end()));
+
         // If the parent is a node that brings its own parentheses, exclude the closing parenthesis
         // from our search range. Otherwise, we risk matching on calls, like `func(x)`, for which
         // the open and close parentheses are part of the `Arguments` node.
-        let exclusive_parent_end = if parent.is_arguments() {
-            parent.end() - ")".text_len()
+        // The closing parenthesis may be missing in an incomplete call.
+        if parent.is_arguments()
+            && let Some((last, remaining)) = after_tokens.split_last()
+            && last.kind() == TokenKind::Rpar
+        {
+            remaining
         } else {
-            parent.end()
-        };
-
-        tokens.in_range(TextRange::new(expr.end(), exclusive_parent_end))
+            after_tokens
+        }
     } else {
         tokens.after(expr.end())
     };

--- a/crates/ty_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/cast.md
@@ -217,3 +217,142 @@ help: Remove the redundant `cast`
 16 +     print(x + y)
    |
 ```
+
+## Fixes for multiline conditional expressions
+
+Removing a redundant cast preserves the parentheses that allow its argument to span multiple lines.
+
+```py
+from typing import cast
+
+# fmt: off
+def choose(x: int, y: int, flag: bool) -> int:
+    # snapshot: redundant-cast
+    return cast(int, (x if flag
+                     else y))
+```
+
+```snapshot
+warning[redundant-cast]: Value is already of type `int`
+ --> src/mdtest_snippet.py:6:12
+  |
+6 |       return cast(int, (x if flag
+  |  ____________^
+7 | |                      else y))
+  | |_____________________________^
+help: Remove the redundant `cast`
+  |
+5 |     # snapshot: redundant-cast
+  -     return cast(int, (x if flag
+  -                      else y))
+6 +     return (x if flag
+7 +                      else y)
+  |
+```
+
+## Fixes for multiline arithmetic expressions
+
+An argument can rely on the call's parentheses for line continuation without having parentheses of
+its own. Removing the call adds parentheses to keep the arithmetic expression on one logical line.
+
+```py
+from typing import cast
+
+# fmt: off
+def add(x: int, y: int) -> int:
+    # snapshot: redundant-cast
+    return cast(int, x +
+                    y)
+```
+
+```snapshot
+warning[redundant-cast]: Value is already of type `int`
+ --> src/mdtest_snippet.py:6:12
+  |
+6 |       return cast(int, x +
+  |  ____________^
+7 | |                     y)
+  | |______________________^
+help: Remove the redundant `cast`
+  |
+5 |     # snapshot: redundant-cast
+  -     return cast(int, x +
+6 +     return (x +
+7 |                     y)
+  |
+```
+
+A line break before an operator also needs parentheses. Without them, the following fix would
+produce valid syntax but return only `x`, leaving `+ y` as an unreachable statement.
+
+```py
+# fmt: off
+def add_with_leading_operator(x: int, y: int) -> int:
+    # snapshot: redundant-cast
+    return cast(int, x
+    + y)
+```
+
+```snapshot
+warning[redundant-cast]: Value is already of type `int`
+  --> src/mdtest_snippet.py:11:12
+   |
+11 |       return cast(int, x
+   |  ____________^
+12 | |     + y)
+   | |________^
+help: Remove the redundant `cast`
+   |
+10 |     # snapshot: redundant-cast
+   -     return cast(int, x
+11 +     return (x
+12 |     + y)
+   |
+```
+
+## Fixes preserve comments in parenthesized arguments
+
+The fix retains comments inside an argument's parentheses, including when the value is passed by
+keyword before the type argument.
+
+```py
+from typing import cast
+
+def add(x: int, y: int) -> int:
+    # snapshot: redundant-cast
+    return cast(
+        val=(
+            # Leading comment.
+            x + y  # Trailing comment.
+        ),
+        typ=int,
+    )
+```
+
+```snapshot
+warning[redundant-cast]: Value is already of type `int`
+  --> src/mdtest_snippet.py:5:12
+   |
+ 5 |       return cast(
+   |  ____________^
+ 6 | |         val=(
+ 7 | |             # Leading comment.
+ 8 | |             x + y  # Trailing comment.
+ 9 | |         ),
+10 | |         typ=int,
+11 | |     )
+   | |_____^
+help: Remove the redundant `cast`
+  |
+4 |     # snapshot: redundant-cast
+  -     return cast(
+  -         val=(
+5 +     return (
+6 |             # Leading comment.
+7 |             x + y  # Trailing comment.
+  -         ),
+  -         typ=int,
+  -     )
+8 +         )
+  |
+```

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -60,7 +60,9 @@ use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::find_node::covering_node;
+use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::{self as ast, OperatorPrecedence, ParameterWithDefault};
+use ruff_source_file::LineRanges;
 use ruff_text_size::Ranged;
 use salsa::plumbing::AsId;
 use ty_module_resolver::{ImportingFile, KnownModule, ModuleName, file_to_module, resolve_module};
@@ -2696,22 +2698,36 @@ impl KnownFunction {
                         }
                         if let Some(value) = call_expression.arguments.find_argument_value("val", 1)
                         {
-                            let covering = covering_node(
-                                context.module().syntax().into(),
-                                call_expression.range(),
-                            );
-                            let needs_parens = covering
-                                .parent()
-                                .and_then(ast::AnyNodeRef::as_expr_ref)
-                                .is_some_and(|parent| {
-                                    let value_precedence = OperatorPrecedence::from_expr(value);
-                                    OperatorPrecedence::from_expr_ref(parent) >= value_precedence
-                                });
-                            let value_text = &source_text(db, context.file())[value.range()];
-                            let replacement = if needs_parens {
-                                format!("({value_text})")
+                            let source = source_text(db, context.file());
+                            let replacement = if let Some(range) = parenthesized_range(
+                                value.into(),
+                                (&call_expression.arguments).into(),
+                                context.module().tokens(),
+                            ) {
+                                source[range].to_string()
                             } else {
-                                value_text.to_string()
+                                let covering = covering_node(
+                                    context.module().syntax().into(),
+                                    call_expression.range(),
+                                );
+                                // A multiline value can rely on the call's parentheses for
+                                // line continuation, independently of operator precedence.
+                                let needs_parens = source.contains_line_break(value.range())
+                                    || covering
+                                        .parent()
+                                        .and_then(ast::AnyNodeRef::as_expr_ref)
+                                        .is_some_and(|parent| {
+                                            let value_precedence =
+                                                OperatorPrecedence::from_expr(value);
+                                            OperatorPrecedence::from_expr_ref(parent)
+                                                >= value_precedence
+                                        });
+                                let value_text = &source[value.range()];
+                                if needs_parens {
+                                    format!("({value_text})")
+                                } else {
+                                    value_text.to_string()
+                                }
                             };
                             diagnostic.help("Remove the redundant `cast`");
                             diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -771,6 +771,21 @@ value.bit_count()
     Ok(())
 }
 
+#[test]
+fn redundant_cast_without_closing_parenthesis() -> anyhow::Result<()> {
+    let mut db = setup_db();
+
+    // A final newline changes the recovered argument range, so these files deliberately omit it.
+    for suffix in ["", " # comment"] {
+        let source =
+            format!("from typing import cast\n\ndef f(x: int):\n    return cast(int, x{suffix}");
+        db.write_file("/src/main.py", &source)?;
+        assert_file_diagnostics(&db, "/src/main.py", &["Value is already of type `int`"]);
+    }
+
+    Ok(())
+}
+
 // Incremental inference tests
 #[track_caller]
 fn first_public_binding<'db>(db: &'db TestDb, file: File, name: &str) -> Definition<'db> {


### PR DESCRIPTION
Removing a redundant `typing.cast` could discard parentheses needed for multiline expressions, introducing syntax errors or silently changing arithmetic results. Preserve the argument's existing parentheses and enclosed comments, and add grouping when a multiline argument relies on the call's parentheses for line continuation.

The shared parentheses lookup now checks for an actual closing token so that constructing a fix for an unfinished call does not panic.

Fixes https://github.com/astral-sh/ty/issues/4399.

## Test plan

- Added mdtests for multiline conditional and arithmetic expressions, including a line break before an operator that must not become a separate statement.
- Covered reordered keyword arguments and comments inside argument parentheses.
- Added unit coverage for unterminated casts with no final newline, with and without a trailing comment.
