### PR TITLE
[ty] Select the first overload when return types are equivalent

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -2212,6 +2212,32 @@ def _(s: str):
 reveal_type(f((None, None, None)))  # revealed: Literal[b""]
 ```
 
+## Selecting the first overload with equivalent return types
+
+When the remaining overloads have equivalent return types, we select the first. Only that overload
+contributes constraints when inferring the contents of an initially empty collection.
+
+The `dict.update` overloads all return `None`. Updating from an unknown value does not introduce
+string keys from later overloads that accept keyword arguments when no keywords were supplied.
+
+```py
+def update_from_unknown(source):
+    result = {}
+    result.update(source)
+    reveal_type(result)  # revealed: dict[Unknown, Unknown]
+```
+
+A mapping with tuple keys also matches an overload accepting an iterable of key-value pairs. When
+the input can be unknown, selecting the mapping overload prevents tuple keys from being interpreted
+as separate keys and values.
+
+```py
+def update_from_mapping(other, source: dict[tuple[str, int], str]):
+    result = {}
+    result.update(other or source)
+    reveal_type(result)  # revealed: dict[tuple[str, int], str]
+```
+
 ## Bidirectional Type Inference
 
 ```toml
@@ -2363,4 +2389,70 @@ def takes_str_or_float(x: float): ...
 def takes_str_or_float(x: float | str): ...
 
 takes_str_or_float(round(1.0))
+```
+
+## Optional return context for a filter predicate
+
+The predicate receives an integer from `values`, even though the enclosing function can return
+`None`. Its parameter should not inherit `None` from that return annotation.
+
+```py
+def first(values: list[int]) -> int | None:
+    # TODO: The return context incorrectly makes the predicate parameter optional.
+    # error: [unresolved-attribute] "Attribute `real` is not defined on `None`"
+    return next(filter(lambda value: value.real, values), None)
+```
+
+## Nested calls with competing argument contexts
+
+The inner call passes an integer to its callback, so the callback can use `& 1`. The outer call's
+second overload accepts the result. Selecting its first overload should not make the callback's
+parameter a string.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import Callable, TypeVar, overload
+
+T = TypeVar("T")
+
+@overload
+def invoke(): ...
+@overload
+def invoke(callback: Callable[[T], object], value: T) -> T: ...
+@overload
+def consume(key: str): ...
+@overload
+def consume(key: object): ...
+
+# TODO: Re-inferring the callback with the selected overload's context produces false positives.
+# error: [invalid-argument-type]
+# error: [unsupported-operator] "Operator `&` is not supported between objects of type `str` and `Literal[1]`"
+consume(invoke(lambda value: value & 1, 1))
+```
+
+## Nested calls forwarding a ParamSpec
+
+The `lazy` wrapper preserves its argument's parameters while wrapping the return type in a tuple.
+The result is accepted by `as_default`, including when the calls are nested.
+
+```py
+from typing import Callable, ParamSpec, TypeVar, overload
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+@overload
+def lazy(function: int) -> None: ...
+@overload
+def lazy(function: Callable[P, T]) -> Callable[P, tuple[T]]: ...
+def lazy(*args): ...
+@overload
+def as_default(function: Callable[P, tuple[T]]): ...
+@overload
+def as_default(function: Callable[P, T]): ...
+def as_default(*args): ...
+
+# TODO: The selected overload's unresolved ParamSpec incorrectly constrains the inner call.
+as_default(lazy(lambda: None))  # error: [no-matching-overload] "No overload of function `lazy` matches arguments"
 ```

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -1089,7 +1089,8 @@ info[dynamic-function-decorator-return]: Decorator returns `Unknown`
 help: Add a return type annotation to `dynamic`
 ```
 
-When multiple overloads match, the definition annotation spans every overload:
+Here, the remaining overloads return `Any` and `Unknown`, which are equivalent for overload
+resolution. The first is selected, so the diagnostic points to its definition.
 
 ```py
 from collections.abc import Callable
@@ -1114,21 +1115,15 @@ def decorated(value: Any) -> object:
 info[dynamic-function-decorator-return]: Decorator returns `Any`
   --> src/mdtest_snippet.py:27:1
    |
