### PR TITLE
[ty] Narrow functional enum members in `==` and `match`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -3640,10 +3640,28 @@ def color_name_misses_one_variant(color: Color) -> str:
         assert_never(color)  # error: [type-assertion-failure] "Type `Literal[Color.BLUE]` is not equivalent to `Never`"
 ```
 
+A functional enum inherits `object.__eq__`, so comparing members with `==` and `!=` narrows just as
+`is` does:
+
+```py
+def equality(color: Color) -> None:
+    if color == Color.RED:
+        reveal_type(color)  # revealed: Literal[Color.RED]
+    else:
+        reveal_type(color)  # revealed: Literal[Color.GREEN, Color.BLUE]
+
+def inequality(color: Color) -> None:
+    if color != Color.RED:
+        reveal_type(color)  # revealed: Literal[Color.GREEN, Color.BLUE]
+    else:
+        reveal_type(color)  # revealed: Literal[Color.RED]
+```
+
 ## `match` statements (function syntax)
 
-TODO: `match` exhaustiveness does not yet work for functional enums. The pattern matching narrowing
-path does not resolve functional enum members the same way `is` comparisons do.
+Value patterns narrow members of a functional enum exactly as they do for an enum declared with
+class syntax. A `match` that covers every member is exhaustive, so the wildcard case is unreachable
+and `assert_never` holds:
 
 ```toml
 [environment]
@@ -3656,19 +3674,22 @@ from typing_extensions import assert_never
 
 Color = Enum("Color", "RED GREEN BLUE")
 
-# TODO: `assert_never` should not fire here (exhaustive match).
 def color_name(color: Color) -> str:
     match color:
         case Color.RED:
+            reveal_type(color)  # revealed: Literal[Color.RED]
             return "Red"
         case Color.GREEN:
             return "Green"
         case Color.BLUE:
             return "Blue"
         case _:
-            assert_never(color)  # error: [type-assertion-failure]
+            assert_never(color)
+```
 
-# TODO: This should ideally emit `Literal[Color.BLUE]` in the assertion, not `Color`.
+When a member is left uncovered, the wildcard case receives exactly that member:
+
+```py
 def color_name_misses_one_variant(color: Color) -> str:
     match color:
         case Color.RED:
@@ -3676,7 +3697,7 @@ def color_name_misses_one_variant(color: Color) -> str:
         case Color.GREEN:
             return "Green"
         case _:
-            assert_never(color)  # error: [type-assertion-failure] "Type `Color` is not equivalent to `Never`"
+            assert_never(color)  # error: [type-assertion-failure] "Type `Literal[Color.BLUE]` is not equivalent to `Never`"
 ```
 
 ## `__eq__` and `__ne__`

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -713,7 +713,7 @@ impl<'db> ClassLiteral<'db> {
             Self::Dynamic(class) => class.class_member(db, env, name, policy),
             Self::DynamicNamedTuple(namedtuple) => namedtuple.class_member(db, env, name, policy),
             Self::DynamicTypedDict(typeddict) => typeddict.class_member(db, env, name, policy),
-            Self::DynamicEnum(enum_lit) => enum_lit.class_member(db, env, name),
+            Self::DynamicEnum(enum_lit) => enum_lit.class_member(db, env, name, policy),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -251,18 +251,28 @@ impl<'db> DynamicEnumLiteral<'db> {
     ///
     /// If members are unknown and nothing was found in the MRO, returns `Unknown`
     /// as a last resort to avoid false `unresolved-attribute` errors.
+    ///
+    /// `policy` is forwarded to the mixin and enum-base lookups so that those lookups resolve the
+    /// same way they would on an equivalent class-syntax enum. For example, a caller asking for
+    /// `__eq__` with `MRO_NO_OBJECT_FALLBACK` must not be given `object.__eq__`: that would
+    /// describe the enum as defining its own equality and hide its real comparison semantics.
+    ///
+    /// The unknown-member fallback at the end does not consult `policy`. It exists to avoid false
+    /// `unresolved-attribute` errors when the member names are not statically known, which is a
+    /// property of the enum rather than of the lookup being performed.
     pub(crate) fn class_member(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         name: &str,
+        policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         let own = self.own_class_member(db, name);
         if !own.is_undefined() {
             return own.inner;
         }
         if let Some(mixin_class) = self.mixin_class(db, env) {
-            let result = mixin_class.class_member(db, env, name, MemberLookupPolicy::default());
+            let result = mixin_class.class_member(db, env, name, policy);
             if !result.place.is_undefined() {
                 return result;
             }
@@ -271,7 +281,7 @@ impl<'db> DynamicEnumLiteral<'db> {
             .base_class(db)
             .to_class_literal(db, env)
             .as_class_literal()
-            .map(|cls| cls.class_member(db, env, name, MemberLookupPolicy::default()))
+            .map(|cls| cls.class_member(db, env, name, policy))
             .unwrap_or_else(|| Place::Undefined.into());
 
         // When members are unknown (e.g. `Enum("E", some_var)`), any name could


### PR DESCRIPTION
## Summary

Comparing a member of an enum created with the functional syntax did not narrow the compared value, so an exhaustive `match` was not recognized as exhaustive:

```python
from enum import Enum
from typing import assert_never

Answer = Enum("Answer", "NO YES")

def to_string(answer: Answer) -> str:
    match answer:
        case Answer.NO:
            reveal_type(answer)  # Answer, not Literal[Answer.NO]
            return "no"
        case Answer.YES:
            return "yes"
        case _:
            assert_never(answer)  # spurious type-assertion-failure
```

The same enum declared with class syntax narrowed correctly, as did `is` comparisons against a functional enum member.

Equality narrowing first establishes how a class compares by looking up `__eq__` with `MRO_NO_OBJECT_FALLBACK`, which reports the member as undefined when a class inherits `object.__eq__` unchanged. `ClassLiteral::class_member` forwarded the caller's `MemberLookupPolicy` to every variant except `DynamicEnum`, which substituted the default policy when delegating to the mixin and enum base. The lookup therefore reached `object.__eq__`, comparison semantics were treated as unknown, and no constraint was produced.

Forwarding the policy makes the lookup agree with class-syntax enums. This fixes `==` and `!=` narrowing as well as the `match` exhaustiveness that builds on it.

Closes astral-sh/ty#4130

## Test Plan

`enums.md` already contained a section for `match` statements over functional enums, recording the missing exhaustiveness and the imprecise wildcard type as known limitations. That section now specifies the working behavior: member patterns narrow to the corresponding enum literal, a `match` covering every member is exhaustive, and a `match` leaving one member uncovered narrows the wildcard case to exactly that member.

The `if` statements section for functional enums gains coverage for `==` and `!=`, which narrow the same way `is` already did.
