### PR TITLE
[ty] Preserve recursion guards across nested type operations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -4148,6 +4148,26 @@ class Foo: ...
 reveal_type(Foo.__class__)  # revealed: <class 'type'>
 ```
 
+## `__class__` on recursive aliases
+
+For a recursive alias that contains both instances and classes, `value.__class__` agrees with
+`type(value)`. Repeated queries retain both the instance classes and their possible metaclasses.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Meta[T] = type[T]
+type Recursive = int | Meta[Recursive]
+
+def recursive_class(value: Recursive):
+    reveal_type(type(value))  # revealed: type[int | type]
+    reveal_type(value.__class__)  # revealed: type[int | type]
+    reveal_type(type(value))  # revealed: type[int | type]
+```
+
 ## Module attributes
 
 ### Basic

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -68,6 +68,120 @@ def growing(value: Growing[int]):
     reveal_type(type(value))  # revealed: type
 ```
 
+### Classes of recursive class aliases with growing specializations
+
+The arguments of a recursive alias can grow while nested `type` specializations are resolved.
+Computing the class still terminates and retains the possible metaclasses.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Meta[T] = type[T]
+type Growing[T] = T | Meta[Growing[list[T]]]
+
+def growing_class(value: Growing[int]):
+    reveal_type(type(value))  # revealed: type[int | type]
+```
+
+### Classes of recursive class aliases with nested specializations
+
+An alias can forward a class type to another alias. Class inference also terminates when that class
+type contains a growing recursive specialization, retaining the possible metaclasses.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Meta[T] = type[T]
+type NestedMeta[T] = Meta[type[T]]
+type Growing[T] = T | NestedMeta[Growing[list[T]]]
+
+def nested_specialization(value: Growing[int]):
+    reveal_type(type(value))  # revealed: type[int | type]
+```
+
+### Classes of materialized recursive aliases
+
+Upper and lower materializations retain their different class types after recursive alias expansion.
+Interleaving queries with the original alias preserves all three results.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any
+from ty_extensions import Bottom, Top
+
+type Meta[T] = type[T]
+type Gradual = list[Any] | Meta[Gradual]
+
+def materialized_classes(top: Top[Gradual], bottom: Bottom[Gradual], plain: Gradual):
+    reveal_type(type(top))  # revealed: type[Top[list[Any]] | type]
+    reveal_type(type(bottom))  # revealed: type[Bottom[list[Any]] | type]
+    reveal_type(type(plain))  # revealed: type[list[Any] | type]
+    reveal_type(top.__class__)  # revealed: type[Top[list[Any]] | type]
+    reveal_type(bottom.__class__)  # revealed: type[Bottom[list[Any]] | type]
+    reveal_type(type(top))  # revealed: type[Top[list[Any]] | type]
+```
+
+### Classes with an aliased recursive type-variable bound
+
+A type variable cannot appear in its own bound, but this is not yet diagnosed when an alias hides
+the type variable. Computing a parameter's class still terminates in this case.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Meta[T] = type[T]
+
+def recursive_bound[T: Meta[T]](value: type[T]):
+    type(value)
+```
+
+### Classes with an identity alias in a recursive type-variable bound
+
+An identity alias can also hide an invalid bound that refers back to the same type variable.
+Computing a parameter's class terminates after the alias has been expanded.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Identity[T] = T
+
+def recursive_bound[T: Identity[T]](value: type[T]):
+    type(value)
+```
+
+### Classes with aliased recursive type-variable constraints
+
+An alias for `type[T]` can hide an invalid recursive constraint. Although this is not yet diagnosed,
+computing a `type[T]` parameter's class still terminates.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Meta[T] = type[T]
+
+def recursive_constraints[T: (Meta[T], int)](value: type[T]):
+    type(value)
+```
+
 ## Three-argument form (dynamic class creation)
 
 A three-argument call to `type()` creates a new class. We synthesize a class type using the name

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -403,6 +403,34 @@ fn definition_expression_annotation<'db>(
     }
 }
 
+/// Active recursion state shared across nested type operations.
+///
+/// A transformation cache belongs to one mapping, but recursion can span specialization,
+/// materialization, and meta-type projection. Preserve this context when starting a new mapping
+/// visitor. Each operation keeps its own guards because its recursion keys and cycle fallbacks
+/// differ.
+#[derive(Default)]
+struct TypeRecursionContext<'db> {
+    meta_type: MetaTypeRecursion<'db>,
+}
+
+/// Guards shared by meta-type projections and the specializations they trigger.
+///
+/// Each projection also tracks direct alias recursion locally: those cycles add no new classes,
+/// whereas re-entering through another projection can introduce metaclasses.
+#[derive(Default)]
+struct MetaTypeRecursion<'db> {
+    aliases: ActiveRecursionDetector<(Program<'db>, TypeAliasType<'db>)>,
+    growing_aliases: ActiveRecursionDetector<(Program<'db>, Definition<'db>)>,
+    typevars: ActiveRecursionDetector<(Program<'db>, BoundTypeVarIdentity<'db>)>,
+}
+
+impl MetaTypeRecursion<'_> {
+    fn is_active(&self) -> bool {
+        !self.aliases.is_empty() || !self.growing_aliases.is_empty() || !self.typevars.is_empty()
+    }
+}
+
 struct ApplyTypeMappingTag;
 struct ApplyMaterializationEquivalence;
 
@@ -416,6 +444,7 @@ type MaterializationEquivalenceVisitor<'db> =
 /// reuse the result of another.
 pub(crate) struct ApplyTypeMappingVisitor<'env, 'db> {
     env: &'env ProgramEnvironment<'db>,
+    recursion_context: Option<&'env TypeRecursionContext<'db>>,
     default: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     top_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     bottom_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
@@ -430,6 +459,7 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
     fn new(env: &'env ProgramEnvironment<'db>) -> Self {
         Self {
             env,
+            recursion_context: None,
             default: OnceCell::default(),
             top_materialization: OnceCell::default(),
             bottom_materialization: OnceCell::default(),
@@ -438,6 +468,18 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
             promotion: OnceCell::default(),
             skip_promotion: OnceCell::default(),
             materialization_equivalence: OnceCell::default(),
+        }
+    }
+
+    fn with_recursion_context(mut self, context: Option<&'env TypeRecursionContext<'db>>) -> Self {
+        self.recursion_context = context;
+        self
+    }
+
+    fn project_meta_type(&self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+        match self.recursion_context {
+            Some(context) => ty.to_meta_type_with_recursion(db, self.env, context),
+            None => ty.to_meta_type(db, self.env),
         }
     }
 
@@ -493,6 +535,7 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
 
         Self {
             materialization_equivalence,
+            recursion_context: self.recursion_context,
             ..Self::new(self.env)
         }
     }
@@ -7884,17 +7927,21 @@ impl<'db> Type<'db> {
     /// See `Self::dunder_class` for more details.
     #[must_use]
     fn to_meta_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        #[derive(Default)]
-        struct MetaTypeVisitor<'db> {
-            active_aliases: ActiveRecursionDetector<TypeAliasType<'db>>,
-            active_identities: ActiveRecursionDetector<TypeIdentity<'db>>,
-        }
+        self.to_meta_type_with_recursion(db, env, &TypeRecursionContext::default())
+    }
 
+    fn to_meta_type_with_recursion(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        context: &TypeRecursionContext<'db>,
+    ) -> Type<'db> {
         fn to_meta_type_inner<'db>(
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,
             ty: Type<'db>,
-            visitor: &MetaTypeVisitor<'db>,
+            context: &TypeRecursionContext<'db>,
+            visitor: &ActiveRecursionDetector<TypeAliasType<'db>>,
         ) -> Type<'db> {
             match ty {
                 Type::Never => Type::Never,
@@ -7907,11 +7954,11 @@ impl<'db> Type<'db> {
                 Type::SlotDescriptor(_) => {
                     KnownClass::MemberDescriptorType.to_class_literal(db, env)
                 }
-                Type::Union(union) => {
-                    union.map(db, env, |ty| to_meta_type_inner(db, env, *ty, visitor))
-                }
+                Type::Union(union) => union.map(db, env, |ty| {
+                    to_meta_type_inner(db, env, *ty, context, visitor)
+                }),
                 Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db, env),
-                Type::TypeForm(_) => to_meta_type_inner(db, env, Type::object(), visitor),
+                Type::TypeForm(_) => to_meta_type_inner(db, env, Type::object(), context, visitor),
                 Type::LiteralValue(literal) => match literal.kind() {
                     LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db, env),
                     LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_class_literal(db, env),
@@ -7942,21 +7989,34 @@ impl<'db> Type<'db> {
                 }
                 Type::ClassLiteral(class) => class.metaclass(db),
                 Type::GenericAlias(alias) => ClassType::from(alias).metaclass(db),
-                Type::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db, env),
+                Type::SubclassOf(subclass_of_ty)
+                    if let SubclassOfInner::TypeVar(typevar) = subclass_of_ty.subclass_of() =>
+                {
+                    // Transposition changes a type variable's bounds but preserves its bound
+                    // identity. Guard by that identity so newly transposed instances still match.
+                    context.meta_type.typevars.visit(
+                        &(env.program(db), typevar.identity(db)),
+                        || KnownClass::Type.to_instance(db, env),
+                        || subclass_of_ty.to_meta_type_with_recursion(db, env, context),
+                    )
+                }
+                Type::SubclassOf(subclass_of_ty) => {
+                    subclass_of_ty.to_meta_type_with_recursion(db, env, context)
+                }
                 Type::Dynamic(dynamic) => {
                     SubclassOfType::from(db, env, SubclassOfInner::Dynamic(dynamic))
                 }
                 Type::Divergent(_) => ty,
                 Type::Intersection(intersection) => {
                     if let Some(alternatives) = intersection.finite_alternative_union(db, env) {
-                        to_meta_type_inner(db, env, alternatives, visitor)
+                        to_meta_type_inner(db, env, alternatives, context, visitor)
                     } else {
                         // Negative constraints do not generally constrain classes: `int & ~Literal[0]`
                         // still has meta-type `type[int]`. Pure negations are bounded by `object`.
                         let mut builder = IntersectionBuilder::new(db, env);
                         for positive in intersection.positive_elements_or_object(db) {
                             builder.add_positive_in_place(to_meta_type_inner(
-                                db, env, positive, visitor,
+                                db, env, positive, context, visitor,
                             ));
                         }
 
@@ -7986,6 +8046,7 @@ impl<'db> Type<'db> {
                                 db,
                                 env,
                                 narrowed_bound,
+                                context,
                                 visitor,
                             ));
                         }
@@ -7997,6 +8058,7 @@ impl<'db> Type<'db> {
                     db,
                     env,
                     complement.remaining_literal_union(db, env),
+                    context,
                     visitor,
                 ),
                 Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db, env),
@@ -8020,25 +8082,48 @@ impl<'db> Type<'db> {
                     // type arguments can introduce other classes, so use an unconstrained metatype.
                     // Do not cache results: a projection made while another alias is active can omit
                     // classes that are only encountered later in that alias's union.
-                    visitor.active_aliases.visit(
+                    visitor.visit(
                         &alias,
                         || Type::Never,
                         || {
-                            visitor.active_identities.visit(
-                                &Type::TypeAlias(alias).to_type_identity(db),
+                            context.meta_type.aliases.visit(
+                                &(env.program(db), alias),
                                 || KnownClass::Type.to_instance(db, env),
-                                || to_meta_type_inner(db, env, alias.value_type(db), visitor),
+                                || {
+                                    let project_alias = || {
+                                        to_meta_type_inner(
+                                            db,
+                                            env,
+                                            alias.value_type_with_recursion(db, Some(context)),
+                                            context,
+                                            visitor,
+                                        )
+                                    };
+                                    // Identity analysis can itself expand aliases, so establish the
+                                    // exact-alias guard before checking for growing specializations.
+                                    if let TypeIdentity::GrowingTypeAlias(definition) =
+                                        Type::TypeAlias(alias).to_type_identity(db)
+                                    {
+                                        context.meta_type.growing_aliases.visit(
+                                            &(env.program(db), definition),
+                                            || KnownClass::Type.to_instance(db, env),
+                                            project_alias,
+                                        )
+                                    } else {
+                                        project_alias()
+                                    }
+                                },
                             )
                         },
                     )
                 }
                 Type::NewTypeInstance(newtype) => {
-                    to_meta_type_inner(db, env, newtype.concrete_base_type(db), visitor)
+                    to_meta_type_inner(db, env, newtype.concrete_base_type(db), context, visitor)
                 }
             }
         }
 
-        to_meta_type_inner(db, env, self, &MetaTypeVisitor::default())
+        to_meta_type_inner(db, env, self, context, &ActiveRecursionDetector::default())
     }
 
     /// Get the type of the `__class__` attribute of this type.
@@ -8468,7 +8553,9 @@ impl<'db> Type<'db> {
                 match type_mapping {
                     TypeMapping::Materialize(_) if alias.materialization_kind(db).is_some() => self,
                     TypeMapping::EagerExpansion if alias.materialization_kind(db).is_some() => {
-                        alias.value_type(db).expand_eagerly(db, visitor.env)
+                        alias
+                            .value_type_with_recursion(db, visitor.recursion_context)
+                            .expand_eagerly(db, visitor.env)
                     }
                     // For EagerExpansion, expand the raw value type. This path relies on Salsa's cycle
                     // detection rather than the visitor's cycle detection, because the visitor tracks
@@ -8502,7 +8589,11 @@ impl<'db> Type<'db> {
                             alias
                                 .specialization(db)
                                 .unwrap_or_else(|| generic_context.default_specialization(db, None))
-                                .apply_specialization(db, current_specialization)
+                                .apply_specialization_with_recursion(
+                                    db,
+                                    current_specialization,
+                                    visitor.recursion_context,
+                                )
                         }))
                     }
                     _ => {
@@ -8510,18 +8601,18 @@ impl<'db> Type<'db> {
                         // this same TypeAlias again (e.g., in `type RecursiveT = int | tuple[RecursiveT, ...]`), the visitor
                         // will detect the cycle and return the fallback value.
                         let mapped = visitor.visit(db, self, type_mapping, || {
-                            alias.value_type(db).apply_type_mapping_impl(
-                                db,
-                                type_mapping,
-                                tcx,
-                                visitor,
-                            )
+                            alias
+                                .value_type_with_recursion(db, visitor.recursion_context)
+                                .apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                         });
 
                         // If the type mapping does not result in any change to this type alias, keep the
                         // alias node instead of eagerly expanding it. A recursive backedge also returns
                         // the alias itself, and fully static aliases must retain their original identity.
-                        if mapped == self || alias.value_type(db) == mapped {
+                        if mapped == self
+                            || alias.value_type_with_recursion(db, visitor.recursion_context)
+                                == mapped
+                        {
                             self
                         } else if let TypeMapping::Materialize(materialization_kind) = type_mapping
                             && alias.is_recursive(db)

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -1163,6 +1163,10 @@ impl<T> Default for ActiveRecursionDetector<T> {
 }
 
 impl<T: Hash + Eq + Clone> ActiveRecursionDetector<T> {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.seen.borrow().is_empty()
+    }
+
     pub(crate) fn visit<R>(
         &self,
         item: &T,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -36,8 +36,8 @@ use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, KnownInstanceType,
     MaterializationKind, SubclassOfInner, Type, TypeAliasType, TypeContext, TypeMapping,
-    TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType,
-    binding_type, infer_definition_types, inferred_declaration,
+    TypeRecursionContext, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance,
+    UnionAccumulator, UnionType, binding_type, infer_definition_types, inferred_declaration,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -1336,18 +1336,28 @@ impl<'db> Specialization<'db> {
     /// That lets us produce the generic alias `A[int]`, which is the corresponding entry in the
     /// MRO of `B[int]`.
     pub(crate) fn apply_specialization(self, db: &'db dyn Db, other: Specialization<'db>) -> Self {
+        self.apply_specialization_with_recursion(db, other, None)
+    }
+
+    pub(super) fn apply_specialization_with_recursion(
+        self,
+        db: &'db dyn Db,
+        other: Specialization<'db>,
+        recursion_context: Option<&TypeRecursionContext<'db>>,
+    ) -> Self {
         let env = &ProgramEnvironment::from_program(other.generic_context(db).program(db));
-        let new_specialization = self.apply_type_mapping(
+        let new_specialization = self.apply_type_mapping_impl(
             db,
-            env,
             &TypeMapping::ApplySpecialization(ApplySpecialization::specialization(other)),
+            &[],
+            &ApplyTypeMappingVisitor::new(env).with_recursion_context(recursion_context),
         );
         match other.materialization_kind(db) {
             None => new_specialization,
             Some(materialization_kind) => new_specialization.materialize_impl(
                 db,
                 materialization_kind,
-                &ApplyTypeMappingVisitor::new(env),
+                &ApplyTypeMappingVisitor::new(env).with_recursion_context(recursion_context),
             ),
         }
     }
@@ -1364,15 +1374,6 @@ impl<'db> Specialization<'db> {
             materialization_kind,
             self.tuple_inner(db),
         )
-    }
-
-    fn apply_type_mapping<'a>(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        type_mapping: &TypeMapping<'a, 'db>,
-    ) -> Self {
-        self.apply_type_mapping_impl(db, type_mapping, &[], &ApplyTypeMappingVisitor::new(env))
     }
 
     pub(crate) fn apply_type_mapping_impl<'a>(
@@ -1407,7 +1408,8 @@ impl<'db> Specialization<'db> {
                         db,
                         &TypeMapping::ApplySpecialization(*specialization),
                         tcx,
-                        &ApplyTypeMappingVisitor::new(env),
+                        &ApplyTypeMappingVisitor::new(env)
+                            .with_recursion_context(visitor.recursion_context),
                     );
 
                     if new_materialization_kind.is_none() {
@@ -1415,7 +1417,8 @@ impl<'db> Specialization<'db> {
                             db,
                             type_mapping,
                             tcx,
-                            &ApplyTypeMappingVisitor::new(env),
+                            &ApplyTypeMappingVisitor::new(env)
+                                .with_recursion_context(visitor.recursion_context),
                         );
                         if specialized != materialized {
                             new_materialization_kind = Some(*materialization_kind);

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1335,7 +1335,7 @@ impl<'db> Specialization<'db> {
     /// `{U: int}`, we can apply the second specialization to the first, resulting in `T: int`.
     /// That lets us produce the generic alias `A[int]`, which is the corresponding entry in the
     /// MRO of `B[int]`.
-    pub(crate) fn apply_specialization(self, db: &'db dyn Db, other: Specialization<'db>) -> Self {
+    fn apply_specialization(self, db: &'db dyn Db, other: Specialization<'db>) -> Self {
         self.apply_specialization_with_recursion(db, other, None)
     }
 

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -10,7 +10,8 @@ use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, ClassLiteral, ClassType,
     DynamicType, FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind, MemberLookupPolicy,
     ProtocolInstanceType, SpecialFormType, Type, TypeContext, TypeMapping, TypeQualifiers,
-    TypeVarBoundOrConstraints, TypeVarVariance, TypedDictType, UnionType, todo_type,
+    TypeRecursionContext, TypeVarBoundOrConstraints, TypeVarVariance, TypedDictType, UnionType,
+    todo_type,
 };
 use ty_python_core::definition::Definition;
 
@@ -221,7 +222,7 @@ impl<'db> SubclassOfType<'db> {
             SubclassOfInner::TypeVar(typevar) => {
                 let mapped = typevar.apply_type_mapping_impl(db, type_mapping, visitor);
                 Self::try_from_instance(db, visitor.env, mapped)
-                    .unwrap_or_else(|| mapped.to_meta_type(db, visitor.env))
+                    .unwrap_or_else(|| visitor.project_meta_type(db, mapped))
             }
         }
     }
@@ -331,7 +332,19 @@ impl<'db> SubclassOfType<'db> {
     /// For `type[T]` where `T` is a `TypeVar`, this computes the metatype based on the
     /// `TypeVar`'s bounds or constraints.
     pub(crate) fn to_meta_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        match self.subclass_of.with_transposed_type_var(db, env) {
+        Type::SubclassOf(self).to_meta_type(db, env)
+    }
+
+    pub(super) fn to_meta_type_with_recursion(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        context: &TypeRecursionContext<'db>,
+    ) -> Type<'db> {
+        match self
+            .subclass_of
+            .with_transposed_type_var_with_recursion(db, env, context)
+        {
             SubclassOfInner::Dynamic(dynamic) => {
                 SubclassOfType::from(db, env, SubclassOfInner::Dynamic(dynamic))
             }
@@ -342,7 +355,7 @@ impl<'db> SubclassOfType<'db> {
                 .inferred_metaclass(db)
                 .for_inheritance(db, env)
                 .to_instance_approximation(db, env)
-                .map(|instance| instance.to_meta_type(db, env))
+                .map(|instance| instance.to_meta_type_with_recursion(db, env, context))
                 .unwrap_or(SubclassOfType::subclass_of_unknown()),
             // Structural implementations of a protocol can have arbitrary metaclasses. The only
             // guaranteed upper bound is therefore `type`, not the protocol origin's metaclass.
@@ -356,11 +369,11 @@ impl<'db> SubclassOfType<'db> {
                     // `with_transposed_type_var` always adds a bound for unbounded TypeVars
                     None => unreachable!(),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        bound.to_meta_type(db, env)
+                        bound.to_meta_type_with_recursion(db, env, context)
                     }
-                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                        constraints.as_type(db, env).to_meta_type(db, env)
-                    }
+                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+                        .as_type(db, env)
+                        .to_meta_type_with_recursion(db, env, context),
                 }
             }
         }
@@ -597,6 +610,15 @@ impl<'db> SubclassOfInner<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Self {
+        self.with_transposed_type_var_with_recursion(db, env, &TypeRecursionContext::default())
+    }
+
+    fn with_transposed_type_var_with_recursion(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        context: &TypeRecursionContext<'db>,
+    ) -> Self {
         let Some(bound_typevar) = self.into_type_var() else {
             return self;
         };
@@ -608,12 +630,14 @@ impl<'db> SubclassOfInner<'db> {
                         .unwrap_or(SubclassOfType::subclass_of_unknown()),
                 ),
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                    TypeVarBoundOrConstraints::UpperBound(bound.to_meta_type(db, env))
+                    TypeVarBoundOrConstraints::UpperBound(
+                        bound.to_meta_type_with_recursion(db, env, context),
+                    )
                 }
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                    TypeVarBoundOrConstraints::Constraints(
-                        constraints.map(db, |constraint| constraint.to_meta_type(db, env)),
-                    )
+                    TypeVarBoundOrConstraints::Constraints(constraints.map(db, |constraint| {
+                        constraint.to_meta_type_with_recursion(db, env, context)
+                    }))
                 }
             })
         });

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -331,7 +331,7 @@ impl<'db> SubclassOfType<'db> {
     /// excluding the lookup-only typeshed fallback.
     /// For `type[T]` where `T` is a `TypeVar`, this computes the metatype based on the
     /// `TypeVar`'s bounds or constraints.
-    pub(crate) fn to_meta_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
+    fn to_meta_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         Type::SubclassOf(self).to_meta_type(db, env)
     }
 

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -6,7 +6,8 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
         GenericContext, KnownClass, KnownInstanceType, MaterializationKind, Type, TypeContext,
-        TypeMapping, TypeVarVariance, TypingModule, definition_expression_type,
+        TypeMapping, TypeRecursionContext, TypeVarVariance, TypingModule,
+        definition_expression_type,
         display::qualified_name_components_from_scope,
         generics::{ApplySpecialization, Specialization, bind_typevar},
         variance::VarianceInferable,
@@ -140,6 +141,7 @@ impl<'db> PEP695TypeAliasType<'db> {
             self.raw_value_type(db),
             self.generic_context(db),
             self.specialization(db),
+            None,
         )
     }
 
@@ -255,6 +257,7 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
             self.raw_value_type(db),
             self.generic_context(db),
             self.specialization(db),
+            None,
         )
     }
 
@@ -352,6 +355,7 @@ fn apply_type_alias_specialization<'db>(
     ty: Type<'db>,
     generic_context: Option<GenericContext<'db>>,
     specialization: Option<Specialization<'db>>,
+    recursion_context: Option<&TypeRecursionContext<'db>>,
 ) -> Type<'db> {
     let Some(generic_context) = generic_context else {
         return ty;
@@ -372,7 +376,7 @@ fn apply_type_alias_specialization<'db>(
         db,
         &type_mapping,
         TypeContext::default(),
-        &ApplyTypeMappingVisitor::new(&env),
+        &ApplyTypeMappingVisitor::new(&env).with_recursion_context(recursion_context),
     )
 }
 
@@ -456,6 +460,46 @@ impl<'db> TypeAliasType<'db> {
             TypeAliasType::PEP695(type_alias) => type_alias.value_type(db),
             TypeAliasType::ManualPEP695(type_alias) => type_alias.value_type(db),
         }
+    }
+
+    /// Resolve this alias while preserving active recursion guards.
+    ///
+    /// During meta-type projection, results can depend on which aliases or type variables are
+    /// already being projected and must stay out of the materialization cache. The raw alias body
+    /// is still inferred independently by Salsa. Other operations retain ordinary caching unless
+    /// their recursion state also requires context-dependent expansion.
+    pub(super) fn value_type_with_recursion(
+        self,
+        db: &'db dyn Db,
+        context: Option<&TypeRecursionContext<'db>>,
+    ) -> Type<'db> {
+        let Some(context) = context.filter(|context| context.meta_type.is_active()) else {
+            return self.value_type(db);
+        };
+
+        let alias = self.with_materialization_kind(db, None);
+        let value_type = apply_type_alias_specialization(
+            db,
+            alias.raw_value_type(db),
+            alias.generic_context(db),
+            alias.specialization(db),
+            Some(context),
+        );
+
+        let Some(materialization_kind) = self.materialization_kind(db) else {
+            return value_type;
+        };
+        let env = match alias {
+            TypeAliasType::PEP695(alias) => ProgramEnvironment::from_scope(alias.rhs_scope(db)),
+            TypeAliasType::ManualPEP695(alias) => {
+                ProgramEnvironment::from_definition(alias.definition(db))
+            }
+        };
+        value_type.materialize(
+            db,
+            materialization_kind,
+            &ApplyTypeMappingVisitor::new(&env).with_recursion_context(Some(context)),
+        )
     }
 
     /// Materialize the alias body lazily, keeping this alias as the recursive fallback.


### PR DESCRIPTION
On main we still stack overflow when `type(value)` or `value.__class__` traverses recursive aliases containing `type[T]`, or type variables whose recursive bounds or constraints are hidden behind aliases. Specialization and materialization can start nested meta-type projections that lose the original projection's recursion guards.

This change carries a shared `TypeRecursionContext` through those operations while keeping each transformation's result cache separate. Alias expansions that depend on active guards stay out of the materialization cache. Direct alias recursion retains its precise fallback, while re-entering meta-type projection conservatively accounts for possible metaclasses.

The `TypeRecursionContext` is currently used only for `to_meta_type` cycles, but it is intentionally named and structured in such a way that we could add more recursion-trackers to it and start to unify our recursion tracking a bit more, so we can handle more cross-method recursion cases.

Follow-up to #28143.

## Test plan

Adds mdtests for recursive class aliases with growing and nested specializations, aliased recursive type-variable bounds and constraints, and repeated `type()`/`__class__` queries. Materialized recursive-alias tests check that upper, lower, and ordinary alias types retain independent results across interleaved queries.
