### PR TITLE
[ty] Validate declared variance in method signatures

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -303,14 +303,36 @@ class GenericMethods(Generic[P_co]):
 
 ### Variance with explicit receivers
 
-TODO: An explicit receiver can restrict which class specializations expose a method. We defer
-variance validation for these methods until receiver restrictions are taken into account.
+`Self` and the class's own `ParamSpec` do not restrict the receiver. A covariant `ParamSpec` in a
+returned callable's parameters still violates covariance.
+
+```toml
+[environment]
+python-version = "3.11"
+```
 
 ```py
-from typing import Callable, Generic, ParamSpec
+from typing import Callable, Generic, ParamSpec, Self
 
 P_co = ParamSpec("P_co", covariant=True)
 
+class Unrestricted(Generic[P_co]):
+    # error: [invalid-generic-class]
+    def method(self: Self) -> Callable[P_co, None]:
+        raise NotImplementedError
+
+    @classmethod
+    # error: [invalid-generic-class]
+    def class_method(cls: type["Unrestricted[P_co]"]) -> Callable[P_co, None]:
+        raise NotImplementedError
+
+    def accepts(self: "Unrestricted[P_co]", callback: Callable[P_co, None]) -> None: ...
+```
+
+TODO: A specialized receiver can restrict which class specializations expose a method. We defer
+variance validation for these methods until receiver restrictions are taken into account.
+
+```py
 class Restricted(Generic[P_co]):
     def method(self: "Restricted[[int]]") -> Callable[P_co, None]:
         raise NotImplementedError

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -198,8 +198,7 @@ error[invalid-generic-class]: Variance of type variable `P_co` is incompatible w
 info: Type variable `P_co` is declared as covariant, but this method requires it to be contravariant
 ```
 
-Forwarding `P.args` and `P.kwargs` also consumes `P`. An explicit receiver annotation does not
-affect this variance.
+Forwarding `P.args` and `P.kwargs` also consumes `P`.
 
 ```py
 class CovariantForwarder(Generic[P_co]):
@@ -207,8 +206,8 @@ class CovariantForwarder(Generic[P_co]):
     def call(self, *args: P_co.args, **kwargs: P_co.kwargs) -> None: ...
 
 class ContravariantForwarder(Generic[P_contra]):
-    def call(self: "ContravariantForwarder[P_contra]", *args: P_contra.args, **kwargs: P_contra.kwargs) -> None: ...
-    def returns(self: "ContravariantForwarder[P_contra]") -> Callable[P_contra, None]:
+    def call(self, *args: P_contra.args, **kwargs: P_contra.kwargs) -> None: ...
+    def returns(self) -> Callable[P_contra, None]:
         raise NotImplementedError
 ```
 
@@ -226,6 +225,94 @@ def returns() -> Callable[P_co, None]:
 
 class NotGeneric:
     def returns(self) -> Callable[P_co, None]:
+        raise NotImplementedError
+```
+
+Class methods are checked too. A static method has no receiver, so its first parameter contributes
+to its variance.
+
+```py
+class MethodKinds(Generic[P_contra]):
+    @classmethod
+    # error: [invalid-generic-class]
+    def class_method(cls, callback: Callable[P_contra, None]) -> None: ...
+    @staticmethod
+    # error: [invalid-generic-class]
+    def static_method(callback: Callable[P_contra, None]) -> None: ...
+```
+
+### Variance in overloaded methods
+
+TODO: Variance validation is deferred for overloaded methods until it accounts for the complete
+overload set. Neither overloads nor their implementation are checked individually, even when they
+use a covariant `ParamSpec` contravariantly.
+
+```py
+from typing import Callable, Generic, ParamSpec, overload
+
+P_co = ParamSpec("P_co", covariant=True)
+
+class Overloaded(Generic[P_co]):
+    @overload
+    def method(self, value: int) -> Callable[P_co, None]: ...
+    @overload
+    def method(self, value: str) -> None: ...
+    def method(self, value: object) -> Callable[P_co, None] | None:
+        return None
+```
+
+### Variance in generic methods
+
+A method's independent type variable can accept any default. The `Callable[P_contra, None]` arm in
+the parameter annotation is redundant because `T` already accepts that default, and the result
+includes both types. This signature respects the class's contravariance.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, Generic, ParamSpec, TypeVar
+
+P_contra = ParamSpec("P_contra", contravariant=True)
+T = TypeVar("T")
+
+class Defaults(Generic[P_contra]):
+    def get(self, default: Callable[P_contra, None] | T) -> Callable[P_contra, None] | T:
+        return default
+```
+
+TODO: Until those relationships are checked, we defer validation for generic methods, including type
+parameters scoped to a returned callable. The incompatible return annotations below are not yet
+reported.
+
+```py
+P_co = ParamSpec("P_co", covariant=True)
+
+class GenericMethods(Generic[P_co]):
+    def legacy(self, value: T) -> Callable[P_co, T]:
+        raise NotImplementedError
+
+    def pep695[U](self, value: U) -> Callable[P_co, U]:
+        raise NotImplementedError
+
+    def returned_callable(self) -> Callable[P_co, T]:
+        raise NotImplementedError
+```
+
+### Variance with explicit receivers
+
+TODO: An explicit receiver can restrict which class specializations expose a method. We defer
+variance validation for these methods until receiver restrictions are taken into account.
+
+```py
+from typing import Callable, Generic, ParamSpec
+
+P_co = ParamSpec("P_co", covariant=True)
+
+class Restricted(Generic[P_co]):
+    def method(self: "Restricted[[int]]") -> Callable[P_co, None]:
         raise NotImplementedError
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -162,6 +162,73 @@ AmbiguousInferVariance = ParamSpec("AmbiguousInferVariance", infer_variance=cond
 CovariantAndInferred = ParamSpec("CovariantAndInferred", covariant=True, infer_variance=True)
 ```
 
