### PR TITLE
[ty] Suggest variable-length tuple annotations for redundant conditions

### DIFF
--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -1332,6 +1332,20 @@ impl ParameterDefinitionNodeKind {
             }
         }
     }
+
+    pub fn annotation<'ast>(&self, module: &'ast ParsedModuleRef) -> Option<&'ast ast::Expr> {
+        match self {
+            Self::VariadicPositionalParameter(parameter)
+            | Self::VariadicKeywordParameter(parameter) => {
+                parameter.node(module).annotation.as_deref()
+            }
+            Self::Parameter(parameter_with_default) => parameter_with_default
+                .node(module)
+                .parameter
+                .annotation
+                .as_deref(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, get_size2::GetSize)]

--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -173,6 +173,77 @@ warning[redundant-condition]: An empty tuple is always falsy
    |            ^^^^^^^^^^^^^^^^ Inferred type is `tuple[()]`
 ```
 
+Annotating a variable as `tuple[X]` is almost always a mistake (the user almost always meant to
+write `tuple[X, ...]`), so we point to the annotation and suggest an arbitrary-length tuple instead:
+
+```py
+class Bar:
+    def __init__(self):
+        self.single_element_tuple: tuple[int] = (42,)
+
+    def first_method(self):
+        self.single_element_tuple = (56,)
+
+    def other_method(self, y: tuple[str]):
+        if self.single_element_tuple:  # snapshot: redundant-condition
+            pass
+
+        if y:  # snapshot: redundant-condition
+            pass
+```
+
+```snapshot
+warning[redundant-condition]: A 1-element tuple is always truthy
+  --> src/mdtest_snippet.py:51:12
+   |
+51 |         if self.single_element_tuple:  # snapshot: redundant-condition
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `tuple[int]`
+   |
+  ::: src/mdtest_snippet.py:45:36
+   |
+45 |         self.single_element_tuple: tuple[int] = (42,)
+   |                                    ----------
+   |                                    |
+   |                                    Inferred as a 1-element tuple due to this annotation
+   |                                    Did you mean `tuple[int, ...]`?
+
+
+warning[redundant-condition]: A 1-element tuple is always truthy
+  --> src/mdtest_snippet.py:54:12
+   |
+50 |     def other_method(self, y: tuple[str]):
+   |                               ----------
+   |                               |
+   |                               Inferred as a 1-element tuple due to this annotation
+   |                               Did you mean `tuple[str, ...]`?
+51 |         if self.single_element_tuple:  # snapshot: redundant-condition
+52 |             pass
+53 |
+54 |         if y:  # snapshot: redundant-condition
+   |            ^ Inferred type is `tuple[str]`
+```
+
+If the original tuple annotation was variadic, our suggested hint suggests a variadic replacement:
+
+```py
+def f(*args: *tuple[int]):
+    if args:  # snapshot: redundant-condition
+        pass
+```
+
+```snapshot
+warning[redundant-condition]: A 1-element tuple is always truthy
+  --> src/mdtest_snippet.py:57:8
+   |
+56 | def f(*args: *tuple[int]):
+   |              -----------
+   |              |
+   |              Inferred as a 1-element tuple due to this annotation
+   |              Did you mean `*tuple[int, ...]`?
+57 |     if args:  # snapshot: redundant-condition
+   |        ^^^^ Inferred type is `tuple[int]`
+```
+
 And testing `None`:
 
 ```py
@@ -184,9 +255,9 @@ if X:  # snapshot: redundant-condition
 
 ```snapshot
 warning[redundant-condition]: `None` is always falsy
-  --> src/mdtest_snippet.py:45:4
+  --> src/mdtest_snippet.py:61:4
    |
-45 | if X:  # snapshot: redundant-condition
+61 | if X:  # snapshot: redundant-condition
    |    ^
 ```
 
