### PR TITLE
[ty] Add assert_never fixes for redundant final elif branches

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4421,6 +4421,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 }
             }
             ast::Stmt::If(node) => {
+                let final_elif_test = node
+                    .elif_else_clauses
+                    .last()
+                    .and_then(|clause| clause.test.as_ref());
+                let mut chain_start = final_elif_test.map(|_| self.flow_snapshot());
                 self.visit_condition(&node.test);
                 let condition_flow_snapshot = self.flow_snapshot_for_condition(&node.test);
                 let mut falsy = if let Some(snapshots) = condition_flow_snapshot.into_branches() {
@@ -4475,7 +4480,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.record_negated_reachability_constraint(last_reachability_constraint);
 
                     let next_falsy = if let Some(elif_test) = clause_test {
+                        if final_elif_test.is_some_and(|test| test.range() == elif_test.range()) {
+                            self.current_use_def_map_mut()
+                                .set_if_chain_start(chain_start.take());
+                        }
                         self.visit_condition(elif_test);
+                        self.current_use_def_map_mut().set_if_chain_start(None);
                         // A test expression is evaluated whether the branch is taken or not
                         let condition_flow_snapshot = self.flow_snapshot_for_condition(elif_test);
                         let next_falsy =

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -33,8 +33,8 @@ use scope::{NodeWithScopeKey, NodeWithScopeRef, Scope, ScopeId, ScopeKind, Scope
 use symbol::ScopedSymbolId;
 pub use use_def::{
     ApplicableConstraints, BindingWithConstraints, BindingWithConstraintsIterator,
-    DeclarationWithConstraint, DeclarationsIterator, LiveBinding, LoopHeaderId, NarrowingEvaluator,
-    PredicateNarrowingTargets, ScopedDefinitionId, UseDefMap,
+    BindingsSnapshotId, DeclarationWithConstraint, DeclarationsIterator, LiveBinding, LoopHeaderId,
+    NarrowingEvaluator, PredicateNarrowingTargets, ScopedDefinitionId, UseDefMap,
 };
 use use_def::{EnclosingSnapshotKey, ScopedEnclosingSnapshotId};
 

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -41,6 +41,7 @@ use crate::ast_ids::ScopedUseId;
 use crate::predicate::ScopedPredicateId;
 use crate::rank::{RankBitBox, RankBitBoxVec};
 use crate::scope::FileScopeId;
+use crate::use_def::BindingsSnapshotId;
 
 /// The ID of a narrowing formula within one scope.
 ///
@@ -425,6 +426,7 @@ pub enum ConstraintKey {
     NarrowingConstraint(ScopedNarrowingConstraint),
     NestedScope(FileScopeId),
     UseId(ScopedUseId),
+    Snapshot(BindingsSnapshotId),
 }
 
 #[cfg(test)]

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -303,6 +303,10 @@ pub struct LoopHeaderId;
 #[derive(get_size2::GetSize, salsa::SalsaValue)]
 struct InternedBindingsId;
 
+/// A retained set of bindings and constraints at a point in one scope's control flow.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BindingsSnapshotId(InternedBindingsId);
+
 /// Uniquely identifies an interned [`Declarations`] entry in [`UseDefMap::interned_declarations`].
 #[newtype_index]
 #[derive(get_size2::GetSize, salsa::SalsaValue)]
@@ -651,6 +655,9 @@ struct UseDefMapExtra {
     /// [`Bindings`] reaching a [`ScopedUseId`].
     bindings_by_use: FrozenIndexVec<ScopedUseId, InternedBindingsId>,
 
+    /// Bindings before an `if` chain, for uses in its final `elif` condition.
+    if_chain_start_by_use: FrozenMap<ScopedUseId, InternedBindingsId>,
+
     /// [`Bindings`] for each member reaching a [`ScopedUseId`].
     ///
     /// This is only used for kwargs expressions, whose corresponding `bindings_by_use` entry
@@ -962,6 +969,27 @@ impl<'db> UseDefMap<'db> {
         )
     }
 
+    /// Return the state before the enclosing `if` chain for a use in its final `elif` condition.
+    /// No snapshot is recorded when the chain ends with an `else` branch.
+    pub fn if_chain_start_for_use(&self, use_id: ScopedUseId) -> Option<BindingsSnapshotId> {
+        self.extra
+            .as_deref()?
+            .if_chain_start_by_use
+            .get(&use_id)
+            .copied()
+            .map(BindingsSnapshotId)
+    }
+
+    pub fn bindings_at_snapshot(
+        &self,
+        snapshot: BindingsSnapshotId,
+    ) -> BindingWithConstraintsIterator<'_, 'db> {
+        self.bindings_iterator(
+            &self.interned_bindings[snapshot.0],
+            BoundnessAnalysis::BasedOnUnboundVisibility,
+        )
+    }
+
     pub fn multi_bindings_at_use(
         &self,
         use_id: ScopedUseId,
@@ -1007,6 +1035,9 @@ impl<'db> UseDefMap<'db> {
             }
             ConstraintKey::UseId(use_id) => {
                 ApplicableConstraints::ConstrainedBindings(self.bindings_at_use(use_id))
+            }
+            ConstraintKey::Snapshot(snapshot) => {
+                ApplicableConstraints::ConstrainedBindings(self.bindings_at_snapshot(snapshot))
             }
         }
     }
@@ -1887,6 +1918,11 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Restorable identity of the bindings visible to exception handlers.
     checkpoint_state: ExceptionCheckpointState,
 
+    /// Active only while visiting the final `elif` condition of an `if` chain without an `else`.
+    if_chain_start: Option<FlowSnapshot>,
+
+    if_chain_start_by_use: Vec<(ScopedUseId, Bindings)>,
+
     /// Live bindings for each so-far-recorded definition and, for binding-only definitions, the
     /// live declarations.
     definitions_by_definition:
@@ -1935,6 +1971,8 @@ impl<'db> UseDefMapBuilder<'db> {
             boolean_test_roots: Vec::new(),
             checkpoint_flow: ScopedReachabilityConstraintId::ALWAYS_TRUE,
             checkpoint_state: ExceptionCheckpointState::default(),
+            if_chain_start: None,
+            if_chain_start_by_use: Vec::new(),
             definitions_by_definition: FxHashMap::default(),
             symbol_states: IndexVec::new(),
             member_states: IndexVec::new(),
@@ -2533,6 +2571,27 @@ impl<'db> UseDefMapBuilder<'db> {
     }
 
     pub(super) fn record_use(&mut self, place: ScopedPlaceId, use_id: ScopedUseId) {
+        if let Some(snapshot) = &mut self.if_chain_start {
+            let state = match place {
+                ScopedPlaceId::Symbol(symbol) => snapshot.symbol_states.get_mut(symbol),
+                ScopedPlaceId::Member(member) => snapshot.member_states.get_mut(member),
+            };
+            let bindings = state.map_or_else(
+                || Bindings::unbound(snapshot.reachability),
+                |state| {
+                    self.pending_reachability
+                        .materialize_ref_at_use(
+                            state,
+                            snapshot.pending_reachability,
+                            &mut self.reachability_constraints,
+                        )
+                        .bindings()
+                        .clone()
+                },
+            );
+            self.if_chain_start_by_use.push((use_id, bindings));
+        }
+
         let pending = self.pending_reachability.current;
         let place_state =
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
@@ -2544,6 +2603,10 @@ impl<'db> UseDefMapBuilder<'db> {
         let bindings = place_state.bindings().clone();
 
         self.record_use_bindings(bindings, use_id);
+    }
+
+    pub(super) fn set_if_chain_start(&mut self, snapshot: Option<FlowSnapshot>) {
+        self.if_chain_start = snapshot;
     }
 
     pub(super) fn record_multi_use(
@@ -2904,6 +2967,7 @@ impl<'db> UseDefMapBuilder<'db> {
             .count();
         let interned_bindings_capacity = self.definitions_by_definition.len()
             + self.bindings_by_use.len()
+            + self.if_chain_start_by_use.len()
             + self.enclosing_snapshots.len()
             + place_state_count;
         let interned_declarations_capacity =
@@ -2922,6 +2986,12 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let bindings_by_use =
             Self::intern_bindings_by_use(self.bindings_by_use, &mut place_state_interner);
+        let if_chain_start_by_use = FrozenMap::from_entries(
+            self.if_chain_start_by_use
+                .into_iter()
+                .map(|(use_id, bindings)| (use_id, place_state_interner.intern_bindings(&bindings)))
+                .collect(),
+        );
         let symbol_states = self
             .symbol_states
             .into_iter()
@@ -3004,6 +3074,7 @@ impl<'db> UseDefMapBuilder<'db> {
         .then(|| {
             Box::new(UseDefMapExtra {
                 bindings_by_use: bindings_by_use.into(),
+                if_chain_start_by_use,
                 multi_bindings_by_use,
                 member_states,
                 enclosing_snapshots: enclosing_snapshots.into(),

--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -2665,6 +2665,866 @@ def f(value: tuple[int, int, int, int, int, int, int, int, int]):
         pass
 ```
 
+## Adding an exhaustiveness check after a redundant final `elif`
+
+```toml
+[environment]
+python-version = "3.11"
+
+[rules]
+redundant-condition-strict = "error"
+```
+
+When a final `elif` condition is always true, an `else` branch calling `assert_never` makes the
+exhaustiveness check explicit. The argument is a variable whose type is a union before the chain
+narrows it, and which narrows to `Never` when the final condition is false. The original condition
+and body are preserved:
+
+```py
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+        print(value + 1)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + from typing import assert_never
+2  | def exhaustive(value: str | int):
+--------------------------------------------------------------------------------
+7  |         print(value + 1)
+8  +     else:
+9  +         assert_never(value)
+10 | # fmt: off
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+The assertion uses the existing indentation of the branch body, including unconventional
+indentation:
+
+```py
+# fmt: off
+def unconventional_indentation(value: str | int):
+  if isinstance(value, str):
+    print(value)
+  elif isinstance(value, int):  # snapshot: redundant-condition-strict
+    print(value)
+# fmt: on
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:11:8
+   |
+11 |   elif isinstance(value, int):  # snapshot: redundant-condition-strict
+   |        ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + from typing import assert_never
+2  | def exhaustive(value: str | int):
+--------------------------------------------------------------------------------
+13 |     print(value)
+14 +   else:
+15 +     assert_never(value)
+16 | # fmt: on
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+Comments inside a parenthesized condition, after the branch header, and in its body are all
+preserved. Trailing body comments remain before the new `else`:
+
+```py
+def commented_condition(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif (
+        # Explain the defensive runtime check.
+        isinstance(value, int)  # snapshot: redundant-condition-strict
+    ):  # Preserve this header comment.
+        # Preserve this body comment.
+        print(value)
+        # Preserve this trailing body comment.
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:19:9
+   |
+19 |         isinstance(value, int)  # snapshot: redundant-condition-strict
+   |         ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + from typing import assert_never
+2  | def exhaustive(value: str | int):
+--------------------------------------------------------------------------------
+24 |         # Preserve this trailing body comment.
+25 +     else:
+26 +         assert_never(value)
+27 | def assignment_expression(value: str | int):
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+No fix is offered for an assignment expression: the new branch could observe a variable whose value
+the condition has changed:
+
+```py
+def assignment_expression(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif matched := isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(matched)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:27:10
+   |
+27 |     elif matched := isinstance(value, int):  # snapshot: redundant-condition-strict
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+```
+
+If the branch body begins on the same line as its header, the new `else` still goes on a separate
+line. Its body uses the file's indentation style:
+
+```py
+# fmt: off
+def inline_branch(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int): print(value)  # snapshot: redundant-condition-strict
+# fmt: on
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:33:10
+   |
+33 |     elif isinstance(value, int): print(value)  # snapshot: redundant-condition-strict
+   |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + from typing import assert_never
+2  | def exhaustive(value: str | int):
+--------------------------------------------------------------------------------
+34 |     elif isinstance(value, int): print(value)  # snapshot: redundant-condition-strict
+35 +     else:
+36 +         assert_never(value)
+37 | # fmt: on
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+A multiline header can also have a body on the same line as its closing colon:
+
+```py
+# fmt: off
+def multiline_inline_branch(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif (
+        isinstance(value, int)  # snapshot: redundant-condition-strict
+    ): print(value)
+# fmt: on
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:40:9
+   |
+40 |         isinstance(value, int)  # snapshot: redundant-condition-strict
+   |         ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + from typing import assert_never
+2  | def exhaustive(value: str | int):
+--------------------------------------------------------------------------------
+42 |     ): print(value)
+43 +     else:
+44 +         assert_never(value)
+45 | # fmt: on
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+Parser recovery can produce an `elif` branch with no statements. The redundant condition is still
+reported, but no autofix is offered for the incomplete branch:
+
+```py
+def empty_branch(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    # error: [invalid-syntax] "Expected an indented block after `elif` clause"
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:47:10
+   |
+47 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+   |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+```
+
+A redundant check on a variable whose type is `int` before the chain is still reported, but it does
+not receive an exhaustiveness fix: there is no union of alternatives to exhaust.
+
+```py
+def non_boolean_first_condition(items: list[int], value: int):
+    if items:
+        print(items)
+    elif value is not None:  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:51:10
+   |
+51 |     elif value is not None:  # snapshot: redundant-condition-strict
+   |          -----^^^^^^^^^^^^
+   |          |
+   |          Has type `int`
+```
+
+## Exhaustiveness checks after explicit line continuations
+
+The new `else` follows the blank line so it is not part of the continued statement.
+
+<!-- fmt:off -->
+
+```py
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value) \
+
+    print("done")
+```
+
+<!-- fmt:on -->
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + from typing import assert_never
+2  | def exhaustive(value: str | int):
+--------------------------------------------------------------------------------
+7  |
+8  +     else:
+9  +         assert_never(value)
+10 |     print("done")
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Exhaustiveness checks for inferred unions
+
+The union can also be inferred from assignments. An unrelated condition before the first check of
+`value` does not prevent the fix.
+
+```py
+def inferred(flag: bool, enabled: bool):
+    if flag:
+        value = 1
+    else:
+        value = None
+
+    if enabled:
+        print("enabled")
+    elif value is None:
+        print("None")
+    elif value is not None:  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:11:10
+   |
+11 |     elif value is not None:  # snapshot: redundant-condition-strict
+   |          -----^^^^^^^^^^^^
+   |          |
+   |          Has type `Literal[1]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + from typing import assert_never
+2  | def inferred(flag: bool, enabled: bool):
+--------------------------------------------------------------------------------
+12 |     elif value is not None:  # snapshot: redundant-condition-strict
+   -         print(value)
+13 +         print(value)
+14 +     else:
+15 +         assert_never(value)
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Exhaustiveness checks with an aliased condition
+
+A condition stored in a variable can narrow `value` before its first use in the chain. The fix is
+still offered because `value` has a union type before the chain starts.
+
+```py
+def aliased(value: int | None):
+    is_none = value is None
+
+    if is_none:
+        print("None")
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:6:10
+  |
+6 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + from typing import assert_never
+2  | def aliased(value: int | None):
+--------------------------------------------------------------------------------
+7  |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+   -         print(value)
+8  +         print(value)
+9  +     else:
+10 +         assert_never(value)
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## No exhaustiveness check for a type narrowed before the chain
+
+Narrowing before the chain is preserved. Here, `value` already has type `int` when the chain starts,
+so no exhaustiveness fix is offered despite its union annotation.
+
+```py
+def narrowed_before_chain(value: int | None, flag: bool):
+    assert value is not None
+
+    if flag:
+        print("flag")
+    elif value is not None:  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:6:10
+  |
+6 |     elif value is not None:  # snapshot: redundant-condition-strict
+  |          -----^^^^^^^^^^^^
+  |          |
+  |          Has type `int`
+```
+
+## Exhaustiveness checks for captured variables
+
+The type of a captured variable is also checked before the chain narrows it.
+
+```py
+def enclosing(value: int | None):
+    def inner():
+        if value is None:
+            print("None")
+        elif isinstance(value, int):  # snapshot: redundant-condition-strict
+            print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:5:14
+  |
+5 |         elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |              ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+  |
+1 + from typing import assert_never
+2 | def enclosing(value: int | None):
+--------------------------------------------------------------------------------
+6 |         elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  -             print(value)
+7 +             print(value)
+8 +         else:
+9 +             assert_never(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## No exhaustiveness check for a captured variable narrowed before the chain
+
+Narrowing before the chain also applies to captured variables. Although the outer parameter has a
+union type, the assertion narrows it to `int` before the inner function's chain starts.
+
+```py
+def enclosing_narrowed(value: int | None):
+    def inner(flag: bool):
+        assert value is not None
+
+        if flag:
+            print("flag")
+        elif value is not None:  # snapshot: redundant-condition-strict
+            print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:7:14
+  |
+7 |         elif value is not None:  # snapshot: redundant-condition-strict
+  |              -----^^^^^^^^^^^^
+  |              |
+  |              Has type `int`
+```
+
+## Exhaustiveness checks for comparisons
+
+Equality comparisons can narrow a literal union to `Never`. The new assertion reuses the tested
+variable rather than evaluating the comparison again:
+
+```py
+from typing import Literal
+
+def exhaustive(value: Literal["a", "b"]):
+    if value == "a":
+        print(value)
+    elif "b" == value:  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:6:10
+  |
+6 |     elif "b" == value:  # snapshot: redundant-condition-strict
+  |          ---^^^^-----
+  |          |      |
+  |          |      Has type `Literal["b"]`
+  |          Has type `Literal["b"]`
+help: Add an `else` branch that calls `assert_never`
+  |
+  - from typing import Literal
+1 + from typing import Literal, assert_never
+2 |
+--------------------------------------------------------------------------------
+6 |     elif "b" == value:  # snapshot: redundant-condition-strict
+  -         print(value)
+7 +         print(value)
+8 +     else:
+9 +         assert_never(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Exhaustiveness checks with imported aliases
+
+An existing runtime import of `assert_never` can be reused, including an alias:
+
+```py
+from typing import assert_never as unreachable
+
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:6:10
+  |
+6 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+  |
+6 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  -         print(value)
+7 +         print(value)
+8 +     else:
+9 +         unreachable(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Exhaustiveness checks with qualified imports
+
+A qualified module import can also be reused. The assertion goes after the entire branch body,
+including nested statements:
+
+```py
+import typing as t
+
+def exhaustive(value: str | int, flag: bool):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        if flag:
+            print(value)
+        # This comment belongs to the `elif` body.
+    print("done")
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:6:10
+  |
+6 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+9  |         # This comment belongs to the `elif` body.
+10 +     else:
+11 +         t.assert_never(value)
+12 |     print("done")
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Exhaustiveness checks with a shadowed function name
+
+When `assert_never` is already bound, a qualified import avoids that binding:
+
+```py
+def exhaustive(value: str | int, assert_never: int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value, assert_never)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+  |
+1 + import typing
+2 | def exhaustive(value: str | int, assert_never: int):
+3 |     if isinstance(value, str):
+4 |         print(value)
+5 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  -         print(value, assert_never)
+6 +         print(value, assert_never)
+7 +     else:
+8 +         typing.assert_never(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Exhaustiveness checks with shadowed imports
+
+When both the function and module names are shadowed, no fix is offered. An import elsewhere in the
+module does not make a shadowed alias usable:
+
+```py
+import typing as t
+from typing import assert_never
+
+def exhaustive(value: str | int, t: int, typing: int, assert_never: int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:7:10
+  |
+7 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+```
+
+## Exhaustiveness checks with a deleted import
+
+An imported alias that has been deleted cannot be reused. A new qualified import provides a runtime
+binding for the assertion:
+
+```py
+from typing import assert_never as unreachable
+
+del unreachable
+
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:8:10
+  |
+8 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+   |
+1  + import typing
+2  | from typing import assert_never as unreachable
+--------------------------------------------------------------------------------
+9  |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+   -         print(value)
+10 +         print(value)
+11 +     else:
+12 +         typing.assert_never(value)
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Exhaustiveness checks without a reusable variable
+
+Calling a function again could change its result or have side effects, so no fix is offered when the
+tested value is not a plain variable:
+
+```py
+def get_value() -> int:
+    return 1
+
+def exhaustive(flag: bool):
+    if flag:
+        print("flag")
+    elif isinstance(get_value(), int):  # snapshot: redundant-condition-strict
+        print("integer")
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:7:10
+  |
+7 |     elif isinstance(get_value(), int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+```
+
+## Exhaustiveness checks on Python 3.10 without dependency metadata
+
+Python 3.10 does not provide `typing.assert_never`. The fact that we vendor a stub for
+`typing_extensions` from typeshed is not sufficient to establish that the package will be available
+at runtime, so no fix is offered if we are unable to query the dependencies of the project:
+
+```toml
+[environment]
+python-version = "3.10"
+
+[rules]
+redundant-condition-strict = "error"
+```
+
+```py
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+```
+
+## Exhaustiveness checks with a direct `typing_extensions` dependency
+
+On older Python versions, `assert_never` can be imported from `typing_extensions` when
+`typing_extensions` is declared as a direct dependency and the version of `typing_extensions`
+installed into `site-packages` exports the function. The `typing_extensions` stub that we vendor
+from typeshed is not sufficient to establish runtime availability of
+`typing_extensions.assert_never`:
+
+```toml
+[environment]
+python-version = "3.10"
+python = "/.venv"
+
+[rules]
+redundant-condition-strict = "error"
+
+[dependency-metadata]
+projects = [{ path = "/src", dependencies = ["extensions"] }]
+
+[dependency-metadata.distributions]
+extensions = { name = "typing-extensions" }
+
+[dependency-metadata.module-owners]
+typing_extensions = ["extensions"]
+```
+
+### Available runtime function
+
+If the installed version of `typing_extensions` provides `assert_never`, the fix can import it:
+
+`/.venv/<path-to-site-packages>/typing_extensions.py`:
+
+```py
+def assert_never(value):
+    raise AssertionError(value)
+```
+
+`main.py`:
+
+```py
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/main.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Add an `else` branch that calls `assert_never`
+  |
+1 + from typing_extensions import assert_never
+2 | def exhaustive(value: str | int):
+3 |     if isinstance(value, str):
+4 |         print(value)
+5 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  -         print(value)
+6 +         print(value)
+7 +     else:
+8 +         assert_never(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+### Older runtime module
+
+We cannot providea an autofix if the installed version of `typing_extensions` does not export
+`assert_never`. No fix is offered even though the bundled stub from typeshed claims that
+`typing_extensions` always exposes `assert_never`:
+
+`/.venv/<path-to-site-packages>/typing_extensions.py`:
+
+```py
+```
+
+`main.py`:
+
+```py
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/main.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+```
+
+### Missing runtime module
+
+A dependency declaration alone does not establish that `typing_extensions` is installed at runtime.
+If only the bundled stub from typeshed is available, and `typing_extensions` cannot be found in
+`site-packages` despite the dependency declaration, no fix will be offered:
+
+`/.venv/<path-to-site-packages>/unrelated.py`:
+
+```py
+```
+
+`main.py`:
+
+```py
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/main.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+```
+
+## Exhaustiveness checks with an indirect `typing_extensions` dependency
+
+If `typing_extensions` is installed in `site-packages`, this still does not justify adding a runtime
+import unless `typing_extensions` is also declared as a direct dependency. The containing
+workspace's declaration does not make it a direct dependency of a nested project:
+
+```toml
+[environment]
+python-version = "3.10"
+python = "/.venv"
+
+[rules]
+redundant-condition-strict = "error"
+
+[dependency-metadata]
+projects = [
+    { path = "/src", dependencies = ["extensions"] },
+    { path = "/src/member", dependencies = [] },
+]
+
+[dependency-metadata.distributions]
+extensions = { name = "typing-extensions" }
+
+[dependency-metadata.module-owners]
+typing_extensions = ["extensions"]
+```
+
+`/.venv/<path-to-site-packages>/typing_extensions.py`:
+
+```py
+def assert_never(value):
+    raise AssertionError(value)
+```
+
+`member/main.py`:
+
+```py
+def exhaustive(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/member/main.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+```
+
 ## `if` and `while` conditions that use AST literal bools or ints
 
 We maintain a special case for `while` loops, since `while True:` and `while 1:` are common idioms

--- a/crates/ty_python_semantic/src/importer.rs
+++ b/crates/ty_python_semantic/src/importer.rs
@@ -28,9 +28,10 @@ use ruff_python_codegen::Stylist;
 use ruff_python_importer::Insertion;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use ty_module_resolver::{ImportingFile, ModuleName};
-use ty_python_core::ProgramFile;
 use ty_python_core::ast_node_ref::AstNodeRef;
-use ty_python_core::definition::DefinitionKind;
+use ty_python_core::definition::{DefinitionKind, DefinitionState};
+use ty_python_core::scope::FileScopeId;
+use ty_python_core::{ProgramFile, semantic_index};
 
 pub struct Importer<'a> {
     /// The ty Salsa database.
@@ -72,6 +73,11 @@ impl<'a> Importer<'a> {
         }
     }
 
+    /// The file's indentation unit, shared with inserted imports and diagnostic fixes.
+    pub(crate) fn indentation(&self) -> &str {
+        self.stylist.indentation().as_str()
+    }
+
     /// Builds a set of members in scope at the given AST node and position.
     ///
     /// Callers should use this routine to build "in scope members" to be used
@@ -96,7 +102,11 @@ impl<'a> Importer<'a> {
         MembersInScope::new(self.db, self.file, self.parsed, node, at)
     }
 
-    /// Imports a symbol into this importer's module.
+    /// Builds a best-effort import action for this module, usually for an IDE completion.
+    ///
+    /// This method always returns an action, even when it cannot avoid every name conflict.
+    /// For diagnostic fixes inside this crate, `Self::import_for_diagnostic` additionally checks
+    /// bindings without querying inferred types and may decline the import.
     ///
     /// The given request is assumed to be valid. That is, the module
     /// is assumed to be importable and the member is assumed to be a
@@ -197,6 +207,198 @@ impl<'a> Importer<'a> {
                 }
             }
         }
+    }
+
+    /// Builds an import action for a diagnostic fix, returning `None` if its name cannot be used
+    /// confidently at the proposed use site.
+    ///
+    /// [`Self::import`] uses a caller-supplied [`MembersInScope`] to choose an import style and
+    /// always returns an action. This is useful for completions: a candidate can still be offered
+    /// when resolving every possible conflict would be too restrictive. However, constructing
+    /// that map with [`Self::members_in_scope_at`] queries inferred types. Doing so while emitting
+    /// an inference diagnostic can re-enter the inference that is producing the diagnostic.
+    ///
+    /// This method instead checks bindings in the semantic index, without inferring their types.
+    /// It accepts a new name only if visible scopes have no binding or declaration for it, and
+    /// reuses an existing name only if it is a top-level runtime import that has not been
+    /// reassigned or deleted. These checks are deliberately conservative: a later reassignment
+    /// can prevent reuse even when the import would still be available at `at`.
+    ///
+    /// Both APIs assume that the requested module is importable and that it provides the requested
+    /// member. The caller must check Python-version and dependency requirements; neither API
+    /// establishes them. The examples below assume Python 3.11 or newer.
+    ///
+    /// # When the simpler API is sufficient
+    ///
+    /// An `undefined-reveal` diagnostic already establishes that `reveal_type` is unbound here:
+    ///
+    /// ```python
+    /// def show(value: int) -> None:
+    ///     reveal_type(value)
+    /// ```
+    ///
+    /// That fix can call [`Self::import`] with
+    /// `ImportRequest::import_from("typing", "reveal_type").force()` and an empty
+    /// [`MembersInScope`]. Forcing a `from` import avoids introducing a module name that could be
+    /// shadowed. Applying the returned import edit produces:
+    ///
+    /// ```python
+    /// from typing import reveal_type
+    ///
+    /// def show(value: int) -> None:
+    ///     reveal_type(value)
+    /// ```
+    ///
+    /// A fix that introduces a new call cannot generally assume that its chosen function name is
+    /// unbound. For example, `assert_never` could already name a function parameter. An empty
+    /// [`MembersInScope`] would conceal that conflict from [`Self::import`].
+    ///
+    /// # When an existing import is shadowed
+    ///
+    /// For an unforced request for `typing.assert_never`, [`Self::import`] can reuse an existing
+    /// `import typing as t` and return `t.assert_never`, even with a populated [`MembersInScope`].
+    /// Its conflict avoidance chooses between the requested module and member names; it does not
+    /// validate that an alias found in an existing import still refers to that import at the use
+    /// site. A caller adding an exhaustiveness check could therefore produce this incorrect call:
+    ///
+    /// ```python
+    /// import typing as t
+    ///
+    /// def handle(value: int | str, t: int) -> None:
+    ///     if isinstance(value, int):
+    ///         print(value)
+    ///     elif isinstance(value, str):
+    ///         print(value)
+    ///     else:
+    ///         t.assert_never(value)  # `t` is the integer parameter, not the module.
+    /// ```
+    ///
+    /// This method rejects that alias and tries a `from` import instead. It returns an import edit
+    /// and `assert_never` as the symbol text, allowing the caller to construct this fix:
+    ///
+    /// ```python
+    /// from typing import assert_never
+    /// import typing as t
+    ///
+    /// def handle(value: int | str, t: int) -> None:
+    ///     if isinstance(value, int):
+    ///         print(value)
+    ///     elif isinstance(value, str):
+    ///         print(value)
+    ///     else:
+    ///         assert_never(value)
+    /// ```
+    ///
+    /// The caller must use [`ImportAction::symbol_text`] for the new reference and include any
+    /// [`ImportAction::import`] edit. An unshadowed alias can be reused without an import edit;
+    /// an occupied function name can instead require a qualified reference and a module import.
+    ///
+    /// # When neither import style is usable
+    ///
+    /// Both possible names can already have unrelated bindings:
+    ///
+    /// ```python
+    /// def handle(value: int | str, typing: int, assert_never: int) -> None:
+    ///     if isinstance(value, int):
+    ///         print(value)
+    ///     elif isinstance(value, str):
+    ///         print(value)
+    /// ```
+    ///
+    /// With these members in scope, [`Self::import`] still returns a best-effort action: add
+    /// `import typing` at module level and use `typing.assert_never`. That module-level import
+    /// would remain shadowed by the function parameter. This method returns `None`, so the caller
+    /// can omit the import-dependent fix or offer a different fix. It does not invent a fresh alias.
+    ///
+    /// # Use site and shared implementation
+    ///
+    /// `scope` is the scope where the new reference will be evaluated. `at` is an offset in the
+    /// original source at or before the planned reference: existing imports must precede it, and
+    /// notebook import edits must respect its cell boundaries. The requested import style is
+    /// tried first, followed by forced `from` and module imports. Even a forced request can be
+    /// retried with the other style.
+    ///
+    /// All import lookup, formatting, and edit construction is shared with [`Self::import`]. This
+    /// method calls it for each candidate style and then validates the returned name. The extra
+    /// work here is deciding whether a diagnostic can use that action, not constructing a second
+    /// kind of import edit.
+    pub(crate) fn import_for_diagnostic(
+        &self,
+        request: ImportRequest<'_>,
+        scope: FileScopeId,
+        at: TextSize,
+    ) -> Option<ImportAction> {
+        let index = semantic_index(self.db, self.file);
+        let importing_file = ImportingFile::File(
+            self.file.file(self.db),
+            self.file.resolver_environment(self.db),
+        );
+        for request in [
+            request,
+            ImportRequest {
+                style: ImportStyle::ImportFrom,
+                force_style: true,
+                ..request
+            },
+            ImportRequest {
+                style: ImportStyle::Import,
+                force_style: true,
+                ..request
+            },
+        ] {
+            let action = self.import(request, &MembersInScope::empty(at));
+            let root = action.symbol_text().split('.').next()?;
+            let mut existing_import = false;
+            let available = index.visible_ancestor_scopes(scope).all(|(scope, _)| {
+                let places = index.place_table(scope);
+                let Some(symbol_id) = places.symbol_id(root) else {
+                    return true;
+                };
+                let symbol = places.symbol(symbol_id);
+                if !symbol.is_bound() && !symbol.is_declared() {
+                    return true;
+                }
+                if symbol.is_reassigned() {
+                    return false;
+                }
+                // Ignore the implicit initial unbound state, but retain deletions so a deleted
+                // import cannot be reused.
+                let mut bindings = index
+                    .use_def_map(scope)
+                    .end_of_scope_symbol_bindings(symbol_id)
+                    .map(|binding| binding.binding)
+                    .filter(|binding| !matches!(binding, DefinitionState::Undefined));
+                let Some(binding) = bindings.next().and_then(DefinitionState::definition) else {
+                    return false;
+                };
+                if bindings.next().is_some() {
+                    return false;
+                }
+                let import = match binding.kind(self.db) {
+                    DefinitionKind::Import(kind) => AstImportKind::Import(kind.import(self.parsed)),
+                    DefinitionKind::ImportFrom(kind) => {
+                        AstImportKind::ImportFrom(kind.import(self.parsed))
+                    }
+                    _ => return false,
+                };
+                existing_import = import.start() < at
+                    && self
+                        .imports()
+                        .any(|top_level| top_level.stmt.start() == import.start())
+                    && match import.satisfies(self.db, importing_file, &request) {
+                        Some(ImportResponseKind::Qualified { .. }) => true,
+                        Some(ImportResponseKind::Unqualified { alias }) => {
+                            Some(alias.name.as_str()) == request.member
+                        }
+                        _ => false,
+                    };
+                existing_import
+            });
+            if available && (existing_import || action.import().is_some()) {
+                return Some(action);
+            }
+        }
+        None
     }
 
     /// Look for an import already in this importer's module that
@@ -564,7 +766,7 @@ impl<'ast> AstImportKind<'ast> {
 }
 
 /// A request to import a module into the global scope of a Python module.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct ImportRequest<'a> {
     /// The module from which the symbol should be imported (e.g.,
     /// `foo`, in `from foo import bar`).
@@ -804,7 +1006,7 @@ impl ImportResponseKind<'_> {
 }
 
 /// The style of a Python import statement.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum ImportStyle {
     /// Import the symbol using the `import` statement (e.g. `import
     /// foo; foo.bar`).

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -90,8 +90,8 @@ use ty_python_core::place::{PlaceExpr, PlaceExprRef, ScopedPlaceId};
 use ty_python_core::scope::{NodeWithScopeKind, ScopeId, ScopeKind};
 use ty_python_core::symbol::{ScopedSymbolId, Symbol};
 use ty_python_core::{
-    AncestorsIter, BindingWithConstraintsIterator, EnclosingSnapshotResult, FileScopeId,
-    ProgramFile, SemanticIndex,
+    AncestorsIter, BindingWithConstraintsIterator, BindingsSnapshotId, EnclosingSnapshotResult,
+    FileScopeId, ProgramFile, SemanticIndex,
 };
 
 use crate::Db;
@@ -124,6 +124,9 @@ pub(crate) enum PlaceLoadMode<'ast> {
     /// For example, a caller resolving `value` in `print(value)` uses this mode so that only
     /// bindings that reach that occurrence are considered.
     AtExpression(ast::ExprRef<'ast>),
+    /// Resolve a plain name using bindings and constraints retained at an earlier point in
+    /// the same scope. Enclosing-scope resolution still follows the name's lexical scope.
+    AtNameSnapshot(BindingsSnapshotId),
     /// Resolve all bindings reachable in the scope.
     ///
     /// A caller uses this mode for an annotation in any of these contexts:
@@ -897,7 +900,10 @@ impl<'db> PlaceLoadResolutionContext<'db, '_> {
     }
 
     fn uses_enclosing_snapshots(self) -> bool {
-        matches!(self.mode, PlaceLoadMode::AtExpression(_))
+        matches!(
+            self.mode,
+            PlaceLoadMode::AtExpression(_) | PlaceLoadMode::AtNameSnapshot(_)
+        )
     }
 
     fn is_lexical_enclosing_scope(self, enclosing_scope: FileScopeId) -> bool {
@@ -932,6 +938,10 @@ impl<'db> PlaceLoadResolutionContext<'db, '_> {
                     Some((scope, ConstraintKey::UseId(use_id))),
                 ))
             }
+            PlaceLoadMode::AtNameSnapshot(snapshot) => Some((
+                PlaceLoadSourceKind::Bindings(use_def.bindings_at_snapshot(snapshot)),
+                Some((scope, ConstraintKey::Snapshot(snapshot))),
+            )),
             PlaceLoadMode::Deferred | PlaceLoadMode::StringAnnotation => {
                 let source = table
                     .place_id(place_expr)
@@ -957,6 +967,7 @@ impl<'db> PlaceLoadResolutionContext<'db, '_> {
             table
                 .parents(place_expr)
                 .filter_map(|prefix_id| match self.mode {
+                    PlaceLoadMode::AtNameSnapshot(_) => None,
                     PlaceLoadMode::Deferred | PlaceLoadMode::StringAnnotation => {
                         Some(PlaceExprPrefixLoad::AllReachable(prefix_id))
                     }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3061,7 +3061,7 @@ pub(super) fn report_possibly_missing_attribute(
 
 /// Selects a runtime typing module for a fix, checking declared dependencies and installed exports
 /// when the requested member needs a backport.
-fn typing_module_for_fix(
+pub(super) fn typing_module_for_fix(
     context: &InferContext,
     member: &str,
     minimum_version: PythonVersion,

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -8,32 +8,45 @@ use ruff_db::{
     source::source_text,
 };
 use ruff_diagnostics::{Applicability, Edit, Fix};
-use ruff_python_ast::{self as ast, PythonVersion};
-use ruff_source_file::LineRanges;
-use ruff_text_size::Ranged;
+use ruff_python_ast::{
+    self as ast, PythonVersion,
+    helpers::any_over_expr,
+    token::{TokenKind, Tokens},
+};
+use ruff_python_trivia::indentation_at_offset;
+use ruff_source_file::{LineRanges, UniversalNewlineIterator, find_newline};
+use ruff_text_size::{Ranged, TextSize};
 use ty_module_resolver::{SearchPath, file_to_module};
 use ty_python_core::{
     Truthiness,
+    ast_ids::HasScopedUseId,
     definition::DefinitionKind,
+    place::PlaceExpr,
+    predicate::{Predicate, PredicateNode},
     scope::{NodeWithScopeKind, ScopeKind},
 };
 
 use crate::{
     SemanticModel,
+    importer::ImportRequest,
+    place::{Place, PlaceAndQualifiers},
+    place_load::{PlaceLoadMode, PlaceLoadResolutionStep, resolve_place_load},
     types::{
         KnownClass, LintDiagnosticGuard, LintDiagnosticGuardBuilder, MemberLookupPolicy, Type,
         TypeContext,
         call::bind::CallableDescription,
+        diagnostic::typing_module_for_fix,
         enum_metadata,
         function::KnownFunction,
         infer::TypeInferenceBuilder,
         infer_definition_types, infer_scope_types,
+        narrow::{NarrowingConstraint, infer_narrowing_constraints},
         signatures::CallableSignature,
         tuple::{Tuple, TupleLength},
     },
 };
 
-use super::{RedundantCondition, exemptions::condition_definition_info};
+use super::{ConditionKind, RedundantCondition, exemptions::condition_definition_info};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn report_redundant_condition<'ctx>(
@@ -582,6 +595,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 diagnostic
             }
         };
+
         Some(diagnostic)
     }
 
@@ -844,4 +858,181 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         false
     }
+
+    pub(super) fn annotate_redundant_if_or_elif(
+        &self,
+        condition: &RedundantCondition<'_, 'db>,
+        diagnostic: &mut Diagnostic,
+        if_stmt: &ast::StmtIf,
+    ) {
+        let RedundantCondition {
+            expression: test,
+            value_type: _,
+            is_truthy,
+            kind,
+        } = condition;
+
+        if *is_truthy
+            && *kind == ConditionKind::Boolean
+            && let Some(clause) = if_stmt.elif_else_clauses.last()
+            && clause.test.as_ref() == Some(test)
+            && !diagnostic.has_applicable_fix(Applicability::DisplayOnly)
+            && let Some(fix) = self.add_assert_never_else(clause, test)
+        {
+            diagnostic.help("Add an `else` branch that calls `assert_never`");
+            diagnostic.set_fix(fix);
+        }
+    }
+
+    /// Add an explicit exhaustiveness check after a redundant final `elif`.
+    ///
+    /// Only read a plain variable whose type is a union before the chain, and which narrows
+    /// to `Never` when the condition is false. Repeating attribute access or a function call
+    /// could have side effects. Returns `None`
+    /// when no such variable or unshadowed runtime import is available.
+    /// The fix is unsafe because the new branch raises if the static assumptions fail at runtime.
+    fn add_assert_never_else(&self, clause: &ast::ElifElseClause, test: &ast::Expr) -> Option<Fix> {
+        let db = self.db();
+        let first_statement = clause.body.first()?;
+        let source = source_text(db, self.file());
+        let indentation = indentation_at_offset(clause.start(), &source)?;
+        let argument = self.assert_never_argument(test)?;
+
+        let module = typing_module_for_fix(&self.context, "assert_never", PythonVersion::PY311)?;
+        let importer = self.context.importer();
+
+        let action = importer.import_for_diagnostic(
+            ImportRequest::import_from(module.as_str(), "assert_never"),
+            self.scope().file_scope_id(db),
+            clause.start(),
+        )?;
+
+        let body_indentation = indentation_at_offset(first_statement.start(), &source)
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(format!("{indentation}{}", importer.indentation())));
+
+        let line_ending = find_newline(&source)
+            .map(|(_, ending)| ending)
+            .unwrap_or_default()
+            .as_str();
+
+        let mut end = logical_line_end(&source, self.module().tokens(), clause.end());
+
+        // Keep trailing body comments with the `elif`, including those after a nested statement.
+        for line in UniversalNewlineIterator::with_offset(&source[usize::from(end)..], end) {
+            if line.trim().is_empty() {
+                continue;
+            }
+            if line.starts_with(body_indentation.as_ref()) && line.trim_start().starts_with('#') {
+                end = line.full_end();
+            } else {
+                break;
+            }
+        }
+
+        let leading_newline = if source.line_start(end) == end {
+            ""
+        } else {
+            line_ending
+        };
+
+        Some(Fix::unsafe_edits(
+            Edit::insertion(
+                format!(
+                    "{leading_newline}{indentation}else:{line_ending}{body_indentation}{}({}){line_ending}",
+                    action.symbol_text(),
+                    argument.id,
+                ),
+                end,
+            ),
+            action.import().cloned(),
+        ))
+    }
+
+    /// Find a variable tested directly, by a comparison, or by a narrowing function.
+    /// More complex conditions cannot provide an argument without repeating their evaluation.
+    fn assert_never_argument<'a>(&self, test: &'a ast::Expr) -> Option<&'a ast::ExprName> {
+        if any_over_expr(test, ast::Expr::is_named_expr) {
+            return None;
+        }
+
+        let mut operand = test;
+
+        while let ast::Expr::UnaryOp(unary) = operand
+            && unary.op == ast::UnaryOp::Not
+        {
+            operand = &unary.operand;
+        }
+
+        let candidates = match operand {
+            ast::Expr::Name(_) => [Some(operand), None],
+            ast::Expr::Compare(compare) if compare.ops.len() == 1 => {
+                [Some(compare.left.as_ref()), compare.comparators.first()]
+            }
+            ast::Expr::Call(call) => [call.arguments.args.first(), None],
+            _ => return None,
+        };
+
+        let db = self.db();
+        let env = self.program_environment();
+        let places = self.index.place_table(self.scope().file_scope_id(db));
+
+        let predicate = Predicate {
+            node: PredicateNode::Expression(self.index.expression(test)),
+            is_positive: false,
+        };
+
+        candidates.into_iter().flatten().find_map(|candidate| {
+            let name = candidate.as_name_expr()?;
+            let ty = self.expression_type(candidate);
+            if ty.is_never() || !self.type_before_if_chain(name)?.is_union() {
+                return None;
+            }
+            let place = places.symbol_id(&name.id)?;
+            let (constraint, _) = infer_narrowing_constraints(db, predicate, place.into());
+            NarrowingConstraint::intersection(ty)
+                .merge_constraint_and(constraint?)
+                .evaluate_constraint_type(db, env)
+                .is_never()
+                .then_some(name)
+        })
+    }
+
+    /// Resolve a name using the bindings and constraints that precede its `if` chain.
+    /// This preserves earlier narrowing, including constraints on captured variables.
+    fn type_before_if_chain(&self, name: &ast::ExprName) -> Option<Type<'db>> {
+        let db = self.db();
+        let env = self.program_environment();
+        let use_def = self.index.use_def_map(self.scope().file_scope_id(db));
+        let snapshot =
+            use_def.if_chain_start_for_use(name.scoped_use_id(db, self.program_file()))?;
+        let mut resolution = resolve_place_load(
+            db,
+            self.index,
+            self.scope(),
+            PlaceExpr::from_expr_name(name),
+            PlaceLoadMode::AtNameSnapshot(snapshot),
+        );
+        let mut place = PlaceAndQualifiers::from(Place::Undefined);
+        while let Some(PlaceLoadResolutionStep::Source(source)) = resolution.next() {
+            let constraints = resolution.narrowing_constraints_for(&source);
+            place = place.or_fall_back_to(db, env, || {
+                self.infer_place_load_source(resolution.place_expr(), source, constraints)
+            });
+            if place.place.is_definitely_bound() {
+                break;
+            }
+        }
+        place.place.ignore_possibly_undefined()
+    }
+}
+
+/// Returns the end of the logical line at `offset`, including its newline.
+/// A trailing backslash can extend the line beyond its last AST node's physical line.
+fn logical_line_end(source: &str, tokens: &Tokens, offset: TextSize) -> TextSize {
+    tokens
+        .after(offset)
+        .iter()
+        .find(|token| token.kind() == TokenKind::Newline)
+        .map_or_else(|| source.full_line_end(offset), Ranged::end)
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/mod.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/mod.rs
@@ -54,6 +54,7 @@ use ruff_python_ast::{
     helpers::any_over_expr,
     visitor::{Visitor, walk_expr},
 };
+use ruff_text_size::Ranged;
 use ty_python_core::{Truthiness, expression::ExpressionContext, predicate::StatementCall};
 
 use crate::{
@@ -455,7 +456,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             self.boolean_test(test, ExpressionContext::Condition),
                             context,
                         ) {
-                            self.report_redundant_condition(&condition);
+                            if let Some(mut diagnostic) =
+                                self.report_redundant_condition(&condition)
+                                && condition.expression.range() == test.range()
+                            {
+                                self.annotate_redundant_if_or_elif(
+                                    &condition,
+                                    &mut diagnostic,
+                                    if_stmt,
+                                );
+                            }
                         }
                     }
                 }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -1120,6 +1120,80 @@ fn undefined_reveal_fix_updates_after_source_changes() -> anyhow::Result<()> {
 }
 
 #[test]
+fn redundant_elif_fix_preserves_line_endings_and_checks_cleanly() -> anyhow::Result<()> {
+    let registry = crate::default_lint_registry();
+    let mut rules = RuleSelection::from_registry(registry);
+    rules.enable(
+        registry.get("redundant-condition-strict")?,
+        Severity::Warning,
+        LintSource::File,
+    );
+    let mut db = TestDbBuilder::new()
+        .with_python_version(PythonVersion::PY311)
+        .with_rule_selection(rules)
+        .build()?;
+
+    // Reuse the file to check that edits use the current imports and source style.
+    for (newline, indent, trailing_newline, existing_import) in [
+        ("\n", "    ", true, false),
+        ("\r\n", "\t", false, true),
+        ("\r", "  ", false, false),
+    ] {
+        let mut source = format!(
+            "def f(value: str | int):\n\
+            {indent}if isinstance(value, str):\n\
+            {indent}{indent}print(value)\n\
+            {indent}elif isinstance(value, int):\n\
+            {indent}{indent}print(value)  # Inline comment.\n\
+            {indent}{indent}# Trailing comment."
+        )
+        .replace('\n', newline);
+        let (import, name) = if existing_import {
+            (
+                "from typing import assert_never as unreachable",
+                "unreachable",
+            )
+        } else {
+            ("from typing import assert_never", "assert_never")
+        };
+        if existing_import {
+            source = format!("{import}{newline}{source}");
+        }
+        if trailing_newline {
+            source.push_str(newline);
+        }
+        db.write_file("/src/main.py", &source)?;
+        let file = system_path_to_file(&db, "/src/main.py")?;
+        let diagnostics = check_types(&db, program_file(&db, file));
+        let [diagnostic] = diagnostics.as_slice() else {
+            anyhow::bail!("expected one diagnostic: {diagnostics:#?}");
+        };
+        let fix = diagnostic
+            .fix()
+            .ok_or_else(|| anyhow::anyhow!("expected an autofix"))?;
+        let mut fixed = source.clone();
+        for edit in fix.edits().iter().rev() {
+            fixed.replace_range(edit.range().to_std_range(), edit.content().unwrap_or(""));
+        }
+        let prefix = if existing_import {
+            String::new()
+        } else {
+            format!("{import}{newline}")
+        };
+        let separator = if trailing_newline { "" } else { newline };
+        assert_eq!(
+            fixed,
+            format!(
+                "{prefix}{source}{separator}{indent}else:{newline}{indent}{indent}{name}(value){newline}"
+            )
+        );
+        db.write_file("/src/main.py", fixed)?;
+        assert_file_diagnostics(&db, "/src/main.py", &[]);
+    }
+    Ok(())
+}
+
+#[test]
 fn function_inference_regions_are_disjoint() -> anyhow::Result<()> {
     let mut db = setup_db();
     db.write_dedented(


### PR DESCRIPTION
When the final `elif` condition is always true, offer an unsafe fix for `redundant-condition-strict` that adds an `else` branch calling `assert_never`. This makes the code explicit that it intends to be exhaustive.

The argument to `assert_never` is a plain variable that narrows to `Never` when the condition is false. The existing condition and body are preserved.

**Python 3.11+: add a new import.** After the `str` branch, `value` must be an `int`, so the final condition is statically always true. The fix adds an explicit exhaustiveness check:

```diff
+from typing import assert_never
 def handle(value: str | int):
     if isinstance(value, str):
         print(value)
     elif isinstance(value, int):
         print(value)
+    else:
+        assert_never(value)
```

**Reuse an existing runtime import.** An unshadowed alias can be used without adding another import:

```diff
 from typing import assert_never as unreachable
 
 def handle(value: str | int):
     if isinstance(value, str):
         print(value)
     elif isinstance(value, int):
         print(value)
+    else:
+        unreachable(value)
```

An existing qualified import such as `import typing as t` can similarly supply `t.assert_never(value)`.

**Avoid a shadowed function name.** If `assert_never` already names a parameter, the fix uses a qualified reference instead:

```diff
+import typing
 def handle(value: str | int, assert_never: int):
     if isinstance(value, str):
         print(value)
     elif isinstance(value, int):
         print(value, assert_never)
+    else:
+        typing.assert_never(value)
```

**Python 3.10: use an available backport.** When uv dependency metadata identifies `typing_extensions` as a direct dependency available to this file, and the installed runtime module exports `assert_never`, the fix imports from the backport:

```diff
+from typing_extensions import assert_never
 def handle(value: str | int):
     if isinstance(value, str):
         print(value)
     elif isinstance(value, int):
         print(value)
+    else:
+        assert_never(value)
```

No fix is offered if there is no suitable plain variable, if assignment expressions occur in the condition, or if neither an unqualified nor a qualified reference can avoid existing bindings. On older Python versions, missing dependency metadata, an indirect dependency, a missing runtime module, or a backport without `assert_never` also prevent the fix. The new branch raises if the static assumptions fail at runtime, so the fix is unsafe.

The shared importer checks bindings without re-entering type inference and only reuses runtime imports that have not been reassigned or deleted.

Stacked on #28177.