+### Variance in method signatures
+
+Returning `Callable[P, None]` uses `P` contravariantly. Accepting that callable as a parameter
+reverses the direction, using `P` covariantly. An explicit variance declaration must permit these
+uses.
+
+```py
+from typing import Callable, Generic, ParamSpec
+
+P_co = ParamSpec("P_co", covariant=True)
+P_contra = ParamSpec("P_contra", contravariant=True)
+
+class Covariant(Generic[P_co]):
+    def accepts(self, callback: Callable[P_co, None]) -> None: ...
+
+    # snapshot: invalid-generic-class
+    def returns(self) -> Callable[P_co, None]:
+        raise NotImplementedError
+
+class Contravariant(Generic[P_contra]):
+    def returns(self) -> Callable[P_contra, None]:
+        raise NotImplementedError
+
+    # error: [invalid-generic-class] "Variance of type variable `P_contra` is incompatible with method `accepts`"
+    def accepts(self, callback: Callable[P_contra, None]) -> None: ...
+```
+
+```snapshot
+error[invalid-generic-class]: Variance of type variable `P_co` is incompatible with method `returns`
+  --> src/mdtest_snippet.py:10:9
+   |
+10 |     def returns(self) -> Callable[P_co, None]:
+   |         ^^^^^^^
+info: Type variable `P_co` is declared as covariant, but this method requires it to be contravariant
+```
+
+Forwarding `P.args` and `P.kwargs` also consumes `P`. An explicit receiver annotation does not
+affect this variance.
+
+```py
+class CovariantForwarder(Generic[P_co]):
+    # error: [invalid-generic-class]
+    def call(self, *args: P_co.args, **kwargs: P_co.kwargs) -> None: ...
+
+class ContravariantForwarder(Generic[P_contra]):
+    def call(self: "ContravariantForwarder[P_contra]", *args: P_contra.args, **kwargs: P_contra.kwargs) -> None: ...
+    def returns(self: "ContravariantForwarder[P_contra]") -> Callable[P_contra, None]:
+        raise NotImplementedError
+```
+
+Constructors can establish a specialization without respecting its declared variance. A `ParamSpec`
+bound to a function or method instead of the class ignores its declared variance.
+
+```py
+class Constructed(Generic[P_co]):
+    def __init__(self, *args: P_co.args, **kwargs: P_co.kwargs) -> None: ...
+    def __new__(cls, *args: P_co.args, **kwargs: P_co.kwargs) -> "Constructed[P_co]":
+        raise NotImplementedError
+
+def returns() -> Callable[P_co, None]:
+    raise NotImplementedError
+
+class NotGeneric:
+    def returns(self) -> Callable[P_co, None]:
+        raise NotImplementedError
+```
+
 ### Defaults
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -191,10 +191,10 @@ class Contravariant(Generic[P_contra]):
 
 ```snapshot
 error[invalid-generic-class]: Variance of type variable `P_co` is incompatible with method `returns`
-  --> src/mdtest_snippet.py:10:9
+  --> src/mdtest_snippet.py:10:26
    |
 10 |     def returns(self) -> Callable[P_co, None]:
-   |         ^^^^^^^
+   |                          ^^^^^^^^^^^^^^^^^^^^
 info: Type variable `P_co` is declared as covariant, but this method requires it to be contravariant
 ```
 
@@ -202,13 +202,22 @@ Forwarding `P.args` and `P.kwargs` also consumes `P`.
 
 ```py
 class CovariantForwarder(Generic[P_co]):
-    # error: [invalid-generic-class]
+    # snapshot: invalid-generic-class
     def call(self, *args: P_co.args, **kwargs: P_co.kwargs) -> None: ...
 
 class ContravariantForwarder(Generic[P_contra]):
     def call(self, *args: P_contra.args, **kwargs: P_contra.kwargs) -> None: ...
     def returns(self) -> Callable[P_contra, None]:
         raise NotImplementedError
+```
+
+```snapshot
+error[invalid-generic-class]: Variance of type variable `P_co` is incompatible with method `call`
+  --> src/mdtest_snippet.py:21:27
+   |
+21 |     def call(self, *args: P_co.args, **kwargs: P_co.kwargs) -> None: ...
+   |                           ^^^^^^^^^
+info: Type variable `P_co` is declared as covariant, but this method requires it to be contravariant
 ```
 
 Constructors can establish a specialization without respecting its declared variance. A `ParamSpec`
@@ -244,8 +253,8 @@ class MethodKinds(Generic[P_contra]):
 ### Variance in overloaded methods
 
 TODO: Variance validation is deferred for overloaded methods until it accounts for the complete
-overload set. Neither overloads nor their implementation are checked individually, even when they
-use a covariant `ParamSpec` contravariantly.
+overload set. We miss the invalid use of a covariant `ParamSpec` in the first overload's return
+type.
 
 ```py
 from typing import Callable, Generic, ParamSpec, overload
@@ -254,6 +263,7 @@ P_co = ParamSpec("P_co", covariant=True)
 
 class Overloaded(Generic[P_co]):
     @overload
+    # TODO: Emit `invalid-generic-class`; this use of `P_co` requires contravariance.
     def method(self, value: int) -> Callable[P_co, None]: ...
     @overload
     def method(self, value: str) -> None: ...
@@ -263,8 +273,8 @@ class Overloaded(Generic[P_co]):
 
 ### Variance in generic methods
 
-A method's independent type variable can accept any default. The `Callable[P_contra, None]` arm in
-the parameter annotation is redundant because `T` already accepts that default, and the result
+A method's independent type variable can accept any argument. The `Callable[P_contra, None]` arm in
+the parameter annotation is redundant because `T` already accepts that argument, and the result
 includes both types. This signature respects the class's contravariance.
 
 ```toml
@@ -278,9 +288,9 @@ from typing import Callable, Generic, ParamSpec, TypeVar
 P_contra = ParamSpec("P_contra", contravariant=True)
 T = TypeVar("T")
 
-class Defaults(Generic[P_contra]):
-    def get(self, default: Callable[P_contra, None] | T) -> Callable[P_contra, None] | T:
-        return default
+class Contravariant(Generic[P_contra]):
+    def identity(self, value: Callable[P_contra, None] | T) -> Callable[P_contra, None] | T:
+        return value
 ```
 
 TODO: Until those relationships are checked, we defer validation for generic methods, including type
@@ -291,12 +301,15 @@ reported.
 P_co = ParamSpec("P_co", covariant=True)
 
 class GenericMethods(Generic[P_co]):
+    # TODO: Emit `invalid-generic-class`; this use of `P_co` requires contravariance.
     def legacy(self, value: T) -> Callable[P_co, T]:
         raise NotImplementedError
 
+    # TODO: Emit `invalid-generic-class`; this use of `P_co` requires contravariance.
     def pep695[U](self, value: U) -> Callable[P_co, U]:
         raise NotImplementedError
 
+    # TODO: Emit `invalid-generic-class`; this use of `P_co` requires contravariance.
     def returned_callable(self) -> Callable[P_co, T]:
         raise NotImplementedError
 ```
@@ -329,11 +342,11 @@ class Unrestricted(Generic[P_co]):
     def accepts(self: "Unrestricted[P_co]", callback: Callable[P_co, None]) -> None: ...
 ```
 
-TODO: A specialized receiver can restrict which class specializations expose a method. We defer
-variance validation for these methods until receiver restrictions are taken into account.
+A specialized receiver does not make this contravariant use of `P_co` valid.
 
 ```py
 class Restricted(Generic[P_co]):
+    # error: [invalid-generic-class]
     def method(self: "Restricted[[int]]") -> Callable[P_co, None]:
         raise NotImplementedError
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -289,7 +289,7 @@ A callable reverses the variance of its argument types. Returning a callable tha
 from typing import Callable
 
 class Callbacks(Generic[*Ts_contra]):
-    def returns(self: "Callbacks[*Ts_contra]") -> Callable[[*Ts_contra], None]:
+    def returns(self) -> Callable[[*Ts_contra], None]:
         raise NotImplementedError
 
     # error: [invalid-generic-class]
@@ -308,6 +308,86 @@ def accepts(*args: *Ts_co) -> None: ...
 
 class NotGeneric:
     def accepts(self, *args: *Ts_co) -> None: ...