@@ -214,16 +285,16 @@ assert "this asserts that a string literal is truthy -- strange, but it comes up
 
 ```snapshot
 warning[redundant-condition]: A nonempty string is always truthy
-  --> src/mdtest_snippet.py:50:4
+  --> src/mdtest_snippet.py:66:4
    |
-50 | if x:  # snapshot: redundant-condition
+66 | if x:  # snapshot: redundant-condition
    |    ^ Inferred type is `Literal["foo"]`
 
 
 warning[redundant-condition]: An empty string is always falsy
-  --> src/mdtest_snippet.py:53:4
+  --> src/mdtest_snippet.py:69:4
    |
-53 | if y:  # snapshot: redundant-condition
+69 | if y:  # snapshot: redundant-condition
    |    ^ Inferred type is `Literal[""]`
 ```
 
@@ -239,9 +310,9 @@ def f(x: Literal["a", "b"]):
 
 ```snapshot
 warning[redundant-condition]: A nonempty string is always truthy
-  --> src/mdtest_snippet.py:67:8
+  --> src/mdtest_snippet.py:83:8
    |
-67 |     if x:  # snapshot: redundant-condition
+83 |     if x:  # snapshot: redundant-condition
    |        ^ Inferred type is `Literal["a", "b"]`
 ```
 
