### PR TITLE
[ty] Guard recursive meta-type expansion

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -4128,6 +4128,61 @@ class Foo: ...
 reveal_type(Foo.__class__)  # revealed: <class 'type'>
 ```
 
+## Classes of recursive intersections
+
+Mutually recursive aliases can describe the same union of classes. Computing the class of their
+intersection preserves every possible class, regardless of the order in which the aliases are
+expanded.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from ty_extensions import Intersection
+
+type First = Second | int
+type Second = First | str
+
+def recursive(value: Intersection[First, Second]):
+    reveal_type(type(value))  # revealed: type[int | str]
+```
+
+## Classes of recursive aliases with repeating specializations
+
+Rotating the arguments of a recursive alias produces a finite set of specializations. Class
+inference retains the union of those arguments instead of widening to `type`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Rotate[T, U] = T | Rotate[U, T]
+
+def rotating(value: Rotate[int, str]):
+    reveal_type(type(value))  # revealed: type[int | str]
+```
+
+## Classes of recursive aliases with growing specializations
+
+Recursive specialization can introduce classes beyond the initial type argument. Class inference
+terminates even when the type arguments keep growing, conservatively returning `type`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Growing[T] = T | Growing[list[T]]
+
+def growing(value: Growing[int]):
+    reveal_type(type(value))  # revealed: type
+```
+
 ## Module attributes
 
 ### Basic

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -4128,61 +4128,6 @@ class Foo: ...
 reveal_type(Foo.__class__)  # revealed: <class 'type'>
 ```
 
-## Classes of recursive intersections
-
-Mutually recursive aliases can describe the same union of classes. Computing the class of their
-intersection preserves every possible class, regardless of the order in which the aliases are
-expanded.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from ty_extensions import Intersection
-
-type First = Second | int
-type Second = First | str
-
-def recursive(value: Intersection[First, Second]):
-    reveal_type(type(value))  # revealed: type[int | str]
-```
-
-## Classes of recursive aliases with repeating specializations
-
-Rotating the arguments of a recursive alias produces a finite set of specializations. Class
-inference retains the union of those arguments instead of widening to `type`.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-type Rotate[T, U] = T | Rotate[U, T]
-
-def rotating(value: Rotate[int, str]):
-    reveal_type(type(value))  # revealed: type[int | str]
-```
-
-## Classes of recursive aliases with growing specializations
-
-Recursive specialization can introduce classes beyond the initial type argument. Class inference
-terminates even when the type arguments keep growing, conservatively returning `type`.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-type Growing[T] = T | Growing[list[T]]
-
-def growing(value: Growing[int]):
-    reveal_type(type(value))  # revealed: type
-```
-
 ## Module attributes
 
 ### Basic

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -2,12 +2,69 @@
 
 ## Single-argument form
 
