### PR TITLE
[ty] Fix compiler warning seen in `cargo nextest run` invocations locally

### DIFF
--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -1001,6 +1001,7 @@ impl CliTest {
         command
     }
 
+    #[cfg(feature = "test-uv")]
     pub(crate) fn command_inheriting_environment(&self) -> Command {
         let mut command = Command::new(&self.ty_binary_path);
         command.current_dir(&self.project_dir).arg("check");


### PR DESCRIPTION
## Summary

Invoking `cargo nextest run -p ty` locally currently results in this warning:

```
warning: method `command_inheriting_environment` is never used
    --> crates/ty/tests/cli/main.rs:1004:19
     |
 846 | impl CliTest {
     | ------------ method in this implementation
...
1004 |     pub(crate) fn command_inheriting_environment(&self) -> Command {
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: `ty` (test "cli") generated 1 warning
```

which is because the only use of this method is here:

https://github.com/astral-sh/ruff/blob/b4531166f345c2867805107fea99980fb1e78453/crates/ty/tests/cli/scripts.rs#L1435-L1451
