### PR TITLE
[ty] Preserve Final variance in stubs

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -638,6 +638,44 @@ static_assert(is_subtype_of(C[B], C[A]))
 static_assert(not is_subtype_of(C[A], C[B]))
 ```
 
+#### Final attributes in stubs
+
+Stub attributes declared as `Final` are read-only, whether their declarations omit an initializer or
+use an ellipsis placeholder. A type parameter used only in such an attribute is covariant, while one
+used in an ordinary writable attribute is invariant.
+
+`box.pyi`:
+
+```pyi
+from typing import Final
+
+class Box[T]:
+    value: Final[T]
+
+class BoxWithPlaceholder[T]:
+    value: Final[T] = ...
+
+class MutableBox[T]:
+    value: T
+```
+
+`main.py`:
+
+```py
+from box import Box, BoxWithPlaceholder, MutableBox
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+static_assert(is_subtype_of(Box[int], Box[object]))
+static_assert(not is_subtype_of(Box[object], Box[int]))
+
+static_assert(is_subtype_of(BoxWithPlaceholder[int], BoxWithPlaceholder[object]))
+static_assert(not is_subtype_of(BoxWithPlaceholder[object], BoxWithPlaceholder[int]))
+
+static_assert(not is_subtype_of(MutableBox[int], MutableBox[object]))
+static_assert(not is_subtype_of(MutableBox[object], MutableBox[int]))
+```
+
 #### Underscore-prefixed attributes
 
 Underscore-prefixed instance attributes are considered private, and thus are assumed not externally

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -15,8 +15,9 @@ use super::implicit_attributes::implicit_attribute_names;
 use crate::{
     Db, FxIndexMap, FxIndexSet, TypeQualifiers,
     place::{
-        DefinedPlace, Definedness, Place, PlaceAndQualifiers, PublicTypePolicy, TypeOrigin,
-        place_from_bindings, place_from_declarations,
+        ConsideredDefinitions, DefinedPlace, Definedness, Place, PlaceAndQualifiers,
+        PublicTypePolicy, RequiresExplicitReExport, TypeOrigin, place_by_id, place_from_bindings,
+        place_from_declarations,
     },
     reachability::{DeclarationsIteratorExtension, ReachabilityConstraintsExtension},
     types::{
@@ -60,9 +61,7 @@ use ty_python_core::{
     definition::{Definition, DefinitionKind, DefinitionState},
     place_table,
     scope::ScopeId,
-    semantic_index,
-    symbol::Symbol,
-    use_def_map,
+    semantic_index, use_def_map,
 };
 
 /// Representation of a class definition statement in the AST: either a non-generic class, or a
@@ -3434,30 +3433,25 @@ impl<'db> StaticClassLiteral<'db> {
 
         let use_def_map = index.use_def_map(class_body_scope.file_scope_id(db));
         let table = place_table(db, class_body_scope);
-        let attribute_places_and_qualifiers =
-            use_def_map
-                .all_end_of_scope_symbol_declarations()
-                .map(|(symbol_id, declarations)| {
-                    let place_and_qual = place_from_declarations(db, &env, declarations)
-                        .ignore_conflicting_declarations();
-                    (symbol_id, place_and_qual)
-                })
-                .chain(use_def_map.all_end_of_scope_symbol_bindings().map(
-                    |(symbol_id, bindings)| {
-                        (
-                            symbol_id,
-                            place_from_bindings(db, &env, bindings).place.into(),
-                        )
-                    },
-                ))
-                .filter_map(|(symbol_id, place_and_qual)| {
-                    if let Some(name) = table.place(symbol_id).as_symbol().map(Symbol::name) {
-                        (![init_name, new_name].contains(&name))
-                            .then_some((name.to_string(), place_and_qual))
-                    } else {
-                        None
-                    }
-                });
+        // A declaration in a stub also creates a binding with no qualifiers. Resolve
+        // both together so `value: Final[T]` is not also treated as a mutable `T`.
+        let attribute_places_and_qualifiers = use_def_map
+            .all_end_of_scope_symbol_declarations()
+            .filter_map(|(symbol_id, _)| {
+                let name = table.symbol(symbol_id).name();
+                if [init_name, new_name].contains(&name) {
+                    return None;
+                }
+
+                let place_and_qualifiers = place_by_id(
+                    db,
+                    class_body_scope,
+                    symbol_id.into(),
+                    RequiresExplicitReExport::No,
+                    ConsideredDefinitions::EndOfScope,
+                );
+                Some((name.to_string(), place_and_qualifiers))
+            });
 
         // Dataclasses can have some additional synthesized methods (`__eq__`, `__hash__`,
         // `__lt__`, etc.) but none of these will have field types type variables in their signatures, so we


### PR DESCRIPTION
A generic class whose type parameter appears only in a `Final` attribute in a stub was incorrectly inferred as invariant. The stub declaration also creates a binding, which variance inference treated as a separate mutable occurrence of the type parameter without its `Final` qualifier.

This change resolves each symbol in the class body through the existing symbol lookup, combining its declarations and bindings before variance inference. This preserves the declared qualifiers and correctly infers covariance.

Addresses the `Final`-in-stubs portion of astral-sh/ty#4407. The separate recursive receiver issue reported there remains unresolved.

## Test plan

The variance mdtests cover stub attributes annotated as `Final[T]`, both without an initializer and with an ellipsis placeholder. Both forms allow covariance and reject reverse subtyping. A writable stub attribute is checked in both directions to confirm that it remains invariant.
