### PR TITLE
[ty] Watch script dependencies in CLI watch mode

### DIFF
--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -178,6 +178,22 @@ impl Files {
             .map(|entry| *entry.value())
     }
 
+    /// Returns whether a known system file is at or beneath `path`.
+    ///
+    /// Includes directories and missing files. This only inspects cached paths, without accessing
+    /// the filesystem. If `path` itself is unknown, it scans the known paths until finding a match.
+    pub fn has_known_files_under(&self, db: &dyn Db, path: &SystemPath) -> bool {
+        if self.try_system(db, path).is_some() {
+            return true;
+        }
+
+        let path = SystemPath::absolute(path, db.system().current_directory());
+        self.inner
+            .system_by_path
+            .iter()
+            .any(|entry| entry.key().starts_with(&path))
+    }
+
     /// Looks up a vendored file by its path. Returns `Some` if a vendored file for the given path
     /// exists and `None` otherwise.
     fn vendored(&self, db: &dyn Db, path: &VendoredPath) -> Result<File, FileError> {
@@ -781,6 +797,29 @@ mod tests {
 
         let distinct = system_path_to_file(&db, "/foo/baz/bar.py").unwrap();
         assert_ne!(canonical, distinct);
+    }
+
+    #[test]
+    fn known_files_under_path() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("/project/file.py", "value = 1")?;
+        db.write_file("/directory/unread.py", "")?;
+        let has_files_under = |path| db.files().has_known_files_under(&db, SystemPath::new(path));
+        assert!(!has_files_under("/project"));
+
+        assert!(system_path_to_file(&db, "/project/file.py").is_ok());
+
+        assert!(has_files_under("/project"));
+        assert!(has_files_under("project/./file.py"));
+        assert!(!has_files_under("/proj"));
+        assert!(!has_files_under("/project/other"));
+
+        db.files().system(&db, SystemPath::new("/missing/file.py"));
+        assert!(has_files_under("/missing"));
+
+        db.files().system(&db, SystemPath::new("/directory"));
+        assert!(has_files_under("/directory"));
+        Ok(())
     }
 
     #[test]

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -178,22 +178,6 @@ impl Files {
             .map(|entry| *entry.value())
     }
 
-    /// Returns whether a known system file is at or beneath `path`.
-    ///
-    /// Includes directories and missing files. This only inspects cached paths, without accessing
-    /// the filesystem. If `path` itself is unknown, it scans the known paths until finding a match.
-    pub fn has_known_files_under(&self, db: &dyn Db, path: &SystemPath) -> bool {
-        if self.try_system(db, path).is_some() {
-            return true;
-        }
-
-        let path = SystemPath::absolute(path, db.system().current_directory());
-        self.inner
-            .system_by_path
-            .iter()
-            .any(|entry| entry.key().starts_with(&path))
-    }
-
     /// Looks up a vendored file by its path. Returns `Some` if a vendored file for the given path
     /// exists and `None` otherwise.
     fn vendored(&self, db: &dyn Db, path: &VendoredPath) -> Result<File, FileError> {
@@ -797,29 +781,6 @@ mod tests {
 
         let distinct = system_path_to_file(&db, "/foo/baz/bar.py").unwrap();
         assert_ne!(canonical, distinct);
-    }
-
-    #[test]
-    fn known_files_under_path() -> crate::system::Result<()> {
-        let mut db = TestDb::new();
-        db.write_file("/project/file.py", "value = 1")?;
-        db.write_file("/directory/unread.py", "")?;
-        let has_files_under = |path| db.files().has_known_files_under(&db, SystemPath::new(path));
-        assert!(!has_files_under("/project"));
-
-        assert!(system_path_to_file(&db, "/project/file.py").is_ok());
-
-        assert!(has_files_under("/project"));
-        assert!(has_files_under("project/./file.py"));
-        assert!(!has_files_under("/proj"));
-        assert!(!has_files_under("/project/other"));
-
-        db.files().system(&db, SystemPath::new("/missing/file.py"));
-        assert!(has_files_under("/missing"));
-
-        db.files().system(&db, SystemPath::new("/directory"));
-        assert!(has_files_under("/directory"));
-        Ok(())
     }
 
     #[test]

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -190,7 +190,7 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         db.freeze();
     }
 
-    let (main_loop, main_loop_cancellation_token) = MainLoop::new(mode, printer);
+    let (mut main_loop, main_loop_cancellation_token) = MainLoop::new(mode, printer);
 
     // Listen to Ctrl+C and abort the watch mode.
     let main_loop_cancellation_token = Mutex::new(Some(main_loop_cancellation_token));
@@ -201,6 +201,10 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
             token.stop();
         }
     })?;
+
+    // Mark initial script environments pending before watcher setup reads them.
+    let scripts: Vec<_> = db.project().script_files(&db).iter().collect();
+    main_loop.synchronize_scripts(&mut db, &scripts);
 
     let exit_status = if watch {
         main_loop.watch(&mut db)?
@@ -339,10 +343,6 @@ impl MainLoop {
         let mut revision = 0u64;
         let uv_sync_wakeups = db.uv_environments().sync_wakeups();
         let (check_sender, check_receiver) = crossbeam_channel::bounded(1);
-
-        // Initialize the uv environment for all scripts
-        let scripts: Vec<_> = db.project().script_files(db).iter().collect();
-        self.synchronize_scripts(db, &scripts);
 
         request_check(&check_sender);
 
@@ -505,10 +505,11 @@ impl MainLoop {
                             let scripts: Vec<_> = db.project().script_files(db).iter().collect();
                             self.synchronize_scripts(db, &scripts);
                         }
-
-                        if let Some(watcher) = self.watcher.as_mut() {
-                            watcher.update(db);
-                        }
+                    }
+                    if !changes.is_empty()
+                        && let Some(watcher) = self.watcher.as_mut()
+                    {
+                        watcher.update(db);
                     }
                     request_check(&check_sender);
                 }

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -190,7 +190,7 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         db.freeze();
     }
 
-    let (mut main_loop, main_loop_cancellation_token) = MainLoop::new(mode, printer);
+    let (main_loop, main_loop_cancellation_token) = MainLoop::new(mode, printer);
 
     // Listen to Ctrl+C and abort the watch mode.
     let main_loop_cancellation_token = Mutex::new(Some(main_loop_cancellation_token));
@@ -201,10 +201,6 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
             token.stop();
         }
     })?;
