### PR TITLE
[ty] Fix MRO ordering for generic bases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -2396,8 +2396,7 @@ def example(value: str | Any) -> None:
     append([1], value)
 ```
 
-Generic base classes also contribute type context. The MRO uses the first specialization of each
-generic base class, so `Mixed` contributes `str` through `Specialized`:
+This also applies when a generic base class contributes gradual type context:
 
 ```py
 class GenericBase[T]: ...
@@ -2408,7 +2407,7 @@ def g[T](values: list[T], base: GenericBase[T]) -> list[T]:
     return values
 
 reveal_type(g([1], Specialized()))  # revealed: list[int | str]
-reveal_type(g([1], Mixed()))  # revealed: list[int | str]
+reveal_type(g([1], Mixed()))  # revealed: list[int | str | Any]
 ```
 
 Dynamic arguments also participate when inferring the specialization for a nested collection

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -2396,7 +2396,8 @@ def example(value: str | Any) -> None:
     append([1], value)
 ```
 
-This also applies when a generic base class contributes gradual type context:
+Generic base classes also contribute type context. The MRO uses the first specialization of each
+generic base class, so `Mixed` contributes `str` through `Specialized`:
 
 ```py
 class GenericBase[T]: ...
@@ -2407,7 +2408,7 @@ def g[T](values: list[T], base: GenericBase[T]) -> list[T]:
     return values
 
 reveal_type(g([1], Specialized()))  # revealed: list[int | str]
-reveal_type(g([1], Mixed()))  # revealed: list[int | str | Any]
+reveal_type(g([1], Mixed()))  # revealed: list[int | str]
 ```
 
 Dynamic arguments also participate when inferring the specialization for a nested collection

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -3283,6 +3283,21 @@ class StaticHttp(int, Enum):
 reveal_mro(StaticHttp)  # revealed: (<class 'StaticHttp'>, <class 'int'>, <class 'Enum'>, <class 'object'>)
 ```
 
+### Fallback MROs
+
+Putting `object` before `Enum` creates an inconsistent MRO. The fallback still includes `Enum` and
+places `object` last.
+
+```py
+from enum import Enum
+from ty_extensions._internal import reveal_mro
+
+# error: [inconsistent-mro]
+Broken = Enum("Broken", "MEMBER", type=object)
+
+reveal_mro(Broken)  # revealed: (<class 'Broken'>, <class 'Enum'>, <class 'object'>)
+```
+
 ### IntEnum function syntax
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -365,6 +365,37 @@ class BadChild8(Parent[T1, T2], Parent3[T2, T1], Parent4): ...
 class BadChild9(Parent[T1, T2], Parent3[T2, T1], Parent4[Any, Any]): ...
 ```
 
+## Inconsistent type arguments through an unspecified ancestor
+
+A class can inherit the same generic ancestor through unspecified and specialized paths. The
+specialized path still constrains its subclasses, even when the MRO retains the unspecified path's
+type arguments.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]): ...
+class Unspecified(Base): ...  # error: [missing-type-argument]
+class IntBase(Base[int]): ...
+class Combined(Unspecified, IntBase): ...
+
+# error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Base[str]` and `Base[int]`"
+class Conflicting(Combined, Base[str]): ...
+class Compatible(Combined, Base[int]): ...
+class Inherited(Conflicting): ...
+```
+
+Classes constructed with `type()` also account for every inherited specialization.
+
+```py
+class StrBase(Base[str]): ...
+
+# error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Base[str]` and `Base[int]`"
+Dynamic = type("Dynamic", (Combined, StrBase), {})
+```
+
 ## Specializing generic classes explicitly
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -396,6 +396,62 @@ class StrBase(Base[str]): ...
 Dynamic = type("Dynamic", (Combined, StrBase), {})
 ```
 
+## Inconsistent type arguments through partially gradual ancestors
+
+Each non-dynamic type argument constrains later inheritance paths independently. An `Any` in one
+position does not hide a conflict between concrete arguments contributed by other paths.
+
+```py
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Base(Generic[T, U]): ...
+class First(Base[int, Any]): ...
+class Second(Base[Any, str]): ...
+class Combined(First, Second): ...
+class Compatible(Combined, Base[int, str]): ...
+
+# error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Base[int, bytes]` and `Base[Any, str]`"
+class Conflicting(Combined, Base[int, bytes]): ...
+
+# error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Base[bytes, str]` and `Base[int, Any]`"
+class OtherConflict(Combined, Base[bytes, str]): ...
+class Inherited(Conflicting): ...
+```
+
+Reversing the paths preserves both constraints. Each diagnostic identifies the base that supplied
+the conflicting argument.
+
+```py
+class Reversed(Second, First): ...
+class ReversedCompatible(Reversed, Base[int, str]): ...
+
+# error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Base[bytes, str]` and `Base[int, Any]`"
+class ReversedConflict(Reversed, Base[bytes, str]): ...
+```
+
+The same constraints apply when another path contributes a more specialized version of an ancestor.
+
+```py
+class Specific(Base[int, str]): ...
+class Right(Specific, Base[int, Any]): ...
+class Diamond(First, Right): ...
+
+# error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Base[int, bytes]` and `Base[int, str]`"
+class DiamondConflict(Diamond, Base[int, bytes]): ...
+```
+
+Classes constructed with `type()` also preserve constraints from partially gradual ancestors.
+
+```py
+class BytesBase(Base[int, bytes]): ...
+
+# error: [invalid-generic-class] "Inconsistent type arguments: class cannot inherit from both `Base[int, bytes]` and `Base[Any, str]`"
+Dynamic = type("Dynamic", (Combined, BytesBase), {})
+```
+
 ## Specializing generic classes explicitly
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -421,6 +421,25 @@ class OtherConflict(Combined, Base[bytes, str]): ...
 class Inherited(Conflicting): ...
 ```
 
