### PR TITLE
[ty] Apply mixin specialization when validating enum members

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -823,14 +823,14 @@ python-version = "3.12"
 ```
 
 ```py
-from enum import Enum, StrEnum
-from typing import TYPE_CHECKING, Self
+from enum import Enum
+from typing import Self
 
 class GenericMixin[T]:
-    if TYPE_CHECKING:
-        def __new__(cls, value: T) -> Self: ...
+    def __new__(cls, value: T) -> Self:
+        return object.__new__(cls)
 
-class Specialized(GenericMixin[str], StrEnum):
+class Specialized(GenericMixin[str], Enum):
     A = "a"
     B = 1  # error: [invalid-assignment]
 ```
@@ -851,8 +851,8 @@ tuple payload is checked against the corresponding specialized parameter:
 
 ```py
 class Pair[T, U]:
-    if TYPE_CHECKING:
-        def __new__(cls, first: T, second: U) -> Self: ...
+    def __new__(cls, first: T, second: U) -> Self:
+        return object.__new__(cls)
 
 class Unpacked(Pair[str, int], Enum):
     A = ("a", 1)
@@ -865,10 +865,10 @@ even a fully permissive signature rejected every member:
 
 ```py
 class Ignored[T]:
-    if TYPE_CHECKING:
-        def __new__(cls, *args: object, **kwargs: object) -> Self: ...
+    def __new__(cls, *args: object, **kwargs: object) -> Self:
+        return object.__new__(cls)
 
-class Permissive(Ignored[str], StrEnum):
+class Permissive(Ignored[str], Enum):
     A = "a"
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -811,6 +811,67 @@ reveal_type(InheritedWeirdEnum.FROM_INT)  # revealed: Literal[InheritedWeirdEnum
 reveal_type(enum_members(InheritedWeirdEnum))  # revealed: Unknown
 ```
 
+### Generic data-type mixin `__new__`
+
+A data-type mixin may be generic. When an enum lists a specialized alias of that mixin as a base,
+members are validated against the specialized `__new__` signature, not against one whose typevars
+are still free. Here `T` is `str`, so a `str` member is accepted and an `int` member is not:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from enum import Enum, StrEnum
+from typing import TYPE_CHECKING, Self
+
+class GenericMixin[T]:
+    if TYPE_CHECKING:
+        def __new__(cls, value: T) -> Self: ...
+
+class Specialized(GenericMixin[str], StrEnum):
+    A = "a"
+    B = 1  # error: [invalid-assignment]
+```
+
+The specialization is applied through intermediate generic bases, too. `Middle[int]` binds
+`GenericMixin`'s `T` to `int` one step further up the MRO:
+
+```py
+class Middle[T](GenericMixin[T]): ...
+
+class Inherited(Middle[int], Enum):
+    A = 1
+    B = "b"  # error: [invalid-assignment]
+```
+
+A mixin with several type parameters is specialized the same way, and each element of a member's
+tuple payload is checked against the corresponding specialized parameter:
+
+```py
+class Pair[T, U]:
+    if TYPE_CHECKING:
+        def __new__(cls, first: T, second: U) -> Self: ...
+
+class Unpacked(Pair[str, int], Enum):
+    A = ("a", 1)
+    B = ("b", "c")  # error: [invalid-assignment]
+```
+
+A mixin whose `__new__` does not mention its type parameters at all is accepted as well. Before the
+specialization was applied, the free typevar made the synthesized `cls` argument fail to match, so
+even a fully permissive signature rejected every member:
+
+```py
+class Ignored[T]:
+    if TYPE_CHECKING:
+        def __new__(cls, *args: object, **kwargs: object) -> Self: ...
+
+class Permissive(Ignored[str], StrEnum):
+    A = "a"
+```
+
 ### Built-in data types
 
 An enum with an `int` or `str` data type stores the value produced by that type's constructor.

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1531,9 +1531,27 @@ fn inherited_user_defined_mixin_new<'db>(
         .iter_mro(db, None)
         .skip(1)
         .filter_map(ClassBase::into_class)
-        .filter_map(|class| class.class_literal(db).as_static())
-        .filter(|base| base.known(db).is_none())
-        .find_map(|base| custom_enum_method(db, base.body_scope(db), "__new__"))
+        .find_map(|class_type| {
+            let (base, specialization) = class_type.static_class_literal(db)?;
+            if base.known(db).is_some() {
+                return None;
+            }
+            let binding = custom_enum_method(db, base.body_scope(db), "__new__")?;
+            // The mixin may be inherited as a specialized generic alias (`Mixin[str]`). Apply that
+            // specialization, so that members are checked against the specialized `__new__`
+            // signature instead of one with free typevars.
+            let EnumMethodBinding::Function(function) = binding else {
+                return Some(EnumMethodBinding::Opaque);
+            };
+            Some(
+                match Type::FunctionLiteral(function)
+                    .apply_optional_owner_specialization_to_member(db, specialization)
+                {
+                    Type::FunctionLiteral(function) => EnumMethodBinding::Function(function),
+                    _ => EnumMethodBinding::Opaque,
+                },
+            )
+        })
 }
 
 /// Looks up a resolvable method inherited from a known enum class.


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4403.

An enum that inherits a data-type mixin as a specialized generic alias (`Mixin[str]`) reported every
one of its members as incompatible with the mixin's `__new__`, whatever the member value or the
parameter types were:

```py
class GenericMixin[T]:
    if TYPE_CHECKING:
        def __new__(cls, value: T) -> Self: ...

class Bad(GenericMixin[str], StrEnum):
    A = "a"  # error: [invalid-assignment]
```

`inherited_user_defined_mixin_new` walked the MRO and reduced each base to its statement-defined
class literal before looking up `__new__`, which discarded the specialization carried by a generic
alias base. The `__new__` it returned still had the mixin's type parameters free, so the implicit
`cls: type[Self]` had upper bound `Mixin[T@Mixin]` - a bound the enum class does not satisfy.
Inference then failed on the synthesized `cls` argument before the member value was ever considered,
which is why even a mixin whose `__new__` accepts `*args: object` rejected its members.

This keeps the specialization while walking the MRO and projects the function through it with
`apply_optional_owner_specialization_to_member`, which also rewrites the retained synthetic `Self`
domain. Plain `apply_specialization` is not enough: it substitutes the annotations but leaves
`Self`'s upper bound unspecialized, and the false positive survives.

Genuine mismatches are still reported - wrong member type, wrong specialization, wrong tuple arity -
and the `info` line now renders the specialized signature:

```
info: Expected compatible arguments for `def __new__[Self](cls, value: str) -> Self`
```

rather than one naming a free typevar (`value: T@GenericMixin`).

This is unrelated to the "generic enum" case from astral-sh/ty#2416: these enums are not generic, and
`invalid-generic-enum` still fires on a truly generic enum.

## Test Plan

New `mdtest/enums.md` section, "Generic data-type mixin `__new__`", covering a specialized mixin
base, specialization through an intermediate generic base, a multi-parameter mixin checked against a
tuple payload, and a mixin whose `__new__` ignores its type parameter entirely - each with both an
accepted and a rejected member.