-
-    // Mark initial script environments pending before watcher setup reads them.
-    let scripts: Vec<_> = db.project().script_files(&db).iter().collect();
-    main_loop.synchronize_scripts(&mut db, &scripts);
 
     let exit_status = if watch {
         main_loop.watch(&mut db)?
@@ -343,6 +339,10 @@ impl MainLoop {
         let mut revision = 0u64;
         let uv_sync_wakeups = db.uv_environments().sync_wakeups();
         let (check_sender, check_receiver) = crossbeam_channel::bounded(1);
+
+        // Initialize the uv environment for all scripts
+        let scripts: Vec<_> = db.project().script_files(db).iter().collect();
+        self.synchronize_scripts(db, &scripts);
 
         request_check(&check_sender);
 

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -194,7 +194,7 @@ impl TestCase {
         if !changes.is_empty()
             && let Some(watcher) = &mut self.watcher
         {
-            watcher.update(&self.db);
+            watcher.update(&mut self.db);
             assert!(!watcher.has_errored_paths());
         }
 
@@ -510,7 +510,7 @@ where
     let watcher = directory_watcher(move |events| sender.send(events).unwrap())
         .with_context(|| "Failed to create directory watcher")?;
 
-    let watcher = ProjectWatcher::new(watcher, &db);
+    let watcher = ProjectWatcher::new(watcher, &mut db);
     assert!(!watcher.has_errored_paths());
 
     let test_case = TestCase {
@@ -1571,7 +1571,7 @@ fn shared_script_search_paths_are_unwatched_when_unused() -> anyhow::Result<()> 
 }
 
 #[test]
-fn removed_script_search_paths_keep_cached_files_up_to_date() -> anyhow::Result<()> {
+fn readded_script_search_paths_refresh_cached_files() -> anyhow::Result<()> {
     let script = r#"
     # /// script
     # [tool.ty.environment]
@@ -1582,27 +1582,47 @@ fn removed_script_search_paths_keep_cached_files_up_to_date() -> anyhow::Result<
     "#;
     let mut case = setup(|context: &mut SetupContext| {
         context.write_file("dependencies/dependency.py", "value = 1")?;
+        // On Linux, the project watch can also reach this directory through a symlink.
+        // Imports still need events under their search path when the watch is restored.
+        #[cfg(target_os = "linux")]
+        std::os::unix::fs::symlink(
+            context.join_root_path("dependencies").as_std_path(),
+            context
+                .join_project_path("linked_dependencies")
+                .as_std_path(),
+        )?;
         context.write_project_file("script.py", script)
     })?;
     let dependency = case.root_path().join("dependencies/dependency.py");
     assert!(case.db().check().is_empty());
 
-    // Removing the script metadata removes its extra search path from the project.
+    // Removing the script block removes its extra search path from the project.
     update_file(case.project_path("script.py"), "")?;
     let changes = case.take_watch_changes(event_for_file("script.py"));
     case.apply_changes(&changes);
 
     update_file(&dependency, "value = 'wrong'")?;
-    let changes = case.take_watch_changes(event_for_file("dependency.py"));
-    case.apply_changes(&changes);
 
     update_file(case.project_path("script.py"), script)?;
-    let changes = case.stop_watch(event_for_file("script.py"));
+    let changes = case.take_watch_changes(event_for_file("script.py"));
     case.apply_changes(&changes);
 
     let diagnostics = case.db().check();
     assert_eq!(diagnostics.len(), 1);
     assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
+
+    update_file(&dependency, "value = 1")?;
+    let changes = case.stop_watch(event_for_file("dependency.py"));
+    #[cfg(target_os = "linux")]
+    assert!(
+        changes
+            .iter()
+            .any(|event| matches!(event, ChangeEvent::Changed { path, .. } if path == &dependency)),
+        "expected a change at the search path: {changes:?}"
+    );
+    case.apply_changes(&changes);
+
+    assert!(case.db().check().is_empty());
     Ok(())
 }
 
@@ -3137,7 +3157,7 @@ mod uv_metadata {
         if !changes.is_empty()
             && let Some(watcher) = &mut case.watcher
         {
-            watcher.update(&case.db);
+            watcher.update(&mut case.db);
             assert!(!watcher.has_errored_paths());
         }
 

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -1516,6 +1516,7 @@ fn script_dependency_changes() -> anyhow::Result<()> {
             "script.py",
             r#"
             # /// script
+            # requires-python = ">=3.12"
             # [tool.ty.environment]
             # extra-paths = ["../dependencies"]
             # ///
@@ -1538,11 +1539,12 @@ fn script_dependency_changes() -> anyhow::Result<()> {
 }
 
 #[test]
-fn shared_script_search_paths_are_unwatched_when_unused() -> anyhow::Result<()> {
+fn shared_script_search_paths_remain_watched_until_unused() -> anyhow::Result<()> {
     let mut case = setup(|context: &mut SetupContext| {
         context.write_file("dependencies/dependency.py", "value = 1")?;
         let script = r#"
         # /// script
+        # requires-python = ">=3.12"
         # [tool.ty.environment]
         # extra-paths = ["../dependencies"]
         # ///
@@ -1557,13 +1559,21 @@ fn shared_script_search_paths_are_unwatched_when_unused() -> anyhow::Result<()> 
     case.apply_changes(&changes);
 
     update_file(&dependency, "value = 2")?;
-    case.take_watch_changes(event_for_file("dependency.py"));
+    let changes = case.take_watch_changes(event_for_file("dependency.py"));
+    assert!(
+        changes
+            .iter()
+            .any(|event| matches!(event, ChangeEvent::Changed { path, .. } if path == &dependency)),
+        "expected an edit while the search path is shared: {changes:?}"
+    );
 
     update_file(case.project_path("second.py"), "")?;
     let changes = case.take_watch_changes(event_for_file("second.py"));
     case.apply_changes(&changes);
 
     update_file(&dependency, "value = 3")?;
+
+    // Neither script uses this path now, so edits to it should no longer produce watch events.
     let changes = case.try_stop_watch(event_for_file("dependency.py"), Duration::from_millis(100));
 
     assert_eq!(changes, Err(vec![]));
@@ -1571,54 +1581,169 @@ fn shared_script_search_paths_are_unwatched_when_unused() -> anyhow::Result<()> 
 }
 
 #[test]
-fn restored_script_search_paths_refresh_files_and_events() -> anyhow::Result<()> {
+fn restoring_script_metadata_rewatches_search_path() -> anyhow::Result<()> {
     let script = r#"
     # /// script
+    # requires-python = ">=3.12"
     # [tool.ty.environment]
     # extra-paths = ["../dependencies"]
     # ///
-    from dependency import value
-    result: int = value
     "#;
     let mut case = setup(|context: &mut SetupContext| {
         context.write_file("dependencies/dependency.py", "value = 1")?;
-        // On Linux, the project watch can also reach this directory through a symlink.
-        #[cfg(target_os = "linux")]
-        std::os::unix::fs::symlink(
-            context.join_root_path("dependencies").as_std_path(),
-            context
-                .join_project_path("linked_dependencies")
-                .as_std_path(),
-        )?;
         context.write_project_file("script.py", script)
     })?;
     let dependency = case.root_path().join("dependencies/dependency.py");
-    assert!(case.db().check().is_empty());
 
     // Removing the script block removes its extra search path from the project.
     update_file(case.project_path("script.py"), "")?;
     let changes = case.take_watch_changes(event_for_file("script.py"));
     case.apply_changes(&changes);
 
-    update_file(&dependency, "value = 'wrong'")?;
-
+    // Restoring the script re-registers its search path.
     update_file(case.project_path("script.py"), script)?;
     let changes = case.take_watch_changes(event_for_file("script.py"));
+    case.apply_changes(&changes);
+
+    update_file(&dependency, "value = 2")?;
+    let changes = case.stop_watch(event_for_file("dependency.py"));
+    assert!(
+        changes
+            .iter()
+            .any(|event| matches!(event, ChangeEvent::Changed { path, .. } if path == &dependency)),
+        "expected an edit after restoring the script's search path: {changes:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn nested_search_path_picks_up_missed_dependency_edit() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_file("dependencies/pkg/dependency.py", "value = 1")?;
+        context.write_project_file(
+            "main.py",
+            r"
+            from pkg.dependency import value
+            result: int = value
+            ",
+        )?;
+        context.write_project_file(
+            "pyproject.toml",
+            r#"
+            [tool.ty.environment]
+            extra-paths = ["../dependencies"]
+            "#,
+        )
+    })?;
+    let dependency = case.root_path().join("dependencies/pkg/dependency.py");
+
+    // The first check caches the dependency through the parent search path.
+    assert!(case.db().check().is_empty());
+
+    // Stop watching the parent before editing the dependency, so ty misses that file event.
+    update_file(case.project_path("pyproject.toml"), "[tool.ty]\n")?;
+    let changes = case.take_watch_changes(event_for_file("pyproject.toml"));
+    case.apply_changes(&changes);
+
+    update_file(&dependency, "value = 'wrong'")?;
+
+    // The new search path is nested inside the former watch. Registering it must refresh
+    // known files beneath it, even though that exact directory was never watched before.
+    update_file(
+        case.project_path("pyproject.toml"),
+        r#"
+        [tool.ty.environment]
+        extra-paths = ["../dependencies/pkg"]
+        "#,
+    )?;
+    let changes = case.take_watch_changes(event_for_file("pyproject.toml"));
+    case.apply_changes(&changes);
+
+    // Import relative to the new search path and check that ty sees the missed edit.
+    update_file(
+        case.project_path("main.py"),
+        r"
+        from dependency import value
+        result: int = value
+        ",
+    )?;
+    let changes = case.take_watch_changes(event_for_file("main.py"));
     case.apply_changes(&changes);
 
     let diagnostics = case.db().check();
     assert_eq!(diagnostics.len(), 1);
     assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
+    Ok(())
+}
 
-    // The restored watch must report subsequent edits under the search path on Linux.
-    update_file(&dependency, "value = 1")?;
+#[test]
+fn pth_edit_while_unwatched_watches_new_search_path() -> anyhow::Result<()> {
+    let site_packages = if cfg!(windows) {
+        "venv/Lib/site-packages"
+    } else {
+        "venv/lib/python3.12/site-packages"
+    };
+    let project_config = r#"
+    [tool.ty.environment]
+    python = "../venv"
+    "#;
+    let mut case = setup(|context: &mut SetupContext| {
+        let python_home = context.join_root_path("base/bin");
+        context.write_file("base/bin/python", "")?;
+        context.write_file(
+            "venv/pyvenv.cfg",
+            &format!(
+                r"home = {python_home}
+version = 3.12
+"
+            ),
+        )?;
+        context.write_file(
+            format!("{site_packages}/dependency.pth"),
+            context.join_root_path("old").as_str(),
+        )?;
+        context.write_file("old/dependency.py", "value = 1")?;
+        context.write_file("new/dependency.py", "value = 1")?;
+        context.write_project_file(
+            "main.py",
+            r"
+            from dependency import value
+            result: int = value
+            ",
+        )?;
+        context.write_project_file("pyproject.toml", project_config)
+    })?;
+
+    // The initial import resolves through `old`, as named by `dependency.pth`.
+    assert!(case.db().check().is_empty());
+
+    // Stop watching the virtual environment before changing its `.pth` file.
+    update_file(case.project_path("pyproject.toml"), "[tool.ty]\n")?;
+    let changes = case.take_watch_changes(event_for_file("pyproject.toml"));
+    case.apply_changes(&changes);
+
+    // This edit has no watcher event, so the cached `.pth` contents still name `old`.
+    let new = case.root_path().join("new");
+    update_file(
+        case.root_path().join(site_packages).join("dependency.pth"),
+        new.as_str(),
+    )?;
+
+    // Restoring the environment initially sees the cached `old` path. Rewatching
+    // `site-packages` must refresh `.pth` and register `new` in the same update.
+    update_file(case.project_path("pyproject.toml"), project_config)?;
+    let changes = case.take_watch_changes(event_for_file("pyproject.toml"));
+    case.apply_changes(&changes);
+
+    // Receiving this edit proves that `new` is now watched.
+    let dependency = new.join("dependency.py");
+    update_file(&dependency, "value = 2")?;
     let changes = case.stop_watch(event_for_file("dependency.py"));
-    #[cfg(target_os = "linux")]
     assert!(
         changes
             .iter()
             .any(|event| matches!(event, ChangeEvent::Changed { path, .. } if path == &dependency)),
-        "expected a change at the search path: {changes:?}"
+        "expected an edit at the new search path: {changes:?}"
     );
     Ok(())
 }
@@ -2745,7 +2870,9 @@ mod uv_metadata {
     use ty_python_semantic::Db as _;
     use ty_static::EnvVars;
 
-    use super::{SetupContext, TestCase, event_for_file, setup_with_system, update_file};
+    use super::{
+        ChangeEvent, SetupContext, TestCase, event_for_file, setup_with_system, update_file,
+    };
 
     const MANIFEST: &str = r#"
     [project]
@@ -2993,7 +3120,7 @@ mod uv_metadata {
     }
 
     #[test]
-    fn script_editable_install_paths_are_watched() -> anyhow::Result<()> {
+    fn script_pth_adds_watched_search_path() -> anyhow::Result<()> {
         let mut case = setup_uv(
             UseUv::Scripts,
             &[
@@ -3030,13 +3157,15 @@ mod uv_metadata {
 
         assert!(case.db().check().is_empty());
 
-        update_file(dependencies.join("dependency.py"), "value = 'wrong'")?;
+        let dependency = dependencies.join("dependency.py");
+        update_file(&dependency, "value = 2")?;
         let changes = case.stop_watch(event_for_file("dependency.py"));
-        case.apply_changes(&changes);
-
-        let diagnostics = case.db().check();
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
+        assert!(
+            changes.iter().any(
+                |event| matches!(event, ChangeEvent::Changed { path, .. } if path == &dependency)
+            ),
+            "expected an edit at the new search path: {changes:?}"
+        );
         Ok(())
     }
 

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -1571,7 +1571,7 @@ fn shared_script_search_paths_are_unwatched_when_unused() -> anyhow::Result<()> 
 }
 
 #[test]
-fn readded_script_search_paths_refresh_cached_files() -> anyhow::Result<()> {
+fn restored_script_search_paths_refresh_files_and_events() -> anyhow::Result<()> {
     let script = r#"
     # /// script
     # [tool.ty.environment]
@@ -1583,7 +1583,6 @@ fn readded_script_search_paths_refresh_cached_files() -> anyhow::Result<()> {
     let mut case = setup(|context: &mut SetupContext| {
         context.write_file("dependencies/dependency.py", "value = 1")?;
         // On Linux, the project watch can also reach this directory through a symlink.
-        // Imports still need events under their search path when the watch is restored.
         #[cfg(target_os = "linux")]
         std::os::unix::fs::symlink(
             context.join_root_path("dependencies").as_std_path(),
@@ -1611,6 +1610,7 @@ fn readded_script_search_paths_refresh_cached_files() -> anyhow::Result<()> {
     assert_eq!(diagnostics.len(), 1);
     assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
 
+    // The restored watch must report subsequent edits under the search path on Linux.
     update_file(&dependency, "value = 1")?;
     let changes = case.stop_watch(event_for_file("dependency.py"));
     #[cfg(target_os = "linux")]
@@ -1620,9 +1620,6 @@ fn readded_script_search_paths_refresh_cached_files() -> anyhow::Result<()> {
             .any(|event| matches!(event, ChangeEvent::Changed { path, .. } if path == &dependency)),
         "expected a change at the search path: {changes:?}"
     );
-    case.apply_changes(&changes);
-
-    assert!(case.db().check().is_empty());
     Ok(())
 }
 
@@ -3011,8 +3008,7 @@ mod uv_metadata {
                     result: int = value
                     "#,
                 ),
-                ("../first/dependency.py", "value = 1"),
-                ("../second/dependency.py", "value = 1"),
+                ("../dependencies/dependency.py", "value = 1"),
             ],
         )?;
         let db = case.db();
@@ -3027,33 +3023,14 @@ mod uv_metadata {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].id().as_str(), "unresolved-import");
 
-        std::fs::write(pth.as_std_path(), case.root_path().join("first").as_str())?;
+        let dependencies = case.root_path().join("dependencies");
+        std::fs::write(pth.as_std_path(), dependencies.as_str())?;
         let changes = case.take_watch_changes(event_for_file("dependency.pth"));
         case.apply_changes(&changes);
 
         assert!(case.db().check().is_empty());
 
-        update_file(
-            case.root_path().join("first/dependency.py"),
-            "value = 'wrong'",
-        )?;
-        let changes = case.take_watch_changes(event_for_file("dependency.py"));
-        case.apply_changes(&changes);
-
-        let diagnostics = case.db().check();
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
-
-        update_file(&pth, case.root_path().join("second").as_str())?;
-        let changes = case.take_watch_changes(event_for_file("dependency.pth"));
-        case.apply_changes(&changes);
-
-        assert!(case.db().check().is_empty());
-
-        update_file(
-            case.root_path().join("second/dependency.py"),
-            "value = 'wrong'",
-        )?;
+        update_file(dependencies.join("dependency.py"), "value = 'wrong'")?;
         let changes = case.stop_watch(event_for_file("dependency.py"));
         case.apply_changes(&changes);
 

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -189,7 +189,16 @@ impl TestCase {
     }
 
     fn apply_changes(&mut self, changes: &[ChangeEvent]) -> ChangeResult {
-        self.db.apply_changes(changes)
+        let result = self.db.apply_changes(changes);
+
+        if !changes.is_empty()
+            && let Some(watcher) = &mut self.watcher
+        {
+            watcher.update(&self.db);
+            assert!(!watcher.has_errored_paths());
+        }
+
+        result
     }
 
     fn update_options(&mut self, options: Options) -> anyhow::Result<()> {
@@ -205,11 +214,6 @@ impl TestCase {
 
         let changes = self.take_watch_changes(event_for_file("pyproject.toml"));
         self.apply_changes(&changes);
-
-        if let Some(watcher) = &mut self.watcher {
-            watcher.update(&self.db);
-            assert!(!watcher.has_errored_paths());
-        }
 
         Ok(())
     }
@@ -1505,6 +1509,104 @@ fn remove_search_path() -> anyhow::Result<()> {
 }
 
 #[test]
+fn script_dependency_changes() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_file("dependencies/dependency.py", "value = 1")?;
+        context.write_project_file(
+            "script.py",
+            r#"
+            # /// script
+            # [tool.ty.environment]
+            # extra-paths = ["../dependencies"]
+            # ///
+            from dependency import value
+            result: int = value
+            "#,
+        )
+    })?;
+    let dependency = case.root_path().join("dependencies/dependency.py");
+    assert!(case.db().check().is_empty());
+
+    update_file(&dependency, "value = 'wrong'")?;
+    let changes = case.stop_watch(event_for_file("dependency.py"));
+    case.apply_changes(&changes);
+
+    let diagnostics = case.db().check();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
+    Ok(())
+}
+
+#[test]
+fn shared_script_search_paths_are_unwatched_when_unused() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_file("dependencies/dependency.py", "value = 1")?;
+        let script = r#"
+        # /// script
+        # [tool.ty.environment]
+        # extra-paths = ["../dependencies"]
+        # ///
+        "#;
+        context.write_project_file("first.py", script)?;
+        context.write_project_file("second.py", script)
+    })?;
+    let dependency = case.root_path().join("dependencies/dependency.py");
+
+    update_file(case.project_path("first.py"), "")?;
+    let changes = case.take_watch_changes(event_for_file("first.py"));
+    case.apply_changes(&changes);
+
+    update_file(&dependency, "value = 2")?;
+    case.take_watch_changes(event_for_file("dependency.py"));
+
+    update_file(case.project_path("second.py"), "")?;
+    let changes = case.take_watch_changes(event_for_file("second.py"));
+    case.apply_changes(&changes);
+
+    update_file(&dependency, "value = 3")?;
+    let changes = case.try_stop_watch(event_for_file("dependency.py"), Duration::from_millis(100));
+
+    assert_eq!(changes, Err(vec![]));
+    Ok(())
+}
+
+#[test]
+fn removed_script_search_paths_keep_cached_files_up_to_date() -> anyhow::Result<()> {
+    let script = r#"
+    # /// script
+    # [tool.ty.environment]
+    # extra-paths = ["../dependencies"]
+    # ///
+    from dependency import value
+    result: int = value
+    "#;
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_file("dependencies/dependency.py", "value = 1")?;
+        context.write_project_file("script.py", script)
+    })?;
+    let dependency = case.root_path().join("dependencies/dependency.py");
+    assert!(case.db().check().is_empty());
+
+    // Removing the script metadata removes its extra search path from the project.
+    update_file(case.project_path("script.py"), "")?;
+    let changes = case.take_watch_changes(event_for_file("script.py"));
+    case.apply_changes(&changes);
+
+    update_file(&dependency, "value = 'wrong'")?;
+    let changes = case.take_watch_changes(event_for_file("dependency.py"));
+    case.apply_changes(&changes);
+
+    update_file(case.project_path("script.py"), script)?;
+    let changes = case.stop_watch(event_for_file("script.py"));
+    case.apply_changes(&changes);
+
+    let diagnostics = case.db().check();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
+    Ok(())
+}
+
+#[test]
 fn change_python_version_and_platform() -> anyhow::Result<()> {
     let mut case = setup(|context: &mut SetupContext| {
         // `sys.last_exc` is a Python 3.12 only feature
@@ -2621,7 +2723,9 @@ mod uv_metadata {
     use ruff_db::diagnostic::DiagnosticId;
     use ruff_db::files::File;
     use ruff_db::system::{OsSystem, System as _};
+    use ty_module_resolver::system_module_search_paths;
     use ty_project::{Db, ScriptEnvironmentAvailability, UseUv, UvSyncChanges, uv_test_env_vars};
+    use ty_python_semantic::Db as _;
     use ty_static::EnvVars;
 
     use super::{SetupContext, TestCase, event_for_file, setup_with_system, update_file};
@@ -2871,6 +2975,74 @@ mod uv_metadata {
         Ok(())
     }
 
+    #[test]
+    fn script_editable_install_paths_are_watched() -> anyhow::Result<()> {
+        let mut case = setup_uv(
+            UseUv::Scripts,
+            &[
+                (
+                    "script.py",
+                    r#"
+                    # /// script
+                    # dependencies = []
+                    # requires-python = ">=3.12"
+                    # ///
+                    from dependency import value
+                    result: int = value
+                    "#,
+                ),
+                ("../first/dependency.py", "value = 1"),
+                ("../second/dependency.py", "value = 1"),
+            ],
+        )?;
+        let db = case.db();
+        let script = case.system_file(case.project_path("script.py"))?;
+        let environment = db.program_file(script).program(db).resolver_environment(db);
+        let site_packages = system_module_search_paths(db, environment)
+            .find(|path| path.file_name() == Some("site-packages"))
+            .context("script environment has no site-packages")?
+            .to_path_buf();
+        let pth = site_packages.join("dependency.pth");
+        let diagnostics = case.db().check();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].id().as_str(), "unresolved-import");
+
+        std::fs::write(pth.as_std_path(), case.root_path().join("first").as_str())?;
+        let changes = case.take_watch_changes(event_for_file("dependency.pth"));
+        case.apply_changes(&changes);
+
+        assert!(case.db().check().is_empty());
+
+        update_file(
+            case.root_path().join("first/dependency.py"),
+            "value = 'wrong'",
+        )?;
+        let changes = case.take_watch_changes(event_for_file("dependency.py"));
+        case.apply_changes(&changes);
+
+        let diagnostics = case.db().check();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
+
+        update_file(&pth, case.root_path().join("second").as_str())?;
+        let changes = case.take_watch_changes(event_for_file("dependency.pth"));
+        case.apply_changes(&changes);
+
+        assert!(case.db().check().is_empty());
+
+        update_file(
+            case.root_path().join("second/dependency.py"),
+            "value = 'wrong'",
+        )?;
+        let changes = case.stop_watch(event_for_file("dependency.py"));
+        case.apply_changes(&changes);
+
+        let diagnostics = case.db().check();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
+        Ok(())
+    }
+
     fn setup_uv(use_uv: UseUv, files: &[(&str, &str)]) -> anyhow::Result<TestCase> {
         let uv = OsSystem::default().which("uv")?;
         let mut case = setup_with_system(
@@ -2962,7 +3134,7 @@ mod uv_metadata {
             changes.project = completed.project.or(changes.project);
         }
 
-        if changes.project.is_some()
+        if !changes.is_empty()
             && let Some(watcher) = &mut case.watcher
         {
             watcher.update(&case.db);

--- a/crates/ty_project/src/uv/environments.rs
+++ b/crates/ty_project/src/uv/environments.rs
@@ -733,6 +733,7 @@ fn apply_sync_result(
         // previous metadata was cleared along with its virtual-environment path.
         //
         // FIXME: This is overbroad. A file watcher can tell us precisely what changed.
+        // Remove this fallback once the language server also watches script environments.
         // Changes inside virtual environments should instead be watched and processed through `ProjectDatabase::apply_changes`.
         // Using a file watcher also ensures that virtual environment changes in
         // scripts without using uv are detected.

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -4,17 +4,20 @@ use std::hash::Hasher;
 use tracing::info;
 
 use ruff_cache::{CacheKey, CacheKeyHasher};
+use ruff_db::Db as _;
 use ruff_db::system::{SystemPath, SystemPathBuf};
 use ty_module_resolver::system_module_search_paths;
 
+use crate::Project;
 use crate::db::{Db, ProjectDatabase};
+use crate::script::Script;
 use crate::watch::Watcher;
 
 /// Wrapper around a [`Watcher`] that watches the relevant paths of a project.
 pub struct ProjectWatcher {
     watcher: Watcher,
 
-    /// The paths that need to be watched. This includes paths for which setting up file watching failed.
+    /// The watched paths, including paths retained to keep known files up to date.
     watched_paths: Vec<SystemPathBuf>,
 
     /// True if registering a watcher for any path failed.
@@ -40,13 +43,61 @@ impl ProjectWatcher {
     }
 
     pub fn update(&mut self, db: &ProjectDatabase) {
-        let environment = db.project().program(db).resolver_environment(db);
-        let search_paths: Vec<_> = system_module_search_paths(db, environment).collect();
-        let project_path = db.project().root(db);
-
-        let new_cache_key = Self::compute_cache_key(project_path, &search_paths);
+        let project = db.project();
+        let new_cache_key = watch_paths_cache_key(db, project);
 
         if self.cache_key == Some(new_cache_key) {
+            return;
+        }
+
+        let project_path = project.root(db);
+        let config_paths = project.metadata(db).extra_configuration_paths();
+
+        // Watch both the project root and any paths provided by the user on the CLI (removing any redundant nested paths).
+        // This is necessary to observe changes to files that are outside the project root.
+        // We always need to watch the project root to observe changes to its configuration.
+        let mut paths: Vec<_> = ruff_db::system::deduplicate_nested_paths(
+            std::iter::once(project_path).chain(
+                project
+                    .included_paths_list(db)
+                    .iter()
+                    .map(SystemPathBuf::as_path),
+            ),
+        )
+        .map(SystemPath::to_path_buf)
+        .collect();
+        let included_paths_len = paths.len();
+
+        // Find the non-overlapping module search paths and filter out paths that are already covered by the project.
+        // Module search paths are already canonicalized.
+        let unique_module_paths = ruff_db::system::deduplicate_nested_paths(
+            module_search_paths(db, project)
+                .into_iter()
+                .filter(|path| !path.starts_with(project_path)),
+        );
+
+        paths.extend(
+            unique_module_paths
+                .chain(config_paths)
+                .map(SystemPath::to_path_buf),
+        );
+
+        // Removing a search path does not discard its cached files. Keep watching them so
+        // restoring that search path cannot reuse stale file contents or directory listings.
+        let retained_paths: Vec<_> = self
+            .watched_paths
+            .iter()
+            .filter(|path| {
+                !paths.iter().any(|current| path.starts_with(current))
+                    && db.files().has_known_files_under(db, path)
+            })
+            .cloned()
+            .collect();
+        // Current module paths take precedence over retained paths for overlapping symlinks.
+        paths.splice(included_paths_len..included_paths_len, retained_paths);
+
+        if paths == self.watched_paths {
+            self.cache_key = Some(new_cache_key);
             return;
         }
 
@@ -70,35 +121,9 @@ impl ProjectWatcher {
 
         self.has_errored_paths = false;
 
-        let config_paths = db.project().metadata(db).extra_configuration_paths();
-
-        // Watch both the project root and any paths provided by the user on the CLI (removing any redundant nested paths).
-        // This is necessary to observe changes to files that are outside the project root.
-        // We always need to watch the project root to observe changes to its configuration.
-        let included_paths = ruff_db::system::deduplicate_nested_paths(
-            std::iter::once(project_path).chain(
-                db.project()
-                    .included_paths_list(db)
-                    .iter()
-                    .map(SystemPathBuf::as_path),
-            ),
-        );
-
-        // Find the non-overlapping module search paths and filter out paths that are already covered by the project.
-        // Module search paths are already canonicalized.
-        let unique_module_paths = ruff_db::system::deduplicate_nested_paths(
-            search_paths
-                .into_iter()
-                .filter(|path| !path.starts_with(project_path)),
-        );
-
-        // Now add the new paths, first starting with the project path and then
-        // adding the library search paths, and finally the paths for configurations.
-        for path in included_paths
-            .chain(unique_module_paths)
-            .chain(config_paths)
-            .map(SystemPath::to_path_buf)
-        {
+        // Register project paths first, then retained and current module paths, and finally
+        // configuration paths.
+        for path in paths {
             if let Err(error) = watcher_paths.add(&path) {
                 // TODO: Log a user-facing warning.
                 tracing::warn!(
@@ -127,14 +152,6 @@ impl ProjectWatcher {
         self.cache_key = Some(new_cache_key);
     }
 
-    fn compute_cache_key(project_root: &SystemPath, search_paths: &[&SystemPath]) -> u64 {
-        let mut cache_key_hasher = CacheKeyHasher::new();
-        search_paths.cache_key(&mut cache_key_hasher);
-        project_root.cache_key(&mut cache_key_hasher);
-
-        cache_key_hasher.finish()
-    }
-
     /// Returns `true` if setting up watching for any path failed.
     pub fn has_errored_paths(&self) -> bool {
         self.has_errored_paths
@@ -147,6 +164,37 @@ impl ProjectWatcher {
     pub fn stop(self) {
         self.watcher.stop();
     }
+}
+
+#[salsa::tracked(returns(copy))]
+fn watch_paths_cache_key(db: &dyn Db, project: Project) -> u64 {
+    let mut search_paths = module_search_paths(db, project);
+    // Script order and duplicate search paths do not change what needs watching.
+    search_paths.sort_unstable();
+    search_paths.dedup();
+
+    let mut hasher = CacheKeyHasher::new();
+    search_paths.cache_key(&mut hasher);
+    project.root(db).cache_key(&mut hasher);
+    project.included_paths_list(db).cache_key(&mut hasher);
+    for path in project.metadata(db).extra_configuration_paths() {
+        path.cache_key(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn module_search_paths(db: &dyn Db, project: Project) -> Vec<&SystemPath> {
+    let environment = project.program(db).resolver_environment(db);
+    let mut search_paths: Vec<_> = system_module_search_paths(db, environment).collect();
+    for file in project.script_files(db).iter() {
+        if let Some(script) = Script::for_file(db, file) {
+            search_paths.extend(system_module_search_paths(
+                db,
+                script.program(db).resolver_environment(db),
+            ));
+        }
+    }
+    search_paths
 }
 
 struct DisplayWatchedPaths<'a> {
@@ -167,5 +215,55 @@ impl std::fmt::Display for DisplayWatchedPaths<'_> {
         }
 
         f.write_char(']')
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::system::{DbWithWritableSystem as _, SystemPathBuf};
+    use ruff_db::testing::assert_function_query_was_not_run;
+
+    use crate::db::testing::TestDb;
+    use crate::{Db as _, ProjectMetadata};
+
+    use super::watch_paths_cache_key;
+
+    #[test]
+    fn cache_key_is_reused_after_code_edits() -> anyhow::Result<()> {
+        let mut db = TestDb::new(ProjectMetadata::new(
+            "test",
+            SystemPathBuf::from("/project"),
+        ));
+        db.write_file("/project/ordinary.py", "value = 1")?;
+        db.write_dedented(
+            "/project/script.py",
+            r"
+            # /// script
+            # dependencies = []
+            # ///
+            value = 1
+            ",
+        )?;
+        let project = db.project();
+        // The CLI indexes files before setting up the watcher.
+        project.files(&db);
+        let key = watch_paths_cache_key(&db, project);
+
+        db.write_file("/project/ordinary.py", "value = 2")?;
+        db.write_dedented(
+            "/project/script.py",
+            r"
+            # /// script
+            # dependencies = []
+            # ///
+            value = 2
+            ",
+        )?;
+        db.take_salsa_events();
+
+        assert_eq!(watch_paths_cache_key(&db, project), key);
+        let events = db.take_salsa_events();
+        assert_function_query_was_not_run(&db, watch_paths_cache_key, project, &events);
+        Ok(())
     }
 }

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -21,9 +21,6 @@ pub struct ProjectWatcher {
     /// The paths currently watched, in registration order.
     watched_paths: Vec<SystemPathBuf>,
 
-    /// Paths that were unwatched and must be refreshed if they are watched again.
-    inactive_paths: FxHashSet<SystemPathBuf>,
-
     /// True if registering a watcher for any path failed.
     has_errored_paths: bool,
 
@@ -37,7 +34,6 @@ impl ProjectWatcher {
         let mut watcher = Self {
             watcher,
             watched_paths: Vec::new(),
-            inactive_paths: FxHashSet::default(),
             cache_key: None,
             has_errored_paths: false,
         };
@@ -48,15 +44,39 @@ impl ProjectWatcher {
     }
 
     pub fn update(&mut self, db: &mut ProjectDatabase) {
-        let watch_paths = watch_paths(db, db.project());
+        const MAX_RECONCILIATION_PASSES: usize = 10;
 
-        if self.cache_key == Some(watch_paths.cache_key) {
-            return;
+        for _ in 0..MAX_RECONCILIATION_PASSES {
+            if !self.update_once(db) {
+                return;
+            }
+
+            // `watch_paths` reads `.pth` files to find editable module search paths. If a
+            // script's `site-packages` was unwatched when a `.pth` file changed from `/old`
+            // to `/new`, this pass registered `/old` using stale contents. The refresh above
+            // updates the `.pth` file; recompute the plan and register `/new` before returning.
+            if self.cache_key == Some(watch_paths(db, db.project()).cache_key) {
+                return;
+            }
         }
 
-        let paths = &watch_paths.paths;
+        tracing::warn!(
+            "File watcher paths did not stabilize after {MAX_RECONCILIATION_PASSES} updates; changes outside the registered paths may be missed until the next update"
+        );
+    }
+
+    /// Returns whether newly covered paths were refreshed.
+    fn update_once(&mut self, db: &mut ProjectDatabase) -> bool {
+        let watch_plan = watch_paths(db, db.project());
+
+        if self.cache_key == Some(watch_plan.cache_key) {
+            return false;
+        }
+
+        let paths = &watch_plan.paths;
+        let previously_watched = self.watched_paths.clone();
         let mut watcher_paths = self.watcher.paths_mut();
-        let mut rewatched_paths = Vec::new();
+        let mut newly_covered_paths = Vec::new();
 
         // On Linux, overlapping watches through a symlink report events using the path of the
         // last registered watch. If `/project/bar` points to `/bar`, the module search path
@@ -66,11 +86,7 @@ impl ProjectWatcher {
         let first_new_path = if !self.has_errored_paths && paths.starts_with(&self.watched_paths) {
             self.watched_paths.len()
         } else {
-            let requested: FxHashSet<_> = paths.iter().collect();
             for path in self.watched_paths.drain(..) {
-                if !requested.contains(&path) {
-                    self.inactive_paths.insert(path.clone());
-                }
                 if let Err(error) = watcher_paths.remove(&path) {
                     info!("Failed to remove the file watcher for path `{path}`: {error}");
                 }
@@ -88,8 +104,15 @@ impl ProjectWatcher {
                 );
                 self.has_errored_paths = true;
             } else {
-                if self.inactive_paths.remove(path) {
-                    rewatched_paths.push(path.clone());
+                // A previous recursive watch already covered this path, even if it must be
+                // re-registered for precedence. Skip initial setup to avoid rescanning every
+                // project file immediately after discovery.
+                if self.cache_key.is_some()
+                    && !previously_watched
+                        .iter()
+                        .any(|watched| path.starts_with(watched))
+                {
+                    newly_covered_paths.push(path.clone());
                 }
                 self.watched_paths.push(path.clone());
             }
@@ -109,11 +132,17 @@ impl ProjectWatcher {
             }
         );
 
-        self.cache_key = Some(watch_paths.cache_key);
+        self.cache_key = Some(watch_plan.cache_key);
 
-        // Changes to an unwatched path may not have updated Files. Refresh after registering
-        // the watch so changes made during the refresh can still produce watcher events.
-        Files::sync_all_recursive(db, rewatched_paths);
+        if newly_covered_paths.is_empty() {
+            return false;
+        }
+
+        // A newly covered path may contain known files that changed while it was unwatched.
+        // Registering the watch does not update their cached contents, so refresh them here.
+        Files::sync_all_recursive(db, newly_covered_paths);
+
+        true
     }
 
     /// Returns `true` if setting up watching for any path failed.

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -4,8 +4,9 @@ use std::hash::Hasher;
 use tracing::info;
 
 use ruff_cache::{CacheKey, CacheKeyHasher};
-use ruff_db::Db as _;
+use ruff_db::files::Files;
 use ruff_db::system::{SystemPath, SystemPathBuf};
+use rustc_hash::FxHashSet;
 use ty_module_resolver::system_module_search_paths;
 
 use crate::Project;
@@ -17,8 +18,11 @@ use crate::watch::Watcher;
 pub struct ProjectWatcher {
     watcher: Watcher,
 
-    /// The watched paths, including paths retained to keep known files up to date.
+    /// The paths currently watched, in registration order.
     watched_paths: Vec<SystemPathBuf>,
+
+    /// Paths that were unwatched and must be refreshed if they are watched again.
+    inactive_paths: FxHashSet<SystemPathBuf>,
 
     /// True if registering a watcher for any path failed.
     has_errored_paths: bool,
@@ -29,10 +33,11 @@ pub struct ProjectWatcher {
 
 impl ProjectWatcher {
     /// Create a new project watcher.
-    pub fn new(watcher: Watcher, db: &ProjectDatabase) -> Self {
+    pub fn new(watcher: Watcher, db: &mut ProjectDatabase) -> Self {
         let mut watcher = Self {
             watcher,
             watched_paths: Vec::new(),
+            inactive_paths: FxHashSet::default(),
             cache_key: None,
             has_errored_paths: false,
         };
@@ -42,7 +47,7 @@ impl ProjectWatcher {
         watcher
     }
 
-    pub fn update(&mut self, db: &ProjectDatabase) {
+    pub fn update(&mut self, db: &mut ProjectDatabase) {
         let project = db.project();
         let new_cache_key = watch_paths_cache_key(db, project);
 
@@ -66,8 +71,6 @@ impl ProjectWatcher {
         )
         .map(SystemPath::to_path_buf)
         .collect();
-        let included_paths_len = paths.len();
-
         // Find the non-overlapping module search paths and filter out paths that are already covered by the project.
         // Module search paths are already canonicalized.
         let unique_module_paths = ruff_db::system::deduplicate_nested_paths(
@@ -82,26 +85,9 @@ impl ProjectWatcher {
                 .map(SystemPath::to_path_buf),
         );
 
-        // Removing a search path does not discard its cached files. Keep watching them so
-        // restoring that search path cannot reuse stale file contents or directory listings.
-        let retained_paths: Vec<_> = self
-            .watched_paths
-            .iter()
-            .filter(|path| {
-                !paths.iter().any(|current| path.starts_with(current))
-                    && db.files().has_known_files_under(db, path)
-            })
-            .cloned()
-            .collect();
-        // Current module paths take precedence over retained paths for overlapping symlinks.
-        paths.splice(included_paths_len..included_paths_len, retained_paths);
-
-        if paths == self.watched_paths {
-            self.cache_key = Some(new_cache_key);
-            return;
-        }
-
         let mut watcher_paths = self.watcher.paths_mut();
+        let requested: FxHashSet<_> = paths.iter().collect();
+        let mut reactivated_paths = Vec::new();
 
         // Unregister all watch paths because ordering is important for linux because
         // it only emits an event for the last added watcher if a subtree is covered by multiple watchers.
@@ -114,6 +100,9 @@ impl ProjectWatcher {
         //   - foo.py
         // ```
         for path in self.watched_paths.drain(..) {
+            if !requested.contains(&path) {
+                self.inactive_paths.insert(path.clone());
+            }
             if let Err(error) = watcher_paths.remove(&path) {
                 info!("Failed to remove the file watcher for path `{path}`: {error}");
             }
@@ -121,8 +110,7 @@ impl ProjectWatcher {
 
         self.has_errored_paths = false;
 
-        // Register project paths first, then retained and current module paths, and finally
-        // configuration paths.
+        // Register project paths first, then module paths, and finally configuration paths.
         for path in paths {
             if let Err(error) = watcher_paths.add(&path) {
                 // TODO: Log a user-facing warning.
@@ -131,6 +119,9 @@ impl ProjectWatcher {
                 );
                 self.has_errored_paths = true;
             } else {
+                if self.inactive_paths.remove(&path) {
+                    reactivated_paths.push(path.clone());
+                }
                 self.watched_paths.push(path);
             }
         }
@@ -150,6 +141,10 @@ impl ProjectWatcher {
         );
 
         self.cache_key = Some(new_cache_key);
+
+        // Changes to an unwatched path may not have updated Files. Refresh after registering
+        // the watch so changes made during the refresh can still produce watcher events.
+        Files::sync_all_recursive(db, reactivated_paths);
     }
 
     /// Returns `true` if setting up watching for any path failed.

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -27,7 +27,7 @@ pub struct ProjectWatcher {
     /// True if registering a watcher for any path failed.
     has_errored_paths: bool,
 
-    /// Cache key over the paths that need watching. It allows short-circuiting if the paths haven't changed.
+    /// Cache key over the paths requested by the project and its scripts.
     cache_key: Option<u64>,
 }
 
@@ -48,81 +48,50 @@ impl ProjectWatcher {
     }
 
     pub fn update(&mut self, db: &mut ProjectDatabase) {
-        let project = db.project();
-        let new_cache_key = watch_paths_cache_key(db, project);
+        let watch_paths = watch_paths(db, db.project());
 
-        if self.cache_key == Some(new_cache_key) {
+        if self.cache_key == Some(watch_paths.cache_key) {
             return;
         }
 
-        let project_path = project.root(db);
-        let config_paths = project.metadata(db).extra_configuration_paths();
-
-        // Watch both the project root and any paths provided by the user on the CLI (removing any redundant nested paths).
-        // This is necessary to observe changes to files that are outside the project root.
-        // We always need to watch the project root to observe changes to its configuration.
-        let mut paths: Vec<_> = ruff_db::system::deduplicate_nested_paths(
-            std::iter::once(project_path).chain(
-                project
-                    .included_paths_list(db)
-                    .iter()
-                    .map(SystemPathBuf::as_path),
-            ),
-        )
-        .map(SystemPath::to_path_buf)
-        .collect();
-        // Find the non-overlapping module search paths and filter out paths that are already covered by the project.
-        // Module search paths are already canonicalized.
-        let unique_module_paths = ruff_db::system::deduplicate_nested_paths(
-            module_search_paths(db, project)
-                .into_iter()
-                .filter(|path| !path.starts_with(project_path)),
-        );
-
-        paths.extend(
-            unique_module_paths
-                .chain(config_paths)
-                .map(SystemPath::to_path_buf),
-        );
-
+        let paths = &watch_paths.paths;
         let mut watcher_paths = self.watcher.paths_mut();
-        let requested: FxHashSet<_> = paths.iter().collect();
         let mut reactivated_paths = Vec::new();
 
-        // Unregister all watch paths because ordering is important for linux because
-        // it only emits an event for the last added watcher if a subtree is covered by multiple watchers.
-        // A path can be covered by multiple watchers if a subdirectory symlinks to a path that's covered by another watch path:
-        // ```text
-        // - bar
-        //   - baz.py
-        // - project
-        //   - bar -> /bar
-        //   - foo.py
-        // ```
-        for path in self.watched_paths.drain(..) {
-            if !requested.contains(&path) {
-                self.inactive_paths.insert(path.clone());
+        // On Linux, overlapping watches through a symlink report events using the path of the
+        // last registered watch. If `/project/bar` points to `/bar`, the module search path
+        // `/bar` must be watched after `/project` so imports receive events under `/bar`.
+        // Configuration paths come last so their events use their explicit paths. Appending
+        // preserves this precedence; other changes require re-registering in the new order.
+        let first_new_path = if !self.has_errored_paths && paths.starts_with(&self.watched_paths) {
+            self.watched_paths.len()
+        } else {
+            let requested: FxHashSet<_> = paths.iter().collect();
+            for path in self.watched_paths.drain(..) {
+                if !requested.contains(&path) {
+                    self.inactive_paths.insert(path.clone());
+                }
+                if let Err(error) = watcher_paths.remove(&path) {
+                    info!("Failed to remove the file watcher for path `{path}`: {error}");
+                }
             }
-            if let Err(error) = watcher_paths.remove(&path) {
-                info!("Failed to remove the file watcher for path `{path}`: {error}");
-            }
-        }
+            0
+        };
 
         self.has_errored_paths = false;
 
-        // Register project paths first, then module paths, and finally configuration paths.
-        for path in paths {
-            if let Err(error) = watcher_paths.add(&path) {
+        for path in paths.iter().skip(first_new_path) {
+            if let Err(error) = watcher_paths.add(path) {
                 // TODO: Log a user-facing warning.
                 tracing::warn!(
                     "Failed to setup watcher for path `{path}`: {error}. You have to restart ty after making changes to files under this path or you might see stale results."
                 );
                 self.has_errored_paths = true;
             } else {
-                if self.inactive_paths.remove(&path) {
+                if self.inactive_paths.remove(path) {
                     reactivated_paths.push(path.clone());
                 }
-                self.watched_paths.push(path);
+                self.watched_paths.push(path.clone());
             }
         }
 
@@ -140,7 +109,7 @@ impl ProjectWatcher {
             }
         );
 
-        self.cache_key = Some(new_cache_key);
+        self.cache_key = Some(watch_paths.cache_key);
 
         // Changes to an unwatched path may not have updated Files. Refresh after registering
         // the watch so changes made during the refresh can still produce watcher events.
@@ -161,24 +130,37 @@ impl ProjectWatcher {
     }
 }
 
-#[salsa::tracked(returns(copy))]
-fn watch_paths_cache_key(db: &dyn Db, project: Project) -> u64 {
-    let mut search_paths = module_search_paths(db, project);
-    // Script order and duplicate search paths do not change what needs watching.
-    search_paths.sort_unstable();
-    search_paths.dedup();
-
-    let mut hasher = CacheKeyHasher::new();
-    search_paths.cache_key(&mut hasher);
-    project.root(db).cache_key(&mut hasher);
-    project.included_paths_list(db).cache_key(&mut hasher);
-    for path in project.metadata(db).extra_configuration_paths() {
-        path.cache_key(&mut hasher);
-    }
-    hasher.finish()
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WatchPaths {
+    cache_key: u64,
+    paths: Box<[SystemPathBuf]>,
 }
 
-fn module_search_paths(db: &dyn Db, project: Project) -> Vec<&SystemPath> {
+/// Watches are registered in project, module, then configuration order. On Linux, the last
+/// registered watch determines the path reported for overlapping symlinks.
+///
+/// Project roots and explicitly included paths come first because project files are discovered
+/// by walking them. Module search paths come next so imports are reported relative to their
+/// search roots, rather than through symlinks inside the project. Configuration paths come last
+/// so their events use the explicit paths checked for configuration changes.
+#[salsa::tracked(returns(ref))]
+fn watch_paths(db: &dyn Db, project: Project) -> WatchPaths {
+    let project_path = project.root(db);
+
+    // Watch both the project root and any paths provided by the user on the CLI (removing any redundant nested paths).
+    // This is necessary to observe changes to files that are outside the project root.
+    // We always need to watch the project root to observe changes to its configuration.
+    let mut paths: Vec<_> = ruff_db::system::deduplicate_nested_paths(
+        std::iter::once(project_path).chain(
+            project
+                .included_paths_list(db)
+                .iter()
+                .map(SystemPathBuf::as_path),
+        ),
+    )
+    .map(SystemPath::to_path_buf)
+    .collect();
+
     let environment = project.program(db).resolver_environment(db);
     let mut search_paths: Vec<_> = system_module_search_paths(db, environment).collect();
     for file in project.script_files(db).iter() {
@@ -189,7 +171,32 @@ fn module_search_paths(db: &dyn Db, project: Project) -> Vec<&SystemPath> {
             ));
         }
     }
-    search_paths
+
+    // Find the non-overlapping module search paths and filter out paths that are already covered by the project.
+    // Module search paths are already canonicalized.
+    // Deduplication also keeps the watch plan stable regardless of script order.
+    let unique_module_paths = ruff_db::system::deduplicate_nested_paths(
+        search_paths
+            .into_iter()
+            .filter(|path| !path.starts_with(project_path)),
+    );
+
+    // A path that's both included and a module search path must keep its module position.
+    let mut seen: FxHashSet<_> = paths.iter().cloned().collect();
+    for path in unique_module_paths.chain(project.metadata(db).extra_configuration_paths()) {
+        let path = path.to_path_buf();
+        if !seen.insert(path.clone()) {
+            paths.retain(|previous| previous != &path);
+        }
+        paths.push(path);
+    }
+
+    let mut hasher = CacheKeyHasher::new();
+    paths.cache_key(&mut hasher);
+    WatchPaths {
+        cache_key: hasher.finish(),
+        paths: paths.into_boxed_slice(),
+    }
 }
 
 struct DisplayWatchedPaths<'a> {
@@ -221,10 +228,10 @@ mod tests {
     use crate::db::testing::TestDb;
     use crate::{Db as _, ProjectMetadata};
 
-    use super::watch_paths_cache_key;
+    use super::watch_paths;
 
     #[test]
-    fn cache_key_is_reused_after_code_edits() -> anyhow::Result<()> {
+    fn watch_paths_are_reused_after_code_edits() -> anyhow::Result<()> {
         let mut db = TestDb::new(ProjectMetadata::new(
             "test",
             SystemPathBuf::from("/project"),
@@ -240,9 +247,7 @@ mod tests {
             ",
         )?;
         let project = db.project();
-        // The CLI indexes files before setting up the watcher.
-        project.files(&db);
-        let key = watch_paths_cache_key(&db, project);
+        let paths = watch_paths(&db, project).clone();
 
         db.write_file("/project/ordinary.py", "value = 2")?;
         db.write_dedented(
@@ -256,9 +261,9 @@ mod tests {
         )?;
         db.take_salsa_events();
 
-        assert_eq!(watch_paths_cache_key(&db, project), key);
+        assert_eq!(watch_paths(&db, project), &paths);
         let events = db.take_salsa_events();
-        assert_function_query_was_not_run(&db, watch_paths_cache_key, project, &events);
+        assert_function_query_was_not_run(&db, watch_paths, project, &events);
         Ok(())
     }
 }

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -56,7 +56,7 @@ impl ProjectWatcher {
 
         let paths = &watch_paths.paths;
         let mut watcher_paths = self.watcher.paths_mut();
-        let mut reactivated_paths = Vec::new();
+        let mut rewatched_paths = Vec::new();
 
         // On Linux, overlapping watches through a symlink report events using the path of the
         // last registered watch. If `/project/bar` points to `/bar`, the module search path
@@ -89,7 +89,7 @@ impl ProjectWatcher {
                 self.has_errored_paths = true;
             } else {
                 if self.inactive_paths.remove(path) {
-                    reactivated_paths.push(path.clone());
+                    rewatched_paths.push(path.clone());
                 }
                 self.watched_paths.push(path.clone());
             }
@@ -113,7 +113,7 @@ impl ProjectWatcher {
 
         // Changes to an unwatched path may not have updated Files. Refresh after registering
         // the watch so changes made during the refresh can still produce watcher events.
-        Files::sync_all_recursive(db, reactivated_paths);
+        Files::sync_all_recursive(db, rewatched_paths);
     }
 
     /// Returns `true` if setting up watching for any path failed.
@@ -150,16 +150,14 @@ fn watch_paths(db: &dyn Db, project: Project) -> WatchPaths {
     // Watch both the project root and any paths provided by the user on the CLI (removing any redundant nested paths).
     // This is necessary to observe changes to files that are outside the project root.
     // We always need to watch the project root to observe changes to its configuration.
-    let mut paths: Vec<_> = ruff_db::system::deduplicate_nested_paths(
+    let included_paths = ruff_db::system::deduplicate_nested_paths(
         std::iter::once(project_path).chain(
             project
                 .included_paths_list(db)
                 .iter()
                 .map(SystemPathBuf::as_path),
         ),
-    )
-    .map(SystemPath::to_path_buf)
-    .collect();
+    );
 
     let environment = project.program(db).resolver_environment(db);
     let mut search_paths: Vec<_> = system_module_search_paths(db, environment).collect();
@@ -172,30 +170,36 @@ fn watch_paths(db: &dyn Db, project: Project) -> WatchPaths {
         }
     }
 
-    // Find the non-overlapping module search paths and filter out paths that are already covered by the project.
-    // Module search paths are already canonicalized.
-    // Deduplication also keeps the watch plan stable regardless of script order.
+    // The project watch covers search paths inside its root. Deduplicate the others so
+    // shared or nested search paths are registered once in stable order.
     let unique_module_paths = ruff_db::system::deduplicate_nested_paths(
         search_paths
             .into_iter()
             .filter(|path| !path.starts_with(project_path)),
     );
 
-    // A path that's both included and a module search path must keep its module position.
-    let mut seen: FxHashSet<_> = paths.iter().cloned().collect();
-    for path in unique_module_paths.chain(project.metadata(db).extra_configuration_paths()) {
-        let path = path.to_path_buf();
-        if !seen.insert(path.clone()) {
-            paths.retain(|previous| previous != &path);
+    let paths: Vec<_> = included_paths
+        .chain(unique_module_paths)
+        .chain(project.metadata(db).extra_configuration_paths())
+        .map(SystemPath::to_path_buf)
+        .collect();
+
+    // Keep the last occurrence so later groups retain their registration precedence.
+    let mut seen = FxHashSet::default();
+    let mut unique_paths = Vec::new();
+    for path in paths.into_iter().rev() {
+        if seen.insert(path.clone()) {
+            unique_paths.push(path);
         }
-        paths.push(path);
     }
+    unique_paths.reverse();
+    let paths = unique_paths.into_boxed_slice();
 
     let mut hasher = CacheKeyHasher::new();
     paths.cache_key(&mut hasher);
     WatchPaths {
         cache_key: hasher.finish(),
-        paths: paths.into_boxed_slice(),
+        paths,
     }
 }
 
@@ -217,53 +221,5 @@ impl std::fmt::Display for DisplayWatchedPaths<'_> {
         }
 
         f.write_char(']')
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use ruff_db::system::{DbWithWritableSystem as _, SystemPathBuf};
-    use ruff_db::testing::assert_function_query_was_not_run;
-
-    use crate::db::testing::TestDb;
-    use crate::{Db as _, ProjectMetadata};
-
-    use super::watch_paths;
-
-    #[test]
-    fn watch_paths_are_reused_after_code_edits() -> anyhow::Result<()> {
-        let mut db = TestDb::new(ProjectMetadata::new(
-            "test",
-            SystemPathBuf::from("/project"),
-        ));
-        db.write_file("/project/ordinary.py", "value = 1")?;
-        db.write_dedented(
-            "/project/script.py",
-            r"
-            # /// script
-            # dependencies = []
-            # ///
-            value = 1
-            ",
-        )?;
-        let project = db.project();
-        let paths = watch_paths(&db, project).clone();
-
-        db.write_file("/project/ordinary.py", "value = 2")?;
-        db.write_dedented(
-            "/project/script.py",
-            r"
-            # /// script
-            # dependencies = []
-            # ///
-            value = 2
-            ",
-        )?;
-        db.take_salsa_events();
-
-        assert_eq!(watch_paths(&db, project), &paths);
-        let events = db.take_salsa_events();
-        assert_function_query_was_not_run(&db, watch_paths, project, &events);
-        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

This PR implements watching for script search paths. 

Before, changes to files in a script's search path were not picked up by ty, because the virtual environment is typically outside the `project_root` (at least when created by uv) and ty didn't explicitly watch the search paths for changes. 

This PR extends the CLI's watcher to also register script search paths as watched folders (while still deduplicating watched paths as before). 


The one caveat of registering script search paths is that we need to update the search paths after every edit because editing a script metadata block could change the script's search paths (e.g. when a user adds a new `tool.ty.environment` block). To make this as cheap as possible, computing the watch paths is a salsa query and we compute a `cache_key`  that allows us to bail early (and extremely cheaply) if the search paths remain unchanged. 


I plan to make the same change for the LSP, but it's a bit more work because the LSP watcher simply watches the project folder. We never implemented the necessary dynamic registration to watch other search paths (e.g. extra paths outside the project etc). I plan to tackle this next.

## Test Plan

Before, changes to a script's search path were not detected by ty:


https://github.com/user-attachments/assets/06cfe9b8-fa74-4437-aeee-6f54b80d6a5a

Now, changes are recognized and trigger a recheck of the script


https://github.com/user-attachments/assets/2685261b-306d-4129-b238-a3eca2c88713


