### PR TITLE
[ty] Use the subclass receiver when checking method overrides

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1675,6 +1675,111 @@ class B4(A4):
     def method(self, x: int) -> int: ...
 ```
 
+## Overrides with `Self` return types
+
+An inherited `Self` return type refers to the subclass on which the method is called. An override
+can preserve that return type regardless of whether either method explicitly annotates `self`:
+
+```pyi
+from typing_extensions import Self
+
+class Base:
+    def implicit(self) -> Self: ...
+    def explicit(self: Self) -> Self: ...
+
+class PreservesSelf(Base):
+    def implicit(self) -> Self: ...
+    def explicit(self: Self) -> Self: ...
+
+class ChangesReceiverAnnotation(Base):
+    def implicit(self: Self) -> Self: ...
+    def explicit(self) -> Self: ...
+```
+
+Returning the superclass is incompatible: it does not satisfy the inherited promise to return an
+instance of the subclass. Adding or omitting `self: Self` does not change this:
+
+```pyi
+class ReturnsBase(Base):
+    def implicit(self) -> Base: ...  # snapshot: invalid-method-override
+    def explicit(self: Self) -> Base: ...  # error: [invalid-method-override]
+
+class ReturnsBaseWithChangedAnnotation(Base):
+    def implicit(self: Self) -> Base: ...  # error: [invalid-method-override]
+    def explicit(self) -> Base: ...  # error: [invalid-method-override]
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `implicit`
+  --> src/mdtest_snippet.pyi:15:9
+   |
+15 |     def implicit(self) -> Base: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Base.implicit`
+   |
+  ::: src/mdtest_snippet.pyi:4:9
+   |
+ 4 |     def implicit(self) -> Self: ...
+   |         ---------------------- `Base.implicit` defined here
+info: incompatible return types: `Base` is not assignable to `ReturnsBase`
+info: This violates the Liskov Substitution Principle
+```
+
+Repeating an already invalid override does not produce another diagnostic on a subclass:
+
+```pyi
+class RepeatsInvalidOverride(ReturnsBase):
+    def implicit(self) -> Base: ...
+    def explicit(self: Self) -> Base: ...
+```
+
+## Overrides with `Self` parameters
+
+When a method accepts another instance of `Self`, both the inherited and overriding signatures refer
+to the subclass. Explicitly annotating the receiver as `Self` does not change compatibility:
+
+```pyi
+from typing_extensions import Self
+
+class Base:
+    def implicit(self, other: Self) -> None: ...
+    def explicit(self: Self, other: Self) -> None: ...
+
+class PreservesSelf(Base):
+    def implicit(self, other: Self) -> None: ...
+    def explicit(self: Self, other: Self) -> None: ...
+
+class ChangesReceiverAnnotation(Base):
+    def implicit(self: Self, other: Self) -> None: ...
+    def explicit(self, other: Self) -> None: ...
+```
+
+An override cannot replace the `Self` parameter with an unrelated type:
+
+```pyi
+class Incompatible(Base):
+    def implicit(self, other: int) -> None: ...  # error: [invalid-method-override]
+    def explicit(self: Self, other: int) -> None: ...  # error: [invalid-method-override]
+```
+
+For generic superclasses, the override also uses the inherited specialization of the class's type
+parameters:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```pyi
+class GenericBase[T]:
+    def method(self, other: Self, value: T) -> Self: ...
+
+class Specialized(GenericBase[int]):
+    def method(self, other: Self, value: int) -> Self: ...
+
+class IncompatibleSpecialization(GenericBase[int]):
+    def method(self, other: Self, value: str) -> Self: ...  # error: [invalid-method-override]
+```
+
 ## Protocol annotations on mixin receivers
 
 A mixin can annotate `self` with a protocol that the mixin itself does not implement. An override
@@ -2361,6 +2466,37 @@ class InvalidSwapEvent(Event):
     @classmethod
     # error: [invalid-method-override]
     def deserialize(cls: type[InvalidSwapEvent], data: dict[str, int]) -> InvalidSwapEvent: ...