+```
+
+### Variance in overloaded methods
+
+TODO: Variance validation is deferred for overloaded methods until it accounts for the complete
+overload set. Neither overloads nor their implementation are checked individually, even when they
+consume a covariant `TypeVarTuple`.
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import Generic, TypeVarTuple, overload
+
+Ts_co = TypeVarTuple("Ts_co", covariant=True)
+
+class Overloaded(Generic[*Ts_co]):
+    @overload
+    def method(self, value: tuple[*Ts_co]) -> int: ...
+    @overload
+    def method(self, value: int) -> str: ...
+    def method(self, value: tuple[*Ts_co] | int) -> int | str:
+        return 0
+```
+
+### Variance in generic methods
+
+A method's independent type variable can accept any default. The `tuple[*Ts_co]` arm in the
+parameter annotation is redundant because `T` already accepts that default, and the result includes
+both types. This signature respects the class's covariance.
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import Generic, TypeVar, TypeVarTuple
+
+Ts_co = TypeVarTuple("Ts_co", covariant=True)
+T = TypeVar("T")
+
+class Defaults(Generic[*Ts_co]):
+    def get(self, default: tuple[*Ts_co] | T) -> tuple[*Ts_co] | T:
+        return default
+```
+
+TODO: Variance validation is deferred for methods with independent type parameters. The
+contravariant `TypeVarTuple` in the return annotations below would otherwise be rejected.
+
+```py
+Ts_contra = TypeVarTuple("Ts_contra", contravariant=True)
+
+class GenericMethods(Generic[*Ts_contra]):
+    def legacy(self, value: T) -> tuple[*Ts_contra]:
+        raise NotImplementedError
+
+    def pep695[U](self, value: U) -> tuple[*Ts_contra]:
+        raise NotImplementedError
+```
+
+### Variance with explicit receivers
+
+TODO: An explicit receiver can restrict which class specializations expose a method. We defer
+variance validation for these methods until receiver restrictions are taken into account.
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts_co = TypeVarTuple("Ts_co", covariant=True)
+
+class Restricted(Generic[*Ts_co]):
+    def method(self: "Restricted[int]", value: tuple[*Ts_co]) -> None: ...
 ```
 
 ## Generic Classes

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -373,8 +373,8 @@ class GenericMethods(Generic[*Ts_contra]):
 
 ### Variance with explicit receivers
 
-TODO: An explicit receiver can restrict which class specializations expose a method. We defer
-variance validation for these methods until receiver restrictions are taken into account.
+`Self` and the class's own `TypeVarTuple` do not restrict the receiver. Consuming the covariant
+tuple still violates covariance.
 
 ```toml
 [environment]
@@ -382,10 +382,24 @@ python-version = "3.15"
 ```
 
 ```py
-from typing import Generic, TypeVarTuple
+from typing import Generic, Self, TypeVarTuple
 
 Ts_co = TypeVarTuple("Ts_co", covariant=True)
 
+class Unrestricted(Generic[*Ts_co]):
+    # error: [invalid-generic-class]
+    def method(self: "Unrestricted[*Ts_co]", value: tuple[*Ts_co]) -> None: ...
+    @classmethod
+    # error: [invalid-generic-class]
+    def class_method(cls: type[Self], value: tuple[*Ts_co]) -> None: ...
+    def returns(self: Self) -> tuple[*Ts_co]:
+        raise NotImplementedError
+```
+
+TODO: A specialized receiver can restrict which class specializations expose a method. We defer
+variance validation for these methods until receiver restrictions are taken into account.
+
+```py
 class Restricted(Generic[*Ts_co]):
     def method(self: "Restricted[int]", value: tuple[*Ts_co]) -> None: ...
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -245,7 +245,8 @@ Ts_Inferred = TypeVarTuple("Ts_Inferred", infer_variance=True)
 ### Variance in method signatures
 
 A tuple is covariant in its unpacked type variables. Returning `tuple[*Ts]` therefore uses `Ts`
-covariantly, while accepting `*args: *Ts` uses it contravariantly.
+covariantly, while accepting either `*args: *Ts` or a parameter annotated as `tuple[*Ts]` uses it
+contravariantly.
 
 ```toml
 [environment]
@@ -275,11 +276,23 @@ class Contravariant(Generic[*Ts_contra]):
 
 ```snapshot
 error[invalid-generic-class]: Variance of type variable `Ts_co` is incompatible with method `accepts`
-  --> src/mdtest_snippet.py:11:9
+  --> src/mdtest_snippet.py:11:30
    |
 11 |     def accepts(self, *args: *Ts_co) -> None: ...
-   |         ^^^^^^^
+   |                              ^^^^^^
 info: Type variable `Ts_co` is declared as covariant, but this method requires it to be contravariant
+```
+
+Passing the tuple as a single argument has the same variance as unpacking it into variadic
+arguments.
+
+```py
+class CovariantTuple(Generic[*Ts_co]):
+    # error: [invalid-generic-class]
+    def accepts(self, value: tuple[*Ts_co]) -> None: ...
+
+class ContravariantTuple(Generic[*Ts_contra]):
+    def accepts(self, value: tuple[*Ts_contra]) -> None: ...
 ```
 
 A callable reverses the variance of its argument types. Returning a callable that consumes
@@ -313,8 +326,8 @@ class NotGeneric:
 ### Variance in overloaded methods
 
 TODO: Variance validation is deferred for overloaded methods until it accounts for the complete
-overload set. Neither overloads nor their implementation are checked individually, even when they
-consume a covariant `TypeVarTuple`.
+overload set. We miss the invalid use of a covariant `TypeVarTuple` in the first overload's
+parameter.
 
 ```toml
 [environment]
@@ -328,6 +341,7 @@ Ts_co = TypeVarTuple("Ts_co", covariant=True)
 
 class Overloaded(Generic[*Ts_co]):
     @overload
+    # TODO: Emit `invalid-generic-class`; this use of `Ts_co` requires contravariance.
     def method(self, value: tuple[*Ts_co]) -> int: ...
     @overload
     def method(self, value: int) -> str: ...
@@ -337,8 +351,8 @@ class Overloaded(Generic[*Ts_co]):
 
 ### Variance in generic methods
 
-A method's independent type variable can accept any default. The `tuple[*Ts_co]` arm in the
-parameter annotation is redundant because `T` already accepts that default, and the result includes
+A method's independent type variable can accept any argument. The `tuple[*Ts_co]` arm in the
+parameter annotation is redundant because `T` already accepts that argument, and the result includes
 both types. This signature respects the class's covariance.
 
 ```toml
@@ -352,9 +366,9 @@ from typing import Generic, TypeVar, TypeVarTuple
 Ts_co = TypeVarTuple("Ts_co", covariant=True)
 T = TypeVar("T")
 
-class Defaults(Generic[*Ts_co]):
-    def get(self, default: tuple[*Ts_co] | T) -> tuple[*Ts_co] | T:
-        return default
+class Covariant(Generic[*Ts_co]):
+    def identity(self, value: tuple[*Ts_co] | T) -> tuple[*Ts_co] | T:
+        return value
 ```
 
 TODO: Variance validation is deferred for methods with independent type parameters. The
@@ -364,9 +378,11 @@ contravariant `TypeVarTuple` in the return annotations below would otherwise be 
 Ts_contra = TypeVarTuple("Ts_contra", contravariant=True)
 
 class GenericMethods(Generic[*Ts_contra]):
+    # TODO: Emit `invalid-generic-class`; this use of `Ts_contra` requires covariance.
     def legacy(self, value: T) -> tuple[*Ts_contra]:
         raise NotImplementedError
 
+    # TODO: Emit `invalid-generic-class`; this use of `Ts_contra` requires covariance.
     def pep695[U](self, value: U) -> tuple[*Ts_contra]:
         raise NotImplementedError
 ```
@@ -396,11 +412,11 @@ class Unrestricted(Generic[*Ts_co]):
         raise NotImplementedError
 ```
 
-TODO: A specialized receiver can restrict which class specializations expose a method. We defer
-variance validation for these methods until receiver restrictions are taken into account.
+A specialized receiver does not make this contravariant use of `Ts_co` valid.
 
 ```py
 class Restricted(Generic[*Ts_co]):
