### PR TITLE
[ty] Add defensive assertion fallback for redundant `elif` fixes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -2775,8 +2775,8 @@ help: Add an `else` branch that calls `assert_never`
 note: This is an unsafe fix and may change runtime behavior
 ```
 
-No fix is offered for an assignment expression: the new branch could observe a variable whose value
-the condition has changed:
+An unparenthesized assignment expression is valid in an `elif` condition but must be parenthesized
+when moved into an assertion:
 
 ```py
 def assignment_expression(value: str | int):
@@ -2792,6 +2792,15 @@ error[redundant-condition-strict]: Condition is always true
    |
 27 |     elif matched := isinstance(value, int):  # snapshot: redundant-condition-strict
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+   |
+26 |         print(value)
+   -     elif matched := isinstance(value, int):  # snapshot: redundant-condition-strict
+27 +     else:  # snapshot: redundant-condition-strict
+28 +         assert (matched := isinstance(value, int))
+29 |         print(matched)
+   |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 If the branch body begins on the same line as its header, the new `else` still goes on a separate
@@ -2874,6 +2883,7 @@ error[redundant-condition-strict]: Condition is always true
    |
 47 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
    |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
 ```
 
 A redundant check on a variable whose type is `int` before the chain is still reported, but it does
@@ -2895,6 +2905,15 @@ error[redundant-condition-strict]: Condition is always true
    |          -----^^^^^^^^^^^^
    |          |
    |          Has type `int`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+   |
+50 |         print(items)
+   -     elif value is not None:  # snapshot: redundant-condition-strict
+51 +     else:  # snapshot: redundant-condition-strict
+52 +         assert value is not None
+53 |         print(value)
+   |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 ## Exhaustiveness checks after explicit line continuations
@@ -3034,6 +3053,15 @@ error[redundant-condition-strict]: Condition is always true
   |          -----^^^^^^^^^^^^
   |          |
   |          Has type `int`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+5 |         print("flag")
+  -     elif value is not None:  # snapshot: redundant-condition-strict
+6 +     else:  # snapshot: redundant-condition-strict
+7 +         assert value is not None
+8 |         print(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 ## Exhaustiveness checks for captured variables
@@ -3093,6 +3121,15 @@ error[redundant-condition-strict]: Condition is always true
   |              -----^^^^^^^^^^^^
   |              |
   |              Has type `int`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+6 |             print("flag")
+  -         elif value is not None:  # snapshot: redundant-condition-strict
+7 +         else:  # snapshot: redundant-condition-strict
+8 +             assert value is not None
+9 |             print(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 ## Exhaustiveness checks for comparisons
@@ -3234,8 +3271,8 @@ note: This is an unsafe fix and may change runtime behavior
 
 ## Exhaustiveness checks with shadowed imports
 
-When both the function and module names are shadowed, no fix is offered. An import elsewhere in the
-module does not make a shadowed alias usable:
+When both the function and module names are shadowed, the fix converts the original condition into a
+defensive assertion. An import elsewhere in the module does not make a shadowed alias usable:
 
 ```py
 import typing as t
@@ -3254,6 +3291,15 @@ error[redundant-condition-strict]: Condition is always true
   |
 7 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
   |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+6 |         print(value)