+With three direct bases, the diagnostic identifies `First` and the third base as the sources of
+conflicting arguments. `Second` leaves the first type argument unconstrained.
+
+```py
+# snapshot: invalid-generic-class
+class Mixed(First, Second, Base[bytes, str]): ...
+```
+
+```snapshot
+error[invalid-generic-class]: Inconsistent type arguments for `Base` among class bases
+  --> src/mdtest_snippet.py:19:7
+   |
+19 | class Mixed(First, Second, Base[bytes, str]): ...
+   |       ^^^^^^-----^^^^^^^^^^----------------^
+   |             |              |
+   |             |              Later class base is `Base[bytes, str]`
+   |             Earlier class base inherits from `Base[int, Any]`
+```
+
 Reversing the paths preserves both constraints. Each diagnostic identifies the base that supplied
 the conflicting argument.
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1302,6 +1302,72 @@ as_specialized: Base[list[int]] = GenericChild[int]()
 incompatible_specialization: Base[list[str]] = GenericChild[int]()  # error: [unsound-assignment]
 ```
 
+## Method overrides through gradual and concrete inheritance paths
+
+An override must satisfy the concrete return type inherited through `Concrete`, even when the MRO
+retains `Base[Any]` from `Gradual`.
+
+```py
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    def method(self) -> T:
+        raise NotImplementedError
+
+class Gradual(Base[Any]): ...
+class Concrete(Base[int]): ...
+
+class Invalid(Gradual, Concrete):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+
+class Valid(Gradual, Concrete):
+    def method(self) -> int:
+        return 0
+```
+
+The same contract applies when the bases are reversed or another subclass inherits the diamond. Each
+invalid override produces one diagnostic.
+
+```py
+class Reversed(Concrete, Gradual):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+
+class Combined(Gradual, Concrete): ...
+
+reveal_type(Combined().method())  # revealed: Any
+
+class Indirect(Combined):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+```
+
+An override that preserves its parent's signature does not repeat an existing violation in the
+parent's inheritance hierarchy.
+
+```py
+class PreservesInvalid(Invalid):
+    def method(self) -> str:
+        return ""
+```
+
+Specializing a generic intermediate class also specializes the inherited method's return type.
+
+```py
+class GenericDiamond(Gradual, Base[T]): ...
+
+class Specialized(GenericDiamond[int]):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+```
+
 ## Generic methods
 
 Generic classes can contain methods that are themselves generic. The generic methods can refer to

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1251,6 +1251,57 @@ reveal_type(DescriptorChild.descriptor)  # revealed: Unknown
 reveal_type(DescriptorChild[int].descriptor)  # revealed: int
 ```
 
+## Assignability through gradual and concrete inheritance paths
+
+A concrete inheritance path makes `Child` a subtype of `Base[int]` even when an earlier path
+inherits `Base[Any]`. Assigning it to `Base[int]` is sound; assigning it to the invariant
+`Base[str]` is not.
+
+```toml
+[rules]
+unsound-assignment = "error"
+```
+
+```py
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    value: T
+
+class Gradual(Base[Any]): ...
+class Concrete(Base[int]): ...
+class Child(Gradual, Concrete): ...
+
+as_concrete: Concrete = Child()
+as_base: Base[int] = Child()
+incompatible: Base[str] = Child()  # error: [unsound-assignment]
+```
+
+The relationship is preserved when the bases are reversed, through another subclass, and for classes
+constructed with `type()`.
+
+```py
+class Reversed(Concrete, Gradual): ...
+class Grandchild(Child): ...
+
+as_reversed: Base[int] = Reversed()
+as_grandchild: Base[int] = Grandchild()
+
+Dynamic = type("Dynamic", (Gradual, Concrete), {})
+as_dynamic: Base[int] = Dynamic()
+```
+
+Specializing a generic subclass also specializes the concrete inheritance path.
+
+```py
+class GenericChild(Gradual, Base[list[T]]): ...
+
+as_specialized: Base[list[int]] = GenericChild[int]()
+incompatible_specialization: Base[list[str]] = GenericChild[int]()  # error: [unsound-assignment]
+```
+
 ## Generic methods
 
 Generic classes can contain methods that are themselves generic. The generic methods can refer to

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1251,6 +1251,27 @@ reveal_type(DescriptorChild.descriptor)  # revealed: Unknown
 reveal_type(DescriptorChild[int].descriptor)  # revealed: int
 ```
 
+## Fallback MROs preserve generic class identity
+
+Putting `Base` before its subclass makes the MRO inconsistent. During error recovery, the fallback
+MRO includes each class once, retaining its first specialization and placing `object` last.
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions._internal import reveal_mro
+
+T = TypeVar("T")
+
+class Base(Generic[T]): ...
+class IntBase(Base[int]): ...
+
+# error: [inconsistent-mro]
+Broken = type("Broken", (Base, IntBase), {})
+
+# revealed: (<class 'Broken'>, <class 'Base[Unknown]'>, typing.Generic, <class 'IntBase'>, <class 'object'>)
+reveal_mro(Broken)
+```
+
 ## Assignability through gradual and concrete inheritance paths
 
 A concrete inheritance path makes `Child` a subtype of `Base[int]` even when an earlier path

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -843,6 +843,58 @@ reveal_type(PartiallyFixed.fixed)  # revealed: int
 reveal_type(PartiallyFixed.unresolved)  # revealed: Unknown
 ```
 
+## Assignability through gradual and concrete inheritance paths
+
+A concrete inheritance path makes `Child` a subtype of `Base[int]` even when an earlier path
+inherits `Base[Any]`. Assigning it to `Base[int]` is sound; assigning it to the invariant
+`Base[str]` is not.
+
+```toml
+[environment]
+python-version = "3.13"
+
+[rules]
+unsound-assignment = "error"
+```
+
+```py
+from typing import Any
+
+class Base[T]:
+    value: T
+
+class Gradual(Base[Any]): ...
+class Concrete(Base[int]): ...
+class Child(Gradual, Concrete): ...
+
+as_concrete: Concrete = Child()
+as_base: Base[int] = Child()
+incompatible: Base[str] = Child()  # error: [unsound-assignment]
+```
+
+The relationship is preserved when the bases are reversed, through another subclass, and for classes
+constructed with `type()`.
+
+```py
+class Reversed(Concrete, Gradual): ...
+class Grandchild(Child): ...
+
+as_reversed: Base[int] = Reversed()
+as_grandchild: Base[int] = Grandchild()
+
+Dynamic = type("Dynamic", (Gradual, Concrete), {})
+as_dynamic: Base[int] = Dynamic()
+```
+
+Specializing a generic subclass also specializes the concrete inheritance path.
+
+```py
+class GenericChild[T](Gradual, Base[list[T]]): ...
+
+as_specialized: Base[list[int]] = GenericChild[int]()
+incompatible_specialization: Base[list[str]] = GenericChild[int]()  # error: [unsound-assignment]
+```
+
 ## Unbound inherited methods
 
 An inherited method can be called through the subclass, passing the instance explicitly. Without

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -151,6 +151,33 @@ reveal_mro(Baz)
 reveal_mro(Baz[int])
 ```
 