+    # error: [invalid-generic-class]
     def method(self: "Restricted[int]", value: tuple[*Ts_co]) -> None: ...
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -242,6 +242,74 @@ Ts_Contra = TypeVarTuple("Ts_Contra", contravariant=True)
 Ts_Inferred = TypeVarTuple("Ts_Inferred", infer_variance=True)
 ```
 
+### Variance in method signatures
+
+A tuple is covariant in its unpacked type variables. Returning `tuple[*Ts]` therefore uses `Ts`
+covariantly, while accepting `*args: *Ts` uses it contravariantly.
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts_co = TypeVarTuple("Ts_co", covariant=True)
+Ts_contra = TypeVarTuple("Ts_contra", contravariant=True)
+
+class Covariant(Generic[*Ts_co]):
+    def returns(self) -> tuple[*Ts_co]:
+        raise NotImplementedError
+
+    # snapshot: invalid-generic-class
+    def accepts(self, *args: *Ts_co) -> None: ...
+
+class Contravariant(Generic[*Ts_contra]):
+    def accepts(self, *args: *Ts_contra) -> None: ...
+
+    # error: [invalid-generic-class] "Variance of type variable `Ts_contra` is incompatible with method `returns`"
+    def returns(self) -> tuple[*Ts_contra]:
+        raise NotImplementedError
+```
+
+```snapshot
+error[invalid-generic-class]: Variance of type variable `Ts_co` is incompatible with method `accepts`
+  --> src/mdtest_snippet.py:11:9
+   |
+11 |     def accepts(self, *args: *Ts_co) -> None: ...
+   |         ^^^^^^^
+info: Type variable `Ts_co` is declared as covariant, but this method requires it to be contravariant
+```
+
+A callable reverses the variance of its argument types. Returning a callable that consumes
+`Ts_contra` is valid, while accepting the same callable is not.
+
+```py
+from typing import Callable
+
+class Callbacks(Generic[*Ts_contra]):
+    def returns(self: "Callbacks[*Ts_contra]") -> Callable[[*Ts_contra], None]:
+        raise NotImplementedError
+
+    # error: [invalid-generic-class]
+    def accepts(self, callback: Callable[[*Ts_contra], None]) -> None: ...
+```
+
+Constructors and function-scoped type variables do not constrain the class's variance.
+
+```py
+class Constructed(Generic[*Ts_co]):
+    def __init__(self, *args: *Ts_co) -> None: ...
+    def __new__(cls, *args: *Ts_co) -> "Constructed[*Ts_co]":
+        raise NotImplementedError
+
+def accepts(*args: *Ts_co) -> None: ...
+
+class NotGeneric:
+    def accepts(self, *args: *Ts_co) -> None: ...
+```
+
 ## Generic Classes
 
 ### Multiple `TypeVarTuple`s

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
@@ -311,7 +311,7 @@ class Covariant(Generic[T_co]):
     def returns(self) -> T_co:
         raise NotImplementedError
 
-    # error: [invalid-generic-class]
+    # snapshot: invalid-generic-class
     def accepts(self, value: T_co) -> None: ...
     def accepts_callback(self, callback: Callable[[T_co], None]) -> None: ...
 
@@ -321,6 +321,47 @@ class Contravariant(Generic[T_contra]):
     # error: [invalid-generic-class]
     def returns(self) -> T_contra:
         raise NotImplementedError
+```
+
+```snapshot
+error[invalid-generic-class]: Variance of type variable `T_co` is incompatible with method `accepts`
+  --> src/mdtest_snippet.py:11:30
+   |
+11 |     def accepts(self, value: T_co) -> None: ...
+   |                              ^^^^
+info: Type variable `T_co` is declared as covariant, but this method requires it to be contravariant
+```
+
+Returning a mutable `list[T_co]` requires invariance, as does using `T_co` in both parameter and
+return positions. In `identity`, the callback parameter and return annotation respect covariance;
+only the `value` parameter violates it.
+
+```py
+class InvariantMethods(Generic[T_co]):
+    # snapshot: invalid-generic-class
+    def values(self) -> list[T_co]:
+        raise NotImplementedError
+
+    # snapshot: invalid-generic-class
+    def identity(self, callback: Callable[[T_co], None], value: T_co) -> T_co:
+        return value
+```
+
+```snapshot
+error[invalid-generic-class]: Variance of type variable `T_co` is incompatible with method `values`
+  --> src/mdtest_snippet.py:22:25
+   |
+22 |     def values(self) -> list[T_co]:
+   |                         ^^^^^^^^^^
+info: Type variable `T_co` is declared as covariant, but this method requires it to be invariant
+
+
+error[invalid-generic-class]: Variance of type variable `T_co` is incompatible with method `identity`
+  --> src/mdtest_snippet.py:26:65
+   |
+26 |     def identity(self, callback: Callable[[T_co], None], value: T_co) -> T_co:
+   |                                                                 ^^^^
+info: Type variable `T_co` is declared as covariant, but this method requires it to be invariant
 ```
 
 The same variable can be bound independently to a generic method. Its declared variance does not
@@ -353,10 +394,10 @@ class ClassMethods(Generic[T_co]):
     def static_accepts(value: T_co) -> None: ...
 ```
 
-## Generic method defaults
+## Variance in generic methods
 
-A method's independent type variable can accept defaults outside the class's covariant value type.
-The `V_co` arm in the parameter annotation is redundant: `T` already accepts any default, and the
+A method's independent type variable can accept arguments outside the class's covariant value type.
+The `V_co` arm in the parameter annotation is redundant: `T` already accepts any argument, and the
 result includes both types. This signature does not require the class to be invariant.
 
 ```py
@@ -365,18 +406,19 @@ from typing import Generic, TypeVar
 V_co = TypeVar("V_co", covariant=True)
 T = TypeVar("T")
 
-class Mapping(Generic[V_co]):
-    def get(self, default: V_co | T) -> V_co | T:
-        return default
+class Covariant(Generic[V_co]):
+    def identity(self, value: V_co | T) -> V_co | T:
+        return value
 ```
 
-Reusing `T` in another parameter can constrain which defaults the method accepts, so these generic
+Reusing `T` in another parameter can constrain which arguments the method accepts, so these generic
 methods do not always respect covariance. TODO: We defer variance checking for independently generic
 methods until we can account for these relationships, and miss this invalid use of `V_co`.
 
 ```py
 class Correlated(Generic[V_co]):
-    def get(self, default: V_co | T, other: T) -> T:
+    # TODO: Emit `invalid-generic-class`; this use of `V_co` requires contravariance.
+    def get(self, value: V_co | T, other: T) -> T:
         raise NotImplementedError
 ```
 
@@ -438,6 +480,7 @@ T_co = TypeVar("T_co", covariant=True)
 
 class Overloaded(Generic[T_co]):
     @overload
+    # TODO: Emit `invalid-generic-class`; this use of `T_co` requires contravariance.
     def method(self, value: T_co) -> int: ...
     @overload
     def method(self, value: int, other: int) -> int: ...
@@ -480,14 +523,67 @@ class Unrestricted(Generic[T_co]):
         raise NotImplementedError
 ```
 
-A specialized receiver restricts which specializations of the class can call a method. TODO: We
-defer variance checking for these receivers until we can account for their restrictions.
+A specialized receiver does not in general make an incompatible use of a covariant type variable
+valid. These methods still consume the class's type variable.
 
 ```py
 class Restricted(Generic[T_co]):