@@ -289,31 +360,31 @@ def test(
 
 ```snapshot
 warning[redundant-condition]: A TypedDict with 2 required fields is always truthy
-  --> src/mdtest_snippet.py:90:8
-   |
-90 |     if never_empty:  # snapshot: redundant-condition
-   |        ^^^^^^^^^^^ Inferred type is `NeverEmpty`
-   |
-  ::: src/mdtest_snippet.py:71:7
-   |
-71 | class NeverEmpty(TypedDict):
-   |       ---------- `NeverEmpty` defined here
-72 |     x: int
-   |     ------ First required field defined here
+   --> src/mdtest_snippet.py:106:8
+    |
+106 |     if never_empty:  # snapshot: redundant-condition
+    |        ^^^^^^^^^^^ Inferred type is `NeverEmpty`
+    |
+   ::: src/mdtest_snippet.py:87:7
+    |
+ 87 | class NeverEmpty(TypedDict):
+    |       ---------- `NeverEmpty` defined here
+ 88 |     x: int
+    |     ------ First required field defined here
 
 
 warning[redundant-condition]: A TypedDict with 1 required field is always truthy
-  --> src/mdtest_snippet.py:93:8
-   |
-93 |     if also_never_empty:  # snapshot: redundant-condition
-   |        ^^^^^^^^^^^^^^^^ Inferred type is `AlsoNeverEmpty`
-   |
-  ::: src/mdtest_snippet.py:75:7
-   |
-75 | class AlsoNeverEmpty(TypedDict, total=False):
-   |       -------------- `AlsoNeverEmpty` defined here
-76 |     x: Required[int]
-   |     ---------------- Required field declared here
+   --> src/mdtest_snippet.py:109:8
+    |
+109 |     if also_never_empty:  # snapshot: redundant-condition
+    |        ^^^^^^^^^^^^^^^^ Inferred type is `AlsoNeverEmpty`
+    |
+   ::: src/mdtest_snippet.py:91:7
+    |
+ 91 | class AlsoNeverEmpty(TypedDict, total=False):
+    |       -------------- `AlsoNeverEmpty` defined here
+ 92 |     x: Required[int]
+    |     ---------------- Required field declared here
 ```
 
 and testing an object that is known to be always truthy due to it being `@final` and not defining
@@ -329,9 +400,9 @@ def f(x: Pattern[str]):
 
 ```snapshot
 warning[redundant-condition]: Condition is always truthy
-   --> src/mdtest_snippet.py:109:8
+   --> src/mdtest_snippet.py:125:8
     |
-109 |     if x:  # snapshot: redundant-condition
+125 |     if x:  # snapshot: redundant-condition
     |        ^ Inferred type is `Pattern[str]`
 info: `Pattern` instances are always truthy because `Pattern` cannot be subclassed and does not define `__bool__` or `__len__`
    --> stdlib/re.pyi:285:1
@@ -433,6 +504,152 @@ def check(value: Record):
     if "x" in value:
         if value:  # error: [redundant-condition] "A TypedDict with 1 required field is always truthy"
             pass
+```
+
+## One-element tuple annotation hints
+
+A named tuple or another tuple subclass can deliberately have exactly one element. An annotation
+naming that class is not a mistaken use of `tuple[T]`, so we report its truthiness without
+suggesting an arbitrary-length tuple annotation.
+
+```py
+from typing import NamedTuple
+
+class Record(NamedTuple):
+    value: int
+
+class SingleTuple(tuple[int]):
+    pass
+
+def check(record: Record, single: SingleTuple):
+    if record:  # snapshot: redundant-condition
+        print(record.value)
+    if single:  # snapshot: redundant-condition
+        pass
+```
+
+```snapshot
+warning[redundant-condition]: A 1-element tuple is always truthy
+  --> src/mdtest_snippet.py:10:8
+   |
+10 |     if record:  # snapshot: redundant-condition
+   |        ^^^^^^ Inferred type is `Record`
+   |
+  ::: src/mdtest_snippet.py:3:7
+   |
+ 3 | class Record(NamedTuple):
+   |       ------ `Record` defined here
+
+
+warning[redundant-condition]: A 1-element tuple is always truthy
+  --> src/mdtest_snippet.py:12:8
+   |
+12 |     if single:  # snapshot: redundant-condition
+   |        ^^^^^^ Inferred type is `SingleTuple`
+   |
+  ::: src/mdtest_snippet.py:6:7
+   |
+ 6 | class SingleTuple(tuple[int]):
+   |       ----------- `SingleTuple` defined here
+```
+
+An implicit type alias for `tuple[T]` still refers to the built-in tuple type, so it remains
+eligible for the annotation hint.
+
+```py
+IntTuple = tuple[int]
+
+def check_alias(value: IntTuple):
+    if value:  # snapshot: redundant-condition
+        pass
+```
+
+```snapshot
+warning[redundant-condition]: A 1-element tuple is always truthy
+  --> src/mdtest_snippet.py:17:8
+   |
+16 | def check_alias(value: IntTuple):
+   |                        --------
+   |                        |
+   |                        Inferred as a 1-element tuple due to this annotation
+   |                        Did you mean `tuple[int, ...]`?
+17 |     if value:  # snapshot: redundant-condition
+   |        ^^^^^ Inferred type is `tuple[int]`
+```
+
+The diagnostic still explains the one-element annotation when the suggested replacement would
+contain notation that cannot be used in a Python annotation, such as a type variable's scope suffix.
+In these cases, we omit the replacement suggestion, including when the type variable is nested
+inside another generic type.
+
+```py
+def check_generic[T](value: tuple[T]):
+    if value:  # snapshot: redundant-condition
+        pass
+
+def check_nested_generic[T](value: tuple[list[T]]):
+    if value:  # snapshot: redundant-condition
+        pass
+```
+
+```snapshot
+warning[redundant-condition]: A 1-element tuple is always truthy
+  --> src/mdtest_snippet.py:20:8
+   |
+19 | def check_generic[T](value: tuple[T]):
+   |                             -------- Inferred as a 1-element tuple due to this annotation
+20 |     if value:  # snapshot: redundant-condition
+   |        ^^^^^ Inferred type is `tuple[T@check_generic]`
+
+
+warning[redundant-condition]: A 1-element tuple is always truthy
+  --> src/mdtest_snippet.py:24:8
+   |
+23 | def check_nested_generic[T](value: tuple[list[T]]):
+   |                                    -------------- Inferred as a 1-element tuple due to this annotation
+24 |     if value:  # snapshot: redundant-condition
+   |        ^^^^^ Inferred type is `tuple[list[T@check_nested_generic]]`
+```
+
+## Tuple annotations in dependencies
+
+A one-element tuple annotation in a dependency also explains why the condition is redundant. The
+suggestion refers to the dependency's author, since the annotation is outside first-party code.
+
+```toml
+[environment]
+python = "/.venv"
+```
+
+`/.venv/<path-to-site-packages>/records.pyi`:
+
+```pyi
+values: tuple[str]
+```
+
+`main.py`:
+
+```py
+import records
+
+if records.values:  # snapshot: redundant-condition
+    pass
+```
+
+```snapshot
+warning[redundant-condition]: A 1-element tuple is always truthy
+ --> src/main.py:3:4
+  |
+3 | if records.values:  # snapshot: redundant-condition
+  |    ^^^^^^^^^^^^^^ Inferred type is `tuple[str]`
+  |
+ ::: .venv/<path-to-site-packages>/records.pyi:1:9
+  |
+1 | values: tuple[str]
+  |         ----------
+  |         |
+  |         Inferred as a 1-element tuple due to this annotation
+  |         The author of this code might have meant `tuple[str, ...]`?
 ```
 
 ## Other boolean contexts
@@ -923,6 +1140,15 @@ def test(x: tuple[int]):  # the user probably meant to use `tuple[int, ...]` her
 error[redundant-condition-strict]: `x` always has length 1
   --> src/mdtest_snippet.py:28:8
    |
+23 | def test(x: tuple[int]):  # the user probably meant to use `tuple[int, ...]` here
+   |             ----------
+   |             |
+   |             Inferred as a 1-element tuple due to this annotation
+   |             Did you mean `tuple[int, ...]`?
+24 |     # error: [redundant-condition-strict] "`x` always has length 1"
+25 |     if len(x) == 1:
+26 |         pass
+27 |
 28 |     if len(x) == 2:  # snapshot: redundant-condition-strict
    |        ^^^^-^^^^^^
    |            |

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use ruff_db::{
-    diagnostic::{Annotation, Span, SubDiagnostic, SubDiagnosticSeverity},
+    diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity},
     parsed::parsed_module,
     source::source_text,
 };
