### PR TITLE
[ty] Preserve generic receivers in implicit __init_subclass__ calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -836,10 +836,11 @@ class InvalidType(Base[int], arg="x"): ...  # error: [invalid-argument-type]
 python-version = "3.13"
 ```
 
-##### Default type parameters
+##### Type parameter defaults
 
-Defaults do not specialize a subclass during class creation. The implicit `__init_subclass__` call
-accepts `Child[T]` as a subclass of `Base[T]`.
+When checking `cls` for an inherited `__init_subclass__` hook, the generic subclass retains its type
+parameters rather than replacing them with their defaults. `Child[T]` therefore satisfies the
+receiver bound `Base[T]`.
 
 ```py
 class Base[T]:
@@ -883,7 +884,7 @@ class Concrete(RestrictedBase[int]): ...
 class Invalid[T = int](RestrictedBase[T]): ...
 ```
 
-##### Legacy default type parameters
+##### Legacy type parameter defaults
 
 The same receiver relationship holds for subclasses using legacy type variables with defaults.
 
@@ -914,6 +915,12 @@ class Valid[T = int](Base[T], value=cast(T, 1)): ...
 
 # error: [invalid-argument-type] "Expected `T@Invalid`, found `Literal[1]`"
 class Invalid[T = int](Base[T], value=1): ...
+```
+
+An explicitly specialized base accepts the concrete argument.
+
+```py
+class AlsoValid(Base[int], value=1): ...
 ```
 
 ## `@staticmethod`

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -829,6 +829,93 @@ class Valid(Base[int], arg=1): ...
 class InvalidType(Base[int], arg="x"): ...  # error: [invalid-argument-type]
 ```
 
+#### Generic subclasses
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+##### Default type parameters
+
+Defaults do not specialize a subclass during class creation. The implicit `__init_subclass__` call
+accepts `Child[T]` as a subclass of `Base[T]`.
+
+```py
+class Base[T]:
+    def __init_subclass__(cls, *, flag: bool = False) -> None: ...
+
+class NoDefault[T](Base[T]): ...
+class Child[T = int](Base[T]): ...
+class PartialDefault[U, T = int](Base[T]): ...
+```
+
+Class keyword arguments are still checked against the hook's signature.
+
+```py
+class WithKeyword[T = int](Base[T], flag=True): ...
+
+# error: [invalid-argument-type] "Expected `bool`, found"
+class InvalidKeyword[T = int](Base[T], flag="bad"): ...
+```
+
+##### Explicit receiver annotations
+
+The implicit call also accepts an explicit `cls: type[Base[T]]` annotation.
+
+```py
+class Base[T]:
+    def __init_subclass__(cls: type["Base[T]"]) -> None: ...
+
+class Child[T = int](Base[T]): ...
+```
+
+A hook restricted to `RestrictedBase[int]` rejects a subclass that remains generic, even when `int`
+is its default.
+
+```py
+class RestrictedBase[T]:
+    def __init_subclass__(cls: type["RestrictedBase[int]"]) -> None: ...
+
+class Concrete(RestrictedBase[int]): ...
+
+# error: [invalid-argument-type] "Expected `type[RestrictedBase[int]]`"
+class Invalid[T = int](RestrictedBase[T]): ...
+```
+
+##### Legacy default type parameters
+
+The same receiver relationship holds for subclasses using legacy type variables with defaults.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U", default=int)
+
+class Base(Generic[T]):
+    def __init_subclass__(cls) -> None: ...
+
+class Child(Base[U]): ...
+```
+
+##### Keyword arguments using subclass type parameters
+
+Keyword arguments can refer to the subclass's type parameters. The argument must be compatible with
+that type parameter, not just its default: `T` can be specialized to a type other than `int`.
+
+```py
+from typing import cast
+
+class Base[T]:
+    def __init_subclass__(cls, *, value: T) -> None: ...
+
+class Valid[T = int](Base[T], value=cast(T, 1)): ...
+
+# error: [invalid-argument-type] "Expected `T@Invalid`, found `Literal[1]`"
+class Invalid[T = int](Base[T], value=1): ...
+```
+
 ## `@staticmethod`
 
 ### Basic

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -841,8 +841,6 @@ pub(crate) fn check_static_class_definitions<'db>(
                 .ignore_possibly_undefined();
 
             if let Some(init_subclass) = init_subclass_type {
-                // Preserve the subclass's type variables to match the symbolic types in its bases.
-                // A bare class literal would apply defaults only to the receiver.
                 let call_args =
                     call_args.with_self(Some(Type::from(class.identity_specialization(db))));
                 if let Err(call_error) = init_subclass.try_call(db, env, &call_args) {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -841,7 +841,10 @@ pub(crate) fn check_static_class_definitions<'db>(
                 .ignore_possibly_undefined();
 
             if let Some(init_subclass) = init_subclass_type {
-                let call_args = call_args.with_self(Some(Type::from(class)));
+                // Preserve the subclass's type variables to match the symbolic types in its bases.
+                // A bare class literal would apply defaults only to the receiver.
+                let call_args =
+                    call_args.with_self(Some(Type::from(class.identity_specialization(db))));
                 if let Err(call_error) = init_subclass.try_call(db, env, &call_args) {
                     report_subclass_of_class_with_non_callable_init_subclass(
                         context, call_error, class, class_node,


### PR DESCRIPTION
A generic subclass with a defaulted type parameter can incorrectly fail the implicit `__init_subclass__` receiver check. The receiver is default-specialized while the inherited method's `Self` bound retains the subclass's type variables, producing a comparison such as `Child[int]` against `Base[T@Child]`.

Use the subclass's identity specialization for the implicit `cls` argument so the receiver and inherited hook use the same type parameters. This accepts valid class definitions while retaining explicit receiver restrictions and keyword argument validation.

Closes astral-sh/ty#4411.

## Test plan

Added mdtests covering:

- Generic subclass receivers with no defaults, all-default parameters, and mixed required and defaulted parameters.
- Legacy `TypeVar` defaults and explicit `cls` annotations, including rejection of incompatible receiver specializations.
- Class keyword arguments, including values typed using a subclass parameter and rejection of incompatible values.
