### PR TITLE
[ty] Report deprecations for overloads, operators, and properties

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/binary/unions.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/unions.md
@@ -58,8 +58,9 @@ def f5(m: int, n: Literal[-1, 0, 1]):
     return m / n
 ```
 
-Several combinations of union members divide by zero. Each expression gets one warning, including
-when the same operation appears again:
+Binary-operator diagnostics share state across union alternatives, so several combinations that
+divide by zero produce only one warning per expression. Each expression has its own state, so
+repeating the operation still produces a warning:
 
 ```py
 def f6(m: Literal[1, 2], n: Literal[0, 1]):

--- a/crates/ty_python_semantic/resources/mdtest/binary/unions.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/unions.md
@@ -57,3 +57,12 @@ def f5(m: int, n: Literal[-1, 0, 1]):
     # error: [division-by-zero] "Cannot divide object of type `int` by zero"
     return m / n
 ```
+
+Several union alternatives can divide by zero at the same expression. We report it once per
+expression, not once per operand combination:
+
+```py
+def f6(m: Literal[1, 2], n: Literal[-1, 0, 1]):
+    m / n  # error: [division-by-zero]
+    m / n  # error: [division-by-zero]
+```

--- a/crates/ty_python_semantic/resources/mdtest/binary/unions.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/unions.md
@@ -58,11 +58,11 @@ def f5(m: int, n: Literal[-1, 0, 1]):
     return m / n
 ```
 
-Several union alternatives can divide by zero at the same expression. We report it once per
-expression, not once per operand combination:
+Several combinations of union members divide by zero. Each expression gets one warning, including
+when the same operation appears again:
 
 ```py
-def f6(m: Literal[1, 2], n: Literal[-1, 0, 1]):
+def f6(m: Literal[1, 2], n: Literal[0, 1]):
     m / n  # error: [division-by-zero]
     m / n  # error: [division-by-zero]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -891,6 +891,17 @@ def check_marker(value: Old):
         value.value = 1  # error: [deprecated] "union setter"
 ```
 
+An invalid assignment to the first intersection in a union does not hide a deprecated setter in the
+second intersection. A member without the attribute still provides no alternative setter.
+
+```py
+def check_invalid_intersections(value: Wrong | Old):
+    if isinstance(value, Marker):
+        # error: [invalid-assignment]
+        # error: [deprecated] "union setter"
+        value.value = 1
+```
+
 ## Invalid property getter calls
 
 The getter below accepts an `int`, but Python passes a `C` instance. Reading the property reports
@@ -933,6 +944,25 @@ class Deprecated:
 def check(value: Ordinary):
     if isinstance(value, Deprecated):
         value.callback = lambda argument: reveal_type(argument)  # revealed: int
+```
+
+A protocol setter can also provide the inference context. When that setter accepts the assignment
+first, the ordinary attribute suppresses its deprecation without changing the inferred parameter
+type.
+
+```py
+from typing import Protocol
+
+class Callback(Protocol):
+    @property
+    def callback(self) -> Callable[[str], object]: ...
+    @callback.setter
+    @deprecated("callback setter")
+    def callback(self, value: Callable[[str], object]) -> None: ...
+
+def check_protocol(value: Callback):
+    if isinstance(value, Ordinary):
+        value.callback = lambda argument: reveal_type(argument)  # revealed: str
 ```
 
 ## Overloads

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -395,30 +395,30 @@ AliasClass()  # error: [deprecated] "Use OtherType instead"
 
 ### Binary operators
 
-If a dunder like `__add__` is deprecated, then the equivalent syntactic sugar like `+` should fire a
-diagnostic.
+Using `+` invokes `__add__`, so it reports that method's deprecation.
 
 ```py
 from typing_extensions import deprecated
 
-class MyInt:
-    def __init__(self, val):
-        self.val = val
+class Number:
+    @deprecated("old addition")
+    def __add__(self, other: object) -> "Number":
+        return self
 
-    @deprecated("MyInt `+` support is broken")
-    def __add__(self, other):
-        return MyInt(self.val + other.val)
+number = Number()
+number + 1  # error: [deprecated] "old addition"
+```
 
-x = MyInt(1)
-y = MyInt(2)
-z = x + y  # error: [deprecated] "MyInt `+` support is broken"
-x += y  # error: [deprecated] "MyInt `+` support is broken"
+Without an `__iadd__` method, `+=` falls back to `__add__` and reports the same deprecation.
+
+```py
+number += 1  # error: [deprecated] "old addition"
 ```
 
 ### Reflected operators
 
-Only the methods selected by operator resolution trigger deprecations. A deprecated reflected method
-is not used when the left operand accepts the operation.
+When the left operand accepts the operation, a deprecated `__radd__` on the right operand is not
+called and does not produce a warning.
 
 ```py
 from typing_extensions import deprecated
@@ -433,7 +433,12 @@ class Right:
         return 0
 
 Left() + Right()
-1 + Right()  # error: [deprecated] "reflected addition"
+```
+
+Here, `int.__add__` does not accept a `Right` instance, so `+` calls the deprecated
+`Right.__radd__`.
+
+```py
 1 + Right()  # error: [deprecated] "reflected addition"
 ```
 
@@ -455,8 +460,7 @@ RestrictedLeft() + ActiveRight()
 
 ### In-place operators
 
-Augmented assignment calls the in-place method when available, without reporting deprecations on the
-unused binary method.
+When `__iadd__` accepts the operand, `+=` uses it without calling a deprecated `__add__`.
 
 ```py
 from typing_extensions import deprecated
@@ -469,21 +473,25 @@ class Number:
     def __iadd__(self, other: int) -> "Number":
         return self
 
+number = Number()
+number += 1
+```
+
+A deprecated `__iadd__` produces a warning at the augmented assignment.
+
+```py
 class OldNumber:
     @deprecated("in-place addition")
     def __iadd__(self, other: int) -> "OldNumber":
         return self
 
-number = Number()
-number += 1
 old = OldNumber()
 old += 1  # error: [deprecated] "in-place addition"
 ```
 
 ### Callable instances
 
-Calling an instance implicitly invokes its `__call__` method. Explicit references to that method
-already report its deprecation and do not produce a second diagnostic when called.
+Calling an instance invokes its `__call__` method and reports that method's deprecation.
 
 ```py
 from typing_extensions import deprecated
@@ -495,14 +503,23 @@ class Invocable:
 
 invocable = Invocable()
 invocable()  # error: [deprecated] "do not call"
-invocable.__call__()  # error: [deprecated] "do not call"
-invocable.__call__  # error: [deprecated] "do not call"
 ```
+
+An explicit reference to `__call__` is also deprecated. Calling that reference still produces only
+one warning.
+
+```py
+invocable.__call__  # error: [deprecated] "do not call"
+invocable.__call__()  # error: [deprecated] "do not call"
+```
+
+### Overloaded callable instances
 
 For overloaded `__call__` methods, only calls that select a deprecated overload trigger a warning.
 
 ```py
 from typing import overload
+from typing_extensions import deprecated
 
 class Overloaded:
     @overload
@@ -561,8 +578,7 @@ def f(x: MyBits | NoBits):
 
 #### Unions and intersections
 
-A union reports a deprecated operator when any alternative is deprecated. An intersection reports
-deprecated operators only when every applicable implementation is deprecated.
+A unary operation on a union reports a deprecation if any member's operator is deprecated.
 
 ```py
 from typing_extensions import deprecated
@@ -572,21 +588,30 @@ class Deprecated:
     def __invert__(self) -> int:
         return 1
 
-class AlsoDeprecated:
-    @deprecated("another old inversion")
-    def __invert__(self) -> int:
-        return 2
-
 class Ordinary:
     def __invert__(self) -> int:
         return 3
 
 def mixed_union(value: Deprecated | Ordinary) -> None:
     ~value  # error: [deprecated] "old inversion"
+```
 
+An intersection can use a non-deprecated implementation instead, so it does not warn when one is
+available.
+
+```py
 def mixed_intersection(value: Deprecated) -> None:
     if isinstance(value, Ordinary):
         ~value
+```
+
+When every applicable implementation is deprecated, one warning includes both messages.
+
+```py
+class AlsoDeprecated:
+    @deprecated("another old inversion")
+    def __invert__(self) -> int:
+        return 2
 
 def deprecated_intersection(value: Deprecated) -> None:
     if isinstance(value, AlsoDeprecated):
@@ -595,7 +620,7 @@ def deprecated_intersection(value: Deprecated) -> None:
 ```
 
 A gradually typed comparison can produce an intersection of `bool` and `Any`. The unknown
-alternative might provide a nondeprecated operator, so inverting it should not warn.
+alternative might provide a non-deprecated operator, so inverting it should not warn.
 
 ```py
 from typing import Any
@@ -622,7 +647,8 @@ def f(x: bool):
 
 #### Constrained TypeVars
 
-Type variable constraints also should be checked.
+A unary operation on a constrained type variable can invoke the method from any of its constraints.
+If several methods are deprecated, their messages appear in one diagnostic.
 
 ```py
 from typing import TypeVar
@@ -696,9 +722,8 @@ def invalid_operator(value: X) -> None:
 
 ## Property accessors
 
-Only the accessor invoked by an operation triggers its deprecation. Reading a property does not
-invoke its setter, writing does not invoke its getter, and deleting does not invoke either.
-Augmented assignment reads and then writes the property.
+Reading a property invokes its getter. A deprecated getter produces a warning on a read, but not on
+an assignment or deletion.
 
 ```py
 from typing_extensions import deprecated
@@ -717,10 +742,13 @@ class OldGetter:
 old_getter = OldGetter()
 old_getter.value  # error: [deprecated] "old getter"
 old_getter.value = 1
-old_getter.value += 1  # error: [deprecated] "old getter"
 del old_getter.value
-OldGetter.value
+```
 
+Assignments and deletions invoke the setter and deleter, respectively. Neither accessor is called
+when reading the property.
+
+```py
 class OldSetter:
     @property
     def value(self) -> int:
@@ -736,14 +764,23 @@ class OldSetter:
 old_setter = OldSetter()
 old_setter.value
 old_setter.value = 1  # error: [deprecated] "old setter"
-old_setter.value += 1  # error: [deprecated] "old setter"
 del old_setter.value  # error: [deprecated] "old deleter"
-OldSetter.value
 ```
 
-When both accessors are deprecated, augmented assignment reports both messages.
+Access through the class returns the property object without invoking its deprecated getter.
 
 ```py
+OldGetter.value
+```
+
+## Augmented property assignments
+
+Augmented assignment reads and then writes the property. When both the getter and setter are
+deprecated, it reports each accessor's deprecation.
+
+```py
+from typing_extensions import deprecated
+
 class OldBoth:
     @property
     @deprecated("both getter")
@@ -762,9 +799,8 @@ old_both.value += 1
 
 ## Inherited properties
 
-Inherited accessors retain their deprecations. An override can replace a deprecated getter, while
-access through `super()` still invokes the inherited getter. Class-bound `super()` returns the
-property object without invoking its getter.
+Reading or deleting the property on a subclass instance reports the inherited accessor's
+deprecation.
 
 ```py
 from typing_extensions import deprecated
@@ -781,23 +817,58 @@ class Parent:
 
 class Child(Parent): ...
 
+Child().value  # error: [deprecated] "parent getter"
+del Child().value  # error: [deprecated] "parent deleter"
+```
+
+Overriding the getter with a non-deprecated method removes the deprecation on reads.
+
+```py
 class ActiveChild(Parent):
     @property
     def value(self) -> int:
-        return super().value  # error: [deprecated] "parent getter"
+        return 0
 
-Child().value  # error: [deprecated] "parent getter"
 ActiveChild().value
+```
+
+## Properties accessed through `super()`
+
+Reading a property through `super()` invokes the parent getter with the instance as its receiver.
+
+```py
+from typing_extensions import deprecated
+
+class Parent:
+    @property
+    @deprecated("parent getter")
+    def value(self) -> int:
+        return 0
+
+    @value.deleter
+    @deprecated("parent deleter")
+    def value(self) -> None: ...
+
+class Child(Parent):
+    def read(self) -> int:
+        return super().value  # error: [deprecated] "parent getter"
+```
+
+Binding `super()` to a class instead returns the property object without invoking its getter.
+
+```py
 super(Child, Child).value
 ```
 
-Deleting through an instance invokes the inherited deleter. `super()` delegates reads to the owner's
-descriptors, but it does not delegate deletion.
+Deleting an attribute on a `super()` object does not invoke the parent's property deleter.
 
 ```py
-del Child().value  # error: [deprecated] "parent deleter"
 del super(Child, Child()).value
+```
 
+The same holds when the receiver may be either a `super()` object or an ordinary instance.
+
+```py
 class Ordinary:
     value: int
 
@@ -809,7 +880,7 @@ def delete_union(flag: bool):
 ## Metaclass properties
 
 A class is an instance of its metaclass, so reading or writing a metaclass property invokes its
-accessors. Access through the metaclass itself returns the property object.
+accessors.
 
 ```py
 from typing_extensions import deprecated
@@ -828,13 +899,17 @@ class C(metaclass=Meta): ...
 
 C.value  # error: [deprecated] "metaclass getter"
 C.value = 1  # error: [deprecated] "metaclass setter"
+```
+
+Access through the metaclass itself returns the property object without invoking its getter.
+
+```py
 Meta.value
 ```
 
 ## Properties on unions
 
-An access through a union can invoke a deprecated accessor even when another member's accessor is
-not deprecated.
+An attribute access through a union warns if any member uses a deprecated property.
 
 ```py
 from typing_extensions import deprecated
@@ -850,7 +925,7 @@ class Old:
     def value(self, value: int) -> None: ...
 
 class Active:
-    value: int = 0
+    value: int
 
 def check(value: Old | Active):
     value.value  # error: [deprecated] "union getter"
@@ -869,37 +944,56 @@ def check_invalid(value: Wrong | Old):
     value.value = 1
 ```
 
-An intersection can obtain its implementation from a non-deprecated member. We do not warn when that
-member provides an alternative getter or setter.
+An invalid assignment still reports deprecations after an `isinstance` check narrows the union's
+members to intersections.
 
 ```py
-def check_intersection(value: Old):
+class Marker: ...
+
+def check_invalid_intersections(value: Wrong | Old):
+    if isinstance(value, Marker):
+        # error: [invalid-assignment]
+        # error: [deprecated] "union setter"
+        value.value = 1
+```
+
+## Properties on intersections
+
+An intersection can use a non-deprecated member's attribute instead of a deprecated property. We do
+not warn when that alternative is available.
+
+```py
+from typing_extensions import deprecated
+
+class Old:
+    @property
+    @deprecated("old getter")
+    def value(self) -> int:
+        return 0
+
+    @value.setter
+    @deprecated("old setter")
+    def value(self, value: int) -> None: ...
+
+class Active:
+    value: int
+
+def check(value: Old):
     if isinstance(value, Active):
         value.value
         value.value = 1
 ```
 
-An intersection member without the attribute does not provide an alternative accessor, so the
-deprecated property still applies.
+A member without the attribute does not provide an alternative accessor, so the deprecated property
+still applies.
 
 ```py
 class Marker: ...
 
 def check_marker(value: Old):
     if isinstance(value, Marker):
-        value.value  # error: [deprecated] "union getter"
-        value.value = 1  # error: [deprecated] "union setter"
-```
-
-An invalid assignment to the first intersection in a union does not hide a deprecated setter in the
-second intersection. A member without the attribute still provides no alternative setter.
-
-```py
-def check_invalid_intersections(value: Wrong | Old):
-    if isinstance(value, Marker):
-        # error: [invalid-assignment]
-        # error: [deprecated] "union setter"
-        value.value = 1
+        value.value  # error: [deprecated] "old getter"
+        value.value = 1  # error: [deprecated] "old setter"
 ```
 
 ## Invalid property getter calls
@@ -923,9 +1017,8 @@ C().value
 
 ## Setter deprecations and contextual inference
 
-An intersection can use an ordinary attribute annotation to infer a lambda's parameter type.
-Checking the other member's deprecated setter does not replace that inference context, and the
-ordinary attribute provides a non-deprecated alternative.
+The ordinary attribute supplies `int` as the lambda's parameter type. Checking the other member's
+deprecated setter does not change that inferred type or warn about the non-deprecated assignment.
 
 ```py
 from collections.abc import Callable
@@ -946,9 +1039,7 @@ def check(value: Ordinary):
         value.callback = lambda argument: reveal_type(argument)  # revealed: int
 ```
 
-A protocol setter can also provide the inference context. When that setter accepts the assignment
-first, the ordinary attribute suppresses its deprecation without changing the inferred parameter
-type.
+Deprecation checks also preserve the `str` parameter type inferred from a protocol setter.
 
 ```py
 from typing import Protocol
@@ -967,11 +1058,12 @@ def check_protocol(value: Callback):
 
 ## Overloads
 
-Overloads can be deprecated, but only trigger warnings when invoked.
+### Deprecated overloads
+
+A call reports the deprecation of the overload selected by its arguments.
 
 ```py
-from typing_extensions import deprecated
-from typing_extensions import overload
+from typing_extensions import deprecated, overload
 
 @overload
 @deprecated("strings are no longer supported")
@@ -983,31 +1075,39 @@ def f(x):
 
 f(1)
 f("hello")  # error: [deprecated] "strings are no longer supported"
-f  # Referring to the overloaded function does not select an overload.
 ```
 
-If the actual impl is deprecated, the deprecation always fires.
+Referring to the function without calling it does not select an overload and does not warn.
 
 ```py
-from typing_extensions import deprecated
-from typing_extensions import overload
+f
+```
+
+### Deprecated implementations
+
+A deprecated implementation makes every call deprecated. Its message takes precedence over an
+individual overload's deprecation, and a call produces only one warning.
+
+```py
+from typing_extensions import deprecated, overload
 
 @overload
+@deprecated("string overload")
 def f(x: str): ...
 @overload
 def f(x: int): ...
-@deprecated("unusable")
+@deprecated("entire function")
 def f(x):
     print(x)
 
-f(1)  # error: [deprecated] "unusable"
-f("hello")  # error: [deprecated] "unusable"
+f(1)  # error: [deprecated] "entire function"
+f("hello")  # error: [deprecated] "entire function"
 ```
 
-## Overload selection
+### Union arguments
 
-Calls with union arguments can select multiple overloads. We report a deprecation if one of those
-overloads is deprecated, but do not report one when no overload accepts the arguments.
+A union argument can match several overloads. The call reports a deprecation if any matching
+overload is deprecated.
 
 ```py
 from typing import overload
@@ -1023,16 +1123,18 @@ def convert(value: int | str) -> str:
 
 def check(value: int | str):
     convert(value)  # error: [deprecated] "use a string"
