### PR TITLE
[ty] Avoid repeated traversal of shared alias arguments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -1453,6 +1453,19 @@ class Aliased:
 reveal_type(Aliased().copy)
 ```
 
+`Self` also binds in a parameter annotation when the return type does not contain `Self`:
+
+```py
+class ParameterOnly:
+    def consume(self, other: Identity[Self]) -> None: ...
+
+# revealed: bound method ParameterOnly.consume(other: ParameterOnly) -> None
+reveal_type(ParameterOnly().consume)
+
+ParameterOnly().consume(ParameterOnly())
+ParameterOnly().consume(object())  # error: [invalid-argument-type]
+```
+
 In nested functions `self` binds to the method. So in the following example the `self` in `C.b` is
 bound at `C.f`.
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -1466,6 +1466,20 @@ ParameterOnly().consume(ParameterOnly())
 ParameterOnly().consume(object())  # error: [invalid-argument-type]
 ```
 
+Nested uses of the same alias still bind `Self` to the concrete receiver, including when a subclass
+inherits the method:
+
+```py
+class NestedAlias:
+    def copy(self, other: Identity[Identity[Self]]) -> Identity[Identity[Self]]:
+        return other
+
+class NestedChild(NestedAlias): ...
+
+# revealed: bound method NestedChild.copy(other: NestedChild) -> NestedChild
+reveal_type(NestedChild().copy)
+```
+
 In nested functions `self` binds to the method. So in the following example the `self` in `C.b` is
 bound at `C.f`.
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4454,8 +4454,8 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 
 ## `Self` in generic type aliases during protocol matching
 
-Wrapping `Self` in a generic type alias does not change what it denotes. Method parameters and
-return types are bound to the structural implementation before their signatures are compared.
+`Self` in a protocol method's return type refers to the structural implementation, even when it is
+wrapped in a generic type alias. The implementation can return plain `Self`:
 
 ```toml
 [environment]
@@ -4468,17 +4468,12 @@ from typing import Protocol, Self
 type Identity[T] = T
 
 class Cloneable(Protocol):
-    def clone(self, other: Identity[Self]) -> Identity[Self]: ...
-
-class AliasedClone:
-    def clone(self, other: Identity[Self]) -> Identity[Self]:
-        return other
+    def clone(self) -> Identity[Self]: ...
 
 class DirectClone:
-    def clone(self, other: Self) -> Self:
-        return other
+    def clone(self) -> Self:
+        return self
 
-aliased: Cloneable = AliasedClone()
 direct: Cloneable = DirectClone()
 ```
 
@@ -4491,7 +4486,7 @@ class Current(Protocol):
 
 class CurrentImpl:
     @property
-    def current(self) -> Identity[Self]:
+    def current(self) -> Self:
         return self
 
 current: Current = CurrentImpl()

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -108,7 +108,9 @@ pub use crate::types::typevar::{BoundTypeVarInstance, TypeVarKind};
 use crate::types::typevar::{TypeVarInstance, TypeVarSet};
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
-use crate::types::visitor::{any_over_type, dynamic_content};
+use crate::types::visitor::{
+    any_over_type, any_over_type_including_alias_arguments, dynamic_content,
+};
 use crate::{Db, FxOrderSet, HasType, NameKind, Program, SemanticModel};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator, SlotDescriptorType};
@@ -1921,19 +1923,10 @@ impl<'db> Type<'db> {
             return false;
         }
 