-27 |   @dynamic
-   |   ^^^^^^^^
-28 |   def decorated(value: Any) -> object:
-   |       --------- Signature of `decorated` will be obscured by the decorator
+27 | @dynamic
+   | ^^^^^^^^
+28 | def decorated(value: Any) -> object:
+   |     --------- Signature of `decorated` will be obscured by the decorator
    |
-  ::: src/mdtest_snippet.py:17:1
+  ::: src/mdtest_snippet.py:18:5
    |
-17 | / @overload
-18 | | def dynamic(function: Callable[[int], object]) -> Any: ...
-19 | | @overload
-20 | | def dynamic(function: None) -> None: ...
-21 | | @overload
-22 | | def dynamic(function: Callable[[str], object]): ...
-   | |______________________________________________- Overloads of `dynamic` defined here
-help: Ensure all `dynamic` overloads have a return annotation
+18 | def dynamic(function: Callable[[int], object]) -> Any: ...
+   |     ------------------------------------------------- Matching overload defined here
 ```
 
 ### Fully annotated decorators with multiple matching overloads

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4291,6 +4291,11 @@ impl<'db> CallableBinding<'db> {
         if !are_return_types_equivalent_for_all_matching_overloads {
             // Overload matching is ambiguous.
             self.overload_call_return_type = Some(OverloadCallReturnType::Ambiguous);
+        } else {
+            // Step 6: equivalent return types resolve the call to the first remaining overload.
+            for (_, overload) in self.matching_overloads_mut().skip(1) {
+                overload.mark_as_unmatched_overload();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Preliminary to #28134.

We now select the first remaining overload when the remaining return types are equivalent, as described in [step 6 of overload evaluation](https://typing.python.org/en/latest/spec/overload.html#step-6). Previously, we kept every remaining overload marked as matching, even though the call was no longer ambiguous.

Those extra matches can contribute unrelated constraints when inferring collection types. For example, later `dict.update` overloads introduce string keys for keyword arguments, even when the call supplies no keywords:

```python
def update(source):
    values = {}
    values.update(source)
    # Before: dict[Unknown | str, Unknown]
    # After: dict[Unknown, Unknown]
    reveal_type(values)
```

This also limits diagnostic annotations to the selected overload's definition. Calls whose remaining overloads have different return types remain ambiguous.

<details>
<summary>Case analysis</summary>

The dictionary changes in Prefect and SymPy remove unsupported key and value types. SymPy's parser previously inferred integer values by treating a mapping's tuple keys as iterable key-value pairs; selecting the mapping overload removes those values. The dd-trace-py change only refines an existing error message: a dictionary is still rejected where a list is expected.

There are also three unresolved inference regressions, recorded as TODOs in the mdtests. Together they account for all six new non-deprecation errors in the ecosystem comparison. Selecting an overload changes the parameter types used to re-infer nested arguments, which can introduce errors that were absent during overload selection.

In Archinstall, an optional return type incorrectly makes a filter predicate's parameter optional. The iterable contains no `None` values, so the new error is a false positive. This exposes [ty#4016](https://github.com/astral-sh/ty/issues/4016):

```python
def first(values: list[int]) -> int | None:
    # Before: no attribute error. After: invalid access to `real` on None.
    return next(filter(lambda value: value.real, values), None)
```

Freqtrade gains two errors at each of two `reduce` calls used as pandas row selectors. The selected index overload supplies tuple types to the reduction's lambda parameters, even though the iterable contains boolean Series. In this reduced stub, the same issue supplies `str` to a callback that receives `1`:

```python
from typing import Callable, TypeVar, overload

T = TypeVar("T")

@overload
def invoke(): ...
@overload
def invoke(callback: Callable[[T], object], value: T) -> T: ...

@overload
def consume(key: str): ...
@overload
def consume(key: object): ...

# Before: no errors. After: invalid-argument-type and unsupported-operator.
consume(invoke(lambda value: value & 1, 1))
```

Antidote gains a `no-matching-overload` error when one generic wrapper is passed directly to another. The selected overload propagates an unresolved `ParamSpec` into the inner call, exposing [ty#3691](https://github.com/astral-sh/ty/issues/3691). Assigning the inner result to a variable first avoids the error, as it does for the Freqtrade reductions.

These inference regressions remain unresolved; the change is not ready to merge.

</details>
