### PR TITLE
[ty] Track member presence alongside narrowed types

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -31,7 +31,7 @@ use crate::ast_node_ref::AstNodeRef;
 use crate::definition::{
     AnnotatedAssignmentDefinitionNodeRef, AssignmentDefinitionNodeRef, BindingsOwner,
     ComprehensionDefinitionNodeRef, Definition, DefinitionCategory, DefinitionKind,
-    DefinitionNodeKey, DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef,
+    DefinitionNodeKey, DefinitionNodeRef, DefinitionState, Definitions, DictKeyAssignmentNodeRef,
     ExceptHandlerDefinitionNodeRef, ForStmtDefinitionNodeRef, ImportDefinitionNodeRef,
     ImportFromDefinitionNodeRef, ImportFromSubmoduleDefinitionNodeRef,
     LambdaParameterDefinitionNodeRef, LoopHeaderDefinitionNodeRef, LoopStmtRef,
@@ -40,7 +40,7 @@ use crate::definition::{
 };
 use crate::expression::{Expression, ExpressionKind};
 use crate::frozen::{FrozenMap, FrozenSet};
-use crate::member::MemberExprBuilder;
+use crate::member::{Member, MemberExprBuilder};
 use crate::place::{
     PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId,
     match_subject_place_expressions,
@@ -128,6 +128,8 @@ struct ScopeInfo<'ast> {
     this_scope_global_or_nonlocal_declarations: FxHashMap<Name, TextRange>,
     /// Free symbol uses from nested scopes that may resolve to this scope.
     pending_captures: PendingCaptures,
+    /// Members whose enclosing bindings may be invalidated when this eager scope finishes.
+    eager_scope_mutations: FxHashSet<ScopedPlaceId>,
 }
 
 type NestedGlobalOrNonlocalDeclarations = FxHashMap<Name, SmallVec<[NestedDeclaration; 1]>>;
@@ -572,7 +574,86 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             nested_global_or_nonlocal_declarations: FxHashMap::default(),
             this_scope_global_or_nonlocal_declarations: FxHashMap::default(),
             pending_captures: FxHashMap::default(),
+            eager_scope_mutations: FxHashSet::default(),
         });
+    }
+
+    /// Remember mutations of members whose receiver may come from an enclosing scope.
+    /// Class-local receivers do not affect the same spelling in an enclosing scope.
+    fn record_eager_scope_mutation(&mut self, place: ScopedPlaceId) {
+        let scope = self.current_scope();
+        let scope_kind = self.scopes[scope].kind();
+        if !scope_kind.is_eager()
+            || scope_kind.is_module()
+            || self.current_use_def_map().reachability
+                == ScopedReachabilityConstraintId::ALWAYS_FALSE
+        {
+            return;
+        }
+        let PlaceExprRef::Member(member) = self.place_tables[scope].place(place) else {
+            return;
+        };
+        if let Some(symbol_id) =
+            self.place_tables[scope].symbol_id(member.expression().as_ref().symbol_name())
+            && self.place_tables[scope].symbol(symbol_id).is_local()
+        {
+            let bindings: SmallVec<[_; 1]> = self.use_def_maps[scope]
+                .current_bindings(symbol_id.into())
+                .filter(|binding| {
+                    binding.reachability_constraint()
+                        != ScopedReachabilityConstraintId::ALWAYS_FALSE
+                })
+                .map(|binding| binding.binding())
+                .collect();
+            if bindings.iter().all(|binding| {
+                matches!(
+                    self.use_def_maps[scope].definition(*binding),
+                    DefinitionState::Defined(_)
+                )
+            }) {
+                return;
+            }
+        }
+        self.current_scope_info_mut()
+            .eager_scope_mutations
+            .insert(place);
+    }
+
+    /// Discard stale enclosing member bindings after an eager scope executes.
+    ///
+    /// We do not yet propagate the values assigned by nested class bodies. Treat their mutations
+    /// like receiver reassignment: forget both the member and its descendants, then fall back to
+    /// ordinary member lookup. Snapshots for reads inside the child must be recorded first.
+    fn invalidate_eager_scope_mutations(
+        &mut self,
+        popped_scope: FileScopeId,
+        mutations: FxHashSet<ScopedPlaceId>,
+    ) {
+        if mutations.is_empty()
+            || self.current_use_def_map().reachability
+                == ScopedReachabilityConstraintId::ALWAYS_FALSE
+        {
+            return;
+        }
+        for place in mutations.into_iter().sorted_unstable() {
+            let PlaceExprRef::Member(member) = self.place_tables[popped_scope].place(place) else {
+                continue;
+            };
+            let member = Member::new(member.expression().clone());
+            self.add_symbol(Name::new(member.expression().as_ref().symbol_name()));
+            let place = self.add_place(PlaceExpr::Member(member));
+            self.invalidate_narrowing_aliases_for(place);
+            self.current_use_def_map_mut().delete_binding(place);
+            self.delete_associated_bindings(place);
+
+            // Continue through enclosing eager scopes, stopping at the function whose execution
+            // contains the mutation. A class body can skip a receiver local to another class.
+            if self.scopes[self.current_scope()].kind().is_eager() {
+                self.current_scope_info_mut()
+                    .eager_scope_mutations
+                    .insert(place);
+            }
+        }
     }
 
     // Records snapshots of the place states visible from the current eager scope.
@@ -943,6 +1024,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             mut nested_global_or_nonlocal_declarations,
             this_scope_global_or_nonlocal_declarations,
             pending_captures,
+            eager_scope_mutations,
             ..
         } = self
             .scope_stack
@@ -978,6 +1060,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             debug_assert!(self.scope_stack.is_empty());
             return FxHashMap::default();
         }
+
+        self.invalidate_eager_scope_mutations(popped_scope_id, eager_scope_mutations);
 
         // In the common case where we don't have any nested `global` or `nonlocal` declarations at
         // all, short-circuit so that we don't walk the place table for no reason.
@@ -1585,6 +1669,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     }
 
     fn delete_binding(&mut self, place: ScopedPlaceId) {
+        self.record_eager_scope_mutation(place);
         self.current_use_def_map_mut().delete_binding(place);
     }
 
@@ -1735,6 +1820,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         //     x = 1
         // ```
         if !is_loop_header {
+            self.record_eager_scope_mutation(place);
             self.mark_place_bound(place);
             self.invalidate_narrowing_aliases_for(place);
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3537,22 +3537,19 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.mark_current_comprehension_async();
                 }
             }