+```
 
-convert(1)  # error: [deprecated] "use a string"
-convert("one")
+If no overload accepts the argument, there is no selected overload to report as deprecated.
+
+```py
 convert(None)  # error: [no-matching-overload]
 ```
 
-## Specialized receivers
+### Overloads for different receivers
 
-Binding a method can remove overloads whose receiver annotations are incompatible with the instance.
-Deprecation messages still refer to the selected source overload.
+The `self` annotations restrict which overloads each instance can call. A call on `C[str]` reports
+the deprecated string overload, even though binding the method discards the integer overload.
 
 ```py
 from typing import Generic, TypeVar, overload
@@ -1054,32 +1156,9 @@ def check(integer: C[int], string: C[str]):
     string.method("one")  # error: [deprecated] "string method"
 ```
 
-## Deprecated overload and implementation
+## Calls to an inherited deprecated method
 
-When both the implementation and a selected overload are deprecated, the reference to the function
-already reports the implementation's deprecation. We do not emit a second diagnostic for the call.
-
-```py
-from typing import overload
-from typing_extensions import deprecated
-
-@overload
-@deprecated("integer overload")
-def convert(value: int) -> str: ...
-@overload
-def convert(value: str) -> str: ...
-@deprecated("entire function")
-def convert(value: int | str) -> str:
-    return str(value)
-
-convert(1)  # error: [deprecated] "entire function"
-convert("one")  # error: [deprecated] "entire function"
-```
-
-## Repeated inherited deprecations
-
-Both union alternatives can inherit the same deprecated method. Calling it reports that source
-method once at each call site, rather than once per possible receiver.
+When both union members inherit the same deprecated method, a call reports that method once.
 
 ```py
 from typing_extensions import deprecated
@@ -1093,21 +1172,24 @@ class Second(Base): ...
 
 def check(value: First | Second):
     value()  # error: [deprecated] "base call"
-    value()  # error: [deprecated] "base call"
-
-    # error: [deprecated] "base call"
-    # error: [deprecated] "base call"
-    (value(), value())
-
-    value()  # ty: ignore[deprecated]
-    if False:
-        value()
 ```
 
-The same applies to an inherited overload selected through multiple possible receivers.
+Separate calls each produce a warning, even when they are on the same line.
+
+```py
+def two_calls(value: First | Second):
+    # error: 6 [deprecated] "base call"
+    # error: 15 [deprecated] "base call"
+    (value(), value())
+```
+
+## Calls to an inherited deprecated overload
+
+A deprecated overload inherited by both members of a union also produces only one warning per call.
 
 ```py
 from typing import overload
+from typing_extensions import deprecated
 
 class Overloaded:
     @overload
@@ -1125,20 +1207,41 @@ def check_overload(value: FirstOverload | SecondOverload):
     value("one")
 ```
 
-Calls inside a `no_type_check` function remain silent.
+## Suppressing call deprecations
+
+An inline ignore suppresses the deprecation on an instance's implicit `__call__` invocation.
+
+```py
+from typing_extensions import deprecated
+
+class Callable:
+    @deprecated("do not call")
+    def __call__(self) -> None: ...
+
+Callable()()  # ty: ignore[deprecated]
+```
+
+An unreachable call does not produce a warning.
+
+```py
+if False:
+    Callable()()
+```
+
+The same applies to calls inside a `no_type_check` function.
 
 ```py
 from typing import no_type_check
 
 @no_type_check
-def unchecked(value: First | Second):
+def unchecked(value: Callable):
     value()
 ```
 
-## Repeated binary deprecations
+## Repeated binary operations
 
-Expanding union operands can select the same deprecated operator repeatedly. The expression reports
-the method once, even when both operands are unions.
+Several combinations of union members can invoke the same deprecated operator. Each expression
+reports that method once. Repeating the operation still produces a warning at the second expression.
 
 ```py
 from typing_extensions import Self, deprecated
@@ -1156,8 +1259,15 @@ def check(number: First | Second, value: int | str):
     number + value  # error: [deprecated] "addition"
 ```
 
-Augmented assignment also collects the selected methods across union alternatives, including a
-fallback from `__iadd__` to `__add__`.
+The same rule applies when augmented assignment falls back to `__add__`.
+
+```py
+def check_augmented(number: First | Second, value: int | str):
+    number += value  # error: [deprecated] "addition"
+```
+
+When some members provide `__iadd__` and others fall back to `__add__`, the warning includes the
+deprecations of both methods.
 
 ```py
 class InPlace(Number):
@@ -1165,17 +1275,14 @@ class InPlace(Number):
     def __iadd__(self, other: int | str) -> Self:
         return self
 
-def check_augmented(number: First | Second, value: int | str):
-    number += value  # error: [deprecated] "addition"
-
 def check_mixed(number: First | InPlace, value: int | str):
     number += value  # error: [deprecated] "addition; in-place addition"
 ```
 
-## Multiple deprecated targets
+## Calls to different deprecated methods
 
-Distinct deprecated implementations remain visible in a single diagnostic. Each source declaration
-is annotated once, even when several union alternatives inherit it.
+When a call can invoke different deprecated methods, one warning includes both messages and points
+to both method definitions. Inherited copies of the same method are listed only once.
 
 ```py
 from typing_extensions import deprecated

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -590,8 +590,7 @@ def mixed_intersection(value: Deprecated) -> None:
 
 def deprecated_intersection(value: Deprecated) -> None:
     if isinstance(value, AlsoDeprecated):
-        # error: [deprecated] "old inversion"
-        # error: [deprecated] "old inversion"
+        # error: [deprecated] "old inversion; another old inversion"
         ~value
 ```
 
@@ -642,8 +641,7 @@ class Second:
 T = TypeVar("T", First, Second)
 
 def f(value: T) -> None:
-    # error: [deprecated] "first"
-    # error: [deprecated] "second"
+    # error: [deprecated] "first; second"
     ~value
 ```
 
@@ -675,8 +673,7 @@ W = TypeVar("W", First | Third, Second)
 
 def nested_union(value: W) -> None:
     # error: [unsupported-operator]
-    # error: [deprecated] "first"
-    # error: [deprecated] "second"
+    # error: [deprecated] "first; second"
     ~value
 ```
 
@@ -693,8 +690,7 @@ X = TypeVar("X", Invalid, Second)
 
 def invalid_operator(value: X) -> None:
     # error: [unsupported-operator]
-    # error: [deprecated] "invalid inversion"
-    # error: [deprecated] "second"
+    # error: [deprecated] "invalid inversion; second"
     ~value
 ```
 
@@ -961,4 +957,141 @@ def convert(value: int | str) -> str:
 
 convert(1)  # error: [deprecated] "entire function"
 convert("one")  # error: [deprecated] "entire function"
+```
+
+## Repeated inherited deprecations
+
+Both union alternatives can inherit the same deprecated method. Calling it reports that source
+method once at each call site, rather than once per possible receiver.
+
+```py
+from typing_extensions import deprecated
+
+class Base:
+    @deprecated("base call")
+    def __call__(self) -> None: ...
+
+class First(Base): ...
+class Second(Base): ...
+
+def check(value: First | Second):
+    value()  # error: [deprecated] "base call"
+    value()  # error: [deprecated] "base call"
+
+    # error: [deprecated] "base call"
+    # error: [deprecated] "base call"
+    (value(), value())
+
+    value()  # ty: ignore[deprecated]
+    if False:
+        value()
+```
+
+The same applies to an inherited overload selected through multiple possible receivers.
+
+```py
+from typing import overload
+
+class Overloaded:
+    @overload
+    @deprecated("integer call")
+    def __call__(self, value: int) -> None: ...
+    @overload
+    def __call__(self, value: str) -> None: ...
+    def __call__(self, value: int | str) -> None: ...
+
+class FirstOverload(Overloaded): ...
+class SecondOverload(Overloaded): ...
+
+def check_overload(value: FirstOverload | SecondOverload):
+    value(1)  # error: [deprecated] "integer call"
+    value("one")
+```
+
+Calls inside a `no_type_check` function remain silent.
+
+```py
+from typing import no_type_check
+
+@no_type_check
+def unchecked(value: First | Second):
+    value()
+```
+
+## Repeated binary deprecations
+
+Expanding union operands can select the same deprecated operator repeatedly. The expression reports
+the method once, even when both operands are unions.
+
+```py
+from typing_extensions import Self, deprecated
+
+class Number:
+    @deprecated("addition")
+    def __add__(self, other: int | str) -> Self:
+        return self
+
+class First(Number): ...
+class Second(Number): ...
+
+def check(number: First | Second, value: int | str):
+    number + value  # error: [deprecated] "addition"
+    number + value  # error: [deprecated] "addition"
+```
+
+Augmented assignment also collects the selected methods across union alternatives, including a
+fallback from `__iadd__` to `__add__`.
+
+```py
+class InPlace(Number):
+    @deprecated("in-place addition")
+    def __iadd__(self, other: int | str) -> Self:
+        return self
+
+def check_augmented(number: First | Second, value: int | str):
+    number += value  # error: [deprecated] "addition"
+
+def check_mixed(number: First | InPlace, value: int | str):
+    number += value  # error: [deprecated] "addition; in-place addition"
+```
+
+## Multiple deprecated targets
+
+Distinct deprecated implementations remain visible in a single diagnostic. Each source declaration
+is annotated once, even when several union alternatives inherit it.
+
+```py
+from typing_extensions import deprecated
+
+class First:
+    @deprecated("first message")
+    def __call__(self) -> None: ...
+
+class Second:
+    @deprecated("second message")
+    def __call__(self) -> None: ...
+
+class Inherited(First): ...
+
+def check(value: First | Second | Inherited):
+    # snapshot: deprecated
+    value()
+```
+
+```snapshot
+warning[deprecated]: Use of deprecated functions
+  --> src/mdtest_snippet.py:15:5
+   |
+15 |     value()
+   |     ^^^^^ first message; second message
+   |
+  ::: src/mdtest_snippet.py:5:9
+   |
+ 5 |     def __call__(self) -> None: ...
+   |         -------- first message
+ 6 |
+ 7 | class Second:
+ 8 |     @deprecated("second message")
+ 9 |     def __call__(self) -> None: ...
+   |         -------- second message
 ```

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -411,7 +411,111 @@ class MyInt:
 
 x = MyInt(1)
 y = MyInt(2)
-z = x + y  # TODO error: [deprecated] "MyInt `+` support is broken"
+z = x + y  # error: [deprecated] "MyInt `+` support is broken"
+x += y  # error: [deprecated] "MyInt `+` support is broken"
+```
+
+### Reflected operators
+
+Only the methods selected by operator resolution trigger deprecations. A deprecated reflected
+method is not used when the left operand accepts the operation.
+
+```py
+from typing_extensions import deprecated
+
+class Left:
+    def __add__(self, other: object) -> int:
+        return 0
+
+class Right:
+    @deprecated("reflected addition")
+    def __radd__(self, other: object) -> int:
+        return 0
+
+Left() + Right()
+1 + Right()  # error: [deprecated] "reflected addition"
+1 + Right()  # error: [deprecated] "reflected addition"
+```
+
+A deprecated method whose parameter does not accept the other operand does not trigger a warning
+when a compatible reflected method is available.
+
+```py
+class RestrictedLeft:
+    @deprecated("integer addition")
+    def __add__(self, other: int) -> int:
+        return 0
+
+class ActiveRight:
+    def __radd__(self, other: object) -> int:
+        return 0
+
+RestrictedLeft() + ActiveRight()
+```
+
+### In-place operators
+
+Augmented assignment calls the in-place method when available, without reporting deprecations on
+the unused binary method.
+
+```py
+from typing_extensions import deprecated
+
+class Number:
+    @deprecated("binary addition")
+    def __add__(self, other: int) -> "Number":
+        return self
+
+    def __iadd__(self, other: int) -> "Number":
+        return self
+
+class OldNumber:
+    @deprecated("in-place addition")
+    def __iadd__(self, other: int) -> "OldNumber":
+        return self
+
+number = Number()
+number += 1
+old = OldNumber()
+old += 1  # error: [deprecated] "in-place addition"
+```
+
+### Callable instances
+
+Calling an instance implicitly invokes its `__call__` method. Explicit references to that method
+already report its deprecation and do not produce a second diagnostic when called.
+
+```py
+from typing_extensions import deprecated
+
+class Invocable:
+    @deprecated("do not call")
+    def __call__(self) -> int:
+        return 0
+
+invocable = Invocable()
+invocable()  # error: [deprecated] "do not call"
+invocable.__call__()  # error: [deprecated] "do not call"
+invocable.__call__  # error: [deprecated] "do not call"
+```
+
+For overloaded `__call__` methods, only calls that select a deprecated overload trigger a warning.
+
+```py
+from typing import overload
+
+class Overloaded:
+    @overload
+    @deprecated("integer call")
+    def __call__(self, value: int) -> int: ...
+    @overload
+    def __call__(self, value: str) -> str: ...
+    def __call__(self, value: int | str) -> int | str:
+        return value
+
+overloaded = Overloaded()
+overloaded(1)  # error: [deprecated] "integer call"
+overloaded("one")
 ```
 
 ### Unary operators

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -417,8 +417,8 @@ x += y  # error: [deprecated] "MyInt `+` support is broken"
 
 ### Reflected operators
 
-Only the methods selected by operator resolution trigger deprecations. A deprecated reflected
-method is not used when the left operand accepts the operation.
+Only the methods selected by operator resolution trigger deprecations. A deprecated reflected method
+is not used when the left operand accepts the operation.
 
 ```py
 from typing_extensions import deprecated
@@ -455,8 +455,8 @@ RestrictedLeft() + ActiveRight()
 
 ### In-place operators
 
-Augmented assignment calls the in-place method when available, without reporting deprecations on
-the unused binary method.
+Augmented assignment calls the in-place method when available, without reporting deprecations on the
+unused binary method.
 
 ```py
 from typing_extensions import deprecated
@@ -698,6 +698,160 @@ def invalid_operator(value: X) -> None:
     ~value
 ```
 
+## Property accessors
+
+Only the accessor invoked by an operation triggers its deprecation. Reading a property does not
+invoke its setter, writing does not invoke its getter, and deleting does not invoke either.
+Augmented assignment reads and then writes the property.
+
+```py
+from typing_extensions import deprecated
+
+class OldGetter:
+    @property
+    @deprecated("old getter")
+    def value(self) -> int:
+        return 0
+
+    @value.setter
+    def value(self, value: int) -> None: ...
+    @value.deleter
+    def value(self) -> None: ...
+
+old_getter = OldGetter()
+old_getter.value  # error: [deprecated] "old getter"
+old_getter.value = 1
+old_getter.value += 1  # error: [deprecated] "old getter"
+del old_getter.value
+OldGetter.value
+
+class OldSetter:
+    @property
+    def value(self) -> int:
+        return 0
+
+    @value.setter
+    @deprecated("old setter")
+    def value(self, value: int) -> None: ...
+    @value.deleter
+    @deprecated("old deleter")
+    def value(self) -> None: ...
+
+old_setter = OldSetter()
+old_setter.value
+old_setter.value = 1  # error: [deprecated] "old setter"
+old_setter.value += 1  # error: [deprecated] "old setter"
+del old_setter.value  # error: [deprecated] "old deleter"
+OldSetter.value
+```
+
+When both accessors are deprecated, augmented assignment reports both messages.
+
+```py
+class OldBoth:
+    @property
+    @deprecated("both getter")
+    def value(self) -> int:
+        return 0
+
+    @value.setter
+    @deprecated("both setter")
+    def value(self, value: int) -> None: ...
+
+old_both = OldBoth()
+# error: [deprecated] "both getter"
+# error: [deprecated] "both setter"
+old_both.value += 1
+```
+
+## Inherited properties
+
+Inherited accessors retain their deprecations. An override can replace a deprecated getter, while
+access through `super()` still invokes the inherited getter. Class-bound `super()` returns the
+property object without invoking its getter.
+
+```py
+from typing_extensions import deprecated
+
+class Parent:
+    @property
+    @deprecated("parent getter")
+    def value(self) -> int:
+        return 0
+
+class Child(Parent): ...
+
+class ActiveChild(Parent):
+    @property
+    def value(self) -> int:
+        return super().value  # error: [deprecated] "parent getter"
+
+Child().value  # error: [deprecated] "parent getter"
+ActiveChild().value
+super(Child, Child).value
+```
+
+## Metaclass properties
+
+A class is an instance of its metaclass, so reading or writing a metaclass property invokes its
+accessors. Access through the metaclass itself returns the property object.
+
+```py
+from typing_extensions import deprecated
+
+class Meta(type):
+    @property
+    @deprecated("metaclass getter")
+    def value(cls) -> int:
+        return 0
+
+    @value.setter
+    @deprecated("metaclass setter")
+    def value(cls, value: int) -> None: ...
+
+class C(metaclass=Meta): ...
+
+C.value  # error: [deprecated] "metaclass getter"
+C.value = 1  # error: [deprecated] "metaclass setter"
+Meta.value
+```
+
+## Properties on unions
+
+An access through a union can invoke a deprecated accessor even when another member's accessor is
+not deprecated.
+
+```py
+from typing_extensions import deprecated
+
+class Old:
+    @property
+    @deprecated("union getter")
+    def value(self) -> int:
+        return 0
+
+    @value.setter
+    @deprecated("union setter")
+    def value(self, value: int) -> None: ...
+
+class Active:
+    value: int = 0
+
+def check(value: Old | Active):
+    value.value  # error: [deprecated] "union getter"
+    value.value = 1  # error: [deprecated] "union setter"
+```
+
+An intersection can obtain its implementation from a non-deprecated member. We do not warn when that
+member provides an alternative getter or setter.
+
+```py
+def check_intersection(value: Old):
+    if isinstance(value, Active):
+        value.value
+        value.value = 1
+```
+
 ## Overloads
 
 Overloads can be deprecated, but only trigger warnings when invoked.
@@ -764,8 +918,8 @@ convert(None)  # error: [no-matching-overload]
 
 ## Specialized receivers
 
-Binding a method can remove overloads whose receiver annotations are incompatible with the
-instance. Deprecation messages still refer to the selected source overload.
+Binding a method can remove overloads whose receiver annotations are incompatible with the instance.
+Deprecation messages still refer to the selected source overload.
 
 ```py
 from typing import Generic, TypeVar, overload

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -775,6 +775,10 @@ class Parent:
     def value(self) -> int:
         return 0
 
+    @value.deleter
+    @deprecated("parent deleter")
+    def value(self) -> None: ...
+
 class Child(Parent): ...
 
 class ActiveChild(Parent):
@@ -785,6 +789,21 @@ class ActiveChild(Parent):
 Child().value  # error: [deprecated] "parent getter"
 ActiveChild().value
 super(Child, Child).value
