### PR TITLE
[ty] Cancel superseded queued uv requests

### DIFF
--- a/crates/ty_project/src/uv/environments.rs
+++ b/crates/ty_project/src/uv/environments.rs
@@ -62,8 +62,10 @@
 //! therefore bounded by the number of projects and scripts, not the number of changes. The worker
 //! count limits concurrent uv processes, but the queues do not apply backpressure to the host.
 //!
-//! `poll_sync` submits the latest follow-up only after the current job reports completion, keeping
-//! the same progress reporter. This avoids overlapping synchronizations for one environment.
+//! A newer request cancels the previous job if a worker has not started it yet. Running uv processes
+//! are allowed to finish. Both cancelled and executed jobs report completion; only then can
+//! `poll_sync` submit the latest follow-up, keeping the same progress reporter. This avoids both
+//! overlapping synchronizations for one environment and accumulating cancelled queue entries.
 
 use std::hash::Hasher;
 use std::sync::Arc;
@@ -72,6 +74,7 @@ use crossbeam::channel::Receiver;
 use parking_lot::Mutex;
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_db::FxDashMap;
+use ruff_db::cancellation::CancellationTokenSource;
 use ruff_db::files::{File, Files};
 use ruff_db::system::{SystemPath, SystemPathBuf};
 use salsa::Setter;
