### PR TITLE
[ty] Run instrumented benchmarks on Depot

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,7 @@
 self-hosted-runner:
   # Various runners we use that aren't recognized out-of-the-box by actionlint:
   labels:
+    - depot-ubuntu-24.04
     - depot-ubuntu-24.04-4
     - depot-ubuntu-24.04-8
     - depot-ubuntu-22.04-16

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1128,7 +1128,7 @@ jobs:
 
   benchmarks-instrumented-ruff:
     name: "benchmarks instrumented (ruff)"
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     needs: determine_changes
     if: |
       github.repository == 'astral-sh/ruff' &&
@@ -1227,7 +1227,7 @@ jobs:
 
   benchmarks-instrumented-ty-run:
     name: "benchmarks instrumented ty (${{ matrix.mode }}: ${{ matrix.name }})"
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     needs: benchmarks-instrumented-ty-build
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1128,7 +1128,7 @@ jobs:
 
   benchmarks-instrumented-ruff:
     name: "benchmarks instrumented (ruff)"
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     needs: determine_changes
     if: |
       github.repository == 'astral-sh/ruff' &&
@@ -1227,7 +1227,7 @@ jobs:
 
   benchmarks-instrumented-ty-run:
     name: "benchmarks instrumented ty (${{ matrix.mode }}: ${{ matrix.name }})"
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     needs: benchmarks-instrumented-ty-build
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Summary

I don't have any evidence that this will indeed help with the flakes we see. So this is more a speculative change and we should revert it if it isn't fruitful. 

The basic idea is, most flaky benchmark come with a codspeed warning, that the execution environment is different. This matters, because libraries (glibc included) may use different implementation based on the supported CPU instructions (e.g. make use of newer instructions) and cache sizes can also influence the result (https://codspeed.io/blog/why-glibc-faster-github-actions).

This PR switches from GitHub runners to depot runners. I've seen on many PRs that the benchmarks switch between Intel and AMD CPUs. And, not surprising, they have slightly different performance characteristics. 

Depot guarantees that it uses `Intel runners (x86 architecture) use 4th Gen AMD EPYC Genoa CPUs` (https://depot.dev/docs/github-actions/overview#feature-summary). Even if the CPUs might be slightly different within a family, I hope that only using AMD CPUs will reduce variance a fair amount. 

Now, ideally, CodSpeed would fix those parameters for us. But, unfortunately, this is not the case today. This also doesn't protect us against new runner images being rolled out (which can change glibc versions). But most reports that I've seen use the same glibc version and mainly differ in CPU architecture.

An alternative (which is what codspeed suggests) is to use their macro runners, because they have a fixed architecture. But not only are they slow, they are also a fair bit pricier than depot and have a lower concurrency limit. 

## Test Plan

CI