@@ -11,18 +11,25 @@ use ruff_diagnostics::{Applicability, Edit, Fix};
 use ruff_python_ast as ast;
 use ruff_source_file::LineRanges;
 use ruff_text_size::Ranged;
-use ty_python_core::Truthiness;
+use ty_module_resolver::{SearchPath, file_to_module};
+use ty_python_core::{Truthiness, definition::DefinitionKind};
 
 use crate::{
     SemanticModel,
     types::{
         KnownClass, LintDiagnosticGuard, LintDiagnosticGuardBuilder, MemberLookupPolicy, Type,
-        call::bind::CallableDescription, enum_metadata, function::KnownFunction,
-        infer::TypeInferenceBuilder, signatures::CallableSignature, tuple::TupleLength,
+        TypeContext,
+        call::bind::CallableDescription,
+        enum_metadata,
+        function::KnownFunction,
+        infer::TypeInferenceBuilder,
+        infer_definition_types, infer_scope_types,
+        signatures::CallableSignature,
+        tuple::{Tuple, TupleLength},
     },
 };
 
-use super::RedundantCondition;
+use super::{RedundantCondition, exemptions::condition_definition_info};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn report_redundant_condition<'ctx>(
@@ -264,6 +271,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
 
                 annotate_inferred_type(&mut diagnostic);
+                self.diagnose_single_length_tuple(length, test, *test_type, &mut diagnostic);
 
                 diagnostic
             } else if let Type::TypedDict(typed_dict) = test_type
@@ -600,6 +608,125 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     subexpression_type.display(db, env)
                 )),
         );
+        if let Ok(length) = usize::try_from(length) {
+            self.diagnose_single_length_tuple(
+                TupleLength::Fixed(length),
+                test_subexpression,
+                subexpression_type,
+                &mut diagnostic,
+            );
+        }
         diagnostic