-            ast::Expr::Call(call) => {
+            ast::Expr::Call(_) | ast::Expr::BinOp(_) => {
                 walk_expr(self, expr);
                 self.record_exception_checkpoint();
 
                 // The callee is resolved later. Register the member so that a presence guard,
                 // including an alias of `hasattr`, can constrain it before its first use.
-                if let [base, ast::Expr::StringLiteral(name)] = &*call.arguments.args
+                if let ast::Expr::Call(call) = expr
+                    && let [base, ast::Expr::StringLiteral(name)] = &*call.arguments.args
                     && call.arguments.keywords.is_empty()
                     && let Some(member) = PlaceExpr::attribute(base.into(), name.value.to_str())
                 {
                     self.add_place(member);
                 }
-            }
-            ast::Expr::BinOp(_) => {
-                walk_expr(self, expr);
-                self.record_exception_checkpoint();
             }
             ast::Expr::UnaryOp(unary) => {
                 self.visit_expr_with_context(

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3537,7 +3537,20 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.mark_current_comprehension_async();
                 }
             }
-            ast::Expr::Call(_) | ast::Expr::BinOp(_) => {
+            ast::Expr::Call(call) => {
+                walk_expr(self, expr);
+                self.record_exception_checkpoint();
+
+                // The callee is resolved later. Register the member so that a presence guard,
+                // including an alias of `hasattr`, can constrain it before its first use.
+                if let [base, ast::Expr::StringLiteral(name)] = &*call.arguments.args
+                    && call.arguments.keywords.is_empty()
+                    && let Some(member) = PlaceExpr::attribute(base.into(), name.value.to_str())
+                {
+                    self.add_place(member);
+                }
+            }
+            ast::Expr::BinOp(_) => {
                 walk_expr(self, expr);
                 self.record_exception_checkpoint();
             }

--- a/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
+++ b/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
@@ -5,8 +5,8 @@ use crate::place::PlaceExpr;
 use crate::symbol::Symbol;
 
 /// Do a pre-walk of a `while` loop to collect all the places that are bound, prior to visiting the
-/// loop with `SemanticIndexBuilder`. This walk includes bindings in nested loops, but not in
-/// nested scopes. (I.e. we don't descend into function bodies or class definitions.) We need this
+/// loop with `SemanticIndexBuilder`. This walk includes bindings in nested loops and member
+/// mutations in eager class bodies, but not bindings in lazy function bodies. We need this
 /// pre-walk so that we can synthesize "loop header definitions" that are visible to the loop body
 /// (and condition). See `LoopHeader`.
 /// TODO: Handle `nonlocal` bindings from nested scopes somehow.
@@ -27,7 +27,8 @@ pub(crate) fn collect_for_loop_bindings(for_stmt: &ast::StmtFor) -> Vec<PlaceExp
 
 /// The visitor that powers `collect_while_loop_bindings` and `collect_for_loop_bindings`.
 ///
-/// This visitor doesn't walk nested function/class definitions since those are different scopes.
+/// Class-local names stay in their scope, but member mutations can affect later loop iterations.
+/// Function bodies are lazy and are not visited.
 #[derive(Debug, Default)]
 pub(crate) struct LoopBindingsVisitor {
     bound_places: Vec<PlaceExpr>,
@@ -139,7 +140,14 @@ impl<'ast> Visitor<'ast> for LoopBindingsVisitor {
             ast::Stmt::ClassDef(node) => {
                 self.bound_places
                     .push(PlaceExpr::Symbol(Symbol::new(node.name.id.clone())));
-                // Don't descend into class bodies - they're different scopes.
+                let mut nested = Self::default();
+                nested.visit_body(&node.body);
+                self.bound_places.extend(
+                    nested
+                        .bound_places
+                        .into_iter()
+                        .filter(|place| matches!(place, PlaceExpr::Member(_))),
+                );
             }
             ast::Stmt::Match(node) => {
                 self.visit_expr(&node.subject);

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -234,6 +234,8 @@ pub fn global_scope<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> ScopeId<'db
 pub enum EnclosingSnapshotResult<'map, 'db> {
     FoundConstraint(ScopedNarrowingConstraint),
     FoundBindings(BindingWithConstraintsIterator<'map, 'db>),
+    /// Binding state that constrains an enclosing value without supplying a value itself.
+    FoundUnboundBindings(BindingWithConstraintsIterator<'map, 'db>),
     NotFound,
     NoLongerInEagerContext,
 }

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -214,6 +214,16 @@ pub(super) struct MemberExprBuilder {
 }
 
 impl MemberExprBuilder {
+    pub(super) fn attribute(expr: ast::ExprRef<'_>, name: &str) -> Option<Self> {
+        let mut builder = Self::visit_expr(expr)?;
+        let start = builder.path.as_str().text_len();
+        builder.path = CharStr::concat(&[builder.path.as_str(), name]);
+        builder
+            .segments
+            .push(SegmentInfo::new(SegmentKind::Attribute, start));
+        Some(builder)
+    }
+
     pub(super) fn visit_expr(expr: ast::ExprRef) -> Option<MemberExprBuilder> {
         match expr {
             ast::ExprRef::Name(name) => {

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -46,6 +46,8 @@ pub enum PlaceExpr {
 
 impl PlaceExpr {
     /// Construct the member place read by a presence check such as `hasattr(value, "name")`.
+    /// This lets the check constrain `value.name` even without an attribute expression in the AST.
+    /// Returns `None` when the base is not trackable, such as the result of a function call.
     pub fn attribute(base: ast::ExprRef<'_>, name: &str) -> Option<Self> {
         Self::try_from_member_expr(MemberExprBuilder::attribute(base, name)?)
     }

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -45,6 +45,11 @@ pub enum PlaceExpr {
 }
 
 impl PlaceExpr {
+    /// Construct the member place read by a presence check such as `hasattr(value, "name")`.
+    pub fn attribute(base: ast::ExprRef<'_>, name: &str) -> Option<Self> {
+        Self::try_from_member_expr(MemberExprBuilder::attribute(base, name)?)
+    }
+
     /// Create a new `PlaceExpr` from a name.
     ///
     /// This always returns a `PlaceExpr::Symbol` with empty flags and `name`.
@@ -685,6 +690,14 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
     /// or narrow based on TypeGuard/TypeIs return types.
     fn expr_call(&self, expr_call: &ast::ExprCall) -> PossiblyNarrowedPlaces {
         let mut places = PossiblyNarrowedPlaces::default();
+
+        if let [base, ast::Expr::StringLiteral(name)] = &*expr_call.arguments.args
+            && expr_call.arguments.keywords.is_empty()
+            && let Some(member) = PlaceExpr::attribute(base.into(), name.value.to_str())
+            && let Some(place) = self.places.place_id((&member).into())
+        {
+            places.insert(place);
+        }
 
         // Under the current narrowing semantics, we only ever use the first two positional
         // arguments: argument 0 for most narrowing calls, and argument 1 for unbound

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -597,6 +597,7 @@ struct DefinitionsAtDefinition<B, D> {
 enum InternedEnclosingSnapshotId {
     Constraint(ScopedNarrowingConstraint),
     Bindings(InternedBindingsId),
+    UnboundBindings(InternedBindingsId),
 }
 
 /// Lookup tables needed to evaluate reachability and narrowing constraints.
@@ -954,12 +955,11 @@ impl<'db> UseDefMap<'db> {
                 })
             }
             ConstraintKey::NestedScope(nested_scope) => {
-                let EnclosingSnapshotResult::FoundBindings(bindings) =
+                let (EnclosingSnapshotResult::FoundBindings(bindings)
+                | EnclosingSnapshotResult::FoundUnboundBindings(bindings)) =
                     index.enclosing_snapshot(enclosing_scope, expr, nested_scope)
                 else {
-                    unreachable!(
-                        "The result of `SemanticIndex::eager_snapshot` must be `FoundBindings`"
-                    )
+                    unreachable!("Expected binding state for a nested-scope constraint")
                 };
                 ApplicableConstraints::ConstrainedBindings(bindings)
             }
@@ -1073,6 +1073,14 @@ impl<'db> UseDefMap<'db> {
             }
             Some(InternedEnclosingSnapshotId::Bindings(bindings_id)) => {
                 EnclosingSnapshotResult::FoundBindings(
+                    self.bindings_iterator(
+                        &self.interned_bindings[*bindings_id],
+                        boundness_analysis,
+                    ),
+                )
+            }
+            Some(InternedEnclosingSnapshotId::UnboundBindings(bindings_id)) => {
+                EnclosingSnapshotResult::FoundUnboundBindings(
                     self.bindings_iterator(
                         &self.interned_bindings[*bindings_id],
                         boundness_analysis,
@@ -2621,10 +2629,17 @@ impl<'db> UseDefMapBuilder<'db> {
         let is_forwarding_symbol = enclosing_place_expr
             .as_symbol()
             .is_some_and(|symbol| symbol.is_global() || symbol.is_nonlocal());
-        let stores_visible_bindings = enclosing_place_expr.is_bound()
-            && bindings
-                .iter()
-                .any(|binding| !binding.binding().is_unbound());
+        let has_bindings = bindings
+            .iter()
+            .any(|binding| !binding.binding().is_unbound());
+        let stores_visible_bindings = enclosing_place_expr.is_bound() && has_bindings;
+        // Deletions do not bind a member, but nested eager scopes still need their
+        // reachability and narrowing constraints before consulting an enclosing assignment.
+        if enclosing_place.is_member() && !enclosing_place_expr.is_bound() && has_bindings {
+            return self
+                .enclosing_snapshots
+                .push(EnclosingSnapshot::UnboundBindings(bindings.clone()));
+        }
         // Names bound in class scopes are never visible to nested scopes (but
         // attributes/subscripts are visible), so we never need to save eager scope bindings in a
         // class scope. There is one exception to this rule: annotation scopes can see names
@@ -2663,7 +2678,10 @@ impl<'db> UseDefMapBuilder<'db> {
             .bindings()
             .clone();
         match self.enclosing_snapshots.get_mut(snapshot_id) {
-            Some(EnclosingSnapshot::Bindings(bindings)) => {
+            Some(
+                EnclosingSnapshot::Bindings(bindings)
+                | EnclosingSnapshot::UnboundBindings(bindings),
+            ) => {
                 bindings.merge(
                     new_bindings,
                     &mut self.narrowing_constraints,
@@ -3103,6 +3121,10 @@ impl<'db> UseDefMapBuilder<'db> {
                 EnclosingSnapshot::Bindings(bindings) => {
                     let interned_bindings_id = place_state_interner.intern_bindings(&bindings);
                     InternedEnclosingSnapshotId::Bindings(interned_bindings_id)
+                }
+                EnclosingSnapshot::UnboundBindings(bindings) => {
+                    let interned_bindings_id = place_state_interner.intern_bindings(&bindings);
+                    InternedEnclosingSnapshotId::UnboundBindings(interned_bindings_id)
                 }
                 EnclosingSnapshot::Constraint(constraint) => {
                     InternedEnclosingSnapshotId::Constraint(constraint)

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -212,11 +212,13 @@ impl Declarations {
 /// If there are bindings in a (non-class) scope, they are stored in `Bindings`.
 /// Even if it's a class scope (class variables are not visible to nested scopes) or there are no
 /// bindings, the current narrowing constraint is necessary for narrowing, so it's stored in
-/// `Constraint`.
+/// `Constraint`. An unbound member can also carry deletions, which `UnboundBindings` retains
+/// without making this scope the source of the member's value.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub(super) enum EnclosingSnapshot {
     Constraint(ScopedNarrowingConstraint),
     Bindings(Bindings),
+    UnboundBindings(Bindings),
 }
 
 /// Live bindings for a single place at some point in control flow. Each live binding comes

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2675,6 +2675,33 @@ def _(flag1: bool, flag2: bool):
     C().x = 100
 ```
 
+### Never-valued attributes
+
+A `Never`-valued attribute on one union member does not establish that the attribute exists on the
+other members. The receiver can still be an instance of the class without the attribute, so we
+report the missing attribute before the read can produce a value.
+
+```py
+from typing_extensions import Never
+
+class HasValue:
+    value: Never
+
+class Missing: ...
+
+def read(obj: HasValue | Missing):
+    obj.value  # error: [unresolved-attribute]
+```
+
+An assignment on one branch does not establish presence on the other branch.
+
+```py
+def partially_assigned(obj: HasValue | Missing, condition: bool):
+    if condition:
+        obj.value = 1  # error: [invalid-assignment]
+    obj.value  # error: [unresolved-attribute]
+```
+
 ### Possibly-unbound within a class
 
 We raise the same diagnostic if the attribute is possibly-unbound in at least one element of the

--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -208,6 +208,49 @@ def unreachable_deletion_before_comprehension(item: Item):
         [reveal_type(item.value) for _ in range(1)]  # revealed: Literal[1]
 ```
 
+### Presence after deletion across loop iterations
+
+A read before a deletion can still observe that deletion on a later iteration. An assignment before
+the class body does not establish that the attribute is present on every iteration.
+
+```py
+class Item: ...
+
+def deleted_on_previous_iteration(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        for _ in range(2):
+            item.value  # error: [unresolved-attribute]
+            del item.value  # error: [unresolved-attribute]
+```
+
+The deletion also affects a read in a comprehension nested inside the loop.
+
+```py
+def deleted_on_previous_iteration_in_comprehension(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        for _ in range(2):
+            [item.value for _ in range(1)]  # error: [unresolved-attribute]
+            del item.value  # error: [unresolved-attribute]
+```
+
+Assigning the attribute before each read establishes presence again, even when the previous
+iteration deleted it.
+
+```py
+def assigned_on_each_iteration(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        for _ in range(2):
+            item.value = 2  # error: [unresolved-attribute]
+            reveal_type(item.value)  # revealed: Literal[2]
+            del item.value
+```
+
 ### Presence after receiver reassignment
 
 Reassigning the receiver discards evidence that an attribute was assigned on the previous object.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -90,13 +90,63 @@ class _:
 a = A()
 # error: [unresolved-attribute]
 a.dynamically_added = 0
-# error: [unresolved-attribute]
+# The assignment is invalid, but establishes the attribute's presence for subsequent reads.
 reveal_type(a.dynamically_added)  # revealed: Literal[0]
 
 # error: [unresolved-reference]
 does.nt.exist = 0
 # error: [unresolved-reference]
 reveal_type(does.nt.exist)  # revealed: Literal[0]
+```
+
+### Presence after conditional assignments
+
+Assigning an undeclared attribute is still an error, but a subsequent read does not repeat the error
+when every branch assigns the attribute.
+
+```py
+class Item: ...
+
+def assigned_on_both_branches(item: Item, condition: bool):
+    if condition:
+        item.value = 1  # error: [unresolved-attribute]
+    else:
+        item.value = 2  # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[1, 2]
+```
+
+An assignment on only one branch does not establish presence after the conditional.
+
+```py
+def assigned_on_one_branch(item: Item, condition: bool):
+    if condition:
+        item.value = 1  # error: [unresolved-attribute]
+    item.value  # error: [unresolved-attribute]
+```
+
+A branch that exits without reaching the read does not affect whether the attribute is present.
+
+```py
+def assigned_or_raised(item: Item, condition: bool):
+    if condition:
+        item.value = 1  # error: [unresolved-attribute]
+    else:
+        raise ValueError
+    reveal_type(item.value)  # revealed: Literal[1]
+```
+
+### Presence after receiver reassignment
+
+Reassigning the receiver discards evidence that an attribute was assigned on the previous object.
+
+```py
+class Item: ...
+
+def f(item: Item, other: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[1]
+    item = other
+    item.value  # error: [unresolved-attribute]
 ```
 
 ### Narrowing chain

--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -265,6 +265,145 @@ def f(item: Item, other: Item):
     item.value  # error: [unresolved-attribute]
 ```
 
+### Presence after an eager scope exits
+
+A class body executes before the enclosing scope continues. Deleting an attribute in the class body
+invalidates an earlier assignment in the enclosing scope. Assigning it again restores presence.
+
+```py
+class Item: ...
+
+def deleted_in_class(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        reveal_type(item.value)  # revealed: Literal[1]
+        del item.value
+
+    item.value  # error: [unresolved-attribute]
+    [item.value for _ in range(1)]  # error: [unresolved-attribute]
+    item.value = 2  # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[2]
+```
+
+The invalidation also reaches enclosing scopes through nested class bodies.
+
+```py
+def deleted_in_nested_class(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Outer:
+        class Inner:
+            del item.value
+
+        item.value  # error: [unresolved-attribute]
+
+    item.value  # error: [unresolved-attribute]
+```
+
+A conditional deletion can leave the attribute missing. An unreachable deletion preserves the
+earlier assignment.
+
+```py
+def conditionally_deleted_in_class(item: Item, condition: bool):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if condition:
+            del item.value
+
+    item.value  # error: [unresolved-attribute]
+
+def unreachable_deletion_in_class(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if False:
+            del item.value
+
+    reveal_type(item.value)  # revealed: Literal[1]
+```
+
+### Presence after receiver reassignment in an eager scope
+
+Replacing a member invalidates assignments to attributes of the previous object.
+
+```py
+class Item: ...
+
+class Box:
+    item: Item
+
+def replaced_in_class(box: Box):
+    box.item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        box.item = Item()
+
+    box.item.value  # error: [unresolved-attribute]
+```
+
+### Eager mutations across enclosing loop iterations
+
+A class body can delete an attribute before the next iteration reads it.
+
+```py
+class Item: ...
+
+def deleted_in_loop(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    for _ in range(2):
+        item.value  # error: [unresolved-attribute]
+
+        class Inner:
+            del item.value  # error: [unresolved-attribute]
+```
+
+### Mutations that do not affect enclosing presence
+
+A class-local receiver refers to a different object, so deleting its attribute leaves the enclosing
+scope's assignment intact.
+
+```py
+class Item: ...
+
+item = Item()
+item.value = 1  # error: [unresolved-attribute]
+
+class Inner:
+    item = Item()
+    item.value = 2  # error: [unresolved-attribute]
+    del item.value
+
+reveal_type(item.value)  # revealed: Literal[1]
+```
+
+A loop around the class body also preserves the enclosing receiver's attribute.
+
+```py
+for _ in range(2):
+    class InLoop:
+        item = Item()
+        item.value = 2  # error: [unresolved-attribute]
+        del item.value
+
+    reveal_type(item.value)  # revealed: Literal[1]
+```
+
+A function body does not execute when the function is defined, including class bodies nested inside
+it.
+
+```py
+def outer(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    def deferred():
+        class Inner:
+            del item.value  # error: [unresolved-attribute]
+
+    reveal_type(item.value)  # revealed: Literal[1]
+```
+
 ### Narrowing chain
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -180,6 +180,34 @@ def unreachable_deletion(item: Item):
         reveal_type(item.value)  # revealed: Literal[1]
 ```
 
+### Presence after deletion across eager scopes
+
+A comprehension inside a class body observes deletions made before it runs. An earlier assignment in
+the enclosing function does not establish presence after that deletion.
+
+```py
+class Item: ...
+
+def deleted_before_comprehension(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        del item.value
+        [item.value for _ in range(1)]  # error: [unresolved-attribute]
+```
+
+An unreachable deletion does not prevent the comprehension from using the enclosing assignment.
+
+```py
+def unreachable_deletion_before_comprehension(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if False:
+            del item.value
+        [reveal_type(item.value) for _ in range(1)]  # revealed: Literal[1]
+```
+
 ### Presence after receiver reassignment
 
 Reassigning the receiver discards evidence that an attribute was assigned on the previous object.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -135,6 +135,51 @@ def assigned_or_raised(item: Item, condition: bool):
     reveal_type(item.value)  # revealed: Literal[1]
 ```
 
+### Presence after deletion in an eager scope
+
+An assignment in an enclosing scope establishes presence in an eager class body. Deleting the
+attribute in that class body invalidates this evidence, so a later read reports the missing
+attribute.
+
+```py
+class Item: ...
+
+item = Item()
+item.value = 1  # error: [unresolved-attribute]
+
+class Inner:
+    reveal_type(item.value)  # revealed: Literal[1]
+    del item.value
+    item.value  # error: [unresolved-attribute]
+```
+
+A conditional deletion also invalidates presence after the branches join. Assigning the attribute
+again establishes presence for subsequent reads.
+
+```py
+def conditional_deletion(item: Item, condition: bool):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if condition:
+            del item.value
+        item.value  # error: [unresolved-attribute]
+        item.value = 2  # error: [unresolved-attribute]
+        reveal_type(item.value)  # revealed: Literal[2]
+```
+
+An unreachable deletion does not invalidate presence from the enclosing scope.
+
+```py
+def unreachable_deletion(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if False:
+            del item.value
+        reveal_type(item.value)  # revealed: Literal[1]
+```
+
 ### Presence after receiver reassignment
 
 Reassigning the receiver discards evidence that an attribute was assigned on the previous object.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
@@ -1,5 +1,7 @@
 # Narrowing using `hasattr()`
 
+## Basic checks
+
 The builtin function `hasattr()` can be used to narrow nominal and structural types. This is
 accomplished using an intersection with a synthesized protocol:
 
@@ -97,4 +99,77 @@ def f(x: object):
 
         # error: [unresolved-attribute] "Object of type `<Protocol with members '__qualname__'>` has no attribute `foo`"
         reveal_type(x.foo)  # revealed: Unknown
+```
+
+## Presence at branch joins
+
+An attribute is available after a guard when it either passed the check or was assigned in the
+missing branch. Assigning an undeclared attribute still reports an error, but the subsequent read
+does not repeat it.
+
+```py
+class Item: ...
+
+def initialized(item: Item):
+    if not hasattr(item, "value"):
+        item.value = 1  # error: [invalid-assignment]
+    reveal_type(item.value)  # revealed: object
+```
+
+A successful guard on only one branch does not establish presence after the conditional. Aliases of
+`hasattr` provide the same presence information as the builtin.
+
+```py
+from builtins import hasattr as has_attribute
+
+def partially_checked(item: Item, condition: bool):
+    if condition:
+        assert has_attribute(item, "value")
+        reveal_type(item.value)  # revealed: object
+    item.value  # error: [unresolved-attribute]
+```
+
+## Receiver reassignment
+
+Reassigning the receiver forgets the successful guard's presence information. The new object does
+not inherit the member established for the previous object.
+
+```py
+class Item: ...
+
+def f(item: Item, other: Item):
+    if hasattr(item, "value"):
+        reveal_type(item.value)  # revealed: object
+        item = other
+        item.value  # error: [unresolved-attribute]
+```
+
+## Negative checks and later narrowing
+
+A failed check retains its negative protocol constraint. Later checks can use that constraint to
+rule out a receiver with the attribute, regardless of the order of the checks.
+
+```py
+class WithValue:
+    value = 1
+
+def f(obj: object):
+    if not hasattr(obj, "value") and isinstance(obj, WithValue):
+        reveal_type(obj)  # revealed: Never
+
+    if isinstance(obj, WithValue) and not hasattr(obj, "value"):
+        reveal_type(obj)  # revealed: Never
+```
+
+The constraint also excludes intersections of a remaining union member with a type that has the
+attribute.
+
+```py
+class Other: ...
+
+def g(obj: WithValue | Other):
+    if not hasattr(obj, "value"):
+        reveal_type(obj)  # revealed: Other & ~<Protocol with members 'value'>
+        if isinstance(obj, WithValue):
+            reveal_type(obj)  # revealed: Never
 ```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1840,20 +1840,22 @@ fn place_from_bindings_impl<'db>(
             let narrowed = match narrowing_constraint.constraint() {
                 ScopedNarrowingConstraint::ALWAYS_TRUE => binding_ty,
                 ScopedNarrowingConstraint::ALWAYS_FALSE => Type::Never,
-                constraint => narrowing_projector
-                    .get_or_insert_with(|| {
-                        NarrowingProjector::new(
-                            db,
-                            env,
-                            narrowing_constraint.narrowing_constraints(),
-                            predicates,
-                            narrowing_constraint.predicate_narrowing_targets(),
-                            binding.place(db),
-                            NarrowedPlace::new(binding_ty),
-                        )
-                    })
-                    .narrow(constraint, NarrowedPlace::new(binding_ty))
-                    .ty,
+                constraint => {
+                    narrowing_projector
+                        .get_or_insert_with(|| {
+                            NarrowingProjector::new(
+                                db,
+                                env,
+                                narrowing_constraint.narrowing_constraints(),
+                                predicates,
+                                narrowing_constraint.predicate_narrowing_targets(),
+                                binding.place(db),
+                                NarrowedPlace::new(binding_ty),
+                            )
+                        })
+                        .narrow(constraint, NarrowedPlace::new(binding_ty))
+                        .ty
+                }
             };
             Some((narrowed, static_reachability))
         },

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -14,6 +14,7 @@ use crate::reachability::{
     NarrowingProjector, ReachabilityEvaluationCache, evaluate_reachability,
     evaluate_reachability_with_cache,
 };
+use crate::types::narrow::NarrowedPlace;
 use crate::types::{
     DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
     UnionBuilder, UnionType, binding_type, inferred_declaration, is_discarded_dict_key_assignment,
@@ -1848,10 +1849,11 @@ fn place_from_bindings_impl<'db>(
                             predicates,
                             narrowing_constraint.predicate_narrowing_targets(),
                             binding.place(db),
-                            binding_ty,
+                            NarrowedPlace::new(binding_ty),
                         )
                     })
-                    .narrow(constraint, binding_ty),
+                    .narrow(constraint, NarrowedPlace::new(binding_ty))
+                    .ty,
             };
             Some((narrowed, static_reachability))
         },

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -439,6 +439,13 @@ impl<'db, 'ast> PlaceLoadResolution<'db, 'ast> {
                             eagerly_undefined = true;
                         }
                     }
+                    EnclosingSnapshotResult::FoundUnboundBindings(_) => {
+                        self.constraints
+                            .push(enclosing_file_scope, ConstraintKey::NestedScope(file_scope));
+                        if scope.scope(db).is_eager() {
+                            eagerly_undefined = true;
+                        }
+                    }
                     EnclosingSnapshotResult::FoundBindings(bindings) => {
                         if forwards_to_global {
                             self.crosses_scope_declaration = true;
@@ -548,6 +555,13 @@ impl<'db, 'ast> PlaceLoadResolution<'db, 'ast> {
                     self.constraints.push(
                         FileScopeId::global(),
                         ConstraintKey::NarrowingConstraint(constraint),
+                    );
+                    return None;
+                }
+                EnclosingSnapshotResult::FoundUnboundBindings(_) => {
+                    self.constraints.push(
+                        FileScopeId::global(),
+                        ConstraintKey::NestedScope(current_scope),
                     );
                     return None;
                 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -194,6 +194,7 @@
 //! [bdd]: https://en.wikipedia.org/wiki/Binary_decision_diagram
 
 use crate::ProgramEnvironment;
+use crate::types::narrow::NarrowedPlace;
 use std::cell::RefCell;
 
 use crate::{
@@ -877,17 +878,17 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     }
 }
 
-pub(crate) fn narrow_type_by_constraint<'db>(
+pub(crate) fn narrow_place_by_constraint<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     evaluator: &NarrowingEvaluator<'_, 'db>,
-    base_ty: Type<'db>,
+    base_ty: NarrowedPlace<'db>,
     place: ScopedPlaceId,
-) -> Type<'db> {
+) -> NarrowedPlace<'db> {
     let id = evaluator.constraint();
     match id {
         ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
-        ScopedNarrowingConstraint::ALWAYS_FALSE => return Type::Never,
+        ScopedNarrowingConstraint::ALWAYS_FALSE => return NarrowedPlace::new(Type::Never),
         _ => {}
     }
 
@@ -906,13 +907,17 @@ pub(crate) fn narrow_type_by_constraint<'db>(
 fn apply_accumulated_narrowing<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
-    base_ty: Type<'db>,
+    base_ty: NarrowedPlace<'db>,
     accumulated: Option<NarrowingConstraint<'db>>,
-) -> Type<'db> {
+) -> NarrowedPlace<'db> {
     match accumulated {
-        Some(constraint) => NarrowingConstraint::intersection(base_ty)
-            .merge_constraint_and(constraint)
-            .evaluate_constraint_type(db, env),
+        Some(constraint) => {
+            let mut narrowed = NarrowingConstraint::intersection(base_ty.ty)
+                .merge_constraint_and(constraint)
+                .evaluate_place(db, env);
+            narrowed.known_present |= base_ty.known_present;
+            narrowed
+        }
         None => base_ty,
     }
 }
@@ -948,7 +953,7 @@ enum ProjectedNarrowingEntry<'db> {
     /// A nonterminal suffix. Constant suffixes use the graph's existing terminal IDs instead.
     Checkpoint {
         constraint: ScopedNarrowingConstraint,
-        ty: Type<'db>,
+        ty: NarrowedPlace<'db>,
     },
 }
 
@@ -984,7 +989,7 @@ impl<'db> ProjectedNarrowingGraph<'db> {
     }
 }
 
-/// A cached type together with the terminal shape of its canonical projected graph.
+/// A cached value type and presence together with the terminal shape of its projected graph.
 ///
 /// Joins need to recognize an unconstrained suffix before applying `TypeGuard` replacement.
 /// Similarly, an unreachable graph must be eliminated before a later predicate can replace `Never`.
@@ -992,13 +997,13 @@ impl<'db> ProjectedNarrowingGraph<'db> {
 enum ProjectedNarrowingCheckpoint<'db> {
     Unreachable,
     Unconstrained,
-    Narrowed(Type<'db>),
+    Narrowed(NarrowedPlace<'db>),
 }
 
 impl<'db> ProjectedNarrowingCheckpoint<'db> {
-    fn ty(self, base_ty: Type<'db>) -> Type<'db> {
+    fn place(self, base_ty: NarrowedPlace<'db>) -> NarrowedPlace<'db> {
         match self {
-            Self::Unreachable => Type::Never,
+            Self::Unreachable => NarrowedPlace::new(Type::Never),
             Self::Unconstrained => base_ty,
             Self::Narrowed(ty) => ty,
         }
@@ -1008,16 +1013,17 @@ impl<'db> ProjectedNarrowingCheckpoint<'db> {
 /// Evaluates a stable suffix with the canonical projected-graph evaluator.
 ///
 /// The root is projected directly to avoid querying its own checkpoint. Descendant checkpoints
-/// contribute their cached types and terminal shape. Nonterminal suffixes are expanded locally only
+/// contribute their cached types, presence, and terminal shape. Nonterminal suffixes are expanded only
 /// when simplifying a join requires their predicates.
 #[salsa::tracked(
     returns(copy),
-    cycle_initial = |_, id, _, _, _, _| ProjectedNarrowingCheckpoint::Narrowed(Type::divergent(id)),
+    cycle_initial = |_, id, _, _, _, _| ProjectedNarrowingCheckpoint::Narrowed(NarrowedPlace::new(Type::divergent(id))),
     cycle_fn = |db: &'db dyn Db, cycle, previous: &ProjectedNarrowingCheckpoint<'db>, result: ProjectedNarrowingCheckpoint<'db>, scope: ScopeId<'db>, _, _, base_ty| {
         match result {
-            ProjectedNarrowingCheckpoint::Narrowed(ty) => ProjectedNarrowingCheckpoint::Narrowed(
-                ty.cycle_normalized(db, &ProgramEnvironment::from_scope(scope), previous.ty(base_ty), cycle)
-            ),
+            ProjectedNarrowingCheckpoint::Narrowed(narrowed) => ProjectedNarrowingCheckpoint::Narrowed(NarrowedPlace {
+                ty: narrowed.ty.cycle_normalized(db, &ProgramEnvironment::from_scope(scope), previous.place(base_ty).ty, cycle),
+                known_present: narrowed.known_present,
+            }),
             _ => result,
         }
     },
@@ -1028,7 +1034,7 @@ fn evaluate_projected_narrowing_checkpoint<'db>(
     scope: ScopeId<'db>,
     place: ScopedPlaceId,
     constraint: ScopedNarrowingConstraint,
-    base_ty: Type<'db>,
+    base_ty: NarrowedPlace<'db>,
 ) -> ProjectedNarrowingCheckpoint<'db> {
     let env = ProgramEnvironment::from_scope(scope);
     let use_def = use_def_map(db, scope);
@@ -1058,11 +1064,11 @@ pub(crate) struct NarrowingProjector<'a, 'db> {
     predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
     predicate_narrowing_targets: &'a PredicateNarrowingTargets,
     place: ScopedPlaceId,
-    base_ty: Type<'db>,
-    /// Checkpoint entries retain narrowed types, so projections are specific to the binding type.
-    project_cache: FxHashMap<(ScopedNarrowingConstraint, Type<'db>), ProjectedNarrowingNodeId>,
+    base_ty: NarrowedPlace<'db>,
+    /// Checkpoints retain types and presence, so both must be part of the projection key.
+    project_cache: FxHashMap<(ScopedNarrowingConstraint, NarrowedPlace<'db>), ProjectedNarrowingNodeId>,
     graph: ProjectedNarrowingGraph<'db>,
-    narrowed_cache: FxHashMap<(ProjectedNarrowingNodeId, Type<'db>), Type<'db>>,
+    narrowed_cache: FxHashMap<(ProjectedNarrowingNodeId, NarrowedPlace<'db>), NarrowedPlace<'db>>,
 }
 
 impl<'a, 'db> NarrowingProjector<'a, 'db> {
@@ -1074,7 +1080,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
         predicate_narrowing_targets: &'a PredicateNarrowingTargets,
         place: ScopedPlaceId,
-        base_ty: Type<'db>,
+        base_ty: NarrowedPlace<'db>,
     ) -> Self {
         Self {
             db,
@@ -1094,12 +1100,12 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     pub(crate) fn narrow(
         &mut self,
         constraint: ScopedNarrowingConstraint,
-        base_ty: Type<'db>,
-    ) -> Type<'db> {
+        base_ty: NarrowedPlace<'db>,
+    ) -> NarrowedPlace<'db> {
         self.base_ty = base_ty;
         match constraint {
             ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
-            ScopedNarrowingConstraint::ALWAYS_FALSE => return Type::Never,
+            ScopedNarrowingConstraint::ALWAYS_FALSE => return NarrowedPlace::new(Type::Never),
             _ => {}
         }
 
@@ -1119,13 +1125,13 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     fn narrow_projected(
         &mut self,
         root: ProjectedNarrowingNodeId,
-        base_ty: Type<'db>,
-    ) -> Type<'db> {
+        base_ty: NarrowedPlace<'db>,
+    ) -> NarrowedPlace<'db> {
         if root == ProjectedNarrowingNodeId::ALWAYS_TRUE {
             return base_ty;
         }
         if root == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return Type::Never;
+            return NarrowedPlace::new(Type::Never);
         }
         self.graph.record_reference(root);
 
@@ -1486,14 +1492,14 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     }
 }
 
-/// Evaluates narrowed types over a projected narrowing graph.
+/// Evaluates value types and member presence together over a projected narrowing graph.
 struct ProjectedNarrowingContext<'a, 'db> {
     db: &'db dyn Db,
     env: &'a ProgramEnvironment<'db>,
-    base_ty: Type<'db>,
+    base_ty: NarrowedPlace<'db>,
     graph: &'a ProjectedNarrowingGraph<'db>,
-    /// Caches each shared suffix for the binding type being narrowed.
-    join_cache: &'a mut FxHashMap<(ProjectedNarrowingNodeId, Type<'db>), Type<'db>>,
+    /// Caches each shared suffix for the binding type and presence being narrowed.
+    join_cache: &'a mut FxHashMap<(ProjectedNarrowingNodeId, NarrowedPlace<'db>), NarrowedPlace<'db>>,
 }
 
 impl<'db> ProjectedNarrowingContext<'_, 'db> {
@@ -1501,8 +1507,8 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         !id.is_terminal() && self.graph.joins[id.0]
     }
 
-    /// Evaluates one projected join from its boundary and caches its narrowed suffix type.
-    fn narrow_join(&mut self, id: ProjectedNarrowingNodeId) -> Type<'db> {
+    /// Evaluates one projected join from its boundary and caches its narrowed type and presence.
+    fn narrow_join(&mut self, id: ProjectedNarrowingNodeId) -> NarrowedPlace<'db> {
         let key = (id, self.base_ty);
         if let Some(cached) = self.join_cache.get(&key) {
             return *cached;
@@ -1518,7 +1524,7 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         &mut self,
         id: ProjectedNarrowingNodeId,
         accumulated: Option<NarrowingConstraint<'db>>,
-    ) -> Type<'db> {
+    ) -> NarrowedPlace<'db> {
         let db = self.db;
         if self.is_join(id) {
             // Preserve replacement narrowing order at a join: evaluate the shared suffix once,
@@ -1535,10 +1541,10 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         &mut self,
         id: ProjectedNarrowingNodeId,
         accumulated: Option<NarrowingConstraint<'db>>,
-    ) -> Type<'db> {
+    ) -> NarrowedPlace<'db> {
         let db = self.db;
         if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return Type::Never;
+            return NarrowedPlace::new(Type::Never);
         }
 
         if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
@@ -1572,9 +1578,8 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
                 let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
                 let false_ty = self.narrow(node.if_false, false_accumulated);
 
-                let true_or_uncertain =
-                    UnionType::from_two_elements(db, self.env, true_ty, uncertain_ty);
-                UnionType::from_two_elements(db, self.env, true_or_uncertain, false_ty)
+                let true_or_uncertain = NarrowedPlace::union(db, self.env, true_ty, uncertain_ty);
+                NarrowedPlace::union(db, self.env, true_or_uncertain, false_ty)
             }
         }
     }
@@ -2357,7 +2362,7 @@ class TargetB:
                     &predicates,
                     evaluator.predicate_narrowing_targets(),
                     ScopedPlaceId::Symbol(x),
-                    Type::unknown(),
+                    NarrowedPlace::new(Type::unknown()),
                 );
 
                 assert_eq!(

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -194,7 +194,7 @@
 //! [bdd]: https://en.wikipedia.org/wiki/Binary_decision_diagram
 
 use crate::ProgramEnvironment;
-use crate::types::narrow::NarrowedPlace;
+use crate::types::narrow::{NarrowedPlace, NarrowedPlaceBuilder};
 use std::cell::RefCell;
 
 use crate::{
@@ -1066,7 +1066,8 @@ pub(crate) struct NarrowingProjector<'a, 'db> {
     place: ScopedPlaceId,
     base_ty: NarrowedPlace<'db>,
     /// Checkpoints retain types and presence, so both must be part of the projection key.
-    project_cache: FxHashMap<(ScopedNarrowingConstraint, NarrowedPlace<'db>), ProjectedNarrowingNodeId>,
+    project_cache:
+        FxHashMap<(ScopedNarrowingConstraint, NarrowedPlace<'db>), ProjectedNarrowingNodeId>,
     graph: ProjectedNarrowingGraph<'db>,
     narrowed_cache: FxHashMap<(ProjectedNarrowingNodeId, NarrowedPlace<'db>), NarrowedPlace<'db>>,
 }
@@ -1499,7 +1500,8 @@ struct ProjectedNarrowingContext<'a, 'db> {
     base_ty: NarrowedPlace<'db>,
     graph: &'a ProjectedNarrowingGraph<'db>,
     /// Caches each shared suffix for the binding type and presence being narrowed.
-    join_cache: &'a mut FxHashMap<(ProjectedNarrowingNodeId, NarrowedPlace<'db>), NarrowedPlace<'db>>,
+    join_cache:
+        &'a mut FxHashMap<(ProjectedNarrowingNodeId, NarrowedPlace<'db>), NarrowedPlace<'db>>,
 }
 
 impl<'db> ProjectedNarrowingContext<'_, 'db> {
@@ -1578,8 +1580,11 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
                 let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
                 let false_ty = self.narrow(node.if_false, false_accumulated);
 
-                let true_or_uncertain = NarrowedPlace::union(db, self.env, true_ty, uncertain_ty);
-                NarrowedPlace::union(db, self.env, true_or_uncertain, false_ty)
+                let mut union = NarrowedPlaceBuilder::new(db, self.env);
+                union.add(true_ty);
+                union.add(uncertain_ty);
+                union.add(false_ty);
+                union.build()
             }
         }
     }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -888,7 +888,7 @@ pub(crate) fn narrow_place_by_constraint<'db>(
     let id = evaluator.constraint();
     match id {
         ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
-        ScopedNarrowingConstraint::ALWAYS_FALSE => return NarrowedPlace::new(Type::Never),
+        ScopedNarrowingConstraint::ALWAYS_FALSE => return NarrowedPlace::unreachable(),
         _ => {}
     }
 
@@ -1003,7 +1003,7 @@ enum ProjectedNarrowingCheckpoint<'db> {
 impl<'db> ProjectedNarrowingCheckpoint<'db> {
     fn place(self, base_ty: NarrowedPlace<'db>) -> NarrowedPlace<'db> {
         match self {
-            Self::Unreachable => NarrowedPlace::new(Type::Never),
+            Self::Unreachable => NarrowedPlace::unreachable(),
             Self::Unconstrained => base_ty,
             Self::Narrowed(ty) => ty,
         }
@@ -1106,7 +1106,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         self.base_ty = base_ty;
         match constraint {
             ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
-            ScopedNarrowingConstraint::ALWAYS_FALSE => return NarrowedPlace::new(Type::Never),
+            ScopedNarrowingConstraint::ALWAYS_FALSE => return NarrowedPlace::unreachable(),
             _ => {}
         }
 
@@ -1132,7 +1132,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             return base_ty;
         }
         if root == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return NarrowedPlace::new(Type::Never);
+            return NarrowedPlace::unreachable();
         }
         self.graph.record_reference(root);
 
@@ -1546,7 +1546,7 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
     ) -> NarrowedPlace<'db> {
         let db = self.db;
         if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return NarrowedPlace::new(Type::Never);
+            return NarrowedPlace::unreachable();
         }
 
         if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9960,6 +9960,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             {
                                 let mut binding_ty = binding_type(db, definition);
                                 if definition.kind(db).is_loop_header() {
+                                    has_deleted_binding |=
+                                        !loop_header_reachability(db, definition)
+                                            .deleted_reachability
+                                            .is_always_false();
                                     let fallback_ty = self.loop_header_fallback_type(
                                         definition,
                                         narrowed.ty,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -103,8 +103,8 @@ use crate::types::infer::{
     nearest_enclosing_function, original_class_type,
 };
 use crate::types::match_pattern::{ClassPatternPositionalResult, class_pattern_positional_result};
-use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::narrow::pattern_success_types;
+use crate::types::narrow::{NarrowedPlace, NarrowedPlaceBuilder, NarrowingEvaluatorExtension};
 use crate::types::newtype::NewType;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope};
@@ -9893,13 +9893,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         })
     }
 
-    // Perform narrowing with applicable constraints between the current scope and the enclosing scope.
+    /// Narrow a place's value type and presence using constraints from its load resolution.
     fn narrow_place_with_applicable_constraints(
         &self,
         expr: PlaceExprRef,
-        mut ty: Type<'db>,
+        mut narrowed: NarrowedPlace<'db>,
         constraint_keys: &[(FileScopeId, ConstraintKey)],
-    ) -> Type<'db> {
+    ) -> NarrowedPlace<'db> {
         let db = self.db();
         let env = self.program_environment();
         for (enclosing_scope_file_id, constraint_key) in constraint_keys {
@@ -9914,7 +9914,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.index,
             ) {
                 ApplicableConstraints::UnboundBinding(constraint) => {
-                    ty = constraint.narrow(db, env, ty, place);
+                    narrowed = constraint.narrow_place(db, env, narrowed, place);
                 }
                 // Performs narrowing based on constrained bindings.
                 // This handling must be performed even if narrowing is attempted and failed using `infer_place_load`.
@@ -9934,7 +9934,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ApplicableConstraints::ConstrainedBindings(bindings) => {
                     let reachability_constraints = bindings.reachability_constraints();
                     let predicates = bindings.predicates();
-                    let mut union = UnionBuilder::new(db, env);
+                    let mut union = NarrowedPlaceBuilder::new(db, env);
                     let mut loop_header_fallbacks = FxHashMap::default();
                     for binding in bindings {
                         let static_reachability = evaluate_reachability_with_cache(
@@ -9955,7 +9955,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 if definition.kind(db).is_loop_header() {
                                     let fallback_ty = self.loop_header_fallback_type(
                                         definition,
-                                        ty,
+                                        narrowed.ty,
                                         &mut loop_header_fallbacks,
                                     );
                                     binding_ty = UnionType::from_elements(
@@ -9964,17 +9964,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         [binding_ty, fallback_ty],
                                     );
                                 }
-                                union.add_in_place(
+                                let mut bound = NarrowedPlace::new(binding_ty);
+                                if !definition.kind(db).is_loop_header() {
+                                    bound.known_present = true;
+                                }
+                                union.add(
                                     binding
                                         .narrowing_constraint
-                                        .narrow(db, env, binding_ty, place),
+                                        .narrow_place(db, env, bound, place),
                                 );
                             }
                             DefinitionState::Defined(_)
                             | DefinitionState::Undefined
                             | DefinitionState::Deleted => {
-                                union.add_in_place(
-                                    binding.narrowing_constraint.narrow(db, env, ty, place),
+                                union.add(
+                                    binding
+                                        .narrowing_constraint
+                                        .narrow_place(db, env, narrowed, place),
                                 );
                             }
                         }
@@ -9983,11 +9989,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // Since an unbound binding is recorded even for an undefined place,
                     // this can only happen if the code is unreachable
                     // and therefore it is correct to set the result to `Never`.
-                    ty = union.build();
+                    narrowed = union.build();
                 }
             }
         }
-        ty
+        narrowed
     }
 
     /// Compute the type for reads such as `box.value` or `items[0]` in loop iterations after
@@ -10303,7 +10309,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             place
         } else {
             place.map_type(|ty| {
-                self.narrow_place_with_applicable_constraints(place_expr, ty, narrowing_constraints)
+                self.narrow_place_with_applicable_constraints(
+                    place_expr,
+                    NarrowedPlace::new(ty),
+                    narrowing_constraints,
+                )
+                .ty
             })
         }
     }
@@ -10488,9 +10499,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(place_expr) = PlaceExpr::try_from_expr(target) {
             self.narrow_place_with_applicable_constraints(
                 PlaceExprRef::from(&place_expr),
-                target_ty,
+                NarrowedPlace::new(target_ty),
                 constraint_keys,
             )
+            .ty
         } else {
             target_ty
         }
@@ -10594,10 +10606,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .unwrap_or_else(|error| {
                 error.report_diagnostic(&self.context, value_type, attribute, assigned_type);
                 error.fallback_member(db)
-            })
-            .map_type(|ty| {
-                self.narrow_expr_with_applicable_constraints(attribute, ty, &constraint_keys)
             });
+
+        let fallback_place = if let Some(member) = PlaceExpr::try_from_expr(attribute) {
+            let narrowed =
+                NarrowedPlace::new(fallback_place.place.raw_type().unwrap_or_else(Type::object));
+            self.narrow_place_with_applicable_constraints(
+                (&member).into(),
+                narrowed,
+                &constraint_keys,
+            )
+            .apply_to(fallback_place)
+        } else {
+            fallback_place
+        };
 
         // An augmented assignment also loads its target, but its write validation reports this
         // error. Avoid reporting the same invalid access twice.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9964,10 +9964,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         [binding_ty, fallback_ty],
                                     );
                                 }
-                                let mut bound = NarrowedPlace::new(binding_ty);
-                                if !definition.kind(db).is_loop_header() {
-                                    bound.known_present = true;
-                                }
+                                let bound = NarrowedPlace {
+                                    ty: binding_ty,
+                                    known_present: !definition.kind(db).is_loop_header(),
+                                };
                                 union.add(
                                     binding
                                         .narrowing_constraint

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9902,7 +9902,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> NarrowedPlace<'db> {
         let db = self.db();
         let env = self.program_environment();
+        // Constraints are ordered from inner to outer scopes. A deletion blocks presence
+        // evidence from enclosing scopes, while preserving later assignments or guards in
+        // the inner scope.
+        let mut deleted_in_inner_scope = false;
         for (enclosing_scope_file_id, constraint_key) in constraint_keys {
+            let inner_known_present = narrowed.known_present;
+            let mut has_deleted_binding = false;
             let use_def = self.index.use_def_map(*enclosing_scope_file_id);
             let place_table = self.index.place_table(*enclosing_scope_file_id);
             let place = place_table.place_id(expr).unwrap();
@@ -9947,6 +9953,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         if static_reachability.is_always_false() {
                             continue;
                         }
+                        has_deleted_binding |= matches!(binding.binding, DefinitionState::Deleted);
                         match binding.binding {
                             DefinitionState::Defined(definition)
                                 if !is_discarded_dict_key_assignment(db, definition) =>
@@ -9992,6 +9999,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     narrowed = union.build();
                 }
             }
+            if deleted_in_inner_scope {
+                narrowed.known_present = inner_known_present;
+            }
+            deleted_in_inner_scope |= has_deleted_binding;
         }
         narrowed
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9960,10 +9960,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             {
                                 let mut binding_ty = binding_type(db, definition);
                                 if definition.kind(db).is_loop_header() {
+                                    let header = loop_header_reachability(db, definition);
+                                    // The loop prepass can conservatively include a member that
+                                    // is only mutated on a class-local receiver. An empty header
+                                    // contributes no path to the join, including for presence.
+                                    if header.reachable_bindings.is_empty()
+                                        && header.deleted_reachability.is_always_false()
+                                    {
+                                        continue;
+                                    }
                                     has_deleted_binding |=
-                                        !loop_header_reachability(db, definition)
-                                            .deleted_reachability
-                                            .is_always_false();
+                                        !header.deleted_reachability.is_always_false();
                                     let fallback_ty = self.loop_header_fallback_type(
                                         definition,
                                         narrowed.ty,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -718,8 +718,10 @@ impl ClassInfoConstraintFunction {
 }
 
 /// A place's value type and positive evidence that it is present.
-/// Without that evidence, ordinary member lookup determines definedness. `Never` represents an
-/// unreachable path, which contributes neither a value type nor presence at a control-flow join.
+///
+/// `known_present = false` leaves definedness to ordinary member lookup; it does not establish
+/// absence. `Never` represents an unreachable path, which contributes neither a value type nor
+/// presence at a control-flow join.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct NarrowedPlace<'db> {
     pub(crate) ty: Type<'db>,
@@ -734,23 +736,18 @@ impl<'db> NarrowedPlace<'db> {
         }
     }
 
-    pub(crate) fn union(
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        left: Self,
-        right: Self,
-    ) -> Self {
-        Self {
-            ty: UnionType::from_two_elements(db, env, left.ty, right.ty),
-            known_present: match (left.ty.is_never(), right.ty.is_never()) {
-                (true, _) => right.known_present,
-                (_, true) => left.known_present,
-                _ => left.known_present && right.known_present,
-            },
-        }
-    }
-
-    /// Apply flow facts after ordinary lookup, preserving its qualifiers and error recovery.
+    /// Apply flow facts after ordinary lookup and write validation, preserving lookup qualifiers.
+    ///
+    /// An assignment can establish presence for error recovery even when the write is invalid:
+    ///
+    /// ```python
+    /// class C: ...
+    /// c = C()
+    /// c.value = 1  # Reports an undeclared attribute.
+    /// c.value      # Does not repeat the missing-attribute error.
+    /// ```
+    ///
+    /// An unreachable place becomes a defined `Never` to avoid missing-attribute errors there.
     pub(crate) fn apply_to(self, mut member: PlaceAndQualifiers<'db>) -> PlaceAndQualifiers<'db> {
         member = member.map_type(|_| self.ty);
         member.place = match (self.ty, self.known_present, member.place) {
@@ -853,6 +850,7 @@ impl<'db> Conjunctions<'db> {
         self
     }
 
+    /// Apply conjunctions in order, tracking presence independently of constraints on the value.
     fn evaluate_place(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> NarrowedPlace<'db> {
         if let [NarrowingOperation::Intersection(ty) | NarrowingOperation::GenericFiltering(ty)] =
             &*self.conjuncts
@@ -5456,6 +5454,7 @@ fn all_matching_tuple_elements_have_literal_types<'db>(
 }
 
 pub(crate) trait NarrowingEvaluatorExtension<'db> {
+    /// Apply this evaluator's constraints to a place's value type and positive presence evidence.
     fn narrow_place(
         &self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1292,11 +1292,7 @@ impl<'db> NarrowingConstraint<'db> {
     }
 
     /// Evaluate the type, disregarding whether the constraint also establishes member presence.
-    pub(crate) fn evaluate_constraint_type(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Type<'db> {
+    fn evaluate_constraint_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
         self.evaluate_place(db, env).ty
     }
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry};
 
-use crate::place::loop_header_reachability;
+use crate::place::{Definedness, Place, PlaceAndQualifiers, loop_header_reachability};
 use crate::reachability::{
-    binding_reachability, narrow_type_by_constraint, type_narrowed_by_previous_patterns,
+    binding_reachability, narrow_place_by_constraint, type_narrowed_by_previous_patterns,
 };
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
@@ -717,18 +717,99 @@ impl ClassInfoConstraintFunction {
     }
 }
 
+/// A place's value type and positive evidence that it is present.
+/// Without that evidence, ordinary member lookup determines definedness. `Never` represents an
+/// unreachable path, which contributes neither a value type nor presence at a control-flow join.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub(crate) struct NarrowedPlace<'db> {
+    pub(crate) ty: Type<'db>,
+    pub(crate) known_present: bool,
+}
+
+impl<'db> NarrowedPlace<'db> {
+    pub(crate) fn new(ty: Type<'db>) -> Self {
+        Self {
+            ty,
+            known_present: false,
+        }
+    }
+
+    pub(crate) fn union(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        left: Self,
+        right: Self,
+    ) -> Self {
+        Self {
+            ty: UnionType::from_two_elements(db, env, left.ty, right.ty),
+            known_present: match (left.ty.is_never(), right.ty.is_never()) {
+                (true, _) => right.known_present,
+                (_, true) => left.known_present,
+                _ => left.known_present && right.known_present,
+            },
+        }
+    }
+
+    /// Apply flow facts after ordinary lookup, preserving its qualifiers and error recovery.
+    pub(crate) fn apply_to(self, mut member: PlaceAndQualifiers<'db>) -> PlaceAndQualifiers<'db> {
+        member = member.map_type(|_| self.ty);
+        member.place = match (self.ty, self.known_present, member.place) {
+            (Type::Never, _, _) => Place::bound(Type::Never),
+            (_, true, Place::Defined(defined)) => {
+                Place::Defined(defined.with_definedness(Definedness::AlwaysDefined))
+            }
+            (_, true, Place::Undefined) => Place::bound(self.ty),
+            (_, false, place) => place,
+        };
+        member
+    }
+}
+
+/// Join value types and retain only presence facts shared by all reachable alternatives.
+pub(crate) struct NarrowedPlaceBuilder<'db> {
+    types: UnionBuilder<'db>,
+    known_present: bool,
+}
+
+impl<'db> NarrowedPlaceBuilder<'db> {
+    pub(crate) fn new(db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Self {
+        Self {
+            types: UnionBuilder::new(db, env),
+            known_present: false,
+        }
+    }
+
+    pub(crate) fn add(&mut self, place: NarrowedPlace<'db>) {
+        if !place.ty.is_never() {
+            self.known_present =
+                (self.types.is_empty() || self.known_present) && place.known_present;
+        }
+        self.types.add_in_place(place.ty);
+    }
+
+    pub(crate) fn build(self) -> NarrowedPlace<'db> {
+        NarrowedPlace {
+            ty: self.types.build(),
+            known_present: self.known_present,
+        }
+    }
+}
+
 #[derive(Hash, PartialEq, Debug, Eq, Clone, Copy, get_size2::GetSize, salsa::SalsaValue)]
 enum NarrowingOperation<'db> {
     /// Narrow the subject by intersecting it directly with this type.
     Intersection(Type<'db>),
     /// Narrow to this generic type while preserving type arguments already known about the subject.
     GenericFiltering(Type<'db>),
+    /// Establish presence of the member place itself, independently of its value type.
+    MemberPresent,
 }
 
 impl<'db> NarrowingOperation<'db> {
     const fn ty(self) -> Type<'db> {
         match self {
             Self::Intersection(ty) | Self::GenericFiltering(ty) => ty,
+            Self::MemberPresent => Type::object(),
         }
     }
 }
@@ -772,22 +853,28 @@ impl<'db> Conjunctions<'db> {
         self
     }
 
-    fn evaluate_constraint_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        if self.conjuncts.len() == 1 {
-            return self.conjuncts[0].ty();
+    fn evaluate_place(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> NarrowedPlace<'db> {
+        if let [NarrowingOperation::Intersection(ty) | NarrowingOperation::GenericFiltering(ty)] =
+            &*self.conjuncts
+        {
+            return NarrowedPlace::new(*ty);
         }
-
         // Collapse shared union arms before distributing the next constraint over them.
-        self.conjuncts
-            .into_iter()
-            .fold(Type::object(), |accumulated, conjunct| match conjunct {
+        let mut place = NarrowedPlace::new(Type::object());
+        for operation in self.conjuncts {
+            match operation {
                 NarrowingOperation::Intersection(ty) => {
-                    IntersectionType::from_two_elements(db, env, accumulated, ty)
+                    place.ty = IntersectionType::from_two_elements(db, env, place.ty, ty);
                 }
                 NarrowingOperation::GenericFiltering(ty) => {
-                    filter_generic_narrowing_constraint(db, env, accumulated, ty)
+                    place.ty = filter_generic_narrowing_constraint(db, env, place.ty, ty);
                 }
-            })
+                NarrowingOperation::MemberPresent => {
+                    place.known_present = true;
+                }
+            }
+        }
+        place
     }
 }
 
@@ -1092,6 +1179,15 @@ pub(crate) struct NarrowingConstraint<'db> {
 }
 
 impl<'db> NarrowingConstraint<'db> {
+    fn member_present() -> Self {
+        Self {
+            intersection_disjuncts: smallvec![Conjunctions {
+                conjuncts: smallvec![NarrowingOperation::MemberPresent]
+            }],
+            replacement_disjuncts: smallvec![],
+        }
+    }
+
     /// Create an "intersection" constraint: the previous type will be
     /// intersected with this constraint
     pub(crate) fn intersection(constraint: Type<'db>) -> Self {
@@ -1180,23 +1276,30 @@ impl<'db> NarrowingConstraint<'db> {
             .extend(other.replacement_disjuncts);
     }
 
-    /// Evaluate the type this effectively constrains to
-    ///
-    /// Forgets whether each constraint originated from a `replacement` disjunct or not
+    /// Evaluate the type and member-presence constraints together.
+    pub(crate) fn evaluate_place(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> NarrowedPlace<'db> {
+        let mut union = NarrowedPlaceBuilder::new(db, env);
+        for conjunction in self
+            .replacement_disjuncts
+            .into_iter()
+            .chain(self.intersection_disjuncts)
+        {
+            union.add(conjunction.evaluate_place(db, env));
+        }
+        union.build()
+    }
+
+    /// Evaluate the type, disregarding whether the constraint also establishes member presence.
     pub(crate) fn evaluate_constraint_type(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
-        let mut union = UnionBuilder::new(db, env);
-        for conjunctions in self
-            .replacement_disjuncts
-            .into_iter()
-            .chain(self.intersection_disjuncts)
-        {
-            union.add_in_place(conjunctions.evaluate_constraint_type(db, env));
-        }
-        union.build()
+        self.evaluate_place(db, env).ty
     }
 }
 
@@ -4350,14 +4453,22 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         [(attr, Type::object())],
                     );
 
-                    return Some(NarrowingConstraints::from_iter([(
+                    let mut constraints = NarrowingConstraints::from_iter([(
                         place,
                         NarrowingConstraint::intersection(constraint.negate_if(
                             db,
                             &self.env,
                             !is_positive,
                         )),
-                    )]));
+                    )]);
+                    if is_positive
+                        && let Some(member) =
+                            PlaceExpr::attribute((&expr_call.arguments.args[0]).into(), attr)
+                        && let Some(member_place) = self.places().place_id(&member)
+                    {
+                        constraints.insert(member_place, NarrowingConstraint::member_present());
+                    }
+                    return Some(constraints);
                 }
 
                 let function = function.into_classinfo_constraint_function()?;
@@ -5345,16 +5456,14 @@ fn all_matching_tuple_elements_have_literal_types<'db>(
 }
 
 pub(crate) trait NarrowingEvaluatorExtension<'db> {
-    fn narrow(
+    fn narrow_place(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        base_type: Type<'db>,
+        base: NarrowedPlace<'db>,
         place: ScopedPlaceId,
-    ) -> Type<'db>;
-}
+    ) -> NarrowedPlace<'db>;
 
-impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
     fn narrow(
         &self,
         db: &'db dyn Db,
@@ -5362,6 +5471,19 @@ impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
         base_type: Type<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        narrow_type_by_constraint(db, env, self, base_type, place)
+        self.narrow_place(db, env, NarrowedPlace::new(base_type), place)
+            .ty
+    }
+}
+
+impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
+    fn narrow_place(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        base: NarrowedPlace<'db>,
+        place: ScopedPlaceId,
+    ) -> NarrowedPlace<'db> {
+        narrow_place_by_constraint(db, env, self, base, place)
     }
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -720,8 +720,8 @@ impl ClassInfoConstraintFunction {
 /// A place's value type and positive evidence that it is present.
 ///
 /// `known_present = false` leaves definedness to ordinary member lookup; it does not establish
-/// absence. `Never` represents an unreachable path, which contributes neither a value type nor
-/// presence at a control-flow join.
+/// absence. Unreachable paths have type `Never` and contribute neither a value type nor presence
+/// at a control-flow join.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct NarrowedPlace<'db> {
     pub(crate) ty: Type<'db>,
@@ -736,6 +736,14 @@ impl<'db> NarrowedPlace<'db> {
         }
     }
 
+    /// An unreachable path contributes neither values nor missingness at a control-flow join.
+    pub(crate) fn unreachable() -> Self {
+        Self {
+            ty: Type::Never,
+            known_present: true,
+        }
+    }
+
     /// Apply flow facts after ordinary lookup and write validation, preserving lookup qualifiers.
     ///
     /// An assignment can establish presence for error recovery even when the write is invalid:
@@ -747,16 +755,16 @@ impl<'db> NarrowedPlace<'db> {
     /// c.value      # Does not repeat the missing-attribute error.
     /// ```
     ///
-    /// An unreachable place becomes a defined `Never` to avoid missing-attribute errors there.
+    /// A `Never`-valued member can still be missing; only positive presence evidence changes
+    /// definedness.
     pub(crate) fn apply_to(self, mut member: PlaceAndQualifiers<'db>) -> PlaceAndQualifiers<'db> {
         member = member.map_type(|_| self.ty);
-        member.place = match (self.ty, self.known_present, member.place) {
-            (Type::Never, _, _) => Place::bound(Type::Never),
-            (_, true, Place::Defined(defined)) => {
+        member.place = match (self.known_present, member.place) {
+            (true, Place::Defined(defined)) => {
                 Place::Defined(defined.with_definedness(Definedness::AlwaysDefined))
             }
-            (_, true, Place::Undefined) => Place::bound(self.ty),
-            (_, false, place) => place,
+            (true, Place::Undefined) => Place::bound(self.ty),
+            (false, place) => place,
         };
         member
     }
@@ -772,15 +780,12 @@ impl<'db> NarrowedPlaceBuilder<'db> {
     pub(crate) fn new(db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Self {
         Self {
             types: UnionBuilder::new(db, env),
-            known_present: false,
+            known_present: true,
         }
     }
 
     pub(crate) fn add(&mut self, place: NarrowedPlace<'db>) {
-        if !place.ty.is_never() {
-            self.known_present =
-                (self.types.is_empty() || self.known_present) && place.known_present;
-        }
+        self.known_present &= place.known_present;
         self.types.add_in_place(place.ty);
     }
 


### PR DESCRIPTION
## Summary

Previously, we could report a missing attribute immediately after assigning it:

```python
import logging

logging.TRACE = 9  # Before and after: unresolved-attribute.
logging.TRACE  # Before: unresolved-attribute. After: no error.
```

We now use assignments and successful `hasattr` checks to establish that an attribute is available for later reads. We retain that information across a branch join only when every reachable path establishes presence. The assignment above is still rejected because `logging` does not declare `TRACE`, but the following read no longer repeats the error.

Receiver narrowing is unchanged, including the negative protocol constraints from failed `hasattr` checks. We do not add definite-absence read errors or infer which attributes a method call initializes.
