### PR TITLE
[ty] Fix cyclic-alias expectations in type() tests

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -14,9 +14,9 @@ reveal_type(type(1))  # revealed: <class 'int'>
 
 ### Classes of recursive intersections
 
-Mutually recursive aliases can describe the same union of classes. Computing the class of their
-intersection preserves every possible class, regardless of the order in which the aliases are
-expanded.
+These aliases are invalid because expanding either one includes itself as a union member. During
+error recovery, computing the class of their intersection preserves every non-recursive member,
+regardless of expansion order.
 
 ```toml
 [environment]
@@ -26,8 +26,8 @@ python-version = "3.12"
 ```py
 from ty_extensions import Intersection
 
-type First = Second | int
-type Second = First | str
+type First = Second | int  # error: [cyclic-type-alias-definition]
+type Second = First | str  # error: [cyclic-type-alias-definition]
 
 def recursive(value: Intersection[First, Second]):
     reveal_type(type(value))  # revealed: type[int | str]
@@ -35,8 +35,8 @@ def recursive(value: Intersection[First, Second]):
 
 ### Classes of recursive aliases with repeating specializations
 
-Rotating the arguments of a recursive alias produces a finite set of specializations. Class
-inference retains the union of those arguments instead of widening to `type`.
+This invalid cyclic alias rotates its arguments through a finite set of specializations. During
+error recovery, class inference retains the union of those arguments instead of widening to `type`.
 
 ```toml
 [environment]
@@ -44,7 +44,7 @@ python-version = "3.12"
 ```
 
 ```py
-type Rotate[T, U] = T | Rotate[U, T]
+type Rotate[T, U] = T | Rotate[U, T]  # error: [cyclic-type-alias-definition]
 
 def rotating(value: Rotate[int, str]):
     reveal_type(type(value))  # revealed: type[int | str]
@@ -52,8 +52,9 @@ def rotating(value: Rotate[int, str]):
 
 ### Classes of recursive aliases with growing specializations
 
-Recursive specialization can introduce classes beyond the initial type argument. Class inference
-terminates even when the type arguments keep growing, conservatively returning `type`.
+This invalid cyclic alias introduces classes beyond the initial type argument. During error
+recovery, class inference terminates even when the type arguments keep growing, conservatively
+returning `type`.
 
 ```toml
 [environment]
@@ -61,7 +62,7 @@ python-version = "3.12"
 ```
 
 ```py
-type Growing[T] = T | Growing[list[T]]
+type Growing[T] = T | Growing[list[T]]  # error: [cyclic-type-alias-definition]
 
 def growing(value: Growing[int]):
     reveal_type(type(value))  # revealed: type


### PR DESCRIPTION
## Summary

The failure on `main` came from a merge race between [#28143](https://github.com/astral-sh/ruff/pull/28143), which added `type()` inference regression tests using cyclic aliases, and [#28140](https://github.com/astral-sh/ruff/pull/28140), which correctly made those alias definitions emit `cyclic-type-alias-definition`.

[#28140's required CI checks passed](https://github.com/astral-sh/ruff/actions/runs/33198858501/job/98944766069) on 28 August, before #28143 merged its new tests later that day. Those tests passed under the existing alias-checking behavior. When #28140 merged on 29 August, its earlier green CI result did not cover the newly added tests, and their missing diagnostic expectations caused the [post-merge `main` CI failure](https://github.com/astral-sh/ruff/actions/runs/33249006861/job/99091347227).

Add the four missing `cyclic-type-alias-definition` expectations and describe the cases as error recovery. Preserve the existing `reveal_type(type(...))` assertions so these tests continue to cover termination and class inference for invalid recursive aliases. No inference logic changes.
