### PR TITLE
[ty] Bind Self through generic type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -560,6 +560,20 @@ def _(c: MyClass):
     c.field = c
 ```
 
+A generic type alias preserves `Self` when it is used in an attribute annotation:
+
+```py
+type Identity[T] = T
+
+class AliasedNode:
+    parent: Identity[Self]
+
+    def __init__(self) -> None:
+        self.parent = self
+
+reveal_type(AliasedNode().parent)  # revealed: AliasedNode
+```
+
 Self from class body annotations and method signatures represent the same logical type variable.
 When a method returns an attribute annotated with `Self` in the class body, the class-body `Self`
 and the method's `Self` should be considered the same type, even though they have different binding
@@ -1422,6 +1436,21 @@ class D(C): ...
 reveal_type(D().instance_method)
 # revealed: bound method <class 'D'>.class_method() -> D
 reveal_type(D.class_method)
+```
+
+A generic type alias does not prevent binding `Self` in the method signature:
+
+```py
+from typing import Self
+
+type Identity[T] = T
+
+class Aliased:
+    def copy(self, other: Identity[Self]) -> Identity[Self]:
+        return other
+
+# revealed: bound method Aliased.copy(other: Aliased) -> Aliased
+reveal_type(Aliased().copy)
 ```
 
 In nested functions `self` binds to the method. So in the following example the `self` in `C.b` is

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4452,6 +4452,51 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ```
 
+## `Self` in generic type aliases during protocol matching
+
+Wrapping `Self` in a generic type alias does not change what it denotes. Method parameters and
+return types are bound to the structural implementation before their signatures are compared.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, Self
+
+type Identity[T] = T
+
+class Cloneable(Protocol):
+    def clone(self, other: Identity[Self]) -> Identity[Self]: ...
+
+class AliasedClone:
+    def clone(self, other: Identity[Self]) -> Identity[Self]:
+        return other
+
+class DirectClone:
+    def clone(self, other: Self) -> Self:
+        return other
+
+aliased: Cloneable = AliasedClone()
+direct: Cloneable = DirectClone()
+```
+
+The same binding applies to a property return type:
+
+```py
+class Current(Protocol):
+    @property
+    def current(self) -> Identity[Self]: ...
+
+class CurrentImpl:
+    @property
+    def current(self) -> Identity[Self]:
+        return self
+
+current: Current = CurrentImpl()
+```
+
 ## `Self`-returning instance methods in `ParamSpec` protocols
 
 Specializing a protocol's `ParamSpec` preserves the meaning of `Self`: the return type names the

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1921,8 +1921,19 @@ impl<'db> Type<'db> {
             return false;
         }
 
-        any_over_type(db, env, self, false, |ty| {
-            ty.as_typevar().is_some_and(|tv| tv.typevar(db).is_self(db))
+        any_over_type(db, env, self, false, |ty| match ty {
+            Type::TypeVar(typevar) => typevar.typevar(db).is_self(db),
+            Type::TypeAlias(alias) => {
+                // Type alias bodies cannot declare `Self`, but their explicit type arguments can
+                // contain the `Self` from an enclosing method or class.
+                alias.specialization(db).is_some_and(|specialization| {
+                    specialization
+                        .types(db)
+                        .iter()
+                        .any(|ty| ty.contains_self(db, env))
+                })
+            }
+            _ => false,
         })
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1430,8 +1430,6 @@ impl<'db> Signature<'db> {
             return true;
         }
 
-        // TODO: Expand type aliases here so `type Alias = Self` in a class body
-        // participates in receiver-specific overload pruning.
         expected_self_ty = expected_self_ty.bind_self_typevars(db, env, self_type);
 
         // `Self` binding can make the receiver annotation trivially compatible.
@@ -1796,8 +1794,6 @@ impl<'db> Signature<'db> {
         env: &ProgramEnvironment<'db>,
         receiver_is_removed: bool,
     ) -> bool {
-        // TODO: Expand type aliases here so `type Alias = Self` in parameters or returns
-        // triggers binding when a method is accessed on a concrete receiver.
         self.return_ty.contains_self(db, env)
             || self
                 .parameters


### PR DESCRIPTION
## Summary

ty incorrectly rejects structural protocol implementations when `Self` appears as an argument to a generic type alias:

```python
type Identity[T] = T

class Cloneable(Protocol):
    def clone(self) -> Identity[Self]: ...

class Concrete:
    def clone(self) -> Identity[Self]:
        return self
```

`Self` binding uses a preliminary check to avoid applying a type mapping when a type does not contain `Self`. Because type alias bodies are lazy, this check did not inspect the alias specialization and therefore missed the `Self` argument in `Identity[Self]`.

Inspect generic type alias arguments when checking for `Self`, without evaluating the alias body. The existing type mapping can then bind `Self` normally in method parameters and returns, property types, and attribute annotations.

Fixes astral-sh/ty#4409.

## Test Plan

- Added mdtests for binding aliased `Self` in bound method parameters, return types, and attribute annotations.
- Added protocol mdtests covering aliased and direct structural method implementations and property return types.
- Ran the full `ty_python_semantic` test suite.
- Ran Clippy with all targets and features and warnings denied.
- Ran the applicable repository hooks.
