### PR TITLE
[ty] Validate type variable scopes in constructors and aliases

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -5409,11 +5409,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             })
                             .is_none()
                     {
-                        let callable = self.add_standalone_expression_impl(
-                            func,
-                            ExpressionKind::CallTarget,
-                            None,
-                        );
+                        let callable =
+                            self.add_standalone_expression_impl(func, ExpressionKind::Callee, None);
                         let call_expr = self.add_standalone_expression(expr);
 
                         let predicate = Predicate {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -5409,7 +5409,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             })
                             .is_none()
                     {
-                        let callable = self.add_standalone_expression(func);
+                        let callable = self.add_standalone_expression_impl(
+                            func,
+                            ExpressionKind::CallTarget,
+                            None,
+                        );
                         let call_expr = self.add_standalone_expression(expr);
 
                         let predicate = Predicate {

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -24,7 +24,7 @@ pub enum ExpressionKind {
     /// Items = list[T]  # Valid: defines a generic alias.
     /// list[T]()  # Error: no generic context binds T.
     /// ```
-    CallTarget,
+    Callee,
     /// An expression interpreted as a type, such as `int` in `self.x: int = 1`.
     TypeExpression,
 }

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -7,13 +7,14 @@ use ruff_db::files::File;
 use ruff_python_ast as ast;
 use salsa;
 
-/// Whether or not this expression should be inferred as a normal expression or
-/// a type expression. For example, in `self.x: <annotation> = <value>`, the
+/// How this expression should be inferred. For example, in `self.x: <annotation> = <value>`, the
 /// `<annotation>` is inferred as a type expression, while `<value>` is inferred
 /// as a normal expression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum ExpressionKind {
     Normal,
+    /// The callable in a call expression, where type arguments cannot introduce type variables.
+    CallTarget,
     TypeExpression,
 }
 
@@ -59,7 +60,7 @@ pub struct Expression<'db> {
     #[returns(clone)]
     pub assigned_to: Option<AstNodeRef<ast::StmtAssign>>,
 
-    /// Should this expression be inferred as a normal expression or a type expression?
+    /// The inference context for this expression.
     #[returns(copy)]
     pub kind: ExpressionKind,
 }

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -7,14 +7,25 @@ use ruff_db::files::File;
 use ruff_python_ast as ast;
 use salsa;
 
-/// How this expression should be inferred. For example, in `self.x: <annotation> = <value>`, the
-/// `<annotation>` is inferred as a type expression, while `<value>` is inferred
-/// as a normal expression.
+/// The context used to infer an independently tracked expression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum ExpressionKind {
+    /// An ordinary value expression, such as `1` in `self.x: int = 1`.
     Normal,
-    /// The callable in a call expression, where type arguments cannot introduce type variables.
+    /// The callable part of a call, such as `list[T]` in `list[T]()`.
+    ///
+    /// Type variables used to specialize the callable must already be bound. A constructor call
+    /// cannot introduce type variable bindings as a generic alias definition can:
+    ///
+    /// ```python
+    /// from typing import TypeVar
+    ///
+    /// T = TypeVar("T")
+    /// Items = list[T]  # Valid: defines a generic alias.
+    /// list[T]()  # Error: no generic context binds T.
+    /// ```
     CallTarget,
+    /// An expression interpreted as a type, such as `int` in `self.x: int = 1`.
     TypeExpression,
 }
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -611,7 +611,7 @@ reveal_type(OnlyParamSpec[...]().attr)  # revealed: (...) -> None
 def func(c: Callable[P2, None]):
     reveal_type(OnlyParamSpec[P2]().attr)  # revealed: (**P2@func) -> None
 
-# error: [invalid-type-arguments] "ParamSpec `P2` is unbound"
+# error: [unbound-type-variable] "Type variable `P2` is not bound to any outer generic context"
 reveal_type(OnlyParamSpec[P2]().attr)  # revealed: (...) -> None
 
 # error: [invalid-type-arguments] "No type argument provided for required type variable `P1` of class `OnlyParamSpec`"
@@ -656,7 +656,7 @@ reveal_type(TypeVarAndParamSpec[int, [str]]().attr)  # revealed: (str, /) -> int
 reveal_type(TypeVarAndParamSpec[int, ...]().attr)  # revealed: (...) -> int
 reveal_type(ParamSpecAndTypeVar[[int, str], str]().attr)  # revealed: (int, str, /) -> str
 