+    # error: [invalid-generic-class]
     def accepts(self: "Restricted[int]", value: T_co) -> None: ...
     @classmethod
+    # error: [invalid-generic-class]
     def class_accepts(cls: type["Restricted[int]"], value: T_co) -> None: ...
+```
+
+The receiver can sometimes make a use of the type variable redundant. Here, `T_co` must be a subtype
+of `int`, so `T_co | int` accepts exactly the same arguments as `int`. This method does not
+constrain the class's variance.
+
+```py
+class Redundant(Generic[T_co]):
+    # TODO: Do not report an error; the receiver makes the `T_co` arm redundant.
+    # error: [invalid-generic-class]
+    def accepts(self: "Redundant[int]", value: T_co | int) -> None: ...
+```
+
+## Variance in decorated methods
+
+A decorator can replace a method with a value that does not consume the class's type variable.
+Variance checking should account for the exposed attribute, rather than the original signature.
+
+```py
+from typing import Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+def replace(func: object) -> int:
+    return 1
+
+class Decorated(Generic[T_co]):
+    @replace
+    # TODO: Do not report an error; the decorator replaces the method with an `int`.
+    # error: [invalid-generic-class]
+    def method(self, value: T_co) -> None: ...
+
+reveal_type(Decorated[int].method)  # revealed: int
+```
+
+## Variance in deleted methods
+
+A method deleted in the class body is not part of the class's interface and does not constrain its
+variance.
+
+```py
+from typing import Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class Deleted(Generic[T_co]):
+    # TODO: Do not report an error; the method is absent from the final class interface.
+    # error: [invalid-generic-class]
+    def method(self, value: T_co) -> None: ...
+
+    del method
 ```
 
 ## Generic protocol variance

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
@@ -447,14 +447,43 @@ class Overloaded(Generic[T_co]):
 
 ## Variance with explicit receivers
 
-A specialized receiver restricts which specializations of the class can call a method. TODO: We
-defer variance checking for explicit receivers until we can account for these restrictions.
+Annotating the receiver with `Self` or the class's own type parameters does not restrict which
+specializations can call the method. These annotations do not affect variance checking, for either
+instance methods or class methods.
+
+```toml
+[environment]
+python-version = "3.11"
+```
 
 ```py
-from typing import Generic, TypeVar
+from typing import Generic, Self, TypeVar
 
 T_co = TypeVar("T_co", covariant=True)
 
+class Unrestricted(Generic[T_co]):
+    # error: [invalid-generic-class]
+    def accepts_self(self: Self, value: T_co) -> None: ...
+    # error: [invalid-generic-class]
+    def accepts_identity(self: "Unrestricted[T_co]", value: T_co) -> None: ...
+    def returns(self: "Unrestricted[T_co]") -> T_co:
+        raise NotImplementedError
+
+    @classmethod
+    # error: [invalid-generic-class]
+    def class_accepts_self(cls: type[Self], value: T_co) -> None: ...
+    @classmethod
+    # error: [invalid-generic-class]
+    def class_accepts_identity(cls: type["Unrestricted[T_co]"], value: T_co) -> None: ...
+    @classmethod
+    def class_returns(cls: type[Self]) -> T_co:
+        raise NotImplementedError
+```
+
+A specialized receiver restricts which specializations of the class can call a method. TODO: We
+defer variance checking for these receivers until we can account for their restrictions.
+
+```py
 class Restricted(Generic[T_co]):
     def accepts(self: "Restricted[int]", value: T_co) -> None: ...
     @classmethod

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
@@ -308,7 +308,7 @@ T_co = TypeVar("T_co", covariant=True)
 T_contra = TypeVar("T_contra", contravariant=True)
 
 class Covariant(Generic[T_co]):
-    def returns(self: "Covariant[T_co]") -> T_co:
+    def returns(self) -> T_co:
         raise NotImplementedError
 
     # error: [invalid-generic-class]
@@ -336,33 +336,129 @@ class NestedFunction(Generic[T_co]):
         def accepts(value: T_co) -> None: ...
 ```
 
-An explicit `cls` annotation does not consume the type variable. A static method has no receiver, so
-its first parameter still contributes to its variance.
+Class methods also respect the declared variance. A static method has no receiver, so its first
+parameter still contributes to its variance.
 
 ```py
 class ClassMethods(Generic[T_co]):
     @classmethod
-    def returns(cls: type["ClassMethods[T_co]"]) -> T_co:
+    def returns(cls) -> T_co:
         raise NotImplementedError
 
+    @classmethod
+    # error: [invalid-generic-class]
+    def accepts(cls, value: T_co) -> None: ...
     @staticmethod
     # error: [invalid-generic-class]
-    def accepts(value: T_co) -> None: ...
+    def static_accepts(value: T_co) -> None: ...
 ```
 
-Each overload is checked, even when the implementation does not use the class's type variable.
+## Generic method defaults
+
+A method's independent type variable can accept defaults outside the class's covariant value type.
+The `V_co` arm in the parameter annotation is redundant: `T` already accepts any default, and the
+result includes both types. This signature does not require the class to be invariant.
 
 ```py
-from typing import overload
+from typing import Generic, TypeVar
+
+V_co = TypeVar("V_co", covariant=True)
+T = TypeVar("T")
+
+class Mapping(Generic[V_co]):
+    def get(self, default: V_co | T) -> V_co | T:
+        return default
+```
+
+Reusing `T` in another parameter can constrain which defaults the method accepts, so these generic
+methods do not always respect covariance. TODO: We defer variance checking for independently generic
+methods until we can account for these relationships, and miss this invalid use of `V_co`.
+
+```py
+class Correlated(Generic[V_co]):
+    def get(self, default: V_co | T, other: T) -> T:
+        raise NotImplementedError
+```
+
+## Overloads with generic fallbacks
+
+An overload that consumes a covariant type variable can be covered by a generic fallback. The second
+overload below accepts the first overload's arguments with the same result when `T` is `T_co`. The
+complete method therefore respects covariance.
+
+```py
+from typing import Generic, TypeVar, overload
+
+T_co = TypeVar("T_co", covariant=True)
+T = TypeVar("T")
+
+class Sequence(Generic[T_co]):
+    @overload
+    def __add__(self, value: tuple[T_co, ...]) -> tuple[T_co, ...]: ...
+    @overload
+    def __add__(self, value: tuple[T, ...]) -> tuple[T_co | T, ...]: ...
+    def __add__(self, value: tuple[object, ...]) -> tuple[object, ...]:
+        return value
+```
+
+## Overloaded mapping defaults
+
+A mapping can similarly accept its covariant value type as a default when another overload accepts
+arbitrary defaults. The generic overload covers the specialized default without losing its result
+type. The key parameter is invariant and does not affect this value-variance relationship.
+
+`mapping.pyi`:
+
+```pyi
+from typing import Generic, TypeVar, overload
+
+K = TypeVar("K")
+V_co = TypeVar("V_co", covariant=True)
+T = TypeVar("T")
+
+class Mapping(Generic[K, V_co]):
+    @overload
+    def get(self, key: K) -> V_co | None: ...
+    @overload
+    def get(self, key: K, default: V_co) -> V_co: ...
+    @overload
+    def get(self, key: K, default: T) -> V_co | T: ...
+```
+
+## Variance in overloaded methods
+
+TODO: We defer variance checking for overloaded methods until we can account for the complete
+overload set. This also means we miss invalid uses of covariant variables that no other overload
+covers.
+
+```py
+from typing import Generic, TypeVar, overload
+
+T_co = TypeVar("T_co", covariant=True)
 
 class Overloaded(Generic[T_co]):
     @overload