-A single-argument call to `type()` returns an object that has the argument's meta-type. (This is
-tested more extensively in `crates/ty_python_semantic/resources/mdtest/attributes.md`, alongside the
-tests for the `__class__` attribute.)
+A single-argument call to `type()` returns an object that has the argument's meta-type.
+
+### Basic
+
+For an integer literal, the result is the exact class object `int`.
 
 ```py
 reveal_type(type(1))  # revealed: <class 'int'>
+```
+
+### Classes of recursive intersections
+
+Mutually recursive aliases can describe the same union of classes. Computing the class of their
+intersection preserves every possible class, regardless of the order in which the aliases are
+expanded.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from ty_extensions import Intersection
+
+type First = Second | int
+type Second = First | str
+
+def recursive(value: Intersection[First, Second]):
+    reveal_type(type(value))  # revealed: type[int | str]
+```
+
+### Classes of recursive aliases with repeating specializations
+
+Rotating the arguments of a recursive alias produces a finite set of specializations. Class
+inference retains the union of those arguments instead of widening to `type`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Rotate[T, U] = T | Rotate[U, T]
+
+def rotating(value: Rotate[int, str]):
+    reveal_type(type(value))  # revealed: type[int | str]
+```
+
+### Classes of recursive aliases with growing specializations
+
+Recursive specialization can introduce classes beyond the initial type argument. Class inference
+terminates even when the type arguments keep growing, conservatively returning `type`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Growing[T] = T | Growing[list[T]]
+
+def growing(value: Growing[int]):
+    reveal_type(type(value))  # revealed: type
 ```
 
 ## Three-argument form (dynamic class creation)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -398,37 +398,6 @@ fn definition_expression_annotation<'db>(
     }
 }
 
-#[derive(Default)]
-struct MetaTypeVisitor<'db> {
-    active_aliases: ActiveRecursionDetector<TypeAliasType<'db>>,
-    active_identities: ActiveRecursionDetector<TypeIdentity<'db>>,
-}
-
-impl<'db> MetaTypeVisitor<'db> {
-    fn visit_alias(
-        &self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        alias: TypeAliasType<'db>,
-    ) -> Type<'db> {
-        // A repeated specialization adds no new classes to a recursive union. Changing
-        // type arguments can introduce other classes, so use an unconstrained metatype.
-        // Do not cache results: a projection made while another alias is active can omit
-        // classes that are only encountered later in that alias's union.
-        self.active_aliases.visit(
-            &alias,
-            || Type::Never,
-            || {
-                self.active_identities.visit(
-                    &Type::TypeAlias(alias).to_type_identity(db),
-                    || KnownClass::Type.to_instance(db, env),
-                    || alias.value_type(db).to_meta_type_impl(db, env, self),
-                )
-            },
-        )
-    }
-}
-
 struct ApplyTypeMappingTag;
 struct ApplyMaterializationEquivalence;
 
@@ -7834,127 +7803,161 @@ impl<'db> Type<'db> {
     /// See `Self::dunder_class` for more details.
     #[must_use]
     fn to_meta_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        self.to_meta_type_impl(db, env, &MetaTypeVisitor::default())
-    }
+        #[derive(Default)]
+        struct MetaTypeVisitor<'db> {
+            active_aliases: ActiveRecursionDetector<TypeAliasType<'db>>,
+            active_identities: ActiveRecursionDetector<TypeIdentity<'db>>,
+        }
 
-    fn to_meta_type_impl(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        visitor: &MetaTypeVisitor<'db>,
-    ) -> Type<'db> {
-        match self {
-            Type::Never => Type::Never,
-            Type::NominalInstance(instance) => instance.to_meta_type(db, env),
-            Type::KnownInstance(known_instance) => known_instance.to_meta_type(db, env),
-            Type::SpecialForm(special_form) => special_form.to_meta_type(db, env),
-            Type::PropertyInstance(property) => {
-                property.instance_class(db).to_class_literal(db, env)
-            }
-            Type::SlotDescriptor(_) => KnownClass::MemberDescriptorType.to_class_literal(db, env),
-            Type::Union(union) => union.map(db, env, |ty| ty.to_meta_type_impl(db, env, visitor)),
-            Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db, env),
-            Type::TypeForm(_) => Type::object().to_meta_type_impl(db, env, visitor),
-            Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db, env),
-                LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_class_literal(db, env),
-                LiteralValueTypeKind::Int(_) => KnownClass::Int.to_class_literal(db, env),
-                LiteralValueTypeKind::Enum(enum_literal) => {
-                    Type::ClassLiteral(enum_literal.enum_class(db))
+        fn to_meta_type_inner<'db>(
+            db: &'db dyn Db,
+            env: &ProgramEnvironment<'db>,
+            ty: Type<'db>,
+            visitor: &MetaTypeVisitor<'db>,
+        ) -> Type<'db> {
+            match ty {
+                Type::Never => Type::Never,
+                Type::NominalInstance(instance) => instance.to_meta_type(db, env),
+                Type::KnownInstance(known_instance) => known_instance.to_meta_type(db, env),
+                Type::SpecialForm(special_form) => special_form.to_meta_type(db, env),
+                Type::PropertyInstance(property) => {
+                    property.instance_class(db).to_class_literal(db, env)
                 }
-                LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => {
-                    KnownClass::Str.to_class_literal(db, env)
+                Type::SlotDescriptor(_) => {
+                    KnownClass::MemberDescriptorType.to_class_literal(db, env)
                 }
-            },
-            Type::FunctionLiteral(_) => KnownClass::FunctionType.to_class_literal(db, env),
-            Type::BoundMethod(_) => KnownClass::MethodType.to_class_literal(db, env),
-            Type::KnownBoundMethod(method) => method.class().to_class_literal(db, env),
-            Type::WrapperDescriptor(_) => {
-                KnownClass::WrapperDescriptorType.to_class_literal(db, env)
-            }
-            Type::DataclassDecorator(_) => KnownClass::FunctionType.to_class_literal(db, env),
-            Type::Callable(callable) if callable.is_function_like(db) => {
-                KnownClass::FunctionType.to_class_literal(db, env)
-            }
-            Type::Callable(_) | Type::DataclassTransformer(_) => {
-                KnownClass::Type.to_instance(db, env)
-            }
-            Type::ModuleLiteral(_) => KnownClass::ModuleType.to_class_literal(db, env),
-            Type::TypeVar(bound_typevar) => {
-                SubclassOfType::from(db, env, SubclassOfInner::TypeVar(bound_typevar))
-            }
-            Type::ClassLiteral(class) => class.metaclass(db),
-            Type::GenericAlias(alias) => ClassType::from(alias).metaclass(db),
-            Type::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db, env),
-            Type::Dynamic(dynamic) => {
-                SubclassOfType::from(db, env, SubclassOfInner::Dynamic(dynamic))
-            }
-            Type::Divergent(_) => self,
-            Type::Intersection(intersection) => {
-                if let Some(alternatives) = intersection.finite_alternative_union(db, env) {
-                    alternatives.to_meta_type_impl(db, env, visitor)
-                } else {
-                    // Negative constraints do not generally constrain classes: `int & ~Literal[0]`
-                    // still has meta-type `type[int]`. Pure negations are bounded by `object`.
-                    let mut builder = IntersectionBuilder::new(db, env);
-                    for positive in intersection.positive_elements_or_object(db) {
-                        builder.add_positive_in_place(positive.to_meta_type_impl(db, env, visitor));
+                Type::Union(union) => {
+                    union.map(db, env, |ty| to_meta_type_inner(db, env, *ty, visitor))
+                }
+                Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db, env),
+                Type::TypeForm(_) => to_meta_type_inner(db, env, Type::object(), visitor),
+                Type::LiteralValue(literal) => match literal.kind() {
+                    LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db, env),
+                    LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_class_literal(db, env),
+                    LiteralValueTypeKind::Int(_) => KnownClass::Int.to_class_literal(db, env),
+                    LiteralValueTypeKind::Enum(enum_literal) => {
+                        Type::ClassLiteral(enum_literal.enum_class(db))
                     }
-
-                    // An exclusion can narrow a type variable's union bound to a definite class:
-                    // `(T: C | None) & ~None` has meta-type `type[T] & type[C]`.
-                    // If the remaining bound is a class object, retain its metaclass instead.
-                    // Structural bounds need separate runtime-class handling (see `dunder_class`).
-                    if !intersection.negative(db).is_empty()
-                        && intersection
-                            .iter_positive(db)
-                            .any(|positive| matches!(positive, Type::TypeVar(_)))
-                        && let Some(narrowed_bound) = match intersection
-                            .with_expanded_typevars_and_newtypes(db, env)
-                        {
-                            bound @ (Type::NominalInstance(_)
-                            | Type::ClassLiteral(_)
-                            | Type::GenericAlias(_)) => Some(bound),
-                            bound @ Type::SubclassOf(subclass_of)
-                                if let SubclassOfInner::Class(_) = subclass_of.subclass_of() =>
-                            {
-                                Some(bound)
-                            }
-                            _ => None,
+                    LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => {
+                        KnownClass::Str.to_class_literal(db, env)
+                    }
+                },
+                Type::FunctionLiteral(_) => KnownClass::FunctionType.to_class_literal(db, env),
+                Type::BoundMethod(_) => KnownClass::MethodType.to_class_literal(db, env),
+                Type::KnownBoundMethod(method) => method.class().to_class_literal(db, env),
+                Type::WrapperDescriptor(_) => {
+                    KnownClass::WrapperDescriptorType.to_class_literal(db, env)
+                }
+                Type::DataclassDecorator(_) => KnownClass::FunctionType.to_class_literal(db, env),
+                Type::Callable(callable) if callable.is_function_like(db) => {
+                    KnownClass::FunctionType.to_class_literal(db, env)
+                }
+                Type::Callable(_) | Type::DataclassTransformer(_) => {
+                    KnownClass::Type.to_instance(db, env)
+                }
+                Type::ModuleLiteral(_) => KnownClass::ModuleType.to_class_literal(db, env),
+                Type::TypeVar(bound_typevar) => {
+                    SubclassOfType::from(db, env, SubclassOfInner::TypeVar(bound_typevar))
+                }
+                Type::ClassLiteral(class) => class.metaclass(db),
+                Type::GenericAlias(alias) => ClassType::from(alias).metaclass(db),
+                Type::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db, env),
+                Type::Dynamic(dynamic) => {
+                    SubclassOfType::from(db, env, SubclassOfInner::Dynamic(dynamic))
+                }
+                Type::Divergent(_) => ty,
+                Type::Intersection(intersection) => {
+                    if let Some(alternatives) = intersection.finite_alternative_union(db, env) {
+                        to_meta_type_inner(db, env, alternatives, visitor)
+                    } else {
+                        // Negative constraints do not generally constrain classes: `int & ~Literal[0]`
+                        // still has meta-type `type[int]`. Pure negations are bounded by `object`.
+                        let mut builder = IntersectionBuilder::new(db, env);
+                        for positive in intersection.positive_elements_or_object(db) {
+                            builder.add_positive_in_place(to_meta_type_inner(
+                                db, env, positive, visitor,
+                            ));
                         }
-                    {
-                        builder.add_positive_in_place(
-                            narrowed_bound.to_meta_type_impl(db, env, visitor),
-                        );
-                    }
 
-                    builder.build()
+                        // An exclusion can narrow a type variable's union bound to a definite class:
+                        // `(T: C | None) & ~None` has meta-type `type[T] & type[C]`.
+                        // If the remaining bound is a class object, retain its metaclass instead.
+                        // Structural bounds need separate runtime-class handling (see `dunder_class`).
+                        if !intersection.negative(db).is_empty()
+                            && intersection
+                                .iter_positive(db)
+                                .any(|positive| matches!(positive, Type::TypeVar(_)))
+                            && let Some(narrowed_bound) =
+                                match intersection.with_expanded_typevars_and_newtypes(db, env) {
+                                    bound @ (Type::NominalInstance(_)
+                                    | Type::ClassLiteral(_)
+                                    | Type::GenericAlias(_)) => Some(bound),
+                                    bound @ Type::SubclassOf(subclass_of)
+                                        if let SubclassOfInner::Class(_) =
+                                            subclass_of.subclass_of() =>
+                                    {
+                                        Some(bound)
+                                    }
+                                    _ => None,
+                                }
+                        {
+                            builder.add_positive_in_place(to_meta_type_inner(
+                                db,
+                                env,
+                                narrowed_bound,
+                                visitor,
+                            ));
+                        }
+
+                        builder.build()
+                    }
                 }
-            }
-            Type::EnumComplement(complement) => complement
-                .remaining_literal_union(db, env)
-                .to_meta_type_impl(db, env, visitor),
-            Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db, env),
-            Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db, env),
-            // Class-member lookup on a protocol instance must use the protocol's nominal class.
-            // The structural `type[Protocol]` view is exposed by `dunder_class` and explicit
-            // `type[Protocol]` annotations instead.
-            Type::ProtocolInstance(protocol) => protocol.to_nominal_meta_type(db, env),
-            // `TypedDict` instances are instances of `dict` at runtime, but its important that we
-            // understand a more specific meta type in order to correctly handle `__getitem__`.
-            Type::TypedDict(typed_dict) => match typed_dict {
-                TypedDictType::Class(class) => SubclassOfType::from(db, env, class),
-                TypedDictType::Synthesized(_) => SubclassOfType::from(
+                Type::EnumComplement(complement) => to_meta_type_inner(
                     db,
                     env,
-                    todo_type!("TypedDict synthesized meta-type").expect_dynamic(),
+                    complement.remaining_literal_union(db, env),
+                    visitor,
                 ),
-            },
-            Type::TypeAlias(alias) => visitor.visit_alias(db, env, alias),
-            Type::NewTypeInstance(newtype) => newtype
-                .concrete_base_type(db)
-                .to_meta_type_impl(db, env, visitor),
+                Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db, env),
+                Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db, env),
+                // Class-member lookup on a protocol instance must use the protocol's nominal class.
+                // The structural `type[Protocol]` view is exposed by `dunder_class` and explicit
+                // `type[Protocol]` annotations instead.
+                Type::ProtocolInstance(protocol) => protocol.to_nominal_meta_type(db, env),
+                // `TypedDict` instances are instances of `dict` at runtime, but its important that we
+                // understand a more specific meta type in order to correctly handle `__getitem__`.
+                Type::TypedDict(typed_dict) => match typed_dict {
+                    TypedDictType::Class(class) => SubclassOfType::from(db, env, class),
+                    TypedDictType::Synthesized(_) => SubclassOfType::from(
+                        db,
+                        env,
+                        todo_type!("TypedDict synthesized meta-type").expect_dynamic(),
+                    ),
+                },
+                Type::TypeAlias(alias) => {
+                    // A repeated specialization adds no new classes to a recursive union. Changing
+                    // type arguments can introduce other classes, so use an unconstrained metatype.
+                    // Do not cache results: a projection made while another alias is active can omit
+                    // classes that are only encountered later in that alias's union.
+                    visitor.active_aliases.visit(
+                        &alias,
+                        || Type::Never,
+                        || {
+                            visitor.active_identities.visit(
+                                &Type::TypeAlias(alias).to_type_identity(db),
+                                || KnownClass::Type.to_instance(db, env),
+                                || to_meta_type_inner(db, env, alias.value_type(db), visitor),
+                            )
+                        },
+                    )
+                }
+                Type::NewTypeInstance(newtype) => {
+                    to_meta_type_inner(db, env, newtype.concrete_base_type(db), visitor)
+                }
+            }
         }
+
+        to_meta_type_inner(db, env, self, &MetaTypeVisitor::default())
     }
 
     /// Get the type of the `__class__` attribute of this type.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -26,9 +26,9 @@ use ty_module_resolver::{
 
 pub(crate) use self::callable::UpcastPolicy;
 use self::class::ClassInstanceFlags;
-use self::cyclic::ActiveRecursionDetector;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
+use self::cyclic::{ActiveRecursionDetector, TypeIdentity};
 pub use self::dedicated::pytest::{FixtureBinding, fixture_bindings_for_parameter};
 pub(crate) use self::diagnostic::TypeCheckDiagnostics;
 pub(crate) use self::diagnostic::register_lints;
@@ -394,6 +394,37 @@ fn definition_expression_annotation<'db>(
             inference.expression_type(expression),
             TypeOrigin::Declared,
             inference.qualifiers(expression),
+        )
+    }
+}
+
+#[derive(Default)]
+struct MetaTypeVisitor<'db> {
+    active_aliases: ActiveRecursionDetector<TypeAliasType<'db>>,
+    active_identities: ActiveRecursionDetector<TypeIdentity<'db>>,
+}
+
+impl<'db> MetaTypeVisitor<'db> {
+    fn visit_alias(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        alias: TypeAliasType<'db>,
+    ) -> Type<'db> {
+        // A repeated specialization adds no new classes to a recursive union. Changing
+        // type arguments can introduce other classes, so use an unconstrained metatype.
+        // Do not cache results: a projection made while another alias is active can omit
+        // classes that are only encountered later in that alias's union.
+        self.active_aliases.visit(
+            &alias,
+            || Type::Never,
+            || {
+                self.active_identities.visit(
+                    &Type::TypeAlias(alias).to_type_identity(db),
+                    || KnownClass::Type.to_instance(db, env),
+                    || alias.value_type(db).to_meta_type_impl(db, env, self),
+                )
+            },
         )
     }
 }
@@ -7803,6 +7834,15 @@ impl<'db> Type<'db> {
     /// See `Self::dunder_class` for more details.
     #[must_use]
     fn to_meta_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
+        self.to_meta_type_impl(db, env, &MetaTypeVisitor::default())
+    }
+
+    fn to_meta_type_impl(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        visitor: &MetaTypeVisitor<'db>,
+    ) -> Type<'db> {
         match self {
             Type::Never => Type::Never,
             Type::NominalInstance(instance) => instance.to_meta_type(db, env),
@@ -7812,9 +7852,9 @@ impl<'db> Type<'db> {
                 property.instance_class(db).to_class_literal(db, env)
             }
             Type::SlotDescriptor(_) => KnownClass::MemberDescriptorType.to_class_literal(db, env),
-            Type::Union(union) => union.map(db, env, |ty| ty.to_meta_type(db, env)),
+            Type::Union(union) => union.map(db, env, |ty| ty.to_meta_type_impl(db, env, visitor)),
             Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db, env),
-            Type::TypeForm(_) => Type::object().to_meta_type(db, env),
+            Type::TypeForm(_) => Type::object().to_meta_type_impl(db, env, visitor),
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db, env),
                 LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_class_literal(db, env),
@@ -7852,13 +7892,13 @@ impl<'db> Type<'db> {
             Type::Divergent(_) => self,
             Type::Intersection(intersection) => {
                 if let Some(alternatives) = intersection.finite_alternative_union(db, env) {
-                    alternatives.to_meta_type(db, env)
+                    alternatives.to_meta_type_impl(db, env, visitor)
                 } else {
                     // Negative constraints do not generally constrain classes: `int & ~Literal[0]`
                     // still has meta-type `type[int]`. Pure negations are bounded by `object`.
                     let mut builder = IntersectionBuilder::new(db, env);
                     for positive in intersection.positive_elements_or_object(db) {
-                        builder.add_positive_in_place(positive.to_meta_type(db, env));
+                        builder.add_positive_in_place(positive.to_meta_type_impl(db, env, visitor));
                     }
 
                     // An exclusion can narrow a type variable's union bound to a definite class:
@@ -7883,7 +7923,9 @@ impl<'db> Type<'db> {
                             _ => None,
                         }
                     {
-                        builder.add_positive_in_place(narrowed_bound.to_meta_type(db, env));
+                        builder.add_positive_in_place(
+                            narrowed_bound.to_meta_type_impl(db, env, visitor),
+                        );
                     }
 
                     builder.build()
@@ -7891,7 +7933,7 @@ impl<'db> Type<'db> {
             }
             Type::EnumComplement(complement) => complement
                 .remaining_literal_union(db, env)
-                .to_meta_type(db, env),
+                .to_meta_type_impl(db, env, visitor),
             Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db, env),
             Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db, env),
             // Class-member lookup on a protocol instance must use the protocol's nominal class.
@@ -7908,8 +7950,10 @@ impl<'db> Type<'db> {
                     todo_type!("TypedDict synthesized meta-type").expect_dynamic(),
                 ),
             },
-            Type::TypeAlias(alias) => alias.value_type(db).to_meta_type(db, env),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).to_meta_type(db, env),
+            Type::TypeAlias(alias) => visitor.visit_alias(db, env, alias),
+            Type::NewTypeInstance(newtype) => newtype
+                .concrete_base_type(db)
+                .to_meta_type_impl(db, env, visitor),
         }
     }
 


### PR DESCRIPTION
Computing `type(value)` for recursive type aliases can overflow the stack. This change guards
meta-type projection so recursive aliases terminate while preserving the possible classes through
finite specialization cycles. When type arguments grow without bound, inference conservatively
returns `type`.

The guard tracks active alias specializations and recursive identities without reusing partial
results from another branch of a mutually recursive alias.

## Test plan

Added mdtests cover:

- Mutually recursive aliases combined in an intersection, retaining all possible classes.
- Rotating generic type arguments through a finite cycle, retaining `type[int | str]`.
- Generic type arguments that grow without bound, terminating with the conservative result `type`.