+## Inconsistent type arguments through partially gradual ancestors
+
+With three direct bases, the diagnostic identifies `First` and the third base as the sources of
+conflicting arguments. `Second` leaves the first type argument unconstrained.
+
+```py
+from typing import Any
+
+class Base[T, U]: ...
+class First(Base[int, Any]): ...
+class Second(Base[Any, str]): ...
+
+# snapshot: invalid-generic-class
+class Mixed(First, Second, Base[bytes, str]): ...
+```
+
+```snapshot
+error[invalid-generic-class]: Inconsistent type arguments for `Base` among class bases
+ --> src/mdtest_snippet.py:8:7
+  |
+8 | class Mixed(First, Second, Base[bytes, str]): ...
+  |       ^^^^^^-----^^^^^^^^^^----------------^
+  |             |              |
+  |             |              Later class base is `Base[bytes, str]`
+  |             Earlier class base inherits from `Base[int, Any]`
+```
+
 ## Class keyword arguments
 
 Class keyword arguments are evaluated inside the type-parameter scope, so they must be resolved

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -895,6 +895,85 @@ as_specialized: Base[list[int]] = GenericChild[int]()
 incompatible_specialization: Base[list[str]] = GenericChild[int]()  # error: [unsound-assignment]
 ```
 
+## Method overrides through gradual and concrete inheritance paths
+
+An override must satisfy the concrete return type inherited through `Concrete`, even when the MRO
+retains `Base[Any]` from `Gradual`.
+
+```py
+from typing import Any
+
+class Base[T]:
+    def method(self) -> T:
+        raise NotImplementedError
+
+class Gradual(Base[Any]): ...
+class Concrete(Base[int]): ...
+
+class Invalid(Gradual, Concrete):
+    # snapshot: invalid-method-override
+    def method(self) -> str:
+        return ""
+
+class Valid(Gradual, Concrete):
+    def method(self) -> int:
+        return 0
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+  --> src/mdtest_snippet.py:12:9
+   |
+12 |     def method(self) -> str:
+   |         ^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Base.method`
+   |
+  ::: src/mdtest_snippet.py:4:9
+   |
+ 4 |     def method(self) -> T:
+   |         ----------------- `Base.method` defined here
+info: incompatible return types: `str` is not assignable to `int`
+info: This violates the Liskov Substitution Principle
+```
+
+The same contract applies when the bases are reversed or another subclass inherits the diamond. Each
+invalid override produces one diagnostic.
+
+```py
+class Reversed(Concrete, Gradual):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+
+class Combined(Gradual, Concrete): ...
+
+reveal_type(Combined().method())  # revealed: Any
+
+class Indirect(Combined):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+```
+
+An override that preserves its parent's signature does not repeat an existing violation in the
+parent's inheritance hierarchy.
+
+```py
+class PreservesInvalid(Invalid):
+    def method(self) -> str:
+        return ""
+```
+
+Specializing a generic intermediate class also specializes the inherited method's return type.
+
+```py
+class GenericDiamond[T](Gradual, Base[T]): ...
+
+class Specialized(GenericDiamond[int]):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+```
+
 ## Unbound inherited methods
 
 An inherited method can be called through the subclass, passing the instance explicitly. Without

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -843,6 +843,24 @@ reveal_type(PartiallyFixed.fixed)  # revealed: int
 reveal_type(PartiallyFixed.unresolved)  # revealed: Unknown
 ```
 
+## Fallback MROs preserve generic class identity
+
+Putting `Base` before its subclass makes the MRO inconsistent. During error recovery, the fallback
+MRO includes each class once, retaining its first specialization and placing `object` last.
+
+```py
+from ty_extensions._internal import reveal_mro
+
+class Base[T]: ...
+class IntBase(Base[int]): ...
+
+# error: [inconsistent-mro]
+Broken = type("Broken", (Base, IntBase), {})
+
+# revealed: (<class 'Broken'>, <class 'Base[Unknown]'>, typing.Generic, <class 'IntBase'>, <class 'object'>)
+reveal_mro(Broken)
+```
+
 ## Assignability through gradual and concrete inheritance paths
 
 A concrete inheritance path makes `Child` a subtype of `Base[int]` even when an earlier path

--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -684,6 +684,81 @@ class Sub(Intermediate[T], Base): ...
 reveal_mro(Sub)
 ```
 