-        any_over_type(db, env, self, false, |ty| match ty {
-            Type::TypeVar(typevar) => typevar.typevar(db).is_self(db),
-            Type::TypeAlias(alias) => {
-                // Type alias bodies cannot declare `Self`, but their explicit type arguments can
-                // contain the `Self` from an enclosing method or class.
-                alias.specialization(db).is_some_and(|specialization| {
-                    specialization
-                        .types(db)
-                        .iter()
-                        .any(|ty| ty.contains_self(db, env))
-                })
-            }
-            _ => false,
+        // Type alias bodies cannot declare `Self`, but their explicit type arguments can
+        // contain the `Self` from an enclosing method or class.
+        any_over_type_including_alias_arguments(db, env, self, |ty| {
+            ty.as_typevar().is_some_and(|tv| tv.typevar(db).is_self(db))
         })
     }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -18,8 +18,8 @@ use crate::{
         ApplySpecialization, ApplyTypeMappingVisitor, CycleDetector, DynamicType, GenericContext,
         InstanceProjection, IntersectionType, KnownClass, KnownInstanceType, MaterializationKind,
         Parameter, Parameters, Specialization, Type, TypeAliasType, TypeContext, TypeMapping,
-        TypeVarVariance, UnionBuilder, UnionType, any_over_type, binding_type,
-        definition_expression_type,
+        TypeVarVariance, UnionBuilder, UnionType, any_over_type,
+        any_over_type_including_alias_arguments, binding_type, definition_expression_type,
         tuple::Tuple,
         variance::VarianceInferable,
         visitor::{self, TypeCollector, TypeVisitor, walk_type_with_recursion_guard},
@@ -83,17 +83,11 @@ impl<'db> Type<'db> {
         env: &ProgramEnvironment<'db>,
         typevar_id: TypeVarIdentity<'db>,
     ) -> bool {
-        any_over_type(db, env, self, false, |ty| match ty {
+        any_over_type_including_alias_arguments(db, env, self, |ty| match ty {
             Type::TypeVar(typevar) => typevar_id == typevar.typevar(db).identity(db),
             Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
                 typevar_id == typevar.identity(db)
             }
-            Type::TypeAlias(alias) => alias.specialization(db).is_some_and(|specialization| {
-                specialization
-                    .types(db)
-                    .iter()
-                    .any(|ty| ty.references_typevar_through_aliases(db, env, typevar_id))
-            }),
             _ => false,
         })
     }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -644,12 +644,13 @@ fn dynamic_content_impl<'db>(
     visitor.content.get()
 }
 
-/// Implementation for `any_over_type` and `find_over_type`.
+/// Shared implementation for type searches.
 fn any_over_type_impl<'db, F, T>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
     should_visit_lazy_type_attributes: bool,
+    visit_alias_arguments: bool,
     query: F,
 ) -> T
 where
@@ -662,6 +663,7 @@ where
         recursion_guard: TypeCollector<'db>,
         found_matching_type: Cell<U>,
         should_visit_lazy_type_attributes: bool,
+        visit_alias_arguments: bool,
     }
 
     impl<'db, U> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_, U>
@@ -687,7 +689,17 @@ where
             if new_value != default_value {
                 return;
             }
-            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            if self.visit_alias_arguments
+                && let Type::TypeAlias(alias) = ty
+            {
+                if !self.recursion_guard.type_was_already_seen(ty)
+                    && let Some(specialization) = alias.specialization(db)
+                {
+                    walk_specialization_types(db, specialization, self);
+                }
+            } else {
+                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            }
         }
     }
 
@@ -697,6 +709,7 @@ where
         recursion_guard: TypeCollector::default(),
         found_matching_type: Cell::default(),
         should_visit_lazy_type_attributes,
+        visit_alias_arguments,
     };
     visitor.visit_type(db, ty);
     visitor.found_matching_type.get()
@@ -717,7 +730,20 @@ pub(super) fn any_over_type<'db>(
     should_visit_lazy_type_attributes: bool,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, false, query)
+}
+
+/// Searches through the arguments of [`Type::TypeAlias`] without evaluating alias bodies or other
+/// lazy attributes.
+/// This also visits arguments that the alias's value does not use.
+/// Shared arguments use the same recursion guard, so their descendants are not visited repeatedly.
+pub(super) fn any_over_type_including_alias_arguments<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+    query: impl Fn(Type<'db>) -> bool,
+) -> bool {
+    any_over_type_impl(db, env, ty, false, true, query)
 }
 
 /// Searches through type aliases without forcing other lazily inferred type attributes.
@@ -774,7 +800,7 @@ pub(super) fn find_over_type<'db, T>(
 where
     T: Copy + PartialEq,
 {
-    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, false, query)
 }
 
 #[cfg(test)]

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -644,13 +644,30 @@ fn dynamic_content_impl<'db>(
     visitor.content.get()
 }
 
