### PR TITLE
Combine redundant `match` arms in `pathlib` rules

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -21,23 +21,10 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
     let range = call.func.range();
     match qualified_name.segments() {
         // PTH118
-        ["os", "path", "join"] => {
+        ["os", module @ ("path" | "sep"), "join"] => {
             checker.report_diagnostic_if_enabled(
                 OsPathJoin {
-                    module: "path".to_string(),
-                    joiner: if call.arguments.args.iter().any(Expr::is_starred_expr) {
-                        Joiner::Joinpath
-                    } else {
-                        Joiner::Slash
-                    },
-                },
-                range,
-            );
-        }
-        ["os", "sep", "join"] => {
-            checker.report_diagnostic_if_enabled(
-                OsPathJoin {
-                    module: "sep".to_string(),
+                    module: module.to_string(),
                     joiner: if call.arguments.args.iter().any(Expr::is_starred_expr) {
                         Joiner::Joinpath
                     } else {
@@ -56,7 +43,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
             checker.report_diagnostic_if_enabled(PyPath, range);
         }
         // PTH207
-        ["glob", "glob"] => {
+        ["glob", function @ ("glob" | "iglob")] => {
             // `dir_fd` is not supported by pathlib, so check if it's set to non-default values.
             // Signature as of Python 3.13 (https://docs.python.org/3/library/glob.html#glob.glob)
             // ```text
@@ -69,26 +56,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &Checker, call: &ExprCall) {
 
             checker.report_diagnostic_if_enabled(
                 Glob {
-                    function: "glob".to_string(),
-                },
-                range,
-            );
-        }
-
-        ["glob", "iglob"] => {
-            // `dir_fd` is not supported by pathlib, so check if it's set to non-default values.
-            // Signature as of Python 3.13 (https://docs.python.org/3/library/glob.html#glob.iglob)
-            // ```text
-            //                0           1              2            3                 4
-            // glob.iglob(pathname, *, root_dir=None, dir_fd=None, recursive=False, include_hidden=False)
-            // ```
-            if is_keyword_only_argument_non_default(&call.arguments, "dir_fd") {
-                return;
-            }
-
-            checker.report_diagnostic_if_enabled(
-                Glob {
-                    function: "iglob".to_string(),
+                    function: function.to_string(),
                 },
                 range,
             );


### PR DESCRIPTION
Summary
--

Noticed this while reviewing #28027.

Test Plan
--

Existing tests
