### PR TITLE
[ty] Rename Truthiness::and_else to and_then

### DIFF
--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -986,7 +986,7 @@ impl Truthiness {
 
     /// Like [`Truthiness::and`], but evaluates `other` only when `self` may be true.
     #[must_use]
-    pub fn and_else(self, other: impl FnOnce() -> Self) -> Self {
+    pub fn and_then(self, other: impl FnOnce() -> Self) -> Self {
         match self {
             Truthiness::AlwaysFalse => self,
             Truthiness::AlwaysTrue | Truthiness::Ambiguous => self.and(other()),
@@ -1175,15 +1175,15 @@ mod tests {
             assert_eq!(left.and(right), expected, "{left:?}.and({right:?})");
 
             let mut calls = 0;
-            let lazy_result = left.and_else(|| {
+            let lazy_result = left.and_then(|| {
                 calls += 1;
                 right
             });
-            assert_eq!(lazy_result, expected, "{left:?}.and_else(|| {right:?})");
+            assert_eq!(lazy_result, expected, "{left:?}.and_then(|| {right:?})");
             assert_eq!(
                 calls,
                 usize::from(left != AlwaysFalse),
-                "{left:?}.and_else call count"
+                "{left:?}.and_then call count"
             );
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11265,7 +11265,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // truthy. Skip the final comparison's truthiness computation when the prefix is
             // already always false.
             let truthiness = preceding_truthiness
-                .and_else(|| last_comparison_ty.bool(db, self.program_environment()));
+                .and_then(|| last_comparison_ty.bool(db, self.program_environment()));
             let expression = ast::ExprRef::Compare(compare).into();
             if truthiness != ty.bool(db, self.program_environment()) {
                 self.comparison_truthiness.insert(expression, truthiness);


### PR DESCRIPTION
The lazy conjunction helper's name, `Truthiness::and_else`, does not follow Rust's `Option::and_then` convention. Rename it to `and_then` and update its chained-comparison caller and existing tests, without changing evaluation behavior.

Addresses [the review feedback on #28082](https://github.com/astral-sh/ruff/pull/28082#discussion_r3878774178).

## Test plan

Updated the existing truthiness test to use the new name. It covers all nine input combinations and verifies that the closure runs exactly once when the left side may be true, and never when it is always false.