-    # error: [invalid-generic-class]
     def method(self, value: T_co) -> int: ...
     @overload
     def method(self, value: int, other: int) -> int: ...
     def method(self, value: object, other: int = 0) -> int:
         return 0
+```
+
+## Variance with explicit receivers
+
+A specialized receiver restricts which specializations of the class can call a method. TODO: We
+defer variance checking for explicit receivers until we can account for these restrictions.
+
+```py
+from typing import Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class Restricted(Generic[T_co]):
+    def accepts(self: "Restricted[int]", value: T_co) -> None: ...
+    @classmethod
+    def class_accepts(cls: type["Restricted[int]"], value: T_co) -> None: ...
 ```
 
 ## Generic protocol variance

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
@@ -296,6 +296,75 @@ equivalent to) each other.
 
 It is not possible to construct a legacy typevar that is explicitly bivariant.
 
+## Variance in method signatures
+
+Methods must respect the declared variance of the class's type variables. Covariant variables can be
+returned but cannot be consumed, while contravariant variables can be consumed but not returned.
+
+```py
+from typing import Callable, Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class Covariant(Generic[T_co]):
+    def returns(self: "Covariant[T_co]") -> T_co:
+        raise NotImplementedError
+
+    # error: [invalid-generic-class]
+    def accepts(self, value: T_co) -> None: ...
+    def accepts_callback(self, callback: Callable[[T_co], None]) -> None: ...
+
+class Contravariant(Generic[T_contra]):
+    def accepts(self, value: T_contra) -> None: ...
+
+    # error: [invalid-generic-class]
+    def returns(self) -> T_contra:
+        raise NotImplementedError
+```
+
+The same variable can be bound independently to a generic method. Its declared variance does not
+apply to that method binding. A nested function is not part of the class's interface either.
+
+```py
+class GenericMethod(Generic[T_contra]):
+    def identity(self, value: T_co) -> T_co:
+        return value
+
+class NestedFunction(Generic[T_co]):
+    def method(self) -> None:
+        def accepts(value: T_co) -> None: ...
+```
+
+An explicit `cls` annotation does not consume the type variable. A static method has no receiver, so
+its first parameter still contributes to its variance.
+
+```py
+class ClassMethods(Generic[T_co]):
+    @classmethod
+    def returns(cls: type["ClassMethods[T_co]"]) -> T_co:
+        raise NotImplementedError
+
+    @staticmethod
+    # error: [invalid-generic-class]
+    def accepts(value: T_co) -> None: ...
+```
+
+Each overload is checked, even when the implementation does not use the class's type variable.
+
+```py
+from typing import overload
+
+class Overloaded(Generic[T_co]):
+    @overload
+    # error: [invalid-generic-class]
+    def method(self, value: T_co) -> int: ...
+    @overload
+    def method(self, value: int, other: int) -> int: ...
+    def method(self, value: object, other: int = 0) -> int:
+        return 0
+```
+
 ## Generic protocol variance
 
 A protocol's declared variance must match whether its members consume or produce that type variable.

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -359,7 +359,7 @@ impl<'db> OverloadLiteral<'db> {
 
     /// Returns true if this overload is decorated with `@classmethod`, or if it is implicitly a
     /// classmethod.
-    fn is_classmethod(self, db: &dyn Db) -> bool {
+    pub(super) fn is_classmethod(self, db: &dyn Db) -> bool {
         self.has_known_decorator(db, FunctionDecorators::CLASSMETHOD)
             || is_implicit_classmethod(self.name(db))
     }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -359,7 +359,7 @@ impl<'db> OverloadLiteral<'db> {
 
     /// Returns true if this overload is decorated with `@classmethod`, or if it is implicitly a
     /// classmethod.
-    pub(super) fn is_classmethod(self, db: &dyn Db) -> bool {
+    fn is_classmethod(self, db: &dyn Db) -> bool {
         self.has_known_decorator(db, FunctionDecorators::CLASSMETHOD)
             || is_implicit_classmethod(self.name(db))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -1,17 +1,19 @@
 use crate::{
     diagnostic::format_enumeration,
     types::{
-        KnownInstanceType, Signature, Type, TypeVarKind,
+        KnownInstanceType, Signature, Type, TypeVarKind, TypeVarVariance,
         context::InferContext,
         diagnostic::{
-            INVALID_LEGACY_POSITIONAL_PARAMETER, INVALID_TYPE_VARIABLE_DEFAULT,
-            UNBOUND_TYPE_VARIABLE,
+            INVALID_GENERIC_CLASS, INVALID_LEGACY_POSITIONAL_PARAMETER,
+            INVALID_TYPE_VARIABLE_DEFAULT, UNBOUND_TYPE_VARIABLE,
         },
         function::{FunctionDecorators, OverloadLiteral},
         generics::GenericContext,
+        infer::nearest_enclosing_class,
         infer_definition_types,
         signatures::ReturnCallableTypeVarScope,
         typevar::TypeVarInstance,
+        variance::VarianceInferable,
         visitor::find_over_type,
     },
 };
@@ -22,7 +24,7 @@ use ruff_db::{
 };
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
-use ty_python_core::definition::Definition;
+use ty_python_core::{definition::Definition, semantic_index};
 
 pub(crate) fn check_function_definition<'db>(
     context: &InferContext<'db, '_>,
@@ -47,6 +49,78 @@ pub(crate) fn check_function_definition<'db>(
     check_pep695_function_legacy_typevars(context, last_definition, file_expression_type);
     check_legacy_typevar_defaults(context, last_definition, &signature, file_expression_type);
     check_legacy_typevar_ordering(context, last_definition, &signature, file_expression_type);
+    check_method_typevar_variance(context, last_definition, &signature);
+}
+
+/// Check that a method respects the declared variance of its class's type parameters.
+/// Constructors are excluded because their parameters establish the class specialization.
+fn check_method_typevar_variance<'db>(
+    context: &InferContext<'db, '_>,
+    last_definition: OverloadLiteral<'db>,
+    signature: &Signature<'db>,
+) {
+    let db = context.db();
+    let body_scope = last_definition.body_scope(db);
+    if !context.is_lint_enabled(&INVALID_GENERIC_CLASS)
+        || !body_scope.is_method_scope(db)
+        || matches!(last_definition.name(db).as_str(), "__init__" | "__new__")
+    {
+        return;
+    }
+
+    let index = semantic_index(db, body_scope.program_file(db));
+    let Some(class) = nearest_enclosing_class(db, index, body_scope) else {
+        return;
+    };
+    // Protocols have separate checks for variance in their interfaces.
+    if class.is_protocol(db) {
+        return;
+    }
+    let Some(generic_context) = class.generic_context(db) else {
+        return;
+    };
+    if !generic_context.variables(db).any(|typevar| {
+        matches!(
+            typevar.typevar(db).explicit_variance(db),
+            Some(TypeVarVariance::Covariant | TypeVarVariance::Contravariant)
+        )
+    }) {
+        return;
+    }
+    let env = context.program_environment();
+    let signature = if last_definition.has_implicit_receiver(db) {
+        // An explicit `self` or `cls` annotation does not consume the class's type parameters.
+        signature.bind_self(db, env, None)
+    } else {
+        signature.clone()
+    };
+
+    for typevar in generic_context.variables(db) {
+        let Some(declared_variance) = typevar.typevar(db).explicit_variance(db) else {
+            continue;
+        };
+        if declared_variance == TypeVarVariance::Invariant {
+            continue;
+        }
+        let required_variance = (&signature).variance_of(db, env, typevar.identity(db));
+        if declared_variance.join(required_variance) == declared_variance {
+            continue;
+        }
+        let node = last_definition.node(db, context.file(), context.module());
+        if let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, &node.name) {
+            let mut diagnostic = builder.into_diagnostic(format_args!(
+                "Variance of type variable `{}` is incompatible with method `{}`",
+                typevar.name(db),
+                node.name,
+            ));
+            diagnostic.info(format_args!(
+                "Type variable `{}` is declared as {}, but this method requires it to be {}",
+                typevar.name(db),
+                declared_variance.as_str(),
+                required_variance.as_str(),
+            ));
+        }
+    }
 }
 
 /// Check that a function using PEP 695 syntax does not also introduce legacy type variables.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -1,7 +1,7 @@
 use crate::{
     diagnostic::format_enumeration,
     types::{
-        KnownInstanceType, Signature, Type, TypeVarKind, TypeVarVariance,
+        KnownInstanceType, Signature, SubclassOfType, Type, TypeVarKind, TypeVarVariance,
         context::InferContext,
         diagnostic::{
             INVALID_GENERIC_CLASS, INVALID_LEGACY_POSITIONAL_PARAMETER,
@@ -105,10 +105,26 @@ fn check_method_typevar_variance<'db>(
     }
     let env = context.program_environment();
     let signature = if last_definition.has_implicit_receiver(db) {
-        // A specialized receiver can restrict which class specializations expose this method.
-        // Defer these signatures until variance checking accounts for receiver restrictions.
-        if signature.has_explicit_positional_receiver_annotation() {
-            return;
+        if signature.has_explicit_positional_receiver_annotation()
+            && let Some(receiver) = signature.parameters().get(0)
+        {
+            // `Self` and the class's identity specialization expose the method on every
+            // specialization. Other annotations can restrict the receiver; defer those until
+            // variance checking accounts for the restriction.
+            let class_type = class.identity_specialization(db);
+            let instance_type = Type::instance(db, env, class_type);
+            let receiver_type = if last_definition.is_classmethod(db) {
+                SubclassOfType::from(db, env, class_type)
+            } else {
+                instance_type
+            };
+            if !receiver
+                .annotated_type()
+                .bind_self_typevars(db, env, instance_type)
+                .is_equivalent_to(db, env, receiver_type)
+            {
+                return;
+            }
         }
         // The implicit receiver does not consume the class's type parameters.
         signature.bind_self(db, env, None)

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -83,8 +83,8 @@ fn check_method_typevar_variance<'db>(
     // invariant type variables. Nominal classes can be more conservative, so they only reject uses
     // incompatible with a declared covariance or contravariance. Both checks share recursive
     // variance inference, but only nominal classes currently skip overloads and independently
-    // generic methods to avoid false positives. TODO: Handle these cases in shared variance
-    // inference so that both checks can account for them.
+    // generic methods to avoid false positives.
+    // TODO: Handle these cases in shared variance inference so both checks can account for them.
     if class.is_protocol(db) {
         return;
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -1,7 +1,7 @@
 use crate::{
     diagnostic::format_enumeration,
     types::{
-        KnownInstanceType, Signature, SubclassOfType, Type, TypeVarKind, TypeVarVariance,
+        KnownInstanceType, Signature, Type, TypeVarKind, TypeVarVariance,
         context::InferContext,
         diagnostic::{
             INVALID_GENERIC_CLASS, INVALID_LEGACY_POSITIONAL_PARAMETER,
@@ -50,7 +50,9 @@ pub(crate) fn check_function_definition<'db>(
     check_legacy_typevar_defaults(context, last_definition, &signature, file_expression_type);
     check_legacy_typevar_ordering(context, last_definition, &signature, file_expression_type);
     // Variance depends on the complete overload set: a broader overload can cover an otherwise
-    // incompatible signature. Defer checking overloads until we can account for that coverage.
+    // incompatible signature.
+    // TODO: Account for that coverage in shared variance inference before
+    // checking overloaded methods here.
     if !function_type.has_known_decorator(db, FunctionDecorators::OVERLOAD) {
         check_method_typevar_variance(context, last_definition, &signature);
     }
@@ -58,6 +60,7 @@ pub(crate) fn check_function_definition<'db>(
 
 /// Check that a method respects the declared variance of its class's type parameters.
 /// Constructors are excluded because their parameters establish the class specialization.
+/// Recursively checks type variables nested in containers, unions, and callables as well as bare uses.
 fn check_method_typevar_variance<'db>(
     context: &InferContext<'db, '_>,
     last_definition: OverloadLiteral<'db>,
@@ -76,7 +79,12 @@ fn check_method_typevar_variance<'db>(
     let Some(class) = nearest_enclosing_class(db, index, body_scope) else {
         return;
     };
-    // Protocols have separate checks for variance in their interfaces.
+    // Protocols require declared variance to match the inferred variance, including for explicitly
+    // invariant type variables. Nominal classes can be more conservative, so they only reject uses
+    // incompatible with a declared covariance or contravariance. Both checks share recursive
+    // variance inference, but only nominal classes currently skip overloads and independently
+    // generic methods to avoid false positives. TODO: Handle these cases in shared variance
+    // inference so that both checks can account for them.
     if class.is_protocol(db) {
         return;
     }
@@ -93,7 +101,7 @@ fn check_method_typevar_variance<'db>(
     }
 
     // Independent method type parameters can make an occurrence of a class parameter redundant.
-    // Checking those relationships requires more than composing the variance of each occurrence.
+    // TODO: Account for those relationships instead of just composing each occurrence's variance.
     // Use the lexical context so that type parameters moved into a returned callable also count.
     let lexical_signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Lexical);
     if lexical_signature.generic_context.is_some_and(|context| {
@@ -105,33 +113,16 @@ fn check_method_typevar_variance<'db>(
     }
     let env = context.program_environment();
     let signature = if last_definition.has_implicit_receiver(db) {
-        if signature.has_explicit_positional_receiver_annotation()
-            && let Some(receiver) = signature.parameters().get(0)
-        {
-            // `Self` and the class's identity specialization expose the method on every
-            // specialization. Other annotations can restrict the receiver; defer those until
-            // variance checking accounts for the restriction.
-            let class_type = class.identity_specialization(db);
-            let instance_type = Type::instance(db, env, class_type);
-            let receiver_type = if last_definition.is_classmethod(db) {
-                SubclassOfType::from(db, env, class_type)
-            } else {
-                instance_type
-            };
-            if !receiver
-                .annotated_type()
-                .bind_self_typevars(db, env, instance_type)
-                .is_equivalent_to(db, env, receiver_type)
-            {
-                return;
-            }
-        }
         // The implicit receiver does not consume the class's type parameters.
+        // TODO: Account for specialized receivers that make an otherwise incompatible occurrence
+        // redundant, such as `self: C[int]` with a parameter annotated as `T_co | int`.
         signature.bind_self(db, env, None)
     } else {
         signature.clone()
     };
 
+    // TODO: Validate the final class interface: decorators can replace a method, and later
+    // statements in the class body can delete or overwrite it.
     for typevar in generic_context.variables(db) {
         let Some(declared_variance) = typevar.typevar(db).explicit_variance(db) else {
             continue;
@@ -144,7 +135,43 @@ fn check_method_typevar_variance<'db>(
             continue;
         }
         let node = last_definition.node(db, context.file(), context.module());
-        if let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, &node.name) {
+        let range = signature
+            .parameters()
+            .iter()
+            .find_map(|parameter| {
+                // `P.args` and `P.kwargs` both consume `P`, despite having distinct identities.
+                let parameter_type = match parameter.annotated_type() {
+                    Type::TypeVar(typevar) if typevar.paramspec_attr(db).is_some() => {
+                        Type::TypeVar(typevar.without_paramspec_attr(db))
+                    }
+                    ty => ty,
+                };
+                let variance = parameter_type
+                    .with_polarity(TypeVarVariance::Contravariant)
+                    .variance_of(db, env, typevar.identity(db));
+                if declared_variance.join(variance) == declared_variance {
+                    return None;
+                }
+                node.parameters
+                    .iter()
+                    .nth(parameter.source_parameter_index()?)?
+                    .annotation()
+                    .map(Ranged::range)
+            })
+            .or_else(|| {
+                node.returns
+                    .as_deref()
+                    .filter(|_| {
+                        declared_variance.join(signature.return_ty.variance_of(
+                            db,
+                            env,
+                            typevar.identity(db),
+                        )) != declared_variance
+                    })
+                    .map(Ranged::range)
+            })
+            .unwrap_or_else(|| node.name.range());
+        if let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, range) {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Variance of type variable `{}` is incompatible with method `{}`",
                 typevar.name(db),

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -49,7 +49,11 @@ pub(crate) fn check_function_definition<'db>(
     check_pep695_function_legacy_typevars(context, last_definition, file_expression_type);
     check_legacy_typevar_defaults(context, last_definition, &signature, file_expression_type);
     check_legacy_typevar_ordering(context, last_definition, &signature, file_expression_type);
-    check_method_typevar_variance(context, last_definition, &signature);
+    // Variance depends on the complete overload set: a broader overload can cover an otherwise
+    // incompatible signature. Defer checking overloads until we can account for that coverage.
+    if !function_type.has_known_decorator(db, FunctionDecorators::OVERLOAD) {
+        check_method_typevar_variance(context, last_definition, &signature);
+    }
 }
 
 /// Check that a method respects the declared variance of its class's type parameters.
@@ -87,9 +91,26 @@ fn check_method_typevar_variance<'db>(
     }) {
         return;
     }
+
+    // Independent method type parameters can make an occurrence of a class parameter redundant.
+    // Checking those relationships requires more than composing the variance of each occurrence.
+    // Use the lexical context so that type parameters moved into a returned callable also count.
+    let lexical_signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Lexical);
+    if lexical_signature.generic_context.is_some_and(|context| {
+        context
+            .variables(db)
+            .any(|typevar| !typevar.typevar(db).is_self(db))
+    }) {
+        return;
+    }
     let env = context.program_environment();
     let signature = if last_definition.has_implicit_receiver(db) {
-        // An explicit `self` or `cls` annotation does not consume the class's type parameters.
+        // A specialized receiver can restrict which class specializations expose this method.
+        // Defer these signatures until variance checking accounts for receiver restrictions.
+        if signature.has_explicit_positional_receiver_annotation() {
+            return;
+        }
+        // The implicit receiver does not consume the class's type parameters.
         signature.bind_self(db, env, None)
     } else {
         signature.clone()


### PR DESCRIPTION
## Summary

Previously, we used declared variance when comparing generic class specializations, but didn't check whether the class's methods respected it. We now report `invalid-generic-class` when a method uses a class-scoped type parameter in a position that conflicts with its declared variance.

```python
from typing import Generic, TypeVar