@@ -125,22 +128,29 @@ impl UvEnvironments {
         path: &SystemPath,
         make_progress: &ProjectSyncProgressFactory<'_>,
     ) {
-        let progress = {
+        let (progress, cancellation) = {
             let mut project = self.inner.project.lock();
             if let Some(sync) = project.as_mut() {
                 sync.next_request = Some(path.to_path_buf());
+                sync.cancellation.cancel();
                 return;
             }
 
             let progress = make_progress(db, db.project());
-            *project = Some(ProjectSync { next_request: None });
-            progress
+            let cancellation = CancellationTokenSource::new();
+            let token = cancellation.token();
+            *project = Some(ProjectSync {
+                next_request: None,
+                cancellation,
+            });
+            (progress, token)
         };
 
         tracing::debug!("Requested workspace metadata for `{path}`");
         self.inner.sync_service.schedule_one(
             db.system(),
             UvSyncTask::Workspace(path.to_path_buf()),
+            cancellation,
             progress,
         );
     }
@@ -207,9 +217,10 @@ impl UvEnvironments {
     /// whether it can be used while synchronization runs. An existing `ScriptEnvironment`
     /// remains available, even if its virtual environment has not previously been synchronized.
     ///
-    /// If another synchronization is pending, records the latest request to run afterward,
-    /// reusing the existing progress reporter. Otherwise, creates a new progress reporter and
-    /// submits the synchronization.
+    /// If another synchronization is pending, records the latest request to run afterward and
+    /// cancels the queued job if it has not started. Running uv processes are allowed to finish.
+    /// The follow-up reuses the existing progress reporter. Otherwise, creates a new progress
+    /// reporter and submits the synchronization.
     ///
     /// Submission does not wait for uv or queue space.
     pub fn request_sync(
@@ -265,12 +276,15 @@ impl UvEnvironments {
         };
 
         let progress = make_progress(db, file);
+        let cancellation = CancellationTokenSource::new();
+        let token = cancellation.token();
         *state = ScriptEnvironmentState::Synchronizing {
             environment,
             availability,
             sync: InFlightSync {
                 active_cache_key: task.request.cache_key(),
                 next_request: None,
+                cancellation,
             },
         };
 
@@ -281,9 +295,12 @@ impl UvEnvironments {
 
         drop(state);
 
-        self.inner
-            .sync_service
-            .schedule_one(db.system(), UvSyncTask::Script(task), progress);
+        self.inner.sync_service.schedule_one(
+            db.system(),
+            UvSyncTask::Script(task),
+            token,
+            progress,
+        );
     }
 
     /// Applies completed background requests to their projects or script environments.
@@ -294,7 +311,7 @@ impl UvEnvironments {
     ///
     /// If a newer synchronization was requested while the current one was pending, discards the
     /// outdated result and schedules the newer request instead, transferring the existing progress
-    /// reporter.
+    /// reporter. Cancelled jobs also schedule their replacement without changing the environment.
     ///
     /// Reports project completions and changed scripts so callers can refresh diagnostics.
     pub fn poll_sync(&self, db: &mut dyn Db) -> UvSyncChanges {
@@ -311,21 +328,32 @@ impl UvEnvironments {
             } = result;
             match task {
                 UvSyncTask::Workspace(path) => {
-                    let next = self
-                        .inner
-                        .project
-                        .lock()
+                    let mut project_sync = self.inner.project.lock();
+                    let next = project_sync
                         .as_mut()
                         .and_then(|sync| sync.next_request.take());
-                    if let Some(next) = next {
-                        tracing::debug!("Discarded superseded workspace metadata for `{path}`");
-                        self.inner.sync_service.schedule_one(
-                            db.system(),
-                            UvSyncTask::Workspace(next),
-                            progress,
-                        );
-                        continue;
-                    }
+                    let output = match (next, output) {
+                        (None, Some(output)) => output,
+                        (next, _) => {
+                            tracing::debug!("Discarded superseded workspace metadata for `{path}`");
+                            let cancellation = CancellationTokenSource::new();
+                            let token = cancellation.token();
+                            *project_sync = Some(ProjectSync {
+                                next_request: None,
+                                cancellation,
+                            });
+                            drop(project_sync);
+
+                            self.inner.sync_service.schedule_one(
+                                db.system(),
+                                UvSyncTask::Workspace(next.unwrap_or(path)),
+                                token,
+                                progress,
+                            );
+                            continue;
+                        }
+                    };
+                    drop(project_sync);
                     let project = db.project();
                     let environment = match Uv::parse_metadata_output(db.system(), output) {
                         Ok(metadata) => ProjectEnvironment {
@@ -378,30 +406,40 @@ impl UvEnvironments {
                         request.path()
                     );
 
-                    if let Some(next) = sync.next_request.take() {
-                        // uv updates the same environment on disk for every version of this script. If the
-                        // metadata changes A -> B -> A, the B synchronization may already have modified the
-                        // environment. Run A again even though its cache key matches the last completed
-                        // synchronization.
-                        sync.active_cache_key = next.cache_key();
+                    let output = match (sync.next_request.take(), output) {
+                        (None, Some(output)) => output,
+                        (next, _) => {
+                            // uv updates the same environment on disk for every version of this script. If the
+                            // metadata changes A -> B -> A, the B synchronization may already have modified the
+                            // environment. Run A again even though its cache key matches the last completed
+                            // synchronization.
+                            //
+                            // A cancelled request can become current again after another edit. Retry it
+                            // when there is no newer request; cancellation does not update the environment.
+                            let next = next.unwrap_or(request);
+                            sync.active_cache_key = next.cache_key();
+                            sync.cancellation = CancellationTokenSource::new();
+                            let token = sync.cancellation.token();
 
-                        tracing::debug!(
-                            "Discarded superseded script environment synchronization result for `{}`",
-                            next.path()
-                        );
+                            tracing::debug!(
+                                "Discarded superseded script environment synchronization result for `{}`",
+                                next.path()
+                            );
 
-                        drop(state);
+                            drop(state);
 
-                        self.inner.sync_service.schedule_one(
-                            db.system(),
-                            UvSyncTask::Script(ScriptSyncTask {
-                                file,
-                                request: next,
-                            }),
-                            progress,
-                        );
-                        continue;
-                    }
+                            self.inner.sync_service.schedule_one(
+                                db.system(),
+                                UvSyncTask::Script(ScriptSyncTask {
+                                    file,
+                                    request: next,
+                                }),
+                                token,
+                                progress,
+                            );
+                            continue;
+                        }
+                    };
 
                     let environment = *environment;
                     apply_sync_result(db, environment, &request, output);
@@ -578,6 +616,7 @@ impl Default for UvEnvironmentsInner {
 
 struct ProjectSync {
     next_request: Option<SystemPathBuf>,
+    cancellation: CancellationTokenSource,
 }
 
 type ScriptEnvironmentEntry = Mutex<ScriptEnvironmentState>;
@@ -631,13 +670,16 @@ enum ScriptEnvironmentState {
 struct InFlightSync {
     active_cache_key: ScriptEnvironmentCacheKey,
     next_request: Option<ScriptSyncRequest>,
+    /// Signals the worker to skip this request if it has not started.
+    cancellation: CancellationTokenSource,
 }
 
 impl InFlightSync {
     /// Updates the synchronization to run after the active request.
     ///
     /// If `request` matches the active synchronization, removes any previously requested follow-up.
-    /// Otherwise, replaces the follow-up with `request`.
+    /// Otherwise, replaces the follow-up with `request`. A changed request cancels the queued job;
+    /// an already running uv process is allowed to finish.
     ///
     /// Returns whether the requested synchronization changed.
     fn update_next_request(&mut self, request: ScriptSyncRequest) -> bool {
@@ -654,6 +696,7 @@ impl InFlightSync {
         } else {
             Some(request)
         };
+        self.cancellation.cancel();
         true
     }
 }

--- a/crates/ty_project/src/uv/service.rs
+++ b/crates/ty_project/src/uv/service.rs
@@ -2,6 +2,7 @@ use std::process::Output;
 use std::sync::{Arc, OnceLock};
 
 use crossbeam::channel::{Receiver, Sender, TrySendError};
+use ruff_db::cancellation::CancellationToken;
 use ruff_db::files::File;
 use ruff_db::system::{CommandExecutor, System, SystemPathBuf};
 
@@ -19,6 +20,8 @@ use crate::UvSyncProgress;
 /// time, including jobs whose results have not yet been consumed. It retains only the latest
 /// follow-up and submits it after consuming the previous result. Both request and result queues
 /// are therefore bounded by the number of projects and scripts, not the number of changes.
+/// Superseded jobs are cancelled before execution when possible. Running uv processes are not
+/// interrupted, and cancelled jobs still return a result so their replacements can be scheduled.
 ///
 /// The service deliberately owns neither a database nor its `System`. Workers stay alive between
 /// jobs, while the host must be able to apply file changes and completed uv results. Salsa waits
@@ -54,11 +57,13 @@ impl UvMetadataService {
 
     /// Submits one background synchronization.
     ///
-    /// Submission does not wait for queue space.
+    /// Submission does not wait for queue space. Cancellation skips a job that has not started,
+    /// but still produces a result and wakeup. It does not interrupt a running uv process.
     pub(crate) fn schedule_one(
         &self,
         system: &dyn System,
         task: UvSyncTask,
+        cancellation: CancellationToken,
         progress: Option<Box<dyn UvSyncProgress>>,
     ) {
         let workers = match self.worker_pool(system) {
@@ -66,7 +71,7 @@ impl UvMetadataService {
             Err(error) => {
                 self.publish_result(UvMetadataResult {
                     task,
-                    output: Err(error),
+                    output: Some(Err(error)),
                     progress,
                 });
                 return;
@@ -82,6 +87,7 @@ impl UvMetadataService {
 
         let job = UvJob {
             task,
+            cancellation,
             result_sender: self.results_sender.clone(),
             wake_sender: self.wake_sender.clone(),
             progress,
@@ -91,7 +97,7 @@ impl UvMetadataService {
             let job = error.into_inner();
             self.publish_result(UvMetadataResult {
                 task: job.task,
-                output: Err(worker_disconnected()),
+                output: Some(Err(worker_disconnected())),
                 progress: job.progress,
             });
         }
@@ -204,7 +210,8 @@ impl UvSyncTask {
 /// This keeps the progress reporter alive until the result is consumed or rescheduled.
 pub(crate) struct UvMetadataResult {
     pub(crate) task: UvSyncTask,
-    pub(crate) output: std::io::Result<Output>,
+    /// `None` if the worker skipped this request because it was cancelled before execution.
+    pub(crate) output: Option<std::io::Result<Output>>,
     pub(crate) progress: Option<Box<dyn UvSyncProgress>>,
 }
 
@@ -285,24 +292,31 @@ impl UvWorker {
             };
 
             let _span = job.span.enter();
-            let target = job.task.metadata_target();
-            match &target {
-                MetadataTarget::Workspace(path) => {
-                    tracing::info!("Reading workspace metadata for `{path}`");
+            let output = if job.cancellation.is_cancelled() {
+                tracing::debug!("Skipped cancelled uv metadata request");
+                None
+            } else {
+                let target = job.task.metadata_target();
+                match &target {
+                    MetadataTarget::Workspace(path) => {
+                        tracing::info!("Reading workspace metadata for `{path}`");
+                    }
+                    MetadataTarget::Script { path, .. } => {
+                        tracing::info!("Synchronizing script `{path}`");
+                    }
                 }
-                MetadataTarget::Script { path, .. } => {
-                    tracing::info!("Synchronizing script `{path}`");
+                if let Some(progress) = job.progress.as_mut() {
+                    progress.started();
                 }
-            }
-            if let Some(progress) = job.progress.as_mut() {
-                progress.started();
-            }
 
-            let output = self.uv.execute(&*self.executor, &target);
+                let output = self.uv.execute(&*self.executor, &target);
 
-            if let Some(progress) = job.progress.as_mut() {
-                progress.finished();
-            }
+                if let Some(progress) = job.progress.as_mut() {
+                    progress.finished();
+                }
+
+                Some(output)
+            };
 
             // Send the result
             // The receiver disappears when the owning project is dropped.
@@ -325,6 +339,9 @@ impl UvWorker {
 struct UvJob {
     /// The request to return with the synchronization result.
     task: UvSyncTask,
+
+    /// Checked before invoking uv; does not interrupt an already running process.
+    cancellation: CancellationToken,
 
     /// The sender end of the channel communicating with the sync service.
     result_sender: Sender<UvMetadataResult>,


### PR DESCRIPTION
## Summary

Now that we queue all scripts on startup, I thought it's important to have a way to cancel already queued sync requests if they're superseded by a new sync. 

The implementation here is relatively simple. We use our existing `CancellationToken` and check it before a worker invokes `uv metadata`. This is similar to what we do in the LSP.

The downside of this is that the new request for the cancelled script will, again, be queued at the back. I think this is fine for now. We can explore with more elaborate schemas later.

## Test Plan

The focused CLI, LSP, and file-watching tests pass.