+```
+
+Deleting through an instance invokes the inherited deleter. `super()` delegates reads to the owner's
+descriptors, but it does not delegate deletion.
+
+```py
+del Child().value  # error: [deprecated] "parent deleter"
+del super(Child, Child()).value
+
+class Ordinary:
+    value: int
+
+def delete_union(flag: bool):
+    target = super(Child, Child()) if flag else Ordinary()
+    del target.value
 ```
 
 ## Metaclass properties
@@ -838,6 +857,18 @@ def check(value: Old | Active):
     value.value = 1  # error: [deprecated] "union setter"
 ```
 
+An invalid assignment on one union member does not hide a deprecated setter on another member.
+
+```py
+class Wrong:
+    value: str
+
+def check_invalid(value: Wrong | Old):
+    # error: [invalid-assignment]
+    # error: [deprecated] "union setter"
+    value.value = 1
+```
+
 An intersection can obtain its implementation from a non-deprecated member. We do not warn when that
 member provides an alternative getter or setter.
 
@@ -846,6 +877,62 @@ def check_intersection(value: Old):
     if isinstance(value, Active):
         value.value
         value.value = 1
+```
+
+An intersection member without the attribute does not provide an alternative accessor, so the
+deprecated property still applies.
+
+```py
+class Marker: ...
+
+def check_marker(value: Old):
+    if isinstance(value, Marker):
+        value.value  # error: [deprecated] "union getter"
+        value.value = 1  # error: [deprecated] "union setter"
+```
+
+## Invalid property getter calls
+
+The getter below accepts an `int`, but Python passes a `C` instance. Reading the property reports
+both the invalid call and the deprecation.
+
+```py
+from typing_extensions import deprecated
+
+class C:
+    @property
+    @deprecated("invalid getter")
+    def value(self: int) -> int:
+        return self
+
+# error: [invalid-attribute-access]
+# error: [deprecated] "invalid getter"
+C().value
+```
+
+## Setter deprecations and contextual inference
+
+An intersection can use an ordinary attribute annotation to infer a lambda's parameter type.
+Checking the other member's deprecated setter does not replace that inference context, and the
+ordinary attribute provides a non-deprecated alternative.
+
+```py
+from collections.abc import Callable
+from typing_extensions import deprecated
+
+class Ordinary:
+    callback: Callable[[int], object]
+
+class Deprecated:
+    @property
+    def callback(self) -> object: ...
+    @callback.setter
+    @deprecated("old setter")
+    def callback(self, value: Callable[[str], object]) -> None: ...
+
+def check(value: Ordinary):
+    if isinstance(value, Deprecated):
+        value.callback = lambda argument: reveal_type(argument)  # revealed: int
 ```
 
 ## Overloads

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -611,7 +611,8 @@ def f(x):
     print(x)
 
 f(1)
-f("hello")  # TODO: error: [deprecated] "strings are no longer supported"
+f("hello")  # error: [deprecated] "strings are no longer supported"
+f  # Referring to the overloaded function does not select an overload.
 ```
 
 If the actual impl is deprecated, the deprecation always fires.
@@ -630,4 +631,76 @@ def f(x):
 
 f(1)  # error: [deprecated] "unusable"
 f("hello")  # error: [deprecated] "unusable"
+```
+
+## Overload selection
+
+Calls with union arguments can select multiple overloads. We report a deprecation if one of those
+overloads is deprecated, but do not report one when no overload accepts the arguments.
+
+```py
+from typing import overload
+from typing_extensions import deprecated
+
+@overload
+@deprecated("use a string")
+def convert(value: int) -> str: ...
+@overload
+def convert(value: str) -> str: ...
+def convert(value: int | str) -> str:
+    return str(value)
+
+def check(value: int | str):
+    convert(value)  # error: [deprecated] "use a string"
+
+convert(1)  # error: [deprecated] "use a string"
+convert("one")
+convert(None)  # error: [no-matching-overload]
+```
+
+## Specialized receivers
+
+Binding a method can remove overloads whose receiver annotations are incompatible with the
+instance. Deprecation messages still refer to the selected source overload.
+
+```py
+from typing import Generic, TypeVar, overload
+from typing_extensions import deprecated
+
+T = TypeVar("T")
+
+class C(Generic[T]):
+    @overload
+    def method(self: "C[int]", value: int) -> int: ...
+    @overload
+    @deprecated("string method")
+    def method(self: "C[str]", value: str) -> str: ...
+    def method(self, value: int | str) -> int | str:
+        return value
+
+def check(integer: C[int], string: C[str]):
+    integer.method(1)
+    string.method("one")  # error: [deprecated] "string method"
+```
+
+## Deprecated overload and implementation
+
+When both the implementation and a selected overload are deprecated, the reference to the function
+already reports the implementation's deprecation. We do not emit a second diagnostic for the call.
+
+```py
+from typing import overload
+from typing_extensions import deprecated
+
+@overload
+@deprecated("integer overload")
+def convert(value: int) -> str: ...
+@overload
+def convert(value: str) -> str: ...
+@deprecated("entire function")
+def convert(value: int | str) -> str:
+    return str(value)
+
+convert(1)  # error: [deprecated] "entire function"
+convert("one")  # error: [deprecated] "entire function"
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -707,7 +707,7 @@ enum MemberLookupErrorKind<'db> {
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct MemberLookupError<'db> {
     #[returns(copy)]
-    fallback_member: PlaceAndQualifiers<'db>,
+    fallback_member: ResolvedMember<'db>,
     #[returns(copy)]
     kind: MemberLookupErrorKind<'db>,
 }
@@ -833,13 +833,84 @@ impl<'db> MemberLookupError<'db> {
 ///
 /// Unlike [`crate::place::LookupResult`], errors here describe failed attribute-access operations,
 /// not undefined or possibly undefined places.
-type MemberLookupResult<'db> = Result<PlaceAndQualifiers<'db>, MemberLookupError<'db>>;
+type MemberLookupResult<'db> = Result<ResolvedMember<'db>, MemberLookupError<'db>>;
+
+/// A member and the property accessors needed to report deprecations at its use site.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+enum ResolvedMember<'db> {
+    /// A member with no deprecated property accessors.
+    Plain(PlaceAndQualifiers<'db>),
+    /// A member with deprecated property accessors, stored separately to keep ordinary lookups compact.
+    WithDeprecations(DeprecatedMember<'db>),
+}
+
+/// Only members with deprecated property accessors need this additional storage.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+struct DeprecatedMember<'db> {
+    #[returns(copy)]
+    member: PlaceAndQualifiers<'db>,
+    #[returns(copy)]
+    properties: Type<'db>,
+}
+
+impl get_size2::GetSize for DeprecatedMember<'_> {}
+
+impl<'db> ResolvedMember<'db> {
+    fn member(self, db: &'db dyn Db) -> PlaceAndQualifiers<'db> {
+        match self {
+            Self::Plain(member) => member,
+            Self::WithDeprecations(member) => member.member(db),
+        }
+    }
+
+    fn deprecated_properties(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        match self {
+            Self::WithDeprecations(member) => Some(member.properties(db)),
+            Self::Plain(_) => None,
+        }
+    }
+
+    fn new(
+        db: &'db dyn Db,
+        member: PlaceAndQualifiers<'db>,
+        properties: Option<Type<'db>>,
+    ) -> Self {
+        match properties {
+            Some(properties) => {
+                Self::WithDeprecations(DeprecatedMember::new(db, member, properties))
+            }
+            None => Self::Plain(member),
+        }
+    }
+
+    fn map_type(self, db: &'db dyn Db, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Self {
+        Self::new(
+            db,
+            self.member(db).map_type(f),
+            self.deprecated_properties(db),
+        )
+    }
+}
+
+fn union_deprecated_properties<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    left: Option<Type<'db>>,
+    right: Option<Type<'db>>,
+) -> Option<Type<'db>> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(UnionType::from_two_elements(db, env, left, right)),
+        _ => left.or(right),
+    }
+}
 
 fn member_lookup_result<'db>(
     db: &'db dyn Db,
     member: PlaceAndQualifiers<'db>,
     error: Option<MemberLookupErrorKind<'db>>,
+    properties: Option<Type<'db>>,
 ) -> MemberLookupResult<'db> {
+    let member = ResolvedMember::new(db, member, properties);
     match error {
         Some(kind) => Err(MemberLookupError::new(db, member, kind)),
         None => Ok(member),
@@ -852,10 +923,10 @@ fn map_member_lookup_type<'db>(
     f: impl FnOnce(Type<'db>) -> Type<'db>,
 ) -> MemberLookupResult<'db> {
     match result {
-        Ok(member) => Ok(member.map_type(f)),
+        Ok(member) => Ok(member.map_type(db, f)),
         Err(error) => Err(MemberLookupError::new(
             db,
-            error.fallback_member(db).map_type(f),
+            error.fallback_member(db).map_type(db, f),
             error.kind(db),
         )),
     }
@@ -874,6 +945,7 @@ fn distribute_member_lookup_over_bound_or_constraints<'db>(
             .member_lookup_with_policy_and_receiver(db, env, name, policy, Some(symbolic_receiver)),
         TypeVarBoundOrConstraints::Constraints(constraints) => {
             let mut error = None;
+            let mut properties = None;
             let member = constraints.map_with_boundness_and_qualifiers(db, env, |constraint| {
                 let result = constraint.member_lookup_with_policy_and_receiver(
                     db,
@@ -890,9 +962,16 @@ fn distribute_member_lookup_over_bound_or_constraints<'db>(
                         _ => ty,
                     });
                 error = error.or_else(|| result.err().map(|error| error.kind(db)));
-                result.unwrap_or_else(|error| error.fallback_member(db))
+                let member = result.unwrap_or_else(|error| error.fallback_member(db));
+                properties = union_deprecated_properties(
+                    db,
+                    env,
+                    properties,
+                    member.deprecated_properties(db),
+                );
+                member.member(db)
             });
-            member_lookup_result(db, member, error)
+            member_lookup_result(db, member, error, properties)
         }
     }
 }
@@ -903,7 +982,8 @@ fn member_lookup_or_fall_back_to<'db>(
     result: MemberLookupResult<'db>,
     fallback_fn: impl FnOnce() -> MemberLookupResult<'db>,
 ) -> MemberLookupResult<'db> {
-    let member = result.unwrap_or_else(|error| error.fallback_member(db));
+    let resolved = result.unwrap_or_else(|error| error.fallback_member(db));
+    let member = resolved.member(db);
     match member.place {
         Place::Undefined => fallback_fn(),
         Place::Defined(DefinedPlace {
@@ -918,11 +998,17 @@ fn member_lookup_or_fall_back_to<'db>(
             let fallback_member = fallback.unwrap_or_else(|error| error.fallback_member(db));
             member_lookup_result(
                 db,
-                member.or_fall_back_to(db, env, || fallback_member),
+                member.or_fall_back_to(db, env, || fallback_member.member(db)),
                 result
                     .err()
                     .map(|error| error.kind(db))
                     .or_else(|| fallback.err().map(|error| error.kind(db))),
+                union_deprecated_properties(
+                    db,
+                    env,
+                    resolved.deprecated_properties(db),
+                    fallback_member.deprecated_properties(db),
+                ),
             )
         }
     }
@@ -941,18 +1027,25 @@ fn cycle_normalized_member_lookup<'db>(
         .filter(|_| cycle.iteration() <= crate::TAINTED_CYCLES || previous.is_err());
     let member = result.unwrap_or_else(|error| error.fallback_member(db));
     let previous = previous.unwrap_or_else(|error| error.fallback_member(db));
-    member_lookup_result(db, member.cycle_normalized(db, env, previous, cycle), error)
+    member_lookup_result(
+        db,
+        member
+            .member(db)
+            .cycle_normalized(db, env, previous.member(db), cycle),
+        error,
+        member.deprecated_properties(db),
+    )
 }
 
 impl<'db> From<PlaceAndQualifiers<'db>> for MemberLookupResult<'db> {
     fn from(member: PlaceAndQualifiers<'db>) -> Self {
-        Ok(member)
+        Ok(ResolvedMember::Plain(member))
     }
 }
 
 impl<'db> From<Place<'db>> for MemberLookupResult<'db> {
     fn from(place: Place<'db>) -> Self {
-        Ok(place.into())
+        Ok(ResolvedMember::Plain(place.into()))
     }
 }
 
@@ -4082,7 +4175,7 @@ impl<'db> Type<'db> {
         if let Type::ModuleLiteral(module) = self {
             module
                 .static_member(db, env, name)
-                .map_or(Place::Undefined, |member| member.place)
+                .map_or(Place::Undefined, |member| member.member(db).place)
         } else if let place @ Place::Defined(_) = self.class_member(db, env, name).place {
             place
         } else if let Some(place @ Place::Defined(_)) = self
@@ -4092,6 +4185,44 @@ impl<'db> Type<'db> {
             place
         } else {
             self.instance_member(db, env, name).place
+        }
+    }
+
+    /// Whether this descriptor contains a property with a deprecated accessor implementation.
+    /// Overload deprecations require a resolved call and do not apply to accessor references.
+    fn has_deprecated_property(self, db: &'db dyn Db) -> bool {
+        fn deprecated(db: &dyn Db, ty: Type<'_>) -> bool {
+            match ty {
+                Type::FunctionLiteral(function) => function.implementation_deprecated(db).is_some(),
+                Type::BoundMethod(method) => {
+                    method.function(db).implementation_deprecated(db).is_some()
+                }
+                Type::Union(union) => union.elements(db).iter().any(|ty| deprecated(db, *ty)),
+                Type::Intersection(intersection) => intersection
+                    .positive(db)
+                    .iter()
+                    .any(|ty| deprecated(db, *ty)),
+                _ => false,
+            }
+        }
+        match self {
+            Type::PropertyInstance(property) => [
+                property.getter(db),
+                property.setter(db),
+                property.deleter(db),
+            ]
+            .into_iter()
+            .flatten()
+            .any(|ty| deprecated(db, ty)),
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .any(|ty| ty.has_deprecated_property(db)),
+            Type::Intersection(intersection) => intersection
+                .positive(db)
+                .iter()
+                .any(|ty| ty.has_deprecated_property(db)),
+            _ => false,
         }
     }
 
@@ -4682,8 +4813,11 @@ impl<'db> Type<'db> {
         ) = Self::try_call_dunder_get_on_attribute(db, env, meta_attr_plain, Some(receiver), owner);
 
         let meta_attr_error = meta_attr_error.map(MemberLookupErrorKind::DescriptorGet);
+        let meta_properties = meta_attr_ty.filter(|ty| ty.has_deprecated_property(db));
         let fallback_error = fallback.err().map(|error| error.kind(db));
         let fallback_member = fallback.unwrap_or_else(|error| error.fallback_member(db));
+        let fallback_properties = fallback_member.deprecated_properties(db);
+        let fallback_member = fallback_member.member(db);
 
         // A slot stores the same instance attribute described by the receiver's declarations.
         // Unlike an arbitrary data descriptor, its inherited getter must not hide a more precise
@@ -4692,7 +4826,7 @@ impl<'db> Type<'db> {
             && matches!(meta_attr_ty, Some(Type::SlotDescriptor(_)))
             && !fallback_member.place.is_undefined()
         {
-            return member_lookup_result(db, fallback_member, fallback_error);
+            return fallback;
         }
 
         let PlaceAndQualifiers {
@@ -4707,6 +4841,7 @@ impl<'db> Type<'db> {
                 db,
                 meta_attr.with_qualifiers(meta_attr_qualifiers),
                 meta_attr_error,
+                meta_properties,
             ),
 
             // `meta_attr` is the return type of a data descriptor and definitely bound, so we
@@ -4722,6 +4857,7 @@ impl<'db> Type<'db> {
                 db,
                 meta_attr.with_qualifiers(meta_attr_qualifiers),
                 meta_attr_error,
+                meta_properties,
             ),
 
             // `meta_attr` is the return type of a data descriptor, but the attribute on the
@@ -4754,6 +4890,7 @@ impl<'db> Type<'db> {
                 })
                 .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
                 meta_attr_error.or(fallback_error),
+                union_deprecated_properties(db, env, meta_properties, fallback_properties),
             ),
 
             // `meta_attr` is *not* a data descriptor. This means that the `fallback` type has
@@ -4775,6 +4912,7 @@ impl<'db> Type<'db> {
                 db,
                 fallback.with_qualifiers(fallback_qualifiers),
                 fallback_error,
+                fallback_properties,
             ),
 
             // `meta_attr` is *not* a data descriptor. The `fallback` symbol is either possibly
@@ -4807,6 +4945,7 @@ impl<'db> Type<'db> {
                 })
                 .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
                 meta_attr_error.or(fallback_error),
+                union_deprecated_properties(db, env, meta_properties, fallback_properties),
             ),
 
             // If the attribute is not found on the meta-type, we simply return the fallback.
@@ -4814,6 +4953,7 @@ impl<'db> Type<'db> {
                 db,
                 fallback.with_qualifiers(fallback_qualifiers),
                 fallback_error,
+                fallback_properties,
             ),
         }
     }
@@ -4832,6 +4972,7 @@ impl<'db> Type<'db> {
     ) -> PlaceAndQualifiers<'db> {
         self.try_member_lookup(db, env, name)
             .unwrap_or_else(|error| error.fallback_member(db))
+            .member(db)
     }
 
     /// Performs member lookup while retaining errors from implicit attribute-access methods.
@@ -4861,6 +5002,7 @@ impl<'db> Type<'db> {
     ) -> PlaceAndQualifiers<'db> {
         self.member_lookup_with_policy_and_receiver(db, env, name, policy, None)
             .unwrap_or_else(|error| error.fallback_member(db))
+            .member(db)
     }
 
     /// Perform member lookup while optionally binding descriptors and `Self` to a more precise
@@ -4878,7 +5020,7 @@ impl<'db> Type<'db> {
     ) -> MemberLookupResult<'db> {
         #[salsa::tracked(
             returns(copy),
-            cycle_initial=|_, id, _| Ok(Place::bound(Type::divergent(id)).into()),
+            cycle_initial=|_, id, _| Place::bound(Type::divergent(id)).into(),
             cycle_fn=|db, cycle, previous: &MemberLookupResult<'db>, member: MemberLookupResult<'db>, key: MemberLookupKey<'db>| {
                 cycle_normalized_member_lookup(db, &ProgramEnvironment::from_program(key.program(db)), member, *previous, cycle)
             },
@@ -4893,7 +5035,7 @@ impl<'db> Type<'db> {
 
         #[salsa::tracked(
             returns(copy),
-            cycle_initial=|_, id, _, _| Ok(Place::bound(Type::divergent(id)).into()),
+            cycle_initial=|_, id, _, _| Place::bound(Type::divergent(id)).into(),
             cycle_fn=|db, cycle, previous: &MemberLookupResult<'db>, member: MemberLookupResult<'db>, key: MemberLookupKey<'db>, _| {
                 cycle_normalized_member_lookup(db, &ProgramEnvironment::from_program(key.program(db)), member, *previous, cycle)
             },