-# error: [invalid-type-arguments] "ParamSpec `P2` is unbound"
+# error: [unbound-type-variable] "Type variable `P2` is not bound to any outer generic context"
 reveal_type(TypeVarAndParamSpec[int, P2]().attr)  # revealed: (...) -> int
 # error: [invalid-type-arguments] "Type argument for `ParamSpec` must be either a list of types, `ParamSpec`, `Concatenate`, or `...`"
 reveal_type(TypeVarAndParamSpec[int, int]().attr)  # revealed: (...) -> int

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -318,7 +318,7 @@ def func[**P2](c: Callable[P2, None]):
 
 P2 = ParamSpec("P2")
 
-# error: [invalid-type-arguments] "ParamSpec `P2` is unbound"
+# error: [unbound-type-variable] "Type variable `P2` is not bound to any outer generic context"
 reveal_type(OnlyParamSpec[P2]().attr)  # revealed: (...) -> None
 
 # error: [invalid-type-arguments] "No type argument provided for required type variable `P1` of class `OnlyParamSpec`"
@@ -378,7 +378,7 @@ reveal_type(TypeVarAndParamSpec[int, [str]]().attr)  # revealed: (str, /) -> int
 reveal_type(TypeVarAndParamSpec[int, ...]().attr)  # revealed: (...) -> int
 reveal_type(ParamSpecAndTypeVar[[int, str], str]().attr)  # revealed: (int, str, /) -> str
 
-# error: [invalid-type-arguments] "ParamSpec `P2` is unbound"
+# error: [unbound-type-variable] "Type variable `P2` is not bound to any outer generic context"
 reveal_type(TypeVarAndParamSpec[int, P2]().attr)  # revealed: (...) -> int
 # error: [invalid-type-arguments] "Type argument for `ParamSpec` must be"
 reveal_type(TypeVarAndParamSpec[int, int]().attr)  # revealed: (...) -> int

