### PR TITLE
[ty] Infer lambda parameters through callable type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1929,10 +1929,10 @@ _: list[int | str] = f12()  # error: [invalid-assignment]
 reveal_type(f12)  # revealed: () -> list[int]
 ```
 
-## Lambda contextual inference through union type aliases
+## Lambda contextual inference through type aliases
 
-A lambda parameter is inferred from a callable behind a union-valued type alias, including when that
-alias is itself an element of another union:
+A lambda parameter is inferred from a callable behind a type alias, including aliases that resolve
+to unions and aliases used as elements of another union:
 
 ```py
 from typing import Callable
@@ -1941,6 +1941,7 @@ from typing_extensions import TypeAliasType
 type IntCallback = Callable[[int], None]
 type IntCallbackOrInt = Callable[[int], None] | int
 IntCallbackOrIntAliasType = TypeAliasType("IntCallbackOrIntAliasType", Callable[[int], None] | int)
+IntCallbackAliasType = TypeAliasType("IntCallbackAliasType", Callable[[int], None])
 
 def consume(value: int) -> None:
     pass
@@ -1948,10 +1949,8 @@ def consume(value: int) -> None:
 x1: Callable[[int], None] | str = lambda value: consume(reveal_type(value))  # revealed: int
 x2: IntCallbackOrInt | str = lambda value: consume(reveal_type(value))  # revealed: int
 x3: IntCallbackOrIntAliasType | str = lambda value: consume(reveal_type(value))  # revealed: int
-
-# TODO: An alias that does not resolve to a union is not expanded here, so the parameter is not
-# inferred from the type context.
-x4: IntCallback = lambda value: consume(reveal_type(value))  # revealed: Unknown
+x4: IntCallback = lambda value: consume(reveal_type(value))  # revealed: int
+x5: IntCallbackAliasType = lambda value: consume(reveal_type(value))  # revealed: int
 ```
 
 ## Lambda contextual inference through `TypeAliasType` on Python 3.11

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8525,6 +8525,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let callable_tcx = if let Some(tcx) = tcx.annotation
             && let Some(callable) = tcx
                 .filter_union(db, env, Type::is_callable_type)
+                .resolve_type_alias(db)
                 .as_callable()
         {
             match callable.signatures(self.db()).overloads.as_slice() {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

When inferring a lambda the parameters are not resolved if using a type alias unless you explicitly annotate the parameter:

 ```python
 from collections.abc import Callable
from typing import reveal_type

type Callback[T] = Callable[[T], object]


def pep[T](value: T, callback: Callback[T]) -> None:
    pass

def inline[T](value: T, callback: Callable[[T], object]) -> None:
    pass


pep(1, lambda parameter: reveal_type(parameter)) # Unknown

inline(1, lambda parameter: reveal_type(parameter)) # int
```

Resolving the alias in infer_lambda_expression fixes the issue, allowing them to be inferred through the PEP 695 type aliases and TypeAliasType.

## Test Plan

Added mdtests
