### PR TITLE
[ty] Move bound APIs to constraint owners

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -6206,7 +6206,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             let preferred_ty = preferred_type_mappings.get(&typevar.identity(db)).copied();
 
             if let Some(bounds) = bounds {
-                let lower = bounds.evidence_lower?;
+                let lower = bounds.evidence_lower()?;
                 if preferred_ty.is_none_or(|ty| !lower.is_assignable_to(db, self.env, ty)) {
                     return maybe_promote(typevar, bounds);
                 }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1915,9 +1915,8 @@ impl<'db> Constraint<'db> {
 
     /// Returns the effective lower endpoint with its provenance.
     ///
-    /// [`Self::stored_lower_bound`] returns `None` when no lower bound is stored; this method
-    /// instead supplies `Validity(Never)`. A stored `Evidence(Never)` is returned unchanged.
-    /// Use the stored accessor to test for absence or copy bounds without inserting defaults.
+    /// An absent endpoint defaults to `Validity(Never)`. Explicit `Evidence(Never)` is returned
+    /// unchanged.
     fn lower_bound(self) -> ConstraintBound<'db> {
         self.stored_lower_bound()
             .unwrap_or_else(ConstraintBound::missing_lower)
@@ -1925,18 +1924,23 @@ impl<'db> Constraint<'db> {
 
     /// Returns the effective upper endpoint with its provenance.
     ///
-    /// [`Self::stored_upper_bound`] returns `None` when no upper bound is stored; this method
-    /// instead supplies `Validity(object)`. A stored `Evidence(object)` is returned unchanged.
-    /// Use the stored accessor to test for absence or copy bounds without inserting defaults.
+    /// An absent endpoint defaults to `Validity(object)`. Explicit `Evidence(object)` is returned
+    /// unchanged.
     fn upper_bound(self) -> ConstraintBound<'db> {
         self.stored_upper_bound()
             .unwrap_or_else(ConstraintBound::missing_upper)
     }
 
+    /// Returns the stored lower endpoint with its provenance, or `None` if absent.
+    ///
+    /// Use this to test for absence or copy bounds without inserting a default.
     fn stored_lower_bound(self) -> Option<ConstraintBound<'db>> {
         self.bounds.lower
     }
 
+    /// Returns the stored upper endpoint with its provenance, or `None` if absent.
+    ///
+    /// Use this to test for absence or copy bounds without inserting a default.
     fn stored_upper_bound(self) -> Option<ConstraintBound<'db>> {
         self.bounds.upper
     }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -322,10 +322,11 @@ impl<'db> OwnedConstraintSet<'db> {
         f(&builder, set)
     }
 
-    /// Returns the types in constraints that are still reachable from the decision diagram.
+    /// Returns the typevars and stored bound types still reachable from the decision diagram.
     ///
     /// Source ordering can retain constraints that are no longer in the diagram, but their type
     /// variables must not participate in semantic walks or callable freshening.
+    /// Synthetic defaults are not stored types and must not affect these walks either.
     pub(crate) fn types(&self) -> impl Iterator<Item = Type<'db>> + '_ {
         self.inner.iter().flat_map(|inner| {
             inner
@@ -335,11 +336,8 @@ impl<'db> OwnedConstraintSet<'db> {
                 .unique()
                 .map(|constraint| inner.constraints[inner.retained_constraint_index(constraint)])
                 .flat_map(|constraint| {
-                    [
-                        Type::TypeVar(constraint.typevar),
-                        constraint.lower_bound().ty(),
-                        constraint.upper_bound().ty(),
-                    ]
+                    iter::once(Type::TypeVar(constraint.typevar))
+                        .chain(constraint.iter_stored_bounds().map(ConstraintBound::ty))
                 })
         })
     }
@@ -1917,12 +1915,14 @@ impl<'db> Constraint<'db> {
 
     /// Returns the effective lower endpoint, supplying a validity bound when none was provided.
     fn lower_bound(self) -> ConstraintBound<'db> {
-        self.bounds.lower_bound()
+        self.stored_lower_bound()
+            .unwrap_or_else(ConstraintBound::missing_lower)
     }
 
     /// Returns the effective upper endpoint, supplying a validity bound when none was provided.
     fn upper_bound(self) -> ConstraintBound<'db> {
-        self.bounds.upper_bound()
+        self.stored_upper_bound()
+            .unwrap_or_else(ConstraintBound::missing_upper)
     }
 
     fn stored_lower_bound(self) -> Option<ConstraintBound<'db>> {
@@ -1970,10 +1970,12 @@ enum ConstraintBound<'db> {
 }
 
 impl<'db> ConstraintBound<'db> {
+    /// The ordinary lower identity used by storage canonicalization and path aggregation.
     const fn missing_lower() -> Self {
         Self::Validity(Type::Never)
     }
 
+    /// The ordinary upper identity used by storage canonicalization and path aggregation.
     const fn missing_upper() -> Self {
         Self::Validity(Type::object())
     }
@@ -2053,9 +2055,9 @@ impl<'db> ConstraintBound<'db> {
 
 /// The lower and upper bounds for a typevar on one constraint path.
 ///
-/// Missing bounds are stored as `None`, even though this is technically redundant with
-/// `Validity(Never)` or `Validity(object)`. This is purely an optimization, which makes constraint
-/// equality and hashing more performant for the (common) missing-bounds cases.
+/// Missing bounds are stored as `None`, making equality and hashing cheaper for this common case.
+/// Ordinary validity identities (`Never`/`object`) are canonicalized to absence. The owning
+/// [`Constraint`] supplies effective defaults for missing endpoints.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 struct ConstraintBounds<'db> {
     lower: Option<ConstraintBound<'db>>,
@@ -2077,14 +2079,6 @@ impl<'db> ConstraintBounds<'db> {
             Some(ConstraintBound::Evidence(ty)),
             Some(ConstraintBound::Evidence(ty)),
         )
-    }
-
-    fn lower_bound(self) -> ConstraintBound<'db> {
-        self.lower.unwrap_or_else(ConstraintBound::missing_lower)
-    }
-
-    fn upper_bound(self) -> ConstraintBound<'db> {
-        self.upper.unwrap_or_else(ConstraintBound::missing_upper)
     }
 
     fn as_equality(self) -> Option<Type<'db>> {
@@ -2531,20 +2525,22 @@ impl<'db> Constraint<'db> {
             _ => {}
         }
 
-        storage.intern_constraint_typevars(db, env, Constraint::new(typevar, lower, upper));
+        let constraint = Constraint::new(typevar, lower, upper);
+        storage.intern_constraint_typevars(db, env, constraint);
 
         // If `lower ≰ upper` for every possible assignment of typevars, then the constraint cannot
         // be satisfied, since there is no type that is both greater than `lower`, and less than
         // `upper`. We use an existential check here ("is there *some* assignment where
         // `lower ≤ upper`?") rather than a universal check, because the bounds may mention
         // typevars — e.g., `Sequence[int] ≤ A ≤ Sequence[T]` is satisfiable when `int ≤ T`.