--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -28,6 +28,72 @@ def f() -> None:
     x: T
 ```
 
+## Constructor calls require bound type variables
+
+A type argument in a constructor call must be bound in an enclosing generic scope. Assigning the
+result to a variable does not introduce a generic context, and nested type arguments follow the same
+rule.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+# error: [unbound-type-variable]
+list[T]()
+# error: [unbound-type-variable]
+items = list[T]()
+# error: [unbound-type-variable]
+list[list[T]]()
+
+class Box(Generic[T]): ...
+
+# error: [unbound-type-variable]
+Box[T]()
+```
+
+Generic functions and classes can use their own type variables when calling constructors.
+
+```py
+def make(value: T) -> list[T]:
+    result = list[T]([value])
+    reveal_type(result)  # revealed: list[T@make]
+    return result
+
+class Factory(Generic[T]):
+    def make(self, value: T) -> list[T]:
+        return list[T]([value])
+
+def modern[T](value: T) -> list[T]:
+    return list[T]([value])
+```
+
+An alias assignment or a class base can introduce a generic context. Calling a generic alias without
+explicit type arguments also remains valid.
+
+```py
+Alias = list[T]
+reveal_type(Alias[int]())  # revealed: list[int]
+Alias()
+
+class Derived(list[T]): ...
+```
+
+## Constructor calls in stubs
+
+Constructor calls in stubs follow the same scoping rules as calls in Python source files.
+
+```pyi
+from typing import TypeVar
+
+T = TypeVar("T")
+
+# error: [unbound-type-variable]
+list[T]()
+# error: [unbound-type-variable]
+items = list[T]()
+```
+
 ## Legacy typevar used multiple times
 
 > A type variable used in a generic function could be inferred to represent different types in the

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -183,6 +183,62 @@ def takes_list(value: ListAlias) -> None:
 takes_list([1])
 ```
 
+## Class-scoped type variables
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+A legacy generic alias binds its own type variables and cannot capture a type variable already bound
+to its enclosing class. The restriction also applies to stringified aliases.
+
+```py
+from typing import Generic, TypeAlias, TypeVar
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+class Box(Generic[T]):
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Items: TypeAlias = list[T]
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Quoted: TypeAlias = "list[T]"
+
+    Independent: TypeAlias = list[S]
+    Concrete: TypeAlias = list[int]
+
+reveal_type(Box.Independent[str]())  # revealed: list[str]
+reveal_type(Box.Concrete())  # revealed: list[int]
+```
+
+PEP 695 `type` statements can capture the enclosing class's type parameters, but using `TypeAlias`
+inside a PEP 695 class still follows the legacy alias rules.
+
+```py
+class Modern[T]:
+    type Items = list[T]
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Legacy: TypeAlias = list[T]
+```
+
+The same restriction applies to class-scoped `ParamSpec` and `TypeVarTuple` parameters.
+
+```py
+from typing import Callable, ParamSpec, TypeVarTuple
+
+P = ParamSpec("P")
+Ts = TypeVarTuple("Ts")
+
+class Callbacks(Generic[P]):
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `P`"
+    Callback: TypeAlias = Callable[P, None]
+
+class Tuples(Generic[*Ts]):
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `Ts`"
+    Items: TypeAlias = tuple[*Ts]
+```
+
 ## Subscripted generic alias in union
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1464,7 +1464,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.setup_dataclass_field_specifiers();
 
         match expression.kind(self.db()) {
-            ExpressionKind::CallTarget => {
+            ExpressionKind::Callee => {
                 self.context.inference_flags |= InferenceFlags::CHECK_UNBOUND_TYPEVARS;
                 self.infer_expression_impl(expression.node_ref(self.db()).node(self.module()), tcx);
             }
@@ -3453,7 +3453,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // If the RHS is not a standalone expression, this is a simple assignment
                     // (single target, no unpackings). That means it's a valid syntactic form
                     // for a legacy TypeVar creation; check for that.
-                    let callable_type = self.infer_call_target(&call_expr.func);
+                    let callable_type = self.infer_callee(&call_expr.func);
 
                     let ty = if let Some(namedtuple_kind) =
                         NamedTupleKind::from_type(self.db(), callable_type)
@@ -8856,7 +8856,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_expression: &ast::ExprCall,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        let callable_type = self.infer_call_target(&call_expression.func);
+        let callable_type = self.infer_callee(&call_expression.func);
 
         self.infer_call_expression_impl(call_expression, callable_type, tcx)
     }
@@ -8865,7 +8865,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ///
     /// An assignment such as `items = list[T]()` creates an instance, not a generic alias.
     /// Unlike `Items = list[T]`, it requires `T` to be bound in an enclosing generic scope.
-    fn infer_call_target(&mut self, expression: &ast::Expr) -> Type<'db> {
+    fn infer_callee(&mut self, expression: &ast::Expr) -> Type<'db> {
         let previous_binding_context = self.typevar_binding_context.take();
         let previous_check_unbound = self
             .context

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1464,6 +1464,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.setup_dataclass_field_specifiers();
 
         match expression.kind(self.db()) {
+            ExpressionKind::CallTarget => {
+                self.context.inference_flags |= InferenceFlags::CHECK_UNBOUND_TYPEVARS;
+                self.infer_expression_impl(expression.node_ref(self.db()).node(self.module()), tcx);
+            }
             ExpressionKind::Normal => {
                 self.infer_expression_impl(expression.node_ref(self.db()).node(self.module()), tcx);
             }
@@ -3449,10 +3453,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // If the RHS is not a standalone expression, this is a simple assignment
                     // (single target, no unpackings). That means it's a valid syntactic form
                     // for a legacy TypeVar creation; check for that.
-                    let callable_type = self.infer_maybe_standalone_expression(
-                        call_expr.func.as_ref(),
-                        TypeContext::default(),
-                    );
+                    let callable_type = self.infer_call_target(&call_expr.func);
 
                     let ty = if let Some(namedtuple_kind) =
                         NamedTupleKind::from_type(self.db(), callable_type)
@@ -8855,10 +8856,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_expression: &ast::ExprCall,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        let callable_type =
-            self.infer_maybe_standalone_expression(&call_expression.func, TypeContext::default());
+        let callable_type = self.infer_call_target(&call_expression.func);
 
         self.infer_call_expression_impl(call_expression, callable_type, tcx)
+    }
+
+    /// Infer a callable expression without introducing new type variable bindings.
+    ///
+    /// An assignment such as `items = list[T]()` creates an instance, not a generic alias.
+    /// Unlike `Items = list[T]`, it requires `T` to be bound in an enclosing generic scope.
+    fn infer_call_target(&mut self, expression: &ast::Expr) -> Type<'db> {
+        let previous_binding_context = self.typevar_binding_context.take();
+        let previous_check_unbound = self
+            .context
+            .inference_flags
+            .replace(InferenceFlags::CHECK_UNBOUND_TYPEVARS, true);
+        let callable_type =
+            self.infer_maybe_standalone_expression(expression, TypeContext::default());
+        self.context.inference_flags.set(
+            InferenceFlags::CHECK_UNBOUND_TYPEVARS,
+            previous_check_unbound,
+        );
+        self.typevar_binding_context = previous_binding_context;
+        callable_type
     }
 
     fn infer_empty_list_or_set_constructor(

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -22,6 +22,7 @@ use crate::types::signatures::{ConcatenateTail, Signature};
 use crate::types::special_form::{AliasSpec, LegacyStdlibAlias};
 use crate::types::string_annotation::parse_string_annotation;
 use crate::types::tuple::{TupleSpec, TupleSpecBuilder, TupleType};
+use ty_python_core::definition::DefinitionKind;
 use ty_python_core::scope::ScopeKind;
 
 use crate::types::{
@@ -135,7 +136,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 error.into_fallback_type(&self.context, annotation, self.inference_flags())
             });
-        self.check_for_unbound_type_variable(annotation, result_ty)
+        self.check_type_variable_scope(annotation, result_ty)
     }
 
     /// Infer the type of a type expression without storing the result.
@@ -3250,11 +3251,34 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
     }
 
-    /// Checks if the inferred type is an unbound type variable and reports a diagnostic if so.
+    /// Check whether a type variable can be used in the current type expression.
     ///
-    /// Returns `Unknown` as a fallback if the type variable is unbound, otherwise returns the
-    /// original type unchanged.
-    fn check_for_unbound_type_variable(&self, expression: &ast::Expr, ty: Type<'db>) -> Type<'db> {
+    /// Unbound variables fall back to `Unknown`. Bound variables retain their type so that an
+    /// invalid scope does not also make `Callable[P, R]` or `tuple[*Ts]` appear malformed.
+    fn check_type_variable_scope(&self, expression: &ast::Expr, ty: Type<'db>) -> Type<'db> {
+        let db = self.db();
+        // Legacy aliases introduce independent type parameters. PEP 695 aliases can instead
+        // capture their enclosing class's parameters.
+        if let Type::TypeVar(typevar) = ty
+            && self
+                .inference_flags()
+                .contains(InferenceFlags::IN_TYPE_ALIAS)
+            && self.typevar_binding_context.is_some_and(|definition| {
+                matches!(definition.kind(db), DefinitionKind::AnnotatedAssignment(_))
+            })
+            && let Some(owner) = typevar.binding_context(db).definition()
+            && matches!(owner.kind(db), DefinitionKind::Class(_))
+        {
+            self.report_invalid_type_expression(
+                expression,
+                format_args!(
+                    "Type alias cannot capture class-scoped type variable `{}`",
+                    typevar.name(db)
+                ),
+            );
+            return ty;
+        }
+
         if !self
             .inference_flags()
             .contains(InferenceFlags::CHECK_UNBOUND_TYPEVARS)


### PR DESCRIPTION
## Summary

Previously, we allowed constructor calls to use unbound type variables and legacy type aliases to capture their enclosing class's type parameters. We now report `unbound-type-variable` for the former and `invalid-type-form` for the latter.

```python
from typing import Generic, TypeAlias, TypeVar

