### PR TITLE
[ty] Treat captured bound-method receivers covariantly

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -195,6 +195,19 @@ reveal_type(C.inferred_from_value)  # revealed: Unknown
 C.inferred_from_value = "overwritten on class"
 ```
 
+#### Bound methods assigned on narrowed receivers
+
+A bound method keeps the receiver that was used to access it. If `self` is narrowed before the bound
+method is assigned to an inferred instance attribute, the captured receiver remains assignable to
+the receiver used by the inferred attribute type.
+
+```py
+class C:
+    def method(self) -> None:
+        if not isinstance(self, str):
+            self.saved_method = self.method
+```
+
 #### Variable defined in multiple methods
 
 If we see multiple un-annotated assignments to a single attribute (`self.x` below), we build the

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -2412,6 +2412,55 @@ static_assert(not is_subtype_of(TypeOf[A.g], Callable[[], int]))
 static_assert(is_subtype_of(TypeOf[A.f], Callable[[A, int], int]))
 ```
 
+### Bound receivers and `Self`
+
+A bound method exposes its captured receiver through the read-only `__self__` attribute. A method
+bound to a subclass can therefore be a subtype of the same method bound to its base class, but not
+the reverse. A `Self` return type follows the same direction.
+
+```py
+from typing import Self
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_subtype_of
+
+class Base:
+    def plain(self) -> int:
+        return 0
+
+    def returns_self(self) -> Self:
+        return self
+
+    def accepts_self(self, other: Self) -> None: ...
+    @classmethod
+    def make(cls) -> Self:
+        return cls()
+
+class Child(Base): ...
+
+def check(base: Base, child: Child):
+    static_assert(is_subtype_of(TypeOf[child.plain], TypeOf[base.plain]))
+    static_assert(not is_subtype_of(TypeOf[base.plain], TypeOf[child.plain]))
+    static_assert(is_subtype_of(TypeOf[child.returns_self], TypeOf[base.returns_self]))
+    static_assert(not is_subtype_of(TypeOf[base.returns_self], TypeOf[child.returns_self]))
+```
+
+`Self` in a remaining parameter is contravariant: a method that requires a `Child` cannot replace
+one that accepts any `Base`. The reverse substitution still fails the captured-receiver requirement.
+
+```py
+def check_parameters(base: Base, child: Child):
+    static_assert(not is_subtype_of(TypeOf[child.accepts_self], TypeOf[base.accepts_self]))
+    static_assert(not is_subtype_of(TypeOf[base.accepts_self], TypeOf[child.accepts_self]))
+```
+
+Classmethods capture the class object, while `Self` in their return type describes an instance.
+
+```py
+def check_classmethods(base: Base, child: Child):
+    static_assert(is_subtype_of(TypeOf[child.make], TypeOf[base.make]))
+    static_assert(not is_subtype_of(TypeOf[base.make], TypeOf[child.make]))
+```
+
 ### Overloads
 
 #### Subtype overloaded

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -205,13 +205,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: BoundMethodType<'db>,
         target: BoundMethodType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // A bound method is a typically a subtype of itself. However, we must explicitly verify
-        // the subtyping of the underlying function signatures (since they might be specialized
-        // differently), and of the bound self parameter (taking care that parameters, including a
-        // bound self parameter, are contravariant.)
+        // The receiver exposed by `__self__` is an already-captured value, so it is covariant.
+        // However, `Self` can also appear in the remaining parameters, where binding the
+        // receiver must still preserve ordinary callable contravariance.
         self.check_function_pair(db, source.function(db), target.function(db))
             .and(db, self.constraints, || {
-                self.check_type_pair(db, target.self_instance(db), source.self_instance(db))
+                self.check_type_pair(db, source.self_instance(db), target.self_instance(db))
+            })
+            .and(db, self.constraints, || {
+                self.check_callable_signature_pair(
+                    db,
+                    source.bound_signatures(db),
+                    target.bound_signatures(db),
+                )
             })
     }
 }


### PR DESCRIPTION
## Summary

Previously, we compared a bound method's captured receiver contravariantly. We now allow the same method bound to a subclass to be a subtype of the method bound to its base class:

```python
from ty_extensions import static_assert
from ty_extensions._internal import TypeOf, is_subtype_of

class Base:
    def method(self) -> int: ...

class Child(Base): ...

def check(base: Base, child: Child):
    # Before: failed assertion. After: passes.
    static_assert(is_subtype_of(TypeOf[child.method], TypeOf[base.method]))
```

The receiver exposed by `__self__` is an already-captured value, so it is covariant. We also compare the bound signatures, so `Self` in a remaining parameter still follows ordinary callable contravariance. Classmethods follow the same rules.