-        let effective_lower = lower.map_or(Type::Never, ConstraintBound::ty);
-        let effective_upper = upper.map_or(Type::object(), ConstraintBound::ty);
-        let when =
-            effective_lower.when_constraint_set_assignable_to_owned(db, env, effective_upper);
-        let is_never_satisfied = when.query(|_storage, when| when.is_never_satisfied(db, env));
-        if is_never_satisfied {
-            return (ALWAYS_FALSE, None);
+        let effective_lower = constraint.lower_bound().ty();
+        let effective_upper = constraint.upper_bound().ty();
+        if lower.is_some() && upper.is_some() {
+            let when =
+                effective_lower.when_constraint_set_assignable_to_owned(db, env, effective_upper);
+            if when.query(|_storage, when| when.is_never_satisfied(db, env)) {
+                return (ALWAYS_FALSE, None);
+            }
         }
 
         // We have an (arbitrary) ordering for typevars. If the upper and/or lower bounds are
@@ -2800,11 +2796,18 @@ impl ConstraintId {
             if effective_upper.is_nontrivial_intersection(db) {
                 return IntersectionResult::CannotSimplify;
             }
-            Some(ConstraintBound::from_combination(
-                effective_upper,
-                self_constraint.upper_bound(),
-                other_constraint.upper_bound(),
-            ))
+            match (
+                self_constraint.stored_upper_bound(),
+                other_constraint.stored_upper_bound(),
+            ) {
+                (Some(left), Some(right)) => Some(ConstraintBound::from_combination(
+                    effective_upper,
+                    left,
+                    right,
+                )),
+                (Some(upper), None) | (None, Some(upper)) => Some(upper.with_type(effective_upper)),
+                (None, None) => None,
+            }
         };
 
         IntersectionResult::Simplified(Constraint::new(self_constraint.typevar, lower, upper))
@@ -5169,8 +5172,14 @@ impl ConstraintAssignment {
 
         std::fmt::from_fn(move |f| {
             let constraint_data = storage.constraint_data(self.constraint());
-            let lower = constraint_data.lower_bound().ty();
-            let upper = constraint_data.upper_bound().ty();
+            // Render supplied bounds, using the ordinary identities below only for the
+            // shorthand for omitted endpoints.
+            let lower = constraint_data
+                .stored_lower_bound()
+                .map_or(Type::Never, ConstraintBound::ty);
+            let upper = constraint_data
+                .stored_upper_bound()
+                .map_or(Type::object(), ConstraintBound::ty);
             let typevar = constraint_data.typevar;
             if lower.is_equivalent_to(db, env, upper) {
                 // If this typevar is equivalent to another, output the constraint in a

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1913,13 +1913,21 @@ impl<'db> Constraint<'db> {
         self.typevar
     }
 
-    /// Returns the effective lower endpoint, supplying a validity bound when none was provided.
+    /// Returns the effective lower endpoint with its provenance.
+    ///
+    /// [`Self::stored_lower_bound`] returns `None` when no lower bound is stored; this method
+    /// instead supplies `Validity(Never)`. A stored `Evidence(Never)` is returned unchanged.
+    /// Use the stored accessor to test for absence or copy bounds without inserting defaults.
     fn lower_bound(self) -> ConstraintBound<'db> {
         self.stored_lower_bound()
             .unwrap_or_else(ConstraintBound::missing_lower)
     }
 
-    /// Returns the effective upper endpoint, supplying a validity bound when none was provided.
+    /// Returns the effective upper endpoint with its provenance.
+    ///
+    /// [`Self::stored_upper_bound`] returns `None` when no upper bound is stored; this method
+    /// instead supplies `Validity(object)`. A stored `Evidence(object)` is returned unchanged.
+    /// Use the stored accessor to test for absence or copy bounds without inserting defaults.
     fn upper_bound(self) -> ConstraintBound<'db> {
         self.stored_upper_bound()
             .unwrap_or_else(ConstraintBound::missing_upper)
@@ -2039,6 +2047,9 @@ impl<'db> ConstraintBound<'db> {
 
     /// Applies the source range's provenance to an evidence bound derived by comparing that range.
     /// Bounds not produced by the comparison retain their existing provenance.
+    ///
+    /// Missing source endpoints supply only validity bounds, so the derived bound remains evidence
+    /// exactly when at least one stored source endpoint is evidence.
     fn with_source_provenance(self, source: Constraint<'db>) -> Self {
         match self {
             Self::Evidence(ty)
@@ -3899,7 +3910,7 @@ impl<'db> PathBound<'db> {
     }
 
     /// Returns one effective upper bound without expanding factored intersections.
-    pub(crate) fn single_upper_bound(
+    pub(crate) fn as_single_upper_bound(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -4585,7 +4596,7 @@ impl<'db> PathBounds<'db> {
 
                 if let (ty @ Type::TypeVar(_), _) | (_, Some(ty @ Type::TypeVar(_))) = (
                     path_bound.effective_lower(db, env),
-                    path_bound.single_upper_bound(db, env),
+                    path_bound.as_single_upper_bound(db, env),
                 ) {
                     // This path relates two TypeVars, such as passing `S` to a parameter typed as
                     // `T: (int, str)`. The compatibility check above has verified that at least

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -337,8 +337,8 @@ impl<'db> OwnedConstraintSet<'db> {
                 .flat_map(|constraint| {
                     [
                         Type::TypeVar(constraint.typevar),
-                        constraint.bounds.lower_bound().ty(),
-                        constraint.bounds.upper_bound().ty(),
+                        constraint.lower_bound().ty(),
+                        constraint.upper_bound().ty(),
                     ]
                 })
         })
@@ -442,18 +442,33 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         lower: Type<'db>,
         upper: Type<'db>,
     ) -> Self {
+        Self::from_constraint(
+            db,
+            env,
+            builder,
+            Constraint::from_evidence(typevar, Some(lower), Some(upper)),
+        )
+    }
+
+    /// Creates a constraint set for the range described by a constraint.
+    pub(crate) fn from_constraint(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        builder: &'c ConstraintSetBuilder<'db>,
+        constraint: Constraint<'db>,
+    ) -> Self {
         Self::constrain_typevar_with_bounds(
             db,
             env,
             builder,
-            typevar,
-            Some(ConstraintBound::Evidence(lower)),
-            Some(ConstraintBound::Evidence(upper)),
+            constraint.typevar(),
+            constraint.stored_lower_bound(),
+            constraint.stored_upper_bound(),
         )
     }
 
     /// Returns a constraint set that constrains a typevar with explicit lower and/or upper bounds.
-    pub(crate) fn constrain_typevar_with_bounds(
+    fn constrain_typevar_with_bounds(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         builder: &'c ConstraintSetBuilder<'db>,
@@ -475,13 +490,11 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
     ) -> Self {
-        Self::constrain_typevar_with_bounds(
+        Self::from_constraint(
             db,
             env,
             builder,
-            typevar,
-            Some(ConstraintBound::Evidence(lower)),
-            None,
+            Constraint::from_evidence(typevar, Some(lower), None),
         )
     }
 
@@ -493,13 +506,11 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         typevar: BoundTypeVarInstance<'db>,
         upper: Type<'db>,
     ) -> Self {
-        Self::constrain_typevar_with_bounds(
+        Self::from_constraint(
             db,
             env,
             builder,
-            typevar,
-            None,
-            Some(ConstraintBound::Evidence(upper)),
+            Constraint::from_evidence(typevar, None, Some(upper)),
         )
     }
 
@@ -826,10 +837,10 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                 tcx,
                 visitor,
             );
-            let lower = constraint.bounds.lower.map(|lower| {
+            let lower = constraint.stored_lower_bound().map(|lower| {
                 lower.map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             });
-            let upper = constraint.bounds.upper.map(|upper| {
+            let upper = constraint.stored_upper_bound().map(|upper| {
                 upper.map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             });
 
@@ -1387,16 +1398,12 @@ impl<'db> ConstraintSetStorage<'db> {
         &mut self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        typevar: BoundTypeVarInstance<'db>,
-        bounds: ConstraintBounds<'db>,
+        constraint: Constraint<'db>,
     ) -> Support {
         let mut support = Support::default();
-        support.insert(self.intern_typevar(db, typevar));
-        if let Some(lower) = bounds.lower {
-            self.intern_mentioned_typevars_in_type(db, env, lower.ty(), &mut support);
-        }
-        if let Some(upper) = bounds.upper {
-            self.intern_mentioned_typevars_in_type(db, env, upper.ty(), &mut support);
+        support.insert(self.intern_typevar(db, constraint.typevar()));
+        for bound in constraint.iter_stored_bounds() {
+            self.intern_mentioned_typevars_in_type(db, env, bound.ty(), &mut support);
         }
         support
     }
@@ -1407,7 +1414,7 @@ impl<'db> ConstraintSetStorage<'db> {
         env: &ProgramEnvironment<'db>,
         data: Constraint<'db>,
     ) -> ConstraintId {
-        let support = self.intern_constraint_typevars(db, env, data.typevar, data.bounds);
+        let support = self.intern_constraint_typevars(db, env, data);
 
         self.ensure_overlay_identity_caches();
         if let Some(id) = self.constraint_cache.get(&data) {
@@ -1745,8 +1752,8 @@ impl<'db> ConstraintSetStorage<'db> {
                     env,
                     self,
                     old_constraint.typevar,
-                    old_constraint.bounds.lower,
-                    old_constraint.bounds.upper,
+                    old_constraint.stored_lower_bound(),
+                    old_constraint.stored_upper_bound(),
                 )
             })
             .collect();
@@ -1872,6 +1879,74 @@ pub(crate) struct Constraint<'db> {
     bounds: ConstraintBounds<'db>,
 }
 
+impl<'db> Constraint<'db> {
+    fn new(
+        typevar: BoundTypeVarInstance<'db>,
+        lower: Option<ConstraintBound<'db>>,
+        upper: Option<ConstraintBound<'db>>,
+    ) -> Self {
+        Self {
+            typevar,
+            bounds: ConstraintBounds::new(lower, upper),
+        }
+    }
+
+    /// Records supplied endpoints as inference evidence, including explicit `Never` and `object`.
+    pub(crate) fn from_evidence(
+        typevar: BoundTypeVarInstance<'db>,
+        lower: Option<Type<'db>>,
+        upper: Option<Type<'db>>,
+    ) -> Self {
+        Self::new(
+            typevar,
+            lower.map(ConstraintBound::Evidence),
+            upper.map(ConstraintBound::Evidence),
+        )
+    }
+
+    pub(crate) fn exact(typevar: BoundTypeVarInstance<'db>, ty: Type<'db>) -> Self {
+        Self {
+            typevar,
+            bounds: ConstraintBounds::exact(ty),
+        }
+    }
+
+    pub(crate) fn typevar(self) -> BoundTypeVarInstance<'db> {
+        self.typevar
+    }
+
+    /// Returns the effective lower endpoint, supplying a validity bound when none was provided.
+    fn lower_bound(self) -> ConstraintBound<'db> {
+        self.bounds.lower_bound()
+    }
+
+    /// Returns the effective upper endpoint, supplying a validity bound when none was provided.
+    fn upper_bound(self) -> ConstraintBound<'db> {
+        self.bounds.upper_bound()
+    }
+
+    fn stored_lower_bound(self) -> Option<ConstraintBound<'db>> {
+        self.bounds.lower
+    }
+
+    fn stored_upper_bound(self) -> Option<ConstraintBound<'db>> {
+        self.bounds.upper
+    }
+
+    /// Visits supplied endpoints in lower-then-upper order without inserting defaults.
+    fn iter_stored_bounds(self) -> impl Iterator<Item = ConstraintBound<'db>> {
+        iter::chain(self.stored_lower_bound(), self.stored_upper_bound())
+    }
+
+    fn as_equality(self) -> Option<Type<'db>> {
+        self.bounds.as_equality()
+    }
+
+    fn has_concrete_bounds(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
+        self.bounds.is_concrete(db, env)
+    }
+}
+
 /// The lower or upper bound of a constraint, along with its _provenance_
 ///
 /// Most bounds come from specific relationships found at the call site — for instance, the
@@ -1889,7 +1964,7 @@ pub(crate) struct Constraint<'db> {
 /// Every type is a supertype of `Never` and a subtype of `object`, so `Validity(Never)` represents
 /// an absent lower bound and `Validity(object)` represents an absent upper bound.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-pub(crate) enum ConstraintBound<'db> {
+enum ConstraintBound<'db> {
     Validity(Type<'db>),
     Evidence(Type<'db>),
 }
@@ -1962,12 +2037,16 @@ impl<'db> ConstraintBound<'db> {
 
     /// Applies the source range's provenance to an evidence bound derived by comparing that range.
     /// Bounds not produced by the comparison retain their existing provenance.
-    fn with_source_provenance(self, source: ConstraintBounds<'db>) -> Self {
+    fn with_source_provenance(self, source: Constraint<'db>) -> Self {
         match self {
-            Self::Evidence(ty) => {
-                Self::from_transitive_derivation(ty, source.lower_bound(), source.upper_bound())
+            Self::Evidence(ty)
+                if !source
+                    .iter_stored_bounds()
+                    .any(|bound| matches!(bound, Self::Evidence(_))) =>
+            {
+                Self::Validity(ty)
             }
-            Self::Validity(_) => self,
+            _ => self,
         }
     }
 }
@@ -1978,16 +2057,13 @@ impl<'db> ConstraintBound<'db> {
 /// `Validity(Never)` or `Validity(object)`. This is purely an optimization, which makes constraint
 /// equality and hashing more performant for the (common) missing-bounds cases.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-pub(crate) struct ConstraintBounds<'db> {
-    pub(crate) lower: Option<ConstraintBound<'db>>,
-    pub(crate) upper: Option<ConstraintBound<'db>>,
+struct ConstraintBounds<'db> {
+    lower: Option<ConstraintBound<'db>>,
+    upper: Option<ConstraintBound<'db>>,
 }
 
 impl<'db> ConstraintBounds<'db> {
-    pub(crate) fn new(
-        lower: Option<ConstraintBound<'db>>,
-        upper: Option<ConstraintBound<'db>>,
-    ) -> Self {
+    fn new(lower: Option<ConstraintBound<'db>>, upper: Option<ConstraintBound<'db>>) -> Self {
         // Canonicalize missing lower/upper bounds so that we always store them as `None`, instead
         // of `Some(Validity(Never/object))`.
         Self {
@@ -1996,7 +2072,7 @@ impl<'db> ConstraintBounds<'db> {
         }
     }
 
-    pub(crate) fn exact(ty: Type<'db>) -> Self {
+    fn exact(ty: Type<'db>) -> Self {
         Self::new(
             Some(ConstraintBound::Evidence(ty)),
             Some(ConstraintBound::Evidence(ty)),
@@ -2041,7 +2117,7 @@ impl<'db> ConstraintBounds<'db> {
 /// stronger. Consumers that require one effective bound can recover it with
 /// [`UpperBound::as_single_bound`] without eagerly expanding intersections of unions.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-pub(crate) struct UpperBound<'db> {
+struct UpperBound<'db> {
     evidence: FxOrderSet<Type<'db>>,
     validity: FxOrderSet<Type<'db>>,
 }
@@ -2085,11 +2161,7 @@ impl<'db> UpperBound<'db> {
     /// effective bound. Returns `None` instead of materializing intersections when no existing
     /// clause dominates the others. An unconstrained validity bound remains distinct from an
     /// explicit evidence bound of `object`.
-    pub(crate) fn as_single_bound(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Option<Type<'db>> {
+    fn as_single_bound(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Option<Type<'db>> {
         let clauses = self.iter_clauses();
         if clauses.clone().next().is_none() {
             Some(Type::object())
@@ -2223,14 +2295,7 @@ impl ConstraintId {
         lower: Option<ConstraintBound<'db>>,
         upper: Option<ConstraintBound<'db>>,
     ) -> ConstraintId {
-        storage.intern_constraint(
-            db,
-            env,
-            Constraint {
-                typevar,
-                bounds: ConstraintBounds::new(lower, upper),
-            },
-        )
+        storage.intern_constraint(db, env, Constraint::new(typevar, lower, upper))
     }
 }
 
@@ -2311,8 +2376,7 @@ fn max_constructor_and_typevar_depth<'db>(
 
 impl<'db> Constraint<'db> {
     fn bound_depth(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> (u16, u16) {
-        let both_bounds =
-            iter::chain(self.bounds.lower, self.bounds.upper).map(ConstraintBound::ty);
+        let both_bounds = self.iter_stored_bounds().map(ConstraintBound::ty);
         both_bounds.fold((0, 0), |(constructor_depth, typevar_depth), bound| {
             let (bound_constructor_depth, bound_typevar_depth) =
                 max_constructor_and_typevar_depth(db, env, bound);
@@ -2467,7 +2531,7 @@ impl<'db> Constraint<'db> {
             _ => {}
         }
 
-        storage.intern_constraint_typevars(db, env, typevar, ConstraintBounds::new(lower, upper));
+        storage.intern_constraint_typevars(db, env, Constraint::new(typevar, lower, upper));
 
         // If `lower ≰ upper` for every possible assignment of typevars, then the constraint cannot
         // be satisfied, since there is no type that is both greater than `lower`, and less than
@@ -2655,10 +2719,10 @@ impl ConstraintId {
         {
             return false;
         }
-        let other_lower = other_constraint.bounds.lower_bound().ty();
-        let self_lower = self_constraint.bounds.lower_bound().ty();
-        let self_upper = self_constraint.bounds.upper_bound().ty();
-        let other_upper = other_constraint.bounds.upper_bound().ty();
+        let other_lower = other_constraint.lower_bound().ty();
+        let self_lower = self_constraint.lower_bound().ty();
+        let self_upper = self_constraint.upper_bound().ty();
+        let other_upper = other_constraint.upper_bound().ty();
         other_lower.is_constraint_set_assignable_to(db, env, self_lower)
             && self_upper.is_constraint_set_assignable_to(db, env, other_upper)
     }
@@ -2677,8 +2741,8 @@ impl ConstraintId {
         // A typevar cannot be exactly equal to two different statically eligible types under any
         // specialization. Gradual bounds cannot prove this incompatibility because the resulting
         // pair-impossibility sequent participates in transitive closure.
-        if let Some(left) = self_constraint.bounds.as_equality()
-            && let Some(right) = other_constraint.bounds.as_equality()
+        if let Some(left) = self_constraint.as_equality()
+            && let Some(right) = other_constraint.as_equality()
             && left.is_static_sequent_eligible(db, env)
             && right.is_static_sequent_eligible(db, env)
             && !left.can_be_constraint_set_equivalent_to(db, env, right)
@@ -2687,7 +2751,10 @@ impl ConstraintId {
         }
 
         // (s₁ ≤ α ≤ t₁) ∧ (s₂ ≤ α ≤ t₂) = (s₁ ∪ s₂) ≤ α ≤ (t₁ ∩ t₂))
-        let lower = match (self_constraint.bounds.lower, other_constraint.bounds.lower) {
+        let lower = match (
+            self_constraint.stored_lower_bound(),
+            other_constraint.stored_lower_bound(),
+        ) {
             (Some(left), Some(right)) => {
                 let combined = UnionType::from_two_elements(db, env, left.ty(), right.ty());
                 Some(ConstraintBound::from_combination(combined, left, right))
@@ -2696,10 +2763,10 @@ impl ConstraintId {
             (None, None) => None,
         };
         let mut merged_upper = UpperBound::unconstrained();
-        if let Some(upper) = self_constraint.bounds.upper {
+        if let Some(upper) = self_constraint.stored_upper_bound() {
             merged_upper.add_clause(upper);
         }
-        if let Some(upper) = other_constraint.bounds.upper {
+        if let Some(upper) = other_constraint.stored_upper_bound() {
             merged_upper.add_clause(upper);
         }
         let effective_lower = lower.map_or(Type::Never, ConstraintBound::ty);
@@ -2735,15 +2802,12 @@ impl ConstraintId {
             }
             Some(ConstraintBound::from_combination(
                 effective_upper,
-                self_constraint.bounds.upper_bound(),
-                other_constraint.bounds.upper_bound(),
+                self_constraint.upper_bound(),
+                other_constraint.upper_bound(),
             ))
         };
 
-        IntersectionResult::Simplified(Constraint {
-            typevar: self_constraint.typevar,
-            bounds: ConstraintBounds::new(lower, upper),
-        })
+        IntersectionResult::Simplified(Constraint::new(self_constraint.typevar, lower, upper))
     }
 
     fn display<'db, 'a>(
@@ -3111,8 +3175,8 @@ impl NodeId {
                         }
 
                         let constraint = storage.constraint_data(interior.constraint);
-                        found_lower |= constraint.bounds.lower.is_some();
-                        found_upper |= constraint.bounds.upper.is_some();
+                        found_lower |= constraint.stored_lower_bound().is_some();
+                        found_upper |= constraint.stored_upper_bound().is_some();
                         if found_lower && found_upper {
                             // Might be a single conjunction, but doesn't contain _only_
                             // lower-bound-only or upper-bound-only constraints
@@ -3808,9 +3872,9 @@ impl<'db> PathBoundSolution<'db> {
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct PathBound<'db> {
     pub(crate) bound_typevar: BoundTypeVarInstance<'db>,
-    pub(crate) evidence_lower: Option<Type<'db>>,
+    evidence_lower: Option<Type<'db>>,
     validity_lower: Type<'db>,
-    pub(crate) upper: UpperBound<'db>,
+    upper: UpperBound<'db>,
     /// Whether the path contains gradual evidence and no static evidence.
     has_only_gradual_evidence: bool,
 }
@@ -3824,6 +3888,20 @@ impl<'db> PathBound<'db> {
             upper: UpperBound::from_clause(ty),
             has_only_gradual_evidence: false,
         }
+    }
+
+    /// Returns lower-bound inference evidence without supplying a default for a missing bound.
+    pub(crate) fn evidence_lower(&self) -> Option<Type<'db>> {
+        self.evidence_lower
+    }
+
+    /// Returns one effective upper bound without expanding factored intersections.
+    pub(crate) fn single_upper_bound(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Type<'db>> {
+        self.upper.as_single_bound(db, env)
     }
 
     fn effective_lower(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
@@ -4179,8 +4257,7 @@ impl<'db> PathBounds<'db> {
                         return ControlFlow::Continue(None);
                     }
 
-                    let mut bounds = iter::chain(constraint.bounds.lower, constraint.bounds.upper)
-                        .map(ConstraintBound::ty);
+                    let mut bounds = constraint.iter_stored_bounds().map(ConstraintBound::ty);
                     if bounds.any(|bound| {
                         bound.has_typevar(db, env) || bound.has_provisional_marker(db, env)
                     }) {
@@ -4189,8 +4266,7 @@ impl<'db> PathBounds<'db> {
 
                     current = interior.if_true;
                     constraints.push((
-                        constraint.typevar,
-                        constraint.bounds,
+                        constraint,
                         source_orders
                             .get_index_of(&interior.constraint)
                             .expect("every TDD constraint should have a source order"),
@@ -4201,13 +4277,13 @@ impl<'db> PathBounds<'db> {
 
         let mut mappings: FxIndexMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
             FxIndexMap::default();
-        constraints.sort_by_key(|(_, _, source_order)| *source_order);
-        for (typevar, constraint, _) in constraints {
-            let bounds = mappings.entry(typevar).or_default();
-            if let Some(lower) = constraint.lower {
+        constraints.sort_by_key(|(_, source_order)| *source_order);
+        for (constraint, _) in constraints {
+            let bounds = mappings.entry(constraint.typevar()).or_default();
+            if let Some(lower) = constraint.stored_lower_bound() {
                 bounds.add_lower(db, env, lower);
             }
-            if let Some(upper) = constraint.upper {
+            if let Some(upper) = constraint.stored_upper_bound() {
                 bounds.add_upper(db, env, upper);
             }
         }
@@ -4506,7 +4582,7 @@ impl<'db> PathBounds<'db> {
 
                 if let (ty @ Type::TypeVar(_), _) | (_, Some(ty @ Type::TypeVar(_))) = (
                     path_bound.effective_lower(db, env),
-                    path_bound.upper.as_single_bound(db, env),
+                    path_bound.single_upper_bound(db, env),
                 ) {
                     // This path relates two TypeVars, such as passing `S` to a parameter typed as
                     // `T: (int, str)`. The compatibility check above has verified that at least
@@ -4771,8 +4847,8 @@ impl InteriorNode {
             &mut |storage: &ConstraintSetStorage<'_>, constraint| {
                 let constraint = storage.constraint_data(constraint);
                 !constraint.typevar.is_inferable(db, inferable)
-                    && !is_bare_inferable_typevar(constraint.bounds.lower)
-                    && !is_bare_inferable_typevar(constraint.bounds.upper)
+                    && !is_bare_inferable_typevar(constraint.stored_lower_bound())
+                    && !is_bare_inferable_typevar(constraint.stored_upper_bound())
             },
         )
     }
@@ -4989,7 +5065,7 @@ impl InteriorNode {
         for constraint_id in &constraints {
             let constraint = storage.constraint_data(*constraint_id);
             let typevar = storage.typevar_id(db, constraint.typevar);
-            if constraint.bounds.is_concrete(db, env) {
+            if constraint.has_concrete_bounds(db, env) {
                 independent_typevars.insert(typevar);
             } else {
                 dependent_typevars.extend(storage.constraint_support(*constraint_id).iter());
@@ -5093,8 +5169,8 @@ impl ConstraintAssignment {
 
         std::fmt::from_fn(move |f| {
             let constraint_data = storage.constraint_data(self.constraint());
-            let lower = constraint_data.bounds.lower_bound().ty();
-            let upper = constraint_data.bounds.upper_bound().ty();
+            let lower = constraint_data.lower_bound().ty();
+            let upper = constraint_data.upper_bound().ty();
             let typevar = constraint_data.typevar;
             if lower.is_equivalent_to(db, env, upper) {
                 // If this typevar is equivalent to another, output the constraint in a
@@ -5650,8 +5726,7 @@ mod tests {
         let support = storage.intern_constraint_typevars(
             db,
             &env,
-            t,
-            ConstraintBounds::new(None, Some(ConstraintBound::Evidence(actual_bound))),
+            Constraint::from_evidence(t, None, Some(actual_bound)),
         );
         let mentioned = support
             .iter()
@@ -5705,8 +5780,7 @@ mod tests {
             let support = storage.intern_constraint_typevars(
                 db,
                 &env,
-                t,
-                ConstraintBounds::new(None, Some(ConstraintBound::Evidence(Type::TypeVar(u)))),
+                Constraint::from_evidence(t, None, Some(Type::TypeVar(u))),
             );
             let mentioned = support
                 .iter()
@@ -6634,9 +6708,16 @@ class E: ...
             storage: &mut ConstraintSetStorage<'db>,
         ) -> NodeId {
             let PermutedConstraint(typevar, lower, upper) = self;
-            let bounds = ConstraintBounds::new(Some(lower), Some(upper));
-            Constraint::new_node_with_bounds(db, env, storage, typevar, bounds.lower, bounds.upper)
-                .0
+            let constraint = Constraint::new(typevar, Some(lower), Some(upper));
+            Constraint::new_node_with_bounds(
+                db,
+                env,
+                storage,
+                typevar,
+                constraint.stored_lower_bound(),
+                constraint.stored_upper_bound(),
+            )
+            .0
         }
     }
 
@@ -6671,10 +6752,7 @@ class E: ...
                 storage.intern_constraint(
                     db,
                     &env,
-                    Constraint {
-                        typevar,
-                        bounds: ConstraintBounds::new(Some(lower), Some(upper)),
-                    },
+                    Constraint::new(typevar, Some(lower), Some(upper)),
                 );
             }
 
@@ -6684,10 +6762,7 @@ class E: ...
                 let constraint = storage.intern_constraint(
                     db,
                     &env,
-                    Constraint {
-                        typevar,
-                        bounds: ConstraintBounds::new(Some(lower), Some(upper)),
-                    },
+                    Constraint::new(typevar, Some(lower), Some(upper)),
                 );
                 let constraint_source_order = storage.constraint_source_order(constraint);
                 storage.ordered_source_order(source_order, Some(constraint_source_order))

--- a/crates/ty_python_semantic/src/types/constraints/sequents.rs
+++ b/crates/ty_python_semantic/src/types/constraints/sequents.rs
@@ -6,8 +6,8 @@ use std::fmt::{Debug, Display};
 use smallvec::SmallVec;
 
 use crate::types::constraints::{
-    ALWAYS_FALSE, ALWAYS_TRUE, ConstraintBound, ConstraintBounds, ConstraintId,
-    ConstraintSetBuilder, ConstraintSetStorage, IntersectionResult, Node,
+    ALWAYS_FALSE, ALWAYS_TRUE, Constraint, ConstraintBound, ConstraintId, ConstraintSetBuilder,
+    ConstraintSetStorage, IntersectionResult, Node,
 };
 use crate::types::typevar::TypeVarSet;
 use crate::types::variance::VarianceInferable;
@@ -164,10 +164,12 @@ impl SequentMap {
             return false;
         }
 
-        let (Some(left_lower), Some(right_lower)) = (left.bounds.lower, right.bounds.lower) else {
+        let (Some(left_lower), Some(right_lower)) =
+            (left.stored_lower_bound(), right.stored_lower_bound())
+        else {
             return false;
         };
-        if left.bounds.upper.is_some() || right.bounds.upper.is_some() {
+        if left.stored_upper_bound().is_some() || right.stored_upper_bound().is_some() {
             return false;
         }
         let left_lower = left_lower.ty();
@@ -201,8 +203,8 @@ impl SequentMap {
     ) {
         // If the post constraint is unsatisfiable, then the antecedents contradict each other.
         let post_data = storage.constraint_data(post);
-        let post_lower = post_data.bounds.lower_bound().ty();
-        let post_upper = post_data.bounds.upper_bound().ty();
+        let post_lower = post_data.lower_bound().ty();
+        let post_upper = post_data.upper_bound().ty();
         let (when, source_order) = storage.load(
             db,
             env,
@@ -241,8 +243,8 @@ impl SequentMap {
         // If this constraint binds its typevar to `Never ≤ T ≤ object`, then the typevar can take
         // on any type, and the constraint is always satisfied.
         let constraint_data = storage.constraint_data(constraint);
-        let lower = constraint_data.bounds.lower_bound().ty();
-        let upper = constraint_data.bounds.upper_bound().ty();
+        let lower = constraint_data.lower_bound().ty();
+        let upper = constraint_data.upper_bound().ty();
         if lower.is_never() && upper.is_object() {
             self.add_single_tautology(constraint);
             return;
@@ -359,13 +361,11 @@ impl SequentMap {
                         storage,
                         derived.typevar,
                         derived
-                            .bounds
-                            .lower
-                            .map(|bound| bound.with_source_provenance(constraint_data.bounds)),
+                            .stored_lower_bound()
+                            .map(|bound| bound.with_source_provenance(constraint_data)),
                         derived
-                            .bounds
-                            .upper
-                            .map(|bound| bound.with_source_provenance(constraint_data.bounds)),
+                            .stored_upper_bound()
+                            .map(|bound| bound.with_source_provenance(constraint_data)),
                     );
                     if interior.if_true != ALWAYS_FALSE {
                         self.add_single_implication(constraint, derived);
@@ -422,18 +422,10 @@ impl SequentMap {
                 right_constraint,
             );
             self.add_nested_typevar_sequents(db, env, storage, left_constraint, right_constraint);
-        } else if left_constraint_data.bounds.lower_bound().ty().is_type_var()
-            || left_constraint_data.bounds.upper_bound().ty().is_type_var()
-            || right_constraint_data
-                .bounds
-                .lower_bound()
-                .ty()
-                .is_type_var()
-            || right_constraint_data
-                .bounds
-                .upper_bound()
-                .ty()
-                .is_type_var()
+        } else if left_constraint_data.lower_bound().ty().is_type_var()
+            || left_constraint_data.upper_bound().ty().is_type_var()
+            || right_constraint_data.lower_bound().ty().is_type_var()
+            || right_constraint_data.upper_bound().ty().is_type_var()
         {
             self.add_mutual_sequents_for_same_typevars(
                 db,
@@ -479,10 +471,10 @@ impl SequentMap {
         let bound_typevar = bound_constraint_data.typevar;
         let constrained_constraint_data = storage.constraint_data(constrained_constraint);
         let constrained_typevar = constrained_constraint_data.typevar;
-        let constrained_lower_bound = constrained_constraint_data.bounds.lower_bound();
-        let constrained_upper_bound = constrained_constraint_data.bounds.upper_bound();
-        let bound_lower_bound = bound_constraint_data.bounds.lower_bound();
-        let bound_upper_bound = bound_constraint_data.bounds.upper_bound();
+        let constrained_lower_bound = constrained_constraint_data.lower_bound();
+        let constrained_upper_bound = constrained_constraint_data.upper_bound();
+        let bound_lower_bound = bound_constraint_data.lower_bound();
+        let bound_upper_bound = bound_constraint_data.upper_bound();
 
         // Transitive pivots require subtyping; classes with dynamic bases can be assignable to
         // unrelated types without being subtypes.
@@ -676,16 +668,13 @@ impl SequentMap {
         right_constraint: ConstraintId,
     ) {
         // Keep this precheck aligned with `variance_of`, which visits lazy types.
-        let has_typevar_bound = |bounds: ConstraintBounds<'db>| {
-            bounds
-                .lower
-                .is_some_and(|lower| any_over_type(db, env, lower.ty(), true, Type::is_type_var))
-                || bounds.upper.is_some_and(|upper| {
-                    any_over_type(db, env, upper.ty(), true, Type::is_type_var)
-                })
+        let has_typevar_bound = |constraint: Constraint<'db>| {
+            constraint
+                .iter_stored_bounds()
+                .any(|bound| any_over_type(db, env, bound.ty(), true, Type::is_type_var))
         };
-        if !has_typevar_bound(storage.constraint_data(left_constraint).bounds)
-            && !has_typevar_bound(storage.constraint_data(right_constraint).bounds)
+        if !has_typevar_bound(storage.constraint_data(left_constraint))
+            && !has_typevar_bound(storage.constraint_data(right_constraint))
         {
             return;
         }
@@ -695,13 +684,13 @@ impl SequentMap {
                 let bound_data = storage.constraint_data(bound_constraint);
                 let bound_typevar = bound_data.typevar;
                 let bound_identity = bound_typevar.identity(db);
-                let bound_lower_bound = bound_data.bounds.lower_bound();
-                let bound_upper_bound = bound_data.bounds.upper_bound();
+                let bound_lower_bound = bound_data.lower_bound();
+                let bound_upper_bound = bound_data.upper_bound();
                 let constrained_data = storage.constraint_data(constrained_constraint);
                 let constrained_typevar = constrained_data.typevar;
                 let constrained_identity = constrained_typevar.identity(db);
-                let constrained_lower_bound = constrained_data.bounds.lower_bound();
-                let constrained_upper_bound = constrained_data.bounds.upper_bound();
+                let constrained_lower_bound = constrained_data.lower_bound();
+                let constrained_upper_bound = constrained_data.upper_bound();
                 let constrained_lower = constrained_lower_bound.ty();
                 let constrained_upper = constrained_upper_bound.ty();
 
@@ -790,7 +779,7 @@ impl SequentMap {
                             env,
                             storage,
                             constrained_typevar,
-                            constrained_data.bounds.lower,
+                            constrained_data.stored_lower_bound(),
                             Some(ConstraintBound::from_transitive_derivation(
                                 new_upper,
                                 constrained_upper_bound,
@@ -870,7 +859,7 @@ impl SequentMap {
                                 constrained_lower_bound,
                                 replacement,
                             )),
-                            constrained_data.bounds.upper,
+                            constrained_data.stored_upper_bound(),
                         );
                         self.add_pair_implication(
                             db,
@@ -912,13 +901,13 @@ impl SequentMap {
             |bound_constraint: ConstraintId, constrained_constraint: ConstraintId| {
                 let bound_data = storage.constraint_data(bound_constraint);
                 let bound_typevar = bound_data.typevar;
-                let bound_lower_bound = bound_data.bounds.lower_bound();
-                let bound_upper_bound = bound_data.bounds.upper_bound();
+                let bound_lower_bound = bound_data.lower_bound();
+                let bound_upper_bound = bound_data.upper_bound();
                 let bound_lower = bound_lower_bound.ty();
                 let constrained_data = storage.constraint_data(constrained_constraint);
                 let constrained_typevar = constrained_data.typevar;
-                let constrained_lower_bound = constrained_data.bounds.lower_bound();
-                let constrained_upper_bound = constrained_data.bounds.upper_bound();
+                let constrained_lower_bound = constrained_data.lower_bound();
+                let constrained_upper_bound = constrained_data.upper_bound();
                 let constrained_lower = constrained_lower_bound.ty();
                 let constrained_upper = constrained_upper_bound.ty();
 
@@ -972,7 +961,7 @@ impl SequentMap {
                                 env,
                                 storage,
                                 constrained_typevar,
-                                constrained_data.bounds.lower,
+                                constrained_data.stored_lower_bound(),
                                 Some(ConstraintBound::from_transitive_derivation(
                                     new_upper,
                                     constrained_upper_bound,
@@ -1025,7 +1014,7 @@ impl SequentMap {
                                     constrained_lower_bound,
                                     bound,
                                 )),
-                                constrained_data.bounds.upper,
+                                constrained_data.stored_upper_bound(),
                             );
                             self.add_pair_implication(
                                 db,
@@ -1043,10 +1032,10 @@ impl SequentMap {
                 // nested in the constrained constraint's bounds. If so, we can substitute B
                 // (the bound constraint's typevar) for S, producing a weaker but useful
                 // constraint.
-                if let Some(upper) = bound_data.bounds.upper {
+                if let Some(upper) = bound_data.stored_upper_bound() {
                     try_one_bound(upper, true);
                 }
-                if let Some(lower) = bound_data.bounds.lower {
+                if let Some(lower) = bound_data.stored_lower_bound() {
                     try_one_bound(lower, false);
                 }
             };
@@ -1066,11 +1055,11 @@ impl SequentMap {
         let mut try_one_direction =
             |left_constraint: ConstraintId, right_constraint: ConstraintId| {
                 let left_constraint_data = storage.constraint_data(left_constraint);
-                let left_lower = left_constraint_data.bounds.lower_bound();
-                let left_upper = left_constraint_data.bounds.upper_bound();
+                let left_lower = left_constraint_data.lower_bound();
+                let left_upper = left_constraint_data.upper_bound();
                 let right_constraint_data = storage.constraint_data(right_constraint);
-                let right_lower = right_constraint_data.bounds.lower_bound();
-                let right_upper = right_constraint_data.bounds.upper_bound();
+                let right_lower = right_constraint_data.lower_bound();
+                let right_upper = right_constraint_data.upper_bound();
                 let mut new_constraints =
                     |bound_typevar: BoundTypeVarInstance<'db>,
                      mut right_lower: Option<ConstraintBound<'db>>,

--- a/crates/ty_python_semantic/src/types/constraints/sequents.rs
+++ b/crates/ty_python_semantic/src/types/constraints/sequents.rs
@@ -245,7 +245,13 @@ impl SequentMap {
         let constraint_data = storage.constraint_data(constraint);
         let lower = constraint_data.lower_bound().ty();
         let upper = constraint_data.upper_bound().ty();
-        if lower.is_never() && upper.is_object() {
+        if constraint_data
+            .stored_lower_bound()
+            .is_none_or(|bound| bound.ty().is_never())
+            && constraint_data
+                .stored_upper_bound()
+                .is_none_or(|bound| bound.ty().is_object())
+        {
             self.add_single_tautology(constraint);
             return;
         }
@@ -285,8 +291,12 @@ impl SequentMap {
         // implication. (That is, this check directly encodes `(L ≤ T ≤ U) → (L ≤ U)` as an
         // implication.)
 
-        // Skip trivial cases where the assignability check won't produce useful results.
-        if lower.is_never() || upper.is_object() {
+        // Missing endpoints add no relation to derive. Keep defaults out of stored evidence.
+        if constraint_data.stored_lower_bound().is_none()
+            || constraint_data.stored_upper_bound().is_none()
+            || lower.is_never()
+            || upper.is_object()
+        {
             return;
         }
 
@@ -422,10 +432,10 @@ impl SequentMap {
                 right_constraint,
             );
             self.add_nested_typevar_sequents(db, env, storage, left_constraint, right_constraint);
-        } else if left_constraint_data.lower_bound().ty().is_type_var()
-            || left_constraint_data.upper_bound().ty().is_type_var()
-            || right_constraint_data.lower_bound().ty().is_type_var()
-            || right_constraint_data.upper_bound().ty().is_type_var()
+        } else if left_constraint_data
+            .iter_stored_bounds()
+            .chain(right_constraint_data.iter_stored_bounds())
+            .any(|bound| bound.ty().is_type_var())
         {
             self.add_mutual_sequents_for_same_typevars(
                 db,
@@ -471,104 +481,120 @@ impl SequentMap {
         let bound_typevar = bound_constraint_data.typevar;
         let constrained_constraint_data = storage.constraint_data(constrained_constraint);
         let constrained_typevar = constrained_constraint_data.typevar;
-        let constrained_lower_bound = constrained_constraint_data.lower_bound();
-        let constrained_upper_bound = constrained_constraint_data.upper_bound();
-        let bound_lower_bound = bound_constraint_data.lower_bound();
-        let bound_upper_bound = bound_constraint_data.upper_bound();
+        let constrained_lower_bound = constrained_constraint_data.stored_lower_bound();
+        let constrained_upper_bound = constrained_constraint_data.stored_upper_bound();
+        let bound_lower_bound = bound_constraint_data.stored_lower_bound();
+        let bound_upper_bound = bound_constraint_data.stored_upper_bound();
+        // A pivot can equal a missing endpoint's identity, such as an alias of Never. That
+        // comparison is useful even though there is no stored bound to copy.
+        let effective_bound_lower = bound_constraint_data.lower_bound();
+        let effective_bound_upper = bound_constraint_data.upper_bound();
 
         // Transitive pivots require subtyping; classes with dynamic bases can be assignable to
         // unrelated types without being subtypes.
         let (new_lower, new_upper) = match (
-            constrained_lower_bound.ty(),
-            constrained_upper_bound.ty(),
-            bound_lower_bound.ty(),
-            bound_upper_bound.ty(),
+            constrained_lower_bound,
+            constrained_upper_bound,
+            bound_lower_bound,
+            bound_upper_bound,
         ) {
             // (B ≤ C ≤ B) ∧ (BL ≤ B ≤ BU) → (BL ≤ C ≤ BU)
-            (Type::TypeVar(constrained_lower), Type::TypeVar(constrained_upper), _, _)
-                if constrained_lower.is_same_typevar_as(db, bound_typevar)
-                    && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
+            (Some(constrained_lower), Some(constrained_upper), _, _)
+                if let Type::TypeVar(constrained_lower_typevar) = constrained_lower.ty()
+                    && let Type::TypeVar(constrained_upper_typevar) = constrained_upper.ty()
+                    && constrained_lower_typevar.is_same_typevar_as(db, bound_typevar)
+                    && constrained_upper_typevar.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
-                    ConstraintBound::from_transitive_derivation(
-                        bound_lower_bound.ty(),
-                        constrained_lower_bound,
-                        bound_lower_bound,
-                    ),
-                    ConstraintBound::from_transitive_derivation(
-                        bound_upper_bound.ty(),
-                        constrained_upper_bound,
-                        bound_upper_bound,
-                    ),
+                    bound_lower_bound.map(|bound| {
+                        ConstraintBound::from_transitive_derivation(
+                            bound.ty(),
+                            constrained_lower,
+                            bound,
+                        )
+                    }),
+                    bound_upper_bound.map(|bound| {
+                        ConstraintBound::from_transitive_derivation(
+                            bound.ty(),
+                            constrained_upper,
+                            bound,
+                        )
+                    }),
                 )
             }
 
             // (CL ≤ C ≤ B) ∧ (BL ≤ B ≤ BU) → (CL ≤ C ≤ BU)
-            (_, Type::TypeVar(constrained_upper), _, _)
-                if constrained_upper.is_same_typevar_as(db, bound_typevar) =>
+            (_, Some(constrained_upper), _, _)
+                if let Type::TypeVar(constrained_upper_typevar) = constrained_upper.ty()
+                    && constrained_upper_typevar.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
                     constrained_lower_bound,
-                    ConstraintBound::from_transitive_derivation(
-                        bound_upper_bound.ty(),
-                        constrained_upper_bound,
-                        bound_upper_bound,
-                    ),
+                    bound_upper_bound.map(|bound| {
+                        ConstraintBound::from_transitive_derivation(
+                            bound.ty(),
+                            constrained_upper,
+                            bound,
+                        )
+                    }),
                 )
             }
 
             // (B ≤ C ≤ CU) ∧ (BL ≤ B ≤ BU) → (BL ≤ C ≤ CU)
-            (Type::TypeVar(constrained_lower), _, _, _)
-                if constrained_lower.is_same_typevar_as(db, bound_typevar) =>
+            (Some(constrained_lower), _, _, _)
+                if let Type::TypeVar(constrained_lower_typevar) = constrained_lower.ty()
+                    && constrained_lower_typevar.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
-                    ConstraintBound::from_transitive_derivation(
-                        bound_lower_bound.ty(),
-                        constrained_lower_bound,
-                        bound_lower_bound,
-                    ),
+                    bound_lower_bound.map(|bound| {
+                        ConstraintBound::from_transitive_derivation(
+                            bound.ty(),
+                            constrained_lower,
+                            bound,
+                        )
+                    }),
                     constrained_upper_bound,
                 )
             }
 
             // (CL ≤ C ≤ pivot) ∧ (pivot ≤ B ≤ BU) → (CL ≤ C ≤ B)
-            (_, constrained_upper, bound_lower, _)
-                if !constrained_upper.is_never()
-                    && !constrained_upper.is_object()
+            (_, Some(constrained_upper), _, _)
+                if !constrained_upper.ty().is_never()
+                    && !constrained_upper.ty().is_object()
                     && storage.cached_is_constraint_set_subtype_of(
                         db,
                         env,
-                        constrained_upper.top_materialization(db, env),
-                        bound_lower.bottom_materialization(db, env),
+                        constrained_upper.ty().top_materialization(db, env),
+                        effective_bound_lower.ty().bottom_materialization(db, env),
                     ) =>
             {
                 (
                     constrained_lower_bound,
-                    ConstraintBound::from_transitive_derivation(
+                    Some(ConstraintBound::from_transitive_derivation(
                         Type::TypeVar(bound_typevar),
-                        constrained_upper_bound,
-                        bound_lower_bound,
-                    ),
+                        constrained_upper,
+                        effective_bound_lower,
+                    )),
                 )
             }
 
             // (pivot ≤ C ≤ CU) ∧ (BL ≤ B ≤ pivot) → (B ≤ C ≤ CU)
-            (constrained_lower, _, _, bound_upper)
-                if !constrained_lower.is_never()
-                    && !constrained_lower.is_object()
+            (Some(constrained_lower), _, _, _)
+                if !constrained_lower.ty().is_never()
+                    && !constrained_lower.ty().is_object()
                     && storage.cached_is_constraint_set_subtype_of(
                         db,
                         env,
-                        bound_upper.top_materialization(db, env),
-                        constrained_lower.bottom_materialization(db, env),
+                        effective_bound_upper.ty().top_materialization(db, env),
+                        constrained_lower.ty().bottom_materialization(db, env),
                     ) =>
             {
                 (
-                    ConstraintBound::from_transitive_derivation(
+                    Some(ConstraintBound::from_transitive_derivation(
                         Type::TypeVar(bound_typevar),
-                        constrained_lower_bound,
-                        bound_upper_bound,
-                    ),
+                        constrained_lower,
+                        effective_bound_upper,
+                    )),
                     constrained_upper_bound,
                 )
             }
@@ -581,8 +607,8 @@ impl SequentMap {
         // explicit bounds that are equivalent to missing lower/upper bounds, so a derived
         // `T ≤ U ≤ object` can satisfy a later query for `T ≤ U` without requiring a separate
         // materialized-default implication.
-        let mut constrained_lower = (!new_lower.ty().is_never()).then_some(new_lower);
-        let mut constrained_upper = (!new_upper.ty().is_object()).then_some(new_upper);
+        let mut constrained_lower = new_lower.filter(|bound| !bound.ty().is_never());
+        let mut constrained_upper = new_upper.filter(|bound| !bound.ty().is_object());
 
         // The transitive rule above gives us an intended post-condition
         // `new_lower ≤ [constrained] ≤ new_upper`.
@@ -599,7 +625,8 @@ impl SequentMap {
         // `T` in this ordering, we emit two pair implications:
         //   `(Never ≤ [A] ≤ T)` and `(T ≤ [B] ≤ object)`.
         // This preserves the relationship while keeping all derived constraints canonical.
-        if let Type::TypeVar(lower_bound_typevar) = new_lower.ty()
+        if let Some(new_lower) = new_lower
+            && let Type::TypeVar(lower_bound_typevar) = new_lower.ty()
             && !lower_bound_typevar.can_be_bound_for(db, storage, constrained_typevar)
         {
             post_constraints.push(ConstraintId::new_with_bounds(
@@ -613,7 +640,8 @@ impl SequentMap {
             constrained_lower = None;
         }
 
-        if let Type::TypeVar(upper_bound_typevar) = new_upper.ty()
+        if let Some(new_upper) = new_upper
+            && let Type::TypeVar(upper_bound_typevar) = new_upper.ty()
             && !upper_bound_typevar.can_be_bound_for(db, storage, constrained_typevar)
         {
             post_constraints.push(ConstraintId::new_with_bounds(
@@ -684,8 +712,8 @@ impl SequentMap {
                 let bound_data = storage.constraint_data(bound_constraint);
                 let bound_typevar = bound_data.typevar;
                 let bound_identity = bound_typevar.identity(db);
-                let bound_lower_bound = bound_data.lower_bound();
-                let bound_upper_bound = bound_data.upper_bound();
+                let bound_lower_bound = bound_data.stored_lower_bound();
+                let bound_upper_bound = bound_data.stored_upper_bound();
                 let constrained_data = storage.constraint_data(constrained_constraint);
                 let constrained_typevar = constrained_data.typevar;
                 let constrained_identity = constrained_typevar.identity(db);
@@ -727,8 +755,8 @@ impl SequentMap {
                     constrained_upper
                         .variance_of(db, env, bound_identity)
                         .evaluate(db),
-                    bound_lower_bound.ty(),
-                    bound_upper_bound.ty(),
+                    bound_lower_bound,
+                    bound_upper_bound,
                 ) {
                     (TypeVarVariance::Bivariant, _, _) => None,
                     // Skip bare typevars — those are handled by
@@ -736,23 +764,33 @@ impl SequentMap {
                     _ if constrained_upper.is_type_var() => None,
                     // Covariance preserves direction: upper bound on T substitutes into upper
                     // bound. A ≤ B → G[A] ≤ G[B], so (T ≤ u_B) gives G[T] ≤ G[u_B].
-                    (TypeVarVariance::Covariant, _, bound_upper) if !bound_upper.is_object() => {
-                        Some(bound_upper_bound)
+                    (TypeVarVariance::Covariant, _, Some(bound_upper))
+                        if !bound_upper.ty().is_object() =>
+                    {
+                        Some(bound_upper)
                     }
                     // Contravariance flips direction: lower bound on T substitutes into upper
                     // bound. A ≤ B → G[B] ≤ G[A], so (l_B ≤ T) gives G[T] ≤ G[l_B].
-                    (TypeVarVariance::Contravariant, bound_lower, _) if !bound_lower.is_never() => {
-                        Some(bound_lower_bound)
+                    (TypeVarVariance::Contravariant, Some(bound_lower), _)
+                        if !bound_lower.ty().is_never() =>
+                    {
+                        Some(bound_lower)
                     }
                     // Invariance requires equality: only substitute if l_B = u_B.
-                    (TypeVarVariance::Invariant, bound_lower, bound_upper)
-                        if bound_lower == bound_upper && !bound_lower.is_never() =>
+                    (TypeVarVariance::Invariant, Some(bound_lower), Some(bound_upper))
+                        if bound_lower.ty() == bound_upper.ty() && !bound_lower.ty().is_never() =>
                     {
                         Some(ConstraintBound::from_combination(
+                            bound_lower.ty(),
                             bound_lower,
-                            bound_lower_bound,
-                            bound_upper_bound,
+                            bound_upper,
                         ))
+                    }
+                    // An object lower bound already forces equality without a supplied upper bound.
+                    (TypeVarVariance::Invariant, Some(bound_lower), None)
+                        if bound_lower.ty().is_object() =>
+                    {
+                        Some(bound_lower)
                     }
                     _ => None,
                 };
@@ -802,32 +840,39 @@ impl SequentMap {
                     constrained_lower
                         .variance_of(db, env, bound_identity)
                         .evaluate(db),
-                    bound_lower_bound.ty(),
-                    bound_upper_bound.ty(),
+                    bound_lower_bound,
+                    bound_upper_bound,
                 ) {
                     (TypeVarVariance::Bivariant, _, _) => None,
                     _ if constrained_lower.is_type_var() => None,
                     // Covariance preserves direction: lower bound on T substitutes into lower
                     // bound. A ≤ B → G[A] ≤ G[B], so (l_B ≤ T) gives G[l_B] ≤ G[T].
-                    (TypeVarVariance::Covariant, bound_lower, _) if !bound_lower.is_never() => {
-                        Some(bound_lower_bound)
+                    (TypeVarVariance::Covariant, Some(bound_lower), _)
+                        if !bound_lower.ty().is_never() =>
+                    {
+                        Some(bound_lower)
                     }
                     // Contravariance flips direction: upper bound on T substitutes into lower
                     // bound. A ≤ B → G[B] ≤ G[A], so (T ≤ u_B) gives G[u_B] ≤ G[T].
-                    (TypeVarVariance::Contravariant, _, bound_upper)
-                        if !bound_upper.is_object() =>
+                    (TypeVarVariance::Contravariant, _, Some(bound_upper))
+                        if !bound_upper.ty().is_object() =>
                     {
-                        Some(bound_upper_bound)
+                        Some(bound_upper)
                     }
                     // Invariance requires equality: only substitute if l_B = u_B.
-                    (TypeVarVariance::Invariant, bound_lower, bound_upper)
-                        if bound_lower == bound_upper && !bound_lower.is_never() =>
+                    (TypeVarVariance::Invariant, Some(bound_lower), Some(bound_upper))
+                        if bound_lower.ty() == bound_upper.ty() && !bound_lower.ty().is_never() =>
                     {
                         Some(ConstraintBound::from_combination(
+                            bound_lower.ty(),
                             bound_lower,
-                            bound_lower_bound,
-                            bound_upper_bound,
+                            bound_upper,
                         ))
+                    }
+                    (TypeVarVariance::Invariant, Some(bound_lower), None)
+                        if bound_lower.ty().is_object() =>
+                    {
+                        Some(bound_lower)
                     }
                     _ => None,
                 };
@@ -1055,11 +1100,11 @@ impl SequentMap {
         let mut try_one_direction =
             |left_constraint: ConstraintId, right_constraint: ConstraintId| {
                 let left_constraint_data = storage.constraint_data(left_constraint);
-                let left_lower = left_constraint_data.lower_bound();
-                let left_upper = left_constraint_data.upper_bound();
+                let left_lower = left_constraint_data.stored_lower_bound();
+                let left_upper = left_constraint_data.stored_upper_bound();
                 let right_constraint_data = storage.constraint_data(right_constraint);
-                let right_lower = right_constraint_data.lower_bound();
-                let right_upper = right_constraint_data.upper_bound();
+                let right_lower = right_constraint_data.stored_lower_bound();
+                let right_upper = right_constraint_data.stored_upper_bound();
                 let mut new_constraints =
                     |bound_typevar: BoundTypeVarInstance<'db>,
                      mut right_lower: Option<ConstraintBound<'db>>,
@@ -1134,42 +1179,56 @@ impl SequentMap {
 
                         post_constraints
                     };
-                let post_constraints = match (left_lower.ty(), left_upper.ty()) {
-                    (Type::TypeVar(bound_typevar), Type::TypeVar(other_bound_typevar))
-                        if bound_typevar.is_same_typevar_as(db, other_bound_typevar) =>
+                let post_constraints = match (left_lower, left_upper) {
+                    (Some(left_lower), Some(left_upper))
+                        if let Type::TypeVar(bound_typevar) = left_lower.ty()
+                            && let Type::TypeVar(other_bound_typevar) = left_upper.ty()
+                            && bound_typevar.is_same_typevar_as(db, other_bound_typevar) =>
                     {
                         new_constraints(
                             bound_typevar,
-                            Some(ConstraintBound::from_transitive_derivation(
-                                right_lower.ty(),
-                                left_lower,
-                                right_lower,
-                            )),
-                            Some(ConstraintBound::from_transitive_derivation(
-                                right_upper.ty(),
-                                left_upper,
-                                right_upper,
-                            )),
+                            right_lower.map(|bound| {
+                                ConstraintBound::from_transitive_derivation(
+                                    bound.ty(),
+                                    left_lower,
+                                    bound,
+                                )
+                            }),
+                            right_upper.map(|bound| {
+                                ConstraintBound::from_transitive_derivation(
+                                    bound.ty(),
+                                    left_upper,
+                                    bound,
+                                )
+                            }),
                         )
                     }
-                    (Type::TypeVar(bound_typevar), _) => new_constraints(
-                        bound_typevar,
-                        None,
-                        Some(ConstraintBound::from_transitive_derivation(
-                            right_upper.ty(),
-                            left_lower,
-                            right_upper,
-                        )),
-                    ),
-                    (_, Type::TypeVar(bound_typevar)) => new_constraints(
-                        bound_typevar,
-                        Some(ConstraintBound::from_transitive_derivation(
-                            right_lower.ty(),
-                            left_upper,
-                            right_lower,
-                        )),
-                        None,
-                    ),
+                    (Some(left_lower), _) if let Type::TypeVar(bound_typevar) = left_lower.ty() => {
+                        new_constraints(
+                            bound_typevar,
+                            None,
+                            right_upper.map(|bound| {
+                                ConstraintBound::from_transitive_derivation(
+                                    bound.ty(),
+                                    left_lower,
+                                    bound,
+                                )
+                            }),
+                        )
+                    }
+                    (_, Some(left_upper)) if let Type::TypeVar(bound_typevar) = left_upper.ty() => {
+                        new_constraints(
+                            bound_typevar,
+                            right_lower.map(|bound| {
+                                ConstraintBound::from_transitive_derivation(
+                                    bound.ty(),
+                                    left_upper,
+                                    bound,
+                                )
+                            }),
+                            None,
+                        )
+                    }
                     _ => return,
                 };
                 for post_constraint in post_constraints {

--- a/crates/ty_python_semantic/src/types/constraints/solutions.rs
+++ b/crates/ty_python_semantic/src/types/constraints/solutions.rs
@@ -114,7 +114,7 @@ impl<'db> SolutionWalker<'db> {
             for (constraint, _) in path {
                 let constraint = storage.constraint_data(constraint);
                 let typevar = constraint.typevar;
-                if let Some(lower) = constraint.bounds.lower {
+                if let Some(lower) = constraint.stored_lower_bound() {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_lower(db, env, lower);
 
@@ -124,7 +124,7 @@ impl<'db> SolutionWalker<'db> {
                     }
                 }
 
-                if let Some(upper) = constraint.bounds.upper {
+                if let Some(upper) = constraint.stored_upper_bound() {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_upper(db, env, upper);
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -13,9 +13,8 @@ use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::projection::{ProjectionError, SolutionBudget, SolutionProjection};
 use crate::types::constraints::{
-    ConstraintBound, ConstraintBounds, ConstraintSet, ConstraintSetBuilder,
-    IteratorConstraintsExtension, PathBound, PathBoundSolution, PathBounds, SolutionPaths,
-    Solutions, TypeVarSolution,
+    Constraint, ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, PathBound,
+    PathBoundSolution, PathBounds, SolutionPaths, Solutions, TypeVarSolution,
 };
 use crate::types::infer::original_class_type;
 use crate::types::relation::{
@@ -3332,25 +3331,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
-    fn intersect_pending_typevar_constraint(
-        &mut self,
-        bound_typevar: BoundTypeVarInstance<'db>,
-        bounds: ConstraintBounds<'db>,
-    ) {
+    fn intersect_pending_typevar_constraint(&mut self, constraint: Constraint<'db>) {
         let db = self.db;
+        let bound_typevar = constraint.typevar();
         let identity = bound_typevar.identity(db);
         if bound_typevar.is_paramspec(db) && !self.paramspec_seen.insert(identity) {
             return;
         }
 
-        let constraint = ConstraintSet::constrain_typevar_with_bounds(
-            db,
-            self.env,
-            self.constraints,
-            bound_typevar,
-            bounds.lower,
-            bounds.upper,
-        );
+        let constraint = ConstraintSet::from_constraint(db, self.env, self.constraints, constraint);
         self.pending.intersect(db, self.constraints, constraint);
     }
 
@@ -3390,17 +3379,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         ty: Type<'db>,
         variance: TypeVarVariance,
     ) {
-        let bounds = match variance {
-            TypeVarVariance::Covariant => {
-                ConstraintBounds::new(Some(ConstraintBound::Evidence(ty)), None)
-            }
+        let constraint = match variance {
+            TypeVarVariance::Covariant => Constraint::from_evidence(bound_typevar, Some(ty), None),
             TypeVarVariance::Contravariant => {
-                ConstraintBounds::new(None, Some(ConstraintBound::Evidence(ty)))
+                Constraint::from_evidence(bound_typevar, None, Some(ty))
             }
-            TypeVarVariance::Invariant => ConstraintBounds::exact(ty),
+            TypeVarVariance::Invariant => Constraint::exact(bound_typevar, ty),
             TypeVarVariance::Bivariant => return,
         };
-        self.intersect_pending_typevar_constraint(bound_typevar, bounds);
+        self.intersect_pending_typevar_constraint(constraint);
     }
 
     /// Solves one relation without recording it or changing the legacy type mappings.
@@ -3473,7 +3460,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     ) -> Option<ConstraintFailure<'db>> {
         let db = self.db;
         let bound_typevar = path_bound.bound_typevar;
-        let argument = path_bound.evidence_lower?;
+        let argument = path_bound.evidence_lower()?;
         let variance = if path_bound.has_upper_evidence() {
             ConstraintFailureVariance::Invariant
         } else {
@@ -4753,7 +4740,7 @@ mod tests {
                 let inference = builder
                     .build_inference_with(|typevar, bounds| {
                         (typevar == t
-                            && bounds.is_some_and(|bound| bound.evidence_lower == Some(str)))
+                            && bounds.is_some_and(|bound| bound.evidence_lower() == Some(str)))
                         .then_some(PathBoundSolution::BudgetExceeded { fallback })
                     })
                     .map_err(|()| anyhow::anyhow!("incomplete alternatives remain satisfiable"))?;
@@ -5021,7 +5008,7 @@ mod tests {
 
         let inference = builder
             .build_inference_with(|typevar, bounds| {
-                (typevar == t && bounds.is_some_and(|bound| bound.evidence_lower == Some(str)))
+                (typevar == t && bounds.is_some_and(|bound| bound.evidence_lower() == Some(str)))
                     .then_some(PathBoundSolution::Solved(Type::TypeVar(u)))
             })
             .map_err(|()| anyhow::anyhow!("expected satisfiable alternatives"))?;
@@ -5067,7 +5054,7 @@ mod tests {
         // individual path still contains the cycle after merging with object.
         let inference = builder
             .build_inference_with(|typevar, bounds| {
-                let ty = match (typevar, bounds?.evidence_lower) {
+                let ty = match (typevar, bounds?.evidence_lower()) {
                     (typevar, Some(lower)) if typevar == t && lower == int => list_of_u,
                     (typevar, Some(lower)) if typevar == u && lower == str => Type::TypeVar(t),
                     _ => Type::object(),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7946,7 +7946,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .origin(self.db())
             .apply_specialization(db, |_| {
                 builder.build_merged_with(|current_typevar, bounds| {
-                    let lower = bounds?.evidence_lower?;
+                    let lower = bounds?.evidence_lower()?;
 
                     let lower = lower.promote_collection_element_type(
                         db,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1326,7 +1326,7 @@ impl<'db> Signature<'db> {
             if let Some(bounds) = bounds
                 && let Some(lower) = bounds.evidence_lower()
                 && bounds.has_upper_evidence()
-                && let Some(upper) = bounds.single_upper_bound(db, env)
+                && let Some(upper) = bounds.as_single_upper_bound(db, env)
                 && lower.is_equivalent_to(db, env, upper)
                 && let Some(solution) =
                     PathBounds::default_solve(db, env, &constraints, bounds).as_type()

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1324,9 +1324,9 @@ impl<'db> Signature<'db> {
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
         let specialization = builder.build_merged_with(|typevar, bounds| {
             if let Some(bounds) = bounds
-                && let Some(lower) = bounds.evidence_lower
+                && let Some(lower) = bounds.evidence_lower()
                 && bounds.has_upper_evidence()
-                && let Some(upper) = bounds.upper.as_single_bound(db, env)
+                && let Some(upper) = bounds.single_upper_bound(db, env)
                 && lower.is_equivalent_to(db, env, upper)
                 && let Some(solution) =
                     PathBounds::default_solve(db, env, &constraints, bounds).as_type()
@@ -1340,7 +1340,9 @@ impl<'db> Signature<'db> {
                     .variance_of(db, env, typevar.identity(db))
                     .evaluate(db)
                     .is_covariant()
-                && bounds.evidence_lower.is_some_and(|lower| !lower.is_never())
+                && bounds
+                    .evidence_lower()
+                    .is_some_and(|lower| !lower.is_never())
                 && let Some(solution) =
                     PathBounds::default_solve(db, env, &constraints, bounds).as_type()
             {


### PR DESCRIPTION
The ParamSpec work in #28028 needs missing bounds to depend on the type variable being constrained. Ordinary TypeVars use `Never` and `object`; a bare ParamSpec needs the bottom and top parameter lists. `Constraint` knows which type variable is being constrained, but `ConstraintBounds` and `ConstraintBound` currently supply defaults without that context, leaving ParamSpec callers to interpret missing endpoints separately.

An omitted bound also differs from explicitly supplied inference evidence, even when both have the same effective endpoint. For example, an absent upper bound and an explicit `object` bound must remain distinguishable during inference. Callers need access to both stored bounds and effective endpoints without losing the `Validity`/`Evidence` distinction.

This PR moves construction and bound queries onto `Constraint` and `PathBound`, which already carry the type variable, and makes the lower-level storage types private. `Constraint` exposes separate stored and effective bound accessors while retaining provenance. Constraint consumers preserve stored endpoints during propagation, substitution, traversal, and display, while comparisons use effective endpoints where needed. `PathBound` exposes lower-bound evidence and a cheap single-upper-bound query that does not expand factored intersections.

This PR prepares for #28028 without changing existing endpoint defaults, canonicalization, traversal, or aggregation semantics. It does not add ParamSpec endpoint semantics. Existing test assertions and snapshots are unchanged.