T = TypeVar("T")

# Before: no errors. After: unbound-type-variable on each line.
list[T]()
items = list[T]()

class Box(Generic[T]):
    # Before: no error. After: invalid-type-form.
    Items: TypeAlias = list[T]
```

A constructor call cannot introduce a generic context: `items = list[T]()` creates an instance, whereas `Items = list[T]` defines a generic alias. Constructor type arguments must therefore be bound by an enclosing generic function or class. We preserve this distinction for standalone calls, assigned calls, and calls in stubs, including when the callable is inferred independently for reachability analysis.

Legacy aliases bind their own type parameters and cannot reuse parameters already bound to the enclosing class. Aliases with independent parameters, such as `Items: TypeAlias = list[S]` inside `Box[T]`, remain valid. PEP 695 `type` statements can capture enclosing class parameters and are unchanged. The alias check also covers stringified annotations, `ParamSpec`, and `TypeVarTuple`.

This moves [`generics_scoping`](https://github.com/python/typing/blob/cf943ccbea5596ef969eec6e2260097ff697b7ba/conformance/tests/generics_scoping.py) from Partial to Pass by reporting its two missing errors. No other conformance file's outcome changes.

<details>
<summary>Case analysis</summary>

Mypy 2.1.0, pyright 1.1.410, and pyrefly 1.3.0-dev.1 reject both unbound constructor calls and the class-scoped `TypeVar` alias above. They also accept constructor calls inside functions or methods where the type variable is bound, and aliases that introduce independent parameters. Pyrefly comparisons use its `default` preset.

For variadic parameters, pyright and pyrefly reject both captures below. Mypy rejects the `TypeVarTuple` capture but accepts the `ParamSpec` capture:

```python
from typing import Callable, Generic, ParamSpec, TypeAlias, TypeVarTuple

P = ParamSpec("P")
Ts = TypeVarTuple("Ts")

class Callbacks(Generic[P]):
    # ty, pyright, pyrefly: error; mypy: OK.
    Callback: TypeAlias = Callable[P, None]

class Tuples(Generic[*Ts]):
    # All four: error.
    Items: TypeAlias = tuple[*Ts]
```

The distinction between legacy aliases and PEP 695 aliases matters here. We continue to accept this alias, as do pyright and pyrefly. Mypy rejects it because `T` is not declared in the alias's own parameter list:

```python
class Modern[T]:
    # ty, pyright, pyrefly: OK; mypy: error.
    type Items = list[T]
```

</details>