T_co = TypeVar("T_co", covariant=True)

class Source(Generic[T_co]):
    def get(self) -> T_co:
        raise NotImplementedError

    # Before: no error. After: invalid-generic-class.
    def set(self, value: T_co) -> None: ...
```

We reuse the existing variance analysis for `TypeVar`, `ParamSpec`, and `TypeVarTuple`, including variance reversal through `Callable`. Constructors remain exempt, and protocols continue through their separate interface checks.

Explicit receivers equivalent to `Self` or the class's own specialization, such as `C[T]`, are checked as well, including the corresponding classmethod receivers. These annotations do not restrict which class specializations expose the method.

For now, we defer overloaded methods, methods with independent type parameters, and methods with restricted receivers. A broader overload can cover an otherwise incompatible signature, a method's own type parameter can make an input redundant, and a specialized receiver can restrict which class specializations expose the method. Checking these signatures one occurrence at a time can therefore reject valid code. These exclusions apply equally to `TypeVar`, `ParamSpec`, and `TypeVarTuple`; they also leave some invalid signatures unchecked.

For example, this generic default remains valid: `T` already accepts any default, and the return type includes both `T_co` and `T`.

```python
T = TypeVar("T")

class Mapping(Generic[T_co]):
    # No variance error: the T_co arm in the parameter is redundant.
    def get(self, default: T_co | T) -> T_co | T:
        return default