+#[derive(Clone, Copy)]
+enum TypeSearchMode {
+    SkipLazyAttributes,
+    IncludeLazyAttributes,
+    /// Visit alias arguments without evaluating alias bodies or other lazy attributes.
+    IncludeAliasArguments,
+}
+
+impl TypeSearchMode {
+    const fn should_visit_lazy_type_attributes(self) -> bool {
+        matches!(self, Self::IncludeLazyAttributes)
+    }
+
+    const fn should_visit_alias_arguments(self) -> bool {
+        matches!(self, Self::IncludeAliasArguments)
+    }
+}
+
 /// Shared implementation for type searches.
 fn any_over_type_impl<'db, F, T>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     ty: Type<'db>,
-    should_visit_lazy_type_attributes: bool,
-    visit_alias_arguments: bool,
+    mode: TypeSearchMode,
     query: F,
 ) -> T
 where
@@ -662,8 +679,7 @@ where
         query: &'a dyn Fn(Type<'db>) -> U,
         recursion_guard: TypeCollector<'db>,
         found_matching_type: Cell<U>,
-        should_visit_lazy_type_attributes: bool,
-        visit_alias_arguments: bool,
+        mode: TypeSearchMode,
     }
 
     impl<'db, U> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_, U>
@@ -675,7 +691,7 @@ where
         }
 
         fn should_visit_lazy_type_attributes(&self) -> bool {
-            self.should_visit_lazy_type_attributes
+            self.mode.should_visit_lazy_type_attributes()
         }
 
         fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
@@ -689,7 +705,7 @@ where
             if new_value != default_value {
                 return;
             }
-            if self.visit_alias_arguments
+            if self.mode.should_visit_alias_arguments()
                 && let Type::TypeAlias(alias) = ty
             {
                 if !self.recursion_guard.type_was_already_seen(ty)
@@ -708,8 +724,7 @@ where
         query: &query,
         recursion_guard: TypeCollector::default(),
         found_matching_type: Cell::default(),
-        should_visit_lazy_type_attributes,
-        visit_alias_arguments,
+        mode,
     };
     visitor.visit_type(db, ty);
     visitor.found_matching_type.get()
@@ -730,7 +745,12 @@ pub(super) fn any_over_type<'db>(
     should_visit_lazy_type_attributes: bool,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, false, query)
+    let mode = if should_visit_lazy_type_attributes {
+        TypeSearchMode::IncludeLazyAttributes
+    } else {
+        TypeSearchMode::SkipLazyAttributes
+    };
+    any_over_type_impl(db, env, ty, mode, query)
 }
 
 /// Searches through the arguments of [`Type::TypeAlias`] without evaluating alias bodies or other
@@ -743,7 +763,7 @@ pub(super) fn any_over_type_including_alias_arguments<'db>(
     ty: Type<'db>,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, env, ty, false, true, query)
+    any_over_type_impl(db, env, ty, TypeSearchMode::IncludeAliasArguments, query)
 }
 
 /// Searches through type aliases without forcing other lazily inferred type attributes.
@@ -800,7 +820,12 @@ pub(super) fn find_over_type<'db, T>(
 where
     T: Copy + PartialEq,
 {
-    any_over_type_impl(db, env, ty, should_visit_lazy_type_attributes, false, query)
+    let mode = if should_visit_lazy_type_attributes {
+        TypeSearchMode::IncludeLazyAttributes
+    } else {
+        TypeSearchMode::SkipLazyAttributes
+    };
+    any_over_type_impl(db, env, ty, mode, query)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Searching generic alias arguments for `Self` or a type variable starts a fresh type walk for each argument. Shared nested specializations are therefore visited repeatedly, which can make method binding take exponential time even when its annotations contain no `Self`.

Use a shared visitor implementation for both searches, with one recursion guard per search. It visits explicit alias arguments, including arguments unused by the alias body, without evaluating alias bodies or other lazy attributes. Different specializations of the same alias remain distinct.

Follow-up to #28117.

## Test plan

Add mdtests for `Self` used only in an aliased parameter, including accepted and rejected arguments, and nested uses of the same alias in an inherited method. Simplify the protocol fixtures while retaining separate method and property cases for structural `Self` binding.

A minimized example with 32 levels of shared alias arguments completes in about 40 ms; the prior implementation hit a 12-second timeout in the same debug-build setup.