+    }
+
+    fn diagnose_single_length_tuple(
+        &self,
+        length: TupleLength,
+        node: &ast::Expr,
+        node_type: Type<'db>,
+        diagnostic: &mut Diagnostic,
+    ) {
+        let db = self.db();
+        let env = self.program_environment();
+
+        // The ellipsis suggestion is for `tuple[T]`, not named tuples or other
+        // subclasses whose fixed length is part of their definition.
+        if length == TupleLength::Fixed(1)
+            && let Some(tuple_spec) = node_type.tuple_instance_spec(db, env)
+            && let Tuple::Fixed(fixed_length_tuple) = &*tuple_spec
+            && matches!(node, ast::Expr::Name(_) | ast::Expr::Attribute(_))
+        {
+            if node_type.exact_tuple_instance_spec(db).is_none() {
+                if let Some(definition) = node_type.definition(db, env)
+                    && let Some(definition) = definition.definition()
+                {
+                    let module = parsed_module(db, definition.python_file(db)).load(db);
+                    diagnostic.annotate(
+                        Annotation::secondary(Span::from(definition.focus_range(db, &module)))
+                            .message(format_args!(
+                                "`{}` defined here",
+                                node_type.display(db, env)
+                            )),
+                    );
+                }
+                return;
+            }
+
+            let definition_info =
+                condition_definition_info(db, self.program_file(), node, |expr| {
+                    self.expression_type(expr)
+                });
+
+            if let Some(single_definition) = definition_info.single_definition {
+                let file = single_definition.python_file(db);
+                let program_file = single_definition.program_file(db);
+                let module = parsed_module(db, file).load(db);
+                let annotation_info = match single_definition.kind(db) {
+                    DefinitionKind::AnnotatedAssignment(assignment) => {
+                        let annotation = assignment.annotation(&module);
+                        infer_definition_types(db, single_definition)
+                            .try_expression_type(annotation)
+                            .map(|annotation_type| (annotation, annotation_type))
+                    }
+                    DefinitionKind::Parameter(parameter) => {
+                        parameter.annotation(&module).and_then(|annotation| {
+                            let scope = single_definition.scope(db).scope(db).parent()?;
+                            let annotation_type = infer_scope_types(
+                                db,
+                                scope.to_scope_id(db, program_file),
+                                TypeContext::default(),
+                            )
+                            .try_expression_type(annotation)?;
+                            Some((annotation, annotation_type))
+                        })
+                    }
+                    _ => None,
+                };
+                if let Some((annotation, annotation_type)) = annotation_info
+                    && annotation_type == node_type
+                {
+                    let file = single_definition.file(db);
+                    let diagnostic_annotation =
+                        || Annotation::secondary(Span::from(file).with_range(annotation.range()));
+                    diagnostic.annotate(
+                        diagnostic_annotation()
+                            .message("Inferred as a 1-element tuple due to this annotation"),
+                    );
+
+                    let sole_element = fixed_length_tuple.elements_slice()[0];
+                    let suggested_type = Type::homogeneous_tuple(db, env, sole_element)
+                        .display(db, env)
+                        .to_string_parts();
+
+                    if suggested_type.is_valid_syntax {
+                        let resolver_file = single_definition.program_file(db).resolver_file(db);
+                        let annotated_in_first_party_code = file == self.file()
+                            || file_to_module(db, resolver_file)
+                                .and_then(|module| module.search_path(db))
+                                .is_some_and(SearchPath::is_first_party);
+
+                        let maybe_star = if annotation.is_starred_expr() {
+                            "*"
+                        } else {
+                            ""
+                        };
+
+                        let annotation = if annotated_in_first_party_code {
+                            diagnostic_annotation().message(format_args!(
+                                "Did you mean `{maybe_star}{}`?",
+                                suggested_type.label
+                            ))
+                        } else {
+                            diagnostic_annotation().message(format_args!(
+                                "The author of this code might have meant `{maybe_star}{}`?",
+                                suggested_type.label
+                            ))
+                        };
+
+                        diagnostic.annotate(annotation);
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
@@ -362,12 +362,12 @@ fn is_special_cased_condition_expression<'db>(
 }
 
 /// Resolves the condition's source definitions using a scope or an already-inferred receiver type.
-fn condition_definition_info<'db>(
+pub(super) fn condition_definition_info<'db>(
     db: &'db dyn Db,
     file: ProgramFile<'db>,
     expression: &ast::Expr,
     mut expression_type: impl FnMut(&ast::Expr) -> Type<'db>,
-) -> ConditionDefinitionInfo {
+) -> ConditionDefinitionInfo<'db> {
     match expression {
         ast::Expr::Name(name) => {
             let index = semantic_index(db, file);
@@ -386,15 +386,19 @@ fn condition_definition_info<'db>(
     }
 }
 
-/// The information needed for condition exemptions.
+/// The information needed for condition exemptions and annotation hints.
+///
+/// Retaining only the unique definition and the provenance result lets both uses share a lookup
+/// without caching a potentially large list of bindings.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-struct ConditionDefinitionInfo {
+pub(super) struct ConditionDefinitionInfo<'db> {
+    pub(super) single_definition: Option<Definition<'db>>,
     contains_special_cased_condition: bool,
 }
 
-impl ConditionDefinitionInfo {
+impl<'db> ConditionDefinitionInfo<'db> {
     /// Summarizes resolved definitions, following assignments to establish environment provenance.
-    fn from_definitions<'db>(db: &'db dyn Db, definitions: Vec<ResolvedDefinition<'db>>) -> Self {
+    fn from_definitions(db: &'db dyn Db, definitions: &[ResolvedDefinition<'db>]) -> Self {
         // A place is a variable or attribute, and several definitions can bind the same place.
         // The outer map identifies the place by its scope and place ID: place IDs are only unique
         // within a scope. Each inner map associates a definition with the reachability constraint
@@ -429,8 +433,8 @@ impl ConditionDefinitionInfo {
         let mut reachability_by_place = ReachabilityByPlace::default();
 
         let contains_special_cased_condition = definitions
-            .into_iter()
-            .filter_map(|resolved| resolved.definition())
+            .iter()
+            .filter_map(ResolvedDefinition::definition)
             .any(|definition| {
                 let scope = definition.scope(db);
                 let place = definition.place(db);
@@ -457,7 +461,13 @@ impl ConditionDefinitionInfo {
                 definition_contains_special_cased_condition(db, definition, reachability)
             });
 
+        let single_definition = match definitions {
+            [ResolvedDefinition::Definition(definition)] => Some(*definition),
+            _ => None,
+        };
+
         Self {
+            single_definition,
             contains_special_cased_condition,
         }
     }
@@ -480,10 +490,10 @@ fn name_condition_definition_info<'db>(
     db: &'db dyn Db,
     scope: ScopeId<'db>,
     name: Name,
-) -> ConditionDefinitionInfo {
+) -> ConditionDefinitionInfo<'db> {
     ConditionDefinitionInfo::from_definitions(
         db,
-        definitions_for_name(db, scope, &name, ImportAliasResolution::ResolveAliases),
+        &definitions_for_name(db, scope, &name, ImportAliasResolution::ResolveAliases),
     )
 }
 
@@ -505,10 +515,10 @@ fn attribute_condition_definition_info<'db>(
     program: Program<'db>,
     receiver: Type<'db>,
     name: Name,
-) -> ConditionDefinitionInfo {
+) -> ConditionDefinitionInfo<'db> {
     ConditionDefinitionInfo::from_definitions(
         db,
-        definitions_for_attribute(
+        &definitions_for_attribute(
             db,
             &ProgramEnvironment::from_program(program),
             receiver,


### PR DESCRIPTION
`tuple[T]` describes a tuple with exactly one element, so its instances are always truthy. When `redundant-condition` flags such a value, the intended annotation may instead be `tuple[T, ...]`.

This adds a hint pointing to the parameter or variable annotation that establishes the one-element type and suggests the arbitrary-length form. Tuple subclasses are excluded, replacement suggestions that cannot be expressed in Python annotation syntax are omitted, and hints for dependency annotations refer to the dependency's author.

Stacked on #28034.