@@ -4917,7 +5059,9 @@ impl<'db> Type<'db> {
                 env: &ProgramEnvironment<'db>,
                 result: MemberLookupResult<'db>,
             ) -> MemberLookupResult<'db> {
-                let member = result.unwrap_or_else(|error| error.fallback_member(db));
+                let member = result
+                    .unwrap_or_else(|error| error.fallback_member(db))
+                    .member(db);
                 let should_promote = matches!(
                     member.place,
                     Place::Defined(DefinedPlace {
@@ -4976,6 +5120,7 @@ impl<'db> Type<'db> {
 
                 if result
                     .unwrap_or_else(|error| error.fallback_member(db))
+                    .member(db)
                     .is_class_var()
                     && this.is_typed_dict()
                 {
@@ -5013,14 +5158,22 @@ impl<'db> Type<'db> {
             match this {
                 Type::Union(union) => {
                     let mut error = None;
+                    let mut properties = None;
                     let member = union.map_with_boundness_and_qualifiers(db, env, |elem| {
                         let result = elem.member_lookup_with_policy_and_receiver(
                             db, env, name_str, policy, receiver,
                         );
                         error = error.or_else(|| result.err().map(|error| error.kind(db)));
-                        result.unwrap_or_else(|error| error.fallback_member(db))
+                        let member = result.unwrap_or_else(|error| error.fallback_member(db));
+                        properties = union_deprecated_properties(
+                            db,
+                            env,
+                            properties,
+                            member.deprecated_properties(db),
+                        );
+                        member.member(db)
                     });
-                    member_lookup_result(db, member, error)
+                    member_lookup_result(db, member, error, properties)
                 }
 
                 Type::Intersection(intersection) => {
@@ -5032,15 +5185,30 @@ impl<'db> Type<'db> {
                     } else {
                         let receiver = Some(receiver.unwrap_or(this));
                         let mut error = None;
+                        let mut properties = IntersectionBuilder::new(db, env);
+                        let mut all_deprecated = true;
                         let member =
                             intersection.map_with_boundness_and_qualifiers(db, env, |elem| {
                                 let result = elem.member_lookup_with_policy_and_receiver(
                                     db, env, name_str, policy, receiver,
                                 );
                                 error = error.or_else(|| result.err().map(|error| error.kind(db)));
-                                result.unwrap_or_else(|error| error.fallback_member(db))
+                                let member =
+                                    result.unwrap_or_else(|error| error.fallback_member(db));
+                                if let Some(deprecated) = member.deprecated_properties(db) {
+                                    properties.add_positive_in_place(deprecated);
+                                } else if !member.member(db).place.is_undefined() {
+                                    all_deprecated = false;
+                                }
+                                member.member(db)
                             });
-                        member_lookup_result(db, member, error)
+                        member_lookup_result(
+                            db,
+                            member,
+                            error,
+                            (all_deprecated && !member.place.is_undefined())
+                                .then(|| properties.build()),
+                        )
                     }
                 }
 
@@ -5437,6 +5605,7 @@ impl<'db> Type<'db> {
                     if name_str == "func" {
                         match nominal_lookup
                             .unwrap_or_else(|error| error.fallback_member(db))
+                            .member(db)
                             .place
                         {
                             Place::Defined(DefinedPlace {
@@ -5531,6 +5700,7 @@ impl<'db> Type<'db> {
                             db,
                             class_attr_fallback,
                             class_attr_error.map(MemberLookupErrorKind::DescriptorGet),
+                            None,
                         ),
                         InstanceFallbackShadowsNonDataDescriptor::Yes,
                     );
@@ -7046,13 +7216,12 @@ impl<'db> Type<'db> {
             return false;
         }
 
-        !matches!(
-            result,
-            Ok(PlaceAndQualifiers {
-                place: Place::Defined(place),
-                ..
-            }) if place.is_definitely_defined()
-        )
+        !result.is_ok_and(|member| {
+            matches!(
+                member.member(db).place,
+                Place::Defined(place) if place.is_definitely_defined()
+            )
+        })
     }
 
     /// Apply `__getattr__` / `__getattribute__` fallback to an attribute-lookup result.
@@ -7089,6 +7258,7 @@ impl<'db> Type<'db> {
                         receiver: self,
                         name: name_type,
                     }),
+                    None,
                 ),
                 Err(
                     CallDunderError::PossiblyUnbound { .. } | CallDunderError::MethodNotAvailable,
@@ -7124,6 +7294,7 @@ impl<'db> Type<'db> {
                     receiver: self,
                     name: name_type,
                 }),
+                None,
             ),
             Err(CallDunderError::PossiblyUnbound { .. }) => Place::Undefined.into(),
             Err(CallDunderError::MethodNotAvailable) => {
@@ -7133,11 +7304,14 @@ impl<'db> Type<'db> {
 
         if let Err(error) = custom_getattribute {
             let member = result.unwrap_or_else(|error| error.fallback_member(db));
-            return Err(MemberLookupError::new(
+            return member_lookup_result(
                 db,
-                member.or_fall_back_to(db, env, || error.fallback_member(db)),
-                error.kind(db),
-            ));
+                member
+                    .member(db)
+                    .or_fall_back_to(db, env, || error.fallback_member(db).member(db)),
+                Some(error.kind(db)),
+                member.deprecated_properties(db),
+            );
         }
 
         // A custom override runs before the descriptor and might return without invoking it.
@@ -10593,6 +10767,7 @@ impl<'db> ModuleLiteralType<'db> {
                     qualifiers: TypeQualifiers::FROM_MODULE_GETATTR,
                 },
                 error,
+                None,
             );
         }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -883,6 +883,7 @@ impl<'db> ResolvedMember<'db> {
         }
     }
 
+    /// Transform the member's value type without changing its deprecated property descriptors.
     fn map_type(self, db: &'db dyn Db, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Self {
         Self::new(
             db,
@@ -892,6 +893,8 @@ impl<'db> ResolvedMember<'db> {
     }
 }
 
+/// Combine deprecated descriptors from alternative lookup paths. A non-deprecated path (`None`)
+/// does not suppress deprecations from another possible path.
 fn union_deprecated_properties<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -4190,6 +4193,9 @@ impl<'db> Type<'db> {
 
     /// Whether this descriptor contains a property with a deprecated accessor implementation.
     /// Overload deprecations require a resolved call and do not apply to accessor references.
+    ///
+    /// This determines whether to retain deprecation metadata, not whether to report a diagnostic.
+    /// Reporting also accounts for the access kind and non-deprecated intersection alternatives.
     fn has_deprecated_property(self, db: &'db dyn Db) -> bool {
         fn deprecated(db: &dyn Db, ty: Type<'_>) -> bool {
             match ty {

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -325,7 +325,7 @@ pub(super) fn attribute_write_requirement<'db>(
             } else {
                 module
                     .static_member(db, env, attribute)
-                    .unwrap_or_else(|_| Place::Undefined.into())
+                    .map_or_else(|_| Place::Undefined.into(), |member| member.member(db))
             };
             AttributeWriteRequirement::Module(match symbol.place {
                 Place::Defined(DefinedPlace { ty, .. }) => Some(ty),

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -360,8 +360,7 @@ impl<'db> SuperOwnerKind<'db> {
         }
     }
 
-    /// Returns the instance and owner passed to a descriptor, when the super owner is known.
-    pub(super) fn descriptor_binding(
+    fn descriptor_binding(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -950,8 +949,8 @@ impl<'db> BoundSuperType<'db> {
         env: &ProgramEnvironment<'db>,
         attribute: PlaceAndQualifiers<'db>,
     ) -> Option<MemberLookupResult<'db>> {
-        // `super` delegates reads to the owner's descriptors, but not writes or deletions.
-        // Retain only the getters when carrying property accessors out of this lookup.
+        /// Retain only getters in the deprecation metadata: `super` delegates reads to the
+        /// owner's descriptors, but not writes or deletions.
         fn getters_only<'db>(
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -360,7 +360,8 @@ impl<'db> SuperOwnerKind<'db> {
         }
     }
 
-    fn descriptor_binding(
+    /// Returns the instance and owner passed to a descriptor, when the super owner is known.
+    pub(super) fn descriptor_binding(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -950,6 +950,25 @@ impl<'db> BoundSuperType<'db> {
         env: &ProgramEnvironment<'db>,
         attribute: PlaceAndQualifiers<'db>,
     ) -> Option<MemberLookupResult<'db>> {
+        // `super` delegates reads to the owner's descriptors, but not writes or deletions.
+        // Retain only the getters when carrying property accessors out of this lookup.
+        fn getters_only<'db>(
+            db: &'db dyn Db,
+            env: &ProgramEnvironment<'db>,
+            ty: Type<'db>,
+        ) -> Type<'db> {
+            match ty {
+                Type::PropertyInstance(property) => Type::PropertyInstance(
+                    property.with_accessors(db, property.getter(db), None, None),
+                ),
+                Type::Union(union) => union.map(db, env, |ty| getters_only(db, env, *ty)),
+                Type::Intersection(intersection) => {
+                    intersection.map_positive(db, env, |ty| getters_only(db, env, *ty))
+                }
+                _ => ty,
+            }
+        }
+
         let (instance, owner) = self.owner(db).descriptor_binding(db, env)?;
         let (member, _, descriptor_error) =
             Type::try_call_dunder_get_on_attribute(db, env, attribute, instance, owner);
@@ -957,6 +976,10 @@ impl<'db> BoundSuperType<'db> {
             db,
             member,
             descriptor_error.map(MemberLookupErrorKind::DescriptorGet),
+            instance
+                .and_then(|_| attribute.place.ignore_possibly_undefined())
+                .filter(|ty| ty.has_deprecated_property(db))
+                .map(|ty| getters_only(db, env, ty)),
         ))
     }
 

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -3,6 +3,7 @@ use super::{ClassType, Signature, Type, TypeContext, UnionType};
 use crate::Db;
 use crate::place::Provenance;
 use crate::types::call::bind::BindingError;
+use crate::types::function::OverloadLiteral;
 use crate::types::{MemberLookupPolicy, PropertyInstanceType};
 use crate::{Program, ProgramEnvironment};
 use ruff_python_ast as ast;
@@ -149,30 +150,40 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Memoize the pure return-type part of binary dunder resolution so repeated identical
-    /// expressions don't re-run overload selection at every call site.
-    pub(crate) fn try_call_bin_op_return_type(
+    /// Memoize the return type and deprecations from binary dunder resolution, without retaining
+    /// the full call bindings or repeating overload selection at each expression.
+    pub(crate) fn try_call_bin_op_result(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
-    ) -> Option<Type<'db>> {
-        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-        fn try_call_bin_op_return_type_impl<'db>(
+    ) -> Option<(Type<'db>, &'db [OverloadLiteral<'db>])> {
+        #[salsa::tracked(returns(ref), cycle_initial=|_, _, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        fn try_call_bin_op_result_impl<'db>(
             db: &'db dyn Db,
             program: Program<'db>,
             left_ty: Type<'db>,
             op: ast::Operator,
             right_ty: Type<'db>,
-        ) -> Option<Type<'db>> {
+        ) -> Option<(Type<'db>, Box<[OverloadLiteral<'db>]>)> {
             let env = &ProgramEnvironment::from_program(program);
             Type::try_call_bin_op(db, env, left_ty, op, right_ty)
                 .ok()
-                .map(|bindings| bindings.return_type(db, env))
+                .map(|bindings| {
+                    (
+                        bindings.return_type(db, env),
+                        bindings
+                            .deprecated_functions(db)
+                            .map(|(_, function)| function)
+                            .collect(),
+                    )
+                })
         }
 
-        try_call_bin_op_return_type_impl(db, env.program(db), left_ty, op, right_ty)
+        try_call_bin_op_result_impl(db, env.program(db), left_ty, op, right_ty)
+            .as_ref()
+            .map(|(return_type, deprecated)| (*return_type, deprecated.as_ref()))
     }
 
     pub(crate) fn try_call_bin_op(

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -15,6 +15,14 @@ pub(super) use bind::{
     Binding, Bindings, CallDiagnosticOverride, CallableBinding, MatchedArgument,
 };
 
+/// The return type and deprecations retained from binary operator resolution.
+#[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+pub(crate) struct BinaryOperationResult<'db> {
+    pub(crate) return_type: Type<'db>,
+    /// Deprecated implementations or overloads selected for the operation.
+    pub(crate) deprecated_functions: Box<[OverloadLiteral<'db>]>,
+}
+
 /// Whether the right operand's reflected method has priority based on the possible runtime
 /// classes of both operands.
 ///
@@ -158,7 +166,7 @@ impl<'db> Type<'db> {
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
-    ) -> Option<(Type<'db>, &'db [OverloadLiteral<'db>])> {
+    ) -> Option<&'db BinaryOperationResult<'db>> {
         #[salsa::tracked(returns(ref), cycle_initial=|_, _, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
         fn try_call_bin_op_result_impl<'db>(
             db: &'db dyn Db,
@@ -166,24 +174,20 @@ impl<'db> Type<'db> {
             left_ty: Type<'db>,
             op: ast::Operator,
             right_ty: Type<'db>,
-        ) -> Option<(Type<'db>, Box<[OverloadLiteral<'db>]>)> {
+        ) -> Option<BinaryOperationResult<'db>> {
             let env = &ProgramEnvironment::from_program(program);
             Type::try_call_bin_op(db, env, left_ty, op, right_ty)
                 .ok()
-                .map(|bindings| {
-                    (
-                        bindings.return_type(db, env),
-                        bindings
-                            .deprecated_functions(db)
-                            .map(|(_, function)| function)
-                            .collect(),
-                    )
+                .map(|bindings| BinaryOperationResult {
+                    return_type: bindings.return_type(db, env),
+                    deprecated_functions: bindings
+                        .deprecated_functions(db)
+                        .map(|(_, function)| function)
+                        .collect(),
                 })
         }
 
-        try_call_bin_op_result_impl(db, env.program(db), left_ty, op, right_ty)
-            .as_ref()
-            .map(|(return_type, deprecated)| (*return_type, deprecated.as_ref()))
+        try_call_bin_op_result_impl(db, env.program(db), left_ty, op, right_ty).as_ref()
     }
 
     pub(crate) fn try_call_bin_op(

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -160,6 +160,7 @@ impl<'db> Type<'db> {
 
     /// Memoize the return type and deprecations from binary dunder resolution, without retaining
     /// the full call bindings or repeating overload selection at each expression.
+    /// Returns `None` if resolution fails; callers remain responsible for call-site diagnostics.
     pub(crate) fn try_call_bin_op_result(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -893,20 +893,16 @@ impl<'db> Bindings<'db> {
         self.implicit_dunder_init_is_possibly_unbound
     }
 
-    /// Returns the callable bindings for each union element without flattening intersections.
-    fn iter_union_elements(
-        &self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &CallableBinding<'db>> + Clone> + '_ {
-        self.elements.iter().map(BindingsElement::callables)
-    }
-
     /// Returns the deprecated functions invoked by each union alternative. An intersection
     /// only reports deprecations if every member that could implement the call is deprecated.
+    /// The same source can appear in multiple alternatives; callers deduplicate per expression.
     pub(crate) fn deprecated_functions(
         &self,
         db: &'db dyn Db,
     ) -> impl Iterator<Item = (&CallableBinding<'db>, OverloadLiteral<'db>)> {
-        self.iter_union_elements()
+        self.elements
+            .iter()
+            .map(BindingsElement::callables)
             .filter(move |callables| {
                 callables
                     .clone()
@@ -4417,8 +4413,9 @@ impl<'db> CallableBinding<'db> {
             .filter(|(_, overload)| !overload.has_errors_affecting_overload_resolution())
     }
 
-    /// Returns a deprecated implementation, or the deprecated source overloads selected by this
-    /// call. Source indexes preserve overload identities after receiver compatibility filtering.
+    /// Returns the deprecated implementation, taking precedence over any deprecated overloads.
+    /// Otherwise, returns deprecated overloads selected by this call, using their original source
+    /// indexes to preserve their identities after receiver compatibility filtering.
     fn deprecated_functions(
         &self,
         db: &'db dyn Db,
@@ -4431,18 +4428,18 @@ impl<'db> CallableBinding<'db> {
         let (overloads, implementation) = function
             .map(|function| function.overloads_and_implementation(db))
             .unwrap_or_default();
-        let implementation = implementation.filter(|function| function.deprecated(db).is_some());
+        if let Some(implementation) =
+            implementation.filter(|function| function.deprecated(db).is_some())
+        {
+            return Either::Left(std::iter::once(implementation));
+        }
 
-        implementation
-            .into_iter()
-            .chain(self.matching_overloads().filter_map(move |(_, binding)| {
-                overloads
-                    .get(binding.source_overload_index())
-                    .copied()
-                    .filter(|overload| {
-                        implementation.is_none() && overload.deprecated(db).is_some()
-                    })
-            }))
+        Either::Right(self.matching_overloads().filter_map(move |(_, binding)| {
+            overloads
+                .get(binding.source_overload_index())
+                .copied()
+                .filter(|overload| overload.deprecated(db).is_some())
+        }))
     }
 
     /// Returns the overload which call arguments should be inferred against, if every overload is

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -894,7 +894,7 @@ impl<'db> Bindings<'db> {
     }
 
     /// Returns the callable bindings for each union element without flattening intersections.
-    pub(crate) fn iter_union_elements(
+    fn iter_union_elements(
         &self,
     ) -> impl Iterator<Item = impl Iterator<Item = &CallableBinding<'db>> + Clone> + '_ {
         self.elements.iter().map(BindingsElement::callables)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4396,6 +4396,30 @@ impl<'db> CallableBinding<'db> {
             .filter(|(_, overload)| !overload.has_errors_affecting_overload_resolution())
     }
 
+    /// Returns deprecated source overloads selected by this call, preserving their identities
+    /// when receiver binding has filtered or reordered the callable's signatures.
+    pub(crate) fn deprecated_overloads(
+        &self,
+        db: &'db dyn Db,
+    ) -> impl Iterator<Item = OverloadLiteral<'db>> + Clone {
+        let function = match self.signature_type {
+            Type::FunctionLiteral(function) => Some(function),
+            Type::BoundMethod(bound) => Some(bound.function(db)),
+            _ => None,
+        };
+        let overloads = function
+            .filter(|function| function.implementation_deprecated(db).is_none())
+            .map(|function| function.overloads_and_implementation(db).0)
+            .unwrap_or_default();
+
+        self.matching_overloads().filter_map(move |(_, binding)| {
+            overloads
+                .get(binding.source_overload_index())
+                .copied()
+                .filter(|overload| overload.deprecated(db).is_some())
+        })
+    }
+
     /// Returns the overload which call arguments should be inferred against, if every overload is
     /// non-matching.
     pub(crate) fn best_failing_overload(&self) -> Option<&Binding<'db>> {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -900,6 +900,27 @@ impl<'db> Bindings<'db> {
         self.elements.iter().map(BindingsElement::callables)
     }
 
+    /// Returns the deprecated functions invoked by each union alternative. An intersection
+    /// only reports deprecations if every member that could implement the call is deprecated.
+    pub(crate) fn deprecated_functions(
+        &self,
+        db: &'db dyn Db,
+    ) -> impl Iterator<Item = (&CallableBinding<'db>, OverloadLiteral<'db>)> {
+        self.iter_union_elements()
+            .filter(move |callables| {
+                callables
+                    .clone()
+                    .all(|callable| callable.deprecated_functions(db).next().is_some())
+            })
+            .flat_map(move |callables| {
+                callables.flat_map(move |callable| {
+                    callable
+                        .deprecated_functions(db)
+                        .map(move |function| (callable, function))
+                })
+            })
+    }
+
     /// Returns an iterator over all `CallableBinding`s, flattening the two-level structure.
     ///
     /// Note: This loses the union/intersection distinction. The returned iterator yields
@@ -4396,9 +4417,9 @@ impl<'db> CallableBinding<'db> {
             .filter(|(_, overload)| !overload.has_errors_affecting_overload_resolution())
     }
 
-    /// Returns deprecated source overloads selected by this call, preserving their identities
-    /// when receiver binding has filtered or reordered the callable's signatures.
-    pub(crate) fn deprecated_overloads(
+    /// Returns a deprecated implementation, or the deprecated source overloads selected by this
+    /// call. Source indexes preserve overload identities after receiver compatibility filtering.
+    fn deprecated_functions(
         &self,
         db: &'db dyn Db,
     ) -> impl Iterator<Item = OverloadLiteral<'db>> + Clone {
@@ -4407,17 +4428,21 @@ impl<'db> CallableBinding<'db> {
             Type::BoundMethod(bound) => Some(bound.function(db)),
             _ => None,
         };
-        let overloads = function
-            .filter(|function| function.implementation_deprecated(db).is_none())
-            .map(|function| function.overloads_and_implementation(db).0)
+        let (overloads, implementation) = function
+            .map(|function| function.overloads_and_implementation(db))
             .unwrap_or_default();
+        let implementation = implementation.filter(|function| function.deprecated(db).is_some());
 
-        self.matching_overloads().filter_map(move |(_, binding)| {
-            overloads
-                .get(binding.source_overload_index())
-                .copied()
-                .filter(|overload| overload.deprecated(db).is_some())
-        })
+        implementation
+            .into_iter()
+            .chain(self.matching_overloads().filter_map(move |(_, binding)| {
+                overloads
+                    .get(binding.source_overload_index())
+                    .copied()
+                    .filter(|overload| {
+                        implementation.is_none() && overload.deprecated(db).is_some()
+                    })
+            }))
     }
 
     /// Returns the overload which call arguments should be inferred against, if every overload is

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10008,6 +10008,78 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    /// Check the property accessor invoked by an attribute operation. Looking on the receiver's
+    /// class also handles metaclass properties, without invoking getters for `Class.property`.
+    fn check_deprecated_property(
+        &self,
+        attribute: &ast::ExprAttribute,
+        receiver: Type<'db>,
+        access: ExprContext,
+    ) {
+        fn accessors<'db>(
+            db: &'db dyn Db,
+            env: &ProgramEnvironment<'db>,
+            ty: Type<'db>,
+            access: ExprContext,
+        ) -> Type<'db> {
+            match ty {
+                Type::PropertyInstance(property) => match access {
+                    ExprContext::Load => property.getter(db),
+                    ExprContext::Store => property.setter(db),
+                    ExprContext::Del => property.deleter(db),
+                    ExprContext::Invalid => None,
+                }
+                .unwrap_or_else(Type::unknown),
+                Type::Union(union) => union.map(db, env, |ty| accessors(db, env, *ty, access)),
+                Type::Intersection(intersection) => {
+                    intersection.map_positive(db, env, |ty| accessors(db, env, *ty, access))
+                }
+                _ => Type::unknown(),
+            }
+        }
+
+        if !self.context.is_lint_enabled(&diagnostic::DEPRECATED) {
+            return;
+        }
+        let db = self.db();
+        let env = self.program_environment();
+        let member = if let Type::BoundSuper(bound_super) = receiver {
+            // Class-bound super returns the property object, just like access through a class.
+            if access != ExprContext::Load
+                || !matches!(
+                    bound_super.owner(db).descriptor_binding(db, env),
+                    Some((Some(_), _))
+                )
+            {
+                return;
+            }
+            bound_super.find_name_in_mro_after_pivot(
+                db,
+                env,
+                &attribute.attr.id,
+                MemberLookupPolicy::default(),
+            )
+        } else {
+            receiver.class_member(db, env, &attribute.attr.id)
+        };
+        let Some(member) = member.place.ignore_possibly_undefined() else {
+            return;
+        };
+        if !matches!(
+            member,
+            Type::PropertyInstance(_) | Type::Union(_) | Type::Intersection(_)
+        ) {
+            return;
+        }
+        let bindings = accessors(db, env, member, access).bindings(db, env);
+        for (_, function) in bindings.deprecated_functions(db) {
+            // These are accessor references, not resolved overload calls.
+            if !function.is_overload(db) {
+                self.report_deprecated_function(&attribute.attr, function);
+            }
+        }
+    }
+
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
         let db = self.db();
         let expr = PlaceExpr::from_expr_name(name_node);
@@ -10711,6 +10783,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let resolved_type = resolved_type.inner_type();
 
         self.check_deprecated(attr, resolved_type);
+
+        // Deleting an attribute does not invoke its getter. Augmented assignment, however,
+        // reads the property here even though its AST target has a store context.
+        self.check_deprecated_property(
+            attribute,
+            value_type,
+            if attribute.ctx == ExprContext::Del {
+                ExprContext::Del
+            } else {
+                ExprContext::Load
+            },
+        );
 
         // Even if we can obtain the attribute type based on the assignments, we still perform default type inference
         // (to report errors).

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -88,7 +88,7 @@ use crate::types::diagnostic::{
 };
 use crate::types::enums::{enum_ignored_names, is_enum_class_by_inheritance};
 use crate::types::function::{
-    FunctionDecorators, FunctionType, KnownFunction, report_revealed_type,
+    FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral, report_revealed_type,
     same_module_uncached_raw_signature,
 };
 use crate::types::generics::{
@@ -4972,7 +4972,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     TypeContext::default(),
                 );
                 match call {
-                    Ok(outcome) => Ok(outcome.return_type(db, env)),
+                    Ok(outcome) => {
+                        self.check_deprecated_bindings(assignment, &outcome);
+                        Ok(outcome.return_type(db, env))
+                    }
                     Err(CallDunderError::MethodNotAvailable) => {
                         let value_ty = infer_value_ty(self, TypeContext::default());
                         binary_return_ty(self, value_ty)
@@ -4980,6 +4983,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     Err(CallDunderError::PossiblyUnbound {
                         bindings: outcome, ..
                     }) => {
+                        self.check_deprecated_bindings(assignment, &outcome);
                         let value_ty = outcome.type_for_argument(&call_arguments, 0);
                         match binary_return_ty(self, value_ty) {
                             Ok(binary_ty) => Ok(UnionType::from_two_elements(
@@ -9417,7 +9421,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        self.check_deprecated_overloads(func.as_ref(), &bindings);
+        for (binding, function) in bindings.deprecated_functions(db) {
+            // Explicit function references already report implementation deprecations.
+            // Calling an instance instead references the object, not its `__call__` method.
+            if function.is_overload(db) || binding.callable_type != binding.signature_type {
+                self.report_deprecated_function(func.as_ref(), function);
+            }
+        }
 
         if let Some(class) = class {
             pydantic::report_discarded_extra_arguments(&self.context, class, arguments, &bindings);
@@ -9966,53 +9976,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 
-    /// Check selected overloads without reporting deprecations on unused overloads or on
-    /// implementations, which are already checked when the function is referenced.
-    fn check_deprecated_overloads<T: Ranged>(&self, ranged: &T, bindings: &Bindings<'db>) {
+    /// Report the deprecation of a function implementation or a selected overload.
+    fn report_deprecated_function<T: Ranged>(&self, ranged: &T, function: OverloadLiteral<'db>) {
         let db = self.db();
-        for callables in bindings.iter_union_elements() {
-            if callables
-                .clone()
-                .all(|callable| callable.deprecated_overloads(db).next().is_some())
-            {
-                for overload in callables.flat_map(|callable| callable.deprecated_overloads(db)) {
-                    let Some(builder) = self.context.report_lint(&diagnostic::DEPRECATED, ranged)
-                    else {
-                        continue;
-                    };
-                    let mut diagnostic = builder.into_diagnostic(format_args!(
-                        "The overload of `{}` is deprecated",
-                        overload.name(db),
-                    ));
-                    if let Some(message) = overload
-                        .deprecated(db)
-                        .and_then(|deprecated| deprecated.message)
-                    {
-                        diagnostic.set_primary_annotation_message(message.value(db));
-                    }
-                    diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
-                }
-            }
+        let Some(deprecated) = function.deprecated(db) else {
+            return;
+        };
+        let Some(builder) = self.context.report_lint(&diagnostic::DEPRECATED, ranged) else {
+            return;
+        };
+        let kind = if function.is_overload(db) {
+            "overload of"
+        } else {
+            "function"
+        };
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "The {kind} `{}` is deprecated",
+            function.name(db),
+        ));
+        if let Some(message) = deprecated.message {
+            diagnostic.set_primary_annotation_message(message.value(db));
         }
+        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 
     /// Report a deprecated callable only when its union alternative has no non-deprecated
     /// intersection member that could provide the implementation instead.
     fn check_deprecated_bindings<T: Ranged>(&self, ranged: &T, bindings: &Bindings<'db>) {
-        let db = self.db();
-
-        for callables in bindings.iter_union_elements() {
-            if callables.clone().all(|callable| {
-                let ty = match callable.callable_type {
-                    Type::BoundMethod(bound) => Type::FunctionLiteral(bound.function(db)),
-                    ty => ty,
-                };
-                ty.is_deprecated(db)
-            }) {
-                for callable in callables {
-                    self.check_deprecated(ranged, callable.callable_type);
-                }
-            }
+        for (_, function) in bindings.deprecated_functions(self.db()) {
+            self.report_deprecated_function(ranged, function);
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use compact_str::CompactString;
 use itertools::Itertools;
-use ruff_db::diagnostic::Span;
+use ruff_db::diagnostic::{Annotation, Span};
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
@@ -94,6 +94,7 @@ use crate::types::function::{
 use crate::types::generics::{
     GenericContext, Specialization, SpecializationBuilder, bind_typevar, enclosing_binding_contexts,
 };
+use crate::types::infer::builder::binary_expressions::BinaryInferenceState;
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
 use crate::types::infer::builder::paramspec_validation::validate_paramspec_components;
 use crate::types::infer::{
@@ -4894,6 +4895,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         target_type: Type<'db>,
         value_expr: &ast::Expr,
         infer_value_ty: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
+        state: &mut BinaryInferenceState<'db>,
     ) -> Result<Type<'db>, Type<'db>> {
         let db = self.db();
         let env = self.program_environment();
@@ -4902,19 +4904,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let op = assignment.op;
 
         // Fall back to non-augmented binary operator inference.
-        let binary_return_ty = |builder: &mut Self, value_ty| {
-            builder
-                .infer_binary_expression_type(assignment.into(), false, target_type, value_ty, op)
-                .ok_or_else(|| {
-                    report_unsupported_augmented_assignment(
-                        &builder.context,
-                        assignment,
+        let binary_return_ty =
+            |builder: &mut Self, value_ty, state: &mut BinaryInferenceState<'db>| {
+                builder
+                    .infer_binary_expression_type(
+                        assignment.into(),
                         target_type,
                         value_ty,
-                    );
-                    Type::unknown()
-                })
-        };
+                        op,
+                        state,
+                    )
+                    .ok_or_else(|| {
+                        report_unsupported_augmented_assignment(
+                            &builder.context,
+                            assignment,
+                            target_type,
+                            value_ty,
+                        );
+                        Type::unknown()
+                    })
+            };
 
         match target_type {
             Type::Union(union) => {
@@ -4931,6 +4940,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         elem_type,
                         value_expr,
                         &mut |builder, tcx| infer_value_ty.infer_silent(builder, tcx),
+                        state,
                     ) {
                         Ok(ty) => ty,
                         Err(recovery_ty) => {
@@ -4973,19 +4983,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 );
                 match call {
                     Ok(outcome) => {
-                        self.check_deprecated_bindings(assignment, &outcome);
+                        state.deprecated_functions.extend(
+                            outcome
+                                .deprecated_functions(db)
+                                .map(|(_, function)| function),
+                        );
                         Ok(outcome.return_type(db, env))
                     }
                     Err(CallDunderError::MethodNotAvailable) => {
                         let value_ty = infer_value_ty(self, TypeContext::default());
-                        binary_return_ty(self, value_ty)
+                        binary_return_ty(self, value_ty, state)
                     }
                     Err(CallDunderError::PossiblyUnbound {
                         bindings: outcome, ..
                     }) => {
-                        self.check_deprecated_bindings(assignment, &outcome);
+                        state.deprecated_functions.extend(
+                            outcome
+                                .deprecated_functions(db)
+                                .map(|(_, function)| function),
+                        );
                         let value_ty = outcome.type_for_argument(&call_arguments, 0);
-                        match binary_return_ty(self, value_ty) {
+                        match binary_return_ty(self, value_ty, state) {
                             Ok(binary_ty) => Ok(UnionType::from_two_elements(
                                 db,
                                 env,
@@ -5062,10 +5080,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let target_type = target_result.unwrap_or_else(|recovery_ty| recovery_ty);
-        let operation_result =
-            self.infer_augmented_op(assignment, target_type, value, &mut |builder, tcx| {
-                builder.infer_expression(value, tcx)
-            });
+        let mut state = BinaryInferenceState::default();
+        let operation_result = self.infer_augmented_op(
+            assignment,
+            target_type,
+            value,
+            &mut |builder, tcx| builder.infer_expression(value, tcx),
+            &mut state,
+        );
+        self.report_deprecated_functions(assignment, state.deprecated_functions);
 
         match (target_result, operation_result) {
             (Ok(_), Ok(result_ty)) => Ok(result_ty),
@@ -9421,13 +9444,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        for (binding, function) in bindings.deprecated_functions(db) {
-            // Explicit function references already report implementation deprecations.
-            // Calling an instance instead references the object, not its `__call__` method.
-            if function.is_overload(db) || binding.callable_type != binding.signature_type {
-                self.report_deprecated_function(func.as_ref(), function);
-            }
-        }
+        self.report_deprecated_functions(
+            func.as_ref(),
+            bindings
+                .deprecated_functions(db)
+                // Explicit function references already report implementation deprecations.
+                // Calling an instance instead references the object, not its `__call__` method.
+                .filter(|(binding, function)| {
+                    function.is_overload(db) || binding.callable_type != binding.signature_type
+                })
+                .map(|(_, function)| function),
+        );
 
         if let Some(class) = class {
             pydantic::report_discarded_extra_arguments(&self.context, class, arguments, &bindings);
@@ -9976,26 +10003,57 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 
-    /// Report the deprecation of a function implementation or a selected overload.
-    fn report_deprecated_function<T: Ranged>(&self, ranged: &T, function: OverloadLiteral<'db>) {
+    /// Report the distinct deprecated targets of one operation in a single diagnostic.
+    /// Union alternatives can select the same source function or overload more than once.
+    fn report_deprecated_functions(
+        &self,
+        ranged: impl Ranged,
+        functions: impl IntoIterator<Item = OverloadLiteral<'db>>,
+    ) {
         let db = self.db();
-        let Some(deprecated) = function.deprecated(db) else {
+        let functions: SmallVec<[_; 1]> = functions.into_iter().unique().collect();
+        let Some(first) = functions.first() else {
             return;
         };
         let Some(builder) = self.context.report_lint(&diagnostic::DEPRECATED, ranged) else {
             return;
         };
-        let kind = if function.is_overload(db) {
-            "overload of"
+        let mut diagnostic = if functions.len() == 1 {
+            let kind = if first.is_overload(db) {
+                "overload of"
+            } else {
+                "function"
+            };
+            builder.into_diagnostic(format_args!(
+                "The {kind} `{}` is deprecated",
+                first.name(db)
+            ))
         } else {
-            "function"
+            let mut diagnostic = builder.into_diagnostic("Use of deprecated functions");
+            for function in &functions {
+                let mut annotation = Annotation::secondary(function.spans(db).name);
+                if let Some(message) = function
+                    .deprecated(db)
+                    .and_then(|deprecated| deprecated.message)
+                {
+                    annotation = annotation.message(message.value(db));
+                }
+                diagnostic.annotate(annotation);
+            }
+            diagnostic
         };
-        let mut diagnostic = builder.into_diagnostic(format_args!(
-            "The {kind} `{}` is deprecated",
-            function.name(db),
-        ));
-        if let Some(message) = deprecated.message {
-            diagnostic.set_primary_annotation_message(message.value(db));
+        let messages = functions
+            .iter()
+            .filter_map(|function| {
+                function
+                    .deprecated(db)
+                    .and_then(|deprecated| deprecated.message)
+            })
+            .map(|message| message.value(db))
+            .unique()
+            .join("; ");
+        if !messages.is_empty() {
+            diagnostic.set_primary_annotation_message(messages);
         }
         diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
@@ -10003,9 +10061,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Report a deprecated callable only when its union alternative has no non-deprecated
     /// intersection member that could provide the implementation instead.
     fn check_deprecated_bindings<T: Ranged>(&self, ranged: &T, bindings: &Bindings<'db>) {
-        for (_, function) in bindings.deprecated_functions(self.db()) {
-            self.report_deprecated_function(ranged, function);
-        }
+        self.report_deprecated_functions(
+            ranged,
+            bindings
+                .deprecated_functions(self.db())
+                .map(|(_, function)| function),
+        );
     }
 
     /// Check the property accessor invoked by an attribute operation. Looking on the receiver's
@@ -10072,12 +10133,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
         let bindings = accessors(db, env, member, access).bindings(db, env);
-        for (_, function) in bindings.deprecated_functions(db) {
-            // These are accessor references, not resolved overload calls.
-            if !function.is_overload(db) {
-                self.report_deprecated_function(&attribute.attr, function);
-            }
-        }
+        self.report_deprecated_functions(
+            &attribute.attr,
+            bindings
+                .deprecated_functions(db)
+                .map(|(_, function)| function)
+                // These are accessor references, not resolved overload calls.
+                .filter(|function| !function.is_overload(db)),
+        );
     }
 
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
@@ -11037,24 +11100,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 )
                             })
                             .collect();
-                        for outcome in &outcomes {
-                            let bindings = match outcome {
-                                Ok(bindings) => Some(bindings),
-                                // A method can be deprecated even if it is missing from some
-                                // union members or its signature rejects the implicit call.
-                                // Preserve those bindings so the deprecation is reported
-                                // alongside the unsupported-operator diagnostic.
-                                Err(
-                                    CallDunderError::PossiblyUnbound { bindings, .. }
-                                    | CallDunderError::CallError(_, bindings, _),
-                                ) => Some(bindings.as_ref()),
-                                // A completely missing method has no bindings to inspect.
-                                Err(CallDunderError::MethodNotAvailable) => None,
-                            };
-                            if let Some(bindings) = bindings {
-                                self.check_deprecated_bindings(unary, bindings);
-                            }
-                        }
+                        self.report_deprecated_functions(
+                            unary,
+                            outcomes
+                                .iter()
+                                .filter_map(|outcome| match outcome {
+                                    Ok(bindings) => Some(bindings),
+                                    // A method can be deprecated even if it is missing from some
+                                    // union members or its signature rejects the implicit call.
+                                    // Preserve those bindings so the deprecation is reported
+                                    // alongside the unsupported-operator diagnostic.
+                                    Err(
+                                        CallDunderError::PossiblyUnbound { bindings, .. }
+                                        | CallDunderError::CallError(_, bindings, _),
+                                    ) => Some(bindings.as_ref()),
+                                    // A completely missing method has no bindings to inspect.
+                                    Err(CallDunderError::MethodNotAvailable) => None,
+                                })
+                                .flat_map(|bindings| bindings.deprecated_functions(db))
+                                .map(|(_, function)| function),
+                        );
 
                         let mut outcomes = outcomes.into_iter();
                         let result = Self::map_constrained_typevar_constraints(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10069,12 +10069,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
     }
 
-    /// Check the property accessor invoked by an attribute operation. Looking on the receiver's
-    /// class also handles metaclass properties, without invoking getters for `Class.property`.
+    /// Check the accessor invoked by an attribute operation, using the property descriptors
+    /// retained by member lookup or assignment validation.
     fn check_deprecated_property(
         &self,
         attribute: &ast::ExprAttribute,
-        receiver: Type<'db>,
+        member: Type<'db>,
         access: ExprContext,
     ) {
         fn accessors<'db>(
@@ -10104,34 +10104,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
         let db = self.db();
         let env = self.program_environment();
-        let member = if let Type::BoundSuper(bound_super) = receiver {
-            // Class-bound super returns the property object, just like access through a class.
-            if access != ExprContext::Load
-                || !matches!(
-                    bound_super.owner(db).descriptor_binding(db, env),
-                    Some((Some(_), _))
-                )
-            {
-                return;
-            }
-            bound_super.find_name_in_mro_after_pivot(
-                db,
-                env,
-                &attribute.attr.id,
-                MemberLookupPolicy::default(),
-            )
-        } else {
-            receiver.class_member(db, env, &attribute.attr.id)
-        };
-        let Some(member) = member.place.ignore_possibly_undefined() else {
-            return;
-        };
-        if !matches!(
-            member,
-            Type::PropertyInstance(_) | Type::Union(_) | Type::Intersection(_)
-        ) {
-            return;
-        }
         let bindings = accessors(db, env, member, access).bindings(db, env);
         self.report_deprecated_functions(
             &attribute.attr,
@@ -10570,15 +10542,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 assigned_type = Some(ty);
             }
         }
-        let fallback_place = value_type
+        let member_lookup = value_type
             .try_member_lookup(db, env, &attr.id)
             .unwrap_or_else(|error| {
                 error.report_diagnostic(&self.context, value_type, attribute, assigned_type);
                 error.fallback_member(db)
-            })
-            .map_type(|ty| {
-                self.narrow_expr_with_applicable_constraints(attribute, ty, &constraint_keys)
             });
+        let fallback_place = member_lookup.member(db).map_type(|ty| {
+            self.narrow_expr_with_applicable_constraints(attribute, ty, &constraint_keys)
+        });
 
         let attr_name = &attr.id;
         let lookup_result = fallback_place.into_lookup_result(db, env);
@@ -10849,15 +10821,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Deleting an attribute does not invoke its getter. Augmented assignment, however,
         // reads the property here even though its AST target has a store context.
-        self.check_deprecated_property(
-            attribute,
-            value_type,
-            if attribute.ctx == ExprContext::Del {
-                ExprContext::Del
-            } else {
-                ExprContext::Load
-            },
-        );
+        if let Some(properties) = member_lookup.deprecated_properties(db) {
+            self.check_deprecated_property(
+                attribute,
+                properties,
+                if attribute.ctx == ExprContext::Del {
+                    ExprContext::Del
+                } else {
+                    ExprContext::Load
+                },
+            );
+        }
 
         // Even if we can obtain the attribute type based on the assignments, we still perform default type inference
         // (to report errors).

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10004,7 +10004,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Report the distinct deprecated targets of one operation in a single diagnostic.
-    /// Union alternatives can select the same source function or overload more than once.
+    /// Deduplicate by source function or overload, retaining separate source annotations for
+    /// distinct declarations. Include their messages in the primary annotation for concise output.
     fn report_deprecated_functions(
         &self,
         ranged: impl Ranged,
@@ -10070,13 +10071,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Check the accessor invoked by an attribute operation, using the property descriptors
-    /// retained by member lookup or assignment validation.
+    /// retained by member lookup or assignment validation. `access` describes the operation,
+    /// which may differ from the AST context: an augmented assignment also reads its target.
+    ///
+    /// ```python
+    /// from typing_extensions import deprecated
+    ///
+    /// class C:
+    ///     @property
+    ///     @deprecated("old getter")
+    ///     def value(self) -> int:
+    ///         return 0
+    ///
+    ///     @value.setter
+    ///     def value(self, new: int) -> None: ...
+    ///
+    /// c = C()
+    /// c.value = 1   # Only invokes the non-deprecated setter.
+    /// c.value += 1  # Also invokes the deprecated getter.
+    /// ```
     fn check_deprecated_property(
         &self,
         attribute: &ast::ExprAttribute,
         member: Type<'db>,
         access: ExprContext,
     ) {
+        /// Represent absent accessors and non-property members as `Unknown` to retain
+        /// non-deprecated intersection alternatives.
         fn accessors<'db>(
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9417,6 +9417,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
+        self.check_deprecated_overloads(func.as_ref(), &bindings);
+
         if let Some(class) = class {
             pydantic::report_discarded_extra_arguments(&self.context, class, arguments, &bindings);
         }
@@ -9942,10 +9944,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             _ => return,
         };
 
-        // Currently we only check the final implementation for deprecation, as
-        // that check can be done on any reference to the function. Analysis of
-        // deprecated overloads needs to be done in places where we resolve the
-        // actual overloads being used.
+        // References to a function only check its implementation. Deprecated overloads are
+        // checked at call sites, after resolving which signatures accept the arguments.
         let Some(deprecated) = function.implementation_deprecated(self.db()) else {
             return;
         };
@@ -9964,6 +9964,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             diag.set_primary_annotation_message(message.value(self.db()));
         }
         diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+    }
+
+    /// Check selected overloads without reporting deprecations on unused overloads or on
+    /// implementations, which are already checked when the function is referenced.
+    fn check_deprecated_overloads<T: Ranged>(&self, ranged: &T, bindings: &Bindings<'db>) {
+        let db = self.db();
+        for callables in bindings.iter_union_elements() {
+            if callables
+                .clone()
+                .all(|callable| callable.deprecated_overloads(db).next().is_some())
+            {
+                for overload in callables.flat_map(|callable| callable.deprecated_overloads(db)) {
+                    let Some(builder) = self.context.report_lint(&diagnostic::DEPRECATED, ranged)
+                    else {
+                        continue;
+                    };
+                    let mut diagnostic = builder.into_diagnostic(format_args!(
+                        "The overload of `{}` is deprecated",
+                        overload.name(db),
+                    ));
+                    if let Some(message) = overload
+                        .deprecated(db)
+                        .and_then(|deprecated| deprecated.message)
+                    {
+                        diagnostic.set_primary_annotation_message(message.value(db));
+                    }
+                    diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+                }
+            }
+        }
     }
 
     /// Report a deprecated callable only when its union alternative has no non-deprecated

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -108,6 +108,7 @@ enum AttributeWriteEvaluation {
 
 /// The validity and deprecated accessors collected from one assignment requirement.
 struct AttributeWriteOutcome<'db> {
+    /// The validation result; not meaningful when only collecting deprecations.
     valid: bool,
     deprecated_properties: Option<Type<'db>>,
 }
@@ -188,6 +189,9 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
     }
 
     /// Resolve each alternative once, keeping accessor metadata even after validation stops.
+    /// A failed union alternative or successful intersection alternative decides validity; any
+    /// remaining alternatives contribute only deprecations, without re-inferring the value.
+    /// Deprecation collection depends on the enclosing assignment, even for silent trial branches.
     fn evaluate(
         &mut self,
         requirement: &AttributeWriteRequirement<'db>,

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -36,6 +36,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         emit_diagnostics: bool,
     ) -> bool {
         let db = self.db();
+        if emit_diagnostics {
+            self.check_deprecated_property(target, object_ty, ast::ExprContext::Store);
+        }
         let requirement =
             attribute_write_requirement(db, self.program_environment(), object_ty, attribute);
         let mut evaluator = AssignmentAttributeWriteEvaluator {

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -18,8 +18,9 @@ use crate::types::diagnostic::{
 };
 use crate::types::{
     CallDunderError, DisplaySettings, IntersectionType, MemberLookupPolicy, Type, TypeContext,
-    TypeQualifiers, union_deprecated_properties,
+    TypeQualifiers, UnionType,
 };
+use crate::{Db, ProgramEnvironment};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Make sure that the attribute assignment `obj.attribute = value` is valid.
@@ -39,8 +40,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
         let requirement =
             attribute_write_requirement(db, self.program_environment(), object_ty, attribute);
+        let mut deprecation = (emit_diagnostics && self.context.is_lint_enabled(&DEPRECATED))
+            .then_some(AttributeDeprecation::Missing);
         let mut evaluator = AssignmentAttributeWriteEvaluator {
-            collect_deprecations: emit_diagnostics && self.context.is_lint_enabled(&DEPRECATED),
             builder: self,
             target,
             value,
@@ -48,14 +50,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             attribute,
             infer_value_ty: MultiInferenceGuard::new(infer_value_ty),
         };
-        let outcome = evaluator.evaluate(
-            &requirement,
-            AttributeWriteEvaluation::Validate { emit_diagnostics },
-        );
-        if let Some(properties) = outcome.deprecated_properties {
+        let valid = evaluator.evaluate(&requirement, emit_diagnostics, deprecation.as_mut());
+        if let Some(AttributeDeprecation::Deprecated(properties)) = deprecation {
             self.check_deprecated_property(target, properties, ast::ExprContext::Store);
         }
-        outcome.valid
+        valid
     }
 }
 
@@ -93,20 +92,110 @@ enum ContextualInference {
     Speculate,
 }
 
-/// Validation can stop at a decisive alternative while deprecation collection continues.
+/// Whether a resolved write target contributes or suppresses a property deprecation.
 #[derive(Clone, Copy)]
-enum AttributeWriteEvaluation {
-    /// Validate the assignment, optionally reporting its errors.
-    Validate { emit_diagnostics: bool },
-    /// Collect deprecated accessors without inferring the value or validating the assignment.
-    Deprecation,
+enum AttributeDeprecation<'db> {
+    /// No declared member provides an alternative to another member's deprecated accessor.
+    Missing,
+    /// A non-deprecated member can provide the implementation in an intersection.
+    NotDeprecated,
+    /// Property descriptors whose accessor deprecations are checked at the assignment site.
+    Deprecated(Type<'db>),
 }
 
-/// The validity and deprecated accessors collected from one assignment requirement.
-struct AttributeWriteOutcome<'db> {
-    /// The validation result; not meaningful when only collecting deprecations.
-    valid: bool,
-    deprecated_properties: Option<Type<'db>>,
+impl<'db> AttributeDeprecation<'db> {
+    /// Inspect a resolved requirement without inferring or validating the assigned value.
+    /// Only union and intersection children need further attribute lookups.
+    fn from_requirement(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        requirement: &AttributeWriteRequirement<'db>,
+        attribute: &str,
+    ) -> Self {
+        match requirement {
+            AttributeWriteRequirement::All { element_tys, .. } => {
+                element_tys.iter().fold(Self::Missing, |deprecation, ty| {
+                    let requirement = attribute_write_requirement(db, env, *ty, attribute);
+                    deprecation.union(
+                        db,
+                        env,
+                        Self::from_requirement(db, env, &requirement, attribute),
+                    )
+                })
+            }
+            AttributeWriteRequirement::Any { intersection, .. } => {
+                let mut deprecation = Self::Missing;
+                for ty in intersection.positive(db) {
+                    let requirement = attribute_write_requirement(db, env, *ty, attribute);
+                    deprecation = deprecation.intersection(
+                        db,
+                        env,
+                        Self::from_requirement(db, env, &requirement, attribute),
+                    );
+                    if matches!(deprecation, Self::NotDeprecated) {
+                        break;
+                    }
+                }
+                deprecation
+            }
+            AttributeWriteRequirement::ProtocolMember {
+                write: Some(ProtocolMemberWriteRequirement::Descriptor { descriptor_ty, .. }),
+                ..
+            }
+            | AttributeWriteRequirement::Instance {
+                member:
+                    InstanceAttributeWriteMember::Explicit {
+                        member: ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. },
+                        ..
+                    },
+                ..
+            }
+            | AttributeWriteRequirement::Class {
+                member:
+                    ClassAttributeWriteMember::Explicit {
+                        member: ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. },
+                        ..
+                    },
+                ..
+            } if descriptor_ty.has_deprecated_property(db) => Self::Deprecated(*descriptor_ty),
+            AttributeWriteRequirement::Instance {
+                member: InstanceAttributeWriteMember::SetAttr,
+                ..
+            }
+            | AttributeWriteRequirement::Class {
+                member: ClassAttributeWriteMember::Unresolved { .. },
+                ..
+            }
+            | AttributeWriteRequirement::Module(None) => Self::Missing,
+            _ => Self::NotDeprecated,
+        }
+    }
+
+    /// A union can invoke either target, so either target can contribute a deprecation.
+    fn union(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, other: Self) -> Self {
+        match (self, other) {
+            (Self::Deprecated(left), Self::Deprecated(right)) => {
+                Self::Deprecated(UnionType::from_two_elements(db, env, left, right))
+            }
+            (deprecated @ Self::Deprecated(_), _) | (_, deprecated @ Self::Deprecated(_)) => {
+                deprecated
+            }
+            (Self::NotDeprecated, _) | (_, Self::NotDeprecated) => Self::NotDeprecated,
+            (Self::Missing, Self::Missing) => Self::Missing,
+        }
+    }
+
+    /// An intersection can use a non-deprecated member instead, but an absent member cannot
+    /// provide an alternative implementation.
+    fn intersection(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, other: Self) -> Self {
+        match (self, other) {
+            (Self::NotDeprecated, _) | (_, Self::NotDeprecated) => Self::NotDeprecated,
+            (Self::Deprecated(left), Self::Deprecated(right)) => {
+                Self::Deprecated(IntersectionType::from_two_elements(db, env, left, right))
+            }
+            (Self::Missing, other) | (other, Self::Missing) => other,
+        }
+    }
 }
 
 struct AssignmentAttributeWriteEvaluator<'a, 'db, 'ast, 'infer> {
@@ -116,7 +205,6 @@ struct AssignmentAttributeWriteEvaluator<'a, 'db, 'ast, 'infer> {
     object_ty: Type<'db>,
     attribute: &'a str,
     infer_value_ty: MultiInferenceGuard<'db, 'ast, 'infer>,
-    collect_deprecations: bool,
 }
 
 impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
@@ -184,99 +272,66 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         (setattr_result, value_ty)
     }
 
-    /// Resolve each alternative once, keeping accessor metadata even after validation stops.
-    /// A failed union alternative or successful intersection alternative decides validity; any
-    /// remaining alternatives contribute only deprecations, without re-inferring the value.
-    /// Deprecation collection depends on the enclosing assignment, even for silent trial branches.
+    /// Validate the assignment and optionally record its accessor deprecations.
+    /// After validation short-circuits, a pure collector inspects the remaining alternatives
+    /// without changing the inference context selected for the assigned value.
+    /// When provided, `deprecation` receives the result even if validation fails.
     fn evaluate(
         &mut self,
         requirement: &AttributeWriteRequirement<'db>,
-        mode: AttributeWriteEvaluation,
-    ) -> AttributeWriteOutcome<'db> {
+        emit_diagnostics: bool,
+        mut deprecation: Option<&mut AttributeDeprecation<'db>>,
+    ) -> bool {
         let db = self.builder.db();
         let env = self.builder.program_environment();
-        let (validate, emit_diagnostics) = match mode {
-            AttributeWriteEvaluation::Validate { emit_diagnostics } => (true, emit_diagnostics),
-            AttributeWriteEvaluation::Deprecation => (false, false),
-        };
-        let mut deprecated_properties = if self.collect_deprecations {
-            match requirement {
-                AttributeWriteRequirement::ProtocolMember {
-                    write: Some(ProtocolMemberWriteRequirement::Descriptor { descriptor_ty, .. }),
-                    ..
+        if let Some(deprecation) = deprecation.as_deref_mut() {
+            *deprecation = match requirement {
+                AttributeWriteRequirement::All { .. } | AttributeWriteRequirement::Any { .. } => {
+                    AttributeDeprecation::Missing
                 }
-                | AttributeWriteRequirement::Instance {
-                    member:
-                        InstanceAttributeWriteMember::Explicit {
-                            member:
-                                ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. },
-                            ..
-                        },
-                    ..
-                }
-                | AttributeWriteRequirement::Class {
-                    member:
-                        ClassAttributeWriteMember::Explicit {
-                            member:
-                                ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. },
-                            ..
-                        },
-                    ..
-                } => descriptor_ty
-                    .has_deprecated_property(db)
-                    .then_some(*descriptor_ty),
-                _ => None,
-            }
-        } else {
-            None
-        };
-        if !validate
-            && !matches!(
-                requirement,
-                AttributeWriteRequirement::All { .. } | AttributeWriteRequirement::Any { .. }
-            )
-        {
-            // An enclosing alternative already decided validity. Only the accessor metadata
-            // from this result is used, so do not infer the value or validate the write again.
-            return AttributeWriteOutcome {
-                valid: true,
-                deprecated_properties,
+                _ => AttributeDeprecation::from_requirement(db, env, requirement, self.attribute),
             };
         }
 
-        let valid = match requirement {
+        match requirement {
             AttributeWriteRequirement::All {
                 object_ty,
                 element_tys,
             } => {
-                let value_ty =
-                    validate.then(|| self.infer_value(TypeContext::default(), emit_diagnostics));
-                let mut valid = true;
-                for element_ty in *element_tys {
-                    let requirement =
-                        attribute_write_requirement(db, env, *element_ty, self.attribute);
-                    let mode = if validate && valid {
-                        AttributeWriteEvaluation::Validate {
-                            emit_diagnostics: false,
-                        }
-                    } else {
-                        AttributeWriteEvaluation::Deprecation
-                    };
-                    let outcome = self.evaluate(&requirement, mode);
-                    valid &= outcome.valid;
-                    deprecated_properties = union_deprecated_properties(
-                        db,
-                        env,
-                        deprecated_properties,
-                        outcome.deprecated_properties,
+                let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
+                let attribute = self.attribute;
+                let mut requirements = element_tys
+                    .iter()
+                    .map(|ty| attribute_write_requirement(db, env, *ty, attribute));
+                let valid = requirements.by_ref().all(|requirement| {
+                    let mut current = AttributeDeprecation::Missing;
+                    let valid = self.evaluate(
+                        &requirement,
+                        false,
+                        deprecation.as_ref().map(|_| &mut current),
                     );
-                    if !valid && !self.collect_deprecations {
-                        break;
+                    if let Some(deprecation) = deprecation.as_deref_mut() {
+                        *deprecation = deprecation.union(db, env, current);
                     }
+                    valid
+                });
+                if let Some(deprecation) = deprecation {
+                    *deprecation = requirements.fold(*deprecation, |deprecation, requirement| {
+                        deprecation.union(
+                            db,
+                            env,
+                            AttributeDeprecation::from_requirement(
+                                db,
+                                env,
+                                &requirement,
+                                attribute,
+                            ),
+                        )
+                    });
                 }
                 if valid {
                     self.validate_composite_final_assignment(*object_ty, emit_diagnostics);
-                } else if emit_diagnostics && let Some(value_ty) = value_ty {
+                } else if emit_diagnostics {
                     self.report(
                         AssignmentAttributeWriteDiagnostic::InvalidCompositeAssignment {
                             object_ty: *object_ty,
@@ -290,53 +345,43 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 object_ty,
                 intersection,
             } => {
-                let mut valid = false;
-                let mut all_deprecated = true;
-                for element_ty in intersection.positive(db) {
-                    let requirement =
-                        attribute_write_requirement(db, env, *element_ty, self.attribute);
-                    let mode = if validate && !valid {
-                        AttributeWriteEvaluation::Validate {
-                            emit_diagnostics: false,
-                        }
-                    } else {
-                        AttributeWriteEvaluation::Deprecation
-                    };
-                    let outcome = self.evaluate(&requirement, mode);
-                    valid |= outcome.valid;
-                    // An absent member does not provide a non-deprecated alternative setter.
-                    if !matches!(
-                        requirement,
-                        AttributeWriteRequirement::Instance {
-                            member: InstanceAttributeWriteMember::SetAttr,
-                            ..
-                        } | AttributeWriteRequirement::Class {
-                            member: ClassAttributeWriteMember::Unresolved { .. },
-                            ..
-                        } | AttributeWriteRequirement::Module(None)
-                    ) {
-                        if let Some(properties) = outcome.deprecated_properties {
-                            deprecated_properties = Some(match deprecated_properties {
-                                Some(previous) => IntersectionType::from_two_elements(
-                                    db, env, previous, properties,
-                                ),
-                                None => properties,
-                            });
-                        } else {
-                            all_deprecated = false;
-                        }
+                let attribute = self.attribute;
+                let mut requirements = intersection
+                    .positive(db)
+                    .iter()
+                    .map(|ty| attribute_write_requirement(db, env, *ty, attribute));
+                let valid = requirements.by_ref().any(|requirement| {
+                    let mut current = AttributeDeprecation::Missing;
+                    let valid = self.evaluate(
+                        &requirement,
+                        false,
+                        deprecation.as_ref().map(|_| &mut current),
+                    );
+                    if let Some(deprecation) = deprecation.as_deref_mut() {
+                        *deprecation = deprecation.intersection(db, env, current);
                     }
-                    if valid && (!self.collect_deprecations || !all_deprecated) {
-                        break;
+                    valid
+                });
+                if let Some(deprecation) = deprecation {
+                    while !matches!(deprecation, AttributeDeprecation::NotDeprecated)
+                        && let Some(requirement) = requirements.next()
+                    {
+                        *deprecation = deprecation.intersection(
+                            db,
+                            env,
+                            AttributeDeprecation::from_requirement(
+                                db,
+                                env,
+                                &requirement,
+                                attribute,
+                            ),
+                        );
                     }
                 }
-                if !all_deprecated {
-                    deprecated_properties = None;
-                }
-                if validate && valid {
+                if valid {
                     self.infer_with_last_context(emit_diagnostics);
                     self.validate_composite_final_assignment(*object_ty, emit_diagnostics);
-                } else if validate {
+                } else {
                     let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
                     if emit_diagnostics {
                         self.report(
@@ -393,10 +438,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     if let Some(domain) = domain
                         && !self.check_type_pair(value_ty, *domain, emit_diagnostics)
                     {
-                        return AttributeWriteOutcome {
-                            valid: false,
-                            deprecated_properties,
-                        };
+                        return false;
                     }
                     self.evaluate_protocol_descriptor_write(
                         *descriptor_ty,
@@ -430,10 +472,6 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             AttributeWriteRequirement::Class { object_ty, member } => {
                 self.evaluate_class(*object_ty, member, emit_diagnostics)
             }
-        };
-        AttributeWriteOutcome {
-            valid,
-            deprecated_properties,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -48,12 +48,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             attribute,
             infer_value_ty: MultiInferenceGuard::new(infer_value_ty),
         };
-        let mode = if emit_diagnostics {
-            AttributeWriteEvaluation::Validate
-        } else {
-            AttributeWriteEvaluation::ValidateSilently
-        };
-        let outcome = evaluator.evaluate(&requirement, mode);
+        let outcome = evaluator.evaluate(
+            &requirement,
+            AttributeWriteEvaluation::Validate { emit_diagnostics },
+        );
         if let Some(properties) = outcome.deprecated_properties {
             self.check_deprecated_property(target, properties, ast::ExprContext::Store);
         }
@@ -98,12 +96,10 @@ enum ContextualInference {
 /// Validation can stop at a decisive alternative while deprecation collection continues.
 #[derive(Clone, Copy)]
 enum AttributeWriteEvaluation {
-    /// Validate the assignment and report its errors.
-    Validate,
-    /// Validate an alternative without reporting its individual errors.
-    ValidateSilently,
-    /// Inspect accessor metadata without inferring the value or validating the assignment.
-    DeprecationsOnly,
+    /// Validate the assignment, optionally reporting its errors.
+    Validate { emit_diagnostics: bool },
+    /// Collect deprecated accessors without inferring the value or validating the assignment.
+    Deprecation,
 }
 
 /// The validity and deprecated accessors collected from one assignment requirement.
@@ -199,8 +195,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
     ) -> AttributeWriteOutcome<'db> {
         let db = self.builder.db();
         let env = self.builder.program_environment();
-        let validate = !matches!(mode, AttributeWriteEvaluation::DeprecationsOnly);
-        let emit_diagnostics = matches!(mode, AttributeWriteEvaluation::Validate);
+        let (validate, emit_diagnostics) = match mode {
+            AttributeWriteEvaluation::Validate { emit_diagnostics } => (true, emit_diagnostics),
+            AttributeWriteEvaluation::Deprecation => (false, false),
+        };
         let mut deprecated_properties = if self.collect_deprecations {
             match requirement {
                 AttributeWriteRequirement::ProtocolMember {
@@ -258,9 +256,11 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     let requirement =
                         attribute_write_requirement(db, env, *element_ty, self.attribute);
                     let mode = if validate && valid {
-                        AttributeWriteEvaluation::ValidateSilently
+                        AttributeWriteEvaluation::Validate {
+                            emit_diagnostics: false,
+                        }
                     } else {
-                        AttributeWriteEvaluation::DeprecationsOnly
+                        AttributeWriteEvaluation::Deprecation
                     };
                     let outcome = self.evaluate(&requirement, mode);
                     valid &= outcome.valid;
@@ -296,9 +296,11 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     let requirement =
                         attribute_write_requirement(db, env, *element_ty, self.attribute);
                     let mode = if validate && !valid {
-                        AttributeWriteEvaluation::ValidateSilently
+                        AttributeWriteEvaluation::Validate {
+                            emit_diagnostics: false,
+                        }
                     } else {
-                        AttributeWriteEvaluation::DeprecationsOnly
+                        AttributeWriteEvaluation::Deprecation
                     };
                     let outcome = self.evaluate(&requirement, mode);
                     valid |= outcome.valid;

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -12,12 +12,13 @@ use crate::types::call::{Bindings, CallArguments, CallDiagnosticOverride, CallEr
 use crate::types::class::FrozenDataclassDispatch;
 use crate::types::dedicated::pydantic;
 use crate::types::diagnostic::{
-    INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, MISSING_SLOT, UNRESOLVED_ATTRIBUTE,
+    DEPRECATED, INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, MISSING_SLOT, UNRESOLVED_ATTRIBUTE,
     report_bad_dunder_set_call, report_invalid_attribute_assignment,
     report_possibly_missing_attribute,
 };
 use crate::types::{
-    CallDunderError, DisplaySettings, MemberLookupPolicy, Type, TypeContext, TypeQualifiers,
+    CallDunderError, DisplaySettings, IntersectionType, MemberLookupPolicy, Type, TypeContext,
+    TypeQualifiers, union_deprecated_properties,
 };
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
@@ -36,12 +37,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         emit_diagnostics: bool,
     ) -> bool {
         let db = self.db();
-        if emit_diagnostics {
-            self.check_deprecated_property(target, object_ty, ast::ExprContext::Store);
-        }
         let requirement =
             attribute_write_requirement(db, self.program_environment(), object_ty, attribute);
         let mut evaluator = AssignmentAttributeWriteEvaluator {
+            collect_deprecations: emit_diagnostics && self.context.is_lint_enabled(&DEPRECATED),
             builder: self,
             target,
             value,
@@ -49,7 +48,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             attribute,
             infer_value_ty: MultiInferenceGuard::new(infer_value_ty),
         };
-        evaluator.evaluate(&requirement, emit_diagnostics)
+        let mode = if emit_diagnostics {
+            AttributeWriteEvaluation::Validate
+        } else {
+            AttributeWriteEvaluation::ValidateSilently
+        };
+        let outcome = evaluator.evaluate(&requirement, mode);
+        if let Some(properties) = outcome.deprecated_properties {
+            self.check_deprecated_property(target, properties, ast::ExprContext::Store);
+        }
+        outcome.valid
     }
 }
 
@@ -87,6 +95,23 @@ enum ContextualInference {
     Speculate,
 }
 
+/// Validation can stop at a decisive alternative while deprecation collection continues.
+#[derive(Clone, Copy)]
+enum AttributeWriteEvaluation {
+    /// Validate the assignment and report its errors.
+    Validate,
+    /// Validate an alternative without reporting its individual errors.
+    ValidateSilently,
+    /// Inspect accessor metadata without inferring the value or validating the assignment.
+    DeprecationsOnly,
+}
+
+/// The validity and deprecated accessors collected from one assignment requirement.
+struct AttributeWriteOutcome<'db> {
+    valid: bool,
+    deprecated_properties: Option<Type<'db>>,
+}
+
 struct AssignmentAttributeWriteEvaluator<'a, 'db, 'ast, 'infer> {
     builder: &'a mut TypeInferenceBuilder<'db, 'ast>,
     target: &'a ast::ExprAttribute,
@@ -94,6 +119,7 @@ struct AssignmentAttributeWriteEvaluator<'a, 'db, 'ast, 'infer> {
     object_ty: Type<'db>,
     attribute: &'a str,
     infer_value_ty: MultiInferenceGuard<'db, 'ast, 'infer>,
+    collect_deprecations: bool,
 }
 
 impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
@@ -161,61 +187,150 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         (setattr_result, value_ty)
     }
 
+    /// Resolve each alternative once, keeping accessor metadata even after validation stops.
     fn evaluate(
         &mut self,
         requirement: &AttributeWriteRequirement<'db>,
-        emit_diagnostics: bool,
-    ) -> bool {
+        mode: AttributeWriteEvaluation,
+    ) -> AttributeWriteOutcome<'db> {
         let db = self.builder.db();
         let env = self.builder.program_environment();
-        match requirement {
+        let validate = !matches!(mode, AttributeWriteEvaluation::DeprecationsOnly);
+        let emit_diagnostics = matches!(mode, AttributeWriteEvaluation::Validate);
+        let mut deprecated_properties = if self.collect_deprecations {
+            match requirement {
+                AttributeWriteRequirement::ProtocolMember {
+                    write: Some(ProtocolMemberWriteRequirement::Descriptor { descriptor_ty, .. }),
+                    ..
+                }
+                | AttributeWriteRequirement::Instance {
+                    member:
+                        InstanceAttributeWriteMember::Explicit {
+                            member:
+                                ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. },
+                            ..
+                        },
+                    ..
+                }
+                | AttributeWriteRequirement::Class {
+                    member:
+                        ClassAttributeWriteMember::Explicit {
+                            member:
+                                ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. },
+                            ..
+                        },
+                    ..
+                } => descriptor_ty
+                    .has_deprecated_property(db)
+                    .then_some(*descriptor_ty),
+                _ => None,
+            }
+        } else {
+            None
+        };
+        if !validate
+            && !matches!(
+                requirement,
+                AttributeWriteRequirement::All { .. } | AttributeWriteRequirement::Any { .. }
+            )
+        {
+            // An enclosing alternative already decided validity. Only the accessor metadata
+            // from this result is used, so do not infer the value or validate the write again.
+            return AttributeWriteOutcome {
+                valid: true,
+                deprecated_properties,
+            };
+        }
+
+        let valid = match requirement {
             AttributeWriteRequirement::All {
                 object_ty,
                 element_tys,
             } => {
-                let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
+                let value_ty =
+                    validate.then(|| self.infer_value(TypeContext::default(), emit_diagnostics));
                 let mut valid = true;
                 for element_ty in *element_tys {
                     let requirement =
                         attribute_write_requirement(db, env, *element_ty, self.attribute);
-                    if !self.evaluate(&requirement, false) {
-                        valid = false;
+                    let mode = if validate && valid {
+                        AttributeWriteEvaluation::ValidateSilently
+                    } else {
+                        AttributeWriteEvaluation::DeprecationsOnly
+                    };
+                    let outcome = self.evaluate(&requirement, mode);
+                    valid &= outcome.valid;
+                    deprecated_properties = union_deprecated_properties(
+                        db,
+                        env,
+                        deprecated_properties,
+                        outcome.deprecated_properties,
+                    );
+                    if !valid && !self.collect_deprecations {
                         break;
                     }
                 }
                 if valid {
                     self.validate_composite_final_assignment(*object_ty, emit_diagnostics);
-                    true
-                } else {
-                    if emit_diagnostics {
-                        self.report(
-                            AssignmentAttributeWriteDiagnostic::InvalidCompositeAssignment {
-                                object_ty: *object_ty,
-                                value_ty,
-                            },
-                        );
-                    }
-                    false
+                } else if emit_diagnostics && let Some(value_ty) = value_ty {
+                    self.report(
+                        AssignmentAttributeWriteDiagnostic::InvalidCompositeAssignment {
+                            object_ty: *object_ty,
+                            value_ty,
+                        },
+                    );
                 }
+                valid
             }
             AttributeWriteRequirement::Any {
                 object_ty,
                 intersection,
             } => {
                 let mut valid = false;
-                for element_ty in intersection.positive(self.builder.db()) {
+                let mut all_deprecated = true;
+                for element_ty in intersection.positive(db) {
                     let requirement =
                         attribute_write_requirement(db, env, *element_ty, self.attribute);
-                    if self.evaluate(&requirement, false) {
-                        valid = true;
+                    let mode = if validate && !valid {
+                        AttributeWriteEvaluation::ValidateSilently
+                    } else {
+                        AttributeWriteEvaluation::DeprecationsOnly
+                    };
+                    let outcome = self.evaluate(&requirement, mode);
+                    valid |= outcome.valid;
+                    // An absent member does not provide a non-deprecated alternative setter.
+                    if !matches!(
+                        requirement,
+                        AttributeWriteRequirement::Instance {
+                            member: InstanceAttributeWriteMember::SetAttr,
+                            ..
+                        } | AttributeWriteRequirement::Class {
+                            member: ClassAttributeWriteMember::Unresolved { .. },
+                            ..
+                        } | AttributeWriteRequirement::Module(None)
+                    ) {
+                        if let Some(properties) = outcome.deprecated_properties {
+                            deprecated_properties = Some(match deprecated_properties {
+                                Some(previous) => IntersectionType::from_two_elements(
+                                    db, env, previous, properties,
+                                ),
+                                None => properties,
+                            });
+                        } else {
+                            all_deprecated = false;
+                        }
+                    }
+                    if valid && (!self.collect_deprecations || !all_deprecated) {
                         break;
                     }
                 }
-                if valid {
+                if !all_deprecated {
+                    deprecated_properties = None;
+                }
+                if validate && valid {
                     self.infer_with_last_context(emit_diagnostics);
                     self.validate_composite_final_assignment(*object_ty, emit_diagnostics);
-                    true
-                } else {
+                } else if validate {
                     let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
                     if emit_diagnostics {
                         self.report(
@@ -225,8 +340,8 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                             },
                         );
                     }
-                    false
                 }
+                valid
             }
             AttributeWriteRequirement::Unconstrained => {
                 self.infer_value(TypeContext::default(), emit_diagnostics);
@@ -272,7 +387,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     if let Some(domain) = domain
                         && !self.check_type_pair(value_ty, *domain, emit_diagnostics)
                     {
-                        return false;
+                        return AttributeWriteOutcome {
+                            valid: false,
+                            deprecated_properties,
+                        };
                     }
                     self.evaluate_protocol_descriptor_write(
                         *descriptor_ty,
@@ -306,6 +424,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             AttributeWriteRequirement::Class { object_ty, member } => {
                 self.evaluate_class(*object_ty, member, emit_diagnostics)
             }
+        };
+        AttributeWriteOutcome {
+            valid,
+            deprecated_properties,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -292,17 +292,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         op: ast::Operator,
         right_ty: Type<'db>,
     ) -> Option<Type<'db>> {
-        let (return_type, deprecated) = Type::try_call_bin_op_result(
+        let result = Type::try_call_bin_op_result(
             self.db(),
             self.program_environment(),
             left_ty,
             op,
             right_ty,
         )?;
-        for function in deprecated {
-            self.report_deprecated_function(&node, *function);
+        for &function in &result.deprecated_functions {
+            self.report_deprecated_function(&node, function);
         }
-        Some(return_type)
+        Some(result.return_type)
     }
 
     pub(super) fn infer_binary_expression_type(

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -30,7 +30,7 @@ type BinaryExpressionVisitor<'db> =
 /// Diagnostic state shared across the alternatives of one binary or augmented operation.
 #[derive(Default)]
 pub(super) struct BinaryInferenceState<'db> {
-    emitted_division_by_zero_diagnostic: bool,
+    pub(super) emitted_division_by_zero_diagnostic: bool,
     pub(super) deprecated_functions: Vec<OverloadLiteral<'db>>,
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -10,6 +10,7 @@ use crate::types::cyclic::CycleDetector;
 use crate::types::diagnostic::{
     DIVISION_BY_ZERO, report_unsupported_augmented_assignment, report_unsupported_binary_operation,
 };
+use crate::types::function::OverloadLiteral;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::typevar::TypeVarConstraints;
 use crate::types::{
@@ -25,6 +26,13 @@ enum BinaryExpressionOperandTypes<'db> {
 
 type BinaryExpressionVisitor<'db> =
     CycleDetector<'db, ast::Operator, (Type<'db>, ast::Operator, Type<'db>), Option<Type<'db>>, 1>;
+
+/// Diagnostic state shared across the alternatives of one binary or augmented operation.
+#[derive(Default)]
+pub(super) struct BinaryInferenceState<'db> {
+    emitted_division_by_zero_diagnostic: bool,
+    pub(super) deprecated_functions: Vec<OverloadLiteral<'db>>,
+}
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn infer_binary_expression(
@@ -50,11 +58,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 BinaryExpressionOperandTypes::Inferred(left_ty, right_ty) => (left_ty, right_ty),
             };
 
-        self.infer_binary_expression_type(binary.into(), false, left_ty, right_ty, *op)
-            .unwrap_or_else(|| {
-                report_unsupported_binary_operation(&self.context, binary, left_ty, right_ty, *op);
-                Type::unknown()
-            })
+        let mut state = BinaryInferenceState::default();
+        let return_type =
+            self.infer_binary_expression_type(binary.into(), left_ty, right_ty, *op, &mut state);
+        self.report_deprecated_functions(binary, state.deprecated_functions);
+        return_type.unwrap_or_else(|| {
+            report_unsupported_binary_operation(&self.context, binary, left_ty, right_ty, *op);
+            Type::unknown()
+        })
     }
 
     fn infer_pep_604_union_type_alias(
@@ -284,10 +295,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         })
     }
 
-    /// Report deprecations from the selected operator methods while reusing cached resolution.
+    /// Collect deprecations from the selected operator methods while reusing cached resolution.
     fn infer_binary_dunder(
         &self,
-        node: AnyNodeRef<'_>,
+        state: &mut BinaryInferenceState<'db>,
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
@@ -299,45 +310,47 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             op,
             right_ty,
         )?;
-        for &function in &result.deprecated_functions {
-            self.report_deprecated_function(&node, function);
-        }
+        state
+            .deprecated_functions
+            .extend(&result.deprecated_functions);
         Some(result.return_type)
     }
 
+    /// Infer the result type and collect deprecated methods for the enclosing operation.
+    /// The caller reports them together after expanding union operands and in-place fallbacks.
     pub(super) fn infer_binary_expression_type(
         &mut self,
         node: AnyNodeRef<'_>,
-        emitted_division_by_zero_diagnostic: bool,
         left_ty: Type<'db>,
         right_ty: Type<'db>,
         op: ast::Operator,
+        state: &mut BinaryInferenceState<'db>,
     ) -> Option<Type<'db>> {
         self.infer_binary_expression_type_impl(
             node,
-            emitted_division_by_zero_diagnostic,
             left_ty,
             right_ty,
             op,
             &BinaryExpressionVisitor::new(Some(Type::Never)),
+            state,
         )
     }
 
     fn infer_binary_expression_type_impl(
         &mut self,
         node: AnyNodeRef<'_>,
-        mut emitted_division_by_zero_diagnostic: bool,
         left_ty: Type<'db>,
         right_ty: Type<'db>,
         op: ast::Operator,
         visitor: &BinaryExpressionVisitor<'db>,
+        state: &mut BinaryInferenceState<'db>,
     ) -> Option<Type<'db>> {
         let env = self.program_environment();
         let db = self.db();
 
         // Check for division by zero; this doesn't change the inferred type for the expression, but
         // may emit a diagnostic
-        if !emitted_division_by_zero_diagnostic
+        if !state.emitted_division_by_zero_diagnostic
             && matches!(
                 op,
                 ast::Operator::Div | ast::Operator::FloorDiv | ast::Operator::Mod
@@ -346,50 +359,37 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 literal.as_bool() == Some(false) || literal.as_int() == Some(0)
             })
         {
-            emitted_division_by_zero_diagnostic = self.check_division_by_zero(node, op, left_ty);
+            state.emitted_division_by_zero_diagnostic =
+                self.check_division_by_zero(node, op, left_ty);
         }
 
         match (left_ty, right_ty, op) {
             (Type::Union(lhs_union), rhs, _) => lhs_union.try_map(db, env, |lhs_element| {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    *lhs_element,
-                    rhs,
-                    op,
-                    visitor,
-                )
+                self.infer_binary_expression_type_impl(node, *lhs_element, rhs, op, visitor, state)
             }),
             (lhs, Type::Union(rhs_union), _) => rhs_union.try_map(db, env, |rhs_element| {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    lhs,
-                    *rhs_element,
-                    op,
-                    visitor,
-                )
+                self.infer_binary_expression_type_impl(node, lhs, *rhs_element, op, visitor, state)
             }),
 
             (Type::TypeAlias(alias), rhs, _) => visitor.visit(db, (left_ty, op, right_ty), || {
                 self.infer_binary_expression_type_impl(
                     node,
-                    emitted_division_by_zero_diagnostic,
                     alias.value_type(db),
                     rhs,
                     op,
                     visitor,
+                    state,
                 )
             }),
 
             (lhs, Type::TypeAlias(alias), _) => visitor.visit(db, (left_ty, op, right_ty), || {
                 self.infer_binary_expression_type_impl(
                     node,
-                    emitted_division_by_zero_diagnostic,
                     lhs,
                     alias.value_type(db),
                     op,
                     visitor,
+                    state,
                 )
             }),
 
@@ -453,17 +453,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             constraints,
                             |constraint| {
                                 self.infer_binary_expression_type(
-                                    node,
-                                    emitted_division_by_zero_diagnostic,
-                                    constraint,
-                                    constraint,
-                                    op,
+                                    node, constraint, constraint, op, state,
                                 )
                             },
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => self.infer_binary_dunder(node, left_ty, op, right_ty),
+                    _ => self.infer_binary_dunder(state, left_ty, op, right_ty),
                 }
             }
 
@@ -484,18 +480,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             constraints,
                             |constraint| {
                                 self.infer_binary_expression_type_impl(
-                                    node,
-                                    emitted_division_by_zero_diagnostic,
-                                    constraint,
-                                    rhs,
-                                    op,
-                                    visitor,
+                                    node, constraint, rhs, op, visitor, state,
                                 )
                             },
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => self.infer_binary_dunder(node, left_ty, op, right_ty),
+                    _ => self.infer_binary_dunder(state, left_ty, op, right_ty),
                 }
             }
 
@@ -511,18 +502,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             constraints,
                             |constraint| {
                                 self.infer_binary_expression_type_impl(
-                                    node,
-                                    emitted_division_by_zero_diagnostic,
-                                    lhs,
-                                    constraint,
-                                    op,
-                                    visitor,
+                                    node, lhs, constraint, op, visitor, state,
                                 )
                             },
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => self.infer_binary_dunder(node, left_ty, op, right_ty),
+                    _ => self.infer_binary_dunder(state, left_ty, op, right_ty),
                 }
             }
 
@@ -533,27 +519,27 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // positional arguments get. In those cases we need to explicitly delegate to the base
             // type, so that it hits the `Type::Union` branches above.
             (Type::NewTypeInstance(newtype), rhs, _) => self
-                .infer_binary_dunder(node, left_ty, op, right_ty)
+                .infer_binary_dunder(state, left_ty, op, right_ty)
                 .or_else(|| {
                     self.infer_binary_expression_type_impl(
                         node,
-                        emitted_division_by_zero_diagnostic,
                         newtype.concrete_base_type(db),
                         rhs,
                         op,
                         visitor,
+                        state,
                     )
                 }),
             (lhs, Type::NewTypeInstance(newtype), _) => self
-                .infer_binary_dunder(node, left_ty, op, right_ty)
+                .infer_binary_dunder(state, left_ty, op, right_ty)
                 .or_else(|| {
                     self.infer_binary_expression_type_impl(
                         node,
-                        emitted_division_by_zero_diagnostic,
                         lhs,
                         newtype.concrete_base_type(db),
                         op,
                         visitor,
+                        state,
                     )
                 }),
 
@@ -782,19 +768,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         op,
                     ) => self.infer_binary_expression_type(
                         node,
-                        emitted_division_by_zero_diagnostic,
                         Type::int_literal(i64::from(b1)),
                         right_ty,
                         op,
+                        state,
                     ),
 
                     (LiteralValueTypeKind::Int(_), LiteralValueTypeKind::Bool(b2), op) => self
                         .infer_binary_expression_type(
                             node,
-                            emitted_division_by_zero_diagnostic,
                             left_ty,
                             Type::int_literal(i64::from(b2)),
                             op,
+                            state,
                         ),
 
                     (
@@ -850,7 +836,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         Some(result)
                     }
 
-                    _ => self.infer_binary_dunder(node, left_ty, op, right_ty),
+                    _ => self.infer_binary_dunder(state, left_ty, op, right_ty),
                 };
 
                 result.map(|result| match result {
@@ -990,7 +976,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             )
             .ok()
             .map(|binding| {
-                self.check_deprecated_bindings(&node, &binding);
+                state.deprecated_functions.extend(
+                    binding
+                        .deprecated_functions(db)
+                        .map(|(_, function)| function),
+                );
                 binding.return_type(db, env)
             }),
 
@@ -1054,7 +1044,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 | Type::TypeForm(_)
                 | Type::TypedDict(_),
                 op,
-            ) => self.infer_binary_dunder(node, left_ty, op, right_ty),
+            ) => self.infer_binary_dunder(state, left_ty, op, right_ty),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -284,6 +284,27 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         })
     }
 
+    /// Report deprecations from the selected operator methods while reusing cached resolution.
+    fn infer_binary_dunder(
+        &self,
+        node: AnyNodeRef<'_>,
+        left_ty: Type<'db>,
+        op: ast::Operator,
+        right_ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        let (return_type, deprecated) = Type::try_call_bin_op_result(
+            self.db(),
+            self.program_environment(),
+            left_ty,
+            op,
+            right_ty,
+        )?;
+        for function in deprecated {
+            self.report_deprecated_function(&node, *function);
+        }
+        Some(return_type)
+    }
+
     pub(super) fn infer_binary_expression_type(
         &mut self,
         node: AnyNodeRef<'_>,
@@ -442,7 +463,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, env, left_ty, op, right_ty),
+                    _ => self.infer_binary_dunder(node, left_ty, op, right_ty),
                 }
             }
 
@@ -474,7 +495,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, env, left_ty, op, right_ty),
+                    _ => self.infer_binary_dunder(node, left_ty, op, right_ty),
                 }
             }
 
@@ -501,7 +522,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, env, left_ty, op, right_ty),
+                    _ => self.infer_binary_dunder(node, left_ty, op, right_ty),
                 }
             }
 
@@ -511,8 +532,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // get the same `int | float` and `int | float | complex` special treatment that the
             // positional arguments get. In those cases we need to explicitly delegate to the base
             // type, so that it hits the `Type::Union` branches above.
-            (Type::NewTypeInstance(newtype), rhs, _) => {
-                Type::try_call_bin_op_return_type(db, env, left_ty, op, right_ty).or_else(|| {
+            (Type::NewTypeInstance(newtype), rhs, _) => self
+                .infer_binary_dunder(node, left_ty, op, right_ty)
+                .or_else(|| {
                     self.infer_binary_expression_type_impl(
                         node,
                         emitted_division_by_zero_diagnostic,
@@ -521,10 +543,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         op,
                         visitor,
                     )
-                })
-            }
-            (lhs, Type::NewTypeInstance(newtype), _) => {
-                Type::try_call_bin_op_return_type(db, env, left_ty, op, right_ty).or_else(|| {
+                }),
+            (lhs, Type::NewTypeInstance(newtype), _) => self
+                .infer_binary_dunder(node, left_ty, op, right_ty)
+                .or_else(|| {
                     self.infer_binary_expression_type_impl(
                         node,
                         emitted_division_by_zero_diagnostic,
@@ -533,8 +555,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         op,
                         visitor,
                     )
-                })
-            }
+                }),
 
             (todo @ Type::Dynamic(DynamicType::Todo(_)), _, _)
             | (_, todo @ Type::Dynamic(DynamicType::Todo(_)), _) => Some(todo),
@@ -829,7 +850,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         Some(result)
                     }
 
-                    _ => Type::try_call_bin_op_return_type(db, env, left_ty, op, right_ty),
+                    _ => self.infer_binary_dunder(node, left_ty, op, right_ty),
                 };
 
                 result.map(|result| match result {
@@ -968,7 +989,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
             .ok()
-            .map(|binding| binding.return_type(db, env)),
+            .map(|binding| {
+                self.check_deprecated_bindings(&node, &binding);
+                binding.return_type(db, env)
+            }),
 
             // We've handled all of the special cases that we support for literals, so we need to
             // fall back on looking for dunder methods on one of the operand types.
@@ -1030,7 +1054,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 | Type::TypeForm(_)
                 | Type::TypedDict(_),
                 op,
-            ) => Type::try_call_bin_op_return_type(db, env, left_ty, op, right_ty),
+            ) => self.infer_binary_dunder(node, left_ty, op, right_ty),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -476,7 +476,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ..
                     }),
                 qualifiers,
-            } = result.unwrap_or_else(|error| error.fallback_member(db))
+            } = result
+                .unwrap_or_else(|error| error.fallback_member(db))
+                .member(db)
             {
                 if &alias.name != "*" && boundness == Definedness::PossiblyUndefined {
                     // TODO: Consider loading _both_ the attribute and any submodule and unioning them

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2570,6 +2570,7 @@ fn protocol_member_read_type<'db>(
             InstanceFallbackShadowsNonDataDescriptor::No,
         )
         .unwrap_or_else(|error| error.fallback_member(db))
+        .member(db)
         .place
     } else {
         receiver_ty.member(db, env, member.name).place

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -11,6 +11,15 @@ use ty_python_core::program::Program;
 use ty_python_core::{ProgramFile, TestProgramDb as _};
 
 #[test]
+fn member_lookup_result_size() {
+    // Property diagnostics must not enlarge every cached member lookup.
+    assert_eq!(
+        size_of::<MemberLookupResult<'_>>(),
+        size_of::<Result<PlaceAndQualifiers<'_>, MemberLookupError<'_>>>(),
+    );
+}
+
+#[test]
 fn bounded_intersection_preserves_late_union_elements() {
     let db = setup_db();
     let db = &db;


### PR DESCRIPTION
## Summary

Previously, we missed deprecations on selected overloads, implicit operator and `__call__` calls, and property accessors. This PR adds support for reporting `deprecated` in those contexts, e.g.:

```python
from typing import overload
from typing_extensions import deprecated

@overload
@deprecated("Use a string")
def convert(value: int) -> str: ...
@overload
def convert(value: str) -> str: ...
def convert(value: int | str) -> str:
    return str(value)

convert(1)  # Before: no diagnostic. After: deprecated.
convert("one")  # Before and after: no diagnostic.
```

This moves [`directives_deprecated`](https://github.com/python/typing/blob/cf943ccbea5596ef969eec6e2260097ff697b7ba/conformance/tests/directives_deprecated.py) from Partial to Pass.

<details>
<summary>Case analysis</summary>

Mypy 2.1.0, pyright 1.1.410, and pyrefly 1.3.0-dev.1 report all seven required diagnostics in this conformance file. All comparisons explicitly enable deprecation diagnostics. The differences below concern additional cases in the regression tests.

We do not report a deprecated reflected operator when the left operand's method accepts the operation. Pyright and pyrefly agree; mypy also warns about the unused reflected method:

```python
from typing_extensions import deprecated

class Left:
    def __add__(self, other: object) -> int:
        return 0

class Right:
    @deprecated("reflected addition")
    def __radd__(self, other: object) -> int:
        return 0

Left() + Right()  # ty, pyright, pyrefly: OK; mypy: deprecated.
1 + Right()  # All four: deprecated.
```

A deprecated getter still runs during augmented assignment, even when the setter is not deprecated. We report that deprecation, as does pyrefly. Pyright misses the getter during augmented assignment, while mypy loses the getter's deprecation when a non-deprecated setter or deleter is subsequently defined. Access through the class returns the property object without calling the getter; we leave that access quiet, as do mypy and pyrefly:

```python
from typing_extensions import deprecated

class OldGetter:
    @property
    @deprecated("old getter")
    def value(self) -> int:
        return 0

    @value.setter
    def value(self, value: int) -> None: ...
    @value.deleter
    def value(self) -> None: ...

value = OldGetter()
value.value  # ty, pyright, pyrefly: deprecated; mypy: OK.
value.value = 1  # All four: OK.
value.value += 1  # ty, pyrefly: deprecated; mypy, pyright: OK.
OldGetter.value  # ty, mypy, pyrefly: OK; pyright: deprecated.
```

When both an overload and its implementation are deprecated, we emit the implementation's diagnostic once, as does pyright. Mypy and pyrefly emit separate diagnostics for the implementation and selected overload.

Union alternatives that select the same deprecated function produce one diagnostic. If an operation can invoke several distinct deprecated functions, we combine their messages and annotate each source declaration. Augmented assignment still reports deprecated getters and setters separately, since it invokes both.

</details>