+## Generic ancestors shared by multiple inheritance paths
+
+A generic ancestor appears only once in the MRO, even when one inheritance path leaves its type
+arguments unspecified. A concrete override on the other path takes precedence over that ancestor.
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions._internal import reveal_mro
+
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    item: T
+
+    def method(self) -> object: ...
+
+class Unspecified(Base): ...  # error: [missing-type-argument]
+
+class Concrete(Base[int]):
+    def method(self) -> int:
+        return 0
+
+class Child(Unspecified, Concrete): ...
+
+# revealed: (<class 'Child'>, <class 'Unspecified'>, <class 'Concrete'>, <class 'Base[Unknown]'>, typing.Generic, <class 'object'>)
+reveal_mro(Child)
+reveal_type(Child().method())  # revealed: int
+reveal_type(Child().item)  # revealed: Unknown
+```
+
+The same ordering applies when the first path supplies the type argument and the concrete override
+inherits an unspecified specialization. The first path's specialization remains available for
+inherited attributes.
+
+```py
+class Specialized(Base[int]): ...
+
+class UnspecifiedConcrete(Unspecified):
+    def method(self) -> int:
+        return 0
+
+class Other(Specialized, UnspecifiedConcrete): ...
+
+# revealed: (<class 'Other'>, <class 'Specialized'>, <class 'UnspecifiedConcrete'>, <class 'Unspecified'>, <class 'Base[int]'>, typing.Generic, <class 'object'>)
+reveal_mro(Other)
+reveal_type(Other().method())  # revealed: int
+reveal_type(Other().item)  # revealed: int
+```
+
+Classes created with `type()` use the same ordering.
+
+```py
+Dynamic = type("Dynamic", (Unspecified, Concrete), {})
+
+# revealed: (<class 'Dynamic'>, <class 'Unspecified'>, <class 'Concrete'>, <class 'Base[Unknown]'>, typing.Generic, <class 'object'>)
+reveal_mro(Dynamic)
+reveal_type(Dynamic().method())  # revealed: int
+```
+
+## Duplicate generic bases
+
+Different specializations of the same class are still duplicate bases when both appear directly in
+the bases list.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]): ...
+
+# error: [duplicate-base]
+class Duplicate(Base[int], Base[str]): ...
+```
+
 ## Unresolvable MROs involving generics have the original bases reported in the error message, not the resolved bases
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -276,6 +276,42 @@ class AA(Z): ...
 reveal_mro(AA)  # revealed: (<class 'AA'>, <class 'Z'>, Unknown, <class 'object'>)
 ```
 
+## Fallback MROs keep `object` last
+
+A class cannot inherit from `object` before another base. Its fallback MRO retains the known bases
+for member lookup, but defers `object` to the end. Subclasses also keep `object` last, whether they
+use single or multiple inheritance.
+
+```py
+from typing import Any
+from ty_extensions._internal import reveal_mro
+
+class A:
+    value: int
+
+class Other: ...
+
+# error: [inconsistent-mro]
+Broken = type("Broken", (object, A), {})
+
+class Child(Broken): ...
+class Multiple(Broken, Other): ...
+
+reveal_mro(Broken)  # revealed: (<class 'Broken'>, <class 'A'>, <class 'object'>)
+reveal_mro(Child)  # revealed: (<class 'Child'>, <class 'Broken'>, <class 'A'>, <class 'object'>)
+# revealed: (<class 'Multiple'>, <class 'Broken'>, <class 'A'>, <class 'Other'>, <class 'object'>)
+reveal_mro(Multiple)
+reveal_type(Multiple().value)  # revealed: int
+```
+
+The same fallback applies when a gradual base suppresses the MRO error.
+
+```py
+Gradual = type("Gradual", (object, A, Any), {})
+
+reveal_mro(Gradual)  # revealed: (<class 'Gradual'>, <class 'A'>, Any, <class 'object'>)
+```
+
 ## `__bases__` includes a `Union`
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -66,6 +66,7 @@ use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, NodeIndex};
 use ruff_text_size::{Ranged, TextRange};
+use rustc_hash::FxHashSet;
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ProgramFile, place_table, use_def_map};
@@ -1436,6 +1437,37 @@ impl<'db> ClassType<'db> {
         }
     }
 
+    /// Visit this class and each specialization of its explicit ancestors, depth-first and
+    /// left-to-right. Cyclic classes are skipped.
+    ///
+    /// Unlike the MRO, this traversal preserves separate specializations contributed by different
+    /// inheritance paths. For example, a class inheriting both `Base[Any]` and `Base[int]` through
+    /// intermediate classes has a single `Base` entry in its MRO, but both specializations constrain
+    /// its subclasses. Use the MRO for member lookup, where ordering determines which member wins.
+    pub(super) fn iter_explicit_ancestors(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> impl Iterator<Item = Self> {
+        let mut pending = vec![self];
+        let mut seen = FxHashSet::default();
+        std::iter::from_fn(move || {
+            loop {
+                let class = pending.pop()?;
+                if !seen.insert(class) || ClassBase::Class(class).has_cyclic_mro(db) {
+                    continue;
+                }
+                let (literal, specialization) = class.class_literal_and_specialization(db);
+                pending.extend(literal.explicit_bases(db).iter().rev().filter_map(|base| {
+                    ClassBase::try_from_explicit_base(db, env, *base, Some(literal))?
+                        .apply_optional_specialization(db, specialization)
+                        .into_class()
+                }));
+                return Some(class);
+            }
+        })
+    }
+
     /// Is this class final?
     pub(super) fn is_final(self, db: &'db dyn Db) -> bool {
         self.class_literal(db).is_final(db)
@@ -2678,7 +2710,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             _ => {}
         }
 
-        source.iter_mro(db).when_any(db, self.constraints, |base| {
+        let mut generic_target = None;
+        let result = source.iter_mro(db).when_any(db, self.constraints, |base| {
             match base {
                 ClassBase::Any => ConstraintSet::from_bool(
                     self.constraints,
@@ -2708,25 +2741,43 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     }
 
                     // Two generic classes match if they have the same origin and compatible specializations.
-                    (ClassType::Generic(source), ClassType::Generic(target)) => {
-                        ConstraintSet::from_bool(
-                            self.constraints,
-                            source.origin(db) == target.origin(db),
+                    (ClassType::Generic(source), ClassType::Generic(target))
+                        if source.origin(db) == target.origin(db) =>
+                    {
+                        generic_target = Some(target);
+                        self.check_specialization_pair(
+                            db,
+                            source.specialization(db),
+                            target.specialization(db),
                         )
-                        .and(db, self.constraints, || {
-                            self.check_specialization_pair(
-                                db,
-                                source.specialization(db),
-                                target.specialization(db),
-                            )
-                        })
                     }
 
-                    // Generic and non-generic classes don't match.
-                    (ClassType::Generic(_), ClassType::NonGeneric(_))
+                    // Different generic origins, or generic and non-generic classes, don't match.
+                    (ClassType::Generic(_), ClassType::Generic(_) | ClassType::NonGeneric(_))
                     | (ClassType::NonGeneric(_), ClassType::Generic(_)) => self.never(),
                 },
             }
+        });
+
+        let Some(target) = generic_target else {
+            return result;
+        };
+
+        // The MRO retains only one specialization per class. A different inheritance path can
+        // still establish the relation: `Child(Gradual, Concrete)` is a subtype of `Base[int]`
+        // through `Concrete`, even if `Gradual` contributes `Base[Any]` to Child's MRO.
+        result.or(db, self.constraints, || {
+            source
+                .iter_explicit_ancestors(db, self.env)
+                .filter_map(ClassType::into_generic_alias)
+                .filter(|ancestor| ancestor.origin(db) == target.origin(db))
+                .when_any(db, self.constraints, |ancestor| {
+                    self.check_specialization_pair(
+                        db,
+                        ancestor.specialization(db),
+                        target.specialization(db),
+                    )
+                })
         })
     }
 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1437,13 +1437,24 @@ impl<'db> ClassType<'db> {
         }
     }
 
-    /// Visit this class and each specialization of its explicit ancestors, depth-first and
-    /// left-to-right. Cyclic classes are skipped.
+    /// Visit this class and its explicit ancestors depth-first and left-to-right, yielding each
+    /// distinct specialization once. Cyclic classes are skipped.
     ///
     /// Unlike the MRO, this traversal preserves separate specializations contributed by different
-    /// inheritance paths. For example, a class inheriting both `Base[Any]` and `Base[int]` through
-    /// intermediate classes has a single `Base` entry in its MRO, but both specializations constrain
-    /// its subclasses. Use the MRO for member lookup, where ordering determines which member wins.
+    /// inheritance paths, applying type arguments at each step:
+    ///
+    /// ```python
+    /// from typing import Any
+    ///
+    /// class Base[T]: ...
+    /// class Gradual(Base[Any]): ...
+    /// class Concrete[T](Base[T]): ...
+    /// class Child(Gradual, Concrete[int]): ...
+    /// ```
+    ///
+    /// For `Child`, this yields both `Base[Any]` and `Base[int]`, which constrain its subclasses.
+    /// Use [`Self::iter_mro`] for member lookup, where the single `Base[Any]` entry determines
+    /// which specialization to use.
     pub(super) fn iter_explicit_ancestors(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -103,12 +103,20 @@ impl<'db> ClassBase<'db> {
 
     /// Return the identity of this base for method-resolution-order construction.
     ///
+    /// Specializations of a generic class share one runtime class and must occupy the same MRO
+    /// entry. Keep the specialization on the original `ClassBase` for member lookup.
+    ///
     /// The `TypedDict` module affects member lookup, but both special forms represent the same
-    /// pseudo-base when detecting duplicate or conflicting bases.
-    pub(super) const fn mro_identity(self) -> Self {
+    /// pseudo-base when detecting duplicate or conflicting bases. An explicit `Any` base remains
+    /// distinct from a base expression whose type is `Any`.
+    pub(super) fn mro_identity(self, db: &'db dyn Db) -> Type<'db> {
         match self {
-            Self::TypedDict(_) => Self::TypedDict(TypingModule::Typing),
-            _ => self,
+            Self::Any => Type::SpecialForm(SpecialFormType::Any),
+            Self::Class(class) => Type::ClassLiteral(class.class_literal(db)),
+            Self::TypedDict(_) => {
+                Type::SpecialForm(SpecialFormType::TypedDict(TypingModule::Typing))
+            }
+            _ => self.into(),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4775,21 +4775,7 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
             _ => continue,
         };
 
-        // The MRO contains each class only once, but separate inheritance paths can contribute
-        // different specializations. Visit those paths before comparing their type arguments.
-        let mut pending = vec![base_class];
-        let mut seen = FxHashSet::default();
-        while let Some(supercls) = pending.pop() {
-            if !seen.insert(supercls) || ClassBase::Class(supercls).has_cyclic_mro(db) {
-                continue;
-            }
-            let (literal, specialization) = supercls.class_literal_and_specialization(db);
-            pending.extend(literal.explicit_bases(db).iter().rev().filter_map(|base| {
-                ClassBase::try_from_explicit_base(db, env, *base, Some(literal))?
-                    .apply_optional_specialization(db, specialization)
-                    .into_class()
-            }));
-
+        for supercls in base_class.iter_explicit_ancestors(db, env) {
             let ClassType::Generic(supercls_alias) = supercls else {
                 continue;
             };

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4743,11 +4743,14 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
 ) -> bool {
     let db = context.db();
     let env = &context.program_environment();
-    // Maps each generic ancestor's class literal to the first
-    // specialization seen and the index of the explicit base it
-    // came from.
-    let mut ancestor_specs =
-        FxHashMap::<StaticClassLiteral<'db>, (GenericAlias<'db>, usize)>::default();
+    // Track the first non-dynamic argument at each position, along with the alias and explicit
+    // base that supplied it. Compatibility with a gradual argument is not transitive: both
+    // `Base[int, str]` and `Base[int, bytes]` are compatible with `Base[int, Any]`, but conflict
+    // with each other.
+    let mut ancestor_args = FxHashMap::<
+        (StaticClassLiteral<'db>, usize),
+        (Type<'db>, GenericAlias<'db>, usize),
+    >::default();
 
     for (i, base) in explicit_bases.iter().enumerate() {
         let base_class = match base {
@@ -4778,14 +4781,19 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
             };
             let origin = supercls_alias.origin(db);
 
-            if let Some(&(earlier_alias, earlier_idx)) = ancestor_specs.get(&origin) {
-                if earlier_alias
-                    .specialization(db)
-                    .types(db)
-                    .iter()
-                    .zip(supercls_alias.specialization(db).types(db))
-                    .any(|(t1, t2)| !t1.is_dynamic() && !t2.is_dynamic() && t1 != t2)
-                {
+            for (argument_idx, &argument) in supercls_alias
+                .specialization(db)
+                .types(db)
+                .iter()
+                .enumerate()
+            {
+                if argument.is_dynamic() {
+                    continue;
+                }
+                let (earlier_argument, earlier_alias, earlier_idx) = *ancestor_args
+                    .entry((origin, argument_idx))
+                    .or_insert((argument, supercls_alias, i));
+                if earlier_argument != argument {
                     if earlier_idx == i {
                         return true;
                     }
@@ -4846,13 +4854,6 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
                     ));
                     return true;
                 }
-            } else if !supercls_alias
-                .specialization(db)
-                .types(db)
-                .iter()
-                .all(Type::is_dynamic)
-            {
-                ancestor_specs.insert(origin, (supercls_alias, i));
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4721,6 +4721,21 @@ pub(crate) fn report_invalid_typevar_default_reference<'db>(
     }
 }
 
+/// A type parameter of a generic ancestor, independent of its specialization.
+#[derive(PartialEq, Eq, Hash)]
+struct GenericBaseParameter<'db> {
+    origin: StaticClassLiteral<'db>,
+    parameter_index: usize,
+}
+
+/// A non-dynamic type argument and the inheritance path that supplies it.
+struct GenericBaseConstraint<'db> {
+    argument: Type<'db>,
+    alias: GenericAlias<'db>,
+    /// The index in the class's explicit bases list, used to locate the diagnostic annotation.
+    base_index: usize,
+}
+
 /// Report when separate bases contribute incompatible specializations of a generic ancestor.
 ///
 /// For example, if `A` inherits `G[int]` and `B` inherits `G[str]`, neither
@@ -4747,12 +4762,10 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
     // base that supplied it. Compatibility with a gradual argument is not transitive: both
     // `Base[int, str]` and `Base[int, bytes]` are compatible with `Base[int, Any]`, but conflict
     // with each other.
-    let mut ancestor_args = FxHashMap::<
-        (StaticClassLiteral<'db>, usize),
-        (Type<'db>, GenericAlias<'db>, usize),
-    >::default();
+    let mut ancestor_constraints =
+        FxHashMap::<GenericBaseParameter<'db>, GenericBaseConstraint<'db>>::default();
 
-    for (i, base) in explicit_bases.iter().enumerate() {
+    for (base_index, base) in explicit_bases.iter().enumerate() {
         let base_class = match base {
             Type::GenericAlias(alias) => ClassType::Generic(*alias),
             Type::ClassLiteral(class) if class.generic_context(db).is_none() => {
@@ -4781,7 +4794,7 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
             };
             let origin = supercls_alias.origin(db);
 
-            for (argument_idx, &argument) in supercls_alias
+            for (parameter_index, &argument) in supercls_alias
                 .specialization(db)
                 .types(db)
                 .iter()
@@ -4790,11 +4803,18 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
                 if argument.is_dynamic() {
                     continue;
                 }
-                let (earlier_argument, earlier_alias, earlier_idx) = *ancestor_args
-                    .entry((origin, argument_idx))
-                    .or_insert((argument, supercls_alias, i));
-                if earlier_argument != argument {
-                    if earlier_idx == i {
+                let earlier = ancestor_constraints
+                    .entry(GenericBaseParameter {
+                        origin,
+                        parameter_index,
+                    })
+                    .or_insert(GenericBaseConstraint {
+                        argument,
+                        alias: supercls_alias,
+                        base_index,
+                    });
+                if earlier.argument != argument {
+                    if earlier.base_index == base_index {
                         return true;
                     }
                     let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, header_range)
@@ -4811,12 +4831,12 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
                     );
 
                     if let (Some(earlier_base), Some(later_base)) = (
-                        base_nodes.and_then(|nodes| nodes.get(earlier_idx)),
-                        base_nodes.and_then(|nodes| nodes.get(i)),
+                        base_nodes.and_then(|nodes| nodes.get(earlier.base_index)),
+                        base_nodes.and_then(|nodes| nodes.get(base_index)),
                     ) {
                         diagnostic.annotate(context.secondary(earlier_base).message(format_args!(
                             "Earlier class base inherits from `{}`",
-                            earlier_alias.display(db, env)
+                            earlier.alias.display(db, env)
                         )));
                         let later_annotation = context.secondary(later_base);
                         diagnostic.annotate(if later_is_direct {
@@ -4833,7 +4853,7 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
                     } else {
                         diagnostic.info(format_args!(
                             "Earlier class base inherits from `{}`",
-                            earlier_alias.display(db, env)
+                            earlier.alias.display(db, env)
                         ));
                         if later_is_direct {
                             diagnostic.info(format_args!(
@@ -4850,7 +4870,7 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
                     diagnostic.set_concise_message(format_args!(
                         "Inconsistent type arguments: class cannot inherit from both `{}` and `{}`",
                         supercls_alias.display(db, env),
-                        earlier_alias.display(db, env)
+                        earlier.alias.display(db, env)
                     ));
                     return true;
                 }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4758,8 +4758,22 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
             _ => continue,
         };
 
-        for supercls in base_class.iter_mro(db) {
-            let ClassBase::Class(ClassType::Generic(supercls_alias)) = supercls else {
+        // The MRO contains each class only once, but separate inheritance paths can contribute
+        // different specializations. Visit those paths before comparing their type arguments.
+        let mut pending = vec![base_class];
+        let mut seen = FxHashSet::default();
+        while let Some(supercls) = pending.pop() {
+            if !seen.insert(supercls) || ClassBase::Class(supercls).has_cyclic_mro(db) {
+                continue;
+            }
+            let (literal, specialization) = supercls.class_literal_and_specialization(db);
+            pending.extend(literal.explicit_bases(db).iter().rev().filter_map(|base| {
+                ClassBase::try_from_explicit_base(db, env, *base, Some(literal))?
+                    .apply_optional_specialization(db, specialization)
+                    .into_class()
+            }));
+
+            let ClassType::Generic(supercls_alias) = supercls else {
                 continue;
             };
             let origin = supercls_alias.origin(db);

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4722,13 +4722,14 @@ pub(crate) fn report_invalid_typevar_default_reference<'db>(
 }
 
 /// A type parameter of a generic ancestor, independent of its specialization.
-#[derive(PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash, Debug)]
 struct GenericBaseParameter<'db> {
     origin: StaticClassLiteral<'db>,
     parameter_index: usize,
 }
 
 /// A non-dynamic type argument and the inheritance path that supplies it.
+#[derive(Debug)]
 struct GenericBaseConstraint<'db> {
     argument: Type<'db>,
     alias: GenericAlias<'db>,

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -258,8 +258,11 @@ impl<'db> Mro<'db> {
                 let mut duplicate_dynamic_bases = false;
 
                 let duplicate_bases: Vec<DuplicateBaseError<'db>> = {
-                    let mut base_to_indices =
-                        IndexMap::<_, (ClassBase<'db>, Vec<usize>), FxBuildHasher>::default();
+                    let mut base_to_indices = IndexMap::<
+                        Type<'db>,
+                        (ClassBase<'db>, Vec<usize>),
+                        FxBuildHasher,
+                    >::default();
 
                     // We need to iterate over `original_bases` here rather than `resolved_bases`
                     // so that we get the correct index of the duplicate bases if there were any

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -1,10 +1,10 @@
 use crate::Db;
+use crate::FxIndexMap;
 use crate::ProgramEnvironment;
 use std::collections::VecDeque;
 use std::ops::Deref;
 
-use indexmap::IndexMap;
-use rustc_hash::{FxBuildHasher, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use crate::types::class::{DynamicClassLiteral, DynamicEnumLiteral};
 use crate::types::class_base::ClassBase;
@@ -258,11 +258,8 @@ impl<'db> Mro<'db> {
                 let mut duplicate_dynamic_bases = false;
 
                 let duplicate_bases: Vec<DuplicateBaseError<'db>> = {
-                    let mut base_to_indices = IndexMap::<
-                        Type<'db>,
-                        (ClassBase<'db>, Vec<usize>),
-                        FxBuildHasher,
-                    >::default();
+                    let mut base_to_indices =
+                        FxIndexMap::<Type<'db>, (ClassBase<'db>, Vec<usize>)>::default();
 
                     // We need to iterate over `original_bases` here rather than `resolved_bases`
                     // so that we get the correct index of the duplicate bases if there were any

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -475,17 +475,12 @@ impl<'db> Mro<'db> {
         //
         // This matches the `dynamic_fallback` approach used by `of_dynamic_class`.
         let fallback_mro = || {
-            let mut result = vec![self_base];
-            let mut seen = FxHashSet::default();
-            seen.insert(self_base);
-            for base in &resolved_bases {
-                for item in base.mro(db, env, None) {
-                    if seen.insert(item) {
-                        result.push(item);
-                    }
-                }
-            }
-            Self::from(result)
+            Self::fallback_from_bases(
+                db,
+                env,
+                ClassType::NonGeneric(dynamic_enum.into()),
+                resolved_bases.iter().copied(),
+            )
         };
 
         // Standard C3 linearization: build sequences from each base's MRO, plus the
@@ -511,29 +506,47 @@ impl<'db> Mro<'db> {
 
     /// Compute a fallback MRO for a dynamic class when `of_dynamic_class` fails.
     ///
-    /// Iterates over base MROs sequentially with deduplication.
+    /// Preserves known bases even when an invalid base must be replaced with `Unknown`.
     fn dynamic_fallback(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         dynamic: DynamicClassLiteral<'db>,
     ) -> Self {
-        let self_base = ClassBase::Class(ClassType::NonGeneric(dynamic.into()));
+        Self::fallback_from_bases(
+            db,
+            env,
+            ClassType::NonGeneric(dynamic.into()),
+            dynamic.explicit_bases(db).iter().map(|base_type| {
+                ClassBase::try_from_explicit_base(db, env, *base_type, None)
+                    .unwrap_or_else(ClassBase::unknown)
+            }),
+        )
+    }
+
+    /// Retain the first specialization of each class when C3 cannot determine a valid MRO.
+    ///
+    /// Visit the bases' MROs in order, but defer `object` until every other base has been added.
+    /// This preserves known members while keeping class identities unique and `object` last,
+    /// including when subclasses inherit this fallback MRO.
+    fn fallback_from_bases(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        class: ClassType<'db>,
+        bases: impl IntoIterator<Item = ClassBase<'db>>,
+    ) -> Self {
+        let self_base = ClassBase::Class(class);
+        let object_base = ClassBase::object(db, env);
         let mut result = vec![self_base];
-        let mut seen = FxHashSet::default();
-        seen.insert(self_base);
-
-        for base_type in dynamic.explicit_bases(db) {
-            // Convert `Type` to `ClassBase`, falling back to `Unknown` if conversion fails.
-            let base = ClassBase::try_from_explicit_base(db, env, *base_type, None)
-                .unwrap_or_else(ClassBase::unknown);
-
+        let mut seen =
+            FxHashSet::from_iter([self_base.mro_identity(db), object_base.mro_identity(db)]);
+        for base in bases {
             for item in base.mro(db, env, None) {
-                if seen.insert(item) {
+                if seen.insert(item.mro_identity(db)) {
                     result.push(item);
                 }
             }
         }
-
+        result.push(object_base);
         Self::from(result)
     }
 }

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -234,7 +234,7 @@ impl<'db> Mro<'db> {
                         .collect(),
                 );
 
-                if let Some(mro) = c3_merge(seqs) {
+                if let Some(mro) = c3_merge(db, seqs) {
                     return Ok(mro);
                 }
 
@@ -258,14 +258,14 @@ impl<'db> Mro<'db> {
                 let mut duplicate_dynamic_bases = false;
 
                 let duplicate_bases: Vec<DuplicateBaseError<'db>> = {
-                    let mut base_to_indices: IndexMap<ClassBase<'db>, Vec<usize>, FxBuildHasher> =
-                        IndexMap::default();
+                    let mut base_to_indices =
+                        IndexMap::<_, (ClassBase<'db>, Vec<usize>), FxBuildHasher>::default();
 
                     // We need to iterate over `original_bases` here rather than `resolved_bases`
                     // so that we get the correct index of the duplicate bases if there were any
                     // (`resolved_bases` may be a longer list than `original_bases`!). However, we
-                    // need to use a `ClassBase` rather than a `Type` as the key type for the
-                    // `base_to_indices` map so that a class such as
+                    // need to use the base's MRO identity rather than its inferred type as the key
+                    // for the `base_to_indices` map so that a class such as
                     // `class Foo(Protocol[T], Protocol): ...` correctly causes us to emit a
                     // `duplicate-base` diagnostic (matching the runtime behaviour) rather than an
                     // `inconsistent-mro` diagnostic (which would be accurate -- but not nearly as
@@ -279,15 +279,15 @@ impl<'db> Mro<'db> {
                         ) else {
                             continue;
                         };
-                        base_to_indices
-                            .entry(base.mro_identity())
-                            .or_default()
-                            .push(index);
+                        let (_, indices) = base_to_indices
+                            .entry(base.mro_identity(db))
+                            .or_insert_with(|| (base, Vec::new()));
+                        indices.push(index);
                     }
 
                     let mut errors = vec![];
 
-                    for (base, indices) in base_to_indices {
+                    for (base, indices) in base_to_indices.into_values() {
                         let Some((first_index, later_indices)) = indices.split_first() else {
                             continue;
                         };
@@ -403,7 +403,7 @@ impl<'db> Mro<'db> {
         seqs.push(resolved_bases.iter().copied().collect());
 
         // Try C3 merge.
-        if let Some(mro) = c3_merge(seqs) {
+        if let Some(mro) = c3_merge(db, seqs) {
             return Ok(mro);
         }
 
@@ -414,14 +414,12 @@ impl<'db> Mro<'db> {
         let mut duplicates = Vec::new();
         let mut has_duplicate_dynamic_bases = false;
         for base in &resolved_bases {
-            if matches!(base, ClassBase::Any | ClassBase::Dynamic(_)) {
-                if !seen.insert(*base) {
+            if !seen.insert(base.mro_identity(db)) {
+                if matches!(base, ClassBase::Any | ClassBase::Dynamic(_)) {
                     has_duplicate_dynamic_bases = true;
+                } else {
+                    duplicates.push(*base);
                 }
-                continue;
-            }
-            if !seen.insert(base.mro_identity()) {
-                duplicates.push(*base);
             }
         }
 
@@ -505,7 +503,7 @@ impl<'db> Mro<'db> {
         }
         seqs.push(resolved_bases.iter().copied().collect());
 
-        c3_merge(seqs).ok_or_else(|| DynamicMroError {
+        c3_merge(db, seqs).ok_or_else(|| DynamicMroError {
             kind: DynamicMroErrorKind::UnresolvableMro,
             fallback_mro: fallback_mro(),
         })
@@ -820,7 +818,10 @@ pub(super) struct DuplicateBaseError<'db> {
 ///
 /// [C3-merge algorithm]: https://docs.python.org/3/howto/mro.html#python-2-3-mro
 /// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
-fn c3_merge(mut sequences: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
+fn c3_merge<'db>(
+    db: &'db dyn Db,
+    mut sequences: Vec<VecDeque<ClassBase<'db>>>,
+) -> Option<Mro<'db>> {
     // Most MROs aren't that long...
     let mut mro = Vec::with_capacity(8);
 
@@ -838,13 +839,13 @@ fn c3_merge(mut sequences: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
         // with the given bases.
         let mro_entry = sequences.iter().find_map(|outer_sequence| {
             let candidate = outer_sequence[0];
-            let candidate_identity = candidate.mro_identity();
+            let candidate_identity = candidate.mro_identity(db);
 
             let not_head = sequences.iter().all(|sequence| {
                 sequence
                     .iter()
                     .skip(1)
-                    .all(|base| base.mro_identity() != candidate_identity)
+                    .all(|base| base.mro_identity(db) != candidate_identity)
             });
 
             not_head.then_some(candidate)
@@ -853,9 +854,9 @@ fn c3_merge(mut sequences: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
         mro.push(mro_entry);
 
         // Make sure we don't try to add the candidate to the MRO twice:
-        let mro_entry_identity = mro_entry.mro_identity();
+        let mro_entry_identity = mro_entry.mro_identity(db);
         for sequence in &mut sequences {
-            sequence.pop_front_if(|base| base.mro_identity() == mro_entry_identity);
+            sequence.pop_front_if(|base| base.mro_identity(db) == mro_entry_identity);
         }
     }
 }
@@ -902,7 +903,7 @@ fn check_generic_reorder_fixes_mro<'db>(
         seqs.push(base.mro(db, env, None).collect());
     }
     seqs.push(reordered);
-    c3_merge(seqs)?;
+    c3_merge(db, seqs)?;
     Some(single_index)
 }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -87,6 +87,31 @@ pub(super) fn check_class<'db>(
     }
     let enum_info = enum_metadata(db, class.into());
 
+    let mut bases: Vec<_> = class_specialized.iter_mro(db).skip(1).collect();
+    if configuration.check_method_liskov_violations() {
+        let generic_bases: Vec<_> = bases
+            .iter()
+            .filter_map(|base| base.into_class()?.into_generic_alias())
+            .collect();
+        if !generic_bases.is_empty() {
+            // Overrides must respect every inherited specialization. Keep the MRO's bases first
+            // so the immediate parent used to suppress inherited violations is unchanged.
+            let env = &context.program_environment();
+            bases.extend(
+                class_specialized
+                    .iter_explicit_ancestors(db, env)
+                    .filter_map(ClassType::into_generic_alias)
+                    .filter(|ancestor| {
+                        !generic_bases.contains(ancestor)
+                            && generic_bases
+                                .iter()
+                                .any(|base| base.origin(db) == ancestor.origin(db))
+                    })
+                    .map(|ancestor| ClassBase::Class(ClassType::Generic(ancestor))),
+            );
+        }
+    }
+
     #[expect(
         clippy::iter_over_hash_type,
         reason = "each class member is checked independently"
@@ -98,6 +123,7 @@ pub(super) fn check_class<'db>(
             enum_info,
             class_specialized,
             scope,
+            &bases,
             &member,
         );
     }
@@ -438,6 +464,7 @@ fn check_class_declaration<'db>(
     enum_info: Option<&EnumMetadata<'db>>,
     class: ClassType<'db>,
     class_scope: ScopeId<'db>,
+    bases: &[ClassBase<'db>],
     member: &MemberWithDefinition<'db>,
 ) {
     let db = context.db();
@@ -630,7 +657,7 @@ fn check_class_declaration<'db>(
     let mut immediate_parent_variable_kind: Option<(ClassType<'db>, VariableKind)> = None;
 
     if !is_private_member {
-        for class_base in class.iter_mro(db).skip(1) {
+        for &class_base in bases {
             let superclass = match class_base {
                 ClassBase::Protocol | ClassBase::Generic => continue,
                 ClassBase::Any | ClassBase::Dynamic(_) => {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -11,7 +11,7 @@ use ruff_db::{
 };
 use ruff_python_ast::{PythonVersion, name::Name};
 use ruff_python_stdlib::identifiers::is_mangled_private;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     Db, ProgramEnvironment,
@@ -89,9 +89,10 @@ pub(super) fn check_class<'db>(
 
     let mut bases: Vec<_> = class_specialized.iter_mro(db).skip(1).collect();
     if configuration.check_method_liskov_violations() {
-        let generic_bases: Vec<_> = bases
+        let generic_bases: FxHashMap<_, _> = bases
             .iter()
             .filter_map(|base| base.into_class()?.into_generic_alias())
+            .map(|base| (base.origin(db), base))
             .collect();
         if !generic_bases.is_empty() {
             // Overrides must respect every inherited specialization. Keep the MRO's bases first
@@ -102,10 +103,9 @@ pub(super) fn check_class<'db>(
                     .iter_explicit_ancestors(db, env)
                     .filter_map(ClassType::into_generic_alias)
                     .filter(|ancestor| {
-                        !generic_bases.contains(ancestor)
-                            && generic_bases
-                                .iter()
-                                .any(|base| base.origin(db) == ancestor.origin(db))
+                        generic_bases
+                            .get(&ancestor.origin(db))
+                            .is_some_and(|base| base != ancestor)
                     })
                     .map(|ancestor| ClassBase::Class(ClassType::Generic(ancestor))),
             );


### PR DESCRIPTION
## Summary

Previously, mixing gradual and concrete specializations of a generic base could select an ancestor's method ahead of an override and report a false `invalid-method-override`:

```python
from typing import Any, reveal_type

class Base[T]:
    def method(self) -> object: ...

class Unspecified(Base[Any]): ...

class Concrete(Base[int]):
    def method(self) -> int:
        return 0

class Child(Unspecified, Concrete): ...  # Before: invalid-method-override. After: no error.

reveal_type(Child().method())  # Before: object. After: int.
```

We treated `Base[Any]` and `Base[int]` as distinct classes in the MRO, placing `Base[Any]` before `Concrete`. We now compare bases by their underlying class during C3 linearization, while retaining the selected specialization for member lookup. This puts `Base` after both subclasses and includes it only once.

Subtype and override checks still consider every inherited specialization, including those omitted from the MRO used for member lookup. Fallback MROs use the same class identity for deduplication and keep `object` last, including when subclasses inherit an inconsistent MRO.

The relevance of this PR is that it avoids some false positives that would otherwise be introduced by https://github.com/astral-sh/ruff/pull/28167, e.g., in [Home Assistant](https://github.com/home-assistant/core/blob/e4455e962621ad3cd7fbfd9e31a62259ce9c23f1/homeassistant/components/ring/button.py#L34).