+  -     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+7 +     else:  # snapshot: redundant-condition-strict
+8 +         assert isinstance(value, int)
+9 |         print(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 ## Exhaustiveness checks with a deleted import
@@ -3295,8 +3341,8 @@ note: This is an unsafe fix and may change runtime behavior
 
 ## Exhaustiveness checks without a reusable variable
 
-Calling a function again could change its result or have side effects, so no fix is offered when the
-tested value is not a plain variable:
+Calling a function again could change its result or have side effects, so the fix retains the
+original condition as an assertion when the tested value is not a plain variable:
 
 ```py
 def get_value() -> int:
@@ -3315,13 +3361,22 @@ error[redundant-condition-strict]: Condition is always true
   |
 7 |     elif isinstance(get_value(), int):  # snapshot: redundant-condition-strict
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+6 |         print("flag")
+  -     elif isinstance(get_value(), int):  # snapshot: redundant-condition-strict
+7 +     else:  # snapshot: redundant-condition-strict
+8 +         assert isinstance(get_value(), int)
+9 |         print("integer")
+  |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 ## Exhaustiveness checks on Python 3.10 without dependency metadata
 
 Python 3.10 does not provide `typing.assert_never`. The fact that we vendor a stub for
 `typing_extensions` from typeshed is not sufficient to establish that the package will be available
-at runtime, so no fix is offered if we are unable to query the dependencies of the project:
+at runtime, so the fix converts the original condition into an assertion instead:
 
 ```toml
 [environment]
@@ -3345,6 +3400,15 @@ error[redundant-condition-strict]: Condition is always true
   |
 4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
   |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+3 |         print(value)
+  -     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+4 +     else:  # snapshot: redundant-condition-strict
+5 +         assert isinstance(value, int)
+6 |         print(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 ## Exhaustiveness checks with a direct `typing_extensions` dependency
@@ -3417,9 +3481,9 @@ note: This is an unsafe fix and may change runtime behavior
 
 ### Older runtime module
 
-We cannot providea an autofix if the installed version of `typing_extensions` does not export
-`assert_never`. No fix is offered even though the bundled stub from typeshed claims that
-`typing_extensions` always exposes `assert_never`:
+We cannot provide an `assert_never` autofix if the installed version of `typing_extensions` does not
+export `assert_never`, even though the bundled stub from typeshed claims that `typing_extensions`
+always exposes `assert_never`. Here, we provide an autofix that adds an `assert` instead:
 
 `/.venv/<path-to-site-packages>/typing_extensions.py`:
 
@@ -3442,13 +3506,23 @@ error[redundant-condition-strict]: Condition is always true
   |
 4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
   |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+3 |         print(value)
+  -     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+4 +     else:  # snapshot: redundant-condition-strict
+5 +         assert isinstance(value, int)
+6 |         print(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 ### Missing runtime module
 
 A dependency declaration alone does not establish that `typing_extensions` is installed at runtime.
 If only the bundled stub from typeshed is available, and `typing_extensions` cannot be found in
-`site-packages` despite the dependency declaration, no fix will be offered:
+`site-packages` despite the dependency declaration, the fix adds an `assert` instead of using
+`assert_never`:
 
 `/.venv/<path-to-site-packages>/unrelated.py`:
 
@@ -3471,6 +3545,15 @@ error[redundant-condition-strict]: Condition is always true
   |
 4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
   |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+3 |         print(value)
+  -     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+4 +     else:  # snapshot: redundant-condition-strict
+5 +         assert isinstance(value, int)
+6 |         print(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
 ```
 
 ## Exhaustiveness checks with an indirect `typing_extensions` dependency
@@ -3523,7 +3606,263 @@ error[redundant-condition-strict]: Condition is always true
   |
 4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
   |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+3 |         print(value)
+  -     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+4 +     else:  # snapshot: redundant-condition-strict
+5 +         assert isinstance(value, int)
+6 |         print(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
 ```
+
+## Defensive assertions preserve condition formatting
+
+Without an available `assert_never` import, the fix moves the condition into an assertion.
+Parentheses keep a multiline condition valid, and comments within the condition move with it. Header
+and body comments stay with the branch, which retains its original indentation.
+
+```toml
+[environment]
+python-version = "3.10"
+
+[rules]
+redundant-condition-strict = "error"
+```
+
+```py
+# fmt: off
+def commented_condition(value: str | int):
+  if isinstance(value, str):
+    print(value)
+  elif (
+    # Explain the defensive runtime check.
+    isinstance(value, int)  # snapshot: redundant-condition-strict
+  ):  # Preserve this header comment.
+    # Preserve this body comment.
+    print(value)
+# fmt: on
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:7:5
+  |
+7 |     isinstance(value, int)  # snapshot: redundant-condition-strict
+  |     ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+   |
+4  |     print(value)
+   -   elif (
+5  +   else:  # Preserve this header comment.
+6  +     # Preserve this body comment.
+7  +     assert (
+8  |     # Explain the defensive runtime check.
+9  |     isinstance(value, int)  # snapshot: redundant-condition-strict
+   -   ):  # Preserve this header comment.
+   -     # Preserve this body comment.
+10 +   )
+11 |     print(value)
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Defensive assertions with inline bodies
+
+The fallback does not rewrite a branch whose body begins on the header line: inserting an indented
+assertion would require moving the existing body. This also applies when the header spans several
+lines.
+
+```toml
+[environment]
+python-version = "3.10"
+
+[rules]
+redundant-condition-strict = "error"
+```
+
+```py
+# fmt: off
+def inline_branch(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int): print(value)  # snapshot: redundant-condition-strict
+# fmt: on
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:5:10
+  |
+5 |     elif isinstance(value, int): print(value)  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+```
+
+```py
+# fmt: off
+def multiline_inline_branch(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif (
+        isinstance(value, int)  # snapshot: redundant-condition-strict
+    ): print(value)
+# fmt: on
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:12:9
+   |
+12 |         isinstance(value, int)  # snapshot: redundant-condition-strict
+   |         ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+```
+
+## Defensive assertions with continued conditions
+
+A continuation within the condition moves with the condition into the assertion.
+
+```toml
+[environment]
+python-version = "3.10"
+
+[rules]
+redundant-condition-strict = "error"
+```
+
+<!-- fmt:off -->
+
+```py
+def continued_condition(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    # snapshot: redundant-condition-strict
+    elif isinstance(value, \
+                    int):
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:5:10
+  |
+5 |       elif isinstance(value, \
+  |  __________^
+6 | |                     int):
+  | |________________________^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+  |
+4 |     # snapshot: redundant-condition-strict
+  -     elif isinstance(value, \
+  -                     int):
+5 +     else:
+6 +         assert isinstance(value, \
+7 +                     int)
+8 |         print(value)
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+<!-- fmt:on -->
+
+## Defensive assertions with continued inline bodies
+
+An inline body can start on a different physical line when the header ends with a backslash. No fix
+is offered: inserting a newline after the assertion would leave the original statement with an
+unexpected indent.
+
+```toml
+[environment]
+python-version = "3.10"
+
+[rules]
+redundant-condition-strict = "error"
+```
+
+<!-- fmt:off -->
+
+```py
+def continued_inline_body(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    # snapshot: redundant-condition-strict
+    elif isinstance(value, int): \
+        print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:5:10
+  |
+5 |     elif isinstance(value, int): \
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+```
+
+<!-- fmt:on -->
+
+Continuation lines can also have the same indentation as the branch header. No fix is offered here
+either: the newline would move the original statement outside the branch, making it run after either
+branch.
+
+<!-- fmt:off -->
+
+```py
+def continued_inline_body_at_header_indentation(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    # snapshot: redundant-condition-strict
+    elif isinstance(value, int): \
+    print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+  --> src/mdtest_snippet.py:11:10
+   |
+11 |     elif isinstance(value, int): \
+   |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+```
+
+<!-- fmt:on -->
+
+## Defensive assertions with continued indented bodies
+
+The first statement of an indented body can itself start on a continuation line. Its physical
+indentation does not determine the body's indentation, so this case also receives no fix.
+
+```toml
+[environment]
+python-version = "3.10"
+
+[rules]
+redundant-condition-strict = "error"
+```
+
+<!-- fmt:off -->
+
+```py
+def continued_indented_body(value: str | int):
+    if isinstance(value, str):
+        print(value)
+    elif isinstance(value, int):  # snapshot: redundant-condition-strict
+        \
+    print(value)
+```
+
+```snapshot
+error[redundant-condition-strict]: Condition is always true
+ --> src/mdtest_snippet.py:4:10
+  |
+4 |     elif isinstance(value, int):  # snapshot: redundant-condition-strict
+  |          ^^^^^^^^^^^^^^^^^^^^^^ Inferred type is `Literal[True]`
+help: Replace this `elif` with an `else` branch that asserts the condition to be `True`
+```
+
+<!-- fmt:on -->
 
 ## `if` and `while` conditions that use AST literal bools or ints
 

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -11,11 +11,11 @@ use ruff_diagnostics::{Applicability, Edit, Fix};
 use ruff_python_ast::{
     self as ast, PythonVersion,
     helpers::any_over_expr,
-    token::{TokenKind, Tokens},
+    token::{TokenKind, Tokens, parenthesized_range},
 };
 use ruff_python_trivia::indentation_at_offset;
 use ruff_source_file::{LineRanges, UniversalNewlineIterator, find_newline};
-use ruff_text_size::{Ranged, TextSize};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 use ty_module_resolver::{SearchPath, file_to_module};
 use ty_python_core::{
     Truthiness,
@@ -877,10 +877,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             && let Some(clause) = if_stmt.elif_else_clauses.last()
             && clause.test.as_ref() == Some(test)
             && !diagnostic.has_applicable_fix(Applicability::DisplayOnly)
-            && let Some(fix) = self.add_assert_never_else(clause, test)
         {
-            diagnostic.help("Add an `else` branch that calls `assert_never`");
-            diagnostic.set_fix(fix);
+            if let Some(fix) = self.add_assert_never_else(clause, test) {
+                diagnostic.help("Add an `else` branch that calls `assert_never`");
+                diagnostic.set_fix(fix);
+            } else {
+                diagnostic.help(
+                    "Replace this `elif` with an `else` branch \
+                that asserts the condition to be `True`",
+                );
+                if let Some(fix) = self.replace_redundant_elif_with_assertion(clause, test) {
+                    diagnostic.set_fix(fix);
+                }
+            }
         }
     }
 
@@ -1024,6 +1033,77 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         }
         place.place.ignore_possibly_undefined()
+    }
+
+    /// Replaces an always-true final `elif` with an `else` branch and a defensive assertion.
+    ///
+    /// Preserves the original condition, comments, branch indentation, and file-wide line-ending
+    /// style. Bare assignment expressions are parenthesized so they remain valid assertion tests.
+    /// Returns `None` when the branch has no body, its first statement cannot accommodate a new
+    /// indented assertion, or rewriting the header would discard a comment.
+    ///
+    /// The fix is unsafe because an incorrect static assumption can cause the new assertion to
+    /// fail at runtime, and optimized Python execution may remove the assertion entirely.
+    fn replace_redundant_elif_with_assertion(
+        &self,
+        clause: &ast::ElifElseClause,
+        test: &ast::Expr,
+    ) -> Option<Fix> {
+        let first_statement = clause.body.first()?;
+        let source = source_text(self.db(), self.file());
+        let tokens = self.module().tokens();
+        let first_statement_line_start = source.line_start(first_statement.start());
+
+        if first_statement_line_start < logical_line_end(&source, tokens, clause.start()) {
+            return None;
+        }
+
+        // An indent token can span backslash continuations. In that case, the first statement's
+        // physical indentation may differ from the indentation that determines the body's scope.
+        if let Some(token) = tokens.before(first_statement.start()).last()
+            && token.kind() == TokenKind::Indent
+            && token.start() < first_statement_line_start
+        {
+            return None;
+        }
+
+        let indentation = indentation_at_offset(first_statement.start(), &source)?;
+        let parenthesized_test_range = parenthesized_range(test.into(), clause.into(), tokens);
+        let test_range = parenthesized_test_range.unwrap_or(test.range());
+        let header_prefix_range = TextRange::new(clause.start(), test_range.start());
+
+        // Ruff caches `CommentRanges` in its indexer, but ty does not. Constructing
+        // `CommentRanges` here would scan and index every comment in the file just to check
+        // this small range, so inspect the existing tokens directly instead.
+        if tokens
+            .in_range(header_prefix_range)
+            .iter()
+            .any(|token| token.kind().is_comment())
+        {
+            return None;
+        }
+
+        let condition = &source[test_range];
+        let assertion_condition = if test.is_named_expr() && parenthesized_test_range.is_none() {
+            format!("({condition})")
+        } else {
+            condition.to_string()
+        };
+        let line_ending = find_newline(&source)
+            .map(|(_, ending)| ending)
+            .unwrap_or_default()
+            .as_str();
+
+        Some(Fix::unsafe_edits(
+            Edit::range_replacement(
+                "else".to_string(),
+                TextRange::new(clause.start(), test_range.end()),
+            ),
+            [Edit::insertion(
+                format!("assert {assertion_condition}{line_ending}{indentation}"),
+                first_statement.start(),
+            )],
+        ))
     }
 }
 


### PR DESCRIPTION
When the final `elif` condition is always true but ty cannot add an `assert_never` call, offer an unsafe fix for `redundant-condition-strict` that replaces the `elif` with `else` and moves the condition into a defensive assertion.

For example, on Python 3.10 in a project without a direct dependency on `typing_extensions`, the fix makes this change:

```diff
 def handle(value: str | int):
     if isinstance(value, str):
         print(value)
-    elif isinstance(value, int):
+    else:
+        assert isinstance(value, int)
         print(value)
```

After the `str` branch, `value` must be an `int`, so the final `isinstance` check is statically always true. The assertion retains that check at runtime while making the exhaustive branching explicit.

The fallback also applies when the tested value cannot be reused as an `assert_never` argument or import-name conflicts prevent a usable import. It preserves condition parentheses, comments, indentation, and line endings, and parenthesizes bare assignment expressions. No edit is offered when the body cannot accommodate an indented assertion or rewriting the header would discard a comment.

The fix is unsafe because an incorrect static assumption can make the assertion fail at runtime.

Stacked on #28178.
