### PR TITLE
[`ruff`]: warn when an `include` or `lint.per-file-ignores` pattern does not match any files

### DIFF
--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -94,6 +94,41 @@ inline-quotes = "single"
     Ok(())
 }
 
+#[test]
+fn warns_for_unmatched_include_pattern() -> Result<()> {
+    let test = CliTest::with_files([
+        (
+            "ruff.toml",
+            r#"
+include = [
+    "pysrc/**/*.py",
+    "generated/**/*.{py,pyi}",
+    "missing.py",
+    "py-src/main.py",
+]
+
+[lint]
+per-file-ignores = { "old.py" = ["F401"], "missing.py" = ["F401"] }
+"#,
+        ),
+        ("py-src/main.py", "x = 1\n"),
+        ("generated/something/file.py", "x = 2\n"),
+    ])?;
+
+    assert_cmd_snapshot!(test.check_command().arg("."), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: The following `include` patterns in `[TMP]/ruff.toml` did not match any files: missing.py, pysrc/**/*.py
+    warning: The following `lint.per-file-ignores` patterns in `[TMP]/ruff.toml` did not match any files: missing.py, old.py
+    "#);
+
+    Ok(())
+}
+
 /// Tests that configurations from the top-level and `lint` section are merged together.
 #[test]
 fn mixed_levels() -> Result<()> {

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -1,12 +1,12 @@
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::ops::Deref;
+use std::ops::{Deref, Range};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::string::ToString;
 
 use anyhow::{Context, Result, bail};
-use globset::{Glob, GlobMatcher, GlobSet, GlobSetBuilder};
+use globset::{Candidate, Glob, GlobMatcher, GlobSet, GlobSetBuilder};
 use log::debug;
 use pep440_rs::{VersionSpecifier, VersionSpecifiers};
 use ruff_db::diagnostic::DiagnosticFormat;
@@ -202,25 +202,41 @@ pub enum FilePattern {
 }
 
 impl FilePattern {
-    pub fn add_to(self, builder: &mut GlobSetBuilder) -> Result<()> {
+    pub fn is_builtin(&self) -> bool {
+        matches!(self, Self::Builtin(_))
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Builtin(pattern) => pattern,
+            Self::Config(pattern) | Self::User(pattern, _) => pattern,
+        }
+    }
+
+    pub fn add_to(&self, builder: &mut GlobSetBuilder, next_index: usize) -> Result<Range<usize>> {
+        let start = next_index;
+        let mut count = 0;
         match self {
             FilePattern::Builtin(pattern) => {
                 builder.add(Glob::from_str(pattern)?);
+                count += 1;
             }
             FilePattern::Config(pattern) => {
-                builder.add(Glob::new(&pattern)?);
+                builder.add(Glob::new(pattern)?);
+                count += 1;
             }
             FilePattern::User(pattern, absolute) => {
                 // Add the absolute path.
                 builder.add(Glob::new(&absolute.to_string_lossy())?);
-
+                count += 1;
                 // Add basename path.
                 if !pattern.contains(std::path::MAIN_SEPARATOR) {
-                    builder.add(Glob::new(&pattern)?);
+                    builder.add(Glob::new(pattern)?);
+                    count += 1;
                 }
             }
         }
-        Ok(())
+        Ok(start..start + count)
     }
 }
 
@@ -252,14 +268,11 @@ impl FromStr for FilePattern {
 pub struct FilePatternSet {
     set: GlobSet,
     cache_key: u64,
-    // This field is only for displaying the internals
-    // of `set`.
-    #[expect(clippy::used_underscore_binding)]
-    _set_internals: Vec<FilePattern>,
+    pattern_ranges: Vec<Range<usize>>,
+    patterns: Vec<FilePattern>,
 }
 
 impl FilePatternSet {
-    #[expect(clippy::used_underscore_binding)]
     pub fn try_from_iter<I>(patterns: I) -> Result<Self, anyhow::Error>
     where
         I: IntoIterator<Item = FilePattern>,
@@ -267,12 +280,16 @@ impl FilePatternSet {
         let mut builder = GlobSetBuilder::new();
         let mut hasher = CacheKeyHasher::new();
 
-        let mut _set_internals = vec![];
+        let mut collected_patterns: Vec<FilePattern> = Vec::new();
+        let mut pattern_ranges = Vec::new();
+        let mut next_index = 0;
 
         for pattern in patterns {
-            _set_internals.push(pattern.clone());
             pattern.cache_key(&mut hasher);
-            pattern.add_to(&mut builder)?;
+            let range = pattern.add_to(&mut builder, next_index)?;
+            next_index = range.end;
+            pattern_ranges.push(range);
+            collected_patterns.push(pattern);
         }
 
         let set = builder.build()?;
@@ -280,18 +297,40 @@ impl FilePatternSet {
         Ok(FilePatternSet {
             set,
             cache_key: hasher.finish(),
-            _set_internals,
+            pattern_ranges,
+            patterns: collected_patterns,
         })
+    }
+
+    pub fn patterns(&self) -> &[FilePattern] {
+        &self.patterns
+    }
+
+    pub fn matches_pattern(&self, index: usize, path: &Path) -> bool {
+        let Some(range) = self.pattern_ranges.get(index) else {
+            return false;
+        };
+        let file_name = path.file_name();
+        self.set
+            .matches_candidate(&Candidate::new(path))
+            .iter()
+            .any(|matched| range.contains(matched))
+            || file_name.is_some_and(|name| {
+                self.set
+                    .matches_candidate(&Candidate::new(name))
+                    .iter()
+                    .any(|matched| range.contains(matched))
+            })
     }
 }
 
 impl Display for FilePatternSet {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self._set_internals.is_empty() {
+        if self.patterns.is_empty() {
             write!(f, "[]")?;
         } else {
             writeln!(f, "[")?;
-            for pattern in &self._set_internals {
+            for pattern in &self.patterns {
                 writeln!(f, "\t{pattern},")?;
             }
             write!(f, "]")?;
@@ -825,6 +864,21 @@ impl<T> CompiledPerFileList<T> {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.is_empty()
+    }
+
+    pub fn patterns(&self) -> impl Iterator<Item = &str> {
+        self.inner
+            .iter()
+            .map(|entry| entry.basename_matcher.glob().glob())
+    }
+
+    pub fn matches_pattern(&self, index: usize, path: &Path) -> bool {
+        let Some(file_name) = path.file_name() else {
+            return false;
+        };
+        self.inner.get(index).is_some_and(|entry| {
+            entry.basename_matcher.is_match(file_name) || entry.absolute_matcher.is_match(path)
+        })
     }
 }
 

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -1157,7 +1157,7 @@ mod tests {
         assert!(match_exclusion(
             file_path,
             file_basename,
-            &make_exclusion(exclude),
+            &make_exclusion(&exclude),
         ));
 
         let path = Path::new("foo/bar/baz.py").absolutize_from(project_root);
@@ -1170,7 +1170,7 @@ mod tests {
         assert!(match_exclusion(
             file_path,
             file_basename,
-            &make_exclusion(exclude),
+            &make_exclusion(&exclude),
         ));
 
         let path = Path::new("foo/bar").absolutize_from(project_root);
@@ -1183,7 +1183,7 @@ mod tests {
         assert!(match_exclusion(
             file_path,
             file_basename,
-            &make_exclusion(exclude),
+            &make_exclusion(&exclude),
         ));
 
         let path = Path::new("foo/bar/baz.py").absolutize_from(project_root);
@@ -1196,7 +1196,7 @@ mod tests {
         assert!(match_exclusion(
             file_path,
             file_basename,
-            &make_exclusion(exclude),
+            &make_exclusion(&exclude),
         ));
 
         let path = Path::new("foo/bar/baz.py").absolutize_from(project_root);
@@ -1209,7 +1209,7 @@ mod tests {
         assert!(match_exclusion(
             file_path,
             file_basename,
-            &make_exclusion(exclude),
+            &make_exclusion(&exclude),
         ));
 
         let path = Path::new("foo/bar/baz.py").absolutize_from(project_root);
@@ -1220,7 +1220,7 @@ mod tests {
         assert!(!match_exclusion(
             file_path,
             file_basename,
-            &make_exclusion(exclude),
+            &make_exclusion(&exclude),
         ));
     }
 

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -1130,7 +1130,7 @@ mod tests {
 
     fn make_exclusion(file_pattern: FilePattern) -> GlobSet {
         let mut builder = globset::GlobSetBuilder::new();
-        file_pattern.add_to(&mut builder).unwrap();
+        file_pattern.add_to(&mut builder, 0).unwrap();
         builder.build().unwrap()
     }
 

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -21,6 +21,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use ruff_linter::fs;
 use ruff_linter::package::PackageRoot;
 use ruff_linter::packaging::is_package;
+use ruff_linter::warn_user_once_by_message;
 
 use crate::configuration::Configuration;
 use crate::pyproject::settings_toml;
@@ -189,6 +190,12 @@ impl<'a> Resolver<'a> {
                     self.pyproject_config.path.as_deref(),
                 )),
         }
+    }
+
+    fn settings_with_paths(&self) -> impl Iterator<Item = (&Settings, &Path)> {
+        self.settings
+            .iter()
+            .map(|(settings, path)| (settings, path.as_path()))
     }
 
     /// Return a mapping from Python package to its package root.
@@ -527,8 +534,96 @@ impl<'config> WalkPythonFilesState<'config> {
         error?;
 
         let deduplicated_files = deduplicate_files(files);
+        warn_about_unmatched_patterns(&deduplicated_files, &self.resolver);
 
         Ok((deduplicated_files, self.resolver.into_inner().unwrap()))
+    }
+}
+
+fn warn_unmatched<'a>(
+    label: &str,
+    config_path: &str,
+    pattern_count: usize,
+    pattern_str: impl Fn(usize) -> &'a str,
+    matches: impl Fn(usize, &Path) -> bool,
+    paths: &[&Path],
+) {
+    let mut unmatched: Vec<&str> = (0..pattern_count)
+        .filter(|&index| !paths.iter().any(|path| matches(index, path)))
+        .map(pattern_str)
+        .collect();
+
+    unmatched.sort_unstable();
+
+    if !unmatched.is_empty() {
+        warn_user_once_by_message!(
+            "The following `{label}` patterns in `{config_path}` did not match any files: {}",
+            unmatched.join(", ")
+        );
+    }
+}
+
+fn warn_about_unmatched_patterns(
+    files: &[Result<ResolvedFile, ignore::Error>],
+    resolver: &RwLock<Resolver<'_>>,
+) {
+    let resolver = resolver.read().unwrap();
+    let paths: Vec<&Path> = files
+        .iter()
+        .filter_map(|file| file.as_ref().ok())
+        .map(ResolvedFile::path)
+        .collect();
+
+    for (settings, config_path) in std::iter::once((
+        &resolver.pyproject_config.settings,
+        resolver.pyproject_config.path.as_deref(),
+    ))
+    .chain(
+        resolver
+            .settings_with_paths()
+            .map(|(settings, path)| (settings, Some(path))),
+    ) {
+        let config_path = config_path.map_or_else(
+            || "<default>".to_string(),
+            |path| path.display().to_string(),
+        );
+
+        for (name, patterns) in [
+            ("include", &settings.file_resolver.include),
+            ("extend-include", &settings.file_resolver.extend_include),
+        ] {
+            let non_builtin: Vec<usize> = patterns
+                .patterns()
+                .iter()
+                .enumerate()
+                .filter(|(_, pattern)| !pattern.is_builtin())
+                .map(|(index, _)| index)
+                .collect();
+
+            warn_unmatched(
+                name,
+                &config_path,
+                patterns.patterns().len(),
+                |index| patterns.patterns()[index].as_str(),
+                |index, path| non_builtin.contains(&index) && patterns.matches_pattern(index, path),
+                &paths,
+            );
+        }
+
+        let per_file_patterns: Vec<&str> = settings.linter.per_file_ignores.patterns().collect();
+        warn_unmatched(
+            "lint.per-file-ignores",
+            &config_path,
+            per_file_patterns.len(),
+            |index| per_file_patterns[index],
+            |index, path| {
+                settings
+                    .linter
+                    .per_file_ignores
+                    .matches_pattern(index, path)
+            },
+            &paths,
+        );
     }
 }
 

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -1128,7 +1128,7 @@ mod tests {
         Ok(())
     }
 
-    fn make_exclusion(file_pattern: FilePattern) -> GlobSet {
+    fn make_exclusion(file_pattern: &FilePattern) -> GlobSet {
         let mut builder = globset::GlobSetBuilder::new();
         file_pattern.add_to(&mut builder, 0).unwrap();
         builder.build().unwrap()

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -1146,7 +1146,7 @@ mod tests {
         assert!(match_exclusion(
             file_path,
             file_basename,
-            &make_exclusion(exclude),
+            &make_exclusion(&exclude),
         ));
 
         let path = Path::new("foo/bar").absolutize_from(project_root);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Closes #28107

## Test Plan

```console
cargo test -p ruff --test cli warns_for_unmatched -- --nocapture
```