```

This moves [`generics_paramspec_variance`](https://github.com/python/typing/blob/5672d88d54c149de13d0bbd3f2995b5449f72e20/conformance/tests/generics_paramspec_variance.py) and [`generics_typevartuple_variance`](https://github.com/python/typing/blob/5672d88d54c149de13d0bbd3f2995b5449f72e20/conformance/tests/generics_typevartuple_variance.py) from Partial to Pass.

<details>
<summary>Case analysis</summary>

Mypy 2.1.0, pyright 1.1.410, and pyrefly 1.3.0-dev.1 also reject the ordinary `TypeVar` misuse above. Those versions do not support explicit variance on `ParamSpec` or `TypeVarTuple`: they report errors on valid variance declarations, so they do not pass these conformance cases or provide a direct comparison for the method checks below.

Returning `Callable[P, None]` uses `P` contravariantly, while accepting that callable as a parameter uses `P` covariantly. A covariant `ParamSpec` permits the latter but not the former:

```python
from typing import Callable, Generic, ParamSpec

# ty: OK; mypy, pyright, pyrefly: error (unsupported variance argument).
P_co = ParamSpec("P_co", covariant=True)

class Callbacks(Generic[P_co]):
    def accepts(self, callback: Callable[P_co, None]) -> None: ...  # ty: OK

    # ty before: no error. ty after: invalid-generic-class.
    def returns(self) -> Callable[P_co, None]:
        raise NotImplementedError
```

For `TypeVarTuple`, accepting unpacked arguments uses the type variable tuple contravariantly, while returning a tuple uses it covariantly. A contravariant `TypeVarTuple` permits the former but not the latter:

```python
from typing import Generic
from typing_extensions import TypeVarTuple

# ty: OK; mypy, pyright, pyrefly: error (unsupported variance argument).
Ts_contra = TypeVarTuple("Ts_contra", contravariant=True)

class Arguments(Generic[*Ts_contra]):
    def accepts(self, *args: *Ts_contra) -> None: ...  # ty: OK

    # ty before: no error. ty after: invalid-generic-class.
    def returns(self) -> tuple[*Ts_contra]:
        raise NotImplementedError
```


</details>