+```
+
+## Classmethod overrides with `Self`
+
+In a class method, `Self` refers to an instance of the subclass, while `cls` is a class object. An
+override can preserve a `Self` parameter with or without an explicit `cls: type[Self]` annotation:
+
+```pyi
+from typing_extensions import Self
+
+class Base:
+    @classmethod
+    def compare(cls, other: Self) -> None: ...
+    @classmethod
+    def copy(cls) -> Self: ...
+
+class ImplicitReceiver(Base):
+    @classmethod
+    def compare(cls, other: Self) -> None: ...
+
+class ExplicitReceiver(Base):
+    @classmethod
+    def compare(cls: type[Self], other: Self) -> None: ...
+```
+
+An override that returns the superclass does not satisfy the inherited `Self` return type:
+
+```pyi
+class ReturnsBase(Base):
+    @classmethod
+    def copy(cls) -> Base: ...  # error: [invalid-method-override]
 ```
 
 ## Overloaded methods with positional-only parameters with defaults

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -1055,10 +1055,12 @@ class MyMapping(MutableMapping[KT, VT]):
     def __len__(self) -> int:
         raise NotImplementedError
     def update(self, arg: MapOrItems[KT, VT] = (), /, **kw: VT) -> None: ...
+```
 
-# TODO: We should emit an `invalid-method-override` diagnostic on
-# `DeferredChild1.method`. The `DeferredChild1`-specific overload applies to
-# this subclass, so its override cannot remove the `extra` parameter.
+The `DeferredChild1`-specific overload applies on that subclass, so its override cannot remove the
+`extra` parameter:
+
+```py
 class DeferredBase:
     @overload
     def method(self) -> None: ...
@@ -1067,7 +1069,7 @@ class DeferredBase:
     def method(self, extra: str = "") -> None: ...
 
 class DeferredChild1(DeferredBase):
-    def method(self) -> None: ...
+    def method(self) -> None: ...  # error: [invalid-method-override]
 
 # TODO: A strict Liskov check would emit an `invalid-method-override`
 # diagnostic here too. A subclass could inherit from both `DeferredChild1`

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1014,7 +1014,7 @@ fn method_override_types<'db>(
     let (subclass_type, superclass_type) = match (subclass_type, superclass_type) {
         (Type::BoundMethod(subclass_method), Type::BoundMethod(superclass_method)) => {
             let superclass_signature = superclass_method.function(db).signature(db);
-            let receiver = match superclass_signature.overloads.as_slice() {
+            let explicit_receiver = match superclass_signature.overloads.as_slice() {
                 [signature] => signature
                     .parameters()
                     .get(0)
@@ -1026,29 +1026,33 @@ fn method_override_types<'db>(
                 _ => None,
             };
 
-            receiver.map_or((subclass_type, superclass_type), |receiver| {
-                let typing_self_type = subclass_method.typing_self_type(db);
-                let receiver = receiver.bind_self_typevars(db, env, typing_self_type);
-                let receiver = IntersectionType::from_elements(
+            let typing_self_type = subclass_method.typing_self_type(db);
+            let receiver =
+                explicit_receiver.map_or(subclass_method.self_instance(db), |receiver| {
+                    let receiver = receiver.bind_self_typevars(db, env, typing_self_type);
+                    IntersectionType::from_elements(
+                        db,
+                        env,
+                        [subclass_method.self_instance(db), receiver],
+                    )
+                });
+
+            // Both signatures describe calls on the subclass. In particular, inherited `Self`
+            // annotations refer to the subclass even when the receiver is implicitly annotated.
+            (
+                Type::Callable(subclass_method.into_callable_type_with_receiver(
                     db,
                     env,
-                    [subclass_method.self_instance(db), receiver],
-                );
-                (
-                    Type::Callable(subclass_method.into_callable_type_with_receiver(
-                        db,
-                        env,
-                        receiver,
-                        typing_self_type,
-                    )),
-                    Type::Callable(superclass_method.into_callable_type_with_receiver(
-                        db,
-                        env,
-                        receiver,
-                        typing_self_type,
-                    )),
-                )
-            })
+                    receiver,
+                    typing_self_type,
+                )),
+                Type::Callable(superclass_method.into_callable_type_with_receiver(
+                    db,
+                    env,
+                    receiver,
+                    typing_self_type,
+                )),
+            )
         }
         _ => (subclass_type, superclass_type),
     };


### PR DESCRIPTION
Method override checks treated inherited `Self` differently depending on whether the superclass method explicitly annotated its receiver. With implicit `self`, the superclass signature remained bound to the superclass while the override was bound to the subclass. This could accept an override that returns the superclass despite an inherited `Self` return type, or reject an override that preserves a `Self` parameter.

Bind both method signatures to the subclass receiver before comparing them, while preserving explicit receiver restrictions. This also retains superclass overloads restricted to the subclass, so an override cannot omit arguments accepted by those overloads.

## Test plan

Added mdtests covering implicit and explicit `Self` receivers, compatible `Self` parameters, incompatible return types and parameters, classmethods, generic superclass specialization, and suppression of repeated diagnostics for an already invalid inherited override. A diagnostic snapshot verifies the incompatible return type explanation. Updated the existing overload test to reject an override that omits an argument accepted by an overload restricted to that subclass.
